### PR TITLE
[Tests-only] remove need to authorize phoenix in kopano

### DIFF
--- a/tests/config/drone/identifier-registration.yml
+++ b/tests/config/drone/identifier-registration.yml
@@ -6,6 +6,7 @@ clients:
     name: OCIS
     application_type: web
     insecure: yes
+    trusted: yes
     redirect_uris:
       - http://ocis-server:9100/oidc-callback.html
       - http://ocis-server:9100


### PR DESCRIPTION
analog to https://github.com/owncloud/phoenix/pull/3374
with `trusted: yes` in the configuration the authentication of the webapp (phoenix) in kopano is not needed

the basic configuration when starting `ocis server` has that setting set, so we avoid different environments and confusion during testing