### PR TITLE
[tests-only] Bump core commit id for API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '4f7fb95e5926f9bce6a89b1d4c62ee0368b7b866',
+    'coreCommit': 'e235a60740a52bedec1f5a4b5ee5237a3bbf3e31',
     'numberOfParts': 10
   },
   'uiTests': {


### PR DESCRIPTION
1) Bump core commit id for API tests - this will include any test code changes in:
https://github.com/owncloud/core/pull/38112 [tests-only] Fix test steps for when REPLACE_USERNAMES is in effect
https://github.com/owncloud/core/pull/38117 [tests-only] Add test for adding a public link shared file to your ownCloud