### PR TITLE
[Tests-Only] Use latest osixia/openldap in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -933,14 +933,13 @@ def ldap():
   return [
     {
       'name': 'ldap',
-      'image': 'osixia/openldap:1.3.0',
+      'image': 'osixia/openldap',
       'pull': 'always',
       'environment': {
         'LDAP_DOMAIN': 'owncloud.com',
         'LDAP_ORGANISATION': 'ownCloud',
         'LDAP_ADMIN_PASSWORD': 'admin',
         'LDAP_TLS_VERIFY_CLIENT': 'never',
-        'HOSTNAME': 'ldap'
       },
     }
   ]


### PR DESCRIPTION
Part of issue https://github.com/owncloud/user_ldap/issues/578

Remove the offending `HOSTNAME`env var in CI. Use the latest osixia/openldap

See similar fix in https://github.com/owncloud/phoenix/pull/3738
