### PR TITLE
Fix reva public link service command + changelog

### DIFF
--- a/changelog/unreleased/update-reva-config
+++ b/changelog/unreleased/update-reva-config
@@ -1,0 +1,8 @@
+Change: Update reva config
+
+- EOS homes are not configured with an enable-flag anymore, but with a dedicated storage driver.
+- We're using it now and adapted default configs of storages
+
+https://github.com/owncloud/ocis/pull/336
+https://github.com/owncloud/ocis/pull/337
+https://github.com/owncloud/ocis-reva/pull/891

--- a/pkg/command/revastoragepubliclink.go
+++ b/pkg/command/revastoragepubliclink.go
@@ -38,5 +38,5 @@ func configureRevaStoragePublicLink(cfg *config.Config) *svcconfig.Config {
 }
 
 func init() {
-	register.AddCommand(RevaStorageOCCommand)
+	register.AddCommand(RevaStoragePublicLinkCommand)
 }


### PR DESCRIPTION
Add missing changelog for the eos config change.
Fixed the reva public link service command to register properly.

