### PR TITLE
[tests-only] Bump core commit id for API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '773cf3ea127430699f3bfb4c1b24e96a271a8884',
+    'coreCommit': '31105a0d3e6e6ef0a0da2c16c66d4261fd91c069',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -2470,3 +2470,25 @@ apiVersions/fileVersionsSharingToShares.feature:279
 # https://github.com/owncloud/ocis/issues/719 when a share exists its impossible to share a renamed folder
 apiShareManagementBasicToShares/createShareToSharesFolder.feature:611
 apiShareManagementBasicToShares/createShareToSharesFolder.feature:612
+
+# https://github.com/owncloud/ocis/issues/965 ocis-storage does not use the mtime send in the `Upload-Metadata` header when uploading via TUS
+apiWebdavUploadTUS/uploadFileMtime.feature:17
+apiWebdavUploadTUS/uploadFileMtime.feature:18
+apiWebdavUploadTUS/uploadFileMtime.feature:27
+apiWebdavUploadTUS/uploadFileMtime.feature:28
+apiWebdavUploadTUS/uploadFileMtime.feature:38
+apiWebdavUploadTUS/uploadFileMtime.feature:39
+apiWebdavUploadTUS/uploadFileMtime.feature:49
+apiWebdavUploadTUS/uploadFileMtime.feature:50
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:40
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:41
+
+# https://github.com/owncloud/ocis/issues/968 [ocis-storage] PROPFIND on a file uploaded by share receiver is not possible
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:26
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:27
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:55
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:56
+
+# https://github.com/owncloud/ocis/issues/763 [OCIS-storage] reading a file that a collaborator uploaded is impossible
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:70
+apiWebdavUploadTUS/uploadFileMtimeShares.feature:71


### PR DESCRIPTION
to get TUS tests that check uploads with mtime, see https://github.com/owncloud/core/pull/38148