### PR TITLE
[docs-only] Fix link urls to oc10 in web config

### DIFF
--- a/deployments/examples/ocis_oc10_backend/ocis/config/web/config.json
+++ b/deployments/examples/ocis_oc10_backend/ocis/config/web/config.json
@@ -16,7 +16,7 @@
         "de": "Klassisches ownCloud"
       },
       "icon": "switch_ui",
-      "url": "https://ocis.example.org",
+      "url": "https://oc10.example.org",
       "target": "_self"
     },
     {
@@ -25,7 +25,7 @@
         "de": "Einstellungen"
       },
       "icon": "application",
-      "url": "https://ocis.example.org/index.php/settings/personal",
+      "url": "https://oc10.example.org/index.php/settings/personal",
       "target": "_self",
       "menu": "user"
     }


### PR DESCRIPTION
Web config of bridge setup was pointing to ocis for the switch to `Classic Design` and `Settings`. Changed it to oc10.

This is not docs but deployment example config. However, it doesn't affect the code base, so running as "[docs-only]"...