### PR TITLE
[tests-only] Bump core commit id for API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -17,7 +17,7 @@ config = {
   },
   'apiTests': {
     'coreBranch': 'master',
-    'coreCommit': '52105a981c0c74fc81c84218e9076d443b06f074',
+    'coreCommit': '27eaa32d777052d1d210647cd38895e647c48fed',
     'numberOfParts': 10
   },
   'uiTests': {

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -2414,3 +2414,11 @@ apiShareManagementBasicToShares/createShareToSharesFolder.feature:612
 # https://github.com/owncloud/ocis/issues/1012 TUS OPTIONS requests does not reply with TUS headers when invalid password
 apiWebdavUploadTUS/optionsRequest.feature:29
 apiWebdavUploadTUS/optionsRequest.feature:40
+
+# https://github.com/owncloud/ocis/issues/1047 500 Internal Server Error on Post request for TUS upload
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:29
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:30
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:43
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:44
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:57
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:58


### PR DESCRIPTION
Includes various new TUS upload tests in the API test suite from oC10 core.

Matching PR in `cs3org/reva` is https://github.com/cs3org/reva/pull/1372