### PR TITLE
[Docs-only] add version command to docs

### DIFF
--- a/docs/extensions/accounts/getting-started.md
+++ b/docs/extensions/accounts/getting-started.md
@@ -57,5 +57,12 @@ The program provides a few sub-commands on execution. The available configuratio
 The server command is used to start the grpc server. For further help please execute:
 
 {{< highlight txt >}}
-ocis-accounts server --help
+accounts server --help
 {{< / highlight >}}
+
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+accounts version --help
+{{< /highlight >}}

--- a/docs/extensions/konnectd/getting-started.md
+++ b/docs/extensions/konnectd/getting-started.md
@@ -42,7 +42,7 @@ The program provides a few sub-commands on execution. The available configuratio
 The server command is used to start the http and debug server on two addresses within a single process. The http server is serving the general webservice while the debug server is used for health check, readiness check and to server the metrics mentioned below. For further help please execute:
 
 {{< highlight txt >}}
-ocis-konnectd server --help
+konnectd server --help
 {{< / highlight >}}
 
 ### Health
@@ -50,8 +50,15 @@ ocis-konnectd server --help
 The health command is used to execute a health check, if the exit code equals zero the service should be up and running, if the exist code is greater than zero the service is not in a healthy state. Generally this command is used within our Docker containers, it could also be used within Kubernetes.
 
 {{< highlight txt >}}
-ocis-konnectd health --help
+konnectd health --help
 {{< / highlight >}}
+
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+konnectd version --help
+{{< /highlight >}}
 
 ## Metrics
 

--- a/docs/extensions/ocs/getting-started.md
+++ b/docs/extensions/ocs/getting-started.md
@@ -42,7 +42,7 @@ The program provides a few sub-commands on execution. The available configuratio
 The server command is used to start the http and debug server on two addresses within a single process. The http server is serving the general webservice while the debug server is used for health check, readiness check and to server the metrics mentioned below. For further help please execute:
 
 {{< highlight txt >}}
-ocis-ocs server --help
+ocs server --help
 {{< / highlight >}}
 
 ### Health
@@ -50,8 +50,15 @@ ocis-ocs server --help
 The health command is used to execute a health check, if the exit code equals zero the service should be up and running, if the exist code is greater than zero the service is not in a healthy state. Generally this command is used within our Docker containers, it could also be used within Kubernetes.
 
 {{< highlight txt >}}
-ocis-ocs health --help
+ocs health --help
 {{< / highlight >}}
+
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+ocs version --help
+{{< /highlight >}}
 
 ## Metrics
 

--- a/docs/extensions/proxy/getting-started.md
+++ b/docs/extensions/proxy/getting-started.md
@@ -42,5 +42,12 @@ The program provides a few sub-commands on execution. The available configuratio
 The server command is used to start the http server. For further help please execute:
 
 {{< highlight txt >}}
-ocis-proxy server --help
+proxy server --help
 {{< / highlight >}}
+
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+proxy version --help
+{{< /highlight >}}

--- a/docs/extensions/settings/getting-started.md
+++ b/docs/extensions/settings/getting-started.md
@@ -160,7 +160,7 @@ The program provides a few sub-commands on execution. The available configuratio
 The server command is used to start the http and debug server on two addresses within a single process. The http server is serving the general webservice while the debug server is used for health check, readiness check and to server the metrics mentioned below. For further help please execute:
 
 {{< highlight txt >}}
-ocis-settings server --help
+settings server --help
 {{< / highlight >}}
 
 ### Health
@@ -168,8 +168,15 @@ ocis-settings server --help
 The health command is used to execute a health check, if the exit code equals zero the service should be up and running, if the exist code is greater than zero the service is not in a healthy state. Generally this command is used within our Docker containers, it could also be used within Kubernetes.
 
 {{< highlight txt >}}
-ocis-settings health --help
+settings health --help
 {{< / highlight >}}
+
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+settings version --help
+{{< /highlight >}}
 
 ## Metrics
 

--- a/docs/extensions/store/getting-started.md
+++ b/docs/extensions/store/getting-started.md
@@ -160,7 +160,7 @@ The program provides a few sub-commands on execution. The available configuratio
 The server command is used to start the http and debug server on two addresses within a single process. The http server is serving the general webservice while the debug server is used for health check, readiness check and to server the metrics mentioned below. For further help please execute:
 
 {{< highlight txt >}}
-ocis-store server --help
+store server --help
 {{< / highlight >}}
 
 ### Health
@@ -168,8 +168,15 @@ ocis-store server --help
 The health command is used to execute a health check, if the exit code equals zero the service should be up and running, if the exist code is greater than zero the service is not in a healthy state. Generally this command is used within our Docker containers, it could also be used within Kubernetes.
 
 {{< highlight txt >}}
-ocis-store health --help
+store health --help
 {{< / highlight >}}
+
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+store version --help
+{{< /highlight >}}
 
 ## Metrics
 

--- a/docs/extensions/thumbnails/getting-started.md
+++ b/docs/extensions/thumbnails/getting-started.md
@@ -189,6 +189,13 @@ The health command is used to execute a health check, if the exit code equals ze
 {{ Name }} health --help
 {{< / highlight >}}
 
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+{{ Name }} version --help
+{{< /highlight >}}
+
 ## Metrics
 
 This service provides some [Prometheus](https://prometheus.io/) metrics through the debug endpoint, you can optionally secure the metrics endpoint by some random token, which got to be configured through one of the flag `--debug-token` or the environment variable `THUMBNAILS_DEBUG_TOKEN` mentioned above. By default the metrics endpoint is bound to `http://0.0.0.0:9114/metrics`.

--- a/docs/extensions/webdav/getting-started.md
+++ b/docs/extensions/webdav/getting-started.md
@@ -157,7 +157,7 @@ The program provides a few sub-commands on execution. The available configuratio
 The server command is used to start the http and debug server on two addresses within a single process. The http server is serving the general webservice while the debug server is used for health check, readiness check and to server the metrics mentioned below. For further help please execute:
 
 {{< highlight txt >}}
-ocis-webdav server --help
+webdav server --help
 {{< / highlight >}}
 
 #### Health
@@ -165,8 +165,15 @@ ocis-webdav server --help
 The health command is used to execute a health check, if the exit code equals zero the service should be up and running, if the exist code is greater than zero the service is not in a healthy state. Generally this command is used within our Docker containers, it could also be used within Kubernetes.
 
 {{< highlight txt >}}
-ocis-webdav health --help
+webdav health --help
 {{< / highlight >}}
+
+### Version
+The version command lists the versions of all running instances. For further help please execute:
+
+{{< highlight txt >}}
+webdav version --help
+{{< /highlight >}}
 
 ### Metrics
 


### PR DESCRIPTION
We could consider just pasting the usage printed by the commands to the docs since they are 'documentation' and are easier to update.

For example here the usage from the accounts service:
```
NAME:
   ocis accounts - Start accounts server

USAGE:
   ocis accounts command [command options] [arguments...]

COMMANDS:
   list, ls        List existing accounts
   add, create, a  Create a new account
   update          Make changes to an existing account
   remove, rm      Removes an existing account
   inspect         Show detailed data on an existing account
   version         Print the versions of the running instances
   help, h         Shows a list of commands or help for one command

OPTIONS:
   --http-namespace value             Set the base namespace for the http namespace (default: "com.owncloud.web") [$ACCOUNTS_HTTP_NAMESPACE]
   --http-addr value                  Address to bind http server (default: "0.0.0.0:9181") [$ACCOUNTS_HTTP_ADDR]
   --http-root value                  Root path of http server (default: "/") [$ACCOUNTS_HTTP_ROOT]
   --grpc-namespace value             Set the base namespace for the grpc namespace (default: "com.owncloud.api") [$ACCOUNTS_GRPC_NAMESPACE]
   --grpc-addr value                  Address to bind grpc server (default: "0.0.0.0:9180") [$ACCOUNTS_GRPC_ADDR]
   --name value                       service name (default: "accounts") [$ACCOUNTS_NAME]
   --accounts-data-path value         accounts folder (default: "/var/tmp/ocis-accounts") [$ACCOUNTS_DATA_PATH]
   --asset-path value                 Path to custom assets [$ACCOUNTS_ASSET_PATH]
   --jwt-secret value                 Used to create JWT to talk to reva, should equal reva's jwt-secret (default: "Pive-Fumkiu4") [$ACCOUNTS_JWT_SECRET]
   --storage-disk-path value          Path on the local disk, e.g. /var/tmp/ocis-accounts [$ACCOUNTS_STORAGE_DISK_PATH]
   --storage-cs3-provider-addr value  bind address for the metadata storage provider (default: "localhost:9215") [$ACCOUNTS_STORAGE_CS3_PROVIDER_ADDR]
   --storage-cs3-data-url value       http endpoint of the metadata storage (default: "http://localhost:9216") [$ACCOUNTS_STORAGE_CS3_DATA_URL]
   --storage-cs3-data-prefix value    path prefix for the http endpoint of the metadata storage, without leading slash (default: "data") [$ACCOUNTS_STORAGE_CS3_DATA_PREFIX]
   --storage-cs3-jwt-secret value     Used to create JWT to talk to reva, should equal reva's jwt-secret (default: "Pive-Fumkiu4") [$ACCOUNTS_STORAGE_CS3_JWT_SECRET]
   --service-user-uuid value          uuid of the internal service user (required on EOS) (default: "95cb8724-03b2-11eb-a0a6-c33ef8ef53ad") [$ACCOUNTS_SERVICE_USER_UUID]
   --service-user-username value      username of the internal service user (required on EOS) [$ACCOUNTS_SERVICE_USER_USERNAME]
   --service-user-uid value           uid of the internal service user (required on EOS) (default: 0) [$ACCOUNTS_SERVICE_USER_UID]
   --service-user-gid value           gid of the internal service user (required on EOS) (default: 0) [$ACCOUNTS_SERVICE_USER_GID]
   --uid-index-lower-bound value      define a starting point for the account UID (default: 0) [$ACCOUNTS_UID_INDEX_LOWER_BOUND]
   --gid-index-lower-bound value      define a starting point for the account GID (default: 1000) [$ACCOUNTS_GID_INDEX_LOWER_BOUND]
   --uid-index-upper-bound value      define an ending point for the account UID (default: 0) [$ACCOUNTS_UID_INDEX_UPPER_BOUND]
   --gid-index-upper-bound value      define an ending point for the account GID (default: 1000) [$ACCOUNTS_GID_INDEX_UPPER_BOUND]
   --help                             Show the help (default: false)
   --version                          Print the version (default: false)
```