### PR TITLE
make reva ocis storage driver uuid configurable

### DIFF
--- a/storage/pkg/command/drivers.go
+++ b/storage/pkg/command/drivers.go
@@ -91,7 +91,7 @@ func drivers(cfg *config.Config) map[string]interface{} {
 			"user_layout":         cfg.Reva.Storages.Common.UserLayout,
 			"treetime_accounting": true,
 			"treesize_accounting": true,
-			"owner":               "95cb8724-03b2-11eb-a0a6-c33ef8ef53ad", // the accounts service system account uuid
+			"owner":               cfg.Reva.Storages.OCIS.ServiceUserUUID, // the accounts service system account uuid
 		},
 		"s3": map[string]interface{}{
 			"region":     cfg.Reva.Storages.S3.Region,

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -165,6 +165,7 @@ type StorageConfig struct {
 	OwnCloud DriverOwnCloud
 	S3       DriverS3
 	Common   DriverCommon
+	OCIS     DriverOCIS
 	// TODO checksums ... figure out what that is supposed to do
 }
 
@@ -240,6 +241,11 @@ type DriverEOS struct {
 
 	// gateway service to use for uid lookups
 	GatewaySVC string
+}
+
+// DriverOCIS defines the available oCIS storage driver configuration.
+type DriverOCIS struct {
+	ServiceUserUUID string
 }
 
 // DriverOwnCloud defines the available ownCloud storage driver configuration.

--- a/storage/pkg/flagset/driverocis.go
+++ b/storage/pkg/flagset/driverocis.go
@@ -30,5 +30,12 @@ func DriverOCISWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"STORAGE_DRIVER_OCIS_LAYOUT"},
 			Destination: &cfg.Reva.Storages.Common.UserLayout,
 		},
+		&cli.StringFlag{
+			Name:        "service-user-uuid",
+			Value:       "95cb8724-03b2-11eb-a0a6-c33ef8ef53ad",
+			Usage:       "uuid of the internal service user",
+			EnvVars:     []string{"STORAGE_DRIVER_OCIS_SERVICE_USER_UUID"},
+			Destination: &cfg.Reva.Storages.OCIS.ServiceUserUUID,
+		},
 	}
 }


### PR DESCRIPTION
## Description
Currently the system user UUID for oCIS storage is hardcoded in the driver configuration:
https://github.com/owncloud/ocis/blob/dea1fa87a97bcabe1aacf89028441b583898399d/storage/pkg/command/drivers.go#L94

On the accounts side it is configurable:
https://github.com/owncloud/ocis/blob/dea1fa87a97bcabe1aacf89028441b583898399d/accounts/pkg/flagset/flagset.go#L178-L184

## Related Issue

## Motivation and Context
It should be configurable on both sides.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
