### PR TITLE
introduce OCIS_EOS_TAG and BRANCH into docker-compose-eos-test.yml

### DIFF
--- a/ocis/docker-compose-eos-test.yml
+++ b/ocis/docker-compose-eos-test.yml
@@ -8,9 +8,11 @@ networks:
 services:
   ocis:
     container_name: ocis
-    #image: owncloud/eos-ocis:1.0.0-rc2
-    build:
-      context: ./docker/eos-ocis
+    image: owncloud/eos-ocis:${EOS_OCIS_TAG:-1.0.0-rc5}
+    #build:
+    #  context: ./docker/eos-ocis
+    #  args:
+    #    BRANCH: ${BRANCH:-v1.0.0-rc5}
     tty: true
     privileged: true
     stdin_open: true

--- a/ocis/docker-compose-eos-test.yml
+++ b/ocis/docker-compose-eos-test.yml
@@ -8,6 +8,8 @@ networks:
 services:
   ocis:
     container_name: ocis
+    ## Comment out either the 'build:' section or the 'image:' line. They are mutually exclusive.
+    ## Using an image is prefered, as this is the published way of building and faster.
     image: owncloud/eos-ocis:${EOS_OCIS_TAG:-1.0.0-rc5}
     #build:
     #  context: ./docker/eos-ocis


### PR DESCRIPTION
To better pin a version build from source or a build with an image from docker hub.

Also switch the alternatives: Before we defaulted to build from source, now we can use a prebuilt image from dockerhub to speed things up. 

As discussed with @micbar -- it should be possible to use environment variables there. 
Not sure where to merge it. Probably not for master at all. My view of the world is probably still way off.

