### PR TITLE
add webhook step to drone build to update ocis.owncloud.works

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -76,6 +76,7 @@ def main(ctx):
     readme(ctx),
     badges(ctx),
     website(ctx),
+    updateDeployment(ctx)
   ]
 
   return before + stages + after
@@ -610,6 +611,46 @@ def binary(ctx, name):
         'refs/pull/**',
       ],
     },
+  }
+
+def updateDeployment(ctx):
+  return {
+    'kind': 'pipeline',
+    'type': 'docker',
+    'name': 'updateDeployment',
+    'platform': {
+      'os': 'linux',
+      'arch': 'amd64',
+    },
+    'steps': [
+      {
+        'name': 'webhook',
+        'image': 'plugins/webhook',
+        'settings': {
+          'username': {
+            'from_secret': 'webhook_username',
+          },
+          'password': {
+            'from_secret': 'webhook_password',
+          },
+          'method': 'GET',
+          'urls': 'https://ocis.owncloud.works/hooks/update-ocis',
+        }
+      }
+    ],
+    'depends_on': [
+      'amd64',
+      'arm64',
+      'arm',
+      'linux',
+      'darwin',
+      'windows',
+    ],
+    'trigger': {
+      'ref': [
+        'refs/heads/master',
+      ],
+    }
   }
 
 def manifest(ctx):


### PR DESCRIPTION
Before this gets merged we need to add the `webhook_username` and `webhook_password` to the secrets.
