### PR TITLE
[QA] docker/eos-ocis builds without tagging

### DIFF
--- a/ocis/docker-compose-eos-test.yml
+++ b/ocis/docker-compose-eos-test.yml
@@ -11,6 +11,8 @@ services:
     #image: owncloud/eos-ocis:1.0.0-rc2
     build:
       context: ./docker/eos-ocis
+      args:
+        BRANCH: v1.0.0-rc3
     tty: true
     privileged: true
     stdin_open: true


### PR DESCRIPTION
Seen in ocis v1.0.0-rc3 using ocis/ocis/docker-compose-eos-test.yml

The Dockerfile in docker/eos-ocis is run without a BRANCH build arg, and thus currently always defaults to master.

In general, version pinning is very important for reproducable results, but:
CAUTION: With v1.0.0-rc3, ldap stops working, when we apply this PR.

`nslcd -d` is running, but `id einstein` fails with `no such user`.

docker logs
```
Attaching to ocis
ocis          | 2020-11-06 10:46:01.968715 I | handleSearchRequest error LDAP Result Code 1 "Operations Error": search error: error listing users
ocis          | nslcd: [7b23c6] <passwd=20000> ldap_result() failed: Operations error
ocis          | 2020-11-06T10:46:17Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | 2020-11-06T10:46:47Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | 2020-11-06T10:47:17Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | 2020-11-06T10:47:47Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | 2020-11-06T10:48:17Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | 2020-11-06T10:48:47Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | 2020-11-06T10:49:17Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | 2020-11-06T10:49:47Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
ocis          | nslcd: [3c9869] DEBUG: connection from pid=317 uid=0 gid=0
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: myldap_search(base="dc=example,dc=org", filter="(&(objectClass=posixAccount)(uid=einstein))")
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_initialize(ldap://ocis.testnet:9125/)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_rebind_proc()
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_option(LDAP_OPT_PROTOCOL_VERSION,3)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_option(LDAP_OPT_DEREF,0)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_option(LDAP_OPT_TIMELIMIT,0)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_option(LDAP_OPT_TIMEOUT,0)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_option(LDAP_OPT_NETWORK_TIMEOUT,0)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_option(LDAP_OPT_REFERRALS,LDAP_OPT_ON)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_set_option(LDAP_OPT_RESTART,LDAP_OPT_ON)
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_simple_bind_s("cn=reva,ou=sysusers,dc=example,dc=org","***") (uri="ldap://ocis.testnet:9125/")
ocis          | 2020-11-06T10:50:13Z DBG Bind request basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org handler=ocis service=glauth src={"IP":"172.18.0.7","Port":49908,"Zone":""}
ocis          | nslcd: DEBUG: accept() failed (ignored): Resource temporarily unavailable
ocis          | 2020-11-06T10:50:14Z DBG Bind success binddn=cn=reva,ou=sysusers,dc=example,dc=org handler=ocis service=glauth src={"IP":"172.18.0.7","Port":49908,"Zone":""}
ocis          | 2020-11-06T10:50:14Z DBG Search request basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org filter=(&(objectClass=posixAccount)(uid=einstein)) handler=ocis service=glauth src={"IP":"172.18.0.7","Port":49908,"Zone":""}
ocis          | 2020-11-06T10:50:14Z DBG parsed query basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org filter=(&(objectClass=posixAccount)(uid=einstein)) handler=ocis qtype=users query="on_premises_sam_account_name eq 'einstein'" service=glauth
ocis          | 2020-11-06T10:50:14Z DBG found account AccountEnabled=true CreatedDateTime=null DeletedDateTime=null Description= DisplayName="Albert Einstein" GidNumber=30000 Id=4c510ada-c86b-4815-8820-42cdf82c3d51 Identities=null IsResourceAccount=false Mail=einstein@example.org MemberOf=[{"id":"509a9dcd-bb37-4f4f-a01a-19dca27d9cfa"},{"id":"6040aa17-9c64-4fef-9bd0-77234d71bad0"},{"id":"dd58e5ec-842e-498b-8800-61f2ec6f911f"},{"id":"262982c1-2362-4afa-bfdf-8cbfef64a06e"}] OnPremisesDistinguishedName= OnPremisesLastSyncDateTime=null OnPremisesSamAccountName=einstein OnPremisesSecurityIdentifier= OnPremisesSyncEnabled=false OnPremisesUserPrincipalName= PreferredName=einstein UidNumber=20000 service=accounts
ocis          | 2020-11-06T10:50:14Z DBG AP: Search OK basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org filter=(&(objectClass=posixAccount)(uid=einstein)) handler=ocis num_entries=1 service=glauth src={"IP":"172.18.0.7","Port":49908,"Zone":""}
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_result(): cn=einstein,ou=users,dc=example,dc=org
ocis          | nslcd: [3c9869] <passwd="einstein"> cn=einstein,ou=users,dc=example,dc=org: homeDirectory: missing
ocis          | nslcd: [3c9869] <passwd="einstein"> DEBUG: ldap_result(): end of results (1 total)
ocis          | nslcd: [334873] DEBUG: connection from pid=317 uid=0 gid=0
ocis          | nslcd: [334873] <passwd=20000> DEBUG: myldap_search(base="dc=example,dc=org", filter="(&(objectClass=posixAccount)(uidNumber=20000))")
ocis          | nslcd: [334873] <passwd=20000> ldap_search_ext() failed: Can't contact LDAP server: Broken pipe
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_unbind()
ocis          | nslcd: [334873] <passwd=20000> no available LDAP server found, sleeping 1 seconds
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_initialize(ldap://ocis.testnet:9125/)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_rebind_proc()
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_option(LDAP_OPT_PROTOCOL_VERSION,3)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_option(LDAP_OPT_DEREF,0)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_option(LDAP_OPT_TIMELIMIT,0)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_option(LDAP_OPT_TIMEOUT,0)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_option(LDAP_OPT_NETWORK_TIMEOUT,0)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_option(LDAP_OPT_REFERRALS,LDAP_OPT_ON)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_set_option(LDAP_OPT_RESTART,LDAP_OPT_ON)
ocis          | nslcd: [334873] <passwd=20000> DEBUG: ldap_simple_bind_s("cn=reva,ou=sysusers,dc=example,dc=org","***") (uri="ldap://ocis.testnet:9125/")
ocis          | 2020-11-06T10:50:15Z DBG Bind request basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org handler=ocis service=glauth src={"IP":"172.18.0.7","Port":49914,"Zone":""}
ocis          | 2020-11-06T10:50:15Z DBG Bind success binddn=cn=reva,ou=sysusers,dc=example,dc=org handler=ocis service=glauth src={"IP":"172.18.0.7","Port":49914,"Zone":""}
ocis          | nslcd: [334873] <passwd=20000> connected to LDAP server ldap://ocis.testnet:9125/
ocis          | 2020-11-06T10:50:15Z DBG Search request basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org filter=(&(objectClass=posixAccount)(uidNumber=20000)) handler=ocis service=glauth src={"IP":"172.18.0.7","Port":49914,"Zone":""}
ocis          | 2020-11-06T10:50:15Z DBG parsed query basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org filter=(&(objectClass=posixAccount)(uidNumber=20000)) handler=ocis qtype=users query="uid_number eq 20000" service=glauth
ocis          | 2020-11-06T10:50:15Z ERR Could not list accounts error="{\"id\":\"com.owncloud.api.accounts\",\"code\":400,\"detail\":\"unsupported query uid_number eq 20000\",\"status\":\"Bad Request\"}" basedn=dc=example,dc=org binddn=cn=reva,ou=sysusers,dc=example,dc=org filter=(&(objectClass=posixAccount)(uidNumber=20000)) handler=ocis query="uid_number eq 20000" service=glauth src={"IP":"172.18.0.7","Port":49914,"Zone":""}
ocis          | 2020-11-06 10:50:15.256272 I | handleSearchRequest error LDAP Result Code 1 "Operations Error": search error: error listing users
ocis          | nslcd: [334873] <passwd=20000> ldap_result() failed: Operations error
ocis          | 2020-11-06T10:50:17Z DBG refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.storage","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.storage-0a36ed03-abe8-4961-b1db-39b8c1614a42","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}
```