### PR TITLE
fix 820 - race condition

### DIFF
--- a/accounts/pkg/command/server.go
+++ b/accounts/pkg/command/server.go
@@ -83,8 +83,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 				gr.Add(func() error {
 					logger.Info().Str("service", server.Name()).Msg("Reporting settings bundles to settings service")
-					go svc.RegisterSettingsBundles(&logger)
-					go svc.RegisterPermissions(&logger)
+					svc.RegisterSettingsBundles(&logger)
+					svc.RegisterPermissions(&logger)
 					return server.Run()
 				}, func(_ error) {
 					logger.Info().

--- a/accounts/pkg/service/v0/permissions.go
+++ b/accounts/pkg/service/v0/permissions.go
@@ -35,9 +35,9 @@ func RegisterPermissions(l *olog.Logger) {
 		res, err := service.AddSettingToBundle(context.Background(), &permissionRequests[i])
 		bundleID := permissionRequests[i].BundleId
 		if err != nil {
-			l.Err(err).Str("bundle", bundleID).Str("setting", permissionRequests[i].Setting.Id).Msg("error adding setting to bundle")
+			l.Err(err).Str("bundle", bundleID).Str("setting", permissionRequests[i].Setting.Id).Msg("error adding permission to bundle")
 		} else {
-			l.Info().Str("bundle", bundleID).Str("setting", res.Setting.Id).Msg("successfully added setting to bundle")
+			l.Info().Str("bundle", bundleID).Str("setting", res.Setting.Id).Msg("successfully added permission to bundle")
 		}
 	}
 }

--- a/changelog/unreleased/fix-820.md
+++ b/changelog/unreleased/fix-820.md
@@ -1,0 +1,5 @@
+Bugfix: Make settings service start without go coroutines
+
+The go routines cause a race condition that sometimes causes the tests to fail. The ListRoles request would not return all permissions.
+
+https://github.com/owncloud/ocis/pull/835


### PR DESCRIPTION
The go routines cause a race condition that sometimes causes the tests to fail. The ListRoles request would not return all permissions.