### PR TITLE
allow dataproviders to authenticate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ eos-ocis-storage-home:
 .PHONY: eos-ocis
 eos-ocis:
 	export OCIS_LOG_LEVEL=debug; \
-	export DAV_FILES_NAMESPACE="/home/"; \
+	export DAV_FILES_NAMESPACE="/eos/users/{{substr 0 1 .Username}}/"; \
 	bin/ocis micro & \
 	bin/ocis glauth & \
 	bin/ocis graph-explorer & \
@@ -285,7 +285,6 @@ eos-ocis:
 	bin/ocis reva-sharing & \
 	bin/ocis reva-users & \
 	bin/ocis proxy &
-
 
 .PHONY: eos-start
 eos-start: eos-deploy eos-setup eos-copy-ocis eos-ocis-storage-home eos-ocis

--- a/Makefile
+++ b/Makefile
@@ -256,18 +256,20 @@ eos-ocis-storage-home:
 	docker exec -i \
 	--env OCIS_LOG_LEVEL=debug \
 	--env REVA_STORAGE_HOME_DATA_DRIVER=eos \
+	--env REVA_GATEWAY_URL=host.docker.internal:9142 \
 	eos-cli1 ocis reva-storage-home-data &
 	docker exec -i \
 	--env OCIS_LOG_LEVEL=debug \
 	eos-cli1 ocis reva-storage-eos &
 	docker exec -i \
 	--env OCIS_LOG_LEVEL=debug \
+	--env REVA_GATEWAY_URL=host.docker.internal:9142 \
 	eos-cli1 ocis reva-storage-eos-data &
 
 .PHONY: eos-ocis
 eos-ocis:
 	export OCIS_LOG_LEVEL=debug; \
-	export DAV_FILES_NAMESPACE="/eos/"; \
+	export DAV_FILES_NAMESPACE="/home/"; \
 	bin/ocis micro & \
 	bin/ocis glauth & \
 	bin/ocis graph-explorer & \


### PR DESCRIPTION
- allows dataproviders to authenticate againts the reva gateway running on the host
- uses a new template layout for the /eos namespace to matdch where files are landing when using /home (requires https://github.com/cs3org/reva/pull/674/commits/9c4ff7cc45734f8704cc97665c10596ce35f9631)
