### PR TITLE
[Tests-Only] Bump phoenix test commit id

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -50,7 +50,7 @@ def main(ctx):
     linting(ctx),
     unitTests(ctx),
     apiTests(ctx, 'master', 'a3cac3dad60348fc962d1d8743b202bc5f79596b'),
-  ] + acceptance(ctx, 'master', '66ae7ceb02fe46fb01bbc23a0dae3679d9e0548d')
+  ] + acceptance(ctx, 'master', '604e8b5e083c835308f147e51a850df643374107')
 
   stages = [
     docker(ctx, 'amd64'),


### PR DESCRIPTION
to the latest commit id from phoenix master.

(may as well do this now, #366 is updating the core commit id for tests but is blocked waiting for a suitable `ocis-reva` to become available)