### PR TITLE
[Docs] Add skeleton dir path env variable in test run

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -82,6 +82,7 @@ TEST_SERVER_URL=http://localhost:9140 \
 TEST_EXTERNAL_USER_BACKENDS=true \
 TEST_OCIS=true \
 OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
+SKELETON_DIR=apps/testing/data/apiSkeleton \
 BEHAT_FILTER_TAGS='~@skipOnOcis'
 ```
 


### PR DESCRIPTION
Add env variable for path to skeleton directory in documentation to run API acceptance tests.