### PR TITLE
[docs-only] Expected-failures files changed to .md from .txt in documentation

### DIFF
--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -131,12 +131,12 @@ To run a single test add `BEHAT_FEATURE=<feature file>`
 ### use existing tests for BDD
 
 As a lot of scenarios are written for oC10, we can use those tests for Behaviour driven development in ocis.
-Every scenario that does not work in oCIS with "owncloud" storage, is listed in `tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt` with a link to the related issue.
-Every scenario that does not work in oCIS with "ocis" storage, is listed in `tests/acceptance/expected-failures-on-OCIS-storage.txt` with a link to the related issue.
+Every scenario that does not work in oCIS with "owncloud" storage, is listed in `tests/acceptance/expected-failures-on-OWNCLOUD-storage.md` with a link to the related issue.
+Every scenario that does not work in oCIS with "ocis" storage, is listed in `tests/acceptance/expected-failures-on-OCIS-storage.md` with a link to the related issue.
 
 Those scenarios are run in the ordinary acceptance test pipeline in CI. The scenarios that fail are checked against the
 expected failures. If there are any differences then the CI pipeline fails.
-Similarly, scenarios that do not work in oCIS with EOS storage are listed in `tests/acceptance/expected-failures-on-EOS-storage.txt`.
+Similarly, scenarios that do not work in oCIS with EOS storage are listed in `tests/acceptance/expected-failures-on-EOS-storage.md`.
 Additionally, some issues have scenarios that demonstrate the current buggy behaviour in ocis(reva).
 Those scenarios are in this ocis repository in `tests/acceptance/features/apiBugDemonstration`.
 Have a look into the [documentation](https://doc.owncloud.com/server/developer_manual/testing/acceptance-tests.html#writing-scenarios-for-bugs) to understand why we are writing those tests.


### PR DESCRIPTION

## Description
Expected - failure files were changed to `.md` from `.txt` but the documentation still mentioned expected-failure files to be `.txt` , this PR fixes that.

## Related Issue
- https://github.com/owncloud/ocis/issues/1634
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: <https://github.com/owncloud/ocis/issues/1634> 
