### PR TITLE
[docs-only] make OCIS name consistent throught the docs

### DIFF
--- a/docs/extensions/konnectd/_index.md
+++ b/docs/extensions/konnectd/_index.md
@@ -7,4 +7,4 @@ geekdocFilePath: _index.md
 geekdocCollapseSection: true
 ---
 
-This service provides an OpenID Connect provider which is the default way to authenticate in OCIS.
+This service provides an OpenID Connect provider which is the default way to authenticate in oCIS.

--- a/docs/extensions/storage/storages.md
+++ b/docs/extensions/storage/storages.md
@@ -99,7 +99,7 @@ The *minimal* storage driver for a POSIX based filesystem. It literally supports
 - grant persistence
   - using POSIX ACLs
     - requires an LDAP server to make guest accounts available in the OS
-      - OCIS has glauth which contains all users
+      - oCIS has glauth which contains all users
       - an existing LDAP could be used if guests ar provisioned in another way
   - using extended attributes to implement expiry or sharing that does not require OS level integration
   - fuse filesystem overlay

--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -130,19 +130,19 @@ BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS'
 
 Make sure to adjust the settings `TEST_SERVER_URL` and `OCIS_REVA_DATA_ROOT` according to your environment.
 
-This will run all tests that are relevant to OCIS.
+This will run all tests that are relevant to oCIS.
 
 To run a single test add `BEHAT_FEATURE=<feature file>`
 
 ### use existing tests for BDD
 
 As a lot of scenarios are written for oC10, we can use those tests for Behaviour driven development in ocis.
-Every scenario that does not work in OCIS with "owncloud" storage, is listed in `tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt` with a link to the related issue.
-Every scenario that does not work in OCIS with "ocis" storage, is listed in `tests/acceptance/expected-failures-on-OCIS-storage.txt` with a link to the related issue.
+Every scenario that does not work in oCIS with "owncloud" storage, is listed in `tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt` with a link to the related issue.
+Every scenario that does not work in oCIS with "ocis" storage, is listed in `tests/acceptance/expected-failures-on-OCIS-storage.txt` with a link to the related issue.
 
 Those scenarios are run in the ordinary acceptance test pipeline in CI. The scenarios that fail are checked against the
 expected failures. If there are any differences then the CI pipeline fails.
-Similarly, scenarios that do not work in OCIS with EOS storage are listed in `tests/acceptance/expected-failures-on-EOS-storage.txt`.
+Similarly, scenarios that do not work in oCIS with EOS storage are listed in `tests/acceptance/expected-failures-on-EOS-storage.txt`.
 Additionally, some issues have scenarios that demonstrate the current buggy behaviour in ocis(reva).
 Those scenarios are in this ocis repository in `tests/acceptance/features/apiOcisSpecific`.
 Have a look into the [documentation](https://doc.owncloud.com/server/developer_manual/testing/acceptance-tests.html#writing-scenarios-for-bugs) to understand why we are writing those tests.


### PR DESCRIPTION
Change `OCIS` to `oCIS` in docs to make the naming consistent.