### PR TITLE
Call urfave before hook

### DIFF
--- a/pkg/command/konnectd.go
+++ b/pkg/command/konnectd.go
@@ -18,12 +18,14 @@ func KonnectdCommand(cfg *config.Config) *cli.Command {
 		Category: "Extensions",
 		Flags:    flagset.ServerWithConfig(cfg.Konnectd),
 		Action: func(c *cli.Context) error {
-			scfg := configureKonnectd(cfg)
+			serverConfig := configureKonnectd(cfg)
+			serverCommand := command.Server(serverConfig)
 
-			return cli.HandleAction(
-				command.Server(scfg).Action,
-				c,
-			)
+			if err := serverCommand.Before(c); err != nil {
+				return err
+			}
+
+			return cli.HandleAction(serverCommand.Action, c)
 		},
 	}
 }


### PR DESCRIPTION
I assumed that ocis will call the required [hooks](https://github.com/owncloud/ocis-konnectd/blob/05b45e4802e88ddb51a3cc9ea47b65102f15754a/pkg/command/server.go#L33) "automatically". Turns out this is not the case. 

Should all sub-commands be modified to call Before, or are we able to centralize this somehow? Is it the responsibility of the service to care for the hook calling order in ocis?

I didn't wrap the before call in Before because this would require to call configureServer twice.

Please advice. 

Closes #121 