### PR TITLE
[Tests-only] use .drone.env for checking out tests in docker based acceptance tests

### DIFF
--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -18,9 +18,6 @@ COMPOSE_FILE ?= src/redis.yml:src/ocis-base.yml:src/acceptance.yml
 ## user input
 BEHAT_FEATURE ?=
 
-CORE_BRANCH ?= master
-CORE_COMMIT ?= 52105a981c0c74fc81c84218e9076d443b06f074
-
 ifdef OCIS_IMAGE_TAG
 	COMPOSE_FILE := $(COMPOSE_FILE):src/ocis-image.yml
 else
@@ -184,8 +181,6 @@ testSuite: clean-docker-container
 	OCIS_IMAGE_TAG=$(OCIS_IMAGE_TAG) \
 	BEHAT_SUITE=$(BEHAT_SUITE) \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
-	CORE_BRANCH=$(CORE_BRANCH) \
-	CORE_COMMIT=$(CORE_COMMIT) \
 	DIVIDE_INTO_NUM_PARTS=$(DIVIDE_INTO_NUM_PARTS) \
 	RUN_PART=$(RUN_PART) \
 	docker-compose up -d --build --remove-orphans --force-recreate
@@ -201,8 +196,6 @@ clean-docker-container: ## clean docker containers created during acceptance tes
 	@COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 	COMPOSE_FILE=$(COMPOSE_FILE) \
 	BEHAT_SUITE="" \
-	CORE_BRANCH="" \
-	CORE_COMMIT="" \
 	DIVIDE_INTO_NUM_PARTS="" \
 	OCIS_IMAGE_TAG="" \
 	RUN_PART="" \
@@ -216,8 +209,6 @@ clean-docker-volumes: ## clean docker volumes created during acceptance tests
 	STORAGE=$(STORAGE) \
 	COMPOSE_FILE=$(COMPOSE_FILE) \
 	BEHAT_SUITE="" \
-	CORE_BRANCH="" \
-	CORE_COMMIT="" \
 	DIVIDE_INTO_NUM_PARTS="" \
 	OCIS_IMAGE_TAG="" \
 	RUN_PART="" \

--- a/tests/acceptance/docker/src/acceptance.yml
+++ b/tests/acceptance/docker/src/acceptance.yml
@@ -10,14 +10,14 @@ services:
       TEST_SERVER_URL: https://ocis-server:9200
       TESTING_DIR: /srv/app/tmp/testing
 
-      CORE_BRANCH: $CORE_BRANCH
-      CORE_COMMIT: $CORE_COMMIT
       STORAGE: $STORAGE
       TEST_SOURCE: $TEST_SOURCE
       BEHAT_SUITE: ${BEHAT_SUITE:-}
       BEHAT_FEATURE: ${BEHAT_FEATURE:-}
       DIVIDE_INTO_NUM_PARTS: $DIVIDE_INTO_NUM_PARTS
       RUN_PART: $RUN_PART
+    env_file:
+      - ../../../../.drone.env
     volumes:
       - ./run-tests.sh:/test/run-tests.sh
       - oCISownCloud10testsuite:/srv

--- a/tests/acceptance/docker/src/run-tests.sh
+++ b/tests/acceptance/docker/src/run-tests.sh
@@ -15,11 +15,11 @@ if cd $PATH_TO_CORE > /dev/null 2>&1
 then
     git checkout $CORE_BRANCH
     git pull
-    git checkout $CORE_COMMIT
+    git checkout $CORE_COMMITID
 else
     git clone -b $CORE_BRANCH --single-branch --no-tags https://github.com/owncloud/core.git $PATH_TO_CORE
     cd $PATH_TO_CORE
-    git checkout $CORE_COMMIT
+    git checkout $CORE_COMMITID
 fi
 
 ## CONFIGURE TEST


### PR DESCRIPTION
needs #1149 merged first. 

removes duplication https://github.com/owncloud/ocis/pull/1117#issuecomment-747571408