### PR TITLE
use default paths

### DIFF
--- a/deployments/examples/ocis_keycloak/README.md
+++ b/deployments/examples/ocis_keycloak/README.md
@@ -1,5 +1,5 @@
 ---
-document this deployment example in docs/ocis/deployment/ocis_keycloak.md
+document this deployment example in: docs/ocis/deployment/ocis_keycloak.md
 ---
 
 Please refer to [our documentation](https://owncloud.github.io/ocis/deployment/ocis_keycloak/)

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -63,17 +63,8 @@ services:
       STORAGE_DATAGATEWAY_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/data
       STORAGE_FRONTEND_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/
       STORAGE_OIDC_ISSUER: https://${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}
-      STORAGE_METADATA_ROOT:  /opt/ocis-metadata
-      STORAGE_DRIVER_OCIS_ROOT: /opt/ocis-storage
-      # store config
-      STORE_DATA_PATH: /opt/ocis-store
-      # settings config
-      SETTINGS_DATA_PATH: /opt/ocis-settings
     volumes:
-      - ocis-storage:/opt/ocis-storage
-      - ocis-metadata:/opt/ocis-metadata
-      - ocis-store:/opt/ocis-store
-      - ocis-settings:/opt/ocis-settings
+      - ocis-data:/var/tmp/ocis
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.ocis.entrypoints=http"
@@ -129,8 +120,4 @@ services:
 
 volumes:
   certs:
-  ocis-storage:
-  ocis-metadata:
-  ocis-store:
-  ocis-settings:
-  keycloak_postgres_data:
+  ocis-data:

--- a/deployments/examples/ocis_traefik/README.md
+++ b/deployments/examples/ocis_traefik/README.md
@@ -1,6 +1,6 @@
 ---
-document this deployment example in docs/ocis/deployment/owncloud10_with_ocis_web.md
+document this deployment example in: docs/ocis/deployment/ocis_traefik.md
 ---
 
-Please refer to [our documentation](https://owncloud.github.io/ocis/deployment/owncloud10_with_ocis_web/)
+Please refer to [our documentation](https://owncloud.github.io/ocis/deployment/ocis_traefik/)
 for instructions on how to deploy this scenario.

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -68,21 +68,12 @@ services:
       STORAGE_DATAGATEWAY_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/data
       STORAGE_FRONTEND_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/
       STORAGE_OIDC_ISSUER: https://${OCIS_DOMAIN:-ocis.owncloud.test}
-      STORAGE_METADATA_ROOT:  /opt/ocis-metadata
-      STORAGE_DRIVER_OCIS_ROOT: /opt/ocis-storage
-      # store config
-      STORE_DATA_PATH: /opt/ocis-store
-      # settings config
-      SETTINGS_DATA_PATH: /opt/ocis-settings
       # idp config
       KONNECTD_ISS: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       KONNECTD_TLS: 'false'
     volumes:
       - ./config:/config
-      - ocis-storage:/opt/ocis-storage
-      - ocis-metadata:/opt/ocis-metadata
-      - ocis-store:/opt/ocis-store
-      - ocis-settings:/opt/ocis-settings
+      - ocis-data:/var/tmp/ocis
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.ocis.entrypoints=http"
@@ -99,7 +90,4 @@ services:
 
 volumes:
   certs:
-  ocis-storage:
-  ocis-metadata:
-  ocis-store:
-  ocis-settings:
+  ocis-data:

--- a/deployments/examples/owncloud10_with_oc_web/README.md
+++ b/deployments/examples/owncloud10_with_oc_web/README.md
@@ -1,5 +1,5 @@
 ---
-document this deployment example in docs/ocis/deployment/ocis_oc10_backend.md
+document this deployment example in: docs/ocis/deployment/owncloud10_with_oc_web.md
 ---
 
 Please refer to [our documentation](https://owncloud.github.io/ocis/deployment/owncloud10_with_oc_web/)

--- a/deployments/examples/owncloud10_with_oc_web/docker-compose.yml
+++ b/deployments/examples/owncloud10_with_oc_web/docker-compose.yml
@@ -105,18 +105,9 @@ services:
       STORAGE_FRONTEND_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       STORAGE_DATAGATEWAY_PUBLIC_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}/data
       STORAGE_LDAP_IDP: https://${OCIS_DOMAIN:-ocis.owncloud.test}
-      STORAGE_METADATA_ROOT:  /opt/ocis-metadata
-      STORAGE_DRIVER_OCIS_ROOT: /opt/ocis-storage
-      # store config
-      STORE_DATA_PATH: /opt/ocis-store
-      # settings config
-      SETTINGS_DATA_PATH: /opt/ocis-settings
     volumes:
       - ./config/ocis:/config
-      - ocis-storage:/opt/ocis-storage
-      - ocis-metadata:/opt/ocis-metadata
-      - ocis-store:/opt/ocis-store
-      - ocis-settings:/opt/ocis-settings
+      - ocis-data:/var/tmp/ocis
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.ocis.entrypoints=http"
@@ -204,10 +195,7 @@ services:
 
 volumes:
   certs:
-  ocis-storage:
-  ocis-metadata:
-  ocis-store:
-  ocis-settings:
+  ocis-data:
   files:
     driver: local
   mysql:


### PR DESCRIPTION
This reverts all path settings to default. This seems more simple and less to break for the example deployments.

For example the current deployment examples do not start properly because of a missing folder structure. Also not everything was persisted, eg. because of missing `STORAGE_SHARING_USER_JSON_FILE`.
```
ocis_1     | 2020-12-09T22:27:40Z ERR error starting the grpc server error="unable to register services: rgrpc: grpc service usershareprovider could not be started,: error loading the file containing the shares: error opening/creating the file: /var/tmp/ocis/shares.json: open /var/tmp/ocis/shares.json: no such file or directory" service=storage
ocis_1     | process [storage-sharing] exited with code: 1
```

Path logic will be also tackled in #1048