### PR TITLE
[Tests-Only] Fix .drone.star syntax

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -293,9 +293,9 @@ def uploadCoverage(ctx):
           'SONAR_TOKEN': {
             'from_secret': 'sonar_token',
           },
-          'SONAR_PULL_REQUEST_BASE': 'master' if ctx.build.event == 'pull_request' else None,
-          'SONAR_PULL_REQUEST_BRANCH': ctx.build.source if ctx.build.event == 'pull_request' else None,
-          'SONAR_PULL_REQUEST_KEY': ctx.build.ref.replace("refs/pull/", "").split("/")[0] if ctx.build.event == 'pull_request' else None,
+          'SONAR_PULL_REQUEST_BASE': '%s' % ('master' if ctx.build.event == 'pull_request' else None),
+          'SONAR_PULL_REQUEST_BRANCH': '%s' % (ctx.build.source if ctx.build.event == 'pull_request' else None),
+          'SONAR_PULL_REQUEST_KEY': '%s' % (ctx.build.ref.replace("refs/pull/", "").split("/")[0] if ctx.build.event == 'pull_request' else None),
         },
       },
       {


### PR DESCRIPTION
## Description

`.drone.star` syntax is currently broken.

Hotfix