### PR TITLE
[Tests-Only] Run API and UI tests from specified branch-commits

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,6 +1,6 @@
 def main(ctx):
   before = [
-    testing(ctx),
+    testing(ctx, 'master', '158bd976047ea8abd137e2c61905d9dd63dc977d', 'master', '934606e8e1701dbdf433c0c55a6272ec1cc0b9aa'),
   ]
 
   stages = [
@@ -22,7 +22,7 @@ def main(ctx):
 
   return before + stages + after
 
-def testing(ctx):
+def testing(ctx, coreBranch = 'master', coreCommit = '', phoenixBranch = 'master', phoenixCommit = ''):
   return {
     'kind': 'pipeline',
     'type': 'docker',
@@ -184,8 +184,11 @@ def testing(ctx):
         },
         'commands': [
           'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/tmp/testing',
-          'git clone -b master --depth=1 https://github.com/owncloud/core.git /srv/app/testrunner',
+          'git clone -b %s --single-branch --no-tags https://github.com/owncloud/core.git /srv/app/testrunner' % (coreBranch),
           'cd /srv/app/testrunner',
+		] + ([
+          'git checkout %s' % (coreCommit)
+		] if coreCommit != '' else []) + [
           'make test-acceptance-api',
         ],
         'volumes': [{
@@ -210,9 +213,12 @@ def testing(ctx):
         },
         'commands': [
           'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/testing',
-          'git clone -b master --depth=1 https://github.com/owncloud/phoenix.git /srv/app/phoenix',
+          'git clone -b %s --single-branch --no-tags https://github.com/owncloud/phoenix.git /srv/app/phoenix' % (phoenixBranch),
           'cp -r /srv/app/phoenix/tests/acceptance/filesForUpload/* /uploads',
           'cd /srv/app/phoenix',
+		] + ([
+          'git checkout %s' % (phoenixCommit)
+		] if phoenixCommit != '' else []) + [
           'yarn install-all',
           'yarn dist',
           'cp -r /drone/src/tests/config/drone/ocis-config.json /srv/app/phoenix/dist/config.json',


### PR DESCRIPTION
Part of issue #303 

Specify the branch, and commit in that branch, to use when fetching the ownCloud10 core API test runner code. And also for when fetching the phoenix UI test runner code.
