### PR TITLE
[Tests-Only] clean up sonar excludes

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,5 +32,5 @@ sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 sonar.go.coverage.reportPaths=coverage/*_coverage.out
 
 # Exclude files
-sonar.exclusions=changelog/**,*/pkg/assets/embed.go,konnectd/assets/identifier/**,**/package.json,**/rollup.config.js,CHANGELOG.md
-sonar.coverage.exclusions=docs/**,**/third_party,**/pkg/proto/*.pb.*,**/*_test.go
+sonar.exclusions=**/third_party,docs/**,changelog/**,*/pkg/assets/embed.go,konnectd/assets/identifier/**,**/package.json,**/rollup.config.js,CHANGELOG.md,**/pkg/proto/*.pb.*,deployments/**,tests/**,vendor-bin/**,README.m
+sonar.coverage.exclusions=**/*_test.go


### PR DESCRIPTION
Updated the sonar excludes.
Things in `sonar.exclusions` don't need to be listed `sonar.coverage.exclusions` since it will take it from the former.
Added new non source folders like `deployments/` and `tests/`.