### PR TITLE
modify docker-compose file to work with mono repo

### DIFF
--- a/ocis/docker-compose.yml
+++ b/ocis/docker-compose.yml
@@ -21,6 +21,17 @@ services:
       - testnet
     volumes:
       - .:/ocis
+      - ../accounts:/accounts
+      - ../glauth:/glauth
+      - ../konnectd:/konnectd
+      - ../ocis-phoenix:/ocis-phoenix
+      - ../ocis-pkg:/ocis-pkg
+      - ../ocs:/ocs
+      - ../proxy:/proxy
+      - ../settings:/settings
+      - ../store:/store
+      - ../thumbnails:/thumbnails
+      - ../webdav:/webdav
       - ../ocis-reva:/ocis-reva
       - ../reva:/reva
     environment:


### PR DESCRIPTION
added volumes for the different submodules to make the docker compose file work with the replaces in go.mod

Fixes: https://github.com/owncloud/product/issues/242