### PR TITLE
[docs-only] fix failed docs deployment

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -23,7 +23,7 @@ docs-copy:
 	git remote add origin https://github.com/owncloud/owncloud.github.io; \
 	git fetch --depth=1; \
 	git checkout origin/source -f; \
-	rsync -ax --delete --exclude hugo/ --exclude Makefile  --exclude README.md ../. content/; \
+	rsync -ax --delete --exclude hugo/ --exclude Makefile --exclude .gitignore --exclude README.md ../. content/; \
 
 .PHONY: docs-serve
 docs-serve: config-docs-generate docs-copy


### PR DESCRIPTION
Update of owncloud.github.io fails: https://drone.owncloud.com/owncloud/owncloud.github.io/161/1/3

This is because of rsyncing files (https://drone.owncloud.com/owncloud/ocis/1923/85/3) including .gitignore files and then automatically commiting them (https://drone.owncloud.com/owncloud/ocis/1923/85/6).

In this process the configuration.md for ocis gets lost.