### PR TITLE
[Tests-Only] update core commitid for test runner

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '6e5e252dcd18448709006cb2de6fe86cb6d0ecec',
+    'coreCommit': '5279179f6b70ace81d6a7758d2f46c3d284d7933',
     'numberOfParts': 6
   },
   'uiTests': {

--- a/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -1511,46 +1511,46 @@ apiWebdavPreviews/previews.feature:179
 #
 # https://github.com/owncloud/product/issues/241 deleting an item updates etags of grandparent but not on parent
 #
-apiWebdavEtagPropagation1/deleteFileFolder.feature:25
 apiWebdavEtagPropagation1/deleteFileFolder.feature:26
-apiWebdavEtagPropagation1/deleteFileFolder.feature:43
-apiWebdavEtagPropagation1/deleteFileFolder.feature:44
-apiWebdavEtagPropagation1/deleteFileFolder.feature:62
-apiWebdavEtagPropagation1/deleteFileFolder.feature:63
-apiWebdavEtagPropagation1/deleteFileFolder.feature:185
-apiWebdavEtagPropagation1/deleteFileFolder.feature:199
+apiWebdavEtagPropagation1/deleteFileFolder.feature:27
+apiWebdavEtagPropagation1/deleteFileFolder.feature:45
+apiWebdavEtagPropagation1/deleteFileFolder.feature:46
+apiWebdavEtagPropagation1/deleteFileFolder.feature:65
+apiWebdavEtagPropagation1/deleteFileFolder.feature:66
+apiWebdavEtagPropagation1/deleteFileFolder.feature:193
+apiWebdavEtagPropagation1/deleteFileFolder.feature:208
 #
 # https://github.com/owncloud/product/issues/241 deleting an item updates etags of grandparent but not on parent
 # https://github.com/owncloud/product/issues/243 etags don't change for a share receiver
 #
-apiWebdavEtagPropagation1/deleteFileFolder.feature:91
-apiWebdavEtagPropagation1/deleteFileFolder.feature:92
-apiWebdavEtagPropagation1/deleteFileFolder.feature:120
-apiWebdavEtagPropagation1/deleteFileFolder.feature:121
-apiWebdavEtagPropagation1/deleteFileFolder.feature:151
-apiWebdavEtagPropagation1/deleteFileFolder.feature:152
-apiWebdavEtagPropagation1/deleteFileFolder.feature:182
-apiWebdavEtagPropagation1/deleteFileFolder.feature:183
+apiWebdavEtagPropagation1/deleteFileFolder.feature:95
+apiWebdavEtagPropagation1/deleteFileFolder.feature:96
+apiWebdavEtagPropagation1/deleteFileFolder.feature:125
+apiWebdavEtagPropagation1/deleteFileFolder.feature:126
+apiWebdavEtagPropagation1/deleteFileFolder.feature:157
+apiWebdavEtagPropagation1/deleteFileFolder.feature:158
+apiWebdavEtagPropagation1/deleteFileFolder.feature:189
+apiWebdavEtagPropagation1/deleteFileFolder.feature:190
 #
 # https://github.com/owncloud/product/issues/243 etags don't change for a share receiver
 #
-apiWebdavEtagPropagation1/moveFileFolder.feature:235
-apiWebdavEtagPropagation1/moveFileFolder.feature:236
-apiWebdavEtagPropagation1/moveFileFolder.feature:303
-apiWebdavEtagPropagation1/moveFileFolder.feature:304
-apiWebdavEtagPropagation2/copyFileFolder.feature:152
-apiWebdavEtagPropagation2/copyFileFolder.feature:153
+apiWebdavEtagPropagation1/moveFileFolder.feature:244
+apiWebdavEtagPropagation1/moveFileFolder.feature:245
+apiWebdavEtagPropagation1/moveFileFolder.feature:314
+apiWebdavEtagPropagation1/moveFileFolder.feature:315
+apiWebdavEtagPropagation2/copyFileFolder.feature:158
+apiWebdavEtagPropagation2/copyFileFolder.feature:159
 #
 # https://github.com/owncloud/product/issues/209 Implement Trashbin Feature for ocis storage
 #
-apiWebdavEtagPropagation2/restoreFromTrash.feature:25
 apiWebdavEtagPropagation2/restoreFromTrash.feature:26
-apiWebdavEtagPropagation2/restoreFromTrash.feature:46
-apiWebdavEtagPropagation2/restoreFromTrash.feature:47
-apiWebdavEtagPropagation2/restoreFromTrash.feature:65
-apiWebdavEtagPropagation2/restoreFromTrash.feature:66
-apiWebdavEtagPropagation2/restoreFromTrash.feature:86
-apiWebdavEtagPropagation2/restoreFromTrash.feature:87
+apiWebdavEtagPropagation2/restoreFromTrash.feature:27
+apiWebdavEtagPropagation2/restoreFromTrash.feature:48
+apiWebdavEtagPropagation2/restoreFromTrash.feature:49
+apiWebdavEtagPropagation2/restoreFromTrash.feature:68
+apiWebdavEtagPropagation2/restoreFromTrash.feature:69
+apiWebdavEtagPropagation2/restoreFromTrash.feature:90
+apiWebdavEtagPropagation2/restoreFromTrash.feature:91
 #
 # https://github.com/owncloud/product/issues/210 Implement Versions Feature for ocis storage
 #

--- a/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/ocis/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -619,6 +619,7 @@ apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:115
 #
 # https://github.com/owncloud/ocis-reva/issues/11 listing received shares does not work
 #
+apiShareManagementBasicToShares/createShareToSharesFolder.feature:367
 apiSharePublicLink2/updatePublicLinkShare.feature:303
 apiSharePublicLink2/updatePublicLinkShare.feature:304
 apiSharePublicLink2/updatePublicLinkShare.feature:322
@@ -1412,6 +1413,23 @@ apiWebdavUpload2/uploadFileUsingOldChunking.feature:98
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:99
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:100
 #
+# https://github.com/owncloud/ocis-reva/issues/243  Sharing does not work
+#
+apiShareManagementBasicToShares/createShareToSharesFolder.feature:529
+apiShareManagementBasicToShares/createShareToSharesFolder.feature:547
+apiShareManagementBasicToShares/createShareToSharesFolder.feature:565
+#
+# https://github.com/owncloud/ocis-reva/issues/357  Delete shares from user when user is deleted
+# https://github.com/owncloud/ocis-reva/issues/302  when sharing a file mime-type field is set to `application/octet-stream
+# https://github.com/owncloud/ocis-reva/issues/301  no displayname_owner shown when creating a share
+#
+apiShareOperationsToShares/gettingShares.feature:167
+apiShareOperationsToShares/gettingShares.feature:168
+#
+# https://github.com/owncloud/ocis-reva/issues/335  Moving resource loses associated shares
+#
+apiSharePublicLink2/multilinkSharing.feature:181
+#
 # https://github.com/owncloud/ocis/issues/187 Previews via webDAV API tests fail on OCIS
 #
 apiWebdavPreviews/previews.feature:15
@@ -1536,3 +1554,40 @@ apiVersions/fileVersionsSharingToShares.feature:267
 #
 apiVersions/fileVersionsSharingToShares.feature:252
 apiVersions/fileVersionsSharingToShares.feature:253
+
+#
+# https://github.com/owncloud/product/issues/279 etags are not updated on file operations
+#
+# renaming file/folder doesn't changes the etag of parent
+# moving a file/folder from one folder to another doesn't changes etag of destination folder
+# renaming a file/folder inside another folder doesn't changes etag of parent folder
+# restoring a file doesn't changes the etags of the parents
+#
+apiWebdavEtagPropagation1/moveFileFolder.feature:21
+apiWebdavEtagPropagation1/moveFileFolder.feature:22
+apiWebdavEtagPropagation1/moveFileFolder.feature:41
+apiWebdavEtagPropagation1/moveFileFolder.feature:42
+apiWebdavEtagPropagation1/moveFileFolder.feature:61
+apiWebdavEtagPropagation1/moveFileFolder.feature:62
+apiWebdavEtagPropagation1/moveFileFolder.feature:78
+apiWebdavEtagPropagation1/moveFileFolder.feature:79
+apiWebdavEtagPropagation1/moveFileFolder.feature:98
+apiWebdavEtagPropagation1/moveFileFolder.feature:99
+apiWebdavEtagPropagation1/moveFileFolder.feature:146
+apiWebdavEtagPropagation1/moveFileFolder.feature:147
+apiWebdavEtagPropagation1/moveFileFolder.feature:174
+apiWebdavEtagPropagation1/moveFileFolder.feature:175
+apiWebdavEtagPropagation1/moveFileFolder.feature:244
+apiWebdavEtagPropagation1/moveFileFolder.feature:245
+apiWebdavEtagPropagation1/moveFileFolder.feature:314
+apiWebdavEtagPropagation1/moveFileFolder.feature:315
+apiWebdavEtagPropagation1/moveFileFolder.feature:318
+apiWebdavEtagPropagation1/moveFileFolder.feature:334
+apiWebdavEtagPropagation2/restoreFromTrash.feature:26
+apiWebdavEtagPropagation2/restoreFromTrash.feature:27
+apiWebdavEtagPropagation2/restoreFromTrash.feature:48
+apiWebdavEtagPropagation2/restoreFromTrash.feature:49
+apiWebdavEtagPropagation2/restoreFromTrash.feature:68
+apiWebdavEtagPropagation2/restoreFromTrash.feature:69
+apiWebdavEtagPropagation2/restoreFromTrash.feature:90
+apiWebdavEtagPropagation2/restoreFromTrash.feature:91


### PR DESCRIPTION
Includes changes from:
https://github.com/owncloud/core/pull/38075 [Tests-Only] Remove skipOnOcis tags
https://github.com/owncloud/core/pull/38079 [Tests-Only] unskip etag propagation tests for oc storage in ocis
https://github.com/owncloud/core/pull/38080 [tests-only] Adjust skipOnOcis-OC-Storage for etag test scenarios

This gets more of the API test scenarios running in CI. So we will know if their pass/fail status changes with new PRs.
