### PR TITLE
[tests-only] bump core commit id for API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -15,8 +15,8 @@ config = {
     'onlyoffice':'frontend'
   },
   'apiTests': {
-    'coreBranch': 'upload-to-moved-tusTests',
-    'coreCommit': '',
+    'coreBranch': 'master',
+    'coreCommit': 'b1e3888c39de7f450ce782f598d97867f4f50120',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/.drone.star
+++ b/.drone.star
@@ -15,8 +15,8 @@ config = {
     'onlyoffice':'frontend'
   },
   'apiTests': {
-    'coreBranch': 'master',
-    'coreCommit': 'a5df08ca512c3c8e65a01d018c9eec81b9cfccaa',
+    'coreBranch': 'upload-to-moved-tusTests',
+    'coreCommit': '',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -2500,3 +2500,7 @@ apiWebdavUploadTUS/uploadToShare.feature:38
 # https://github.com/owncloud/product/issues/293 sharing with group not available
 apiWebdavUploadTUS/uploadToShare.feature:52
 apiWebdavUploadTUS/uploadToShare.feature:53
+
+# https://github.com/owncloud/ocis/issues/968 [ocis-storage] PROPFIND on a file uploaded by share receiver is not possible
+apiWebdavUploadTUS/uploadToShare.feature:66
+apiWebdavUploadTUS/uploadToShare.feature:67


### PR DESCRIPTION
- to get TUS tests for upload to moved file and upload to overwrite file, see owncloud/core#38177
- to get TUS tests for the creation extension, see owncloud/core#38178  