### PR TITLE
reduce warn logs

### DIFF
--- a/thumbnails/pkg/thumbnail/storage/filesystem.go
+++ b/thumbnails/pkg/thumbnail/storage/filesystem.go
@@ -41,7 +41,7 @@ func (s *FileSystem) Get(username string, key string) []byte {
 	img := filepath.Join(userDir, key)
 	content, err := ioutil.ReadFile(img)
 	if err != nil {
-		s.logger.Warn().Err(err).Msgf("could not read file %s", key)
+		s.logger.Debug().Str("err", err.Error()).Str("key", key).Msg("could not load thumbnail from store")
 		return nil
 	}
 	return content


### PR DESCRIPTION
When we try to load the thumbnail from the store for the first time we expect it to fail so we shouldn't log with level warn.

