### PR TITLE
Serve index html

### DIFF
--- a/changelog/unreleased/pkg-serve-index-html.md
+++ b/changelog/unreleased/pkg-serve-index-html.md
@@ -1,0 +1,6 @@
+Bugfix: Serve index.html for directories
+
+The static middleware in ocis-pkg now serves index.html instead of returning 404 on paths with a trailing `/`.
+
+https://github.com/owncloud/ocis/pull/912
+https://github.com/owncloud/ocis-pkg/issues/63

--- a/ocis-pkg/middleware/static.go
+++ b/ocis-pkg/middleware/static.go
@@ -30,14 +30,10 @@ func Static(root string, fs http.FileSystem, ttl int) func(http.Handler) http.Ha
 			if strings.HasPrefix(r.URL.Path, path.Join(root, "api")) {
 				next.ServeHTTP(w, r)
 			} else {
-				if strings.HasSuffix(r.URL.Path, "/") {
-					http.NotFound(w, r)
-				} else {
-					w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s", strconv.Itoa(ttl)))
-					w.Header().Set("Last-Modified", lastModified)
-					w.Header().Del("Expires")
-					static.ServeHTTP(w, r)
-				}
+				w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s", strconv.Itoa(ttl)))
+				w.Header().Set("Last-Modified", lastModified)
+				w.Header().Del("Expires")
+				static.ServeHTTP(w, r)
 			}
 		})
 	}


### PR DESCRIPTION
It's already the default behaviour of `http.FileServer` to serve an `index.html`.

Fixes https://github.com/owncloud/ocis-pkg/issues/63