### PR TITLE
Delay accounts service startup

### DIFF
--- a/changelog/unreleased/accounts-init-regression.md
+++ b/changelog/unreleased/accounts-init-regression.md
@@ -1,0 +1,8 @@
+Bugfix: Purposely delay accounts service startup
+
+As it turns out the race condition between `accounts <-> storage-metadata` still remains. This PR is a hotfix, and it should be followed up with a proper fix. Either:
+
+- block the accounts' initialization until the storage metadata is ready (using the registry) or
+- allow the accounts service to initialize and use a message broker to signal the accounts the metadata storage is ready to receive requests.
+
+https://github.com/owncloud/ocis/pull/1734

--- a/ocis/pkg/runtime/runtime.go
+++ b/ocis/pkg/runtime/runtime.go
@@ -50,13 +50,11 @@ var (
 		"thumbnails",
 		"web",
 		"webdav",
-		"accounts",
-		//"graph",
-		//"graph-explorer",
 	}
 
 	dependants = []string{
 		"storage-sharing",
+		"accounts",
 	}
 	// Maximum number of retries until getting a connection to the rpc runtime service.
 	maxRetries = 10


### PR DESCRIPTION
As it turns out the race condition between `accounts <-> storage-metadata` still remains. This PR is a hotfix and it should be followed up with a proper fix. Either:

- block the accounts initialization until the storage metadata is ready (using the registry) or
- allow the accounts service to initialize and use a message broker to signal the accounts the metadata storage is ready to receive requests.