### PR TITLE
[Tests-Only] Add TrashbinContext to local acceptance tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -26,6 +26,7 @@ default:
         - FavoritesContext:
         - FilesVersionsContext:
         - PublicWebDavContext:
+        - TrashbinContext:
         - WebDavPropertiesContext:
 
   extensions:


### PR DESCRIPTION
Local API tests are getting:

https://cloud.drone.io/owncloud/ocis/1317/3/7
```
148 scenarios (143 passed, 5 undefined)
1118 steps (1092 passed, 21 undefined, 5 skipped)
3m58.15s (15.84Mb)

--- FeatureContext has missing steps. Define them with these snippets:

    /**
     * @Given as :arg1 file :arg2 should exist in the trashbin
     */
    public function asFileShouldExistInTheTrashbin($arg1, $arg2)
    {
        throw new PendingException();
    }
...
```

Trashbin tests were introduced in #489 but TrashbinContext was not added.