### PR TITLE
[docs-only] [CI only] fix docs-only pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -207,7 +207,7 @@ def main(ctx):
   or \
   (ctx.build.event != "pull" and '[docs-only]' in (ctx.build.title + ctx.build.message)):
   # [docs-only] is not taken from PR messages, but from commit messages
-    pipelines = docs(ctx)
+    pipelines = [docs(ctx)]
 
   else:
     if '[with-benchmarks]' in (ctx.build.title + ctx.build.message):


### PR DESCRIPTION
docs only pipelines fail since #973. Eg. https://drone.owncloud.com/owncloud/ocis/2303

[docs-only] is in the PR title to demonstrate that it works again.