### PR TITLE
update docs to use latest ocis

### DIFF
--- a/docs/ocis/getting-started.md
+++ b/docs/ocis/getting-started.md
@@ -16,16 +16,20 @@ We are distributing oCIS as binaries and Docker images.
 You can find more deployments examples in the [deployment section](https://owncloud.github.io/ocis/deployment/)
 
 ### Binaries
+You can find the latest official release of ocis at [our download mirror](https://download.owncloud.com/ocis/ocis/) or on [GitHub](https://github.com/owncloud/ocis/releases).
+The latest build from the master branch can be found at [our download mirrors testing section](https://download.owncloud.com/ocis/ocis/testing/).
 
-The binaries for different platforms are downloadable at [our download mirror](https://download.owncloud.com/ocis/ocis/) or on [GitHub](https://github.com/owncloud/ocis/releases). Latest binaries from the master branch can be found at [our download mirrors testing section](https://download.owncloud.com/ocis/ocis/testing/).
+To run ocis as binary you need to download it first and then run the following commands.
+For this example, assuming version 1.1.0 of ocis running on a Linux AMD64 host:
 
 ```console
-# for mac
-curl https://download.owncloud.com/ocis/ocis/1.0.0/ocis-1.0.0-darwin-amd64 --output ocis
-# for linux
-curl https://download.owncloud.com/ocis/ocis/1.0.0/ocis-1.0.0-linux-amd64 --output ocis
+# download
+curl https://download.owncloud.com/ocis/ocis/1.1.0/ocis-1.1.0-linux-amd64 --output ocis
+
 # make binary executable
 chmod +x ocis
+
+# run
 ./ocis server
 ```
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of OCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
current version of docs are still using ocis 1.0.0 as an example for binary installation. This PR slightly updates the wording and changes the ocis installation example

## Motivation and Context
we need clean docs 🚀 

## Types of changes
- [X] Update documentation
