### PR TITLE
Set process environment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/owncloud/ocis-settings v0.0.0-20200602115916-d10179c1aa59
 	github.com/owncloud/ocis-thumbnails v0.1.2
 	github.com/owncloud/ocis-webdav v0.1.0
-	github.com/refs/pman v0.0.0-20200527204655-c9ccd1c53cc3
+	github.com/refs/pman v0.0.0-20200701173654-f05b8833071a
 	github.com/restic/calens v0.2.0
 	github.com/valyala/fasttemplate v1.1.1 // indirect
 	go.opencensus.io v0.22.4

--- a/go.sum
+++ b/go.sum
@@ -1415,6 +1415,12 @@ github.com/refs/pman v0.0.0-20200523070049-0e3e499ca44c h1:RObWeoWH9jKuDr5XKdKIZ
 github.com/refs/pman v0.0.0-20200523070049-0e3e499ca44c/go.mod h1:0ivDlwrVfoxdAIbFV1RN1EDPJHMtUG8iJrhW3erRiwM=
 github.com/refs/pman v0.0.0-20200527204655-c9ccd1c53cc3 h1:yW8kN4AEKZGKIq1fEmROGLtWe5lwmMcI7usWTjexOf8=
 github.com/refs/pman v0.0.0-20200527204655-c9ccd1c53cc3/go.mod h1:fp4xg8dOs/XaZfB3abn1pxvclh10MtG4tdCc61lrmCo=
+github.com/refs/pman v0.0.0-20200602090702-79950bdf64d6 h1:jbqqRCNOV7TvIR6QA8f7PHoOF7yVnduM3ZOB120690g=
+github.com/refs/pman v0.0.0-20200602090702-79950bdf64d6/go.mod h1:fp4xg8dOs/XaZfB3abn1pxvclh10MtG4tdCc61lrmCo=
+github.com/refs/pman v0.0.0-20200701172222-73b4b2c4ea66 h1:lrJYtPUTIoVSlI2Axrok+LAeC1eHSukD4o+eDLQOW7Y=
+github.com/refs/pman v0.0.0-20200701172222-73b4b2c4ea66/go.mod h1:fp4xg8dOs/XaZfB3abn1pxvclh10MtG4tdCc61lrmCo=
+github.com/refs/pman v0.0.0-20200701173654-f05b8833071a h1:GCYFb7layULUl1HvZG97ur0zyqtEPo3VHcJCcBSvk7M=
+github.com/refs/pman v0.0.0-20200701173654-f05b8833071a/go.mod h1:fp4xg8dOs/XaZfB3abn1pxvclh10MtG4tdCc61lrmCo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/restic/calens v0.1.0/go.mod h1:u67f5msOjCTDYNzOf/NoAUSdmXP03YXPCwIQLYADy5M=

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -7,7 +7,8 @@ import (
 	"net/rpc"
 	"os"
 
-	"github.com/micro/cli/v2"
+	cli "github.com/micro/cli/v2"
+
 	"github.com/owncloud/ocis/pkg/config"
 	"github.com/owncloud/ocis/pkg/register"
 	"github.com/refs/pman/pkg/process"
@@ -39,7 +40,7 @@ func RunCommand(cfg *config.Config) *cli.Command {
 				log.Fatal("dialing:", err)
 			}
 
-			proc := process.NewProcEntry(os.Args[2], []string{os.Args[2]}...)
+			proc := process.NewProcEntry(os.Args[2], os.Environ(), []string{os.Args[2]}...)
 			var res int
 
 			if err := client.Call("Service.Start", proc, &res); err != nil {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	golog "log"
 	"net/rpc"
+	"os"
 	"time"
 
-	"github.com/micro/cli/v2"
+	cli "github.com/micro/cli/v2"
 
 	"github.com/micro/micro/v2/client/api"
 	"github.com/micro/micro/v2/client/web"
@@ -99,7 +100,7 @@ func (r *Runtime) Launch(services []string) {
 
 OUT:
 	for _, v := range services {
-		args := process.NewProcEntry(v, []string{v}...)
+		args := process.NewProcEntry(v, os.Environ(), []string{v}...)
 		var reply int
 
 		if err := client.Call("Service.Start", args, &reply); err != nil {
@@ -114,7 +115,7 @@ OUT:
 	if len(services) >= len(Extensions) { // it will not run for ocis_simple builds.
 		time.Sleep(2 * time.Second)
 		for _, v := range dependants {
-			args := process.NewProcEntry(v, []string{v}...)
+			args := process.NewProcEntry(v, os.Environ(), []string{v}...)
 			var reply int
 
 			if err := client.Call("Service.Start", args, &reply); err != nil {


### PR DESCRIPTION
### Test it!

1. start runtime: `ocis server`

on another session:

2. `ocis kill phoenix`
3. `export PHOENIX_HTTP_ADDR=localhost:9888`
4. `ocis run phoenix`
5. `lsof -i:9888`

expected: phoenix running on `localhost:9888`, as propagated from the parent process environment. `ocis run` will receive the environment of the caller process