### PR TITLE
[Tests-Only] Add failing Tus test to expected failure file

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '8ff1bda2f3c09500b92775c666c1b2236876edd3',
+    'coreCommit': '26322d3bbedb5afe9a78ed5bcf88cfbf4ab2fd79',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -1465,11 +1465,6 @@ apiWebdavUpload2/uploadFileUsingOldChunking.feature:98
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:99
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:100
 #
-# https://github.com/owncloud/product/issues/293 sharing with group not available
-#
-apiWebdavUploadTUS/uploadToShare.feature:52
-apiWebdavUploadTUS/uploadToShare.feature:53
-#
 # https://github.com/owncloud/ocis/issues/187 Previews via webDAV API tests fail on OCIS
 #
 apiWebdavPreviews/previews.feature:15
@@ -2495,3 +2490,13 @@ apiWebdavUploadTUS/uploadFileMtimeShares.feature:56
 # https://github.com/owncloud/ocis/issues/763 [OCIS-storage] reading a file that a collaborator uploaded is impossible
 apiWebdavUploadTUS/uploadFileMtimeShares.feature:70
 apiWebdavUploadTUS/uploadFileMtimeShares.feature:71
+
+# https://github.com/owncloud/ocis/issues/968 [ocis-storage] PROPFIND on a file uploaded by share receiver is not possible
+apiWebdavUploadTUS/uploadToShare.feature:23
+apiWebdavUploadTUS/uploadToShare.feature:24
+apiWebdavUploadTUS/uploadToShare.feature:37
+apiWebdavUploadTUS/uploadToShare.feature:38
+
+# https://github.com/owncloud/product/issues/293 sharing with group not available
+apiWebdavUploadTUS/uploadToShare.feature:52
+apiWebdavUploadTUS/uploadToShare.feature:53

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -1465,6 +1465,11 @@ apiWebdavUpload2/uploadFileUsingOldChunking.feature:98
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:99
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:100
 #
+# https://github.com/owncloud/product/issues/293 sharing with group not available
+#
+apiWebdavUploadTUS/uploadToShare.feature:52
+apiWebdavUploadTUS/uploadToShare.feature:53
+#
 # https://github.com/owncloud/ocis/issues/187 Previews via webDAV API tests fail on OCIS
 #
 apiWebdavPreviews/previews.feature:15

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -1402,6 +1402,11 @@ apiWebdavUpload2/uploadFileUsingOldChunking.feature:98
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:99
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:100
 #
+# https://github.com/owncloud/product/issues/293 sharing with group not available
+#
+apiWebdavUploadTUS/uploadToShare.feature:52
+apiWebdavUploadTUS/uploadToShare.feature:53
+#
 # https://github.com/owncloud/ocis-reva/issues/243  Sharing does not work
 #
 apiShareManagementBasicToShares/createShareToSharesFolder.feature:529


### PR DESCRIPTION
- Added failing TUS tests `apiWebdavUploadTUS/uploadToShare.feature:52` and `apiWebdavUploadTUS/uploadToShare.feature:53` to expected failure file
- Bump core commit id for API tests