### PR TITLE
[tests-only] Bump phoenix commit id used for UI tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -20,7 +20,7 @@ config = {
   },
   'uiTests': {
     'phoenixBranch': 'master',
-    'phoenixCommit': 'f6d2f9bd869758b645debaadb29c60e0154e20c3',
+    'phoenixCommit': '645d91f0dadde314b3173afafe30eb3cff12bf59',
     'suites': {
       'phoenixWebUI1': [
         'webUICreateFilesFolders',


### PR DESCRIPTION
This brings phoenix UI test improvements from:
https://github.com/owncloud/phoenix/pull/4291 [tests-only] remove skipOnOCIS tag from moveFiles test
https://github.com/owncloud/phoenix/pull/4297 [tests-only] fix loginAsUser
https://github.com/owncloud/phoenix/pull/4285 [Tests-Only] update ocis commit id for running acceptance tests (note: this does not change any of the actual test code that will be used here)
