### PR TITLE
Update ocis-reva 2020-09-10

### DIFF
--- a/changelog/unreleased/update-reva-10_09_2020.md
+++ b/changelog/unreleased/update-reva-10_09_2020.md
@@ -1,0 +1,9 @@
+Enhancement: Update ocis-reva 2020-09-10
+
+- ocis-reva v0.13.1-0.20200910085648-26465bbdcf46
+- fixes file operations for received shares by changing OC storage default config
+- adds ability to overwrite storage registry rules
+
+https://github.com/owncloud/ocis/pull/334
+https://github.com/owncloud/ocis-reva/pull/461
+

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/owncloud/ocis-phoenix v0.13.0
 	github.com/owncloud/ocis-pkg/v2 v2.4.1-0.20200902134813-1e87c6173ada
 	github.com/owncloud/ocis-proxy v0.7.1-0.20200907105449-201b9a652685
-	github.com/owncloud/ocis-reva v0.13.0
+	github.com/owncloud/ocis-reva v0.13.1-0.20200910085648-26465bbdcf46
 	github.com/owncloud/ocis-settings v0.3.2-0.20200903035407-ad5de8264f91
 	github.com/owncloud/ocis-store v0.1.1
 	github.com/owncloud/ocis-thumbnails v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1331,6 +1331,8 @@ github.com/owncloud/ocis-reva v0.12.1-0.20200819133706-f68defd1ff27 h1:LupXoJXY0
 github.com/owncloud/ocis-reva v0.12.1-0.20200819133706-f68defd1ff27/go.mod h1:mZpI9axqlcOy8rk19JicZFGUIVB8VxD/0VLiIJxi6GE=
 github.com/owncloud/ocis-reva v0.13.0 h1:np4Xk/hBWSOIsahimP6tnwiEl1YKj8okJ7M5IAaNfBY=
 github.com/owncloud/ocis-reva v0.13.0/go.mod h1:cTcLFOO/tg4/GyYygi/VVXFjZAQWE3YxlyfhZ/vcAj4=
+github.com/owncloud/ocis-reva v0.13.1-0.20200910085648-26465bbdcf46 h1:V+LuunhiVuQZX40jlkBVoqlHxU/aUgbS8jJXxWy9ges=
+github.com/owncloud/ocis-reva v0.13.1-0.20200910085648-26465bbdcf46/go.mod h1:cTcLFOO/tg4/GyYygi/VVXFjZAQWE3YxlyfhZ/vcAj4=
 github.com/owncloud/ocis-settings v0.0.0-20200522101320-46ea31026363 h1:wk/7aAUITTrM192TFoIDq4fqzJQtFOQ0dDdSRkJ25SU=
 github.com/owncloud/ocis-settings v0.0.0-20200522101320-46ea31026363/go.mod h1:/h0ceztOoFc3KAnm8nqZI4zwsaaZK9q4MTgtintwsXc=
 github.com/owncloud/ocis-settings v0.0.0-20200629120229-69693c5f8f43 h1:IekDKhkoaOhUnpIHSG5d02hGMOW5u4tZEEfxVC1KGgk=

--- a/tests/acceptance/expected-failures-on-OC-storage.txt
+++ b/tests/acceptance/expected-failures-on-OC-storage.txt
@@ -283,7 +283,6 @@ apiShareManagement/acceptShares.feature:696
 #
 # https://github.com/owncloud/product/issues/208 After accepting a share data in the received file cannot be downloaded
 apiShareManagement/acceptSharesToSharesFolder.feature:15
-apiShareManagement/acceptSharesToSharesFolder.feature:22
 #
 # https://github.com/owncloud/product/issues/207 Response is empty when accepting a share
 apiShareManagement/acceptSharesToSharesFolder.feature:30


### PR DESCRIPTION
- ocis-reva v0.13.1-0.20200910085648-26465bbdcf46
- fixes file operations for received shares by changing OC storage default config
- adds ability to overwrite storage registry rules

Closes https://github.com/owncloud/product/issues/193
Closes https://github.com/owncloud/product/issues/205