### PR TITLE
use eos driver for /eos namespace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,28 +24,29 @@ services:
       - ../ocis-reva:/ocis-reva
       - ../reva:/reva
     environment:
-      EOS_MGM_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      # ocis log level will be used for all services
+      OCIS_LOG_LEVEL: debug
+      # domain setup
+      # TODO currently the below lines hardcode the port to 9200, use an OCIS_URL that includes protocol and port
       OCIS_DOMAIN: ${OCIS_DOMAIN:-localhost}
+      PROXY_OIDC_ISSUER: https://${OCIS_DOMAIN:-localhost}:9200
       KONNECTD_ISS: https://${OCIS_DOMAIN:-localhost}:9200
-      KONNECTD_LOG_LEVEL: debug
-      KONNECTD_TLS: '0'
       PHOENIX_OIDC_AUTHORITY: https://${OCIS_DOMAIN:-localhost}:9200
       PHOENIX_OIDC_METADATA_URL: https://${OCIS_DOMAIN:-localhost}:9200/.well-known/openid-configuration
       PHOENIX_WEB_CONFIG_SERVER: https://${OCIS_DOMAIN:-localhost}:9200
-      PROXY_HTTP_ADDR: 0.0.0.0:9200
       REVA_OIDC_ISSUER: https://${OCIS_DOMAIN:-localhost}:9200
       REVA_LDAP_IDP: https://${OCIS_DOMAIN:-localhost}:9200
-      OCIS_LOG_LEVEL: debug
-      REVA_TRANSFER_EXPIRES: 86400
-      REVA_STORAGE_EOS_DRIVER: eoshome
-      REVA_STORAGE_EOS_DATA_DRIVER: eoshome
-      REVA_STORAGE_EOS_NAMESPACE: "/eos/dockertest/reva/users"
-      REVA_STORAGE_EOS_MASTER_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
-      REVA_STORAGE_EOS_SLAVE_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
-      REVA_STORAGE_EOS_LAYOUT: "{{substr 0 1 .Id.OpaqueId}}"
+      # TODO make id the default in ocis-reva
+      REVA_STORAGE_EOS_LAYOUT: "{{substr 0 1 .Id.OpaqueId}}/{{.Id.OpaqueId}}"
       REVA_FRONTEND_URL: https://${OCIS_DOMAIN:-localhost}:9200
       REVA_DATAGATEWAY_URL: https://${OCIS_DOMAIN:-localhost}:9200/data
-
+      # common eos settings used for both drivers: eos and eoshome
+      REVA_STORAGE_EOS_MASTER_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      REVA_STORAGE_EOS_SLAVE_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      REVA_STORAGE_EOS_NAMESPACE: "/eos/dockertest/reva/users"
+      # the eos end xrdcopy binaries use this env var to find the eos mgm
+      EOS_MGM_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+  
   mgm-master:
     container_name: mgm-master
     image: owncloud/eos-mgm:4.6.5

--- a/docs/eos.md
+++ b/docs/eos.md
@@ -57,34 +57,25 @@ docker-compose exec ocis ./bin/ocis run reva-users
 
 ### 3. Home storage
 
-Kill the home storage. By default it uses the `owncloud` storage driver. We need to switch it to the `eoshome` driver and a new layout:
+Kill the home storage. By default it uses the `owncloud` storage driver. We need to switch it to the `eoshome` driver and make it use the storage id of the eos storage provider:
 
 ```
 docker-compose exec ocis ./bin/ocis kill reva-storage-home
-docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Id.OpaqueId}}/{{.Id.OpaqueId}}" -e REVA_STORAGE_HOME_DRIVER=eoshome ocis ./bin/ocis run reva-storage-home
+docker-compose exec -e REVA_STORAGE_HOME_DRIVER=eoshome -e REVA_STORAGE_HOME_MOUNT_ID=1284d238-aa92-42ce-bdc4-0b0000009158 ocis ./bin/ocis run reva-storage-home
 ```
 
 ### 4. Home data provider
 
-Kill the home data provider. By default it uses the `owncloud` storage driver. We need to switch it to the `eoshome` driver and a new layout:
+Kill the home data provider. By default it uses the `owncloud` storage driver. We need to switch it to the `eoshome` driver and make it use the storage id of the eos storage provider:
 
 ```
 docker-compose exec ocis ./bin/ocis kill reva-storage-home-data
-docker-compose exec -e REVA_STORAGE_EOS_LAYOUT="{{substr 0 1 .Id.OpaqueId}}/{{.Id.OpaqueId}}" -e REVA_STORAGE_HOME_DATA_DRIVER=eoshome ocis ./bin/ocis run reva-storage-home-data
+docker-compose exec -e REVA_STORAGE_HOME_DATA_DRIVER=eoshome ocis ./bin/ocis run reva-storage-home-data
 ```
 
 {{< hint info >}}
 The difference between the *home storage* and the *home data provider* are that the former is responsible for metadata changes while the latter is responsible for actual data transfer. The *home storage* uses the cs3 api to manage a folder hierarchy, while the *home data provider* is responsible for moving bytes to and from the storage.
 {{< /hint >}}
-
-### 4. Frontend files namespace
-
-Restart the reva frontend with a new namespace (pointing to the eos storage provider) for the dav files endpoint
-
-```
-docker-compose exec ocis ./bin/ocis kill reva-frontend
-docker-compose exec -e DAV_FILES_NAMESPACE="/eos/" ocis ./bin/ocis run reva-frontend
-```
 
 ## Verification
 


### PR DESCRIPTION
when accessing /eos we need to use the `eos` driver that does not apply the home layout. The first path segment is provided by clients accessing the `/dav/files/<userid>` endpoint. This PR will make the current configuration work with the existing code in reva for the eos driver as well as the ocdav implementation for the `/dav/files` endpoint.

- [x] ~~submit PR to reva that applies the user layout in ocdav when accessing via `/dav/files` so we can route to any users files. access permissions are checked in the storage provider but the dav endpoint is needed to access other users storage.~~ was already possible, but i forgot it. and it is not needed for the setup.

The `/Shared` folder only makes sense for the `/home` namespace. when accessing `/eos` it is not part of the tree.