### PR TITLE
Fix processing for prompt select_account with consent

### DIFF
--- a/changelog/unreleased/konnectd-switchacc-consent.md
+++ b/changelog/unreleased/konnectd-switchacc-consent.md
@@ -1,0 +1,9 @@
+Bugfix: Allow consent-prompt with switch-account
+
+Multiple prompt values are allowed and this change fixes the check for
+select_account if it was used together with other prompt values. Where
+select_account previously was ignored, it is now processed as required,
+fixing the use case when a RP wants to trigger select_account first
+while at the same time wants also to request interactive consent.
+
+https://github.com/owncloud/ocis/pull/788

--- a/konnectd/ui/src/containers/Login/Login.js
+++ b/konnectd/ui/src/containers/Login/Login.js
@@ -44,7 +44,7 @@ class Login extends React.PureComponent {
   componentDidMount() {
     const { hello, query, dispatch, history } = this.props;
     if (hello && hello.state && history.action !== 'PUSH') {
-      if (query.prompt !== 'select_account') {
+      if (!query.prompt || query.prompt.indexOf('select_account') == -1) {
         dispatch(advanceLogonFlow(true, history));
         return;
       }


### PR DESCRIPTION
Multiple prompt values are allowed and this change fixes the check for
select_account if it was used together with other prompt values. Where
select_account previously was ignored, it is now processed as required,
fixing the use case when a RP wants to trigger select_account first
while at the same time wants also to request interactive consent.

