### PR TITLE
[Tests-only] add slash at the end of redirect_uri to allow correct logout

### DIFF
--- a/tests/config/drone/identifier-registration.yml
+++ b/tests/config/drone/identifier-registration.yml
@@ -8,7 +8,7 @@ clients:
     insecure: yes
     redirect_uris:
       - http://ocis-server:9100/oidc-callback.html
-      - http://ocis-server:9100
+      - http://ocis-server:9100/
     origins:
       -  http://ocis-server:9100
 


### PR DESCRIPTION
for the logout to work correctly with kopano, we need the `/` at the end of the uri