### PR TITLE
[Tests-Only] Refactor svc_test to add constants for repeated strings

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -16,7 +16,7 @@ config = {
   'apiTests': {
     'coreBranch': 'master',
     'coreCommit': '35c53c096f40dd15ae15940c589965379e921857',
-    'numberOfParts': 4
+    'numberOfParts': 6
   },
   'uiTests': {
     'phoenixBranch': 'master',


### PR DESCRIPTION
SonarCloud reports that `svc_test.go` is the code with the highest amount of duplications - https://sonarcloud.io/component_measures?id=owncloud_ocis&metric=duplicated_blocks&selected=owncloud_ocis%3Aocs%2Fpkg%2Fserver%2Fhttp%2Fsvc_test.go&view=list

I wanted to see what SonarCloud does when improving this sort of stuff. And also to not touch "real"  code at first. So here is a refactoring of test code.

Does it seem "a good thing" to add a bunch of constants that remove the main repeated crud throughout the tests?