### PR TITLE
make tracing defaults consistent

### DIFF
--- a/ocis/pkg/flagset/flagset.go
+++ b/ocis/pkg/flagset/flagset.go
@@ -51,14 +51,14 @@ func RootWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tracing-endpoint",
-			Value:       "localhost:6831",
+			Value:       "",
 			Usage:       "Endpoint for the agent",
 			EnvVars:     []string{"OCIS_TRACING_ENDPOINT"},
 			Destination: &cfg.Tracing.Endpoint,
 		},
 		&cli.StringFlag{
 			Name:        "tracing-collector",
-			Value:       "http://localhost:14268/api/traces",
+			Value:       "",
 			Usage:       "Endpoint for the collector",
 			EnvVars:     []string{"OCIS_TRACING_COLLECTOR"},
 			Destination: &cfg.Tracing.Collector,

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -77,7 +77,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tracing-collector",
-			Value:       "http://localhost:14268/api/traces",
+			Value:       "",
 			Usage:       "Endpoint for the collector",
 			EnvVars:     []string{"PROXY_TRACING_COLLECTOR"},
 			Destination: &cfg.Tracing.Collector,


### PR DESCRIPTION
ocis and proxy are the only extensions which have a default for tracing endpoints. There shouldn't be a default at all, because there is a comparison if OCIS_TRACING_COLLECTOR is empty:

https://github.com/owncloud/ocis/blob/a591d651198758ca1d958b40c55a7984cc99f521/proxy/pkg/command/server.go#L81-L89

Which calls this: https://github.com/census-ecosystem/opencensus-go-exporter-jaeger/blob/30c8b0fe8ad9d0eac5785893f3941b2e72c5aaaa/jaeger.go#L88-L98


For example if you want to use OCIS_TRACING_ENDPOINT at the moment you have to explicitly override OCIS_TRACING_COLLECTOR with an empty string. The  configuration looks like this:

```
export OCIS_TRACING_COLLECTOR=""
export OCIS_TRACING_ENABLED=true
export OCIS_TRACING_ENDPOINT=127.0.0.1:6831
```

After the merge this would look like this:

```
export OCIS_TRACING_ENABLED=true
export OCIS_TRACING_ENDPOINT=127.0.0.1:6831
```


Loosely related: https://github.com/cs3org/reva/pull/1379