### PR TITLE
lower the open pull request limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,29 +4,29 @@ updates:
     directory: "/ocis"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
 
   - package-ecosystem: "npm"
     directory: "/accounts"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
 
   - package-ecosystem: "npm"
     directory: "/settings"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
 
   - package-ecosystem: "npm"
     directory: "/onlyoffice"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
 
   - package-ecosystem: "npm"
     directory: "/idp"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
 


### PR DESCRIPTION
Updated the max PR limit so that dependabot doesn't DoS the CI server.