### PR TITLE
fix jpeg thumbnails

### DIFF
--- a/changelog/unreleased/fix-jpeg-thumbnails.md
+++ b/changelog/unreleased/fix-jpeg-thumbnails.md
@@ -1,0 +1,6 @@
+Bugfix: Fix thumbnail generation for jpegs 
+
+Images with the extension `.jpeg` were not properly supported.
+
+https://github.com/owncloud/ocis/issues/1490
+https://github.com/owncloud/ocis/pull/1785

--- a/tests/acceptance/expected-failures-webUI-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-webUI-on-OWNCLOUD-storage.md
@@ -18,7 +18,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIPreview/imageMediaViewer.feature:174](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L174)
 
 ### [Media Viewer preview not visible for files with .jpeg, .ogg, .webm and .gif formats](https://github.com/owncloud/ocis/issues/1490)
--   [webUIPreview/imageMediaViewer.feature:127](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L127)
 -   [webUIPreview/imageMediaViewer.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L136)
 -   [webUIPreview/imageMediaViewer.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L145)
 -   [webUIPreview/imageMediaViewer.feature:154](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L154)
@@ -198,9 +197,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### Image-Media-Viewer-Issue
 -   [webUIPreview/imageMediaViewer.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L33)
-
-### [media viewer does not display jpeg file](https://github.com/owncloud/web/issues/4296)
--   [webUIPreview/imageMediaViewer.feature:15](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L15)
 
 ### webUI-Private-Links
 -   [webUIPrivateLinks/accessingPrivateLinks.feature:8](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature#L8)

--- a/webdav/pkg/dav/thumbnails/thumbnail.go
+++ b/webdav/pkg/dav/thumbnails/thumbnail.go
@@ -20,7 +20,7 @@ const (
 // Request combines all parameters provided when requesting a thumbnail
 type Request struct {
 	Filepath      string
-	Filetype      string
+	Extension      string
 	Etag          string
 	Width         int
 	Height        int
@@ -50,7 +50,7 @@ func NewRequest(r *http.Request) (Request, error) {
 
 	tr := Request{
 		Filepath:      path,
-		Filetype:      strings.Replace(filepath.Ext(path), ".", "", 1),
+		Extension:     filepath.Ext(path),
 		Etag:          etag,
 		Width:         width,
 		Height:        height,

--- a/webdav/pkg/service/v0/service.go
+++ b/webdav/pkg/service/v0/service.go
@@ -65,7 +65,7 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 	c := thumbnails.NewThumbnailService("com.owncloud.api.thumbnails", grpc.DefaultClient)
 	rsp, err := c.GetThumbnail(r.Context(), &thumbnails.GetRequest{
 		Filepath:      strings.TrimLeft(tr.Filepath, "/"),
-		Filetype:      extensionToFiletype(tr.Filetype),
+		Filetype:      extensionToFiletype(strings.TrimLeft(tr.Extension, ".")),
 		Etag:          tr.Etag,
 		Width:         int32(tr.Width),
 		Height:        int32(tr.Height),
@@ -90,11 +90,17 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 }
 
 func extensionToFiletype(ext string) thumbnails.GetRequest_FileType {
-	val, ok := thumbnails.GetRequest_FileType_value[strings.ToUpper(ext)]
-	if !ok {
+	ext = strings.ToUpper(ext)
+	switch ext {
+	case "JPG", "PNG":
+		val := thumbnails.GetRequest_FileType_value[ext]
+		return thumbnails.GetRequest_FileType(val)
+	case "JPEG":
+		val := thumbnails.GetRequest_FileType_value["JPG"]
+		return thumbnails.GetRequest_FileType(val)
+	default:
 		return thumbnails.GetRequest_FileType(-1)
 	}
-	return thumbnails.GetRequest_FileType(val)
 }
 
 func mustWrite(logger log.Logger, w io.Writer, val []byte) {


### PR DESCRIPTION
Quick fix to support `.jpeg` files again. Ideally this should also be changed when rewriting the thumbnails API.