### PR TITLE
[tests-only] Add some expected-failures

### DIFF
--- a/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -115,6 +115,8 @@ apiCapabilities/capabilitiesWithNormalUser.feature:11
 #
 apiFavorites/favorites.feature:91
 apiFavorites/favorites.feature:92
+apiFavorites/favorites.feature:107
+apiFavorites/favorites.feature:108
 apiFavorites/favorites.feature:112
 apiFavorites/favorites.feature:113
 apiFavorites/favorites.feature:128

--- a/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -119,6 +119,8 @@ apiCapabilities/capabilitiesWithNormalUser.feature:11
 #
 apiFavorites/favorites.feature:91
 apiFavorites/favorites.feature:92
+apiFavorites/favorites.feature:100
+apiFavorites/favorites.feature:101
 apiFavorites/favorites.feature:112
 apiFavorites/favorites.feature:113
 apiFavorites/favorites.feature:128


### PR DESCRIPTION
Purposely add some expected-failures in order to test the output of the API test logs.