### PR TITLE
Use micro default client for connections to account service

### DIFF
--- a/changelog/unreleased/glauth-micro-client
+++ b/changelog/unreleased/glauth-micro-client
@@ -1,0 +1,7 @@
+Bugfix: Use micro default client
+
+Tags: glauth
+
+We found a file descriptor leak in the glauth connections to the accounts service. Fixed it by using the micro default client.
+
+https://github.com/owncloud/ocis/pull/718

--- a/glauth/pkg/command/server.go
+++ b/glauth/pkg/command/server.go
@@ -17,7 +17,6 @@ import (
 	glauthcfg "github.com/glauth/glauth/pkg/config"
 
 	"github.com/micro/cli/v2"
-	"github.com/micro/go-micro/v2"
 	"github.com/micro/go-micro/v2/client"
 	"github.com/oklog/run"
 	openzipkin "github.com/openzipkin/zipkin-go"
@@ -192,11 +191,7 @@ func Server(cfg *config.Config) *cli.Command {
 					}
 				}
 
-				as, gs, err := getAccountsServices()
-				if err != nil {
-					return err
-				}
-
+				as, gs := getAccountsServices()
 				server, err := glauth.Server(
 					glauth.AccountsService(as),
 					glauth.GroupsService(gs),
@@ -312,19 +307,7 @@ func Server(cfg *config.Config) *cli.Command {
 }
 
 // getAccountsServices returns an ocis-accounts service
-func getAccountsServices() (accounts.AccountsService, accounts.GroupsService, error) {
-	service := micro.NewService()
-
-	// parse command line flags
-	service.Init()
-
-	err := service.Client().Init(
-		client.ContentType("application/json"),
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-	return accounts.NewAccountsService("com.owncloud.api.accounts", service.Client()),
-		accounts.NewGroupsService("com.owncloud.api.accounts", service.Client()),
-		nil
+func getAccountsServices() (accounts.AccountsService, accounts.GroupsService) {
+	return accounts.NewAccountsService("com.owncloud.api.accounts", client.DefaultClient),
+		accounts.NewGroupsService("com.owncloud.api.accounts", client.DefaultClient)
 }


### PR DESCRIPTION
... was causing file descriptor leaks