### PR TITLE
Added config.json inside phoenix dist

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -208,6 +208,7 @@ def testing(ctx):
           'cd /srv/app/phoenix',
           'yarn install-all',
           'yarn dist',
+          'cp -r /drone/src/tests/config/drone/ocis-config.json /srv/app/phoenix/dist/config.json',
           'yarn run acceptance-tests-drone'
         ],
         'volumes': [{


### PR DESCRIPTION
Phoenix acceptance tests were failing in ocis ci due to missing phoenix config.json file inside dist folder
This pr adds config.json inside dist of phoenix source