### PR TITLE
generate cryptographically secure state token

### DIFF
--- a/changelog/unreleased/generate-secure-state.md
+++ b/changelog/unreleased/generate-secure-state.md
@@ -1,0 +1,7 @@
+Change: generate cryptographically secure state token 
+
+Replaced Math.random with a cryptographically secure way to generate the oidc state token using the javascript crypto api. 
+
+https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+https://github.com/owncloud/ocis/pull/1203

--- a/konnectd/ui/src/utils.js
+++ b/konnectd/ui/src/utils.js
@@ -1,5 +1,9 @@
 export function withClientRequestState(obj) {
-  obj.state = Math.random().toString(36).substring(7);
+  // Generate a 16 byte random token
+  const values = new Uint8Array(16);
+  crypto.getRandomValues(values);
+  // Convert the 16 byte to a hex string and assign to the state attribute
+  obj.state = Array.prototype.map.call(values, x => x.toString(16)).join('');
 
   return obj;
 }


### PR DESCRIPTION
Replaced Math.random with a cryptographically secure way to generate the oidc state token using the javascript crypto api.

https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random