### PR TITLE
[Tests-Only] Bump core commit for tests 20200914

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 config = {
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': 'e9850b40657ff78f32cb5585ec00342fe07a5ff2',
+    'coreCommit': 'b3404863626519fc2aa758286385290abdf43d52',
     'numberOfParts': 4
   },
   'uiTests': {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -152,8 +152,7 @@ apiProvisioning-v1/getUser.feature:34
 apiProvisioning-v1/getUser.feature:35
 apiProvisioning-v1/getUser.feature:37
 apiProvisioning-v1/getUser.feature:81
-apiProvisioning-v1/getUsers.feature:11
-apiProvisioning-v1/getUsers.feature:35
+apiProvisioning-v1/getUsers.feature:43
 apiProvisioning-v1/resetUserPassword.feature:21
 apiProvisioning-v1/resetUserPassword.feature:55
 apiProvisioning-v2/addUser.feature:29
@@ -197,8 +196,7 @@ apiProvisioning-v2/getUser.feature:35
 apiProvisioning-v2/getUser.feature:37
 apiProvisioning-v2/getUser.feature:47
 apiProvisioning-v2/getUser.feature:82
-apiProvisioning-v2/getUsers.feature:11
-apiProvisioning-v2/getUsers.feature:36
+apiProvisioning-v2/getUsers.feature:44
 apiProvisioning-v2/resetUserPassword.feature:21
 apiProvisioning-v2/resetUserPassword.feature:55
 #

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -152,8 +152,7 @@ apiProvisioning-v1/getUser.feature:34
 apiProvisioning-v1/getUser.feature:35
 apiProvisioning-v1/getUser.feature:37
 apiProvisioning-v1/getUser.feature:81
-apiProvisioning-v1/getUsers.feature:11
-apiProvisioning-v1/getUsers.feature:35
+apiProvisioning-v1/getUsers.feature:43
 apiProvisioning-v1/resetUserPassword.feature:21
 apiProvisioning-v1/resetUserPassword.feature:55
 apiProvisioning-v2/addUser.feature:29
@@ -197,8 +196,7 @@ apiProvisioning-v2/getUser.feature:35
 apiProvisioning-v2/getUser.feature:37
 apiProvisioning-v2/getUser.feature:47
 apiProvisioning-v2/getUser.feature:82
-apiProvisioning-v2/getUsers.feature:11
-apiProvisioning-v2/getUsers.feature:36
+apiProvisioning-v2/getUsers.feature:44
 apiProvisioning-v2/resetUserPassword.feature:21
 apiProvisioning-v2/resetUserPassword.feature:55
 #


### PR DESCRIPTION
Gets https://github.com/owncloud/core/pull/37882 "[Tests-Only] Add some more flexible provisioning API tests for getUsers"