### PR TITLE
Use registry interface value

### DIFF
--- a/accounts/pkg/command/version.go
+++ b/accounts/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListAccountsWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.GRPC.Namespace + "." + cfg.Server.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get accounts services from the registry: %v", err))

--- a/changelog/unreleased/use-registry-interface.md
+++ b/changelog/unreleased/use-registry-interface.md
@@ -1,0 +1,6 @@
+Enhancement: Add initial nats and kubernetes registry support
+
+We added initial support to use nats and kubernetes as a service registry using `MICRO_REGISTRY=nats` and `MICRO_REGISTRY=kubernetes` respectively.
+Multiple nodes can be given with `MICRO_REGISTRY_ADDRESS=1.2.3.4,5.6.7.8,9.10.11.12`.
+
+https://github.com/owncloud/ocis/pull/1697

--- a/idp/pkg/command/version.go
+++ b/idp/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListIDPWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.Service.Namespace + "." + cfg.Service.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get idp services from the registry: %v", err))

--- a/ocis-pkg/registry/registry.go
+++ b/ocis-pkg/registry/registry.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	etcdr "github.com/asim/go-micro/plugins/registry/etcd/v3"
+	kubernetesr "github.com/asim/go-micro/plugins/registry/kubernetes/v3"
 	mdnsr "github.com/asim/go-micro/plugins/registry/mdns/v3"
+	natsr "github.com/asim/go-micro/plugins/registry/nats/v3"
 
 	"github.com/asim/go-micro/v3/registry"
 )
@@ -23,6 +25,14 @@ func GetRegistry() registry.Registry {
 
 	var r registry.Registry
 	switch os.Getenv(registryEnv) {
+	case "nats":
+		r = natsr.NewRegistry(
+			registry.Addrs(addresses...),
+		)
+	case "kubernetes":
+		r = kubernetesr.NewRegistry(
+			registry.Addrs(addresses...),
+		)
 	case "etcd":
 		r = etcdr.NewRegistry(
 			registry.Addrs(addresses...),

--- a/ocis-pkg/registry/registry.go
+++ b/ocis-pkg/registry/registry.go
@@ -18,7 +18,7 @@ var (
 // GetRegistry returns a configured micro registry based on Micro env vars.
 // It defaults to mDNS, so mind that systems with mDNS disabled by default (i.e SUSE) will have a hard time
 // and it needs to explicitly use etcd. Os awareness for providing a working registry out of the box should be done.
-func GetRegistry() *registry.Registry {
+func GetRegistry() registry.Registry {
 	addresses := strings.Split(os.Getenv(registryAddressEnv), ",")
 
 	var r registry.Registry
@@ -31,5 +31,5 @@ func GetRegistry() *registry.Registry {
 		r = mdnsr.NewRegistry()
 	}
 
-	return &r
+	return r
 }

--- a/ocis-pkg/service/grpc/service.go
+++ b/ocis-pkg/service/grpc/service.go
@@ -39,7 +39,7 @@ func NewService(opts ...Option) Service {
 		micro.Version(sopts.Version),
 		micro.Context(sopts.Context),
 		micro.Flags(sopts.Flags...),
-		micro.Registry(*registry.GetRegistry()),
+		micro.Registry(registry.GetRegistry()),
 		micro.RegisterTTL(time.Second * 30),
 		micro.RegisterInterval(time.Second * 10),
 		micro.WrapHandler(prometheus.NewHandlerWrapper()),

--- a/ocis-pkg/service/http/service.go
+++ b/ocis-pkg/service/http/service.go
@@ -32,7 +32,7 @@ func NewService(opts ...Option) Service {
 		micro.Version(sopts.Version),
 		micro.Context(sopts.Context),
 		micro.Flags(sopts.Flags...),
-		micro.Registry(*registry.GetRegistry()),
+		micro.Registry(registry.GetRegistry()),
 		micro.RegisterTTL(time.Second * 30),
 		micro.RegisterInterval(time.Second * 10),
 	}

--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -44,7 +44,7 @@ func Execute() error {
 		)
 	}
 
-	//r := *registry.GetRegistry()
+	//r := registry.GetRegistry()
 
 	//opts := micro.Options{
 	//	Registry: r,

--- a/ocis/pkg/command/version.go
+++ b/ocis/pkg/command/version.go
@@ -19,7 +19,7 @@ func VersionCommand(cfg *config.Config) *cli.Command {
 		Usage:    "Lists running services with version",
 		Category: "Runtime",
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			serviceList, err := reg.ListServices()
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not list services: %v", err))

--- a/ocs/pkg/command/version.go
+++ b/ocs/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListOcsWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.Service.Namespace + "." + cfg.Service.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get ocs services from the registry: %v", err))

--- a/proxy/pkg/command/version.go
+++ b/proxy/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListProxyWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.Service.Namespace + "." + cfg.Service.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get proxy services from the registry: %v", err))

--- a/settings/pkg/command/version.go
+++ b/settings/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListSettingsWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.GRPC.Namespace + "." + cfg.Service.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get settings services from the registry: %v", err))

--- a/storage/pkg/service/external/external.go
+++ b/storage/pkg/service/external/external.go
@@ -19,13 +19,13 @@ func RegisterGRPCEndpoint(ctx context.Context, serviceID, uuid, addr string, log
 		Address:  addr,
 		Metadata: make(map[string]string),
 	}
+	r := oregistry.GetRegistry()
+
 	node.Metadata["broker"] = broker.String()
-	node.Metadata["registry"] = registry.String()
+	node.Metadata["registry"] = r.String()
 	node.Metadata["server"] = "grpc"
 	node.Metadata["transport"] = "grpc"
 	node.Metadata["protocol"] = "grpc"
-
-	r := *oregistry.GetRegistry()
 
 	service := &registry.Service{
 		Name:      serviceID,

--- a/store/pkg/command/version.go
+++ b/store/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListStoreWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.Service.Namespace + "." + cfg.Service.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get store services from the registry: %v", err))

--- a/thumbnails/pkg/command/version.go
+++ b/thumbnails/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListThumbnailsWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.Server.Namespace + "." + cfg.Server.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get thumbnails services from the registry: %v", err))

--- a/webdav/pkg/command/version.go
+++ b/webdav/pkg/command/version.go
@@ -19,7 +19,7 @@ func PrintVersion(cfg *config.Config) *cli.Command {
 		Usage: "Print the versions of the running instances",
 		Flags: flagset.ListWebdavWithConfig(cfg),
 		Action: func(c *cli.Context) error {
-			reg := *registry.GetRegistry()
+			reg := registry.GetRegistry()
 			services, err := reg.GetService(cfg.Service.Namespace + "." + cfg.Service.Name)
 			if err != nil {
 				fmt.Println(fmt.Errorf("could not get webdav services from the registry: %v", err))


### PR DESCRIPTION
We added initial support to use nats and kubernetes as a service registry using `MICRO_REGISTRY=nats` and `MICRO_REGISTRY=kubernetes` respectively.
Multiple nodes can be given with `MICRO_REGISTRY_ADDRESS=1.2.3.4,5.6.7.8,9.10.11.12`.
