### PR TITLE
[tests-only] Bump core commit id for API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '10e758b14ab71f1524b382df78ec00fba6cb4901',
+    'coreCommit': 'ff3a6997165307f43534ed510bb96df858037cf2',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': 'edda1ed3ff29d9e12ad12f08cd1289e6f4ea3bba',
+    'coreCommit': '10e758b14ab71f1524b382df78ec00fba6cb4901',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': 'ff3a6997165307f43534ed510bb96df858037cf2',
+    'coreCommit': '2c019a4dfe2c5de58a9bdf270984f8adebe9c37f',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/ocis/vendor-bin/behat/composer.json
+++ b/ocis/vendor-bin/behat/composer.json
@@ -5,10 +5,9 @@
     }
   },
   "require": {
-    "behat/behat": "^3.7",
+    "behat/behat": "^3.8",
     "behat/mink": "1.7.1",
     "behat/mink-extension": "^2.3",
-    "behat/mink-goutte-driver": "^1.2",
     "behat/mink-selenium2-driver": "^1.4",
     "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
     "jarnaiz/behat-junit-formatter": "^1.3",
@@ -16,7 +15,7 @@
     "sensiolabs/behat-page-object-extension": "^2.3",
     "symfony/translation": "^4.4",
     "sabre/xml": "^2.2",
-    "guzzlehttp/guzzle": "^6.5",
+    "guzzlehttp/guzzle": "^7.2",
     "phpunit/phpunit": "^8.5",
     "laminas/laminas-ldap": "^2.10"
   }

--- a/ocis/vendor-bin/behat/composer.json
+++ b/ocis/vendor-bin/behat/composer.json
@@ -16,7 +16,7 @@
     "symfony/translation": "^4.4",
     "sabre/xml": "^2.2",
     "guzzlehttp/guzzle": "^7.2",
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^9.4",
     "laminas/laminas-ldap": "^2.10"
   }
 }


### PR DESCRIPTION
1) bump the core commit id for API tests - gets us:
https://github.com/owncloud/core/pull/38120 [Tests-Only] Update issue tags for test scenarios
https://github.com/owncloud/core/pull/38127 [tests-only] Fix tests WebDav.php BadResponseException

2) Adjust behat composer.json for API tests to be like oC10 core - does similar to core PRs:
https://github.com/owncloud/core/pull/38122 [tests-only] Bump test tool dependencies
https://github.com/owncloud/core/pull/38128 [tests-only] Use guzzle7 in acceptance tests

3) Bump core commit to include core PR https://github.com/owncloud/core/pull/38130

4) Use phpunit9 in acceptance tests like https://github.com/owncloud/core/pull/38130

5) bump the core commit id for API tests to include core PR https://github.com/owncloud/core/pull/38131
