### PR TITLE
remove ocis config file option

### DIFF
--- a/changelog/unreleased/ocis_config_file_option.md
+++ b/changelog/unreleased/ocis_config_file_option.md
@@ -1,0 +1,3 @@
+Bugfix: Remove unimplemented config file option for oCIS root command
+
+https://github.com/owncloud/ocis/pull/1636

--- a/ocis/pkg/config/config.go
+++ b/ocis/pkg/config/config.go
@@ -61,7 +61,6 @@ type TokenManager struct {
 
 // Config combines all available configuration parts.
 type Config struct {
-	File         string
 	Registry     string
 	Log          Log
 	Debug        Debug

--- a/ocis/pkg/flagset/flagset.go
+++ b/ocis/pkg/flagset/flagset.go
@@ -9,13 +9,6 @@ import (
 func RootWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:        "config-file",
-			Value:       "",
-			Usage:       "Path to config file",
-			EnvVars:     []string{"OCIS_CONFIG_FILE"},
-			Destination: &cfg.File,
-		},
-		&cli.StringFlag{
 			Name:        "log-level",
 			Value:       "info",
 			Usage:       "Set logging level",


### PR DESCRIPTION
## Description
The oCIS root command offers a config file option `ocis --config-file` which does not do anything.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1618 confusion caused by the available option

## Motivation and Context
As far as I know, there aren't any plans to support a single config file which can be load by the oCIS root command.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
