### PR TITLE
[DO-NOT-MERGE][Tests-Only] Remove skipOnOcis tags for the tests that pass

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -184,7 +184,7 @@ def testing(ctx):
         },
         'commands': [
           'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/tmp/testing',
-          'git clone -b master --depth=1 https://github.com/owncloud/core.git /srv/app/testrunner',
+          'git clone -b getSharedSharedWithMe --depth=1 https://github.com/owncloud/core.git /srv/app/testrunner',
           'cd /srv/app/testrunner',
           'make test-acceptance-api',
         ],


### PR DESCRIPTION

This PR checks if the tests for which `skipOnOcis` tags are skipped pass on ocis.