### PR TITLE
fix status trigger for missing notification on failing pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1369,6 +1369,9 @@ def notify(ctx):
         'refs/heads/release*',
         'refs/tags/**',
       ],
+      'status': [
+				'failure'
+			]
     }
   }
 


### PR DESCRIPTION
A pipeline triggers on status success (https://docs.drone.io/pipeline/triggers/#by-status). But we want notifications be triggered on failure.