### PR TITLE
[tests-only] Bump webCommit for UI tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -22,7 +22,7 @@ config = {
   },
   'uiTests': {
     'webBranch': 'master',
-    'webCommit': 'a96ce8dfa86dc668b620b609830b75dfa4c07a3d',
+    'webCommit': '5dae1886973ddbab0243e364800fa207fb716a20',
       'suites': {
         'webUIBasic': [
           'webUILogin',

--- a/.drone.star
+++ b/.drone.star
@@ -624,11 +624,11 @@ def uiTestPipeline(ctx, suiteName, webBranch = 'master', webCommit = '', storage
         'commands': [
           'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/testing',
           'git clone -b %s --single-branch --no-tags https://github.com/owncloud/web.git /srv/app/web' % (webBranch),
-          'cp -r /srv/app/web/tests/acceptance/filesForUpload/* /uploads',
           'cd /srv/app/web',
         ] + ([
           'git checkout %s' % (webCommit)
         ] if webCommit != '' else []) + [
+          'cp -r tests/acceptance/filesForUpload/* /uploads',
           'yarn install-all',
           'yarn run acceptance-tests-drone'
         ],
@@ -691,11 +691,11 @@ def accountsUITests(ctx, webBranch, webCommit, storage = 'owncloud', accounts_ha
         'commands': [
           'git clone -b master --depth=1 https://github.com/owncloud/testing.git /srv/app/testing',
           'git clone -b %s --single-branch --no-tags https://github.com/owncloud/web.git /srv/app/web' % (webBranch),
-          'cp -r /srv/app/web/tests/acceptance/filesForUpload/* /uploads',
           'cd /srv/app/web',
         ] + ([
           'git checkout %s' % (webCommit)
         ] if webCommit != '' else []) + [
+          'cp -r tests/acceptance/filesForUpload/* /uploads',
           'yarn install-all',
           'cd /drone/src/accounts',
           'yarn install --all',


### PR DESCRIPTION
Gets test code from web PRs:
https://github.com/owncloud/web/pull/4508 Fix random typos
https://github.com/owncloud/web/pull/4509 Fix: Delete file in trashbin UI test step not working
https://github.com/owncloud/web/pull/4512 Support an EXPECTED_FAILURES_FILE for web UI tests

Note: this does not actually add an expected-failures file for web UI tests here in `owncloud/ocis` - that will come in a later PR when there are test scenarios enabled in `owncloud/web` that fail here in `owncloud/ocis`