### PR TITLE
Disable public link expiration by default

### DIFF
--- a/changelog/unreleased/storage-public-link-expiration.md
+++ b/changelog/unreleased/storage-public-link-expiration.md
@@ -1,0 +1,8 @@
+Bugfix: Disable public link expiration by default
+
+Tags: storage
+
+The public link expiration was enabled by default and didn't have a default expiration span by default, which resulted in already expired public links coming from the public link quick action. We fixed this by disabling the public link expiration by default.
+
+https://github.com/owncloud/ocis/issues/987
+https://github.com/owncloud/ocis/pull/1035

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -139,7 +139,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 							},
 							"ocs": map[string]interface{}{
 								"share_prefix": cfg.Reva.Frontend.OCSSharePrefix,
-								"prefix": cfg.Reva.Frontend.OCSPrefix,
+								"prefix":       cfg.Reva.Frontend.OCSPrefix,
 								"config": map[string]interface{}{
 									"version": "1.8",
 									"website": "reva",
@@ -196,7 +196,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 													},
 												},
 												"expire_date": map[string]interface{}{
-													"enabled": true,
+													"enabled": false,
 												},
 											},
 											"user": map[string]interface{}{

--- a/tests/acceptance/features/apiOcisSpecific/apiCapabilities-capabilitiesWithNormalUser.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiCapabilities-capabilitiesWithNormalUser.feature
@@ -31,7 +31,7 @@ Feature: default capabilities for normal user
       | files_sharing | public@@@enforced_for@@@read_write        | EMPTY             |
       | files_sharing | public@@@enforced_for@@@upload_only       | EMPTY             |
       | files_sharing | public@@@enforced_for@@@read_write_delete | EMPTY             |
-      | files_sharing | public@@@expire_date@@@enabled            | 1                 |
+      | files_sharing | public@@@expire_date@@@enabled            | 0                 |
       | files_sharing | public@@@defaultPublicLinkShareName       | EMPTY             |
       | files_sharing | resharing                                 | 1                 |
       | files_sharing | federation@@@outgoing                     | 1                 |


### PR DESCRIPTION
The public link expiration was enabled by default and didn't have a default expiration span by default, which resulted in already expired public links coming from the public link quick action. We fixed this by disabling the public link expiration by default.

Fixes https://github.com/owncloud/ocis/issues/987