### PR TITLE
[tests-only] bump core test commit id to get TUS chunking tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,7 +15,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '26322d3bbedb5afe9a78ed5bcf88cfbf4ab2fd79',
+    'coreCommit': 'a5df08ca512c3c8e65a01d018c9eec81b9cfccaa',
     'numberOfParts': 10
   },
   'uiTests': {


### PR DESCRIPTION
get tests from https://github.com/owncloud/core/pull/38164 into the ocis test run