### PR TITLE
hide account.id in ocs api, use username

### DIFF
--- a/changelog/unreleased/ocs-map-userid-to-username.md
+++ b/changelog/unreleased/ocs-map-userid-to-username.md
@@ -7,3 +7,4 @@ service. The userid in OCS requests is in fact the username, not our internal ac
 as our internal account id though, because the account id is part of various `path` formats.
 
 https://github.com/owncloud/ocis/pull/709
+https://github.com/owncloud/ocis/pull/816

--- a/ocs/pkg/service/v0/users.go
+++ b/ocs/pkg/service/v0/users.go
@@ -56,7 +56,7 @@ func (o Ocs) GetSelf(w http.ResponseWriter, r *http.Request) {
 	o.logger.Debug().Interface("account", account).Msg("got user")
 
 	d := &data.User{
-		UserID:            account.Id,
+		UserID:            account.OnPremisesSamAccountName,
 		DisplayName:       account.DisplayName,
 		LegacyDisplayName: account.DisplayName,
 		Email:             account.Mail,
@@ -104,7 +104,7 @@ func (o Ocs) GetUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	d := &data.User{
-		UserID:            account.Id,
+		UserID:            account.OnPremisesSamAccountName,
 		DisplayName:       account.DisplayName,
 		LegacyDisplayName: account.DisplayName,
 		Email:             account.Mail,
@@ -218,7 +218,7 @@ func (o Ocs) AddUser(w http.ResponseWriter, r *http.Request) {
 		enabled = "false"
 	}
 	render.Render(w, r, response.DataRender(&data.User{
-		UserID:            account.Id,
+		UserID:            account.OnPremisesSamAccountName,
 		DisplayName:       account.DisplayName,
 		LegacyDisplayName: account.DisplayName,
 		Email:             account.Mail,


### PR DESCRIPTION
the ocs should always expose the username. it is oblivious of our persistent account.id
- [x] changelog, for now I want to see if the tests break