### PR TITLE
readd the eos docker config

### DIFF
--- a/ocis/config/eos-docker.env
+++ b/ocis/config/eos-docker.env
@@ -1,0 +1,12 @@
+EOS_MQ_URL=mq-master.testnet
+EOS_MGM_ALIAS=mgm-master.testnet
+EOS_QDB_NODES=quark-1.testnet:7777 quark-2.testnet:7777 quark-3.testnet:7777
+EOS_LDAP_HOST=ocis.testnet:9125
+EOS_GEOTAG=test
+EOS_INSTANCE_NAME=eostest
+EOS_MAIL_CC=eos@localhost
+EOS_USE_QDB=1
+EOS_USE_QDB_MASTER=1
+EOS_NS_ACCOUNTING=1
+EOS_SYNCTIME_ACCOUNTING=1
+EOS_UTF8=1


### PR DESCRIPTION
This configuration file was missing after the mono repo was created.