### PR TITLE
Introduce permission checks for WRITE access via http

### DIFF
--- a/changelog/unreleased/settings-permissions.md
+++ b/changelog/unreleased/settings-permissions.md
@@ -1,0 +1,7 @@
+Bugfix: Permission checks for settings write access
+
+Tags: settings
+
+There were several endpoints with write access to the settings service that were not protected by permission checks. We introduced a generic settings management permission to fix this for now. Will be more fine grained later on.
+
+https://github.com/owncloud/ocis/pull/1092

--- a/ocis-pkg/middleware/account.go
+++ b/ocis-pkg/middleware/account.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
@@ -46,7 +47,8 @@ func ExtractAccountUUID(opts ...account.Option) func(http.Handler) http.Handler 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := r.Header.Get("x-access-token")
 			if len(token) == 0 {
-				ctx := metadata.Set(r.Context(), RoleIDs, "")
+				roleIDsJSON, _ := json.Marshal([]string{})
+				ctx := metadata.Set(r.Context(), RoleIDs, string(roleIDsJSON))
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}

--- a/ocis-pkg/middleware/account.go
+++ b/ocis-pkg/middleware/account.go
@@ -46,7 +46,8 @@ func ExtractAccountUUID(opts ...account.Option) func(http.Handler) http.Handler 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := r.Header.Get("x-access-token")
 			if len(token) == 0 {
-				next.ServeHTTP(w, r)
+				ctx := metadata.Set(r.Context(), RoleIDs, "")
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 

--- a/settings/go.sum
+++ b/settings/go.sum
@@ -196,6 +196,7 @@ github.com/cs3org/go-cs3apis v0.0.0-20200730121022-c4f3d4f7ddfd/go.mod h1:UXha4T
 github.com/cs3org/go-cs3apis v0.0.0-20200810113633-b00aca449666/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20201007120910-416ed6cf8b00 h1:LVl25JaflluOchVvaHWtoCynm5OaM+VNai0IYkcCSe0=
 github.com/cs3org/go-cs3apis v0.0.0-20201007120910-416ed6cf8b00/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20201118090759-87929f5bae21 h1:mZpylrgnCgSeaZ5EznvHIPIKuaQHMHZDi2wkJtk4M8Y=
 github.com/cs3org/go-cs3apis v0.0.0-20201118090759-87929f5bae21/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v1.1.0 h1:Gih6ECHvMMGSx523SFluFlDmNMuhYelXYShdWvjvW38=
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
@@ -1332,6 +1333,7 @@ golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff h1:1CPUrky56AcgSpxz/KfgzQWzfG09u5YOL8MvPYBlrL8=
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201101102859-da207088b7d1 h1:a/mKvvZr9Jcc8oKfcmgzyp7OwF73JPWsQLvH1z2Kxck=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/settings/pkg/proto/v0/settings.pb.micro_test.go
+++ b/settings/pkg/proto/v0/settings.pb.micro_test.go
@@ -382,7 +382,7 @@ func TestGetBundleHavingFullPermissionsOnAnotherRole(t *testing.T) {
 	defer teardown()
 
 	ctx := metadata.Set(context.Background(), middleware.AccountID, testAccountID)
-	ctx = metadata.Set(ctx, middleware.RoleIDs, getRoleIDAsJSON(svc.BundleUUIDRoleUser))
+	ctx = metadata.Set(ctx, middleware.RoleIDs, getRoleIDAsJSON(svc.BundleUUIDRoleAdmin))
 
 	saveRequest := proto.SaveBundleRequest{
 		Bundle: &bundleStub,
@@ -392,6 +392,8 @@ func TestGetBundleHavingFullPermissionsOnAnotherRole(t *testing.T) {
 	assert.Equal(t, bundleStub.Id, saveResponse.Bundle.Id)
 
 	setFullReadWriteOnBundleForAdmin(ctx, t, bundleStub.Id)
+
+	ctx = metadata.Set(ctx, middleware.RoleIDs, getRoleIDAsJSON(svc.BundleUUIDRoleUser))
 	getRequest := proto.GetBundleRequest{BundleId: bundleStub.Id}
 	getResponse, err := bundleService.GetBundle(ctx, &getRequest)
 	assert.Empty(t, getResponse)

--- a/settings/pkg/service/v0/settings.go
+++ b/settings/pkg/service/v0/settings.go
@@ -16,6 +16,11 @@ const (
 	RoleManagementPermissionID string = "a53e601e-571f-4f86-8fec-d4576ef49c62"
 	// RoleManagementPermissionName is the hardcoded setting name for the role management permission
 	RoleManagementPermissionName string = "role-management"
+
+	// SettingsManagementPermissionID is the hardcoded setting UUID for the settings management permission
+	SettingsManagementPermissionID string = "79e13b30-3e22-11eb-bc51-0b9f0bad9a58"
+	// SettingsManagementPermissionName is the hardcoded setting name for the settings management permission
+	SettingsManagementPermissionName string = "settings-management"
 )
 
 // generateBundlesDefaultRoles bootstraps the default roles.
@@ -78,6 +83,25 @@ func generatePermissionRequests() []*settings.AddSettingToBundleRequest {
 				Name:        RoleManagementPermissionName,
 				DisplayName: "Role Management",
 				Description: "This permission gives full access to everything that is related to role management.",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_USER,
+					Id:   "all",
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_READWRITE,
+						Constraint: settings.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+		},
+		{
+			BundleId: BundleUUIDRoleAdmin,
+			Setting: &settings.Setting{
+				Id:          SettingsManagementPermissionID,
+				Name:        SettingsManagementPermissionName,
+				DisplayName: "Settings Management",
+				Description: "This permission gives full access to everything that is related to settings management.",
 				Resource: &settings.Resource{
 					Type: settings.Resource_TYPE_USER,
 					Id:   "all",


### PR DESCRIPTION
This PR introduces permission checks for the write access http endpoints, so this already improves security.

There is another issue, that users can save values of other users. This is not tackled, yet. Could happen in a separate PR if we want to merge this one here quickly.