### PR TITLE
Add autoprovision accounts flag

### DIFF
--- a/proxy/changelog/unreleased/add-autoprovision-accounts-flag.md
+++ b/proxy/changelog/unreleased/add-autoprovision-accounts-flag.md
@@ -1,0 +1,6 @@
+Enhancement: Add autoprovision accounts flag
+
+Added a new `PROXY_AUTOPROVISION_ACCOUNTS` environment variable. When enabled, the proxy will try to create a new account when it cannot match the username or email from the oidc userinfo to an existing user. Enable it to learn users from an external identity provider. Defaults to false.
+
+https://github.com/owncloud/product/issues/219
+https://github.com/owncloud/ocis/issues/629

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -265,6 +265,7 @@ func loadMiddlewares(ctx context.Context, l log.Logger, cfg *config.Config) alic
 		middleware.TokenManagerConfig(cfg.TokenManager),
 		middleware.AccountsClient(accounts),
 		middleware.SettingsRoleService(roles),
+		middleware.AutoprovisionAccounts(cfg.AutoprovisionAccounts),
 	)
 
 	// the connection will be established in a non blocking fashion

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -85,19 +85,20 @@ type Reva struct {
 
 // Config combines all available configuration parts.
 type Config struct {
-	File           string
-	Log            Log
-	Debug          Debug
-	HTTP           HTTP
-	Service        Service
-	Tracing        Tracing
-	Asset          Asset
-	Policies       []Policy
-	OIDC           OIDC
-	TokenManager   TokenManager
-	PolicySelector *PolicySelector `mapstructure:"policy_selector"`
-	Reva           Reva
-	PreSignedURL   PreSignedURL
+	File                  string
+	Log                   Log
+	Debug                 Debug
+	HTTP                  HTTP
+	Service               Service
+	Tracing               Tracing
+	Asset                 Asset
+	Policies              []Policy
+	OIDC                  OIDC
+	TokenManager          TokenManager
+	PolicySelector        *PolicySelector `mapstructure:"policy_selector"`
+	Reva                  Reva
+	PreSignedURL          PreSignedURL
+	AutoprovisionAccounts bool
 }
 
 // OIDC is the config for the OpenID-Connect middleware. If set the proxy will try to authenticate every request

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -202,6 +202,17 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"PROXY_OIDC_INSECURE"},
 			Destination: &cfg.OIDC.Insecure,
 		},
+
+		&cli.BoolFlag{
+			Name:        "autoprovision-accounts",
+			Value:       false,
+			Usage:       "create accounts from OIDC access tokens to learn new users",
+			EnvVars:     []string{"PROXY_AUTOPROVISION_ACCOUNTS"},
+			Destination: &cfg.AutoprovisionAccounts,
+		},
+
+		// Presigned URLs
+
 		&cli.StringSliceFlag{
 			Name:    "presignedurl-allow-method",
 			Value:   cli.NewStringSlice("GET"),

--- a/proxy/pkg/middleware/account_uuid.go
+++ b/proxy/pkg/middleware/account_uuid.go
@@ -104,7 +104,7 @@ func AccountUUID(opts ...Option) func(next http.Handler) http.Handler {
 				w.WriteHeader(http.StatusInternalServerError)
 			}
 			if status != 0 || account == nil {
-				if status == http.StatusNotFound {
+				if opt.AutoprovisionAccounts && status == http.StatusNotFound {
 					account, status = createAccount(l, claims, opt.AccountsClient)
 					if status != 0 {
 						w.WriteHeader(status)

--- a/proxy/pkg/middleware/options.go
+++ b/proxy/pkg/middleware/options.go
@@ -1,8 +1,9 @@
 package middleware
 
 import (
-	settings "github.com/owncloud/ocis/settings/pkg/proto/v0"
 	"net/http"
+
+	settings "github.com/owncloud/ocis/settings/pkg/proto/v0"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	acc "github.com/owncloud/ocis/accounts/pkg/proto/v0"
@@ -36,6 +37,8 @@ type Options struct {
 	Store storepb.StoreService
 	// PreSignedURLConfig to configure the middleware
 	PreSignedURLConfig config.PreSignedURL
+	// AutoprovisionAccounts when an account does not exist.
+	AutoprovisionAccounts bool
 }
 
 // newOptions initializes the available default options.
@@ -116,5 +119,12 @@ func Store(sc storepb.StoreService) Option {
 func PreSignedURLConfig(cfg config.PreSignedURL) Option {
 	return func(o *Options) {
 		o.PreSignedURLConfig = cfg
+	}
+}
+
+// AutoprovisionAccounts provides a function to set the AutoprovisionAccounts config
+func AutoprovisionAccounts(val bool) Option {
+	return func(o *Options) {
+		o.AutoprovisionAccounts = val
 	}
 }


### PR DESCRIPTION
Added a new `PROXY_AUTOPROVISION_ACCOUNTS` environment variable. When enabled, the proxy will try to create a new account when it cannot match the username or email from the oidc userinfo to an existing user. Enable it to learn users from an external identity provider. Defaults to false.

fixes https://github.com/owncloud/product/issues/219
fixes https://github.com/owncloud/ocis/issues/629