### PR TITLE
Update pman to 7406747552bc

### DIFF
--- a/ocis/go.mod
+++ b/ocis/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/owncloud/ocis/thumbnails v0.1.6
 	github.com/owncloud/ocis/web v0.0.0-00010101000000-000000000000
 	github.com/owncloud/ocis/webdav v0.0.0-00010101000000-000000000000
-	github.com/refs/pman v0.0.0-20201214134707-9ce4dcebbbf8
+	github.com/refs/pman v0.0.0-20210125101615-7406747552bc
 	github.com/restic/calens v0.2.0
 	github.com/spf13/viper v1.7.1
 	go.opencensus.io v0.22.5

--- a/ocis/go.sum
+++ b/ocis/go.sum
@@ -1161,6 +1161,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/refs/pman v0.0.0-20201214134707-9ce4dcebbbf8 h1:7Pz7RrqgDeEp/nTGK55clOWODZ4+2D7J5K0VFOiYHU0=
 github.com/refs/pman v0.0.0-20201214134707-9ce4dcebbbf8/go.mod h1:EHI7tmxO5Ct3xBLHU43j51o5/U6VQz0TM6ik8RPE570=
+github.com/refs/pman v0.0.0-20210125101615-7406747552bc h1:bh42GGXCDC/sVwu/1bYm4BCHBeXeX1qY8WSokQYuykQ=
+github.com/refs/pman v0.0.0-20210125101615-7406747552bc/go.mod h1:OQcXtpEk2nPkbM32jtWRIyZHTTFReKIFmTrJb06pVY4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/restic/calens v0.1.0/go.mod h1:u67f5msOjCTDYNzOf/NoAUSdmXP03YXPCwIQLYADy5M=
@@ -1281,6 +1283,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1 h1:TPyHV/OgChqNcnYqCoCvIFjR9TU60gFXXBKnhOBzVEI=
 github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1/go.mod h1:gCcfDlA1Y7GqOaeEKw5l9dOGx1VLdc/HuQSlQAaZ30s=
 github.com/subosito/gotenv v1.1.1/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/ocis/pkg/runtime/runtime.go
+++ b/ocis/pkg/runtime/runtime.go
@@ -80,10 +80,12 @@ func New(cfg *config.Config) Runtime {
 // Start rpc runtime
 func (r *Runtime) Start() error {
 	go r.Launch()
-	return service.Start()
+	return service.Start(
+		service.WithLogPretty(r.c.Log.Pretty),
+	)
 }
 
-// Launch ocis default ocis extensions.
+// Launch oCIS default extensions.
 func (r *Runtime) Launch() {
 	var client *rpc.Client
 	var err error


### PR DESCRIPTION
## Note
This will be the latest PR regarding the runtime that requires refs/pman. The runtime will be moved to owncloud/ocis/ocis.

Pman's changelog:

[source](https://github.com/refs/pman/pull/10)
- pman now catches `SIGHUP`, preventing leaving zombie processes when losing control of a terminal
- encountered the good old halting problem with the way ocis initializes extensions. A bandaid is a `time.Sleep` added to delay shutdown and wait for the last write. Logically, there is a case scenario when writers write (or, fail to write) after the shutdown reads and deletes entries, ending up in an empty db file and an orphan process.
- fixes https://github.com/owncloud/ocis/issues/1173 by a global recovery handler.
- adds support for setting `RUNTIME_PORT` on your environment. **NOTE: When combined with oCIS it requires changes in the source, as currently the runtime port is hardcoded in oCIS to 10666**
- no more file management for tracking extension+PID tuples.

While the sync solution is only a bandaid and a more robust solution is due, we'll get this rolling first, track it and move along while is not an issue. It needs to be tested in slow machines.

This has been tested with the following diff on oCIS:

```diff
diff --git a/ocis/go.mod b/ocis/go.mod
index bda423ae..dfbf75c9 100644
--- a/ocis/go.mod
+++ b/ocis/go.mod
@@ -39,6 +39,7 @@ require (
 
 replace (
 	github.com/gomodule/redigo => github.com/gomodule/redigo v1.8.2
+	github.com/refs/pman => ../../../refs/pman
 	github.com/owncloud/ocis/accounts => ../accounts
 	github.com/owncloud/ocis/glauth => ../glauth
 	github.com/owncloud/ocis/konnectd => ../konnectd
diff --git a/ocis/go.sum b/ocis/go.sum
index a67c3209..0adb6770 100644
--- a/ocis/go.sum
+++ b/ocis/go.sum
@@ -1279,6 +1279,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1 h1:TPyHV/OgChqNcnYqCoCvIFjR9TU60gFXXBKnhOBzVEI=
 github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1/go.mod h1:gCcfDlA1Y7GqOaeEKw5l9dOGx1VLdc/HuQSlQAaZ30s=
 github.com/subosito/gotenv v1.1.1/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
diff --git a/ocis/pkg/runtime/runtime.go b/ocis/pkg/runtime/runtime.go
index de5061a4..711f377d 100644
--- a/ocis/pkg/runtime/runtime.go
+++ b/ocis/pkg/runtime/runtime.go
@@ -80,10 +80,12 @@ func New(cfg *config.Config) Runtime {
 // Start rpc runtime
 func (r *Runtime) Start() error {
 	go r.Launch()
-	return service.Start()
+	return service.Start(
+		service.WithLogPretty(r.c.Log.Pretty),
+	)
 }
 
-// Launch ocis default ocis extensions.
+// Launch oCIS default extensions.
 func (r *Runtime) Launch() {
 	var client *rpc.Client
 	var err error

```

# Gotchas

- Note that if the runtime (a.k.a process thst runs `ocis server` is killed with SIGKILL children processes will be left orphan)
- If spamming starting a server and interrupting the startup, sometimes a race condition-like scenario happens.