### PR TITLE
Mint token with uid and gid

### DIFF
--- a/accounts/pkg/indexer/index/cs3/autoincrement.go
+++ b/accounts/pkg/indexer/index/cs3/autoincrement.go
@@ -12,9 +12,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/owncloud/ocis/accounts/pkg/storage"
+
 	idxerrs "github.com/owncloud/ocis/accounts/pkg/indexer/errors"
 
-	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
@@ -60,12 +61,11 @@ func NewAutoincrementIndex(o ...option.Option) index.Index {
 		indexBaseDir: path.Join(opts.DataDir, "index.cs3"),
 		indexRootDir: path.Join(path.Join(opts.DataDir, "index.cs3"), strings.Join([]string{"autoincrement", opts.TypeName, opts.IndexBy}, ".")),
 		cs3conf: &Config{
-			ProviderAddr:    opts.ProviderAddr,
-			DataURL:         opts.DataURL,
-			DataPrefix:      opts.DataPrefix,
-			JWTSecret:       opts.JWTSecret,
-			ServiceUserName: opts.ServiceUserName,
-			ServiceUserUUID: opts.ServiceUserUUID,
+			ProviderAddr: opts.ProviderAddr,
+			DataURL:      opts.DataURL,
+			DataPrefix:   opts.DataPrefix,
+			JWTSecret:    opts.JWTSecret,
+			ServiceUser:  opts.ServiceUser,
 		},
 		dataProvider: dataProviderClient{
 			baseURL: singleJoiningSlash(opts.DataURL, opts.DataPrefix),
@@ -284,7 +284,6 @@ func (idx *Autoincrement) createSymlink(oldname, newname string) error {
 	}
 
 	return nil
-
 }
 
 func (idx *Autoincrement) resolveSymlink(name string) (string, error) {
@@ -317,37 +316,11 @@ func (idx *Autoincrement) resolveSymlink(name string) (string, error) {
 }
 
 func (idx *Autoincrement) makeDirIfNotExists(ctx context.Context, folder string) error {
-	var rootPathRef = &provider.Reference{
-		Spec: &provider.Reference_Path{Path: fmt.Sprintf("/meta/%v", folder)},
-	}
-
-	resp, err := idx.storageProvider.Stat(ctx, &provider.StatRequest{
-		Ref: rootPathRef,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	if resp.Status.Code == v1beta11.Code_CODE_NOT_FOUND {
-		_, err := idx.storageProvider.CreateContainer(ctx, &provider.CreateContainerRequest{
-			Ref: rootPathRef,
-		})
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return storage.MakeDirIfNotExist(ctx, idx.storageProvider, folder)
 }
 
 func (idx *Autoincrement) authenticate(ctx context.Context) (token string, err error) {
-	u := &user.User{
-		Id:     &user.UserId{OpaqueId: idx.cs3conf.ServiceUserUUID},
-		Groups: []string{},
-	}
-	return idx.tokenManager.MintToken(ctx, u)
+	return storage.AuthenticateCS3(ctx, idx.cs3conf.ServiceUser, idx.tokenManager)
 }
 
 func (idx *Autoincrement) next() (int, error) {

--- a/accounts/pkg/indexer/index/cs3/non_unique.go
+++ b/accounts/pkg/indexer/index/cs3/non_unique.go
@@ -10,7 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/owncloud/ocis/accounts/pkg/storage"
+
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
@@ -66,12 +67,11 @@ func NewNonUniqueIndexWithOptions(o ...option.Option) index.Index {
 		indexBaseDir:    path.Join(opts.DataDir, "index.cs3"),
 		indexRootDir:    path.Join(path.Join(opts.DataDir, "index.cs3"), strings.Join([]string{"non_unique", opts.TypeName, opts.IndexBy}, ".")),
 		cs3conf: &Config{
-			ProviderAddr:    opts.ProviderAddr,
-			DataURL:         opts.DataURL,
-			DataPrefix:      opts.DataPrefix,
-			JWTSecret:       opts.JWTSecret,
-			ServiceUserName: opts.ServiceUserName,
-			ServiceUserUUID: opts.ServiceUserUUID,
+			ProviderAddr: opts.ProviderAddr,
+			DataURL:      opts.DataURL,
+			DataPrefix:   opts.DataPrefix,
+			JWTSecret:    opts.JWTSecret,
+			ServiceUser:  opts.ServiceUser,
 		},
 		dataProvider: dataProviderClient{
 			baseURL: singleJoiningSlash(opts.DataURL, opts.DataPrefix),
@@ -315,38 +315,8 @@ func (idx *NonUnique) FilesDir() string {
 	return idx.filesDir
 }
 
-func (idx *NonUnique) authenticate(ctx context.Context) (token string, err error) {
-	u := &user.User{
-		Id:     &user.UserId{OpaqueId: idx.cs3conf.ServiceUserUUID},
-		Groups: []string{},
-	}
-	return idx.tokenManager.MintToken(ctx, u)
-}
-
 func (idx *NonUnique) makeDirIfNotExists(ctx context.Context, folder string) error {
-	var rootPathRef = &provider.Reference{
-		Spec: &provider.Reference_Path{Path: fmt.Sprintf("/meta/%v", folder)},
-	}
-
-	resp, err := idx.storageProvider.Stat(ctx, &provider.StatRequest{
-		Ref: rootPathRef,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	if resp.Status.Code == v1beta11.Code_CODE_NOT_FOUND {
-		_, err := idx.storageProvider.CreateContainer(ctx, &provider.CreateContainerRequest{
-			Ref: rootPathRef,
-		})
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return storage.MakeDirIfNotExist(ctx, idx.storageProvider, folder)
 }
 
 func (idx *NonUnique) createSymlink(oldname, newname string) error {
@@ -368,7 +338,6 @@ func (idx *NonUnique) createSymlink(oldname, newname string) error {
 	}
 
 	return nil
-
 }
 
 func (idx *NonUnique) resolveSymlink(name string) (string, error) {
@@ -407,4 +376,8 @@ func (idx *NonUnique) getAuthenticatedContext(ctx context.Context) (context.Cont
 	}
 	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
 	return ctx, nil
+}
+
+func (idx *NonUnique) authenticate(ctx context.Context) (token string, err error) {
+	return storage.AuthenticateCS3(ctx, idx.cs3conf.ServiceUser, idx.tokenManager)
 }

--- a/accounts/pkg/indexer/indexer.go
+++ b/accounts/pkg/indexer/indexer.go
@@ -69,8 +69,7 @@ func (i Indexer) AddIndex(t interface{}, indexBy, pkName, entityDirName, indexTy
 			option.WithDataPrefix(i.config.Repo.CS3.DataPrefix),
 			option.WithJWTSecret(i.config.Repo.CS3.JWTSecret),
 			option.WithProviderAddr(i.config.Repo.CS3.ProviderAddr),
-			option.WithServiceUserUUID(i.config.ServiceUser.UUID),
-			option.WithServiceUserName(i.config.ServiceUser.Username),
+			option.WithServiceUser(i.config.ServiceUser),
 		)
 	}
 

--- a/accounts/pkg/indexer/option/option.go
+++ b/accounts/pkg/indexer/option/option.go
@@ -1,5 +1,7 @@
 package option
 
+import "github.com/owncloud/ocis/accounts/pkg/config"
+
 // Option defines a single option function.
 type Option func(o *Options)
 
@@ -25,12 +27,11 @@ type Options struct {
 	Entity        interface{}
 
 	// CS3 options
-	DataURL         string
-	DataPrefix      string
-	JWTSecret       string
-	ProviderAddr    string
-	ServiceUserUUID string
-	ServiceUserName string
+	DataURL      string
+	DataPrefix   string
+	JWTSecret    string
+	ProviderAddr string
+	ServiceUser  config.ServiceUser
 }
 
 // CaseInsensitive sets the CaseInsensitive field.
@@ -117,16 +118,9 @@ func WithProviderAddr(val string) Option {
 	}
 }
 
-// WithServiceUserUUID sets the option ServiceUserUUID.
-func WithServiceUserUUID(val string) Option {
+// WithServiceUser sets the option ServiceUser.
+func WithServiceUser(val config.ServiceUser) Option {
 	return func(o *Options) {
-		o.ServiceUserUUID = val
-	}
-}
-
-// WithServiceUserName sets the option ServiceUserName.
-func WithServiceUserName(val string) Option {
-	return func(o *Options) {
-		o.ServiceUserName = val
+		o.ServiceUser = val
 	}
 }

--- a/accounts/pkg/storage/cs3.go
+++ b/accounts/pkg/storage/cs3.go
@@ -8,11 +8,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
@@ -95,7 +97,7 @@ func (r CS3Repo) LoadAccount(ctx context.Context, id string, a *proto.Account) (
 		return err
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
+	if resp.StatusCode != http.StatusOK {
 		return &notFoundErr{"account", id}
 	}
 
@@ -222,6 +224,18 @@ func (r CS3Repo) authenticate(ctx context.Context) (token string, err error) {
 			OpaqueId: r.cfg.ServiceUser.UUID,
 		},
 		Groups: []string{},
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"uid": {
+					Decoder: "plain",
+					Value:   []byte(strconv.FormatInt(r.cfg.ServiceUser.UID, 10)),
+				},
+				"gid": {
+					Decoder: "plain",
+					Value:   []byte(strconv.FormatInt(r.cfg.ServiceUser.GID, 10)),
+				},
+			},
+		},
 	}
 	return r.tm.MintToken(ctx, u)
 }

--- a/accounts/pkg/storage/cs3.go
+++ b/accounts/pkg/storage/cs3.go
@@ -219,25 +219,30 @@ func (r CS3Repo) DeleteGroup(ctx context.Context, id string) (err error) {
 }
 
 func (r CS3Repo) authenticate(ctx context.Context) (token string, err error) {
+	return AuthenticateCS3(ctx, r.cfg.ServiceUser, r.tm)
+}
+
+// AuthenticateCS3 mints an auth token for communicating with cs3 storage based on a service user from config
+func AuthenticateCS3(ctx context.Context, su config.ServiceUser, tm token.Manager) (token string, err error) {
 	u := &user.User{
 		Id: &user.UserId{
-			OpaqueId: r.cfg.ServiceUser.UUID,
+			OpaqueId: su.UUID,
 		},
 		Groups: []string{},
 		Opaque: &types.Opaque{
 			Map: map[string]*types.OpaqueEntry{
 				"uid": {
 					Decoder: "plain",
-					Value:   []byte(strconv.FormatInt(r.cfg.ServiceUser.UID, 10)),
+					Value:   []byte(strconv.FormatInt(su.UID, 10)),
 				},
 				"gid": {
 					Decoder: "plain",
-					Value:   []byte(strconv.FormatInt(r.cfg.ServiceUser.GID, 10)),
+					Value:   []byte(strconv.FormatInt(su.GID, 10)),
 				},
 			},
 		},
 	}
-	return r.tm.MintToken(ctx, u)
+	return tm.MintToken(ctx, u)
 }
 
 func (r CS3Repo) accountURL(id string) string {
@@ -249,11 +254,16 @@ func (r CS3Repo) groupURL(id string) string {
 }
 
 func (r CS3Repo) makeRootDirIfNotExist(ctx context.Context, folder string) error {
+	return MakeDirIfNotExist(ctx, r.storageProvider, folder)
+}
+
+// MakeDirIfNotExist will create a root node in the metadata storage. Requires an authenticated context.
+func MakeDirIfNotExist(ctx context.Context, sp provider.ProviderAPIClient, folder string) error {
 	var rootPathRef = &provider.Reference{
 		Spec: &provider.Reference_Path{Path: path.Join("/meta", folder)},
 	}
 
-	resp, err := r.storageProvider.Stat(ctx, &provider.StatRequest{
+	resp, err := sp.Stat(ctx, &provider.StatRequest{
 		Ref: rootPathRef,
 	})
 
@@ -262,7 +272,7 @@ func (r CS3Repo) makeRootDirIfNotExist(ctx context.Context, folder string) error
 	}
 
 	if resp.Status.Code == v1beta11.Code_CODE_NOT_FOUND {
-		_, err := r.storageProvider.CreateContainer(ctx, &provider.CreateContainerRequest{
+		_, err := sp.CreateContainer(ctx, &provider.CreateContainerRequest{
 			Ref: rootPathRef,
 		})
 

--- a/changelog/unreleased/mint-token-with-uid.md
+++ b/changelog/unreleased/mint-token-with-uid.md
@@ -1,0 +1,8 @@
+Bugfix: Mint token with uid and gid
+
+Tags: accounts
+
+The eos driver expects the uid and gid from the opaque map of a user. While the proxy does mint tokens correctly, the accounts service wasn't.
+
+https://github.com/owncloud/ocis/pull/737
+


### PR DESCRIPTION
The eos driver expects the uid and gid from the opaque map of a user. While the proxy does mint tokens correctly, the accounts service wasn't.