### PR TITLE
[tests-only] try different timing of etag propagation tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=85da111d5ec5660f7294a789304b4bfc32580d95
-CORE_BRANCH=master
+CORE_COMMITID=871017cce3595e8ef782818a7aab2489178d7f0c
+CORE_BRANCH=test-etag-timing
 
 # The test runner source for UI tests
 WEB_COMMITID=4d5539fe1ebb3eab700ca692a9d7407cc650de1d

--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=871017cce3595e8ef782818a7aab2489178d7f0c
+CORE_COMMITID=9f813dab1386de8f69536715acea22cd8ec72795
 CORE_BRANCH=test-etag-timing
 
 # The test runner source for UI tests


### PR DESCRIPTION
1) wait 2 seconds before checking etags

2) after first creating a file and remembering the etag, wait 2 seconds. That makes sure that the next action (renaming/moving the file...) happens in a different Unix timestamp second

Both of these "pass". That is, the expected-failures are the same, no scenarios "magically" started to pass. So the reason for the failures is not just the test timing.

Issue https://github.com/owncloud/product/issues/279