### PR TITLE
[docs-only] Fix docs

### DIFF
--- a/docs/extensions/storage/testing.md
+++ b/docs/extensions/storage/testing.md
@@ -83,7 +83,7 @@ make test-acceptance-api \
 TEST_SERVER_URL=http://localhost:9140 \
 TEST_EXTERNAL_USER_BACKENDS=true \
 TEST_OCIS=true \
-OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
+OCIS_REVA_DATA_ROOT=/var/tmp/ocis/owncloud/ \
 BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~@preview-extension-required' \
 SKELETON_DIR=apps/testing/data/apiSkeleton
 ```
@@ -128,7 +128,7 @@ If you want to work on a specific issue
     TEST_SERVER_URL=http://localhost:9140 \
     TEST_EXTERNAL_USER_BACKENDS=true \
     TEST_OCIS=true \
-    OCIS_REVA_DATA_ROOT=/var/tmp/reva/ \
+    OCIS_REVA_DATA_ROOT=/var/tmp/ocis/owncloud/ \
     BEHAT_FEATURE='tests/acceptance/features/apiComments/comments.feature:123'
     ```
 

--- a/docs/extensions/storage/testing.md
+++ b/docs/extensions/storage/testing.md
@@ -80,7 +80,7 @@ In the ownCloud 10 core repo run
 
 ```
 make test-acceptance-api \
-TEST_SERVER_URL=http://localhost:9140 \
+TEST_SERVER_URL=https://localhost:9200 \
 TEST_EXTERNAL_USER_BACKENDS=true \
 TEST_OCIS=true \
 OCIS_REVA_DATA_ROOT=/var/tmp/ocis/owncloud/ \
@@ -125,7 +125,7 @@ If you want to work on a specific issue
     E.g.:
     ```
     make test-acceptance-api \
-    TEST_SERVER_URL=http://localhost:9140 \
+    TEST_SERVER_URL=https://localhost:9200 \
     TEST_EXTERNAL_USER_BACKENDS=true \
     TEST_OCIS=true \
     OCIS_REVA_DATA_ROOT=/var/tmp/ocis/owncloud/ \


### PR DESCRIPTION
1. default ocis data-root has changed
2. the proxy address should be used everywhere, so that all ocis functions are availiable