### PR TITLE
Cleanup from Runtime

### DIFF
--- a/graph-explorer/pkg/flagset/flagset.go
+++ b/graph-explorer/pkg/flagset/flagset.go
@@ -12,19 +12,19 @@ func RootWithConfig(cfg *config.Config) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "log-level",
 			Usage:       "Set logging level",
-			EnvVars:     []string{"GRAPH_EXPLORER_LOG_LEVEL"},
+			EnvVars:     []string{"GRAPH_EXPLORER_LOG_LEVEL", "OCIS_LOG_LEVEL"},
 			Destination: &cfg.Log.Level,
 		},
 		&cli.BoolFlag{
 			Name:        "log-pretty",
 			Usage:       "Enable pretty logging",
-			EnvVars:     []string{"GRAPH_EXPLORER_LOG_PRETTY"},
+			EnvVars:     []string{"GRAPH_EXPLORER_LOG_PRETTY", "OCIS_LOG_PRETTY"},
 			Destination: &cfg.Log.Pretty,
 		},
 		&cli.BoolFlag{
 			Name:        "log-color",
 			Usage:       "Enable colored logging",
-			EnvVars:     []string{"GRAPH_EXPLORER_LOG_COLOR"},
+			EnvVars:     []string{"GRAPH_EXPLORER_LOG_COLOR", "OCIS_LOG_COLOR"},
 			Destination: &cfg.Log.Color,
 		},
 	}

--- a/graph/pkg/flagset/flagset.go
+++ b/graph/pkg/flagset/flagset.go
@@ -19,19 +19,19 @@ func RootWithConfig(cfg *config.Config) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "log-level",
 			Usage:       "Set logging level",
-			EnvVars:     []string{"GRAPH_LOG_LEVEL"},
+			EnvVars:     []string{"GRAPH_LOG_LEVEL", "OCIS_LOG_LEVEL"},
 			Destination: &cfg.Log.Level,
 		},
 		&cli.BoolFlag{
 			Name:        "log-pretty",
 			Usage:       "Enable pretty logging",
-			EnvVars:     []string{"GRAPH_LOG_PRETTY"},
+			EnvVars:     []string{"GRAPH_LOG_PRETTY", "OCIS_LOG_PRETTY"},
 			Destination: &cfg.Log.Pretty,
 		},
 		&cli.BoolFlag{
 			Name:        "log-color",
 			Usage:       "Enable colored logging",
-			EnvVars:     []string{"GRAPH_LOG_COLOR"},
+			EnvVars:     []string{"GRAPH_LOG_COLOR", "OCIS_LOG_COLOR"},
 			Destination: &cfg.Log.Color,
 		},
 	}

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -70,6 +70,7 @@ type Mode int
 // Config combines all available configuration parts.
 type Config struct {
 	Mode Mode
+	File string
 
 	Registry     string
 	Log          Log

--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -46,14 +46,6 @@ func Execute() error {
 		)
 	}
 
-	//r := registry.GetRegistry()
-
-	//opts := micro.Options{
-	//	Registry: r,
-	//}
-
-	//runtime.AddMicroPlatform(app, opts)
-
 	cli.HelpFlag = &cli.BoolFlag{
 		Name:  "help,h",
 		Usage: "Show the help",

--- a/ocis/pkg/flagset/flagset.go
+++ b/ocis/pkg/flagset/flagset.go
@@ -9,6 +9,12 @@ import (
 func RootWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "config-file",
+			Usage:       "Load config file from a non standard location.",
+			EnvVars:     []string{"OCIS_CONFIG_FILE"},
+			Destination: &cfg.File,
+		},
+		&cli.StringFlag{
 			Name:        "ocis-log-level",
 			Value:       "info",
 			Usage:       "Set logging level",


### PR DESCRIPTION
- add `config-file` flag & `OCIS_CONFIG_FILE` env variable to the ocis single binary.
- propagate log config to graph and graph-explorer.