### PR TITLE
[tests-only] Trigger CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -14,8 +14,8 @@ config = {
     'webdav':'',
   },
   'apiTests': {
-    'coreBranch': 'master',
-    'coreCommit': '5279179f6b70ace81d6a7758d2f46c3d284d7933',
+    'coreBranch': 'fix-ocis-failure',
+    'coreCommit': 'f184f5217361ccc92ab00f59402f4afa0e472cb1',
     'numberOfParts': 6
   },
   'uiTests': {


### PR DESCRIPTION
CI has been getting acceptance test pipelines that suddenly start having a big list of failures. It might be that the accounts provisioning is not working reliably, and so when an account (e.g. `Alice`) does not get fully deleted, then all the remaining test scenarios fail in the pipeline.

Demonstration for issue #819 