### PR TITLE
Skip account-service by talking to CS3 user-api

### DIFF
--- a/changelog/unreleased/allow-ldap-user-backend.md
+++ b/changelog/unreleased/allow-ldap-user-backend.md
@@ -1,0 +1,12 @@
+Change: CS3 can be used as accounts-backend
+
+Tags: proxy
+
+PROXY_ACCOUNT_BACKEND_TYPE=cs3
+PROXY_ACCOUNT_BACKEND_TYPE=accounts (default)
+
+By using a backend which implements the CS3 user-api (currently provided by reva/storage) it is possible to bypass
+the ocis-accounts service and for example use ldap directly.
+
+
+https://github.com/owncloud/ocis/pull/1020

--- a/deployments/examples/cs3_users_ocis/.env
+++ b/deployments/examples/cs3_users_ocis/.env
@@ -1,0 +1,26 @@
+# If you're on a internet facing server please comment out following line.
+# It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
+INSECURE=true
+
+### Traefik settings ###
+# Domain of Traefik, where you can find the dashboard. Defaults to "traefik.owncloud.test"
+TRAEFIK_DOMAIN=
+# Basic authentication for the dashboard. Defaults to user "admin" and password "admin"
+TRAEFIK_BASIC_AUTH_USERS=
+# Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
+TRAEFIK_ACME_MAIL=
+
+### oCIS settings ###
+# oCIS version. Defaults to "latest"
+OCIS_DOCKER_TAG=
+# Domain of oCIS, where you can find the frontend. Defaults to "ocis.owncloud.test"
+OCIS_DOMAIN=
+
+
+### LDAP server settings ###
+# Password of LDAP user "cn=admin,dc=owncloud,dc=test". Defaults to "admin"
+LDAP_ADMIN_PASSWORD=
+
+### LDAP manager settings ###
+# Domain of LDAP manager. Defaults to "ldap.owncloud.test"
+LDAP_MANAGER_DOMAIN=

--- a/deployments/examples/cs3_users_ocis/README.md
+++ b/deployments/examples/cs3_users_ocis/README.md
@@ -1,0 +1,6 @@
+---
+document this deployment example in docs/ocis/deployment/cs3_users_ocis.md
+---
+
+Please refer to [our documentation](https://owncloud.github.io/ocis/deployment/cs3_users_ocis/)
+for instructions on how to deploy this scenario.

--- a/deployments/examples/cs3_users_ocis/config/ldap/ldif/10_owncloud_schema.ldif
+++ b/deployments/examples/cs3_users_ocis/config/ldap/ldif/10_owncloud_schema.ldif
@@ -1,0 +1,9 @@
+# This LDIF files describes the ownCloud schema and can be used to
+# add two optional attributes: ownCloudQuota and ownCloudUUID
+# The ownCloudUUID is used to store a unique, non-reassignable, persistent identifier for users and groups
+dn: cn=owncloud,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: owncloud
+olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.1 NAME 'ownCloudQuota' DESC 'User Quota (e.g. 2 GB)' EQUALITY caseExactMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.2 NAME 'ownCloudUUID' DESC 'A non-reassignable and persistent account ID)' EQUALITY uuidMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE )
+olcObjectClasses: ( 1.3.6.1.4.1.39430.1.2.1 NAME 'ownCloud' DESC 'ownCloud LDAP Schema' AUXILIARY MAY ( ownCloudQuota $ ownCloudUUID ) )

--- a/deployments/examples/cs3_users_ocis/config/ldap/ldif/20_users.ldif
+++ b/deployments/examples/cs3_users_ocis/config/ldap/ldif/20_users.ldif
@@ -1,0 +1,64 @@
+dn: ou=users,dc=owncloud,dc=com
+objectClass: organizationalUnit
+ou: users
+
+# Start dn with uid (user identifier / login), not cn (Firstname + Surname)
+dn: uid=einstein,ou=users,dc=owncloud,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: ownCloud
+objectClass: person
+objectClass: posixAccount
+objectClass: top
+uid: einstein
+givenName: Albert
+sn: Einstein
+cn: Albert Einstein
+displayName: Albert Einstein
+description: A German-born theoretical physicist who developed the theory of relativity, one of the two pillars of modern physics (alongside quantum mechanics).
+mail: einstein@example.org
+uidNumber: 20000
+gidNumber: 30000
+homeDirectory: /home/einstein
+ownCloudUUID:: NGM1MTBhZGEtYzg2Yi00ODE1LTg4MjAtNDJjZGY4MmMzZDUx
+userPassword:: e1NTSEF9TXJEcXpFNGdKbXZxbVRVTGhvWEZ1VzJBbkV3NWFLK3J3WTIvbHc9PQ==
+
+dn: uid=marie,ou=users,dc=owncloud,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: ownCloud
+objectClass: person
+objectClass: posixAccount
+objectClass: top
+uid: marie
+givenName: Marie
+sn: Curie
+cn: Marie Curie
+displayName: Marie Skłodowska Curie
+description: A Polish and naturalized-French physicist and chemist who conducted pioneering research on radioactivity.
+mail: marie@example.org
+uidNumber: 20001
+gidNumber: 30000
+homeDirectory: /home/marie
+ownCloudUUID:: ZjdmYmY4YzgtMTM5Yi00Mzc2LWIzMDctY2YwYThjMmQwZDlj
+userPassword:: e1NTSEF9UmFvQWs3TU9jRHBIUWY3bXN3MGhHNnVraFZQWnRIRlhOSUNNZEE9PQ==
+
+dn: uid=richard,ou=users,dc=owncloud,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: ownCloud
+objectClass: person
+objectClass: posixAccount
+objectClass: top
+uid: richard
+givenName: Richard
+sn: Feynman
+cn: Richard Feynman
+displayName: Richard Phillips Feynman
+description: An American theoretical physicist, known for his work in the path integral formulation of quantum mechanics, the theory of quantum electrodynamics, the physics of the superfluidity of supercooled liquid helium, as well as his work in particle physics for which he proposed the parton model.
+mail: richard@example.org
+uidNumber: 20002
+gidNumber: 30000
+homeDirectory: /home/richard
+ownCloudUUID:: OTMyYjQ1NDAtOGQxNi00ODFlLThlZjQtNTg4ZTRiNmIxNTFj
+userPassword:: e1NTSEF9Z05LZTRreHdmOGRUREY5eHlhSmpySTZ3MGxSVUM1d1RGcWROTVE9PQ==

--- a/deployments/examples/cs3_users_ocis/config/ldap/ldif/30_groups.ldif
+++ b/deployments/examples/cs3_users_ocis/config/ldap/ldif/30_groups.ldif
@@ -1,0 +1,95 @@
+dn: ou=groups,dc=owncloud,dc=com
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=users,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: users
+description: Users
+gidNumber: 30000
+ownCloudUUID:: NTA5YTlkY2QtYmIzNy00ZjRmLWEwMWEtMTlkY2EyN2Q5Y2Zh
+uniqueMember: uid=einstein,ou=users,dc=owncloud,dc=com
+uniqueMember: uid=marie,ou=users,dc=owncloud,dc=com
+uniqueMember: uid=richard,ou=users,dc=owncloud,dc=com
+
+dn: cn=sailing-lovers,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: sailing-lovers
+description: Sailing lovers
+gidNumber: 30001
+ownCloudUUID:: NjA0MGFhMTctOWM2NC00ZmVmLTliZDAtNzcyMzRkNzFiYWQw
+uniqueMember: uid=einstein,ou=users,dc=owncloud,dc=com
+
+dn: cn=violin-haters,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: violin-haters
+description: Violin haters
+gidNumber: 30002
+ownCloudUUID:: ZGQ1OGU1ZWMtODQyZS00OThiLTg4MDAtNjFmMmVjNmY5MTFm
+uniqueMember: uid=einstein,ou=users,dc=owncloud,dc=com
+
+dn: cn=radium-lovers,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: radium-lovers
+description: Radium lovers
+gidNumber: 30003
+ownCloudUUID:: N2I4N2ZkNDktMjg2ZS00YTVmLWJhZmQtYzUzNWQ1ZGQ5OTdh
+uniqueMember: uid=marie,ou=users,dc=owncloud,dc=com
+
+dn: cn=polonium-lovers,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: polonium-lovers
+description: Polonium lovers
+gidNumber: 30004
+ownCloudUUID:: Y2VkYzIxYWEtNDA3Mi00NjE0LTg2NzYtZmE5MTY1ZjU5OGZm
+uniqueMember: uid=marie,ou=users,dc=owncloud,dc=com
+
+dn: cn=quantum-lovers,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: quantum-lovers
+description: Quantum lovers
+gidNumber: 30005
+ownCloudUUID:: YTE3MjYxMDgtMDFmOC00YzMwLTg4ZGYtMmIxYTlkMWNiYTFh
+uniqueMember: uid=richard,ou=users,dc=owncloud,dc=com
+
+dn: cn=philosophy-haters,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: philosophy-haters
+description: Philosophy haters
+gidNumber: 30006
+ownCloudUUID:: MTY3Y2JlZTItMDUxOC00NTVhLWJmYjItMDMxZmUwNjIxZTVk
+uniqueMember: uid=richard,ou=users,dc=owncloud,dc=com
+
+dn: cn=physics-lovers,ou=groups,dc=owncloud,dc=com
+objectClass: groupOfUniqueNames
+objectClass: posixGroup
+objectClass: ownCloud
+objectClass: top
+cn: physics-lovers
+description: Physics lovers
+gidNumber: 30007
+ownCloudUUID:: MjYyOTgyYzEtMjM2Mi00YWZhLWJmZGYtOGNiZmVmNjRhMDZl
+uniqueMember: uid=einstein,ou=users,dc=owncloud,dc=com
+uniqueMember: uid=marie,ou=users,dc=owncloud,dc=com
+uniqueMember: uid=richard,ou=users,dc=owncloud,dc=com

--- a/deployments/examples/cs3_users_ocis/config/ocis/.gitignore
+++ b/deployments/examples/cs3_users_ocis/config/ocis/.gitignore
@@ -1,0 +1,1 @@
+identifier-registration.yaml

--- a/deployments/examples/cs3_users_ocis/config/ocis/identifier-registration.dist.yaml
+++ b/deployments/examples/cs3_users_ocis/config/ocis/identifier-registration.dist.yaml
@@ -1,0 +1,41 @@
+---
+
+# OpenID Connect client registry.
+clients:
+  - id: phoenix
+    name: OCIS
+    application_type: web
+    insecure: yes
+    trusted: yes
+    redirect_uris:
+      - https://ocis.owncloud.test/
+      - https://ocis.owncloud.test/oidc-callback.html
+      - https://ocis.owncloud.test/oidc-silent-redirect.html
+    origins:
+      - https://ocis.owncloud.test
+
+  - id: ocis-explorer.js
+    name: oCIS Graph Explorer
+    trusted: yes
+    insecure: yes
+
+  - id: xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69
+    secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
+    name: ownCloud desktop app
+    application_type: native
+    insecure: true
+
+  - id: e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD
+    secret: dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD
+    name: ownCloud Android app
+    application_type: native
+    redirect_uris:
+      - oc://android.owncloud.com
+
+  - id: mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1
+    secret: KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx
+    name: ownCloud iOS app
+    application_type: native
+    redirect_uris:
+      - oc://ios.owncloud.com
+      - oc.ios://ios.owncloud.com

--- a/deployments/examples/cs3_users_ocis/config/ocis/proxy-config.json
+++ b/deployments/examples/cs3_users_ocis/config/ocis/proxy-config.json
@@ -1,0 +1,82 @@
+{
+  "HTTP": {
+    "Namespace": "com.owncloud"
+  },
+  "policy_selector": {
+    "static": {
+      "policy": "ocis"
+    }
+  },
+  "policies": [
+    {
+      "name": "ocis",
+      "routes": [
+        {
+          "endpoint": "/",
+          "backend": "http://localhost:9100"
+        },
+        {
+          "endpoint": "/.well-known/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/konnect/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/signin/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "type": "regex",
+          "endpoint": "/ocs/v[12].php/cloud/user/signing-key",
+          "backend": "http://localhost:9110"
+        },
+        {
+          "endpoint": "/ocs/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/remote.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/dav/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/webdav/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/status.php",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/index.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/data",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/api/v0/settings",
+          "backend":  "http://localhost:9190"
+        },
+        {
+          "endpoint": "/settings.js",
+          "backend":  "http://localhost:9190"
+	},
+	{
+          "endpoint": "/api/v0/greet",
+          "backend": "http://localhost:9105"
+        },
+        {
+          "endpoint": "/hello.js",
+          "backend": "http://localhost:9105"
+        }
+      ]
+    }
+  ]
+}

--- a/deployments/examples/cs3_users_ocis/docker-compose.yaml
+++ b/deployments/examples/cs3_users_ocis/docker-compose.yaml
@@ -1,0 +1,147 @@
+---
+version: "3.7"
+
+services:
+  traefik:
+    image: "traefik:v2.3"
+    networks:
+      default:
+        aliases:
+          - ${OCIS_DOMAIN:-ocis.owncloud.test}
+    command:
+      #- "--log.level=DEBUG"
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-'example@example.org'}"
+      - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
+      - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+      - "--api.dashboard=true"
+      - "--entryPoints.http.address=:80"
+      - "--entryPoints.https.address=:443"
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+      - "--providers.docker.exposedByDefault=false"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "certs:/certs"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik.entrypoints=http"
+      - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$apr1$4vqie50r$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
+      - "traefik.http.middlewares.traefik-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.traefik.middlewares=traefik-https-redirect"
+      - "traefik.http.routers.traefik-secure.entrypoints=https"
+      - "traefik.http.routers.traefik-secure.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.routers.traefik-secure.middlewares=traefik-auth"
+      - "traefik.http.routers.traefik-secure.tls=true"
+      - "traefik.http.routers.traefik-secure.tls.certresolver=http"
+      - "traefik.http.routers.traefik-secure.service=api@internal"
+    restart: always
+
+  ocis:
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - | # as long as https://github.com/owncloud/product/issues/15 is open we need this step to template konnectd config
+        cp /config/identifier-registration.dist.yaml /config/identifier-registration.yaml
+        sed -i 's/ocis.owncloud.test/${OCIS_DOMAIN:-ocis.owncloud.test}/g' /config/identifier-registration.yaml
+        ocis server
+    depends_on:
+      - ldap-server
+    environment:
+      # CS3 users frpm ldap specific config
+      PROXY_CONFIG_FILE: "/config/proxy-config.json"
+      LDAP_FILTER: "(&(objectclass=inetOrgPerson)(objectClass=owncloud))"
+      LDAP_URI: ldap://ldap-server:389
+      LDAP_BINDDN: "cn=admin,dc=owncloud,dc=test"
+      LDAP_BINDPW: ${LDAP_ADMIN_PASSWORD:-admin}
+      LDAP_BASEDN: "dc=owncloud,dc=test"
+      LDAP_LOGIN_ATTRIBUTE: uid
+      LDAP_UUID_ATTRIBUTE: "ownclouduuid"
+      LDAP_UUID_ATTRIBUTE_TYPE: binary
+      PROXY_ACCOUNT_BACKEND_TYPE: cs3
+      STORAGE_LDAP_HOSTNAME: ldap-server
+      STORAGE_LDAP_PORT: 636
+      STORAGE_LDAP_BASE_DN: "dc=owncloud,dc=test"
+      STORAGE_LDAP_BIND_DN: "cn=admin,dc=owncloud,dc=test"
+      STORAGE_LDAP_BIND_PASSWORD: ${LDAP_ADMIN_PASSWORD:-admin}
+      STORAGE_LDAP_LOGINFILTER: '(&(objectclass=inetOrgPerson)(objectclass=owncloud)(|(uid={{login}})(mail={{login}})))'
+      STORAGE_LDAP_USERFILTER: '(&(objectclass=inetOrgPerson)(objectclass=owncloud)(|(ownclouduuid={{.OpaqueId}})(uid={{.OpaqueId}})))'
+      STORAGE_LDAP_ATTRIBUTEFILTER: '(&(objectclass=owncloud)({{attr}}={{value}}))'
+      STORAGE_LDAP_FINDFILTER: '(&(objectclass=owncloud)(|(uid={{query}}*)(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)(description={{query}}*)))'
+      STORAGE_LDAP_GROUPFILTER: '(&(objectclass=groupOfUniqueNames)(objectclass=owncloud)(ownclouduuid={{.OpaqueId}}*))'
+      # General ocis config
+      OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
+      OCIS_LOG_LEVEL: error
+      # proxy config
+      PROXY_AUTOPROVISION_ACCOUNTS: "true"
+      PROXY_OIDC_INSECURE: "${INSECURE:-false}"
+      PROXY_OIDC_ISSUER: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      PROXY_TLS: "false"
+      # phoenix config
+      PHOENIX_OIDC_AUTHORITY: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      PHOENIX_OIDC_METADATA_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/.well-known/openid-configuration
+      PHOENIX_WEB_CONFIG_APPS: files,draw-io,markdown-editor,media-viewer
+      PHOENIX_WEB_CONFIG_SERVER: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      # storage config
+      STORAGE_DATAGATEWAY_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/data
+      STORAGE_FRONTEND_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/
+      STORAGE_OIDC_ISSUER: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      # idp config
+      KONNECTD_ISS: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      KONNECTD_TLS: 'false'
+    volumes:
+      - ./config/ocis:/config
+      - ocis-data:/var/tmp/ocis
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ocis.entrypoints=http"
+      - "traefik.http.routers.ocis.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.middlewares.ocis-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.ocis.middlewares=ocis-https-redirect"
+      - "traefik.http.routers.ocis-secure.entrypoints=https"
+      - "traefik.http.routers.ocis-secure.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.routers.ocis-secure.tls=true"
+      - "traefik.http.routers.ocis-secure.tls.certresolver=http"
+      - "traefik.http.routers.ocis-secure.service=ocis"
+      - "traefik.http.services.ocis.loadbalancer.server.port=9200"
+    restart: always
+
+  ldap-server:
+    image: osixia/openldap:latest
+    command: --copy-service --loglevel debug
+    environment:
+      LDAP_TLS_VERIFY_CLIENT: never
+      LDAP_DOMAIN: owncloud.test
+      LDAP_ORGANISATION: ownCloud
+      LDAP_ADMIN_PASSWORD: ${LDAP_ADMIN_PASSWORD:-admin}
+      LDAP_RFC2307BIS_SCHEMA: "true"
+      LDAP_REMOVE_CONFIG_AFTER_SETUP: "false"
+    volumes:
+      - ./config/ldap/ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom
+    restart: always
+
+  ldap-manager:
+    image: osixia/phpldapadmin:0.9.0
+    environment:
+      PHPLDAPADMIN_LDAP_HOSTS: ldap-server
+      PHPLDAPADMIN_HTTPS: "false"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ldap-manager.entrypoints=http"
+      - "traefik.http.routers.ldap-manager.rule=Host(`${LDAP_MANAGER_DOMAIN:-ldap.owncloud.test}`)"
+      - "traefik.http.middlewares.ldap-manager-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.ldap-manager.middlewares=ldap-manager-https-redirect"
+      - "traefik.http.routers.ldap-manager-secure.entrypoints=https"
+      - "traefik.http.routers.ldap-manager-secure.rule=Host(`${LDAP_MANAGER_DOMAIN:-ldap.owncloud.test}`)"
+      - "traefik.http.routers.ldap-manager-secure.tls=true"
+      - "traefik.http.routers.ldap-manager-secure.tls.certresolver=http"
+      - "traefik.http.routers.ldap-manager-secure.service=ldap-manager"
+      - "traefik.http.services.ldap-manager.loadbalancer.server.port=80"
+    restart: always
+
+volumes:
+  certs:
+  ocis-data:

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -115,6 +115,7 @@ type Config struct {
 	PolicySelector        *PolicySelector `mapstructure:"policy_selector"`
 	Reva                  Reva
 	PreSignedURL          PreSignedURL
+	AccountBackend        string
 	AutoprovisionAccounts bool
 	EnableBasicAuth       bool
 	InsecureBackends      bool

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -256,6 +256,14 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.EnableBasicAuth,
 		},
 
+		&cli.StringFlag{
+			Name:        "account-backend-type",
+			Value:       "accounts",
+			Usage:       "account-backend-type",
+			EnvVars:     []string{"PROXY_ACCOUNT_BACKEND_TYPE"},
+			Destination: &cfg.AccountBackend,
+		},
+
 		// Reva Middlewares Config
 		&cli.StringSliceFlag{
 			Name:    "proxy-user-agent-lock-in",

--- a/proxy/pkg/middleware/_account_resolver_test.go
+++ b/proxy/pkg/middleware/_account_resolver_test.go
@@ -1,5 +1,10 @@
 package middleware
 
+/*
+
+Temporarily disabled
+
+
 import (
 	"context"
 	"fmt"

--- a/proxy/pkg/middleware/authentication.go
+++ b/proxy/pkg/middleware/authentication.go
@@ -122,6 +122,7 @@ func newOIDCAuth(options Options) func(http.Handler) http.Handler {
 // newBasicAuth returns a configured basic middleware
 func newBasicAuth(options Options) func(http.Handler) http.Handler {
 	return BasicAuth(
+		UserProvider(options.UserProvider),
 		Logger(options.Logger),
 		EnableBasicAuth(options.EnableBasicAuth),
 		AccountsClient(options.AccountsClient),

--- a/proxy/pkg/middleware/options.go
+++ b/proxy/pkg/middleware/options.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 	"net/http"
 	"time"
 
@@ -26,6 +27,8 @@ type Options struct {
 	HTTPClient *http.Client
 	// AccountsClient for resolving accounts
 	AccountsClient acc.AccountsService
+	// UP
+	UserProvider backend.UserBackend
 	// SettingsRoleService for the roles API in settings
 	SettingsRoleService settings.RoleService
 	// OIDCProviderFunc to lazily initialize an oidc provider, must be set for the oidc_auth middleware
@@ -163,5 +166,12 @@ func TokenCacheSize(size int) Option {
 func TokenCacheTTL(ttl time.Duration) Option {
 	return func(o *Options) {
 		o.UserinfoCacheTTL = ttl
+	}
+}
+
+// UserProvider sets the accounts user provider
+func UserProvider(up backend.UserBackend) Option {
+	return func(o *Options) {
+		o.UserProvider = up
 	}
 }

--- a/proxy/pkg/user/backend/accounts.go
+++ b/proxy/pkg/user/backend/accounts.go
@@ -1,0 +1,218 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	cs3 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
+	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/owncloud/ocis/ocis-pkg/oidc"
+	settings "github.com/owncloud/ocis/settings/pkg/proto/v0"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// NewAccountsServiceUserBackend creates a user-provider which fetches users from the ocis accounts-service
+func NewAccountsServiceUserBackend(ac accounts.AccountsService, rs settings.RoleService, oidcISS string, logger log.Logger) UserBackend {
+	return &accountsServiceBackend{
+		accountsClient:      ac,
+		settingsRoleService: rs,
+		OIDCIss:             oidcISS,
+		logger:              logger,
+	}
+}
+
+type accountsServiceBackend struct {
+	accountsClient      accounts.AccountsService
+	settingsRoleService settings.RoleService
+	OIDCIss             string
+	logger              log.Logger
+}
+
+func (a accountsServiceBackend) GetUserByClaims(ctx context.Context, claim, value string, withRoles bool) (*cs3.User, error) {
+	var account *accounts.Account
+	var status int
+	var query string
+
+	switch claim {
+	case "mail":
+		query = fmt.Sprintf("mail eq '%s'", strings.ReplaceAll(value, "'", "''"))
+	case "username":
+		query = fmt.Sprintf("preferred_name eq '%s'", strings.ReplaceAll(value, "'", "''"))
+	case "id":
+		query = fmt.Sprintf("id eq '%s'", strings.ReplaceAll(value, "'", "''"))
+	default:
+		return nil, fmt.Errorf("invalid user by claim lookup must be  'mail', 'username' or 'id")
+	}
+
+	account, status = a.getAccount(ctx, query)
+	if status == http.StatusNotFound {
+		return nil, ErrAccountNotFound
+	}
+
+	if status != 0 || account == nil {
+		return nil, fmt.Errorf("could not get account, got status: %d", status)
+	}
+
+	if !account.AccountEnabled {
+		return nil, ErrAccountDisabled
+	}
+
+	user := a.accountToUser(account)
+
+	if !withRoles {
+		return user, nil
+	}
+
+	if err := injectRoles(ctx, user, a.settingsRoleService); err != nil {
+		a.logger.Warn().Err(err).Msgf("Could not load roles... continuing without")
+	}
+
+	return user, nil
+
+}
+
+// Authenticate authenticates against the accounts services and returns the user on success
+func (a *accountsServiceBackend) Authenticate(ctx context.Context, username string, password string) (*cs3.User, error) {
+	query := fmt.Sprintf(
+		"login eq '%s' and password eq '%s'",
+		strings.ReplaceAll(username, "'", "''"),
+		strings.ReplaceAll(password, "'", "''"),
+	)
+	account, status := a.getAccount(ctx, query)
+
+	if status != 0 {
+		return nil, fmt.Errorf("could not authenticate with username, password for user %s. Status: %d", username, status)
+	}
+
+	user := a.accountToUser(account)
+
+	if err := injectRoles(ctx, user, a.settingsRoleService); err != nil {
+		a.logger.Warn().Err(err).Msgf("Could not load roles... continuing without")
+	}
+
+	return user, nil
+}
+
+func (a accountsServiceBackend) CreateUserFromClaims(ctx context.Context, claims *oidc.StandardClaims) (*cs3.User, error) {
+	// TODO check if fields are missing.
+	req := &accounts.CreateAccountRequest{
+		Account: &accounts.Account{
+			DisplayName:              claims.DisplayName,
+			PreferredName:            claims.PreferredUsername,
+			OnPremisesSamAccountName: claims.PreferredUsername,
+			Mail:                     claims.Email,
+			CreationType:             "LocalAccount",
+			AccountEnabled:           true,
+		},
+	}
+	created, err := a.accountsClient.CreateAccount(context.Background(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	user := a.accountToUser(created)
+
+	if err := injectRoles(ctx, user, a.settingsRoleService); err != nil {
+		a.logger.Warn().Err(err).Msgf("Could not load roles... continuing without")
+	}
+
+	return user, nil
+}
+
+func (a accountsServiceBackend) GetUserGroups(ctx context.Context, userID string) {
+	panic("implement me")
+}
+
+// accountToUser converts an owncloud account struct to a reva user struct. In the proxy
+// we work with the reva struct as a token can be minted from it.
+func (a *accountsServiceBackend) accountToUser(account *accounts.Account) *cs3.User {
+	user := &cs3.User{
+		Id: &cs3.UserId{
+			OpaqueId: account.Id,
+			Idp:      a.OIDCIss,
+		},
+		Username:     account.OnPremisesSamAccountName,
+		DisplayName:  account.DisplayName,
+		Mail:         account.Mail,
+		MailVerified: account.ExternalUserState == "" || account.ExternalUserState == "Accepted",
+		Groups:       expandGroups(account),
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{},
+		},
+	}
+
+	user.Opaque.Map["uid"] = &types.OpaqueEntry{
+		Decoder: "plain",
+		Value:   []byte(strconv.FormatInt(account.UidNumber, 10)),
+	}
+	user.Opaque.Map["gid"] = &types.OpaqueEntry{
+		Decoder: "plain",
+		Value:   []byte(strconv.FormatInt(account.GidNumber, 10)),
+	}
+	return user
+}
+
+func (a *accountsServiceBackend) getAccount(ctx context.Context, query string) (account *accounts.Account, status int) {
+	resp, err := a.accountsClient.ListAccounts(ctx, &accounts.ListAccountsRequest{
+		Query:    query,
+		PageSize: 2,
+	})
+
+	if err != nil {
+		a.logger.Error().Err(err).Str("query", query).Msgf("error fetching from accounts-service")
+		status = http.StatusInternalServerError
+		return
+	}
+
+	if len(resp.Accounts) <= 0 {
+		a.logger.Error().Str("query", query).Msgf("account not found")
+		status = http.StatusNotFound
+		return
+	}
+
+	if len(resp.Accounts) > 1 {
+		a.logger.Error().Str("query", query).Msgf("more than one account found, aborting")
+		status = http.StatusForbidden
+		return
+	}
+
+	account = resp.Accounts[0]
+	return
+}
+
+func expandGroups(account *accounts.Account) []string {
+	groups := make([]string, len(account.MemberOf))
+	for i := range account.MemberOf {
+		// reva needs the unix group name
+		groups[i] = account.MemberOf[i].OnPremisesSamAccountName
+	}
+	return groups
+}
+
+// injectRoles adds roles from the roles-service to the user-struct by mutating an existing struct
+func injectRoles(ctx context.Context, u *cs3.User, ss settings.RoleService) error {
+	roleIDs, err := loadRolesIDs(ctx, u.Id.OpaqueId, ss)
+	if err != nil {
+		return err
+	}
+
+	if len(roleIDs) == 0 {
+		return nil
+	}
+
+	enc, err := encodeRoleIDs(roleIDs)
+	if err != nil {
+		return err
+	}
+
+	u.Opaque = &types.Opaque{
+		Map: map[string]*types.OpaqueEntry{
+			"roles": enc,
+		},
+	}
+
+	return nil
+}

--- a/proxy/pkg/user/backend/backend.go
+++ b/proxy/pkg/user/backend/backend.go
@@ -1,0 +1,66 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	cs3 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/owncloud/ocis/ocis-pkg/oidc"
+	settings "github.com/owncloud/ocis/settings/pkg/proto/v0"
+	"google.golang.org/grpc"
+)
+
+var (
+	// ErrAccountNotFound account not found
+	ErrAccountNotFound = errors.New("user not found")
+	// ErrAccountDisabled account disabled
+	ErrAccountDisabled = errors.New("account disabled")
+	// ErrNotSupported operation not supported by user-backend
+	ErrNotSupported = errors.New("operation not supported")
+)
+
+// UserBackend allows the proxy to retrieve users from different user-backends (accounts-service, CS3)
+type UserBackend interface {
+	GetUserByClaims(ctx context.Context, claim, value string, withRoles bool) (*cs3.User, error)
+	Authenticate(ctx context.Context, username string, password string) (*cs3.User, error)
+	CreateUserFromClaims(ctx context.Context, claims *oidc.StandardClaims) (*cs3.User, error)
+	GetUserGroups(ctx context.Context, userID string)
+}
+
+// RevaAuthenticator helper interface to mock auth-method from reva gateway-client.
+type RevaAuthenticator interface {
+	Authenticate(ctx context.Context, in *gateway.AuthenticateRequest, opts ...grpc.CallOption) (*gateway.AuthenticateResponse, error)
+}
+
+// loadRolesIDs returns the role-ids assigned to an user
+func loadRolesIDs(ctx context.Context, opaqueUserID string, rs settings.RoleService) ([]string, error) {
+	req := &settings.ListRoleAssignmentsRequest{AccountUuid: opaqueUserID}
+	assignmentResponse, err := rs.ListRoleAssignments(ctx, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	roleIDs := make([]string, 0)
+
+	for _, assignment := range assignmentResponse.Assignments {
+		roleIDs = append(roleIDs, assignment.RoleId)
+	}
+
+	return roleIDs, nil
+}
+
+// encodeRoleIDs encoded the given role id's in to reva-specific format to be able to mint a token from them
+func encodeRoleIDs(roleIDs []string) (*types.OpaqueEntry, error) {
+	roleIDsJSON, err := json.Marshal(roleIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.OpaqueEntry{
+		Decoder: "json",
+		Value:   roleIDsJSON,
+	}, nil
+}

--- a/proxy/pkg/user/backend/cs3.go
+++ b/proxy/pkg/user/backend/cs3.go
@@ -1,0 +1,100 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	cs3 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/owncloud/ocis/ocis-pkg/oidc"
+	settings "github.com/owncloud/ocis/settings/pkg/proto/v0"
+)
+
+type cs3backend struct {
+	userProvider        cs3.UserAPIClient
+	settingsRoleService settings.RoleService
+	authProvider        RevaAuthenticator
+	logger              log.Logger
+}
+
+// NewCS3UserBackend creates a user-provider which fetches users from a CS3 UserBackend
+func NewCS3UserBackend(up cs3.UserAPIClient, rs settings.RoleService, ap RevaAuthenticator, logger log.Logger) UserBackend {
+	return &cs3backend{
+		userProvider:        up,
+		settingsRoleService: rs,
+		authProvider:        ap,
+		logger:              logger,
+	}
+}
+
+func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, withRoles bool) (*cs3.User, error) {
+	res, err := c.userProvider.GetUserByClaim(ctx, &cs3.GetUserByClaimRequest{
+		Claim: claim,
+		Value: value,
+	})
+
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("could not get user by claim %v with value %v: %w", claim, value, err)
+	case res.Status.Code != rpcv1beta1.Code_CODE_OK:
+		if res.Status.Code == rpcv1beta1.Code_CODE_NOT_FOUND {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("could not get user by claim %v with value %v : %w ", claim, value, err)
+	}
+
+	user := res.User
+
+	if !withRoles {
+		return user, nil
+	}
+
+	roleIDs, err := loadRolesIDs(ctx, user.Id.OpaqueId, c.settingsRoleService)
+	if err != nil {
+		c.logger.Error().Err(err).Msg("Could not load roles")
+	}
+
+	if len(roleIDs) == 0 {
+		return user, nil
+
+	}
+
+	enc, err := encodeRoleIDs(roleIDs)
+	if err != nil {
+		c.logger.Error().Err(err).Msg("Could not encode loaded roles")
+	}
+
+	user.Opaque = &types.Opaque{
+		Map: map[string]*types.OpaqueEntry{
+			"roles": enc,
+		},
+	}
+
+	return res.User, nil
+}
+
+func (c *cs3backend) Authenticate(ctx context.Context, username string, password string) (*cs3.User, error) {
+	res, err := c.authProvider.Authenticate(ctx, &gateway.AuthenticateRequest{
+		ClientId:     username,
+		ClientSecret: password,
+	})
+
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("could not authenticate with username and password user: %s, %w", username, err)
+	case res.Status.Code != rpcv1beta1.Code_CODE_OK:
+		return nil, fmt.Errorf("could not authenticate with username and password user: %s, got code: %d", username, res.Status.Code)
+	}
+
+	return res.User, nil
+}
+
+func (c *cs3backend) CreateUserFromClaims(ctx context.Context, claims *oidc.StandardClaims) (*cs3.User, error) {
+	return nil, fmt.Errorf("CS3 Backend does not support creating users from claims")
+}
+
+func (c cs3backend) GetUserGroups(ctx context.Context, userID string) {
+	panic("implement me")
+}


### PR DESCRIPTION
Hides user and auth related communication behind a facade (provider/user.go) to minimize logic-duplication across middlewares. Allows to switich the account backend from accounts to cs3.
```
PROXY_ACCOUNT_BACKEND_TYPE=cs3
PROXY_ACCOUNT_BACKEND_TYPE=accounts
````



# Setup for cs3 
```
mkdir -p  ~/ldapserver/bootscheama
```
Create file ~/ldapserver/bootschema/owncloud.lidif
```
#
# SOURCE:
# https://github.com/valerytschopp/owncloud-ldap-schema
#
# WARNING: the spaces ' ' in the definitions are very important!!!

dn: cn=owncloud,cn=schema,cn=config
objectClass: olcSchemaConfig
cn: owncloud
olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.1 NAME 'ownCloudQuota' DESC 'User Quota (e.g. 2 GB)' EQUALITY caseExactMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.2 NAME 'ownCloudUUID' DESC 'A non-reassignable and persistent account ID)' EQUALITY uuidMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE )
olcObjectClasses: ( 1.3.6.1.4.1.39430.1.2.1 NAME 'ownCloud' DESC 'ownCloud LDAP Schema' AUXILIARY MAY ( ownCloudQuota $ ownCloudUUID ) )
```

Create file ~/ldapserver/bootschema/users.ldif
```
n: ou=users,dc=owncloud,dc=com
objectClass: organizationalUnit
ou: users

dn: cn=einstein,ou=users,dc=owncloud,dc=com
objectClass: inetOrgPerson
objectClass: organizationalPerson
objectClass: ownCloud
objectClass: person
objectClass: top
cn: einstein
givenName: Albert
sn: Einstein
displayName: Albert Einstein
mail: einstein@example.org
ownCloudUUID:: NGM1MTBhZGEtYzg2Yi00ODE1LTg4MjAtNDJjZGY4MmMzZDUx
uid: einstein
userPassword:: e1NTSEF9TXJEcXpFNGdKbXZxbVRVTGhvWEZ1VzJBbkV3NWFLK3J3WTIvbHc9PQ==

dn: cn=marie,ou=users,dc=owncloud,dc=com
objectClass: inetOrgPerson
objectClass: organizationalPerson
objectClass: ownCloud
objectClass: person
objectClass: top
cn: marie
givenName: Marie
sn: Curie
displayName: Marie Curie
mail: marie@example.org
ownCloudUUID:: ZjdmYmY4YzgtMTM5Yi00Mzc2LWIzMDctY2YwYThjMmQwZDlj
uid: marie
userPassword:: e1NTSEF9UmFvQWs3TU9jRHBIUWY3bXN3MGhHNnVraFZQWnRIRlhOSUNNZEE9PQ==

dn: cn=richard,ou=users,dc=owncloud,dc=com
objectClass: inetOrgPerson
objectClass: organizationalPerson
objectClass: ownCloud
objectClass: person
objectClass: top
cn: richard
givenName: Richard
sn: Feynman
displayName: Richard Feynman
mail: richard@example.org
ownCloudUUID:: ZjdmYmY4YzgtMTM5Yi00Mzc2LWIzMDctY2YwYThjMmQwZDlj
uid: richard
userPassword:: e1NTSEF9Z05LZTRreHdmOGRUREY5eHlhSmpySTZ3MGxSVUM1d1RGcWROTVE9PQ==
```

Start ldap-server:
```
cd ~/ldapserver
```

```
 docker run --rm --hostname localhost  \
 -e LDAP_TLS_VERIFY_CLIENT=never \                     
 -e LDAP_DOMAIN=owncloud.com \                     
 -e LDAP_ORGANISATION=ownCloud \                     
 -e LDAP_ADMIN_PASSWORD=admin \                      
 --name docker-slapd \                     
 -p 127.0.0.1:389:389 \                    
 -p 636:636 \                      
 -v ${PWD}/bootschema:/bootschema osixia/openldap --loglevel debug 
```

Modify schema and create test-users (einstein + marie)
```
docker exec docker-slapd ldapadd -Y EXTERNAL -H ldapi:/// -f /bootschema/owncloud.ldif
docker exec docker-slapd ldapadd -Y EXTERNAL -H ldapi:/// -f /bootschema/users.ldif
```

Start ocis:
```
PROXY_ACCOUNT_BACKEND_TYPE=cs3 \
LDAP_FILTER="(objectClass=owncloud)" \ 
LDAP_URI=ldap://localhost:389 \ 
LDAP_BINDDN="cn=admin,dc=owncloud,dc=com" LDAP_BINDPW=admin \
LDAP_BASEDN="dc=owncloud,dc=com" \ 
STORAGE_LDAP_HOSTNAME=localhost STORAGE_LDAP_PORT=636 STORAGE_LDAP_BASE_DN="dc=owncloud,dc=com" \
STORAGE_LDAP_BIND_DN="cn=admin,dc=owncloud,dc=com" \ 
STORAGE_LDAP_BIND_PASSWORD=admin \ 
STORAGE_LDAP_LOGINFILTER='(&(objectclass=owncloud)(|(cn={{login}})(mail={{login}})))' \
STORAGE_LDAP_USERFILTER='(&(objectclass=owncloud)(|(ownclouduuid={{.OpaqueId}})(cn={{.OpaqueId}})))' STORAGE_LDAP_ATTRIBUTEFILTER='(&(objectclass=owncloud)({{attr}}={{value}}))' \
STORAGE_LDAP_FINDFILTER='(&(objectclass=owncloud)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))' STORAGE_LDAP_GROUPFILTER='(objectclass=*)' go run cmd/ocis/main.go server
```

# TODO:
- [x] Clean the dirt
- [x] Better naming for "provider"
- [ ] Adjust tests
- [ ] Test in CI?