### PR TITLE
[tests-only] do not let someone accidentally commit a local .drone.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ composer.lock
 vendor
 vendor-bin/**/vendor
 vendor-bin/**/composer.lock
+
+# drone CI is in .drone.star, do not let someone accidentally commit a local .drone.yml
+.drone.yml


### PR DESCRIPTION
## Description
When debugging what pipeline `.drone.star` actually produces, it is possibly to locally do:
```
drone starlark
```

And that produces a generated `.drone.yml` that you can examine.

We do not want people to accidentally commit that file.

Note: this is already ignored in `owncloud/core`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
