### PR TITLE
[Tests-Only] Bump Phoenix UI test commit id

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ config = {
   },
   'uiTests': {
     'phoenixBranch': 'master',
-    'phoenixCommit': '2ccec3966abebc7cff54cfdbd0aa9942253584a7',
+    'phoenixCommit': 'fe61ed73d37b08eb189cdc4c067777d3acb23215',
     'suites': {
       'phoenixWebUI1': [
         'webUICreateFilesFolders',


### PR DESCRIPTION
https://cloud.drone.io/owncloud/ocis/1622/13/7
```
✖ Then the "people" details panel should be visible # tests/acceptance/stepDefinitions/filesContext.js:766
       'people-panel' should be visible, but is not
       AssertionError [ERR_ASSERTION]: 'people-panel' should be visible, but is not
```

The test code in Phoenix now has the knowledge about the recent changes in Phoenix - e.g. "Collaborators" are "People". So bumping the Phoenix commit id for the UI tests also needs the built-in Phoenix in `owncloud/ocis` to be updated to match.