### PR TITLE
introduce docker-compose eos setup

### DIFF
--- a/ocis/docker-compose-eos-test.yml
+++ b/ocis/docker-compose-eos-test.yml
@@ -1,0 +1,184 @@
+---
+version: '3.5'
+
+networks:
+  testnet:
+    name: testnet
+
+services:
+  ocis:
+    container_name: ocis
+    #image: owncloud/eos-ocis:1.0.0-rc2
+    build:
+      context: ./docker/eos-ocis
+    tty: true
+    privileged: true
+    stdin_open: true
+    ports:
+      - 9200:9200
+    env_file:
+      - ./config/eos-docker.env
+    hostname: ocis
+    networks:
+      - testnet
+    environment:
+      # ocis log level will be used for all services
+      OCIS_LOG_LEVEL: debug
+      # domain setup
+      # TODO currently the below lines hardcode the port to 9200, use an OCIS_URL that includes protocol and port
+      OCIS_DOMAIN: ${OCIS_DOMAIN:-localhost}
+      PROXY_OIDC_ISSUER: https://${OCIS_DOMAIN:-localhost}:9200
+      KONNECTD_ISS: https://${OCIS_DOMAIN:-localhost}:9200
+      PHOENIX_OIDC_AUTHORITY: https://${OCIS_DOMAIN:-localhost}:9200
+      PHOENIX_OIDC_METADATA_URL: https://${OCIS_DOMAIN:-localhost}:9200/.well-known/openid-configuration
+      PHOENIX_WEB_CONFIG_SERVER: https://${OCIS_DOMAIN:-localhost}:9200
+      STORAGE_OIDC_ISSUER: https://${OCIS_DOMAIN:-localhost}:9200
+      STORAGE_LDAP_IDP: https://${OCIS_DOMAIN:-localhost}:9200
+      # make home and users storages use eos
+      STORAGE_HOME_DRIVER: eoshome
+      STORAGE_USERS_DRIVER: eos
+      # make accounts use ocis storage driver
+      # TODO provision metadata storage in eos and switch to cs3 backend for accounts
+      ACCOUNTS_LOG_LEVEL: debug
+      ACCOUNTS_STORAGE_DISK_PATH: /var/tmp/ocis-accounts
+      # TODO make id the default in ocis-storage
+      STORAGE_DRIVER_EOS_LAYOUT: "{{substr 0 1 .Id.OpaqueId}}/{{.Id.OpaqueId}}"
+      STORAGE_FRONTEND_URL: https://${OCIS_DOMAIN:-localhost}:9200
+      STORAGE_DATAGATEWAY_URL: https://${OCIS_DOMAIN:-localhost}:9200/data
+      # common eos settings used for both drivers: eos and eoshome
+      STORAGE_DRIVER_EOS_MASTER_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      STORAGE_DRIVER_EOS_SLAVE_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      STORAGE_DRIVER_EOS_NAMESPACE: "/eos/dockertest/reva/users"
+      # the eos end xrdcopy binaries use this env var to find the eos mgm
+      EOS_MGM_URL: ${EOS_MGM_URL:-root://mgm-master.testnet:1094}
+      # TODO without this the /etc/nclcd.conf file is empty
+      LDAP_BINDDN: "cn=reva,ou=sysusers,dc=example,dc=org"
+      LDAP_BINDPW: "reva"
+
+  mgm-master:
+    container_name: mgm-master
+    image: owncloud/eos-mgm:4.6.5
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: mgm-master.testnet
+    networks:
+    - testnet
+    volumes:
+    - eos-mgm-master-log:/var/log/eos
+    - eos-mgm-master-config:/var/eos/config
+    - eos-mgm-master-ns-queue:/var/eos/ns-queue
+    # this volume kills mgm-master during startup
+    # - ./e/master/var/eos/md:/var/eos/md
+    environment:
+      EOS_SET_MASTER: 1
+
+  mq-master:
+    container_name: mq-master
+    image: owncloud/eos-mq:4.6.5
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: mq-master.testnet
+    networks:
+    - testnet
+    volumes:
+    - eos-mq-master-log:/var/log/eos
+    - eos-mq-master-config:/var/eos/config
+    - eos-mq-master-ns-queue:/var/eos/ns-queue
+    environment:
+      EOS_SET_MASTER: 1
+
+  fst:
+    container_name: fst
+    image: owncloud/eos-fst:4.6.5
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: fst.testnet
+    networks:
+    - testnet
+    volumes:
+    - eos-fst-log:/var/log/eos
+    - eos-fst-disks:/disks
+    environment:
+      EOS_MGM_URL: "root://mgm-master.testnet"
+
+  quark-1:
+    container_name: quark-1
+    image: owncloud/eos-qdb:4.6.5
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: quark-1.testnet
+    networks:
+    - testnet
+    volumes:
+    - eos-quarkdb1:/var/lib/quarkdb
+    environment:
+      EOS_QDB_DIR: "/var/lib/quarkdb/eosns"
+      EOS_QDB_PORT: "7777"
+      EOS_QDB_MODE: "raft"
+      EOS_QDB_CLUSTER_ID: "3d659c1a-e70f-43f0-bed4-941a2ca0765b"
+      EOS_QDB_NODES: "quark-1.testnet:7777,quark-2.testnet:7777,quark-3.testnet:7777"
+
+  quark-2:
+    container_name: quark-2
+    image: owncloud/eos-qdb:4.6.5
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: quark-2.testnet
+    networks:
+    - testnet
+    volumes:
+    - eos-quarkdb2:/var/lib/quarkdb
+    environment:
+      EOS_QDB_DIR: "/var/lib/quarkdb/eosns"
+      EOS_QDB_PORT: "7777"
+      EOS_QDB_MODE: "raft"
+      EOS_QDB_CLUSTER_ID: "3d659c1a-e70f-43f0-bed4-941a2ca0765b"
+      EOS_QDB_NODES: "quark-1.testnet:7777,quark-2.testnet:7777,quark-3.testnet:7777"
+
+  quark-3:
+    container_name: quark-3
+    image: owncloud/eos-qdb:4.6.5
+    tty: true
+    privileged: true
+    stdin_open: true
+    env_file:
+    - ./config/eos-docker.env
+    hostname: quark-3.testnet
+    networks:
+    - testnet
+    volumes:
+    - eos-quarkdb3:/var/lib/quarkdb
+    environment:
+      EOS_QDB_DIR: "/var/lib/quarkdb/eosns"
+      EOS_QDB_PORT: "7777"
+      EOS_QDB_MODE: "raft"
+      EOS_QDB_CLUSTER_ID: "3d659c1a-e70f-43f0-bed4-941a2ca0765b"
+      EOS_QDB_NODES: "quark-1.testnet:7777,quark-2.testnet:7777,quark-3.testnet:7777"
+
+volumes:
+  eos-mgm-master-log:
+  eos-mgm-master-config:
+  eos-mgm-master-ns-queue:
+  eos-mq-master-log:
+  eos-mq-master-config:
+  eos-mq-master-ns-queue:
+  eos-fst-log:
+  eos-fst-disks:
+  eos-quarkdb1:
+  eos-quarkdb2:
+  eos-quarkdb3:

--- a/ocis/docker/eos-ocis/entrypoint
+++ b/ocis/docker/eos-ocis/entrypoint
@@ -19,23 +19,4 @@ mkdir -p /var/tmp/reva
 
 echo "----- [ocis] Starting oCIS -----"
 # todo start ocis as daemon not as root
-ocis reva-storage-home &
-ocis reva-storage-home-data &
-ocis reva-storage-eos & 
-ocis reva-storage-eos-data &
-ocis reva-storage-public-link &
-ocis micro &
-ocis glauth &
-ocis graph-explorer &
-ocis graph &
-ocis konnectd &
-ocis phoenix &
-ocis thumbnails &
-ocis webdav &
-ocis reva-auth-basic &
-ocis reva-auth-bearer &
-ocis reva-frontend &
-ocis reva-gateway &
-ocis reva-sharing &
-ocis reva-users &
-exec ocis proxy
+exec ocis server


### PR DESCRIPTION
We introduce a PR that adds a new docker compose file for testing on eos.

```
cd ocis
docker-compose -f docker-compose-eos-test.yml up
```