### PR TITLE
[tests-only] Bump core commit for API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '1df47648f944ab21521f6c8d538dc183e1e8f1ea',
+    'coreCommit': '914992f5f6d4bb562534fa52273e5bd0bc11b208',
     'numberOfParts': 6
   },
   'uiTests': {

--- a/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -187,6 +187,8 @@ apiProvisioning-v1/addUser.feature:99
 apiProvisioning-v1/addUser.feature:100
 apiProvisioning-v1/addUser.feature:102
 apiProvisioning-v1/getUser.feature:37
+apiProvisioning-v1/getUser.feature:113
+apiProvisioning-v1/getUser.feature:124
 apiProvisioning-v2/addUser.feature:96
 apiProvisioning-v2/addUser.feature:97
 apiProvisioning-v2/addUser.feature:98
@@ -194,6 +196,8 @@ apiProvisioning-v2/addUser.feature:99
 apiProvisioning-v2/addUser.feature:100
 apiProvisioning-v2/addUser.feature:102
 apiProvisioning-v2/getUser.feature:37
+apiProvisioning-v2/getUser.feature:114
+apiProvisioning-v2/getUser.feature:125
 apiProvisioning-v1/deleteUser.feature:32
 apiProvisioning-v2/deleteUser.feature:32
 #
@@ -1376,11 +1380,11 @@ apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature:50
 # https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
 #
 apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:13
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:20
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:19
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:35
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:36
 apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:37
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:38
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:39
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:42
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:40
 #
 # https://github.com/owncloud/ocis-reva/issues/56 remote.php/dav/uploads endpoint does not exist
 #
@@ -1394,11 +1398,11 @@ apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature:52
 # https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
 #
 apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:13
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:21
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:20
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:37
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:38
 apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:39
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:40
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:41
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:44
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:42
 #
 # https://github.com/owncloud/ocis-reva/issues/56 remote.php/dav/uploads endpoint does not exist
 #
@@ -1420,16 +1424,16 @@ apiWebdavUpload2/uploadFileUsingNewChunking.feature:158
 # https://github.com/owncloud/ocis-reva/issues/17  uploading with old-chunking does not work
 #
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:13
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:26
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:35
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:44
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:25
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:34
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:43
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:75
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:76
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:77
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:96
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:97
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:98
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:99
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:100
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:101
 #
 # https://github.com/owncloud/ocis/issues/187 Previews via webDAV API tests fail on OCIS
 #

--- a/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -191,6 +191,8 @@ apiProvisioning-v1/addUser.feature:99
 apiProvisioning-v1/addUser.feature:100
 apiProvisioning-v1/addUser.feature:102
 apiProvisioning-v1/getUser.feature:37
+apiProvisioning-v1/getUser.feature:113
+apiProvisioning-v1/getUser.feature:124
 apiProvisioning-v2/addUser.feature:96
 apiProvisioning-v2/addUser.feature:97
 apiProvisioning-v2/addUser.feature:98
@@ -198,6 +200,8 @@ apiProvisioning-v2/addUser.feature:99
 apiProvisioning-v2/addUser.feature:100
 apiProvisioning-v2/addUser.feature:102
 apiProvisioning-v2/getUser.feature:37
+apiProvisioning-v2/getUser.feature:114
+apiProvisioning-v2/getUser.feature:125
 apiProvisioning-v1/deleteUser.feature:32
 apiProvisioning-v2/deleteUser.feature:32
 #
@@ -1371,31 +1375,31 @@ apiWebdavUpload2/uploadFileUsingNewChunking.feature:158
 # https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
 #
 apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:13
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:20
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:19
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:35
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:36
 apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:37
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:38
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:39
-apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:42
+apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:40
 apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:13
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:21
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:20
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:37
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:38
 apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:39
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:40
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:41
-apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:44
+apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:42
 #
 # https://github.com/owncloud/ocis-reva/issues/17  uploading with old-chunking does not work
 #
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:13
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:26
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:35
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:44
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:25
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:34
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:43
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:75
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:76
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:77
+apiWebdavUpload2/uploadFileUsingOldChunking.feature:96
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:97
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:98
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:99
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:100
-apiWebdavUpload2/uploadFileUsingOldChunking.feature:101
 #
 # https://github.com/owncloud/ocis/issues/187 Previews via webDAV API tests fail on OCIS
 #


### PR DESCRIPTION
1) Includes these core test-related PRs in the testing:
https://github.com/owncloud/core/pull/38020 [Tests-Only] Fix mixed-case and uppercase username in API test
https://github.com/owncloud/core/pull/38022 [tests-only] remove unused folder parameter from Favorites test-functions
https://github.com/owncloud/core/pull/38023 [Tests-Only]Refactored bug demonstration scenarios for api test
https://github.com/owncloud/core/pull/38024 [Tests-Only]Refactored some more bug demonstration scenarios for webUI test
https://github.com/owncloud/core/pull/38025 [Tests-Only] Oc10 bug demonstration scenarios added separately for webUI tests
https://github.com/owncloud/core/pull/38026 [tests-only] Remove misleading error output from run.sh

Note: some of these refactor webUI tests, which are not run in `cs3org/reva` anyway, but I listed them for completeness.

2) adjust the expected-failures for some changes to line numbers, and some extra test scenarios that now get run.

The matching PR in `cs3org/reva` is https://github.com/cs3org/reva/pull/1267
