### PR TITLE
Fix tracing service names

### DIFF
--- a/changelog/unreleased/ocis-root-config.md
+++ b/changelog/unreleased/ocis-root-config.md
@@ -5,3 +5,4 @@ Tags: ocis
 We moved the tracing config to the `root` flagset so that they are parsed on all commands. We also introduced a `JWTSecret` flag in the root flagset, in order to apply a common default JWTSecret to all services that have one.
 
 https://github.com/owncloud/ocis/pull/842
+https://github.com/owncloud/ocis/pull/843

--- a/glauth/pkg/command/server.go
+++ b/glauth/pkg/command/server.go
@@ -76,7 +76,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/konnectd/pkg/command/server.go
+++ b/konnectd/pkg/command/server.go
@@ -81,7 +81,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/ocis-phoenix/pkg/command/server.go
+++ b/ocis-phoenix/pkg/command/server.go
@@ -70,7 +70,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/ocis/pkg/command/glauth.go
+++ b/ocis/pkg/command/glauth.go
@@ -43,7 +43,6 @@ func configureGLAuth(cfg *config.Config) *svcconfig.Config {
 		cfg.GLAuth.Tracing.Type = cfg.Tracing.Type
 		cfg.GLAuth.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.GLAuth.Tracing.Collector = cfg.Tracing.Collector
-		cfg.GLAuth.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.GLAuth

--- a/ocis/pkg/command/konnectd.go
+++ b/ocis/pkg/command/konnectd.go
@@ -44,7 +44,6 @@ func configureKonnectd(cfg *config.Config) *svcconfig.Config {
 		cfg.Konnectd.Tracing.Type = cfg.Tracing.Type
 		cfg.Konnectd.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Konnectd.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Konnectd.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Konnectd

--- a/ocis/pkg/command/ocs.go
+++ b/ocis/pkg/command/ocs.go
@@ -45,7 +45,6 @@ func configureOCS(cfg *config.Config) *svcconfig.Config {
 		cfg.OCS.Tracing.Type = cfg.Tracing.Type
 		cfg.OCS.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.OCS.Tracing.Collector = cfg.Tracing.Collector
-		cfg.OCS.Tracing.Service = cfg.Tracing.Service
 	}
 
 	if cfg.TokenManager.JWTSecret != "" {

--- a/ocis/pkg/command/phoenix.go
+++ b/ocis/pkg/command/phoenix.go
@@ -47,7 +47,6 @@ func configurePhoenix(cfg *config.Config) *config.Config {
 		cfg.Phoenix.Tracing.Type = cfg.Tracing.Type
 		cfg.Phoenix.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Phoenix.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Phoenix.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg

--- a/ocis/pkg/command/proxy.go
+++ b/ocis/pkg/command/proxy.go
@@ -45,7 +45,6 @@ func configureProxy(cfg *config.Config) *svcconfig.Config {
 		cfg.Proxy.Tracing.Type = cfg.Tracing.Type
 		cfg.Proxy.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Proxy.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Proxy.Tracing.Service = cfg.Tracing.Service
 	}
 
 	if cfg.TokenManager.JWTSecret != "" {

--- a/ocis/pkg/command/settings.go
+++ b/ocis/pkg/command/settings.go
@@ -45,7 +45,6 @@ func configureSettings(cfg *config.Config) *svcconfig.Config {
 		cfg.Settings.Tracing.Type = cfg.Tracing.Type
 		cfg.Settings.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Settings.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Settings.Tracing.Service = cfg.Tracing.Service
 	}
 
 	if cfg.TokenManager.JWTSecret != "" {

--- a/ocis/pkg/command/storageauthbasic.go
+++ b/ocis/pkg/command/storageauthbasic.go
@@ -39,7 +39,6 @@ func configureStorageAuthBasic(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storageauthbearer.go
+++ b/ocis/pkg/command/storageauthbearer.go
@@ -4,11 +4,11 @@ package command
 
 import (
 	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
-	"github.com/owncloud/ocis/ocis/pkg/config"
-	"github.com/owncloud/ocis/ocis/pkg/register"
 )
 
 // StorageAuthBearerCommand is the entrypoint for the reva-auth-bearer command.
@@ -39,7 +39,6 @@ func configureStorageAuthBearer(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storagefrontend.go
+++ b/ocis/pkg/command/storagefrontend.go
@@ -4,11 +4,11 @@ package command
 
 import (
 	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
-	"github.com/owncloud/ocis/ocis/pkg/config"
-	"github.com/owncloud/ocis/ocis/pkg/register"
 )
 
 // StorageFrontendCommand is the entrypoint for the reva-frontend command.
@@ -39,7 +39,6 @@ func configureStorageFrontend(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storagegateway.go
+++ b/ocis/pkg/command/storagegateway.go
@@ -4,11 +4,11 @@ package command
 
 import (
 	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
-	"github.com/owncloud/ocis/ocis/pkg/config"
-	"github.com/owncloud/ocis/ocis/pkg/register"
 )
 
 // StorageGatewayCommand is the entrypoint for the reva-gateway command.
@@ -39,7 +39,6 @@ func configureStorageGateway(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storagehome.go
+++ b/ocis/pkg/command/storagehome.go
@@ -39,7 +39,6 @@ func configureStorageHome(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storagemetadata.go
+++ b/ocis/pkg/command/storagemetadata.go
@@ -38,7 +38,6 @@ func configureStorageMetadata(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storagepubliclink.go
+++ b/ocis/pkg/command/storagepubliclink.go
@@ -39,7 +39,6 @@ func configureStoragePublicLink(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storagesharing.go
+++ b/ocis/pkg/command/storagesharing.go
@@ -4,11 +4,11 @@ package command
 
 import (
 	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
-	"github.com/owncloud/ocis/ocis/pkg/config"
-	"github.com/owncloud/ocis/ocis/pkg/register"
 )
 
 // StorageSharingCommand is the entrypoint for the reva-sharing command.
@@ -39,7 +39,6 @@ func configureStorageSharing(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storageuserprovider.go
+++ b/ocis/pkg/command/storageuserprovider.go
@@ -39,7 +39,6 @@ func configureStorageUserProvider(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/storageusers.go
+++ b/ocis/pkg/command/storageusers.go
@@ -39,7 +39,6 @@ func configureStorageUsers(cfg *config.Config) *svcconfig.Config {
 		cfg.Storage.Tracing.Type = cfg.Tracing.Type
 		cfg.Storage.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Storage.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Storage.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Storage

--- a/ocis/pkg/command/store.go
+++ b/ocis/pkg/command/store.go
@@ -4,12 +4,12 @@ package command
 
 import (
 	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/store/pkg/command"
 	svcconfig "github.com/owncloud/ocis/store/pkg/config"
 	"github.com/owncloud/ocis/store/pkg/flagset"
-	"github.com/owncloud/ocis/ocis/pkg/config"
-	"github.com/owncloud/ocis/ocis/pkg/register"
 )
 
 // StoreCommand is the entrypoint for the ocs command.
@@ -45,7 +45,6 @@ func configureStore(cfg *config.Config) *svcconfig.Config {
 		cfg.Store.Tracing.Type = cfg.Tracing.Type
 		cfg.Store.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Store.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Store.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Store

--- a/ocis/pkg/command/thumbnails.go
+++ b/ocis/pkg/command/thumbnails.go
@@ -4,11 +4,11 @@ package command
 
 import (
 	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/thumbnails/pkg/command"
 	"github.com/owncloud/ocis/thumbnails/pkg/flagset"
-	"github.com/owncloud/ocis/ocis/pkg/config"
-	"github.com/owncloud/ocis/ocis/pkg/register"
 
 	svcconfig "github.com/owncloud/ocis/thumbnails/pkg/config"
 )
@@ -46,7 +46,6 @@ func configureThumbnails(cfg *config.Config) *svcconfig.Config {
 		cfg.Thumbnails.Tracing.Type = cfg.Tracing.Type
 		cfg.Thumbnails.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.Thumbnails.Tracing.Collector = cfg.Tracing.Collector
-		cfg.Thumbnails.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.Thumbnails

--- a/ocis/pkg/command/webdav.go
+++ b/ocis/pkg/command/webdav.go
@@ -4,12 +4,12 @@ package command
 
 import (
 	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/webdav/pkg/command"
 	svcconfig "github.com/owncloud/ocis/webdav/pkg/config"
 	"github.com/owncloud/ocis/webdav/pkg/flagset"
-	"github.com/owncloud/ocis/ocis/pkg/config"
-	"github.com/owncloud/ocis/ocis/pkg/register"
 )
 
 // WebDAVCommand is the entrypoint for the webdav command.
@@ -19,7 +19,7 @@ func WebDAVCommand(cfg *config.Config) *cli.Command {
 		Usage:    "Start webdav server",
 		Category: "Extensions",
 		Flags:    flagset.ServerWithConfig(cfg.WebDAV),
-		Subcommands: []*cli.Command {
+		Subcommands: []*cli.Command{
 			command.PrintVersion(cfg.WebDAV),
 		},
 		Action: func(c *cli.Context) error {
@@ -45,7 +45,6 @@ func configureWebDAV(cfg *config.Config) *svcconfig.Config {
 		cfg.WebDAV.Tracing.Type = cfg.Tracing.Type
 		cfg.WebDAV.Tracing.Endpoint = cfg.Tracing.Endpoint
 		cfg.WebDAV.Tracing.Collector = cfg.Tracing.Collector
-		cfg.WebDAV.Tracing.Service = cfg.Tracing.Service
 	}
 
 	return cfg.WebDAV

--- a/ocis/pkg/tracing/tracing.go
+++ b/ocis/pkg/tracing/tracing.go
@@ -45,7 +45,9 @@ func Start(cfg *config.Config) error {
 				jaeger.Options{
 					AgentEndpoint:     cfg.Tracing.Endpoint,
 					CollectorEndpoint: cfg.Tracing.Collector,
-					ServiceName:       cfg.Tracing.Service,
+					Process: jaeger.Process{
+						ServiceName: cfg.Tracing.Service,
+					},
 				},
 			)
 

--- a/ocs/pkg/command/server.go
+++ b/ocs/pkg/command/server.go
@@ -66,7 +66,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -83,7 +83,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/settings/pkg/command/server.go
+++ b/settings/pkg/command/server.go
@@ -70,7 +70,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/store/pkg/command/server.go
+++ b/store/pkg/command/server.go
@@ -64,7 +64,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/thumbnails/pkg/command/server.go
+++ b/thumbnails/pkg/command/server.go
@@ -63,7 +63,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 

--- a/webdav/pkg/command/server.go
+++ b/webdav/pkg/command/server.go
@@ -66,7 +66,9 @@ func Server(cfg *config.Config) *cli.Command {
 						jaeger.Options{
 							AgentEndpoint:     cfg.Tracing.Endpoint,
 							CollectorEndpoint: cfg.Tracing.Collector,
-							ServiceName:       cfg.Tracing.Service,
+							Process: jaeger.Process{
+								ServiceName: cfg.Tracing.Service,
+							},
 						},
 					)
 


### PR DESCRIPTION
service names were all showing up as `ocis` in jaeger before this PR