### PR TITLE
add permission check to role management

### DIFF
--- a/accounts/pkg/command/add_account.go
+++ b/accounts/pkg/command/add_account.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+
 	"github.com/micro/cli/v2"
 	"github.com/micro/go-micro/v2/client/grpc"
 	"github.com/owncloud/ocis/accounts/pkg/config"

--- a/changelog/unreleased/check-role-management-permissions.md
+++ b/changelog/unreleased/check-role-management-permissions.md
@@ -1,0 +1,7 @@
+Enhancement: add permission check when assigning and removing roles 
+
+Everyone could add and remove roles from users.  
+Added a new permission and a check so that only users with the role management permissions can assign and unassign roles.
+
+
+https://github.com/owncloud/ocis/issues/879

--- a/proxy/pkg/middleware/create_home.go
+++ b/proxy/pkg/middleware/create_home.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"net/http"
+
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -11,7 +13,6 @@ import (
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"google.golang.org/grpc/metadata"
-	"net/http"
 )
 
 // CreateHome provides a middleware which sends a CreateHome request to the reva gateway

--- a/settings/pkg/service/v0/settings.go
+++ b/settings/pkg/service/v0/settings.go
@@ -11,6 +11,11 @@ const (
 
 	// BundleUUIDRoleGuest represents the guest role.
 	BundleUUIDRoleGuest = "38071a68-456a-4553-846a-fa67bf5596cc"
+
+	// RoleManagementPermissionID is the hardcoded setting UUID for the role management permission
+	RoleManagementPermissionID string = "a53e601e-571f-4f86-8fec-d4576ef49c62"
+	// RoleManagementPermissionName is the hardcoded setting name for the role management permission
+	RoleManagementPermissionName string = "role-management"
 )
 
 // generateBundlesDefaultRoles bootstraps the default roles.
@@ -61,5 +66,29 @@ func generateBundleGuestRole() *settings.Bundle {
 			Type: settings.Resource_TYPE_SYSTEM,
 		},
 		Settings: []*settings.Setting{},
+	}
+}
+
+func generatePermissionRequests() []*settings.AddSettingToBundleRequest {
+	return []*settings.AddSettingToBundleRequest{
+		{
+			BundleId: BundleUUIDRoleAdmin,
+			Setting: &settings.Setting{
+				Id:          RoleManagementPermissionID,
+				Name:        RoleManagementPermissionName,
+				DisplayName: "Role Management",
+				Description: "This permission gives full access to everything that is related to role management.",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_USER,
+					Id:   "all",
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_READWRITE,
+						Constraint: settings.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
Enhancement: add permission check when assigning and removing roles 

Everyone could add and remove roles from users.  
Added a new permission and a check so that only users with the role management permissions can assign and unassign roles.

Fixes https://github.com/owncloud/ocis/issues/879