### PR TITLE
External app config

### DIFF
--- a/changelog/unreleased/clear-external-apps.md
+++ b/changelog/unreleased/clear-external-apps.md
@@ -1,0 +1,5 @@
+Bugfix: Don't enforce empty external apps slice
+
+The command for ocis-phoenix enforced an empty external apps configuration. This was removed, as it was blocking a new set of default external apps in ocis-phoenix.
+
+https://github.com/owncloud/ocis/pull/473

--- a/pkg/command/phoenix_ocis.go
+++ b/pkg/command/phoenix_ocis.go
@@ -20,8 +20,5 @@ func configurePhoenix(cfg *config.Config) *svcconfig.Config {
 		cfg.Phoenix.Tracing.Service = cfg.Tracing.Service
 	}
 
-	// disable ocis-hello extension
-	cfg.Phoenix.Phoenix.Config.ExternalApps = []svcconfig.ExternalApp{}
-
 	return cfg.Phoenix
 }


### PR DESCRIPTION
We have a new feature in ocis-phoenix, that creates a default set of external apps if there is no config.json for ocis-web provided. There was this line in ocis, that was blocking the default set of external apps from ocis-phoenix. As it was not doing what it comment promised anyway, we can safely remove it and let ocis-phoenix handle the defaults.