### PR TITLE
[tests-only] Sync tests with cs3org reva

### DIFF
--- a/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -1,7 +1,7 @@
 # this file contains the scenarios from ownCloud10 core API tests that are currently expected to fail
-# when run with OC storage
+# when run with OWNCLOUD storage
 #
-# test scenarios that specifically fail with OC storage (that were tagged skipOnOcis-OC-Storage in core)
+# test scenarios that specifically fail with OWNCLOUD storage (that were tagged skipOnOcis-OC-Storage in core)
 #
 apiWebdavProperties1/setFileProperties.feature:32
 apiWebdavProperties1/setFileProperties.feature:33

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiAuthOcs-ocsDELETEAuth.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiAuthOcs-ocsDELETEAuth.feature
@@ -22,37 +22,37 @@ Feature: auth
 
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     When the administrator requests these endpoints with "DELETE" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v1.php/cloud/users/%username%                              |
-      | /ocs/v1.php/cloud/users/%username%/subadmins                    |
+      | endpoint                                     |
+      | /ocs/v1.php/cloud/users/%username%           |
+      | /ocs/v1.php/cloud/users/%username%/subadmins |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "998"
 
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     When the administrator requests these endpoints with "DELETE" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v2.php/cloud/users/%username%                              |
+      | endpoint                           |
+      | /ocs/v2.php/cloud/users/%username% |
     Then the HTTP status code of responses on all endpoints should be "404"
     And the OCS status code of responses on all endpoints should be "998"
 
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     When the administrator requests these endpoints with "DELETE" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v1.php/cloud/users/%username%/groups                       |
+      | endpoint                                  |
+      | /ocs/v1.php/cloud/users/%username%/groups |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "996"
 
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     When the administrator requests these endpoints with "DELETE" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v2.php/cloud/users/%username%/groups                       |
+      | endpoint                                  |
+      | /ocs/v2.php/cloud/users/%username%/groups |
     Then the HTTP status code of responses on all endpoints should be "500"
     And the OCS status code of responses on all endpoints should be "996"
 
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     When the administrator requests these endpoints with "DELETE" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v2.php/cloud/users/%username%                              |
-      | /ocs/v2.php/cloud/users/%username%/subadmins                    |
+      | endpoint                                     |
+      | /ocs/v2.php/cloud/users/%username%           |
+      | /ocs/v2.php/cloud/users/%username%/subadmins |
     Then the HTTP status code of responses on all endpoints should be "404"
     And the OCS status code of responses on all endpoints should be "998"

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiAuthOcs-ocsPOSTAuth.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiAuthOcs-ocsPOSTAuth.feature
@@ -31,13 +31,13 @@ Feature: auth
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: send POST requests to OCS endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v1.php/cloud/users                                         |
+      | endpoint                |
+      | /ocs/v1.php/cloud/users |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "400"
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v2.php/cloud/users                                         |
+      | endpoint                |
+      | /ocs/v2.php/cloud/users |
     Then the HTTP status code of responses on all endpoints should be "400"
     And the OCS status code of responses on all endpoints should be "400"
 
@@ -45,13 +45,13 @@ Feature: auth
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: send POST requests to OCS endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v1.php/cloud/users/%username%/groups                       |
+      | endpoint                                  |
+      | /ocs/v1.php/cloud/users/%username%/groups |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "400"
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v2.php/cloud/users/%username%/groups                       |
+      | endpoint                                  |
+      | /ocs/v2.php/cloud/users/%username%/groups |
     Then the HTTP status code of responses on all endpoints should be "400"
     And the OCS status code of responses on all endpoints should be "400"
 
@@ -59,12 +59,12 @@ Feature: auth
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: send POST requests to OCS endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v1.php/cloud/users/%username%/subadmins                    |
+      | endpoint                                     |
+      | /ocs/v1.php/cloud/users/%username%/subadmins |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "998"
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                                        |
-      | /ocs/v2.php/cloud/users/%username%/subadmins                    |
+      | endpoint                                     |
+      | /ocs/v2.php/cloud/users/%username%/subadmins |
     Then the HTTP status code of responses on all endpoints should be "404"
     And the OCS status code of responses on all endpoints should be "998"

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiAuthOcs-ocsPUTAuth.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiAuthOcs-ocsPUTAuth.feature
@@ -17,13 +17,13 @@ Feature: auth
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: send PUT request to OCS endpoints as admin with wrong password
     When the administrator requests these endpoints with "PUT" with body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                         |
-      | /ocs/v1.php/cloud/users/%username%               |
+      | endpoint                           |
+      | /ocs/v1.php/cloud/users/%username% |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "103"
     When the administrator requests these endpoints with "PUT" with body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                         |
-      | /ocs/v2.php/cloud/users/%username%               |
+      | endpoint                           |
+      | /ocs/v2.php/cloud/users/%username% |
     Then the HTTP status code of responses on all endpoints should be "400"
     And the OCS status code of responses on all endpoints should be "103"
 
@@ -32,15 +32,15 @@ Feature: auth
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: send PUT request to OCS endpoints as admin with wrong password
     When the administrator requests these endpoints with "PUT" with body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                         |
-      | /ocs/v1.php/cloud/users/%username%/disable       |
-      | /ocs/v1.php/cloud/users/%username%/enable        |
+      | endpoint                                   |
+      | /ocs/v1.php/cloud/users/%username%/disable |
+      | /ocs/v1.php/cloud/users/%username%/enable  |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "998"
     When the administrator requests these endpoints with "PUT" with body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                         |
-      | /ocs/v2.php/cloud/users/%username%/disable       |
-      | /ocs/v2.php/cloud/users/%username%/enable        |
+      | endpoint                                   |
+      | /ocs/v2.php/cloud/users/%username%/disable |
+      | /ocs/v2.php/cloud/users/%username%/enable  |
     Then the HTTP status code of responses on all endpoints should be "404"
     And the OCS status code of responses on all endpoints should be "998"
 

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiShareCreateSpecial2-createShareWithInvalidPermissions.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiShareCreateSpecial2-createShareWithInvalidPermissions.feature
@@ -21,8 +21,8 @@ Feature: cannot share resources with invalid permissions
     And as "Brian" entry "textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | eos_status_code | http_status_code_ocs | http_status_code_eos |
-      | 1               | 100               | 996               | 200                | 500                |
-      | 2               | 200               | 996               | 200                | 500                |
+      | 1               | 100             | 996             | 200                  | 500                  |
+      | 2               | 200             | 996             | 200                  | 500                  |
 
   @issue-ocis-reva-45 @issue-ocis-reva-243
   # after fixing all issues delete this Scenario and use the one from oC10 core
@@ -38,8 +38,8 @@ Feature: cannot share resources with invalid permissions
     And the HTTP status code should be "<http_status_code_ocs>" or "<http_status_code_eos>"
     And as "Brian" entry "textfile0.txt" should not exist
     Examples:
-      | ocs_api_version | eos_status_code | ocs_status_code | http_status_code_ocs | http_status_code_eos | permissions    |
-      | 1               | 100               | 996               | 200                | 500                | delete         |
-      | 2               | 200               | 996               |  200               | 500                |  delete        |
-      | 1               | 100               | 996               |  200               | 500                |  create,delete |
-      | 2               | 200               | 996               |  200               | 500                |  create,delete |
+      | ocs_api_version | eos_status_code | ocs_status_code | http_status_code_ocs | http_status_code_eos | permissions   |
+      | 1               | 100             | 996             | 200                  | 500                  | delete        |
+      | 2               | 200             | 996             | 200                  | 500                  | delete        |
+      | 1               | 100             | 996             | 200                  | 500                  | create,delete |
+      | 2               | 200             | 996             | 200                  | 500                  | create,delete |

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiShareManagementBasic-createShare.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiShareManagementBasic-createShare.feature
@@ -53,8 +53,8 @@ Feature: sharing
     And as "Brian" file "randomfile.txt" should not exist
     Examples:
       | ocs_api_version | http_status_code_ocs | http_status_code_eos |
-      | 1               | 200                | 500                |
-      | 2               | 200                | 500                |
+      | 1               | 200                  | 500                  |
+      | 2               | 200                  | 500                  |
 
   @skipOnOcis-OC-Storage @skipOnOcis-OCIS-Storage @issue-ocis-reva-301 @issue-ocis-reva-302
   # after fixing all issues delete this Scenario and use the one from oC10 core
@@ -66,16 +66,16 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
-      | share_with             | %username%           |
-      | file_target            | /FOLDER              |
-      | path                   | /FOLDER              |
-      | permissions            | all                  |
-      | uid_owner              | %username%           |
-      | displayname_owner      |                      |
-      | item_type              | folder               |
-      | mimetype               | httpd/unix-directory |
-      | storage_id             | ANY_VALUE            |
-      | share_type             | user                 |
+      | share_with        | %username%           |
+      | file_target       | /FOLDER              |
+      | path              | /FOLDER              |
+      | permissions       | all                  |
+      | uid_owner         | %username%           |
+      | displayname_owner |                      |
+      | item_type         | folder               |
+      | mimetype          | httpd/unix-directory |
+      | storage_id        | ANY_VALUE            |
+      | share_type        | user                 |
     And the fields of the last response should not include
       | share_with_displayname | %displayname% |
     Examples:

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiShareOperations-gettingShares.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiShareOperations-gettingShares.feature
@@ -2,14 +2,15 @@
 Feature: sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   @issue-ocis-reva-374
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Get a share with a user that didn't receive the share
-    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     When user "Carol" gets the info of the last share using the sharing API
@@ -24,9 +25,7 @@ Feature: sharing
   @issue-ocis-reva-372
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: getting all the shares inside the folder
-    Given user "Alice" has created folder "/PARENT"
-    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     When user "Alice" gets all the shares inside the folder "PARENT/parent.txt" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink1-createPublicLinkShare.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink1-createPublicLinkShare.feature
@@ -23,7 +23,7 @@ Feature: create a public link share
     Given user "Alice" has created folder "testFolder"
     When user "Alice" uploads file with content "uploaded content for file name ending with a dot" to "testFolder/file.txt" using the WebDAV API
     And user "Alice" has created a public link share with settings
-      | path        | /testFolder |
+      | path        | /testFolder               |
       | permissions | read,update,create,delete |
     And the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then as "Alice" file "/testFolder/file.txt" should exist

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-updatePublicLinkShare.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-updatePublicLinkShare.feature
@@ -3,8 +3,7 @@ Feature: update a public link share
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has been created with default attributes and skeleton files
 
   @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-37653
   # after fixing all issues delete this Scenario and use the one from oC10 core

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-uploadToPublicLinkShare.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-uploadToPublicLinkShare.feature
@@ -3,8 +3,7 @@
 Feature: upload to a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/FOLDER"
+    Given user "Alice" has been created with default attributes and skeleton files
 
   @issue-ocis-reva-290
   # after fixing all issues delete this Scenario and use the one from oC10 core

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiShareUpdate-updateShare.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiShareUpdate-updateShare.feature
@@ -59,18 +59,18 @@ Feature: sharing
     When user "Brian" moves folder "/Alice-folder/folder2" to "/Carol-folder/folder2" using the WebDAV API
     And user "Carol" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Carol" sharing with user "Brian" should include
-      | id                | A_STRING             |
-      | item_type         | folder               |
-      | item_source       | A_STRING             |
-      | share_type        | user                 |
-      | file_source       | A_STRING             |
-      | file_target       | /Carol-folder        |
-      | permissions       | all                  |
-      | stime             | A_NUMBER             |
-      | storage           | A_STRING             |
-      | mail_send         | 0                    |
-      | uid_owner         | %username%           |
-      | mimetype          | httpd/unix-directory |
+      | id          | A_STRING             |
+      | item_type   | folder               |
+      | item_source | A_STRING             |
+      | share_type  | user                 |
+      | file_source | A_STRING             |
+      | file_target | /Carol-folder        |
+      | permissions | all                  |
+      | stime       | A_NUMBER             |
+      | storage     | A_STRING             |
+      | mail_send   | 0                    |
+      | uid_owner   | %username%           |
+      | mimetype    | httpd/unix-directory |
     And as "Alice" folder "/Alice-folder/folder2" should exist
     And as "Carol" folder "/Carol-folder/folder2" should not exist
 

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiShareUpdate-updateShare.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiShareUpdate-updateShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis-EOS-Storage @toFixOnOCIS @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Share ownership change after moving a shared file to another share
     Given these users have been created with default attributes and without skeleton files:
@@ -43,7 +43,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should exist
     And as "Carol" folder "/Carol-folder/folder2" should not exist
 
-  @skipOnOcis-OC-Storage @toFixOnOCIS @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
+  @skipOnOcis-OC-Storage @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # same as oC10 core Scenario but without displayname_owner because EOS does not report it
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Share ownership change after moving a shared file to another share
@@ -74,7 +74,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should exist
     And as "Carol" folder "/Carol-folder/folder2" should not exist
 
-  @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
+  @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share
     Given using OCS API version "<ocs_api_version>"

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
@@ -19,7 +19,6 @@ Feature: files and folders can be deleted from the trashbin
   @issue-product-179
   Scenario Outline: Trashbin cannot be emptied
   # after fixing all issues delete this Scenario and use the one from oC10 core
-  # because of @issue-product-178 we cannot perform this test using new dav, so only old dav is being used
     Given user "Alice" has uploaded file with content "file with comma" to "sample,0.txt"
     And user "Alice" has uploaded file with content "file with comma" to "sample,1.txt"
     And using <dav-path> DAV path

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavMove1-moveFolderToBlacklistedName.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavMove1-moveFolderToBlacklistedName.feature
@@ -8,7 +8,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-211 @skipOnOcis-EOS-Storage @skipOnOcis-OCIS-Storage @issue-ocis-reva-269
+  @issue-ocis-reva-211 @skipOnOcis-EOS-Storage @issue-ocis-reva-269 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Renaming a folder to a name that is banned by default is allowed
     Given using <dav_version> DAV path

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFile.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFile.feature
@@ -7,13 +7,13 @@ Feature: move (rename) file
   Background:
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "some welcome data" to "/welcome.txt"
+    And user "Alice" has uploaded file with content "text file 0" to "/textfile0.txt"
 
   @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: rename a file into an invalid filename
     Given using <dav_version> DAV path
-    When user "Alice" moves file "/welcome.txt" to "/a\\a" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" to "/a\\a" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/a\\a" should exist
     Examples:
@@ -25,9 +25,9 @@ Feature: move (rename) file
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Renaming a file to a path with extension .part is possible
     Given using <dav_version> DAV path
-    When user "Alice" moves file "/welcome.txt" to "/welcome.part" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" to "/textfile0.part" using the WebDAV API
     Then the HTTP status code should be "201"
-    And as "Alice" file "/welcome.part" should exist
+    And as "Alice" file "/textfile0.part" should exist
     Examples:
       | dav_version |
       | old         |

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFileToBlacklistedName.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFileToBlacklistedName.feature
@@ -7,13 +7,13 @@ Feature: users cannot move (rename) a file to a blacklisted name
   Background:
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "some welcome data" to "/welcome.txt"
+    And user "Alice" has uploaded file with content "text file 0" to "/textfile0.txt"
 
   @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: rename a file to a filename that is banned by default
     Given using <dav_version> DAV path
-    When user "Alice" moves file "/welcome.txt" to "/.htaccess" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" to "/.htaccess" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/.htaccess" should exist
     Examples:

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties1-setFileProperties.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties1-setFileProperties.feature
@@ -8,7 +8,7 @@ Feature: set file properties
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis-OC-Storage @skipOnOcis-OCIS-Storage @issue-ocis-reva-276
+  @skipOnOcis-OC-Storage @issue-ocis-reva-276 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Setting custom DAV property
     Given using <dav_version> DAV path

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties2-getFileProperties.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties2-getFileProperties.feature
@@ -17,10 +17,10 @@ Feature: get file properties
     Then the properties response should contain an etag
     And the value of the item "//d:response/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>/"
     Examples:
-      | dav_version | file_name     | expected_href                        |
-      | old         | /C++ file.cpp | webdav\/C\+\+%20file\.cpp            |
-      | old         | /file #2.txt  | webdav\/file%20%232\.txt             |
-      | old         | /file &2.txt  | webdav\/file%20&2\.txt               |
+      | dav_version | file_name     | expected_href                             |
+      | old         | /C++ file.cpp | webdav\/C\+\+%20file\.cpp                 |
+      | old         | /file #2.txt  | webdav\/file%20%232\.txt                  |
+      | old         | /file &2.txt  | webdav\/file%20&2\.txt                    |
       | new         | /C++ file.cpp | dav\/files\/%username%\/C\+\+%20file\.cpp |
       | new         | /file #2.txt  | dav\/files\/%username%\/file%20%232\.txt  |
       | new         | /file &2.txt  | dav\/files\/%username%\/file%20&2\.txt    |
@@ -45,11 +45,11 @@ Feature: get file properties
     When user "Alice" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
     Then the HTTP status code should be "500"
     Examples:
-      | dav_version | file_name     |
-      | old         | /file ?2.txt  |
-      | new         | /file ?2.txt  |
+      | dav_version | file_name    |
+      | old         | /file ?2.txt |
+      | new         | /file ?2.txt |
 
-  @issue-ocis-reva-214 @skipOnOcis-OCIS-Storage @issue-ocis-reva-471
+  @issue-ocis-reva-214 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path
@@ -61,21 +61,21 @@ Feature: get file properties
     And the value of the item "//d:response[2]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file1.txt/"
     And the value of the item "//d:response[3]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file2.txt/"
     Examples:
-      | dav_version | folder_name     | expected_href                                                             |
-      | old         | /upload         | webdav\/upload                                                            |
-      | old         | /strängé folder | webdav\/str%C3%A4ng%C3%A9%20folder                                        |
-      | old         | /C++ folder     | webdav\/C\+\+%20folder                                                      |
-      | old         | /नेपाली         | webdav\/%E0%A4%A8%E0%A5%87%E0%A4%AA%E0%A4%BE%E0%A4%B2%E0%A5%80            |
-      | old         | /folder #2.txt  | webdav\/folder%20%232\.txt                                                |
-      | old         | /folder &2.txt  | webdav\/folder%20&2\.txt                                                  |
+      | dav_version | folder_name     | expected_href                                                                  |
+      | old         | /upload         | webdav\/upload                                                                 |
+      | old         | /strängé folder | webdav\/str%C3%A4ng%C3%A9%20folder                                             |
+      | old         | /C++ folder     | webdav\/C\+\+%20folder                                                         |
+      | old         | /नेपाली         | webdav\/%E0%A4%A8%E0%A5%87%E0%A4%AA%E0%A4%BE%E0%A4%B2%E0%A5%80                 |
+      | old         | /folder #2.txt  | webdav\/folder%20%232\.txt                                                     |
+      | old         | /folder &2.txt  | webdav\/folder%20&2\.txt                                                       |
       | new         | /upload         | dav\/files\/%username%\/upload                                                 |
       | new         | /strängé folder | dav\/files\/%username%\/str%C3%A4ng%C3%A9%20folder                             |
-      | new         | /C++ folder     | dav\/files\/%username%\/C\+\+%20folder                                           |
+      | new         | /C++ folder     | dav\/files\/%username%\/C\+\+%20folder                                         |
       | new         | /नेपाली         | dav\/files\/%username%\/%E0%A4%A8%E0%A5%87%E0%A4%AA%E0%A4%BE%E0%A4%B2%E0%A5%80 |
       | new         | /folder #2.txt  | dav\/files\/%username%\/folder%20%232\.txt                                     |
       | new         | /folder &2.txt  | dav\/files\/%username%\/folder%20&2\.txt                                       |
 
-  @issue-ocis-reva-214 @skipOnOcis-EOS-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage @issue-ocis-reva-471
+  @issue-ocis-reva-214 @skipOnOcis-EOS-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path
@@ -87,11 +87,11 @@ Feature: get file properties
     And the value of the item "//d:response[2]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file1.txt/"
     And the value of the item "//d:response[3]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file2.txt/"
     Examples:
-      | dav_version | folder_name     | expected_href                                                             |
-      | old         | /folder ?2.txt  | webdav\/folder%20%3F2\.txt                                                |
-      | new         | /folder ?2.txt  | dav\/files\/%username%\/folder%20%3F2\.txt                                     |
+      | dav_version | folder_name    | expected_href                              |
+      | old         | /folder ?2.txt | webdav\/folder%20%3F2\.txt                 |
+      | new         | /folder ?2.txt | dav\/files\/%username%\/folder%20%3F2\.txt |
 
-  @skipOnOcis-OC-Storage @skipOnOcis-OCIS-Storage @issue-ocis-reva-265
+  @skipOnOcis-OC-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
@@ -8,7 +8,7 @@ Feature: upload file
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis-OC-Storage @skipOnOcis-OCIS-Storage @issue-ocis-reva-265
+  @skipOnOcis-OC-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path
@@ -19,7 +19,7 @@ Feature: upload file
       | old         | "file ?2.txt"       |
       | new         | "file ?2.txt"       |
 
-  @skipOnOcis-OC-Storage @skipOnOcis-OCIS-Storage @issue-product-127
+  @skipOnOcis-OC-Storage @issue-product-127 @skipOnOcis-OCIS-Storage
   # this scenario passes/fails intermittently on OC storage, so do not run it in CI
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: uploading a file inside a folder changes its etag

--- a/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
+++ b/ocis/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
@@ -15,9 +15,9 @@ Feature: upload file
     When user "Alice" uploads file with content "uploaded content" to <file_name> using the WebDAV API
     Then the content of file <file_name> for user "Alice" should be ""
     Examples:
-      | dav_version | file_name           |
-      | old         | "file ?2.txt"       |
-      | new         | "file ?2.txt"       |
+      | dav_version | file_name     |
+      | old         | "file ?2.txt" |
+      | new         | "file ?2.txt" |
 
   @skipOnOcis-OC-Storage @issue-product-127 @skipOnOcis-OCIS-Storage
   # this scenario passes/fails intermittently on OC storage, so do not run it in CI


### PR DESCRIPTION
Apply minor differences from the test files in `cs3org/reva` to here in `owncloud/ocis` so that there is less brain-pain when comparing the state of the tests between the 2 repos.