### PR TITLE
[tests-only] Adjust PHP dependencies for composer 2.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -352,7 +352,7 @@ def localApiTests(ctx, coreBranch = 'master', coreCommit = '', storage = 'ownclo
       cloneCoreRepos(coreBranch, coreCommit) + [
       {
         'name': 'localApiTests-%s-storage' % (storage),
-        'image': 'owncloudci/php:7.2',
+        'image': 'owncloudci/php:7.4',
         'pull': 'always',
         'environment' : {
           'TEST_SERVER_URL': 'https://ocis-server:9200',
@@ -407,7 +407,7 @@ def coreApiTests(ctx, coreBranch = 'master', coreCommit = '', part_number = 1, n
       cloneCoreRepos(coreBranch, coreCommit) + [
       {
         'name': 'oC10ApiTests-%s-storage-%s' % (storage, part_number),
-        'image': 'owncloudci/php:7.2',
+        'image': 'owncloudci/php:7.4',
         'pull': 'always',
         'environment' : {
           'TEST_SERVER_URL': 'https://ocis-server:9200',
@@ -1430,7 +1430,7 @@ def cloneCoreRepos(coreBranch, coreCommit):
   return [
     {
       'name': 'clone-core-repos',
-      'image': 'owncloudci/php:7.2',
+      'image': 'owncloudci/php:7.4',
       'pull': 'always',
       'commands': [
         'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/tmp/testing',

--- a/ocis/vendor-bin/behat/composer.json
+++ b/ocis/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
   "config" : {
     "platform": {
-      "php": "7.2"
+      "php": "7.4"
     }
   },
   "require": {


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/38067

See issue for details - `behat` acceptance tests need to use PHP  7.4 for the dependencies to sort themselves out with composer 2.0
