### PR TITLE
[tests-only] Set OCIS_LOG_LEVEL to warn in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1485,6 +1485,7 @@ def ocisServer(storage, accounts_hash_difficulty = 4):
     'KONNECTD_IDENTIFIER_REGISTRATION_CONF': '/drone/src/tests/config/drone/identifier-registration.yml',
     'KONNECTD_ISS': 'https://ocis-server:9200',
     'KONNECTD_TLS': 'true',
+    'OCIS_LOG_LEVEL': 'warn',
   }
 
   # Pass in "default" accounts_hash_difficulty to not set this environment variable.


### PR DESCRIPTION
to reduce the amount of "log noise" that drone CI needs to save.