### PR TITLE
[tests-only] fix gopath volume for ocis modules testing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -307,6 +307,12 @@ def testing(ctx, module):
         'refs/pull/**',
       ],
     },
+    'volumes': [
+      {
+        'name': 'gopath',
+        'temp': {},
+      },
+    ],
   }
 
 def uploadCoverage(ctx):


### PR DESCRIPTION
without volumes section in pipeline, the volumes are not reused between the steps. This leads to go dependency downloads in every step (see former pipelines).