### PR TITLE
[docs-only] remove singlequotes around email address

### DIFF
--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -11,7 +11,7 @@ services:
           - ${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}
     command:
       #- "--log.level=DEBUG"
-      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-'example@example.org'}"
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
       - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
       - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
       - "--api.dashboard=true"

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -10,7 +10,7 @@ services:
           - ${OCIS_DOMAIN:-ocis.owncloud.test}
     command:
       #- "--log.level=DEBUG"
-      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-'example@example.org'}"
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
       - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
       - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
       - "--api.dashboard=true"

--- a/deployments/examples/owncloud10_with_oc_web/docker-compose.yml
+++ b/deployments/examples/owncloud10_with_oc_web/docker-compose.yml
@@ -11,7 +11,7 @@ services:
           - ${OC10_DOMAIN:-oc10.owncloud.test}
     command:
       #- "--log.level=DEBUG"
-      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-'example@example.org'}"
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
       - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
       - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
       - "--api.dashboard=true"


### PR DESCRIPTION
Traefik complains that `'example@example.com'` has invalid characters. The quotes must not be there.

