### PR TITLE
OCS: use user from context when rendering self

### DIFF
--- a/changelog/unreleased/ocs-use-self-from-context.md
+++ b/changelog/unreleased/ocs-use-self-from-context.md
@@ -1,0 +1,5 @@
+Enhancement: OCS use user from context when rendering self
+
+Instead of querying the accounts service we can render the result by using the user in the context, which has been populated by the proxy. This is possible because the proxy can handle basic auth.
+
+https://github.com/owncloud/ocis/pull/855

--- a/ocs/pkg/server/http/svc_test.go
+++ b/ocs/pkg/server/http/svc_test.go
@@ -1417,57 +1417,6 @@ func TestUpdateUser(t *testing.T) {
 	}
 }
 
-// This is a bug verification test for endpoint '/cloud/user'
-// Link to the fixed issue: https://github.com/owncloud/ocis-ocs/issues/52
-func TestGetSingleUser(t *testing.T) {
-	user := User{
-		Enabled:     "true",
-		ID:          "rutherford",
-		Email:       "rutherford@example.com",
-		Displayname: "Ernest RutherFord",
-		Password:    "password",
-	}
-
-	for _, ocsVersion := range ocsVersions {
-		for _, format := range formats {
-			err := createUser(user)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			formatpart := getFormatString(format)
-			res, err := sendRequest(
-				"GET",
-				fmt.Sprintf("/%v/cloud/user%v", ocsVersion, formatpart),
-				"",
-				&User{ID: user.ID},
-				[]string{ssvc.BundleUUIDRoleUser},
-			)
-
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			var userResponse SingleUserResponse
-			if format == "json" {
-				if err := json.Unmarshal(res.Body.Bytes(), &userResponse); err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				if err := xml.Unmarshal(res.Body.Bytes(), &userResponse.Ocs); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			assertStatusCode(t, 200, res, ocsVersion)
-			assert.True(t, userResponse.Ocs.Meta.Success(ocsVersion), "The response was expected to pass but it failed")
-			assertUserSame(t, user, userResponse.Ocs.Data)
-
-			cleanUp(t)
-		}
-	}
-}
-
 // This is a bug demonstration test for endpoint '/cloud/user'
 // Link to the issue: https://github.com/owncloud/ocis/ocs/issues/53
 func TestGetUserSigningKey(t *testing.T) {

--- a/ocs/pkg/service/v0/data/user.go
+++ b/ocs/pkg/service/v0/data/user.go
@@ -8,7 +8,7 @@ type Users struct {
 // User holds the payload for a GetUser response
 type User struct {
 	Enabled           string `json:"enabled" xml:"enabled"`
-	UserID            string `json:"id" xml:"id"`// UserID is mapped to the preferred_name attribute in accounts
+	UserID            string `json:"id" xml:"id"` // UserID is mapped to the preferred_name attribute in accounts
 	DisplayName       string `json:"display-name" xml:"display-name"`
 	LegacyDisplayName string `json:"displayname" xml:"displayname"`
 	Email             string `json:"email" xml:"email"`


### PR DESCRIPTION
Instead of querying the accounts service we can render the result by using the user in the context, which has been populated by the proxy. This is possible because the proxy can handle basic auth.

Note that this PR should have a positive effect on every login in the web ui, because phoenix fetches the  ocs `/user` endpoint as part of the login.

Fixes https://github.com/owncloud/ocis-ocs/issues/52