### PR TITLE
[docs-only] fix gitignores in hugo docs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1284,14 +1284,6 @@ def docs(ctx):
         ],
       },
       {
-        'name': 'list and remove temporary files',
-        'image': 'owncloudci/alpine:latest',
-        'commands': [
-          'tree hugo/public',
-          'rm -rf docs/hugo',
-        ],
-      },
-      {
         'name': 'publish',
         'image': 'plugins/gh-pages:1',
         'pull': 'always',
@@ -1302,7 +1294,7 @@ def docs(ctx):
           'password': {
             'from_secret': 'github_token',
           },
-          'pages_directory': 'docs/',
+          'pages_directory': 'docs/hugo/content',
           'target_branch': 'docs',
         },
         'when': {
@@ -1312,6 +1304,14 @@ def docs(ctx):
             ],
           },
         },
+      },
+      {
+        'name': 'list and remove temporary files',
+        'image': 'owncloudci/alpine:latest',
+        'commands': [
+          'tree hugo/public',
+          'rm -rf docs/hugo',
+        ],
       },
       {
         'name': 'downstream',


### PR DESCRIPTION
#1003 did not fix the gitignore issue for owncloud.github.io documentation.

The files where gitignore files are filtered out by rsync were not used at all. This is changed by this PR.