### PR TITLE
[tests-only] Bump Phoenix UI test commit id

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ config = {
   },
   'uiTests': {
     'phoenixBranch': 'master',
-    'phoenixCommit': 'abce2ae2384c814c74de4efb65adc2c92244e08d',
+    'phoenixCommit': '2ccec3966abebc7cff54cfdbd0aa9942253584a7',
     'suites': {
       'phoenixWebUI1': [
         'webUICreateFilesFolders',


### PR DESCRIPTION
Gets us these test-related changes:

https://github.com/owncloud/phoenix/pull/4005 [tests-only] Add ocis-accounts default admin user to tests
https://github.com/owncloud/phoenix/pull/4050 [tests-only] mark some tests as @ocisSmokeTest
https://github.com/owncloud/phoenix/pull/4051 [tests-only] Skip a test that blows up the environment on ocis
https://github.com/owncloud/phoenix/pull/4036 [Tests-Only]Added test for accessing a permalink anonymously