### PR TITLE
[docs-only] fix certificate issuing limit for continuously deployed examples

### DIFF
--- a/deployments/continuous-deployment-config/cs3_users_ocis/latest.yml
+++ b/deployments/continuous-deployment-config/cs3_users_ocis/latest.yml
@@ -10,6 +10,8 @@
       owner: wkloucek
       for: oCIS-continuous-deployment-examples
     rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
 
   domains:
     - "*.ocis-cs3-users.latest.owncloud.works"

--- a/deployments/continuous-deployment-config/cs3_users_ocis/released.yml
+++ b/deployments/continuous-deployment-config/cs3_users_ocis/released.yml
@@ -10,6 +10,8 @@
       owner: wkloucek
       for: oCIS-continuous-deployment-examples
     rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
 
   domains:
     - "*.ocis-cs3-users.released.owncloud.works"

--- a/deployments/continuous-deployment-config/ocis_keycloak/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_keycloak/latest.yml
@@ -10,6 +10,8 @@
       owner: wkloucek
       for: oCIS-continuous-deployment-examples
     rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
 
   domains:
     - "*.ocis-keycloak.latest.owncloud.works"

--- a/deployments/continuous-deployment-config/ocis_keycloak/released.yml
+++ b/deployments/continuous-deployment-config/ocis_keycloak/released.yml
@@ -10,6 +10,8 @@
       owner: wkloucek
       for: oCIS-continuous-deployment-examples
     rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
 
   domains:
     - "*.ocis-keycloak.released.owncloud.works"

--- a/deployments/continuous-deployment-config/ocis_traefik/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_traefik/latest.yml
@@ -10,6 +10,8 @@
       owner: wkloucek
       for: oCIS-continuous-deployment-examples
     rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
 
   domains:
     - "*.ocis-traefik.latest.owncloud.works"

--- a/deployments/continuous-deployment-config/ocis_traefik/released.yml
+++ b/deployments/continuous-deployment-config/ocis_traefik/released.yml
@@ -10,6 +10,8 @@
       owner: wkloucek
       for: oCIS-continuous-deployment-examples
     rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
 
   domains:
     - "*.ocis-traefik.released.owncloud.works"


### PR DESCRIPTION
## Description
Continuously deployed servers are pruned every night. This also includes LetsEncrypt certificates. This means we are requesting new certificates every night and therefore run in certificate issuing limits.

This PR carries the certificates from the pruned to the new instances to circumvent this.

Implemented in https://github.com/owncloud-devops/continuous-deployment/pull/8

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
