### PR TITLE
enable ocis driver treetime accounting

### DIFF
--- a/ocis-reva/changelog/unreleased/enable-treetime-accounting.md
+++ b/ocis-reva/changelog/unreleased/enable-treetime-accounting.md
@@ -1,0 +1,5 @@
+Enhancement: enable ocis driver treetime accounting 
+
+We enabled treetime accounting in the ocis driver
+
+https://github.com/owncloud/ocis/pull/620

--- a/ocis-reva/pkg/command/drivers.go
+++ b/ocis-reva/pkg/command/drivers.go
@@ -86,9 +86,11 @@ func drivers(cfg *config.Config) map[string]interface{} {
 			"userprovidersvc": cfg.Reva.Users.URL,
 		},
 		"ocis": map[string]interface{}{
-			"root":        cfg.Reva.Storages.Common.Root,
-			"enable_home": cfg.Reva.Storages.Common.EnableHome,
-			"user_layout": cfg.Reva.Storages.Common.UserLayout,
+			"root":                cfg.Reva.Storages.Common.Root,
+			"enable_home":         cfg.Reva.Storages.Common.EnableHome,
+			"user_layout":         cfg.Reva.Storages.Common.UserLayout,
+			"treetime_accounting": true,
+			"treesize_accounting": true,
 		},
 		"s3": map[string]interface{}{
 			"region":     cfg.Reva.Storages.S3.Region,


### PR DESCRIPTION
We enabled treetime accounting in the ocis driver.