### PR TITLE
[tests-only] Bump commit ids for tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '4f7fb95e5926f9bce6a89b1d4c62ee0368b7b866',
+    'coreCommit': 'd706b16da44ec94c6d80b34579d734e6beaf74b7',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/.drone.star
+++ b/.drone.star
@@ -20,7 +20,7 @@ config = {
   },
   'uiTests': {
     'phoenixBranch': 'master',
-    'phoenixCommit': '645d91f0dadde314b3173afafe30eb3cff12bf59',
+    'phoenixCommit': '779d002fb18e5f183c8a3fe012558f6dd1de8ba2',
     'suites': {
       'phoenixWebUI1': [
         'webUICreateFilesFolders',


### PR DESCRIPTION
1) Bump core commit id for API tests - this will include any test code changes in:
https://github.com/owncloud/core/pull/38112 [tests-only] Fix test steps for when REPLACE_USERNAMES is in effect

2) Bump phoenix commit id for UI tests - this will include any test code changes in:
https://github.com/owncloud/phoenix/pull/4299 [tests-only] added issue tag in imageMediaViewer test
https://github.com/owncloud/phoenix/pull/4306 Fix dynamic client registration
https://github.com/owncloud/phoenix/pull/4255 Move actions to sidebar
https://github.com/owncloud/phoenix/pull/4313 Version bump for release 0.25.0
Note: probably we will need to also update the actual phoenix code being run - see #868 