### PR TITLE
[tests-only] Add tests using the default ACCOUNTS_HASH_DIFFICULTY

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1383,37 +1383,44 @@ def frontend(module):
     }
   ]
 
-def ocisServer(storage):
+def ocisServer(storage, accounts_hash_difficulty = 4):
+  environment = {
+    #'OCIS_LOG_LEVEL': 'debug',
+    'STORAGE_HOME_DRIVER': '%s' % (storage),
+    'STORAGE_USERS_DRIVER': '%s' % (storage),
+    'STORAGE_DRIVER_OCIS_ROOT': '/srv/app/tmp/ocis/storage/users',
+    'STORAGE_DRIVER_LOCAL_ROOT': '/srv/app/tmp/ocis/local/root',
+    'STORAGE_METADATA_ROOT': '/srv/app/tmp/ocis/metadata',
+    'STORAGE_DRIVER_OWNCLOUD_DATADIR': '/srv/app/tmp/ocis/owncloud/data',
+    'STORAGE_DRIVER_OWNCLOUD_REDIS_ADDR': 'redis:6379',
+    'STORAGE_LDAP_IDP': 'https://ocis-server:9200',
+    'STORAGE_OIDC_ISSUER': 'https://ocis-server:9200',
+    'PROXY_OIDC_ISSUER': 'https://ocis-server:9200',
+    'STORAGE_HOME_DATA_SERVER_URL': 'http://ocis-server:9155/data',
+    'STORAGE_DATAGATEWAY_PUBLIC_URL': 'https://ocis-server:9200/data',
+    'STORAGE_USERS_DATA_SERVER_URL': 'http://ocis-server:9158/data',
+    'STORAGE_FRONTEND_PUBLIC_URL': 'https://ocis-server:9200',
+    'PROXY_ENABLE_BASIC_AUTH': True,
+    'PHOENIX_WEB_CONFIG': '/drone/src/ocis/tests/config/drone/ocis-config.json',
+    'KONNECTD_IDENTIFIER_REGISTRATION_CONF': '/drone/src/ocis/tests/config/drone/identifier-registration.yml',
+    'KONNECTD_ISS': 'https://ocis-server:9200',
+    'KONNECTD_TLS': 'true',
+  }
+
+  # Pass in "default" accounts_hash_difficulty to not set this environment variable.
+  # That will allow OCIS to use whatever its built-in default is.
+  # Otherwise pass in a value from 4 to about 11 or 12 (default 4, for making regular tests fast)
+  # The high values cause lots of CPU to be used when hashing passwords, and really slow down the tests.
+  if (accounts_hash_difficulty != 'default'):
+    environment['ACCOUNTS_HASH_DIFFICULTY'] = accounts_hash_difficulty
+
   return [
     {
       'name': 'ocis-server',
       'image': 'webhippie/golang:1.14',
       'pull': 'always',
       'detach': True,
-      'environment' : {
-        #'OCIS_LOG_LEVEL': 'debug',
-        'STORAGE_HOME_DRIVER': '%s' % (storage),
-        'STORAGE_USERS_DRIVER': '%s' % (storage),
-        'STORAGE_DRIVER_OCIS_ROOT': '/srv/app/tmp/ocis/storage/users',
-        'STORAGE_DRIVER_LOCAL_ROOT': '/srv/app/tmp/ocis/local/root',
-        'STORAGE_METADATA_ROOT': '/srv/app/tmp/ocis/metadata',
-        'STORAGE_DRIVER_OWNCLOUD_DATADIR': '/srv/app/tmp/ocis/owncloud/data',
-        'STORAGE_DRIVER_OWNCLOUD_REDIS_ADDR': 'redis:6379',
-        'STORAGE_LDAP_IDP': 'https://ocis-server:9200',
-        'STORAGE_OIDC_ISSUER': 'https://ocis-server:9200',
-        'PROXY_OIDC_ISSUER': 'https://ocis-server:9200',
-        'STORAGE_HOME_DATA_SERVER_URL': 'http://ocis-server:9155/data',
-        'STORAGE_DATAGATEWAY_PUBLIC_URL': 'https://ocis-server:9200/data',
-        'STORAGE_USERS_DATA_SERVER_URL': 'http://ocis-server:9158/data',
-        'STORAGE_FRONTEND_PUBLIC_URL': 'https://ocis-server:9200',
-        'PROXY_ENABLE_BASIC_AUTH': True,
-        'PHOENIX_WEB_CONFIG': '/drone/src/ocis/tests/config/drone/ocis-config.json',
-        'KONNECTD_IDENTIFIER_REGISTRATION_CONF': '/drone/src/ocis/tests/config/drone/identifier-registration.yml',
-        'KONNECTD_ISS': 'https://ocis-server:9200',
-        'KONNECTD_TLS': 'true',
-        # 4 is the lowest possible value. ONLY FOR TESTS
-        'ACCOUNTS_HASH_DIFFICULTY': 4,
-      },
+      'environment' : environment,
       'commands': [
         'apk add mailcap', # install /etc/mime.types
         'mkdir -p /srv/app/tmp/ocis/owncloud/data/',

--- a/ocis/tests/acceptance/config/behat.yml
+++ b/ocis/tests/acceptance/config/behat.yml
@@ -3,9 +3,9 @@ default:
     '': '%paths.base%/../features/bootstrap'
 
   suites:
-    apiOcisSpecific:
+    apiBasic:
       paths:
-        - '%paths.base%/../features/apiOcisSpecific'
+        - '%paths.base%/../features/apiBasic'
       context: &common_ldap_suite_context
         parameters:
           ldapAdminPassword: admin
@@ -21,6 +21,22 @@ default:
             adminPassword: admin
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
+        - CapabilitiesContext:
+        - ChecksumContext:
+        - FavoritesContext:
+        - FilesVersionsContext:
+        - PublicWebDavContext:
+        - TrashbinContext:
+        - WebDavPropertiesContext:
+
+    apiOcisSpecific:
+      paths:
+        - '%paths.base%/../features/apiOcisSpecific'
+      context: *common_ldap_suite_context
+      contexts:
+        - RevaContext:
+        - OccContext:
+        - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
         - ChecksumContext:
         - FavoritesContext:

--- a/ocis/tests/acceptance/features/apiBasic/addUser.feature
+++ b/ocis/tests/acceptance/features/apiBasic/addUser.feature
@@ -1,0 +1,18 @@
+@api @provisioning_api-app-required @skipOnLDAP
+Feature: add user
+  As an admin
+  I want to be able to add users
+  So that I can give people controlled individual access to resources on the ownCloud server
+
+  Scenario Outline: admin creates a user
+    Given using OCS API version "<ocs_api_version>"
+    And user "brand-new-user" has been deleted
+    When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
+    And user "brand-new-user" should be able to access a skeleton file
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/ocis/tests/acceptance/features/apiBasic/createShareToSharesFolder.feature
+++ b/ocis/tests/acceptance/features/apiBasic/createShareToSharesFolder.feature
@@ -1,0 +1,18 @@
+@api @files_sharing-app-required
+Feature: sharing
+
+  Scenario Outline: Creating a share of a file with a user
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using OCS API version "<ocs_api_version>"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
+    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the HTTP status code should be "200"
+    And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0"
+    Examples:
+      | ocs_api_version |
+      | 1               |
+      | 2               |

--- a/ocis/tests/acceptance/features/apiBasic/uploadFile.feature
+++ b/ocis/tests/acceptance/features/apiBasic/uploadFile.feature
@@ -1,0 +1,18 @@
+@api
+Feature: upload file
+  As a user
+  I want to be able to upload files
+  So that I can store and share files between multiple client systems
+
+  Scenario Outline: upload a file and check download content
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And using <dav_version> DAV path
+    When user "Alice" uploads file with content "uploaded content" to "/upload.txt" using the WebDAV API
+    Then the content of file "/upload.txt" for user "Alice" should be "uploaded content"
+    Examples:
+      | ocs_api_version | dav_version |
+      | 1               | old         |
+      | 1               | new         |
+      | 2               | old         |
+      | 2               | new         |

--- a/ocis/tests/acceptance/features/apiBasic/webDavPUTAuthInvalid.feature
+++ b/ocis/tests/acceptance/features/apiBasic/webDavPUTAuthInvalid.feature
@@ -1,0 +1,26 @@
+@api
+Feature: attempt to PUT files with invalid password
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+
+  Scenario: send PUT requests to webDav endpoints as normal user with wrong password
+    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/webdav/textfile0.txt                   |
+      | /remote.php/dav/files/%username%/textfile0.txt     |
+      | /remote.php/webdav/PARENT                          |
+      | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  Scenario: send PUT requests to webDav endpoints as normal user with no password
+    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/webdav/textfile0.txt                   |
+      | /remote.php/dav/files/%username%/textfile0.txt     |
+      | /remote.php/webdav/PARENT                          |
+      | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"


### PR DESCRIPTION
The acceptance tests currently use ACCOUNTS_HASH_DIFFICULTY of 4, the minimum value. This is good for getting the general tests to run fast. Not too much time is spent computing the hash of test user passwords. But we should also have a small number of tests that confirm that the default setting (currently 11) does actually work.

1) Make ACCOUNTS_HASH_DIFFICULTY optional/settable in .drone.star

2) Add a short local API test pipeline that sets accounts_hash_difficulty to "default". It runs a new local suite called `apiBasic`. I put some basic tests in there that confirm:
- user can be created
- share can be created and sharee can access it
- file can be uploaded
- some attempts to do things with an invalid password fail

That should confirm that with the higher "default" hash difficulty (currently 11) password checks are still working.