### PR TITLE
Show basic_auth warning only on startup

### DIFF
--- a/changelog/unreleased/dont-nag-about-basicauth.md
+++ b/changelog/unreleased/dont-nag-about-basicauth.md
@@ -1,0 +1,6 @@
+Enhancement: Show basic-auth warning only once
+
+Show basic-auth warning only on startup instead on every request.
+
+
+https://github.com/owncloud/ocis/pull/886

--- a/proxy/pkg/middleware/basic_auth.go
+++ b/proxy/pkg/middleware/basic_auth.go
@@ -15,6 +15,9 @@ const publicFilesEndpoint = "/remote.php/dav/public-files/"
 // BasicAuth provides a middleware to check if BasicAuth is provided
 func BasicAuth(optionSetters ...Option) func(next http.Handler) http.Handler {
 	options := newOptions(optionSetters...)
+	if options.EnableBasicAuth {
+		options.Logger.Warn().Msg("basic auth enabled, use only for testing or development")
+	}
 
 	return func(next http.Handler) http.Handler {
 		return &basicAuth{
@@ -40,8 +43,6 @@ func (m basicAuth) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		m.next.ServeHTTP(w, req)
 		return
 	}
-
-	m.logger.Warn().Msg("basic auth enabled, use only for testing or development")
 
 	login, password, _ := req.BasicAuth()
 


### PR DESCRIPTION
warning on every request is spamming the logs. /cc @felixboehm 