### PR TITLE
Update phoenix to 0.27.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -20,7 +20,7 @@ config = {
   },
   'uiTests': {
     'phoenixBranch': 'master',
-    'phoenixCommit': '4395234656fb70c869ee960ca5d7b853ffcc5ef8',
+    'phoenixCommit': 'fd281418cc30af9c9795e627692caf45c0d3bf30',
       'suites': {
         'webUIBasic': [
           'webUILogin',

--- a/changelog/unreleased/update-phoenix-0.26.0.md
+++ b/changelog/unreleased/update-phoenix-0.26.0.md
@@ -1,0 +1,8 @@
+Change: Update phoenix to v0.26.0
+
+Tags: web
+
+We updated phoenix to v0.26.0. Please refer to the changelog (linked) for details on the phoenix release.
+
+https://github.com/owncloud/phoenix/releases/tag/v0.26.0
+https://github.com/owncloud/ocis/pull/935

--- a/changelog/unreleased/update-phoenix-0.27.0.md
+++ b/changelog/unreleased/update-phoenix-0.27.0.md
@@ -1,0 +1,8 @@
+Change: Update phoenix to v0.27.0
+
+Tags: web
+
+We updated phoenix to v0.27.0. Please refer to the changelog (linked) for details on the phoenix release.
+
+https://github.com/owncloud/ocis/pull/943
+https://github.com/owncloud/phoenix/releases/tag/v0.27.0

--- a/changelog/unreleased/update-web-0.26.0.md
+++ b/changelog/unreleased/update-web-0.26.0.md
@@ -1,8 +1,0 @@
-Change: Update phoenix to v0.26.0
-
-Tags: web
-
-We updated phoenix to v0.26.0. Please refer to the changelog (linked) for details on the phoenix release.
-
-https://github.com/owncloud/phoenix/releases/tag/v0.26.0
-https://github.com/owncloud/ocis/pull/935

--- a/ocis-phoenix/Makefile
+++ b/ocis-phoenix/Makefile
@@ -3,7 +3,7 @@ NAME := ocis-phoenix
 IMPORT := github.com/owncloud/ocis/$(NAME)
 BIN := bin
 DIST := dist
-PHOENIX_ASSETS_VERSION = v0.26.0
+PHOENIX_ASSETS_VERSION = v0.27.0
 
 ifeq ($(OS), Windows_NT)
 	EXECUTABLE := $(NAME).exe


### PR DESCRIPTION
This updates phoenix to 0.27.0, which contains a bugfix regarding extension loading:

There was an error in the extension loading handlers which caused routes to be loaded multiple times when extensions from the config.json were unavailable. We hardened the extension loading handlers to just skip those extensions without side effects.