### PR TITLE
get rid of unused AccountsDataPath

### DIFF
--- a/accounts/pkg/config/config.go
+++ b/accounts/pkg/config/config.go
@@ -40,10 +40,9 @@ type GRPC struct {
 
 // Server configures a server.
 type Server struct {
-	Version          string
-	Name             string
-	AccountsDataPath string
-	HashDifficulty   int
+	Version        string
+	Name           string
+	HashDifficulty int
 }
 
 // Asset defines the available asset configuration.

--- a/accounts/pkg/flagset/flagset.go
+++ b/accounts/pkg/flagset/flagset.go
@@ -119,13 +119,6 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"ACCOUNTS_NAME"},
 			Destination: &cfg.Server.Name,
 		},
-		&cli.StringFlag{
-			Name:        "accounts-data-path",
-			Value:       "/var/tmp/ocis-accounts",
-			Usage:       "accounts folder",
-			EnvVars:     []string{"ACCOUNTS_DATA_PATH"},
-			Destination: &cfg.Server.AccountsDataPath,
-		},
 		&cli.IntFlag{
 			Name:        "accounts-hash-difficulty",
 			Value:       11,

--- a/accounts/pkg/proto/v0/accounts.pb.micro_test.go
+++ b/accounts/pkg/proto/v0/accounts.pb.micro_test.go
@@ -78,7 +78,6 @@ func init() {
 	)
 
 	cfg := config.New()
-	cfg.Server.AccountsDataPath = dataPath
 	cfg.Repo.Disk.Path = dataPath
 	var hdlr *svc.Service
 	var err error

--- a/accounts/pkg/service/v0/accounts_permission_test.go
+++ b/accounts/pkg/service/v0/accounts_permission_test.go
@@ -33,7 +33,6 @@ var (
 func init() {
 	cfg := config.New()
 	cfg.Server.Name = "accounts"
-	cfg.Server.AccountsDataPath = dataPath
 	cfg.Repo.Disk.Path = dataPath
 	logger := olog.NewLogger(olog.Color(true), olog.Pretty(true))
 	roleServiceMock = buildRoleServiceMock()

--- a/accounts/pkg/service/v0/groups.go
+++ b/accounts/pkg/service/v0/groups.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"path"
-	"path/filepath"
 	"strconv"
 
 	"github.com/gofrs/uuid"
@@ -182,7 +181,6 @@ func (s Service) DeleteGroup(c context.Context, in *proto.DeleteGroupRequest, ou
 	if id, err = cleanupID(in.Id); err != nil {
 		return merrors.InternalServerError(s.id, "could not clean up group id: %v", err.Error())
 	}
-	path := filepath.Join(s.Config.Server.AccountsDataPath, "groups", id)
 
 	g := &proto.Group{}
 	if err = s.repo.LoadGroup(c, id, g); err != nil {
@@ -212,7 +210,7 @@ func (s Service) DeleteGroup(c context.Context, in *proto.DeleteGroupRequest, ou
 	}
 
 	if err = s.index.Delete(g); err != nil {
-		s.log.Error().Err(err).Str("id", id).Str("path", path).Msg("could not remove group from index")
+		s.log.Error().Err(err).Str("id", id).Msg("could not remove group from index")
 		return merrors.InternalServerError(s.id, "could not remove group from index: %v", err.Error())
 	}
 

--- a/ocs/pkg/server/http/svc_test.go
+++ b/ocs/pkg/server/http/svc_test.go
@@ -539,9 +539,7 @@ func init() {
 	)
 
 	c := &accountsCfg.Config{
-		Server: accountsCfg.Server{
-			AccountsDataPath: dataPath,
-		},
+		Server: accountsCfg.Server{},
 		Repo: accountsCfg.Repo{
 			Disk: accountsCfg.Disk{
 				Path: dataPath,


### PR DESCRIPTION
As noticed in #1048 (https://github.com/owncloud/ocis/pull/1048#discussion_r540457917) AccountsDataPath is not used anymore except for logging.