### PR TITLE
Update extensions ocis-reva and ocis-thumbnails

### DIFF
--- a/changelog/unreleased/update-extensions-20_50_2020.md
+++ b/changelog/unreleased/update-extensions-20_50_2020.md
@@ -1,0 +1,7 @@
+Enhancement: Update extensions
+
+We've updated various extensions:
+- ocis-reva v0.2.2-0.20200519090125-efaa4fa209da
+- ocis-thumbnails v0.1.3-0.20200519093216-7867c5389055
+
+https://github.com/owncloud/ocis/pull/285

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/owncloud/ocis-phoenix v0.6.0
 	github.com/owncloud/ocis-pkg/v2 v2.2.1
 	github.com/owncloud/ocis-proxy v0.3.1
-	github.com/owncloud/ocis-reva v0.2.2-0.20200513073117-ee9cd9b8d3ab
-	github.com/owncloud/ocis-thumbnails v0.1.2-0.20200422124828-f92a40879feb
+	github.com/owncloud/ocis-reva v0.2.2-0.20200519090125-efaa4fa209da
+	github.com/owncloud/ocis-thumbnails v0.1.3-0.20200519093216-7867c5389055
 	github.com/owncloud/ocis-webdav v0.1.0
 	github.com/restic/calens v0.2.0
 	go.opencensus.io v0.22.3

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/aws/aws-sdk-go v1.29.26/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTg
 github.com/aws/aws-sdk-go v1.30.12 h1:KrjyosZvkpJjcwMk0RNxMZewQ47v7+ZkbQDXjWsJMs8=
 github.com/aws/aws-sdk-go v1.30.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.30.25/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.30.29/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
@@ -231,6 +232,7 @@ github.com/cs3org/reva v0.1.0/go.mod h1:8j6QyyAq9Kjj7RPfJb7M1aEmw5DmsuCJKUULXxYO
 github.com/cs3org/reva v0.1.1-0.20200427161359-c1549a8110eb h1:NmIewIBHshEpn8q1pezRDoG2B7hRVgnWYLX1XSVjx1E=
 github.com/cs3org/reva v0.1.1-0.20200427161359-c1549a8110eb/go.mod h1:I20R3mjgLU9y9Ol3pIckY3M948l7mkJORdpfSR9w9tM=
 github.com/cs3org/reva v0.1.1-0.20200512135421-3aa67e818a8d/go.mod h1:YIgUciBl5fg6xhV+ZPWkfWlc5H4wjXg/8+ngIYPzvKI=
+github.com/cs3org/reva v0.1.1-0.20200518061204-dd26e9bf62cd/go.mod h1:XGcK/IC3PQ+C8pKlkfDbGbFKSeN8D2FV6qlwaR35rCY=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -378,6 +380,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
@@ -598,6 +601,7 @@ github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180219170247-931426f7535a/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -795,9 +799,13 @@ github.com/owncloud/ocis-reva v0.2.1 h1:4aOOJT7tn9GCeNCM+qr33de2xobW4nAKJUvbb0Bp
 github.com/owncloud/ocis-reva v0.2.1/go.mod h1:Ew9XgScQzFbdpSZySq1PHVISgd4y03Ms62lFy+mAx2s=
 github.com/owncloud/ocis-reva v0.2.2-0.20200513073117-ee9cd9b8d3ab h1:WNIv1WkJi5JiLEEf8OzSZXUjiad9pqYk9+EUKklwq9k=
 github.com/owncloud/ocis-reva v0.2.2-0.20200513073117-ee9cd9b8d3ab/go.mod h1:mO2vMom9eC3mdMKOtOIYUUlk3eocUZcVXidKk7IfSWA=
+github.com/owncloud/ocis-reva v0.2.2-0.20200519090125-efaa4fa209da h1:rufrRYQUzf45Ty2ctWoMhY+2xVuZnWYVtxrLp+zp0PA=
+github.com/owncloud/ocis-reva v0.2.2-0.20200519090125-efaa4fa209da/go.mod h1:dkXikZp6HbawRNbaQn7Dh8uQ5JLTSm3MyQLuSqUxEYU=
 github.com/owncloud/ocis-thumbnails v0.0.0-20200318131505-e0ab0b37a5a4/go.mod h1:VmCoxwitTs6oRxIaGz6xridLPwA6ReRMej22jBhkRIM=
 github.com/owncloud/ocis-thumbnails v0.1.2-0.20200422124828-f92a40879feb h1:eLvwnJ88x0erIsjMEa2b6dI1pBTEz52eMKrBPJfIOLM=
 github.com/owncloud/ocis-thumbnails v0.1.2-0.20200422124828-f92a40879feb/go.mod h1:N9zPXTyUmQ7vi19Y5EO94MRw19up/3SK3SSX5P3PvFw=
+github.com/owncloud/ocis-thumbnails v0.1.3-0.20200519093216-7867c5389055 h1:sAhwQ2lpb0vFUyoz+2BYx3Z0QCXoX6RHJuXPPlyjOoE=
+github.com/owncloud/ocis-thumbnails v0.1.3-0.20200519093216-7867c5389055/go.mod h1:N9zPXTyUmQ7vi19Y5EO94MRw19up/3SK3SSX5P3PvFw=
 github.com/owncloud/ocis-webdav v0.1.0 h1:A7wI6knfIDwvlAMrW+YOmP9gxF7bxAtsgIuFs11+fM4=
 github.com/owncloud/ocis-webdav v0.1.0/go.mod h1:hB3KbiMS7kyq9bG/BwKSI+lLM4PIMYEckrT2IFYTGxg=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
@@ -1290,6 +1298,7 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/Acconut/lockfile.v1 v1.1.0/go.mod h1:6UCz3wJ8tSFUsPR6uP/j8uegEtDuEEqFxlpi0JI4Umw=
 gopkg.in/DataDog/dd-trace-go.v1 v1.19.0/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=


### PR DESCRIPTION
- ocis-reva v0.2.2-0.20200519090125-efaa4fa209da
- ocis-thumbnails v0.1.3-0.20200519093216-7867c5389055

