### PR TITLE
[docs-only] keycloak example: remove demo users from accounts

### DIFF
--- a/deployments/examples/ocis_keycloak/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_keycloak/config/ocis/entrypoint-override.sh
@@ -22,7 +22,7 @@ echo "default secrets changed"
 echo "##################################################"
 
 echo "##################################################"
-echo "delete demo users:" # demo users are provided by keycloak
+echo "delete demo users" # demo users are provided by keycloak
 
 set +e # accounts can only delete once, so it will fail the second time
 ocis accounts remove 4c510ada-c86b-4815-8820-42cdf82c3d51
@@ -34,6 +34,4 @@ set -e
 
 echo "##################################################"
 
-killall ocis
-
-ocis server
+wait # wait for oCIS to exit

--- a/deployments/examples/ocis_keycloak/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_keycloak/config/ocis/entrypoint-override.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -evx
+set -e
 
 ocis server&
 sleep 10
@@ -18,8 +18,22 @@ REVA_USER_UUID=$(ocis accounts list | grep " | Reva Inter " | egrep '[0-9a-f]{8}
 echo "  Reva user UUID: $REVA_USER_UUID"
 ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD $REVA_USER_UUID
 
-killall ocis
 echo "default secrets changed"
 echo "##################################################"
+
+echo "##################################################"
+echo "delete demo users:" # demo users are provided by keycloak
+
+set +e # accounts can only delete once, so it will fail the second time
+ocis accounts remove 4c510ada-c86b-4815-8820-42cdf82c3d51
+ocis accounts remove ddc2004c-0977-11eb-9d3f-a793888cd0f8
+ocis accounts remove 932b4540-8d16-481e-8ef4-588e4b6b151c
+ocis accounts remove 058bff95-6708-4fe5-91e4-9ea3d377588b
+ocis accounts remove f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c
+set -e
+
+echo "##################################################"
+
+killall ocis
 
 ocis server

--- a/deployments/examples/ocis_traefik/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_traefik/config/ocis/entrypoint-override.sh
@@ -18,8 +18,7 @@ REVA_USER_UUID=$(ocis accounts list | grep " | Reva Inter " | egrep '[0-9a-f]{8}
 echo "  Reva user UUID: $REVA_USER_UUID"
 ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD $REVA_USER_UUID
 
-killall ocis
 echo "default secrets changed"
 echo "##################################################"
 
-ocis server
+wait # wait for oCIS to exit

--- a/deployments/examples/ocis_traefik/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_traefik/config/ocis/entrypoint-override.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -evx
+set -e
 
 ocis server&
 sleep 10


### PR DESCRIPTION
## Description
This PR removes demo users from accounts for the keycloak deployment example since they will be provided by Keycloak itself.

On the long run we should make demo users optional (default: not use them?). This would make this script obsolete.

## Related Issue
- #1628 

## Motivation and Context
Even after #1628 is applied, thumbnails will not be shown for demo users logging in with keycloak if the demo users are already present in accounts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- running oCIS Keycloak example locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
