### PR TITLE
[Tests-Only] Update phoenix acceptance test commit id

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -50,7 +50,7 @@ def main(ctx):
     linting(ctx),
     unitTests(ctx),
     apiTests(ctx, 'master', 'a3cac3dad60348fc962d1d8743b202bc5f79596b'),
-  ] + acceptance(ctx, 'master', '604e8b5e083c835308f147e51a850df643374107')
+  ] + acceptance(ctx, 'master', 'ccdca163c7e9e6ecc57e08a298b08b1d1175f1d5')
 
   stages = [
     docker(ctx, 'amd64'),


### PR DESCRIPTION
So that we have the latest phoenix test-runner scenarios when testing.