### PR TITLE
[Tests-Only] Bump core and phoenix test commit IDs to latest

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2,7 +2,7 @@ def main(ctx):
   before = [
     linting(ctx),
     unitTests(ctx),
-    apiTests(ctx, 'master', 'ad274cb7f2a20ffba7fb9c65726ae9ef9270e4c0'),
+    apiTests(ctx, 'master', '0dc76b2452ef0c4388af765a738679097bd1491d'),
     acceptanceTests(ctx, 'master', 'f9a0874dc016ee0269c698914ef3f2c75ce3e2e6'),
   ]
 


### PR DESCRIPTION
Run the test infrastructure from:
- apiTests - core commit d5c495eeff535a61856762ae7f8baf6e74abeecf
- UI tests - phoenix commit f9a0874dc016ee0269c698914ef3f2c75ce3e2e6 (that got merged last night in #334 )

To demonstrate that the latest test code passes against the current OCIS.

If it passes, then it is fine to merge. At least this will demonstrate that the test code is all OK with the current OCIS master.

Note: these commit ids should be updated regularly