### PR TITLE
Disable auto-provisioning

### DIFF
--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -55,7 +55,6 @@ services:
       OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error}
       # proxy config
-      PROXY_AUTOPROVISION_ACCOUNTS: "true"
       PROXY_OIDC_INSECURE: "${INSECURE:-false}"
       PROXY_OIDC_ISSUER: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       PROXY_TLS: "false"


### PR DESCRIPTION
Fixes a issue where deleted users get re-provisioned from claims. 
Closes #1072

