### PR TITLE
store signing-key with correct key

### DIFF
--- a/ocs/pkg/service/v0/users.go
+++ b/ocs/pkg/service/v0/users.go
@@ -421,8 +421,8 @@ func (o Ocs) GetSigningKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// use the user's UUID
-	userID := u.Id.OpaqueId
+	// use the user's username
+	username := u.Username
 
 	c := storepb.NewStoreService("com.owncloud.api.store", grpc.NewClient())
 	res, err := c.Read(r.Context(), &storepb.ReadRequest{
@@ -430,11 +430,11 @@ func (o Ocs) GetSigningKey(w http.ResponseWriter, r *http.Request) {
 			Database: "proxy",
 			Table:    "signing-keys",
 		},
-		Key: userID,
+		Key: username,
 	})
 	if err == nil && len(res.Records) > 0 {
 		render.Render(w, r, response.DataRender(&data.SigningKey{
-			User:       userID,
+			User:       username,
 			SigningKey: string(res.Records[0].Value),
 		}))
 		return
@@ -464,7 +464,7 @@ func (o Ocs) GetSigningKey(w http.ResponseWriter, r *http.Request) {
 			Table:    "signing-keys",
 		},
 		Record: &storepb.Record{
-			Key:   userID,
+			Key:   username,
 			Value: []byte(signingKey),
 			// TODO Expiry?
 		},
@@ -477,7 +477,7 @@ func (o Ocs) GetSigningKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	render.Render(w, r, response.DataRender(&data.SigningKey{
-		User:       userID,
+		User:       username,
 		SigningKey: signingKey,
 	}))
 }

--- a/proxy/pkg/middleware/presigned_url.go
+++ b/proxy/pkg/middleware/presigned_url.go
@@ -32,7 +32,7 @@ func PresignedURL(opts ...Option) func(next http.Handler) http.Handler {
 				if signedRequestIsValid(l, r, opt.Store, cfg) {
 					// use openid claims to let the account_uuid middleware do a lookup by username
 					claims := ocisoidc.StandardClaims{
-						OcisID: r.URL.Query().Get("OC-Credential"),
+						PreferredUsername: r.URL.Query().Get("OC-Credential"),
 					}
 
 					// inject claims to the request context for the account_uuid middleware


### PR DESCRIPTION
Fixes: https://github.com/owncloud/ocis/issues/761
- [x] fix signing-key lookup
- [x] change claim from userid to username
- [ ] fix new error
- [ ] write changelog

Now after fixing the lookup and changing the userid to username there is this error when downloading stuff with presigned urls.

```
2020-11-13 17:01:50.646911 I | http: superfluous response.WriteHeader call from net/http/httputil.(*ReverseProxy).ServeHTTP (reverseproxy.go:326)
2020-11-13 17:01:50.646941 I | suppressing panic for copyResponse error in test; copy error: http: wrote more than the declared Content-Length
2020-11-13T17:01:50+01:00 ERR error finishing copying data to response error="write tcp [::1]:9140->[::1]:49304: write: connection reset by peer" pkg=rhttp service=storage traceid=8844913546ad0e8b8f1eb5982a342cdb
2020-11-13 17:01:50.647093 I | suppressing panic for copyResponse error in test; copy error: write tcp [::1]:9200->[::1]:59854: write: connection reset by peer
2020-11-13T17:01:50+01:00 INF http end="13/Nov/2020:17:01:50 +0100" host=::1 method=GET pkg=rhttp proto=HTTP/1.1 service=storage size=98304 start="13/Nov/2020:17:01:50 +0100" status=200 time_ns=10263924 traceid=8844913546ad0e8b8f1eb5982a342cdb uri=/remote.php/webdav/zane-lee-scifuYvqstc-unsplash.jpg?OC-Credential=einstein&OC-Date=2020-11-13T16%3A01%3A50.146Z&OC-Expires=1200&OC-Verb=GET url=/remote.php/webdav/zane-lee-scifuYvqstc-unsplash.jpg?OC-Credential=einstein&OC-Date=2020-11-13T16%3A01%3A50.146Z&OC-Expires=1200&OC-Verb=GET
2020-11-13T17:01:50+01:00 ERR error writing body after headers were sent error="write tcp [::1]:9140->[::1]:49346: write: broken pipe" pkg=rhttp service=storage traceid=8844913546ad0e8b8f1eb5982a342cdb
2020-11-13T17:01:50+01:00 ERR error copying data to response error="write tcp [::1]:9155->[::1]:52010: write: connection reset by peer" pkg=rhttp service=storage traceid=8844913546ad0e8b8f1eb5982a342cdb
2020-11-13T17:01:50+01:00 INF http end="13/Nov/2020:17:01:50 +0100" host=::1 method=GET pkg=rhttp proto=HTTP/1.1 service=storage size=757752 start="13/Nov/2020:17:01:50 +0100" status=200 time_ns=1155617 traceid=8844913546ad0e8b8f1eb5982a342cdb uri=/data/zane-lee-scifuYvqstc-unsplash.jpg url=/data/zane-lee-scifuYvqstc-unsplash.jpg
```