### PR TITLE
fix token cache TTL

### DIFF
--- a/changelog/unreleased/fix-tokencache-ttl.md
+++ b/changelog/unreleased/fix-tokencache-ttl.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the ttl of the authentication middleware cache 
+
+The authentication cache ttl was multiplied with `time.Second` multiple times. This resulted in a ttl that was not intended.
+
+https://github.com/owncloud/ocis/pull/1699

--- a/proxy/pkg/middleware/authentication.go
+++ b/proxy/pkg/middleware/authentication.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"time"
 )
 
 var (
@@ -114,7 +113,7 @@ func newOIDCAuth(options Options) func(http.Handler) http.Handler {
 		HTTPClient(options.HTTPClient),
 		OIDCIss(options.OIDCIss),
 		TokenCacheSize(options.UserinfoCacheSize),
-		TokenCacheTTL(time.Second*time.Duration(options.UserinfoCacheTTL)),
+		TokenCacheTTL(options.UserinfoCacheTTL),
 		CredentialsByUserAgent(options.CredentialsByUserAgent),
 	)
 }


### PR DESCRIPTION
The TTL was supplied to the middleware as a duration and then in that middleware multiplied by `time.Second` again. Durations should not be multiplied because they result in unintended values.
 ```go
            time.Second * 1 = 1s
            time.Second * time.Second = 277777h46m40s
```