### PR TITLE
Asset caching

### DIFF
--- a/accounts/pkg/config/config.go
+++ b/accounts/pkg/config/config.go
@@ -29,6 +29,7 @@ type HTTP struct {
 	Addr      string
 	Namespace string
 	Root      string
+	CacheTTL  int
 }
 
 // GRPC defines the available grpc configuration.

--- a/accounts/pkg/flagset/flagset.go
+++ b/accounts/pkg/flagset/flagset.go
@@ -57,6 +57,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"ACCOUNTS_HTTP_ROOT"},
 			Destination: &cfg.HTTP.Root,
 		},
+		&cli.IntFlag{
+			Name:        "http-cache-ttl",
+			Value:       604800, // 7 days
+			Usage:       "Set the static assets caching duration in seconds",
+			EnvVars:     []string{"ACCOUNTS_CACHE_TTL"},
+			Destination: &cfg.HTTP.CacheTTL,
+		},
 		&cli.StringFlag{
 			Name:        "grpc-namespace",
 			Value:       "com.owncloud.api",

--- a/accounts/pkg/server/http/server.go
+++ b/accounts/pkg/server/http/server.go
@@ -52,6 +52,7 @@ func Server(opts ...Option) http.Service {
 			assets.Logger(options.Logger),
 			assets.Config(options.Config),
 		),
+		options.Config.HTTP.CacheTTL,
 	))
 
 	mux.Route(options.Config.HTTP.Root, func(r chi.Router) {

--- a/accounts/pkg/server/http/server.go
+++ b/accounts/pkg/server/http/server.go
@@ -29,7 +29,7 @@ func Server(opts ...Option) http.Service {
 
 	mux.Use(middleware.RealIP)
 	mux.Use(middleware.RequestID)
-	mux.Use(middleware.Cache)
+	mux.Use(middleware.NoCache)
 	mux.Use(middleware.Cors)
 	mux.Use(middleware.Secure)
 	mux.Use(middleware.ExtractAccountUUID(

--- a/changelog/unreleased/web-assets-caching.md
+++ b/changelog/unreleased/web-assets-caching.md
@@ -1,0 +1,7 @@
+Change: Caching for static web assets
+
+Tags: accounts, settings, web
+
+We now set http caching headers for static web assets, so that they don't get force-reloaded on each request. The max-age for the caching is configurable and defaults to 7 days. The last modified date of the assets is set to the service start date, so that a service restart results in cache invalidation.
+
+https://github.com/owncloud/ocis/pull/866

--- a/konnectd/pkg/server/http/server.go
+++ b/konnectd/pkg/server/http/server.go
@@ -58,7 +58,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.Middleware(
 			middleware.RealIP,
 			middleware.RequestID,
-			middleware.Cache,
+			middleware.NoCache,
 			middleware.Cors,
 			middleware.Secure,
 			middleware.Version(

--- a/ocis-phoenix/pkg/config/config.go
+++ b/ocis-phoenix/pkg/config/config.go
@@ -20,6 +20,7 @@ type HTTP struct {
 	Addr      string
 	Root      string
 	Namespace string
+	CacheTTL  int
 }
 
 // Tracing defines the available tracing configuration.

--- a/ocis-phoenix/pkg/flagset/flagset.go
+++ b/ocis-phoenix/pkg/flagset/flagset.go
@@ -136,6 +136,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"PHOENIX_NAMESPACE"},
 			Destination: &cfg.HTTP.Namespace,
 		},
+		&cli.IntFlag{
+			Name:        "http-cache-ttl",
+			Value:       604800, // 7 days
+			Usage:       "Set the static assets caching duration in seconds",
+			EnvVars:     []string{"PHOENIX_CACHE_TTL"},
+			Destination: &cfg.HTTP.CacheTTL,
+		},
 		&cli.StringFlag{
 			Name:        "asset-path",
 			Value:       "",

--- a/ocis-phoenix/pkg/server/http/server.go
+++ b/ocis-phoenix/pkg/server/http/server.go
@@ -28,7 +28,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.Middleware(
 			middleware.RealIP,
 			middleware.RequestID,
-			middleware.Cache,
+			middleware.NoCache,
 			middleware.Cors,
 			middleware.Secure,
 			phoenixmid.SilentRefresh,

--- a/ocis-pkg/middleware/header.go
+++ b/ocis-pkg/middleware/header.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// Cache writes required cache headers to all requests.
-func Cache(next http.Handler) http.Handler {
+// NoCache writes required cache headers to all requests.
+func NoCache(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate, value")
 		w.Header().Set("Expires", "Thu, 01 Jan 1970 00:00:00 GMT")

--- a/ocis-pkg/middleware/static.go
+++ b/ocis-pkg/middleware/static.go
@@ -1,13 +1,16 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // Static is a middleware that serves static assets.
-func Static(root string, fs http.FileSystem) func(http.Handler) http.Handler {
+func Static(root string, fs http.FileSystem, ttl int) func(http.Handler) http.Handler {
 	if !strings.HasSuffix(root, "/") {
 		root = root + "/"
 	}
@@ -19,6 +22,9 @@ func Static(root string, fs http.FileSystem) func(http.Handler) http.Handler {
 		),
 	)
 
+	// we don't have a last modification date of the static assets, so we use the service start date
+	lastModified := time.Now().UTC().Format(http.TimeFormat)
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if strings.HasPrefix(r.URL.Path, path.Join(root, "api")) {
@@ -27,6 +33,9 @@ func Static(root string, fs http.FileSystem) func(http.Handler) http.Handler {
 				if strings.HasSuffix(r.URL.Path, "/") {
 					http.NotFound(w, r)
 				} else {
+					w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s", strconv.Itoa(ttl)))
+					w.Header().Set("Last-Modified", lastModified)
+					w.Header().Del("Expires")
 					static.ServeHTTP(w, r)
 				}
 			}

--- a/ocis-pkg/service/debug/service.go
+++ b/ocis-pkg/service/debug/service.go
@@ -49,7 +49,7 @@ func NewService(opts ...Option) *http.Server {
 		Handler: alice.New(
 			middleware.RealIP,
 			middleware.RequestID,
-			middleware.Cache,
+			middleware.NoCache,
 			middleware.Cors,
 			middleware.Secure,
 			middleware.Version(

--- a/ocs/pkg/server/http/server.go
+++ b/ocs/pkg/server/http/server.go
@@ -26,7 +26,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.Middleware(
 			middleware.RealIP,
 			middleware.RequestID,
-			middleware.Cache,
+			middleware.NoCache,
 			middleware.Cors,
 			middleware.Secure,
 			middleware.Version(

--- a/settings/pkg/config/config.go
+++ b/settings/pkg/config/config.go
@@ -20,6 +20,7 @@ type HTTP struct {
 	Addr      string
 	Namespace string
 	Root      string
+	CacheTTL  int
 }
 
 // GRPC defines the available grpc configuration.

--- a/settings/pkg/flagset/flagset.go
+++ b/settings/pkg/flagset/flagset.go
@@ -136,6 +136,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"SETTINGS_HTTP_ROOT"},
 			Destination: &cfg.HTTP.Root,
 		},
+		&cli.IntFlag{
+			Name:        "http-cache-ttl",
+			Value:       604800, // 7 days
+			Usage:       "Set the static assets caching duration in seconds",
+			EnvVars:     []string{"SETTINGS_CACHE_TTL"},
+			Destination: &cfg.HTTP.CacheTTL,
+		},
 		&cli.StringFlag{
 			Name:        "grpc-addr",
 			Value:       "0.0.0.0:9191",

--- a/settings/pkg/server/http/server.go
+++ b/settings/pkg/server/http/server.go
@@ -60,6 +60,7 @@ func Server(opts ...Option) http.Service {
 			assets.Logger(options.Logger),
 			assets.Config(options.Config),
 		),
+		options.Config.HTTP.CacheTTL,
 	))
 
 	mux.Route(options.Config.HTTP.Root, func(r chi.Router) {

--- a/settings/pkg/server/http/server.go
+++ b/settings/pkg/server/http/server.go
@@ -37,7 +37,7 @@ func Server(opts ...Option) http.Service {
 
 	mux.Use(middleware.RealIP)
 	mux.Use(middleware.RequestID)
-	mux.Use(middleware.Cache)
+	mux.Use(middleware.NoCache)
 	mux.Use(middleware.Cors)
 	mux.Use(middleware.Secure)
 	mux.Use(middleware.ExtractAccountUUID(

--- a/webdav/pkg/server/http/server.go
+++ b/webdav/pkg/server/http/server.go
@@ -26,7 +26,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.Middleware(
 			middleware.RealIP,
 			middleware.RequestID,
-			middleware.Cache,
+			middleware.NoCache,
 			middleware.Cors,
 			middleware.Secure,
 			middleware.Version(


### PR DESCRIPTION
Introducing http caching headers for static web assets.

Also renamed the `Cache` middleware to `NoCache` because it was doing the opposite of what the name suggests.