### PR TITLE
set missing env vars

### DIFF
--- a/changelog/unreleased/add-missing-env-vars.md
+++ b/changelog/unreleased/add-missing-env-vars.md
@@ -1,0 +1,5 @@
+Bugfix: add missing env vars to docker compose
+
+Without setting `REVA_FRONTEND_URL` and `REVA_DATAGATEWAY_URL` uploads would default to locahost and fail if `OCIS_DOMAIN` was used to run ocis on a remote host.
+
+https://github.com/owncloud/ocis/pull/392

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       REVA_STORAGE_EOS_MASTER_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
       REVA_STORAGE_EOS_SLAVE_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
       REVA_STORAGE_EOS_LAYOUT: "{{substr 0 1 .Id.OpaqueId}}"
+      REVA_FRONTEND_URL: https://${OCIS_DOMAIN:-localhost}:9200
+      REVA_DATAGATEWAY_URL: https://${OCIS_DOMAIN:-localhost}:9200/data
 
   mgm-master:
     container_name: mgm-master


### PR DESCRIPTION
REVA_FRONTEND_URL and REVA_DATAGATEWAY_URL need to be set to the OCIS_DOMAIN so upload is not using localhost ;-)
cc @jnweiger

