### PR TITLE
Update bridge documentation

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -72,12 +72,10 @@ In an `ocis` folder
 ```
 $ git clone git@github.com:owncloud/ocis-glauth.git
 $ cd ocis-glauth
-$ git checkout start-glauth
 $ make
 ```
 This should give you a `bin/ocis-glauth` binary. Try listing the help with `bin/ocis-glauth --help`.
 
-TODO merge glauth PR https://github.com/owncloud/ocis-glauth/pull/1
 
 #### Run it!
 


### PR DESCRIPTION
Update bridge documentation to current code status

Also we probably have to erase or rewrite this part due to finally the decision taken was in favor of a non core change in the oauth app: owncloud/oauth2#255 :

```
Patch owncloud

While the UserSession in ownCloud 10 is currently used to test all available IAuthModule implementations, it immediately logs out the user when an exception occurs. However, existing owncloud 10 instances use the oauth2 app to create Bearer tokens for mobile and desktop clients.

To give the openidconnect app a chance to verify the tokens we need to change the code a bit. See https://github.com/owncloud/core/pull/37043 for a possible solution.

    Note: The PR is hot … as in younger than this list of steps. And it messes with authentication. Use with caution.

```
