### PR TITLE
cache ocis build artifact for tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -153,7 +153,12 @@ def main(ctx):
 
     pipelines = before + [ notify_pipeline ]
 
-  elif '[docs-only]' in (ctx.build.title + ctx.build.message):
+  elif \
+  (ctx.build.event == "pull" and '[docs-only]' in ctx.build.title) \
+  or \
+  (ctx.build.event != "pull" and '[docs-only]' in (ctx.build.title + ctx.build.message)):
+  # [docs-only] is not taken from PR messages, but from commit messages
+
     docs_pipeline = docs(ctx)
     docs_pipeline['depends_on'] = []
     docs_pipelines = [ docs_pipeline ]

--- a/.drone.star
+++ b/.drone.star
@@ -145,7 +145,7 @@ def main(ctx):
     badges(ctx),
     docs(ctx),
     updateDeployment(ctx),
-    purge,
+    #purge,
   ]
 
   if ctx.build.event == "cron":
@@ -1614,7 +1614,6 @@ def genericCache(name, action, mounts, cache_key):
         'mount': mounts,
       },
     }
-
   return step
 
 def genericCachePurge(name, cache_key):

--- a/.drone.star
+++ b/.drone.star
@@ -145,7 +145,7 @@ def main(ctx):
     badges(ctx),
     docs(ctx),
     updateDeployment(ctx),
-    #purge,
+    purge,
   ]
 
   if ctx.build.event == "cron":
@@ -1620,7 +1620,7 @@ def genericCachePurge(name, cache_key):
   return {
     'kind': 'pipeline',
     'type': 'docker',
-    'name': 'purge_%s_build_artifact_cache' %(name),
+    'name': 'purge_%s' %(name),
     'platform': {
       'os': 'linux',
       'arch': 'amd64',


### PR DESCRIPTION
Reopen of #961, since CI was stuck on that PR.

oCIS binary is build once and then provided for all tests (acceptance test, ui tests, but not for go linting, ...).

Diffs between master and branch look good for following tests:
- drone starlark
- drone starlark --build.event cron
- drone starlark --build.event pull
- drone starlark --build.event pull --build.message "[docs-only.]"
- drone starlark --build.message "[docs-only.]"