### PR TITLE
initial docker-compose.yml for developers

### DIFF
--- a/config/eos-docker.env
+++ b/config/eos-docker.env
@@ -1,0 +1,12 @@
+EOS_MQ_URL=mq-master.testnet
+EOS_MGM_ALIAS=mgm-master.testnet
+EOS_QDB_NODES=quark-1.testnet:7777 quark-2.testnet:7777 quark-3.testnet:7777
+EOS_LDAP_HOST=ocis.testnet:9125
+EOS_GEOTAG=test
+EOS_INSTANCE_NAME=eostest
+EOS_MAIL_CC=eos@localhost
+EOS_USE_QDB=1
+EOS_USE_QDB_MASTER=1
+EOS_NS_ACCOUNTING=1
+EOS_SYNCTIME_ACCOUNTING=1
+EOS_UTF8=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,162 @@
+---
+version: '3.5'
+
+networks:
+  testnet:
+    name: testnet
+
+services:
+  ocis:
+    container_name: ocis
+    image: owncloud/eos-ocis-dev:latest
+    tty: true
+    privileged: true
+    stdin_open: true
+    ports:
+      - 9200:9200
+    env_file:
+      - ./config/eos-docker.env
+    hostname: ocis
+    networks:
+      - testnet
+    volumes:
+      - .:/ocis
+      - ../ocis-reva:/ocis-reva
+      - ../reva:/reva
+    environment:
+      EOS_MGM_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      OCIS_DOMAIN: ${OCIS_DOMAIN:-localhost}
+      KONNECTD_IDENTIFIER_REGISTRATION_CONF: /ocis/config/identifier-registration.yml
+      KONNECTD_ISS: https://${OCIS_DOMAIN:-localhost}:9200
+      KONNECTD_LOG_LEVEL: debug
+      KONNECTD_TLS: '0'
+      PHOENIX_OIDC_AUTHORITY: https://${OCIS_DOMAIN:-localhost}:9200
+      PHOENIX_OIDC_METADATA_URL: https://${OCIS_DOMAIN:-localhost}:9200/.well-known/openid-configuration
+      PHOENIX_WEB_CONFIG_SERVER: https://${OCIS_DOMAIN:-localhost}:9200
+      PROXY_HTTP_ADDR: 0.0.0.0:9200
+      REVA_OIDC_ISSUER: https://${OCIS_DOMAIN:-localhost}:9200
+      OCIS_LOG_LEVEL: debug
+      REVA_STORAGE_HOME_DRIVER: eoshome
+      REVA_STORAGE_HOME_MOUNT_ID: 1284d238-aa92-42ce-bdc4-0b0000009154
+      REVA_STORAGE_HOME_DATA_DRIVER: eoshome
+      REVA_STORAGE_EOS_MASTER_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      REVA_STORAGE_EOS_SLAVE_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      REVA_STORAGE_EOS_NAMESPACE: "/eos/dockertest/reva/users"
+      REVA_STORAGE_EOS_LAYOUT: "{{substr 0 1 .Username}}"
+      REVA_GATEWAY_URL: host.docker.internal:9142
+      DAV_FILES_NAMESPACE: "/eos/"
+
+  mgm-master:
+    container_name: mgm-master
+    image: owncloud/eos-mgm
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: mgm-master.testnet
+    networks:
+    - testnet
+    volumes:
+    - ./e/master/var/log/eos:/var/log/eos
+    - ./e/master/var/eos/config:/var/eos/config
+    - ./e/master/var/eos/ns-queue:/var/eos/ns-queue
+    # this volume kills mgm-master during startup
+    # - ./e/master/var/eos/md:/var/eos/md
+    environment:
+      EOS_SET_MASTER: 1
+
+  mq-master:
+    container_name: mq-master
+    image: owncloud/eos-mq
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: mq-master.testnet
+    networks:
+    - testnet
+    volumes:
+    - ./e/master/var/log/eos:/var/log/eos
+    - ./e/master/var/eos/config:/var/eos/config
+    - ./e/master/var/eos/ns-queue:/var/eos/ns-queue
+    environment:
+      EOS_SET_MASTER: 1
+
+  fst:
+    container_name: fst
+    image: owncloud/eos-fst
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: fst.testnet
+    networks:
+    - testnet
+    volumes:
+    - ./e/master/var/log/eos:/var/log/eos
+    - ./e/disks:/disks
+    environment:
+      EOS_MGM_URL: "root://mgm-master.testnet"
+
+  quark-1:
+    container_name: quark-1
+    image: owncloud/eos-qdb
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: quark-1.testnet
+    networks:
+    - testnet
+    volumes:
+    - ./e/quark-1/var/lib/quarkdb:/var/lib/quarkdb
+    environment:
+      EOS_QDB_DIR: "/var/lib/quarkdb/eosns"
+      EOS_QDB_PORT: "7777"
+      EOS_QDB_MODE: "raft"
+      EOS_QDB_CLUSTER_ID: "3d659c1a-e70f-43f0-bed4-941a2ca0765b"
+      EOS_QDB_NODES: "quark-1.testnet:7777,quark-2.testnet:7777,quark-3.testnet:7777"
+
+  quark-2:
+    container_name: quark-2
+    image: owncloud/eos-qdb
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: quark-2.testnet
+    networks:
+    - testnet
+    volumes:
+    - ./e/quark-2/var/lib/quarkdb:/var/lib/quarkdb
+    environment:
+      EOS_QDB_DIR: "/var/lib/quarkdb/eosns"
+      EOS_QDB_PORT: "7777"
+      EOS_QDB_MODE: "raft"
+      EOS_QDB_CLUSTER_ID: "3d659c1a-e70f-43f0-bed4-941a2ca0765b"
+      EOS_QDB_NODES: "quark-1.testnet:7777,quark-2.testnet:7777,quark-3.testnet:7777"
+
+  quark-3:
+    container_name: quark-3
+    image: owncloud/eos-qdb
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: quark-3.testnet
+    networks:
+    - testnet
+    volumes:
+    - ./e/quark-3/var/lib/quarkdb:/var/lib/quarkdb
+    environment:
+      EOS_QDB_DIR: "/var/lib/quarkdb/eosns"
+      EOS_QDB_PORT: "7777"
+      EOS_QDB_MODE: "raft"
+      EOS_QDB_CLUSTER_ID: "3d659c1a-e70f-43f0-bed4-941a2ca0765b"
+      EOS_QDB_NODES: "quark-1.testnet:7777,quark-2.testnet:7777,quark-3.testnet:7777"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     environment:
       EOS_MGM_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
       OCIS_DOMAIN: ${OCIS_DOMAIN:-localhost}
-      KONNECTD_IDENTIFIER_REGISTRATION_CONF: /ocis/config/identifier-registration.yml
       KONNECTD_ISS: https://${OCIS_DOMAIN:-localhost}:9200
       KONNECTD_LOG_LEVEL: debug
       KONNECTD_TLS: '0'
@@ -36,15 +35,13 @@ services:
       PROXY_HTTP_ADDR: 0.0.0.0:9200
       REVA_OIDC_ISSUER: https://${OCIS_DOMAIN:-localhost}:9200
       OCIS_LOG_LEVEL: debug
-      REVA_STORAGE_HOME_DRIVER: eoshome
-      REVA_STORAGE_HOME_MOUNT_ID: 1284d238-aa92-42ce-bdc4-0b0000009154
-      REVA_STORAGE_HOME_DATA_DRIVER: eoshome
+      REVA_TRANSFER_EXPIRES: 86400
+      REVA_STORAGE_EOS_DRIVER: eoshome
+      REVA_STORAGE_EOS_DATA_DRIVER: eoshome
+      REVA_STORAGE_EOS_NAMESPACE: "/eos/dockertest/reva/users"
       REVA_STORAGE_EOS_MASTER_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
       REVA_STORAGE_EOS_SLAVE_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
-      REVA_STORAGE_EOS_NAMESPACE: "/eos/dockertest/reva/users"
       REVA_STORAGE_EOS_LAYOUT: "{{substr 0 1 .Username}}"
-      REVA_GATEWAY_URL: host.docker.internal:9142
-      DAV_FILES_NAMESPACE: "/eos/"
 
   mgm-master:
     container_name: mgm-master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   mgm-master:
     container_name: mgm-master
-    image: owncloud/eos-mgm
+    image: owncloud/eos-mgm:4.6.5
     tty: true
     privileged: true
     stdin_open: true
@@ -65,7 +65,7 @@ services:
 
   mq-master:
     container_name: mq-master
-    image: owncloud/eos-mq
+    image: owncloud/eos-mq:4.6.5
     tty: true
     privileged: true
     stdin_open: true
@@ -83,7 +83,7 @@ services:
 
   fst:
     container_name: fst
-    image: owncloud/eos-fst
+    image: owncloud/eos-fst:4.6.5
     tty: true
     privileged: true
     stdin_open: true
@@ -100,7 +100,7 @@ services:
 
   quark-1:
     container_name: quark-1
-    image: owncloud/eos-qdb
+    image: owncloud/eos-qdb:4.6.5
     tty: true
     privileged: true
     stdin_open: true
@@ -120,7 +120,7 @@ services:
 
   quark-2:
     container_name: quark-2
-    image: owncloud/eos-qdb
+    image: owncloud/eos-qdb:4.6.5
     tty: true
     privileged: true
     stdin_open: true
@@ -140,7 +140,7 @@ services:
 
   quark-3:
     container_name: quark-3
-    image: owncloud/eos-qdb
+    image: owncloud/eos-qdb:4.6.5
     tty: true
     privileged: true
     stdin_open: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,14 @@
+---
+title: "Getting Started with Development"
+date: 2020-07-07T20:35:00+01:00
+weight: 15
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs
+geekdocFilePath: development.md
+---
+
+{{< toc >}}
+
 ## Docker dev environment
 
 To build and run your local ocis code with default storage driver
@@ -25,11 +36,13 @@ docker-compose exec ocis ./bin/ocis list
 ## Docker dev environment for eos storage
 
 1. Start the eos cluster and ocis via the compose stack
+
 ```
 docker-compose up -d
 ```
 
 2. Start the ldap authentication
+
 ```
 docker-compose exec -d ocis /start-ldap
 ```
@@ -37,18 +50,28 @@ docker-compose exec -d ocis /start-ldap
 3. Configure to use eos storage driver instead of default storage driver
 
 - kill the home storage and data providers. we need to switch them to the eoshome driver:
-`docker-compose exec ocis ./bin/ocis kill reva-storage-home`
-`docker-compose exec ocis ./bin/ocis kill reva-storage-home-data`
+
+```
+docker-compose exec ocis ./bin/ocis kill reva-storage-home
+docker-compose exec ocis ./bin/ocis kill reva-storage-home-data
+```
 
 - restart them with the eoshome driver and a new layout:
-`docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis reva-storage-home`
-`docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis reva-storage-home-data`
+
+```
+docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis run reva-storage-home
+docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis run reva-storage-home-data
+```
 
 - restart the reva frontend with a new namespace (pointing to the eos storage provider) for the dav files endpoint
-`docker-compose exec ocis ./bin/ocis kill reva-frontend`
-`docker-compose exec -e DAV_FILES_NAMESPACE="/eos/" -d ocis ./bin/ocis reva-frontend`
+
+```
+docker-compose exec ocis ./bin/ocis kill reva-frontend
+docker-compose exec -e DAV_FILES_NAMESPACE="/eos/" -d ocis ./bin/ocis run reva-frontend
+```
 
 - login with `einstein / relativity`, upload a file to einsteins home and verify the file is there using 
+
 ```
 docker-compose exec ocis eos ls -l /eos/dockertest/reva/users/e/einstein/
 -rw-r--r--   1 einstein users              10 Jul  1 15:24 newfile.txt

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,7 +60,7 @@ docker-compose exec ocis ./bin/ocis kill reva-storage-home-data
 
 ```
 docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis run reva-storage-home
-docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis run reva-storage-home-data
+docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DATA_DRIVER=eoshome -d ocis ./bin/ocis run reva-storage-home-data
 ```
 
 - restart the reva frontend with a new namespace (pointing to the eos storage provider) for the dav files endpoint

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,55 @@
+## Docker dev environment
+
+To build and run your local ocis code with default storage driver
+
+```
+docker run --rm -ti --name ocis -v $PWD:/ocis -p 9200:9200 owncloud/eos-ocis-dev
+```
+
+ocis will use the owncloud storage driver and store files in the container at /var/tmp/reva/data/<username>/files
+
+Data is here: `docker exec -it ocis ll /var/tmp/reva/`
+
+Alternative: With the `docker-compose.yml` file in ocis repo you can also start ocis via compose:
+
+```
+docker-compose up -d ocis
+```
+
+Now try to list the running services
+
+```
+docker-compose exec ocis ./bin/ocis list
+```
+
+## Docker dev environment for eos storage
+
+1. Start the eos cluster and ocis via the compose stack
+```
+docker-compose up -d
+```
+
+2. Start the ldap authentication
+```
+docker-compose exec -d ocis /start-ldap
+```
+
+3. Configure to use eos storage driver instead of default storage driver
+
+- kill the home storage and data providers. we need to switch them to the eoshome driver:
+`docker-compose exec ocis ./bin/ocis kill reva-storage-home`
+`docker-compose exec ocis ./bin/ocis kill reva-storage-home-data`
+
+- restart them with the eoshome driver and a new layout:
+`docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis reva-storage-home`
+`docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis reva-storage-home-data`
+
+- restart the reva frontend with a new namespace (pointing to the eos storage provider) for the dav files endpoint
+`docker-compose exec ocis ./bin/ocis kill reva-frontend`
+`docker-compose exec -e DAV_FILES_NAMESPACE="/eos/" -d ocis ./bin/ocis reva-frontend`
+
+- login with `einstein / relativity`, upload a file to einsteins home and verify the file is there using 
+```
+docker-compose exec ocis eos ls -l /eos/dockertest/reva/users/e/einstein/
+-rw-r--r--   1 einstein users              10 Jul  1 15:24 newfile.txt
+```


### PR DESCRIPTION
This PR adds a new docker-compose.yml file that allows developers to quickly spin up a development environment for ocis using both: the owncloud storage driver as well as the eos storage driver. For the latter it also contains the necessary eos containers

# get started using the owncloud storage driver

1. start a container for ocis: `docker-compose up -d ocis`
    > Note: On MacOS do not mount a local folder at the owncloud storage drivers data location. It uses a fuse based driver which does not support extended attributes.
2. initialize empty shares list: `docker-compose exec ocis bash -c "echo '{}' > /var/tmp/reva/shares.json"`
    - [ ] fix this, it is annoying
3. compile ocis inside the container using `docker-compose exec ocis make clean build`. this makes sure that all cgo bindings are there and the binary will work properly when resolving ldap users
4. run ocis server: `docker-compose exec ocis ./bin/ocis server`
5. in another terminal list running ocis extensions: `docker-compose exec ocis ./bin/ocis list`
```
+--------------------------+-----+
|        EXTENSION         | PID |
+--------------------------+-----+
| accounts                 | 200 |
| api                      | 238 |
| glauth                   | 205 |
...
| thumbnails               | 222 |
| web                      | 243 |
| webdav                   |  79 |
+--------------------------+-----+
```
6. test access @ https: https://localhost:9200/
ocis will use the owncloud storage driver and store files in the container at `/var/tmp/reva/data/<username>/files`.

# start eos cluster:

1. open a new terminal to keep the eos log seperate from the ocis log
2. run the necessary eos containers using `docker-compose up quark-1 quark-2 quark-3 mgm-master mq-master fst`
3. enable the default storage space using `docker-compose exec mgm-master eos space set default on` otherwise you will encounter an out of space error (code 54) when trying to upload files.
4. test if the ocis container works using `docker-compose exec ocis eos whoami` ... should give `Virtual Identity: uid=0 (0,99,3) gid=0 (0,99,4) [authz:sss] sudo* host=ocis.testnet domain=testnet`

> Note: restarting eos needs 
>  - a `docker-compose down -v` to delete all volumes
>  - AND the `e` folder must be deleted or eos fsts complain about existing folders

# switch to eos storage driver
1. kill the home storage and data providers. we need to switch them to the eoshome driver:
`docker-compose exec ocis ./bin/ocis kill reva-storage-home`
`docker-compose exec ocis ./bin/ocis kill reva-storage-home-data`
2. restart them with the eoshome driver and a new layout:
`docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DRIVER=eoshome -d ocis ./bin/ocis reva-storage-home`
`docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Username}}/{{.Username}}" -e REVA_STORAGE_HOME_DATA_DRIVER=eoshome -d ocis ./bin/ocis reva-storage-home-data`
3. restart the reva frontend with a new namespace (pointing to the eos storage provider) for the dav files endpoint
`docker-compose exec ocis ./bin/ocis kill reva-frontend`
`docker-compose exec -e DAV_FILES_NAMESPACE="/eos/" -d ocis ./bin/ocis reva-frontend`
4. upload a file to einsteins home and verify the file is there using 
```
docker-compose exec ocis eos ls -l /eos/dockertest/reva/users/e/einstein/
-rw-r--r--   1 einstein users              10 Jul  1 15:24 newfile.txt
```

TODO
- [ ] add make targets?
- [x] document usage in devdocs. The above is a start...
    - all replaces in the go.mod must be added to the ocis volumes in the docker compose file as well

