### PR TITLE
pre allocate slices

### DIFF
--- a/glauth/pkg/server/glauth/ocis.go
+++ b/glauth/pkg/server/glauth/ocis.go
@@ -275,7 +275,7 @@ func attribute(name string, values ...string) *ldap.EntryAttribute {
 }
 
 func (h ocisHandler) mapAccounts(accounts []*accounts.Account) []*ldap.Entry {
-	var entries []*ldap.Entry
+	entries := make([]*ldap.Entry, 0, len(accounts))
 	for i := range accounts {
 		attrs := []*ldap.EntryAttribute{
 			attribute("objectClass", "posixAccount", "inetOrgPerson", "organizationalPerson", "Person", "top"),
@@ -314,7 +314,7 @@ func (h ocisHandler) mapAccounts(accounts []*accounts.Account) []*ldap.Entry {
 }
 
 func (h ocisHandler) mapGroups(groups []*accounts.Group) []*ldap.Entry {
-	var entries []*ldap.Entry
+	entries := make([]*ldap.Entry, 0, len(groups))
 	for i := range groups {
 		attrs := []*ldap.EntryAttribute{
 			attribute("objectClass", "posixGroup", "groupOfNames", "top"),

--- a/graph/pkg/service/v0/groups.go
+++ b/graph/pkg/service/v0/groups.go
@@ -53,7 +53,7 @@ func (g Graph) GetGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var groups []*msgraph.Group
+	groups := make([]*msgraph.Group, 0, len(result.Entries))
 
 	for _, group := range result.Entries {
 		groups = append(

--- a/graph/pkg/service/v0/users.go
+++ b/graph/pkg/service/v0/users.go
@@ -76,7 +76,7 @@ func (g Graph) GetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var users []*msgraph.User
+	users := make([]*msgraph.User, 0, len(result.Entries))
 
 	for _, user := range result.Entries {
 		users = append(

--- a/ocis-pkg/conversions/strings.go
+++ b/ocis-pkg/conversions/strings.go
@@ -7,8 +7,8 @@ import (
 
 // StringToSliceString splits a string into a slice string according to separator
 func StringToSliceString(src string, sep string) []string {
-	var parts []string
 	parsed := strings.Split(src, sep)
+	parts := make([]string, 0, len(parsed))
 	for _, v := range parsed {
 		parts = append(parts, strings.TrimSpace(v))
 	}

--- a/ocis-pkg/conversions/strings_test.go
+++ b/ocis-pkg/conversions/strings_test.go
@@ -26,7 +26,7 @@ func TestStringToSliceString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := StringToSliceString(tt.input, tt.separator)
 			for i, v := range tt.out {
-				if tt.out[i] != v {
+				if s[i] != v {
 					t.Errorf("got %q, want %q", s, tt.out)
 				}
 			}

--- a/ocis-pkg/indexer/index/disk/non_unique.go
+++ b/ocis-pkg/indexer/index/disk/non_unique.go
@@ -83,7 +83,7 @@ func (idx *NonUnique) Lookup(v string) ([]string, error) {
 		return []string{}, err
 	}
 
-	var ids []string = nil
+	ids := make([]string, 0, len(fi))
 	for _, f := range fi {
 		ids = append(ids, f.Name())
 	}

--- a/thumbnails/pkg/thumbnail/resolutions.go
+++ b/thumbnails/pkg/thumbnail/resolutions.go
@@ -36,7 +36,7 @@ type Resolutions []image.Rectangle
 
 // ParseResolutions creates an instance of Resolutions from resolution strings.
 func ParseResolutions(strs []string) (Resolutions, error) {
-	var rs Resolutions
+	rs := make(Resolutions, 0, len(strs))
 	for _, s := range strs {
 		r, err := ParseResolution(s)
 		if err != nil {


### PR DESCRIPTION
Pre allocating slices with a target size reduces the number of allocations because we already know how big the slice will be and therefore need to allocate only once