### PR TITLE
Add missing LDAP IDP value

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -962,6 +962,7 @@ def ocisServer():
         'REVA_STORAGE_OWNCLOUD_DATADIR': '/srv/app/tmp/reva/data',
         'REVA_STORAGE_OC_DATA_TEMP_FOLDER': '/srv/app/tmp/',
         'REVA_STORAGE_OWNCLOUD_REDIS_ADDR': 'redis:6379',
+        'REVA_LDAP_IDP': 'https://ocis-server:9200',
         'REVA_OIDC_ISSUER': 'https://ocis-server:9200',
         'PROXY_OIDC_ISSUER': 'https://ocis-server:9200',
         'REVA_STORAGE_OC_DATA_SERVER_URL': 'http://ocis-server:9164/data',


### PR DESCRIPTION
Solves an issue that whenever some tests use basic auth the IDP was
wrong. This would make Reva use the wrong internal user id and IDP
and prevent matching some data like shares to the correct user id.

First part of: https://github.com/owncloud/product/issues/161
Second part will be reenabling the failing tests.