### PR TITLE
To fix ocis ps the default name of go micro runtime is set to com.own…

### DIFF
--- a/pkg/micro/runtime/runtime.go
+++ b/pkg/micro/runtime/runtime.go
@@ -158,6 +158,7 @@ func setDefaults() {
 
 	// runtime
 	runtime.Name = OwncloudNamespace + "runtime"
+	gorun.DefaultName = OwncloudNamespace + "runtime"
 
 	// server
 	server.Name = OwncloudNamespace + "server"


### PR DESCRIPTION
…cloud.runtime

