### PR TITLE
Set expires headers and force asset revalidation

### DIFF
--- a/changelog/unreleased/web-assets-caching.md
+++ b/changelog/unreleased/web-assets-caching.md
@@ -5,3 +5,4 @@ Tags: accounts, settings, web
 We now set http caching headers for static web assets, so that they don't get force-reloaded on each request. The max-age for the caching is configurable and defaults to 7 days. The last modified date of the assets is set to the service start date, so that a service restart results in cache invalidation.
 
 https://github.com/owncloud/ocis/pull/866
+https://github.com/owncloud/ocis/pull/934

--- a/ocis-phoenix/pkg/service/v0/service.go
+++ b/ocis-phoenix/pkg/service/v0/service.go
@@ -169,7 +169,7 @@ func (p Phoenix) Static(ttl int) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s", strconv.Itoa(ttl)))
+		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s, must-revalidate", strconv.Itoa(ttl)))
 		w.Header().Set("Expires", expires)
 		w.Header().Set("Last-Modified", lastModified)
 

--- a/ocis-phoenix/pkg/service/v0/service.go
+++ b/ocis-phoenix/pkg/service/v0/service.go
@@ -146,6 +146,7 @@ func (p Phoenix) Static(ttl int) http.HandlerFunc {
 
 	// we don't have a last modification date of the static assets, so we use the service start date
 	lastModified := time.Now().UTC().Format(http.TimeFormat)
+	expires := time.Now().Add(time.Second * time.Duration(ttl)).UTC().Format(http.TimeFormat)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if rootWithSlash != "/" && r.URL.Path == p.config.HTTP.Root {
@@ -169,8 +170,8 @@ func (p Phoenix) Static(ttl int) http.HandlerFunc {
 		}
 
 		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s", strconv.Itoa(ttl)))
+		w.Header().Set("Expires", expires)
 		w.Header().Set("Last-Modified", lastModified)
-		w.Header().Del("Expires")
 
 		static.ServeHTTP(w, r)
 	}

--- a/ocis-pkg/middleware/static.go
+++ b/ocis-pkg/middleware/static.go
@@ -31,7 +31,7 @@ func Static(root string, fs http.FileSystem, ttl int) func(http.Handler) http.Ha
 			if strings.HasPrefix(r.URL.Path, path.Join(root, "api")) {
 				next.ServeHTTP(w, r)
 			} else {
-				w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s", strconv.Itoa(ttl)))
+				w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s, must-revalidate", strconv.Itoa(ttl)))
 				w.Header().Set("Expires", expires)
 				w.Header().Set("Last-Modified", lastModified)
 				static.ServeHTTP(w, r)

--- a/ocis-pkg/middleware/static.go
+++ b/ocis-pkg/middleware/static.go
@@ -24,6 +24,7 @@ func Static(root string, fs http.FileSystem, ttl int) func(http.Handler) http.Ha
 
 	// we don't have a last modification date of the static assets, so we use the service start date
 	lastModified := time.Now().UTC().Format(http.TimeFormat)
+	expires := time.Now().Add(time.Second * time.Duration(ttl)).UTC().Format(http.TimeFormat)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -31,8 +32,8 @@ func Static(root string, fs http.FileSystem, ttl int) func(http.Handler) http.Ha
 				next.ServeHTTP(w, r)
 			} else {
 				w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s", strconv.Itoa(ttl)))
+				w.Header().Set("Expires", expires)
 				w.Header().Set("Last-Modified", lastModified)
-				w.Header().Del("Expires")
 				static.ServeHTTP(w, r)
 			}
 		})


### PR DESCRIPTION
This is a bug fix. The `Last-Modified` header is meant for content validation when the expiration is reached or when revalidation is enforced. Without an expiration or forced revalidation it doesn't have any effect.

This PR sets the expiration date to now+ttl on service start and enforces revalidation on every request, based on the last modified date. I.e. the request will hit the server to check if the last-modified date of the resource changed. Which it only does, if the service is restarted in the meantime.