### PR TITLE
[tests-only] Bump core commit id to include test code of PR 38077

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': 'f8f9de42f8a3af795fbfe658ca270b83fb435f84',
+    'coreCommit': '6e5e252dcd18448709006cb2de6fe86cb6d0ecec',
     'numberOfParts': 6
   },
   'uiTests': {


### PR DESCRIPTION
Makes sure that we are testing with the code in core PR  https://github.com/owncloud/core/pull/38077

There should be no change needed to OCIS other than bumping the core commit id.