### PR TITLE
[Tests-Only] Use owncloudci/nodejs:11 for phoenixWebUIAcceptanceTests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -195,7 +195,7 @@ def testing(ctx):
       },
       {
         'name': 'phoenixWebUIAcceptanceTests',
-        'image': 'owncloudci/nodejs:10',
+        'image': 'owncloudci/nodejs:11',
         'pull': 'always',
         'environment': {
           'SERVER_HOST': 'http://ocis-server:9100',


### PR DESCRIPTION
Phoenix already uses `owncloudci/nodejs:11` docker images when running acceptance tests.
https://github.com/owncloud/phoenix/blob/master/.drone.star - runWebuiAcceptanceTests
```
'image': 'owncloudci/nodejs:11',
```

Make it consistent here.