### PR TITLE
add demo command with reva based oidc provider

### DIFF
--- a/pkg/command/demo.go
+++ b/pkg/command/demo.go
@@ -1,0 +1,148 @@
+package command
+
+import (
+	"strings"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/jaeger"
+	"contrib.go.opencensus.io/exporter/ocagent"
+	"contrib.go.opencensus.io/exporter/zipkin"
+	"github.com/micro/cli"
+	"github.com/micro/go-micro/config/cmd"
+	openzipkin "github.com/openzipkin/zipkin-go"
+	zipkinhttp "github.com/openzipkin/zipkin-go/reporter/http"
+	"github.com/owncloud/ocis/pkg/config"
+	"github.com/owncloud/ocis/pkg/flagset"
+	"github.com/owncloud/ocis/pkg/micro/runtime"
+	"github.com/owncloud/ocis/pkg/register"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
+)
+
+var demoExtensions = []string{
+	"hello",
+	"phoenix",
+	"oidcp", // TODO replace with konnectd and ldap (replace devldap with glauth)
+}
+
+// Demo is the entrypoint for the demo command.
+func Demo(cfg *config.Config) cli.Command {
+	return cli.Command{
+		Name:     "demo",
+		Usage:    "Start demo server",
+		Category: "Demo",
+		Flags:    flagset.ServerWithConfig(cfg),
+		Before: func(c *cli.Context) error {
+			if cfg.HTTP.Root != "/" {
+				cfg.HTTP.Root = strings.TrimSuffix(cfg.HTTP.Root, "/")
+			}
+
+			return nil
+		},
+		Action: func(c *cli.Context) error {
+			logger := NewLogger(cfg)
+
+			if cfg.Tracing.Enabled {
+				switch t := cfg.Tracing.Type; t {
+				case "agent":
+					exporter, err := ocagent.NewExporter(
+						ocagent.WithReconnectionPeriod(5*time.Second),
+						ocagent.WithAddress(cfg.Tracing.Endpoint),
+						ocagent.WithServiceName(cfg.Tracing.Service),
+					)
+
+					if err != nil {
+						logger.Error().
+							Err(err).
+							Str("endpoint", cfg.Tracing.Endpoint).
+							Str("collector", cfg.Tracing.Collector).
+							Msg("Failed to create agent tracing")
+
+						return err
+					}
+
+					trace.RegisterExporter(exporter)
+					view.RegisterExporter(exporter)
+
+				case "jaeger":
+					exporter, err := jaeger.NewExporter(
+						jaeger.Options{
+							AgentEndpoint:     cfg.Tracing.Endpoint,
+							CollectorEndpoint: cfg.Tracing.Collector,
+							ServiceName:       cfg.Tracing.Service,
+						},
+					)
+
+					if err != nil {
+						logger.Error().
+							Err(err).
+							Str("endpoint", cfg.Tracing.Endpoint).
+							Str("collector", cfg.Tracing.Collector).
+							Msg("Failed to create jaeger tracing")
+
+						return err
+					}
+
+					trace.RegisterExporter(exporter)
+
+				case "zipkin":
+					endpoint, err := openzipkin.NewEndpoint(
+						cfg.Tracing.Service,
+						cfg.Tracing.Endpoint,
+					)
+
+					if err != nil {
+						logger.Error().
+							Err(err).
+							Str("endpoint", cfg.Tracing.Endpoint).
+							Str("collector", cfg.Tracing.Collector).
+							Msg("Failed to create zipkin tracing")
+
+						return err
+					}
+
+					exporter := zipkin.NewExporter(
+						zipkinhttp.NewReporter(
+							cfg.Tracing.Collector,
+						),
+						endpoint,
+					)
+
+					trace.RegisterExporter(exporter)
+
+				default:
+					logger.Warn().
+						Str("type", t).
+						Msg("Unknown tracing backend")
+				}
+
+				trace.ApplyConfig(
+					trace.Config{
+						DefaultSampler: trace.AlwaysSample(),
+					},
+				)
+			} else {
+				logger.Debug().
+					Msg("Tracing is not enabled")
+			}
+
+			runtime := runtime.New(
+				runtime.Services(append(runtime.RuntimeServices, demoExtensions...)),
+				runtime.Logger(logger),
+				runtime.MicroRuntime(cmd.DefaultCmd.Options().Runtime),
+			)
+
+			// fork uses the micro runtime to fork go-micro services
+			runtime.Start()
+
+			// trap blocks until a kill signal is sent
+			runtime.Trap()
+
+			return nil
+		},
+	}
+}
+
+func init() {
+	register.AddCommand(Demo)
+}

--- a/pkg/command/oidcp.go
+++ b/pkg/command/oidcp.go
@@ -1,0 +1,283 @@
+package command
+
+import (
+	"github.com/micro/cli"
+	"github.com/owncloud/ocis-reva/pkg/command"
+	svcconfig "github.com/owncloud/ocis-reva/pkg/config"
+	"github.com/owncloud/ocis-reva/pkg/flagset"
+	"github.com/owncloud/ocis/pkg/config"
+	"github.com/owncloud/ocis/pkg/register"
+)
+
+// OIDCPCommand is the entrypoint for the revaoidcp command.
+func OIDCPCommand(cfg *config.Config) cli.Command {
+	return cli.Command{
+		Name:     "oidcp",
+		Usage:    "Start openid connect provider",
+		Category: "Extensions",
+		Flags:    flagset.ServerWithConfig(cfg.Reva),
+		Action: func(c *cli.Context) error {
+			scfg := configureOIDCProvider(cfg)
+
+			return cli.HandleAction(
+				command.Server(scfg).Action,
+				c,
+			)
+		},
+	}
+}
+
+func configureOIDCProvider(cfg *config.Config) *svcconfig.Config {
+	cfg.Reva.Reva.Configs = map[string]interface{}{
+		"oidcprovider": map[string]interface{}{
+			"core": map[string]interface{}{
+				"max_cpus":             cfg.Reva.Reva.MaxCPUs,
+				"tracing_enabled":      cfg.Reva.Tracing.Enabled,
+				"tracing_endpoint":     cfg.Reva.Tracing.Endpoint,
+				"tracing_collector":    cfg.Reva.Tracing.Collector,
+				"tracing_service_name": cfg.Reva.Tracing.Service,
+			},
+			"log": map[string]interface{}{
+				"level": cfg.Reva.Reva.LogLevel,
+				//TODO mode = "console" # "console" or "json"
+				//TODO output = "./standalone.log"
+			},
+			"http": map[string]interface{}{
+				"network": cfg.Reva.Reva.HTTP.Network,
+				"address": cfg.Reva.Reva.HTTP.Addr,
+				"enabled_services": []string{
+					"oidcprovider",
+					"wellknown",
+					"prometheus",
+					"ocs", // TODO remove when phoenix no longer tries to fetch the capabilities
+				},
+				"enabled_middlewares": []string{
+					"cors",
+					"auth",
+				},
+				"middlewares": map[string]interface{}{
+					"auth": map[string]interface{}{
+						"gateway":          cfg.Reva.Reva.GRPC.Addr,
+						"credential_chain": []string{"basic", "bearer"},
+						"token_strategy":   "header",
+						"token_writer":     "header",
+						"token_manager":    "jwt",
+						"token_managers": map[string]interface{}{
+							"jwt": map[string]interface{}{
+								"secret": cfg.Reva.Reva.JWTSecret,
+							},
+						},
+						"skip_methods": []string{
+							"/favicon.ico",
+							"/oauth2",
+							"/.well-known",
+							"/metrics", // for prometheus metrics
+						},
+					},
+					"cors": map[string]interface{}{
+						"allowed_origins": []string{"*"},
+						"allowed_methods": []string{
+							"OPTIONS",
+							"GET",
+							"PUT",
+							"POST",
+							"DELETE",
+							"MKCOL",
+							"PROPFIND",
+							"PROPPATCH",
+							"MOVE",
+							"COPY",
+							"REPORT",
+							"SEARCH",
+						},
+						"allowed_headers": []string{
+							"Origin",
+							"Accept",
+							"Depth",
+							"Content-Type",
+							"X-Requested-With",
+							"Authorization",
+							"Ocs-Apirequest",
+							"If-Match",
+							"If-None-Match",
+							"Destination",
+							"Overwrite",
+						},
+						"allow_credentials":   true,
+						"options_passthrough": false,
+					},
+				},
+				"services": map[string]interface{}{
+					// TODO investigate: service must be here as well, otherwise eg wellknown won't get started
+					// TODO we hardcoded the url because the config option is used to tell the server which address to bind to,
+					//      which is 0.0.0.0:9135 by default, but the iss needs to use a hostname
+					"wellknown": map[string]interface{}{
+						"prefix":                 ".well-known",
+						"issuer":                 "http://localhost:9135",
+						"authorization_endpoint": "http://localhost:9135/oauth2/auth",
+						"token_endpoint":         "http://localhost:9135/oauth2/token",
+						"revocation_endpoint":    "http://localhost:9135/oauth2/auth",
+						"introspection_endpoint": "http://localhost:9135/oauth2/introspect",
+						"userinfo_endpoint":      "http://localhost:9135/oauth2/userinfo",
+					},
+					"oidcprovider": map[string]interface{}{
+						"prefix":    "oauth2",
+						"gateway":   cfg.Reva.Reva.GRPC.Addr,
+						"auth_type": "basic",
+						// TODO we hardcoded the url because the config option is used to tell the server which address to bind to,
+						//      which is 0.0.0.0:9135 by default, but the iss needs to use a hostname
+						"issuer": "http://localhost:9135",
+						"clients": map[string]interface{}{
+							"phoenix": map[string]interface{}{
+								"id": "phoenix",
+								// use ocis port range for phoenix
+								// TODO should use the micro / ocis http gateway, but then it would no longer be able to run standalone
+								// IMO the ports should be fetched from the ocis registry anyway
+								"redirect_uris":  []string{"http://localhost:9100/oidc-callback.html", "http://localhost:9100/"},
+								"grant_types":    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
+								"response_types": []string{"code"}, // use authorization code flow, see https://developer.okta.com/blog/2019/05/01/is-the-oauth-implicit-flow-dead for details
+								"scopes":         []string{"openid", "profile", "email", "offline"},
+								"public":         true, // force PKCS for public clients
+							},
+							"cli": map[string]interface{}{
+								"id":            "cli",
+								"client_secret": "$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO", // = "foobar"
+								// use hardcoded port credentials for cli
+								"redirect_uris":  []string{"http://localhost:18080/callback"},
+								"grant_types":    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
+								"response_types": []string{"code"}, // use authorization code flow, see https://developer.okta.com/blog/2019/05/01/is-the-oauth-implicit-flow-dead for details
+								"scopes":         []string{"openid", "profile", "email", "offline"},
+							},
+						},
+					},
+					"ocs": map[string]interface{}{
+						"prefix":  "ocs",
+						"gateway": cfg.Reva.Reva.GRPC.Addr,
+					},
+				},
+			},
+			"grpc": map[string]interface{}{
+				"network": cfg.Reva.Reva.GRPC.Network,
+				"address": cfg.Reva.Reva.GRPC.Addr,
+				"enabled_services": []string{
+					"authprovider", // provides basic auth
+					"userprovider", // provides user matadata (used to look up email, displayname etc after a login)
+					"gateway",      // to lookup services and authenticate requests
+					"authregistry", // used by the gateway to look up auth providers
+				},
+				"interceptors": map[string]interface{}{
+					"auth": map[string]interface{}{
+						"token_manager": "jwt",
+						"token_managers": map[string]interface{}{
+							"jwt": map[string]interface{}{
+								"secret": cfg.Reva.Reva.JWTSecret,
+							},
+						},
+						"skip_methods": []string{
+							// we need to allow calls that happen during authentication
+							"/cs3.auth.registry.v1beta1.RegistryAPI/GetAuthProvider",
+							"/cs3.auth.provider.v1beta1.ProviderAPI/Authenticate",
+							"/cs3.gateway.v1beta1.GatewayAPI/Authenticate",
+							"/cs3.identity.user.v1beta1.UserAPI/GetUser",
+							"/cs3.gateway.v1beta1.GatewayAPI/GetUser",
+						},
+					},
+				},
+				"services": map[string]interface{}{
+					"gateway": map[string]interface{}{
+						"authregistrysvc":               cfg.Reva.Reva.GRPC.Addr,
+						"storageregistrysvc":            cfg.Reva.Reva.GRPC.Addr,
+						"appregistrysvc":                cfg.Reva.Reva.GRPC.Addr,
+						"preferencessvc":                cfg.Reva.Reva.GRPC.Addr,
+						"usershareprovidersvc":          cfg.Reva.Reva.GRPC.Addr,
+						"publicshareprovidersvc":        cfg.Reva.Reva.GRPC.Addr,
+						"ocmshareprovidersvc":           cfg.Reva.Reva.GRPC.Addr,
+						"userprovidersvc":               cfg.Reva.Reva.GRPC.Addr,
+						"commit_share_to_storage_grant": true,
+						"datagateway":                   "http://" + cfg.Reva.Reva.HTTP.Addr + "/data",
+						"transfer_shared_secret":        "replace-me-with-a-transfer-secret",
+						"transfer_expires":              6, // give it a moment
+						"token_manager":                 "jwt",
+						"token_managers": map[string]interface{}{
+							"jwt": map[string]interface{}{
+								"secret": cfg.Reva.Reva.JWTSecret,
+							},
+						},
+					},
+					"authregistry": map[string]interface{}{
+						"driver": "static",
+						"drivers": map[string]interface{}{
+							"static": map[string]interface{}{
+								"rules": map[string]interface{}{
+									"basic":  cfg.Reva.Reva.GRPC.Addr,
+									"bearer": "localhost:9138",
+								},
+							},
+						},
+					},
+					"authprovider": map[string]interface{}{
+						"auth_manager":    "demo",
+						"userprovidersvc": cfg.Reva.Reva.GRPC.Addr,
+					},
+					"userprovider": map[string]interface{}{
+						"driver": "demo",
+					},
+				},
+			},
+		},
+		"oidcauthprovider": map[string]interface{}{
+			"core": map[string]interface{}{
+				"max_cpus":             cfg.Reva.Reva.MaxCPUs,
+				"tracing_enabled":      cfg.Reva.Tracing.Enabled,
+				"tracing_endpoint":     cfg.Reva.Tracing.Endpoint,
+				"tracing_collector":    cfg.Reva.Tracing.Collector,
+				"tracing_service_name": cfg.Reva.Tracing.Service,
+			},
+			"log": map[string]interface{}{
+				"level": cfg.Reva.Reva.LogLevel,
+				//TODO mode = "console" # "console" or "json"
+				//TODO output = "./standalone.log"
+			},
+			"grpc": map[string]interface{}{
+				"network": cfg.Reva.Reva.GRPC.Network,
+				"address": "localhost:9138", // use another port
+				"enabled_services": []string{
+					"authprovider", // provides oidc auth
+				},
+				"interceptors": map[string]interface{}{
+					"auth": map[string]interface{}{
+						"token_manager": "jwt",
+						"token_managers": map[string]interface{}{
+							"jwt": map[string]interface{}{
+								"secret": cfg.Reva.Reva.JWTSecret,
+							},
+						},
+						"skip_methods": []string{
+							"/cs3.auth.registry.v1beta1.RegistryAPI/GetAuthProvider",
+							"/cs3.auth.provider.v1beta1.ProviderAPI/Authenticate",
+						},
+					},
+				},
+				"services": map[string]interface{}{
+					"authprovider": map[string]interface{}{
+						"auth_manager":    "oidc",
+						"userprovidersvc": cfg.Reva.Reva.GRPC.Addr,
+						"auth_managers": map[string]interface{}{
+							"oidc": map[string]interface{}{
+								// TODO we hardcoded the url because the config option is used to tell the server which address to bind to,
+								//      which is 0.0.0.0:9135 by default, but the iss needs to use a hostname
+								"issuer": "http://localhost:9135",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return cfg.Reva
+}
+
+func init() {
+	register.AddCommand(OIDCPCommand)
+}


### PR DESCRIPTION
This PR introduces the `ocis demo` command, which ties together *ocis-hello, ocis-phoenix* and *reva* (in the form of an openid connect provider started by the new `ocis oidcp` command). It implements the simple ocis use case.

 `ocis oidcp` allows running an insecure openid connect provider without https and the demo isers from reva.

I did not touch `ocis server` because I was under the impression that that should include a full blown konnectd as well as glauth for ldap and the graph api. It is left for another sprint though.



requires https://github.com/owncloud/ocis-reva/pull/2

# TODO
We need to change the default phoenix config, because we only want to use the hello app:
- [ ] where do we put the phoenix config.json? 
  - a new assets folder in the ocis repo? or add the config as an example to phoenix directly
  - how do we make ocis-phoenix use that config. I am currently using an env var for `ocis demo`, but we should be able to preconfigure the `ocis phoenix` command by setting the env var before the runtime spawns the new process.

- ocis-hello currently builds a hello.js, but phoenix expects `hello.bundle.js`
- ocis-hello is a separate service serving the api at `:9105/api/v0/root`, but phoenix only looks at its own address `/apps/hello`
  - maybe there is some config magic for phoenix to look for app bundles elsewhere?
  - [ ] we would need a reverse proxy to serve
    - `/` from ocis-phoenix and
    - `/apps/hello` from the ocis-hello service
- clicking "submit" gives me an error
```
TypeError: Cannot read property 'url' of null
    at c.submitName (hello.bundle.js:formatted:9900)
    at Array.<anonymous> (core.bundle.js:formatted:427)
    at c.dispatch (core.bundle.js:formatted:560)
    at c.dispatch (core.bundle.js:formatted:249)
    at c.i.dispatch (core.bundle.js:formatted:368)
    at s.x.forEach.r.<computed> (hello.bundle.js:formatted:3046)
    at submit (hello.bundle.js:formatted:10851)
    at Bt (core.bundle.js:formatted:1614)
    at HTMLFormElement.n (core.bundle.js:formatted:1735)
    at HTMLFormElement.Zr.o._wrapper (core.bundle.js:formatted:3650
```

- [ ] find out how to use go micros [proxy](https://github.com/micro/examples/tree/master/proxy/go#http-example) service, an [api with proxy mapping](https://github.com/micro/examples/blob/master/api/README.md#proxy-mapping) or the [API gateway proxy resolver](https://micro.mu/docs/api.html#proxy-resolver) ... if they really are three different things ... and ose tho proper one as a reverse proxy.
  - would get rid of the cors as well as the necessary configuration for it
  - would serve everything from a single endpoint
  - would allow us to use acme when not running as `localhost`
