### PR TITLE
[Tests-only] use built in phoenix to run ui tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -287,8 +287,6 @@ def acceptanceTests(suiteName, phoenixBranch = 'master', phoenixCommit = ''):
           'git checkout %s' % (phoenixCommit)
         ] if phoenixCommit != '' else []) + [
           'yarn install-all',
-          'yarn dist',
-          'cp -r /drone/src/tests/config/drone/ocis-config.json /srv/app/phoenix/dist/config.json',
           'yarn run acceptance-tests-drone'
         ],
         'volumes': [{
@@ -906,7 +904,6 @@ def ocisServer():
         'REVA_DATAGATEWAY_URL': 'https://ocis-server:9200/data',
         'REVA_FRONTEND_URL': 'https://ocis-server:9200',
         'PHOENIX_WEB_CONFIG': '/drone/src/tests/config/drone/ocis-config.json',
-        'PHOENIX_ASSET_PATH': '/srv/app/phoenix/dist',
         'KONNECTD_IDENTIFIER_REGISTRATION_CONF': '/drone/src/tests/config/drone/identifier-registration.yml',
         'KONNECTD_ISS': 'https://ocis-server:9200',
         'KONNECTD_TLS': 'true',


### PR DESCRIPTION
Related Issue: https://github.com/owncloud/ocis/issues/303

Use phoenix assets packaged in the binary to run the webUI tests in CI.