### PR TITLE
Update proxy and accounts for enable/disable, create, delete accounts

### DIFF
--- a/changelog/unreleased/update-accounts-create-users.md
+++ b/changelog/unreleased/update-accounts-create-users.md
@@ -1,0 +1,7 @@
+Change: Create accounts in accounts UI
+
+We've added a form to create new users above the accounts list in the accounts UI.
+
+https://github.com/owncloud/product/issues/148
+https://github.com/owncloud/ocis-accounts/pull/115
+https://github.com/owncloud/ocis/pull/525

--- a/changelog/unreleased/update-accounts-delete-users.md
+++ b/changelog/unreleased/update-accounts-delete-users.md
@@ -1,0 +1,7 @@
+Change: Delete accounts in accounts UI
+
+We've added an action into the actions dropdown of the accounts UI to enable admins to delete users.
+
+https://github.com/owncloud/product/issues/148
+https://github.com/owncloud/ocis-accounts/pull/115
+https://github.com/owncloud/ocis/pull/525

--- a/changelog/unreleased/update-accounts-enable-disable-users.md
+++ b/changelog/unreleased/update-accounts-enable-disable-users.md
@@ -1,0 +1,7 @@
+Change: Enable/disable accounts in accounts UI
+
+We added a new feature in the ocis-accounts web extension to enable or disable accounts. This also introduces batch actions, where accounts can be selected and a batch action applied to them. The UI for this is the same as in the files extension of ocis-web.
+
+https://github.com/owncloud/product/issues/118
+https://github.com/owncloud/ocis-accounts/pull/109
+https://github.com/owncloud/ocis/pull/525

--- a/changelog/unreleased/update-proxy-disable-cache.md
+++ b/changelog/unreleased/update-proxy-disable-cache.md
@@ -4,3 +4,4 @@ We removed the accounts cache in ocis-proxy in order to avoid problems with acco
 
 https://github.com/owncloud/ocis/pull/525
 https://github.com/owncloud/ocis-proxy/pull/100
+https://github.com/owncloud/ocis-accounts/pull/114

--- a/changelog/unreleased/update-proxy-disable-cache.md
+++ b/changelog/unreleased/update-proxy-disable-cache.md
@@ -1,0 +1,6 @@
+Change: Update proxy with disabled accounts cache
+
+We removed the accounts cache in ocis-proxy in order to avoid problems with accounts that have been updated in ocis-accounts.
+
+https://github.com/owncloud/ocis/pull/525
+https://github.com/owncloud/ocis-proxy/pull/100

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/owncloud/ocis-ocs v0.3.1
 	github.com/owncloud/ocis-phoenix v0.13.0
 	github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200828095914-d3b859484b2b
-	github.com/owncloud/ocis-proxy v0.7.1-0.20200904132806-fcceec602fcb
+	github.com/owncloud/ocis-proxy v0.7.1-0.20200907105449-201b9a652685
 	github.com/owncloud/ocis-reva v0.13.0
 	github.com/owncloud/ocis-settings v0.3.2-0.20200902094647-35dc3aeaba78
 	github.com/owncloud/ocis-store v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -7,18 +7,8 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.0
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
 	github.com/UnnoTed/fileb0x v1.1.4
-	github.com/bmatcuk/doublestar v1.3.2 // indirect
-	github.com/coreos/etcd v3.3.21+incompatible // indirect
-	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-log/log v0.2.0 // indirect
-	github.com/karrick/godirwalk v1.16.1 // indirect
-	github.com/labstack/echo v3.3.10+incompatible // indirect
-	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/micro/cli/v2 v2.1.2
 	github.com/micro/micro/v2 v2.8.0
-	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 // indirect
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/owncloud/flaex v0.2.0
 	github.com/owncloud/ocis-accounts v0.4.2-0.20200901074457-6a27781a2741
@@ -30,23 +20,16 @@ require (
 	github.com/owncloud/ocis-migration v0.2.0
 	github.com/owncloud/ocis-ocs v0.3.1
 	github.com/owncloud/ocis-phoenix v0.13.0
-	github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200828095914-d3b859484b2b
+	github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200902134813-1e87c6173ada
 	github.com/owncloud/ocis-proxy v0.7.1-0.20200907105449-201b9a652685
 	github.com/owncloud/ocis-reva v0.13.0
-	github.com/owncloud/ocis-settings v0.3.2-0.20200902094647-35dc3aeaba78
+	github.com/owncloud/ocis-settings v0.3.2-0.20200903035407-ad5de8264f91
 	github.com/owncloud/ocis-store v0.1.1
 	github.com/owncloud/ocis-thumbnails v0.3.0
 	github.com/owncloud/ocis-webdav v0.1.1
 	github.com/refs/pman v0.0.0-20200701173654-f05b8833071a
 	github.com/restic/calens v0.2.0
-	github.com/valyala/fasttemplate v1.2.1 // indirect
 	go.opencensus.io v0.22.4
-	go.uber.org/atomic v1.5.1 // indirect
-	go.uber.org/multierr v1.4.0 // indirect
-	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20200817023811-d00afeaade8f // indirect
 )
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/micro/micro/v2 v2.8.0
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/owncloud/flaex v0.2.0
-	github.com/owncloud/ocis-accounts v0.4.2-0.20200901074457-6a27781a2741
+	github.com/owncloud/ocis-accounts v0.4.2-0.20200909192941-cea2720c3942
 	github.com/owncloud/ocis-glauth v0.5.1-0.20200909064150-0735ec933777
 	github.com/owncloud/ocis-graph v0.0.0-20200318175820-9a5a6e029db7
 	github.com/owncloud/ocis-graph-explorer v0.0.0-20200210111049-017eeb40dc0c

--- a/go.sum
+++ b/go.sum
@@ -1260,6 +1260,8 @@ github.com/owncloud/ocis-accounts v0.4.2-0.20200901074457-6a27781a2741 h1:7Vf+BX
 github.com/owncloud/ocis-accounts v0.4.2-0.20200901074457-6a27781a2741/go.mod h1:ermjPwC2b3Tsh8YF3oUl6cOHMvFPN6MY8ZlkmO6w0xw=
 github.com/owncloud/ocis-accounts v0.4.2-0.20200908142503-8700b63e2afa h1:gQmScmkLn4v1h0zoDQGxNJBqmnzFcl3nZY0kOh7TjDc=
 github.com/owncloud/ocis-accounts v0.4.2-0.20200908142503-8700b63e2afa/go.mod h1:wNACZ+jUb1upH9Uy74+rmGW5ZF4Y3/PBRHDuEfxQrYc=
+github.com/owncloud/ocis-accounts v0.4.2-0.20200909192941-cea2720c3942 h1:glDo8aomf40wQKnhur9SGnV66fbgR7YGNRo+Sv6HM8A=
+github.com/owncloud/ocis-accounts v0.4.2-0.20200909192941-cea2720c3942/go.mod h1:wNACZ+jUb1upH9Uy74+rmGW5ZF4Y3/PBRHDuEfxQrYc=
 github.com/owncloud/ocis-glauth v0.5.1-0.20200731165959-1081de7c60f1 h1:YA7tS4VFSUmjeZBt4Wa+fSoreH1VJYCFlHvoRey3ngM=
 github.com/owncloud/ocis-glauth v0.5.1-0.20200731165959-1081de7c60f1/go.mod h1:lZkoEjBuEi0QZUlBG+XgVvWC4GzbWCTnmZQcIhC2kMg=
 github.com/owncloud/ocis-glauth v0.5.1-0.20200909064150-0735ec933777 h1:WqILokqgQ1M8Iau8o27zr4BV5IWgTzgLlNYGmIkOgJ4=
@@ -1311,6 +1313,7 @@ github.com/owncloud/ocis-pkg/v2 v2.4.0 h1:/3ZOd4txtwjiNKJA9iLT9BjrJw5YgHSX13fQR4
 github.com/owncloud/ocis-pkg/v2 v2.4.0/go.mod h1:FSzIvhx9HcZcq4jgNaDowNvM7PTX/XCyoMvyfzidUpE=
 github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200828095914-d3b859484b2b h1:PRw0b4abdrDKloh417qPsS5lkB/bjJ3Rc4txzHx/hBg=
 github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200828095914-d3b859484b2b/go.mod h1:WdcVM54z0X7aQzS8eyGl7S5sjEMVBtLpfpzsPX3Z+Pw=
+github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200902134813-1e87c6173ada h1:iVknnuT/z8QCAeBpHEcbI/AiQ9FOBvF5aOAFT3TIM+I=
 github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200902134813-1e87c6173ada/go.mod h1:WdcVM54z0X7aQzS8eyGl7S5sjEMVBtLpfpzsPX3Z+Pw=
 github.com/owncloud/ocis-proxy v0.6.1-0.20200819105709-a51b3c8ed42f h1:qY8fwArWIBuIFT4QBYQgpupUSGtvuVGT8QSIOF1R0qg=
 github.com/owncloud/ocis-proxy v0.6.1-0.20200819105709-a51b3c8ed42f/go.mod h1:zyAWyZXjILb3Lsotxc2a+Iwkj4jKXtT4O0ajB5b3jnY=
@@ -1351,6 +1354,7 @@ github.com/owncloud/ocis-settings v0.3.2-0.20200828130413-0cc0f5bf26fe h1:kiU5lz
 github.com/owncloud/ocis-settings v0.3.2-0.20200828130413-0cc0f5bf26fe/go.mod h1:vRge9QDkOsc6j76gPBmZs1Z5uOPrV4DIkZCgZCEFwBA=
 github.com/owncloud/ocis-settings v0.3.2-0.20200902094647-35dc3aeaba78 h1:mCP/1U+mI70dQugeSsTKqf1O2a/GQLInl1KMPXaU2yQ=
 github.com/owncloud/ocis-settings v0.3.2-0.20200902094647-35dc3aeaba78/go.mod h1:J2m9TM5FqYDTvrr2zH78JsC1Xv8hXmd+0dntHCWYYoc=
+github.com/owncloud/ocis-settings v0.3.2-0.20200903035407-ad5de8264f91 h1:fiCEaM9Ysc9Tw7dhZk9mTjdHB8grrx2TEiEfRd4yYNo=
 github.com/owncloud/ocis-settings v0.3.2-0.20200903035407-ad5de8264f91/go.mod h1:KGNSgqec5Kv4tgD4rLbo7Z5vrEYTnxd5g2NHmpUJ3O8=
 github.com/owncloud/ocis-store v0.0.0-20200716140351-f9670592fb7b/go.mod h1:7WRMnx4ffwtckNl4qD2Gj/d5fvl84jyydOV2FbUUu3A=
 github.com/owncloud/ocis-store v0.1.1 h1:lPvWjjPqbVqDW0sfgQdfY3dOOvXK0wC87eTL2fWxRBg=

--- a/go.sum
+++ b/go.sum
@@ -1318,6 +1318,8 @@ github.com/owncloud/ocis-proxy v0.7.1-0.20200831111919-888962f90777 h1:Ozb6XtNoq
 github.com/owncloud/ocis-proxy v0.7.1-0.20200831111919-888962f90777/go.mod h1:zFwhh9GFzPCiHBPM4zyWzxA7d78fYMbLOPB977mGUzk=
 github.com/owncloud/ocis-proxy v0.7.1-0.20200904132806-fcceec602fcb h1:m2eijSU1GXKK1wKQ9Xr2MThqtA3ic641z5Nml5p0uXU=
 github.com/owncloud/ocis-proxy v0.7.1-0.20200904132806-fcceec602fcb/go.mod h1:zFwhh9GFzPCiHBPM4zyWzxA7d78fYMbLOPB977mGUzk=
+github.com/owncloud/ocis-proxy v0.7.1-0.20200907105449-201b9a652685 h1:uWwnJGxoZ+zbSl/vSufE+OzzAuPeo08qpygFFFLKrVo=
+github.com/owncloud/ocis-proxy v0.7.1-0.20200907105449-201b9a652685/go.mod h1:zFwhh9GFzPCiHBPM4zyWzxA7d78fYMbLOPB977mGUzk=
 github.com/owncloud/ocis-reva v0.12.1-0.20200819133706-f68defd1ff27 h1:LupXoJXY0cK33+8s6bBA3M8g4J2kv6YHBY7szyPIsHI=
 github.com/owncloud/ocis-reva v0.12.1-0.20200819133706-f68defd1ff27/go.mod h1:mZpI9axqlcOy8rk19JicZFGUIVB8VxD/0VLiIJxi6GE=
 github.com/owncloud/ocis-reva v0.13.0 h1:np4Xk/hBWSOIsahimP6tnwiEl1YKj8okJ7M5IAaNfBY=

--- a/go.sum
+++ b/go.sum
@@ -1239,6 +1239,7 @@ github.com/ovh/go-ovh v0.0.0-20181109152953-ba5adb4cf014/go.mod h1:joRatxRJaZBsY
 github.com/owncloud/flaex v0.0.0-20200411150708-dce59891a203/go.mod h1:jip86t4OVURJTf8CM/0e2qcji/Y4NG3l2lR8kex4JWw=
 github.com/owncloud/flaex v0.2.0 h1:3FLf8oyMgA6HLK7w4+VJ5N1oVA8G7MptLCVjfxxIaww=
 github.com/owncloud/flaex v0.2.0/go.mod h1:jip86t4OVURJTf8CM/0e2qcji/Y4NG3l2lR8kex4JWw=
+github.com/owncloud/ocis v1.0.0-rc1/go.mod h1:TmghyYp0UgfxWlJobYshsOzJ3i99+OaTYxmbiHPIxDo=
 github.com/owncloud/ocis-accounts v0.1.2-0.20200618163128-aa8ae58dd95e h1:FRD1/lH/6IaaWWzBXCeM4hUAoN86zQAz68nOnvCLqsY=
 github.com/owncloud/ocis-accounts v0.1.2-0.20200618163128-aa8ae58dd95e/go.mod h1:ohb58AUSUgq+kPOFAjy1s1k5Bi33YtPg45qOOPsepeM=
 github.com/owncloud/ocis-accounts v0.1.2-0.20200710152724-fa35a81beb2f/go.mod h1:wxo2B5EoTQlf3ryDeOTR/RAs3z6IHkllu1CvBxrLf1A=
@@ -1257,6 +1258,8 @@ github.com/owncloud/ocis-accounts v0.4.1/go.mod h1:vTIgPpoRz2zrLU4kGY6nGKUap/NvL
 github.com/owncloud/ocis-accounts v0.4.2-0.20200828150703-2ca83cf4ac20/go.mod h1:R2mNcvDvma7D7n1yxpLHIJR9dHUx4As7QfiJlD8e9DE=
 github.com/owncloud/ocis-accounts v0.4.2-0.20200901074457-6a27781a2741 h1:7Vf+BXwXUerJuGPOIThjPbt69rxvJo3PIW1qb0mCn2M=
 github.com/owncloud/ocis-accounts v0.4.2-0.20200901074457-6a27781a2741/go.mod h1:ermjPwC2b3Tsh8YF3oUl6cOHMvFPN6MY8ZlkmO6w0xw=
+github.com/owncloud/ocis-accounts v0.4.2-0.20200908142503-8700b63e2afa h1:gQmScmkLn4v1h0zoDQGxNJBqmnzFcl3nZY0kOh7TjDc=
+github.com/owncloud/ocis-accounts v0.4.2-0.20200908142503-8700b63e2afa/go.mod h1:wNACZ+jUb1upH9Uy74+rmGW5ZF4Y3/PBRHDuEfxQrYc=
 github.com/owncloud/ocis-glauth v0.5.1-0.20200731165959-1081de7c60f1 h1:YA7tS4VFSUmjeZBt4Wa+fSoreH1VJYCFlHvoRey3ngM=
 github.com/owncloud/ocis-glauth v0.5.1-0.20200731165959-1081de7c60f1/go.mod h1:lZkoEjBuEi0QZUlBG+XgVvWC4GzbWCTnmZQcIhC2kMg=
 github.com/owncloud/ocis-glauth v0.5.1-0.20200909064150-0735ec933777 h1:WqILokqgQ1M8Iau8o27zr4BV5IWgTzgLlNYGmIkOgJ4=
@@ -1308,6 +1311,7 @@ github.com/owncloud/ocis-pkg/v2 v2.4.0 h1:/3ZOd4txtwjiNKJA9iLT9BjrJw5YgHSX13fQR4
 github.com/owncloud/ocis-pkg/v2 v2.4.0/go.mod h1:FSzIvhx9HcZcq4jgNaDowNvM7PTX/XCyoMvyfzidUpE=
 github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200828095914-d3b859484b2b h1:PRw0b4abdrDKloh417qPsS5lkB/bjJ3Rc4txzHx/hBg=
 github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200828095914-d3b859484b2b/go.mod h1:WdcVM54z0X7aQzS8eyGl7S5sjEMVBtLpfpzsPX3Z+Pw=
+github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200902134813-1e87c6173ada/go.mod h1:WdcVM54z0X7aQzS8eyGl7S5sjEMVBtLpfpzsPX3Z+Pw=
 github.com/owncloud/ocis-proxy v0.6.1-0.20200819105709-a51b3c8ed42f h1:qY8fwArWIBuIFT4QBYQgpupUSGtvuVGT8QSIOF1R0qg=
 github.com/owncloud/ocis-proxy v0.6.1-0.20200819105709-a51b3c8ed42f/go.mod h1:zyAWyZXjILb3Lsotxc2a+Iwkj4jKXtT4O0ajB5b3jnY=
 github.com/owncloud/ocis-proxy v0.7.0 h1:ruOOz0Ed4crtkjqFRvvbgywUfDldcWDxOqbUQlwthTU=
@@ -1347,6 +1351,7 @@ github.com/owncloud/ocis-settings v0.3.2-0.20200828130413-0cc0f5bf26fe h1:kiU5lz
 github.com/owncloud/ocis-settings v0.3.2-0.20200828130413-0cc0f5bf26fe/go.mod h1:vRge9QDkOsc6j76gPBmZs1Z5uOPrV4DIkZCgZCEFwBA=
 github.com/owncloud/ocis-settings v0.3.2-0.20200902094647-35dc3aeaba78 h1:mCP/1U+mI70dQugeSsTKqf1O2a/GQLInl1KMPXaU2yQ=
 github.com/owncloud/ocis-settings v0.3.2-0.20200902094647-35dc3aeaba78/go.mod h1:J2m9TM5FqYDTvrr2zH78JsC1Xv8hXmd+0dntHCWYYoc=
+github.com/owncloud/ocis-settings v0.3.2-0.20200903035407-ad5de8264f91/go.mod h1:KGNSgqec5Kv4tgD4rLbo7Z5vrEYTnxd5g2NHmpUJ3O8=
 github.com/owncloud/ocis-store v0.0.0-20200716140351-f9670592fb7b/go.mod h1:7WRMnx4ffwtckNl4qD2Gj/d5fvl84jyydOV2FbUUu3A=
 github.com/owncloud/ocis-store v0.1.1 h1:lPvWjjPqbVqDW0sfgQdfY3dOOvXK0wC87eTL2fWxRBg=
 github.com/owncloud/ocis-store v0.1.1/go.mod h1:Rav5iw0fZXYFqJl81IbyTVa/FidaBhgVPtp0XqkgviM=


### PR DESCRIPTION
This PR updates ocis-accounts to a version with our new enable/disable, delete and create features in the web ui. It also updates ocis-proxy with a bugfix for this feature: modified accounts were not updated in the accounts cache in ocis-proxy. Since ocis-accounts is already taking care of caching accounts, we removed the accounts cache in ocis-proxy entirely (at least for now) to spare us from cache invalidation in the proxy when updating an account in ocis-accounts.