### PR TITLE
add GitHub native dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/ocis"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/accounts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/settings"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/onlyoffice"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/konnectd"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+


### PR DESCRIPTION
Setup dependabot for Go.
Also added config for the npm dependencies in accounts, settings, konnectd, and onlyoffice since I don't know if this config file would disable npm scanning.