### PR TITLE
Add option to disable signing keys in the proxy

### DIFF
--- a/deployments/examples/ocis_oc10_backend/docker-compose.yml
+++ b/deployments/examples/ocis_oc10_backend/docker-compose.yml
@@ -70,7 +70,6 @@ services:
       OWNCLOUD_MYSQL_UTF8MB4: "true"
       OWNCLOUD_REDIS_ENABLED: "true"
       OWNCLOUD_REDIS_HOST: redis
-      OWNCLOUD_DEBUG: "true"
       OWNCLOUD_TRUSTED_PROXIES: ${OC10_DOMAIN}
       OWNCLOUD_OVERWRITE_PROTOCOL: https
       OWNCLOUD_OVERWRITE_HOST: ${OC10_DOMAIN}
@@ -111,6 +110,7 @@ services:
       PROXY_OIDC_ISSUER: https://${OCIS_DOMAIN}
       PROXY_AUTOPROVISION_ACCOUNTS: "true"
       PROXY_OIDC_INSECURE: "${INSECURE}"
+      PROXY_ENABLE_PRESIGNEDURLS: "false"
       # konnectd - binddn must exist as oc10 admin user
       KONNECTD_ISS: https://${OCIS_DOMAIN}
       KONNECTD_IDENTIFIER_REGISTRATION_CONF: "/config/identifier-registration.yaml"

--- a/proxy/changelog/unreleased/add-basic-auth-option.md
+++ b/proxy/changelog/unreleased/add-basic-auth-option.md
@@ -1,6 +1,0 @@
-Enhancement: Add basic auth option
-
-We added a new `enable-basic-auth` option and `PROXY_ENABLE_BASIC_AUTH` environment variable that can be set to `true` to make the proxy verify the basic auth header with the accounts service. This should only be used for testing and development and is disabled by default.
-
-https://github.com/owncloud/ocis/pull/627
-https://github.com/owncloud/product/issues/198

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/go-cs3apis v0.0.0-20201007120910-416ed6cf8b00
 	github.com/cs3org/reva v1.3.1-0.20201023144216-cdb3d6688da5
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/uuid v1.1.2
 	github.com/justinas/alice v1.2.0
 	github.com/micro/cli/v2 v2.1.2

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -135,6 +135,7 @@ type TokenManager struct {
 // PreSignedURL is the config for the presigned url middleware
 type PreSignedURL struct {
 	AllowedHTTPMethods []string
+	Enabled            bool
 }
 
 // MigrationSelectorConf is the config for the migration-selector

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -226,12 +226,18 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		},
 
 		// Presigned URLs
-
 		&cli.StringSliceFlag{
 			Name:    "presignedurl-allow-method",
 			Value:   cli.NewStringSlice("GET"),
 			Usage:   "--presignedurl-allow-method GET [--presignedurl-allow-method POST]",
 			EnvVars: []string{"PRESIGNEDURL_ALLOWED_METHODS"},
+		},
+		&cli.BoolFlag{
+			Name:        "enable-presignedurls",
+			Value:       true,
+			Usage:       "Enable or disable handling the presigned urls in the proxy",
+			EnvVars:     []string{"PROXY_ENABLE_PRESIGNEDURLS"},
+			Destination: &cfg.PreSignedURL.Enabled,
 		},
 
 		// Basic auth

--- a/proxy/pkg/middleware/signed_url_auth.go
+++ b/proxy/pkg/middleware/signed_url_auth.go
@@ -6,6 +6,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
 	"github.com/google/uuid"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocis-pkg/log"
@@ -13,10 +18,6 @@ import (
 	"github.com/owncloud/ocis/proxy/pkg/config"
 	store "github.com/owncloud/ocis/store/pkg/proto/v0"
 	"golang.org/x/crypto/pbkdf2"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
 )
 
 // SignedURLAuth provides a middleware to check access secured by a signed URL.
@@ -96,6 +97,9 @@ func (m signedURLAuth) claims(credential string) (*ocisoidc.StandardClaims, erro
 }
 
 func (m signedURLAuth) shouldServe(req *http.Request) bool {
+	if !m.preSignedURLConfig.Enabled {
+		return false
+	}
 	return req.URL.Query().Get("OC-Signature") != ""
 }
 

--- a/proxy/pkg/middleware/signed_url_auth_test.go
+++ b/proxy/pkg/middleware/signed_url_auth_test.go
@@ -10,13 +10,17 @@ func TestSignedURLAuth_shouldServe(t *testing.T) {
 	pua := signedURLAuth{}
 	tests := []struct {
 		url      string
+		enabled  bool
 		expected bool
 	}{
-		{"https://example.com/example.jpg", false},
-		{"https://example.com/example.jpg?OC-Signature=something", true},
+		{"https://example.com/example.jpg", true, false},
+		{"https://example.com/example.jpg?OC-Signature=something", true, true},
+		{"https://example.com/example.jpg", false, false},
+		{"https://example.com/example.jpg?OC-Signature=something", false, false},
 	}
 
 	for _, tt := range tests {
+		pua.preSignedURLConfig.Enabled = tt.enabled
 		r := httptest.NewRequest("", tt.url, nil)
 		result := pua.shouldServe(r)
 
@@ -102,7 +106,7 @@ func TestSignedURLAuth_urlIsExpired(t *testing.T) {
 	}
 
 	tests := []struct {
-		url      string
+		url       string
 		isExpired bool
 	}{
 		{"http://example.com/example.jpg?OC-Date=2020-02-02T12:29:00.000Z&OC-Expires=61", false},


### PR DESCRIPTION
When running the bridge with ownCloud10, we need an option to disable handling of signed urls in the proxy, because we want oc10 to take care of it then. This PR introduces a config option for that and makes use of it in the bridge deployment example.

Please note: deployment example uses the ocis image from dockerhub, so unless this PR is merged, the config option will not have any effect in the deployment example.