### PR TITLE
Add letsencrypt as named volume

### DIFF
--- a/deployments/examples/ocis_oc10_backend/docker-compose.yml
+++ b/deployments/examples/ocis_oc10_backend/docker-compose.yml
@@ -11,6 +11,8 @@ volumes:
     driver: local
   tmp:
     driver: local
+  letsencrypt:
+    driver: local
 
 services:
   traefik:


### PR DESCRIPTION
Fix  "letsencrypt" is used in service "traefik" but no declaration was found in the volumes section.