### PR TITLE
make insecure upstream servers configurable

### DIFF
--- a/changelog/unreleased/proxy-allow-insecure-upstreams.md
+++ b/changelog/unreleased/proxy-allow-insecure-upstreams.md
@@ -1,0 +1,8 @@
+Change: Proxy allow insecure upstreams
+
+Tags: proxy
+
+We can now configure the proxy if insecure upstream servers are allowed.
+This was added since you need to disable certificate checks fore some situations like testing.
+
+https://github.com/owncloud/ocis/pull/1007

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -106,6 +106,7 @@ type Config struct {
 	PreSignedURL          PreSignedURL
 	AutoprovisionAccounts bool
 	EnableBasicAuth       bool
+	Insecure              bool
 }
 
 // OIDC is the config for the OpenID-Connect middleware. If set the proxy will try to authenticate every request

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -106,7 +106,7 @@ type Config struct {
 	PreSignedURL          PreSignedURL
 	AutoprovisionAccounts bool
 	EnableBasicAuth       bool
-	Insecure              bool
+	InsecureBackends      bool
 }
 
 // OIDC is the config for the OpenID-Connect middleware. If set the proxy will try to authenticate every request

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -189,8 +189,8 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Name:        "insecure",
 			Value:       false,
 			Usage:       "allow insecure communication to upstream servers",
-			EnvVars:     []string{"PROXY_INSECURE"},
-			Destination: &cfg.Insecure,
+			EnvVars:     []string{"PROXY_INSECURE_BACKENDS"},
+			Destination: &cfg.InsecureBackends,
 		},
 
 		// OIDC

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -185,6 +185,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"PROXY_REVA_GATEWAY_ADDR"},
 			Destination: &cfg.Reva.Address,
 		},
+		&cli.BoolFlag{
+			Name:        "insecure",
+			Value:       false,
+			Usage:       "allow insecure communication to upstream servers",
+			EnvVars:     []string{"PROXY_INSECURE"},
+			Destination: &cfg.Insecure,
+		},
 
 		// OIDC
 

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -54,7 +54,7 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: options.Config.Insecure,
+			InsecureSkipVerify: options.Config.InsecureBackends,
 		},
 	}
 

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -36,6 +37,12 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 		config:    options.Config,
 	}
 	rp.Director = rp.directorSelectionDirector
+
+	rp.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: options.Config.Insecure,
+		},
+	}
 
 	if options.Config.Policies == nil {
 		rp.logger.Info().Str("source", "runtime").Msg("Policies")


### PR DESCRIPTION
At the moment we can disable certificate verification for the OIDC provider in the proxy. But you can not disable certificate verification for upstream servers defined in the proxy-config.json.

For some situations like testing, it is desirable to turn off certificate verification for upstream servers in the proxy.