### PR TITLE
add missing gatewaysvc config

### DIFF
--- a/changelog/unreleased/add-missing-gatewaysvc-config.md
+++ b/changelog/unreleased/add-missing-gatewaysvc-config.md
@@ -1,0 +1,5 @@
+Bugfix: Add missing gateway config
+
+The auth provider `ldap` and `oidc` drivers now need to be able talk to the reva gateway. We added the `gatewayscv` to the config that is passed to reva.
+
+https://github.com/owncloud/ocis/pull/1716

--- a/storage/pkg/command/authbasic.go
+++ b/storage/pkg/command/authbasic.go
@@ -101,6 +101,7 @@ func AuthBasic(cfg *config.Config) *cli.Command {
 										"bind_username": cfg.Reva.LDAP.BindDN,
 										"bind_password": cfg.Reva.LDAP.BindPassword,
 										"idp":           cfg.Reva.LDAP.IDP,
+										"gatewaysvc":    cfg.Reva.Gateway.Endpoint,
 										"schema": map[string]interface{}{
 											"dn":          "dn",
 											"uid":         cfg.Reva.LDAP.UserSchema.UID,

--- a/storage/pkg/command/authbearer.go
+++ b/storage/pkg/command/authbearer.go
@@ -91,11 +91,12 @@ func AuthBearer(cfg *config.Config) *cli.Command {
 								"auth_manager": "oidc",
 								"auth_managers": map[string]interface{}{
 									"oidc": map[string]interface{}{
-										"issuer":    cfg.Reva.OIDC.Issuer,
-										"insecure":  cfg.Reva.OIDC.Insecure,
-										"id_claim":  cfg.Reva.OIDC.IDClaim,
-										"uid_claim": cfg.Reva.OIDC.UIDClaim,
-										"gid_claim": cfg.Reva.OIDC.GIDClaim,
+										"issuer":     cfg.Reva.OIDC.Issuer,
+										"insecure":   cfg.Reva.OIDC.Insecure,
+										"id_claim":   cfg.Reva.OIDC.IDClaim,
+										"uid_claim":  cfg.Reva.OIDC.UIDClaim,
+										"gid_claim":  cfg.Reva.OIDC.GIDClaim,
+										"gatewaysvc": cfg.Reva.Gateway.Endpoint,
 									},
 								},
 							},

--- a/storage/pkg/flagset/authbasic.go
+++ b/storage/pkg/flagset/authbasic.go
@@ -59,6 +59,16 @@ func AuthBasicWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:   "--service authprovider [--service otherservice]",
 			EnvVars: []string{"STORAGE_AUTH_BASIC_SERVICES"},
 		},
+
+		// Gateway
+
+		&cli.StringFlag{
+			Name:        "gateway-url",
+			Value:       "localhost:9142",
+			Usage:       "URL to use for the storage gateway service",
+			EnvVars:     []string{"STORAGE_GATEWAY_ENDPOINT"},
+			Destination: &cfg.Reva.Gateway.Endpoint,
+		},
 	}
 
 	flags = append(flags, TracingWithConfig(cfg)...)

--- a/storage/pkg/flagset/authbearer.go
+++ b/storage/pkg/flagset/authbearer.go
@@ -86,6 +86,16 @@ func AuthBearerWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:   "--service authprovider [--service otherservice]",
 			EnvVars: []string{"STORAGE_AUTH_BEARER_SERVICES"},
 		},
+
+		// Gateway
+
+		&cli.StringFlag{
+			Name:        "gateway-url",
+			Value:       "localhost:9142",
+			Usage:       "URL to use for the storage gateway service",
+			EnvVars:     []string{"STORAGE_GATEWAY_ENDPOINT"},
+			Destination: &cfg.Reva.Gateway.Endpoint,
+		},
 	}
 
 	flags = append(flags, TracingWithConfig(cfg)...)


### PR DESCRIPTION
The auth provider `ldap` and `oidc` drivers now need to be able talk to the reva gateway. We added the `gatewayscv` to the config that is passed to reva.
