### PR TITLE
Fix id or username query handling

### DIFF
--- a/accounts/pkg/service/v0/accounts.go
+++ b/accounts/pkg/service/v0/accounts.go
@@ -230,7 +230,7 @@ func (s Service) findAccountsByQuery(ctx context.Context, query string) ([]strin
 		qID, qSam := match[1], match[2]
 		tmp := &proto.Account{}
 		err = s.repo.LoadAccount(ctx, qID, tmp)
-		if err != nil {
+		if err != nil && !storage.IsNotFoundErr(err) {
 			return nil, err
 		}
 		searchResults, err = s.index.FindBy(&proto.Account{}, "OnPremisesSamAccountName", qSam)

--- a/changelog/unreleased/fix-id-or-username-query-handling.md
+++ b/changelog/unreleased/fix-id-or-username-query-handling.md
@@ -1,0 +1,7 @@
+Bugfix: Fix id or username query handling
+
+Tags: accounts
+
+The code was stopping execution when encountering an error while loading an account by id. But for or queries we can continue execution.
+
+https://github.com/owncloud/ocis/pull/745


### PR DESCRIPTION
The code was stopping execution when encountering an error while loading an account by id. But for or queries we can continue execution.