### PR TITLE
add build information to metrics

### DIFF
--- a/glauth/changelog/unreleased/add-build-info-metric.md
+++ b/glauth/changelog/unreleased/add-build-info-metric.md
@@ -1,0 +1,5 @@
+Enhancement: add build information to the metrics
+
+Added a new field to the metrics to show build information like the version.
+
+https://github.com/owncloud/product/issues/226

--- a/glauth/pkg/command/root.go
+++ b/glauth/pkg/command/root.go
@@ -32,6 +32,7 @@ func Execute() error {
 		Flags: flagset.RootWithConfig(cfg),
 
 		Before: func(c *cli.Context) error {
+			cfg.Version = version.String
 			return ParseConfig(c, cfg)
 		},
 

--- a/glauth/pkg/command/server.go
+++ b/glauth/pkg/command/server.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"github.com/owncloud/ocis/glauth/pkg/metrics"
 	"os"
 	"os/signal"
 	"strings"
@@ -134,10 +135,12 @@ func Server(cfg *config.Config) *cli.Command {
 			var (
 				gr          = run.Group{}
 				ctx, cancel = context.WithCancel(context.Background())
-				//metrics     = metrics.New()
+				metrics     = metrics.New()
 			)
 
 			defer cancel()
+
+			metrics.BuildInfo.WithLabelValues(cfg.Version).Set(1)
 
 			{
 				cfg := glauthcfg.Config{

--- a/glauth/pkg/config/config.go
+++ b/glauth/pkg/config/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	Ldap    Ldap
 	Ldaps   Ldaps
 	Backend Backend
+	Version string
 }
 
 // New initializes a new configuration with or without defaults.

--- a/glauth/pkg/metrics/metrics.go
+++ b/glauth/pkg/metrics/metrics.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "github.com/prometheus/client_golang/prometheus"
+
 var (
 	// Namespace defines the namespace for the defines metrics.
 	Namespace = "ocis"
@@ -11,6 +13,7 @@ var (
 // Metrics defines the available metrics of this service.
 type Metrics struct {
 	// Counter  *prometheus.CounterVec
+	BuildInfo *prometheus.GaugeVec
 }
 
 // New initializes the available metrics.
@@ -22,6 +25,12 @@ func New() *Metrics {
 		// 	Name:      "greet_total",
 		// 	Help:      "How many greeting requests processed",
 		// }, []string{}),
+		BuildInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "build_info",
+			Help:      "Build Information",
+		}, []string{"version"}),
 	}
 
 	// prometheus.Register(

--- a/ocis/pkg/command/glauth.go
+++ b/ocis/pkg/command/glauth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/owncloud/ocis/glauth/pkg/flagset"
 	"github.com/owncloud/ocis/ocis/pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
+	"github.com/owncloud/ocis/ocis/pkg/version"
 )
 
 // GLAuthCommand is the entrypoint for the glauth command.
@@ -31,6 +32,7 @@ func configureGLAuth(cfg *config.Config) *svcconfig.Config {
 	cfg.GLAuth.Log.Level = cfg.Log.Level
 	cfg.GLAuth.Log.Pretty = cfg.Log.Pretty
 	cfg.GLAuth.Log.Color = cfg.Log.Color
+	cfg.GLAuth.Version = version.String
 
 	if cfg.Tracing.Enabled {
 		cfg.GLAuth.Tracing.Enabled = cfg.Tracing.Enabled


### PR DESCRIPTION
Since the glauth service is not a go-micro service we can not use the registry to list all glauth services, that is why there is no version command (yet).
This adds build information to the glauth service