### PR TITLE
Simplify config

### DIFF
--- a/changelog/unreleased/simplify-tracing.md
+++ b/changelog/unreleased/simplify-tracing.md
@@ -1,0 +1,7 @@
+Enhancement: Simplify tracing config
+
+We now apply the oCIS tracing config to all services which have tracing. With this it is possible
+to set one tracing config for all services at the same time.
+
+https://github.com/owncloud/product/issues/92
+https://github.com/owncloud/ocis/pull/329

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -24,14 +24,24 @@ to get started:
       -p 9411:9411 \
       jaegertracing/all-in-one:1.17
     ```
-2. Every single oCIS service has its own environment variables for enabling and configuring tracing. You can, for example,
-enable tracing in Reva when starting the oCIS single binary like this:
-    ```console
-    REVA_TRACING_ENABLED=true \
-    REVA_TRACING_ENDPOINT=localhost:6831 \
-    REVA_TRACING_COLLECTOR=http://localhost:14268/api/traces \
-    ./bin/ocis server
-    ```
+2. Every single oCIS service has its own environment variables for enabling and configuring tracing.
+    1. You can enable and configure tracing on each service individually. For example, enable tracing
+        in Reva when starting the oCIS single binary like this:
+        ```console
+        REVA_TRACING_ENABLED=true \
+        REVA_TRACING_ENDPOINT=localhost:6831 \
+        REVA_TRACING_COLLECTOR=http://localhost:14268/api/traces \
+        ./bin/ocis server
+        ```
+    2. Enabling and configuring tracing on oCIS itself will forward the configuration to all services:
+        ```console
+        OCIS_TRACING_ENABLED=true \
+        OCIS_TRACING_ENDPOINT=localhost:6831 \
+        OCIS_TRACING_COLLECTOR=http://localhost:14268/api/traces \
+        ./bin/ocis server
+        ```
+       If you want to set individual tracing configuration for each service, make sure to set
+       `OCIS_TRACING_ENABLED=false`.
 3. Make the actual request that you want to trace.
 4. Open up the [Jaeger UI](http://localhost:16686) to analyze request traces.
 

--- a/pkg/command/glauth.go
+++ b/pkg/command/glauth.go
@@ -31,6 +31,15 @@ func configureGLAuth(cfg *config.Config) *svcconfig.Config {
 	cfg.GLAuth.Log.Level = cfg.Log.Level
 	cfg.GLAuth.Log.Pretty = cfg.Log.Pretty
 	cfg.GLAuth.Log.Color = cfg.Log.Color
+
+	if cfg.Tracing.Enabled {
+		cfg.GLAuth.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.GLAuth.Tracing.Type = cfg.Tracing.Type
+		cfg.GLAuth.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.GLAuth.Tracing.Collector = cfg.Tracing.Collector
+		cfg.GLAuth.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.GLAuth
 }
 

--- a/pkg/command/graph-explorer.go
+++ b/pkg/command/graph-explorer.go
@@ -35,6 +35,14 @@ func configureGraphExplorer(cfg *config.Config) *svcconfig.Config {
 	cfg.GraphExplorer.Log.Pretty = cfg.Log.Pretty
 	cfg.GraphExplorer.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.GraphExplorer.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.GraphExplorer.Tracing.Type = cfg.Tracing.Type
+		cfg.GraphExplorer.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.GraphExplorer.Tracing.Collector = cfg.Tracing.Collector
+		cfg.GraphExplorer.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.GraphExplorer
 }
 

--- a/pkg/command/graph.go
+++ b/pkg/command/graph.go
@@ -35,6 +35,14 @@ func configureGraph(cfg *config.Config) *svcconfig.Config {
 	cfg.Graph.Log.Pretty = cfg.Log.Pretty
 	cfg.Graph.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Graph.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Graph.Tracing.Type = cfg.Tracing.Type
+		cfg.Graph.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Graph.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Graph.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Graph
 }
 

--- a/pkg/command/konnectd.go
+++ b/pkg/command/konnectd.go
@@ -34,6 +34,14 @@ func configureKonnectd(cfg *config.Config) *svcconfig.Config {
 	cfg.Konnectd.Log.Color = cfg.Log.Color
 	cfg.Konnectd.HTTP.TLS = false
 
+	if cfg.Tracing.Enabled {
+		cfg.Konnectd.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Konnectd.Tracing.Type = cfg.Tracing.Type
+		cfg.Konnectd.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Konnectd.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Konnectd.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Konnectd
 }
 

--- a/pkg/command/ocs.go
+++ b/pkg/command/ocs.go
@@ -35,6 +35,14 @@ func configureOCS(cfg *config.Config) *svcconfig.Config {
 	cfg.OCS.Log.Pretty = cfg.Log.Pretty
 	cfg.OCS.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.OCS.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.OCS.Tracing.Type = cfg.Tracing.Type
+		cfg.OCS.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.OCS.Tracing.Collector = cfg.Tracing.Collector
+		cfg.OCS.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.OCS
 }
 

--- a/pkg/command/phoenix_ocis.go
+++ b/pkg/command/phoenix_ocis.go
@@ -12,6 +12,14 @@ func configurePhoenix(cfg *config.Config) *svcconfig.Config {
 	cfg.Phoenix.Log.Pretty = cfg.Log.Pretty
 	cfg.Phoenix.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Phoenix.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Phoenix.Tracing.Type = cfg.Tracing.Type
+		cfg.Phoenix.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Phoenix.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Phoenix.Tracing.Service = cfg.Tracing.Service
+	}
+
 	// disable ocis-hello extension
 	cfg.Phoenix.Phoenix.Config.ExternalApps = []svcconfig.ExternalApp{}
 

--- a/pkg/command/phoenix_simple.go
+++ b/pkg/command/phoenix_simple.go
@@ -12,6 +12,14 @@ func configurePhoenix(cfg *config.Config) *svcconfig.Config {
 	cfg.Phoenix.Log.Pretty = cfg.Log.Pretty
 	cfg.Phoenix.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Phoenix.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Phoenix.Tracing.Type = cfg.Tracing.Type
+		cfg.Phoenix.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Phoenix.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Phoenix.Tracing.Service = cfg.Tracing.Service
+	}
+
 	// disable built in apps
 	cfg.Phoenix.Phoenix.Config.Apps = []string{}
 	// enable ocis-hello extension

--- a/pkg/command/proxy.go
+++ b/pkg/command/proxy.go
@@ -35,6 +35,18 @@ func configureProxy(cfg *config.Config) *svcconfig.Config {
 	cfg.Proxy.Log.Pretty = cfg.Log.Pretty
 	cfg.Proxy.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Proxy.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Proxy.Tracing.Type = cfg.Tracing.Type
+		cfg.Proxy.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Proxy.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Proxy.Tracing.Service = cfg.Tracing.Service
+	}
+
+	if cfg.Reva.Reva.JWTSecret != "" {
+		cfg.Proxy.TokenManager.JWTSecret = cfg.Reva.Reva.JWTSecret
+	}
+
 	return cfg.Proxy
 }
 

--- a/pkg/command/revaauthbasic.go
+++ b/pkg/command/revaauthbasic.go
@@ -34,6 +34,14 @@ func configureRevaAuthBasic(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revaauthbearer.go
+++ b/pkg/command/revaauthbearer.go
@@ -34,6 +34,14 @@ func configureRevaAuthBearer(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revafrontend.go
+++ b/pkg/command/revafrontend.go
@@ -34,6 +34,14 @@ func configureRevaFrontend(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revagateway.go
+++ b/pkg/command/revagateway.go
@@ -34,6 +34,14 @@ func configureRevaGateway(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revasharing.go
+++ b/pkg/command/revasharing.go
@@ -34,6 +34,14 @@ func configureRevaSharing(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastorageeos.go
+++ b/pkg/command/revastorageeos.go
@@ -34,6 +34,14 @@ func configureRevaStorageEOS(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastorageeosdata.go
+++ b/pkg/command/revastorageeosdata.go
@@ -34,6 +34,14 @@ func configureRevaStorageEOSData(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastoragehome.go
+++ b/pkg/command/revastoragehome.go
@@ -34,6 +34,14 @@ func configureRevaStorageHome(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastoragehomedata.go
+++ b/pkg/command/revastoragehomedata.go
@@ -34,6 +34,14 @@ func configureRevaStorageHomeData(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastorageoc.go
+++ b/pkg/command/revastorageoc.go
@@ -34,6 +34,14 @@ func configureRevaStorageOC(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastorageocdata.go
+++ b/pkg/command/revastorageocdata.go
@@ -34,6 +34,14 @@ func configureRevaStorageOCData(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastoragepubliclink.go
+++ b/pkg/command/revastoragepubliclink.go
@@ -34,6 +34,14 @@ func configureRevaStoragePublicLink(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revastorageroot.go
+++ b/pkg/command/revastorageroot.go
@@ -34,6 +34,14 @@ func configureRevaStorageRoot(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/revausers.go
+++ b/pkg/command/revausers.go
@@ -34,6 +34,14 @@ func configureRevaUsers(cfg *config.Config) *svcconfig.Config {
 	cfg.Reva.Log.Pretty = cfg.Log.Pretty
 	cfg.Reva.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Reva.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Reva.Tracing.Type = cfg.Tracing.Type
+		cfg.Reva.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Reva.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Reva.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Reva
 }
 

--- a/pkg/command/settings.go
+++ b/pkg/command/settings.go
@@ -35,6 +35,18 @@ func configureSettings(cfg *config.Config) *svcconfig.Config {
 	cfg.Settings.Log.Pretty = cfg.Log.Pretty
 	cfg.Settings.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Settings.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Settings.Tracing.Type = cfg.Tracing.Type
+		cfg.Settings.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Settings.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Settings.Tracing.Service = cfg.Tracing.Service
+	}
+
+	if cfg.Reva.Reva.JWTSecret != "" {
+		cfg.Settings.TokenManager.JWTSecret = cfg.Reva.Reva.JWTSecret
+	}
+
 	return cfg.Settings
 }
 

--- a/pkg/command/thumbnails.go
+++ b/pkg/command/thumbnails.go
@@ -36,6 +36,14 @@ func configureThumbnails(cfg *config.Config) *svcconfig.Config {
 	cfg.Thumbnails.Log.Pretty = cfg.Log.Pretty
 	cfg.Thumbnails.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.Thumbnails.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.Thumbnails.Tracing.Type = cfg.Tracing.Type
+		cfg.Thumbnails.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.Thumbnails.Tracing.Collector = cfg.Tracing.Collector
+		cfg.Thumbnails.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.Thumbnails
 }
 

--- a/pkg/command/webdav.go
+++ b/pkg/command/webdav.go
@@ -35,6 +35,14 @@ func configureWebDAV(cfg *config.Config) *svcconfig.Config {
 	cfg.WebDAV.Log.Pretty = cfg.Log.Pretty
 	cfg.WebDAV.Log.Color = cfg.Log.Color
 
+	if cfg.Tracing.Enabled {
+		cfg.WebDAV.Tracing.Enabled = cfg.Tracing.Enabled
+		cfg.WebDAV.Tracing.Type = cfg.Tracing.Type
+		cfg.WebDAV.Tracing.Endpoint = cfg.Tracing.Endpoint
+		cfg.WebDAV.Tracing.Collector = cfg.Tracing.Collector
+		cfg.WebDAV.Tracing.Service = cfg.Tracing.Service
+	}
+
 	return cfg.WebDAV
 }
 

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -70,14 +70,14 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tracing-endpoint",
-			Value:       "",
+			Value:       "localhost:6831",
 			Usage:       "Endpoint for the agent",
 			EnvVars:     []string{"OCIS_TRACING_ENDPOINT"},
 			Destination: &cfg.Tracing.Endpoint,
 		},
 		&cli.StringFlag{
 			Name:        "tracing-collector",
-			Value:       "",
+			Value:       "http://localhost:14268/api/traces",
 			Usage:       "Endpoint for the collector",
 			EnvVars:     []string{"OCIS_TRACING_COLLECTOR"},
 			Destination: &cfg.Tracing.Collector,


### PR DESCRIPTION
With this PR, the `OCIS_TRACING_*` config variables become the global config for all services. If you want to set individual tracing config for each service, set `OCIS_TRACING_ENABLED=false` (which is the default) and configure tracing for all services individually.

Tracing documentation updated as well, to reflect both different usages (global config and per-service config).

Implementation for https://github.com/owncloud/product/issues/92