### PR TITLE
add version command to ocis

### DIFF
--- a/changelog/unreleased/ocis-version-command.md
+++ b/changelog/unreleased/ocis-version-command.md
@@ -1,0 +1,6 @@
+Enhancement: add a version command to ocis
+
+The version command was only implemented in the extensions.
+This adds the version command to ocis to list all services in the ocis namespace.
+
+https://github.com/owncloud/ocis/pull/915

--- a/ocis/go.mod
+++ b/ocis/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/micro/cli/v2 v2.1.2
 	github.com/micro/go-micro/v2 v2.9.1
 	github.com/micro/micro/v2 v2.8.0
+	github.com/olekukonko/tablewriter v0.0.4
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/owncloud/flaex v0.2.0
 	github.com/owncloud/ocis-graph v0.0.0-20200318175820-9a5a6e029db7

--- a/ocis/pkg/command/version.go
+++ b/ocis/pkg/command/version.go
@@ -1,0 +1,60 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/micro/cli/v2"
+	mreg "github.com/micro/go-micro/v2/registry"
+	tw "github.com/olekukonko/tablewriter"
+	"github.com/owncloud/ocis/ocis-pkg/registry"
+	"github.com/owncloud/ocis/ocis/pkg/config"
+	"github.com/owncloud/ocis/ocis/pkg/register"
+)
+
+// VersionCommand is the entrypoint for the version command.
+func VersionCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:     "version",
+		Usage:    "Lists running services with version",
+		Category: "Runtime",
+		Action: func(c *cli.Context) error {
+			reg := *registry.GetRegistry()
+			serviceList, err := reg.ListServices()
+			if err != nil {
+				fmt.Println(fmt.Errorf("could not list services: %v", err))
+				return err
+			}
+
+			var services []*mreg.Service
+			for _, s := range serviceList {
+				s, err := reg.GetService(s.Name)
+				if err != nil {
+					fmt.Println(fmt.Errorf("could not get service: %v", err))
+					return err
+				}
+				services = append(services, s...)
+			}
+
+			if len(services) == 0 {
+				fmt.Println("No running services found.")
+				return nil
+			}
+
+			table := tw.NewWriter(os.Stdout)
+			table.SetHeader([]string{"Version", "Address", "Id"})
+			table.SetAutoFormatHeaders(false)
+			for _, s := range services {
+				for _, n := range s.Nodes {
+					table.Append([]string{s.Version, n.Address, n.Id})
+				}
+			}
+			table.Render()
+			return nil
+		},
+	}
+}
+
+func init() {
+	register.AddCommand(VersionCommand)
+}


### PR DESCRIPTION
The version command was only implemented in the extensions.
This adds the version command to ocis to list all services in the ocis namespace.