### PR TITLE
[tests-only] Remove some expected-failures

### DIFF
--- a/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -115,8 +115,6 @@ apiCapabilities/capabilitiesWithNormalUser.feature:11
 #
 apiFavorites/favorites.feature:91
 apiFavorites/favorites.feature:92
-apiFavorites/favorites.feature:112
-apiFavorites/favorites.feature:113
 apiFavorites/favorites.feature:128
 apiFavorites/favorites.feature:129
 apiFavorites/favorites.feature:148

--- a/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -121,8 +121,6 @@ apiFavorites/favorites.feature:91
 apiFavorites/favorites.feature:92
 apiFavorites/favorites.feature:112
 apiFavorites/favorites.feature:113
-apiFavorites/favorites.feature:128
-apiFavorites/favorites.feature:129
 apiFavorites/favorites.feature:148
 apiFavorites/favorites.feature:149
 apiFavorites/favorites.feature:176


### PR DESCRIPTION
Purposely remove some expected-failures in order to test the output of the API test logs.
I have seen some drone runs where the "Total unexpected failed scenarios" at the end of the pipeline did not appear in the output.