### PR TITLE
[tests-only] revert selenium chrome docker image to 3.141.59-20200326

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -244,7 +244,7 @@ def testing(ctx):
       },
       {
         'name': 'selenium',
-        'image': 'selenium/standalone-chrome-debug:latest',
+        'image': 'selenium/standalone-chrome-debug:3.141.59-20200326',
         'pull': 'always',
         'volumes': [{
             'name': 'uploads',


### PR DESCRIPTION
CI failed when trying to make a screenshot, seems to be an issue in chromedriver, see SeleniumHQ/selenium#8218
reverting selenium to 3.141.59-20200326

analog to https://github.com/owncloud/phoenix/pull/3394