### PR TITLE
Support logging to file

### DIFF
--- a/accounts/pkg/command/root.go
+++ b/accounts/pkg/command/root.go
@@ -75,6 +75,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -133,6 +134,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Accounts.Supervised = true
 	}
+	cfg.Accounts.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Accounts,
 	}

--- a/accounts/pkg/config/config.go
+++ b/accounts/pkg/config/config.go
@@ -62,6 +62,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Repo defines which storage implementation is to be used.

--- a/accounts/pkg/flagset/flagset.go
+++ b/accounts/pkg/flagset/flagset.go
@@ -34,6 +34,12 @@ func RootWithConfig(cfg *config.Config) []cli.Flag {
 // ServerWithConfig applies cfg to the root flagset
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"ACCOUNTS_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
 		&cli.BoolFlag{
 			Name:        "tracing-enabled",
 			Usage:       "Enable sending traces",

--- a/changelog/unreleased/logging-to-file.md
+++ b/changelog/unreleased/logging-to-file.md
@@ -1,0 +1,9 @@
+Enhancement: File Logging
+
+When running supervised, support for configuring all logs to a single log file:
+`OCIS_LOG_FILE=/Users/foo/bar/ocis.log MICRO_REGISTRY=etcd bin/ocis server`
+
+Supports directing log from single extensions to a log file:
+`PROXY_LOG_FILE=/Users/foo/bar/proxy.log MICRO_REGISTRY=etcd bin/ocis proxy`
+
+https://github.com/owncloud/ocis/pull/1816

--- a/glauth/pkg/command/root.go
+++ b/glauth/pkg/command/root.go
@@ -64,6 +64,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -122,6 +123,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.GLAuth.Supervised = true
 	}
+	cfg.GLAuth.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.GLAuth,
 	}

--- a/glauth/pkg/config/config.go
+++ b/glauth/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/glauth/pkg/flagset/flagset.go
+++ b/glauth/pkg/flagset/flagset.go
@@ -47,6 +47,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"GLAUTH_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
+		&cli.StringFlag{
 			Name:        "config-file",
 			Value:       flags.OverrideDefaultString(cfg.File, ""),
 			Usage:       "Path to config file",

--- a/graph-explorer/pkg/command/root.go
+++ b/graph-explorer/pkg/command/root.go
@@ -64,6 +64,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -122,6 +123,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.GraphExplorer.Supervised = true
 	}
+	cfg.GraphExplorer.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.GraphExplorer,
 	}

--- a/graph-explorer/pkg/config/config.go
+++ b/graph-explorer/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/graph-explorer/pkg/flagset/flagset.go
+++ b/graph-explorer/pkg/flagset/flagset.go
@@ -46,6 +46,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 // ServerWithConfig applies cfg to the root flagset
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"GRAPH_EXPLORER_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
 		&cli.BoolFlag{
 			Name:        "tracing-enabled",
 			Usage:       "Enable sending traces",

--- a/graph/pkg/command/root.go
+++ b/graph/pkg/command/root.go
@@ -65,6 +65,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -123,6 +124,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Graph.Supervised = true
 	}
+	cfg.Graph.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Graph,
 	}

--- a/graph/pkg/config/config.go
+++ b/graph/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/graph/pkg/flagset/flagset.go
+++ b/graph/pkg/flagset/flagset.go
@@ -53,6 +53,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 // ServerWithConfig applies cfg to the root flagset
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"GRAPH_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
 		&cli.BoolFlag{
 			Name:        "tracing-enabled",
 			Usage:       "Enable sending traces",

--- a/idp/pkg/command/root.go
+++ b/idp/pkg/command/root.go
@@ -65,6 +65,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -123,6 +124,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.IDP.Supervised = true
 	}
+	cfg.IDP.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.IDP,
 	}

--- a/idp/pkg/config/config.go
+++ b/idp/pkg/config/config.go
@@ -11,6 +11,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/idp/pkg/flagset/flagset.go
+++ b/idp/pkg/flagset/flagset.go
@@ -47,6 +47,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"IDP_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
+		&cli.StringFlag{
 			Name:        "config-file",
 			Value:       flags.OverrideDefaultString(cfg.File, ""),
 			Usage:       "Path to config file",

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -22,6 +22,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/ocis-pkg/log/log.go
+++ b/ocis-pkg/log/log.go
@@ -64,7 +64,8 @@ func NewLogger(opts ...Option) Logger {
 	} else if options.File != "" {
 		f, err := os.OpenFile(options.File, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
 		if err != nil {
-			panic(err)
+			print(fmt.Sprintf("file could not be opened for writing: %s. error: %v", options.File, err))
+			os.Exit(1)
 		}
 		logger = logger.Output(f)
 	} else {

--- a/ocis-pkg/log/log.go
+++ b/ocis-pkg/log/log.go
@@ -61,6 +61,12 @@ func NewLogger(opts ...Option) Logger {
 				},
 			),
 		)
+	} else if options.File != "" {
+		f, err := os.OpenFile(options.File, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+		if err != nil {
+			panic(err)
+		}
+		logger = logger.Output(f)
 	} else {
 		logger = zerolog.New(os.Stderr)
 	}

--- a/ocis-pkg/log/option.go
+++ b/ocis-pkg/log/option.go
@@ -9,6 +9,7 @@ type Options struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // newOptions initializes the available default options.
@@ -52,5 +53,12 @@ func Pretty(val bool) Option {
 func Color(val bool) Option {
 	return func(o *Options) {
 		o.Color = val
+	}
+}
+
+// File provides a function to set the color option.
+func File(val string) Option {
+	return func(o *Options) {
+		o.File = val
 	}
 }

--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -74,6 +74,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 

--- a/ocis/pkg/flagset/flagset.go
+++ b/ocis/pkg/flagset/flagset.go
@@ -29,6 +29,12 @@ func RootWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"OCIS_LOG_COLOR"},
 			Destination: &cfg.Log.Color,
 		},
+		&cli.StringFlag{
+			Name:        "ocis-log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
 		&cli.BoolFlag{
 			Name:        "tracing-enabled",
 			Usage:       "Enable sending traces",

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -19,8 +19,8 @@ import (
 	"github.com/olekukonko/tablewriter"
 	accounts "github.com/owncloud/ocis/accounts/pkg/command"
 	glauth "github.com/owncloud/ocis/glauth/pkg/command"
-	graph "github.com/owncloud/ocis/graph/pkg/command"
 	graphExplorer "github.com/owncloud/ocis/graph-explorer/pkg/command"
+	graph "github.com/owncloud/ocis/graph/pkg/command"
 	idp "github.com/owncloud/ocis/idp/pkg/command"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
@@ -133,6 +133,7 @@ func Start(o ...Option) error {
 	s.cfg.Storage.Log.Color = s.cfg.Log.Color
 	s.cfg.Storage.Log.Level = s.cfg.Log.Level
 	s.cfg.Storage.Log.Pretty = s.cfg.Log.Pretty
+	s.cfg.Storage.Log.File = s.cfg.Log.File
 
 	// notify goroutines that they are running on supervised mode
 	s.cfg.Mode = ociscfg.SUPERVISED

--- a/ocis/pkg/tracing/tracing.go
+++ b/ocis/pkg/tracing/tracing.go
@@ -114,5 +114,6 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }

--- a/ocs/pkg/command/root.go
+++ b/ocs/pkg/command/root.go
@@ -63,6 +63,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -121,6 +122,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.OCS.Supervised = true
 	}
+	cfg.OCS.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.OCS,
 	}

--- a/ocs/pkg/config/config.go
+++ b/ocs/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/ocs/pkg/flagset/flagset.go
+++ b/ocs/pkg/flagset/flagset.go
@@ -23,6 +23,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"OCS_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
+		&cli.StringFlag{
 			Name:        "log-level",
 			Usage:       "Set logging level",
 			EnvVars:     []string{"OCS_LOG_LEVEL", "OCIS_LOG_LEVEL"},

--- a/onlyoffice/pkg/command/root.go
+++ b/onlyoffice/pkg/command/root.go
@@ -64,6 +64,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -122,6 +123,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Onlyoffice.Supervised = true
 	}
+	cfg.Onlyoffice.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Onlyoffice,
 	}

--- a/onlyoffice/pkg/config/config.go
+++ b/onlyoffice/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/onlyoffice/pkg/flagset/flagset.go
+++ b/onlyoffice/pkg/flagset/flagset.go
@@ -53,6 +53,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 // ServerWithConfig applies cfg to the root flagset
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"ONLYOFFICE_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
 		&cli.BoolFlag{
 			Name:        "tracing-enabled",
 			Usage:       "Enable sending traces",

--- a/proxy/pkg/command/root.go
+++ b/proxy/pkg/command/root.go
@@ -66,6 +66,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -124,6 +125,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Proxy.Supervised = true
 	}
+	cfg.Proxy.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Proxy,
 	}

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -47,6 +47,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"PROXY_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
+		&cli.StringFlag{
 			Name:        "config-file",
 			Value:       "",
 			Usage:       "Path to config file",

--- a/settings/pkg/command/root.go
+++ b/settings/pkg/command/root.go
@@ -66,6 +66,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -124,6 +125,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Settings.Supervised = true
 	}
+	cfg.Settings.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Settings,
 	}

--- a/settings/pkg/config/config.go
+++ b/settings/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/settings/pkg/store/filesystem/store.go
+++ b/settings/pkg/store/filesystem/store.go
@@ -28,6 +28,7 @@ func New(cfg *config.Config) settings.Manager {
 			olog.Color(cfg.Log.Color),
 			olog.Pretty(cfg.Log.Pretty),
 			olog.Level(cfg.Log.Level),
+			olog.File(cfg.Log.File),
 		),
 	}
 

--- a/storage/pkg/command/root.go
+++ b/storage/pkg/command/root.go
@@ -107,5 +107,6 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/store/pkg/command/root.go
+++ b/store/pkg/command/root.go
@@ -66,6 +66,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -124,6 +125,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Store.Supervised = true
 	}
+	cfg.Store.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Store,
 	}

--- a/store/pkg/config/config.go
+++ b/store/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/store/pkg/flagset/flagset.go
+++ b/store/pkg/flagset/flagset.go
@@ -53,6 +53,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 // ServerWithConfig applies cfg to the root flagset
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"STORE_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
 		&cli.BoolFlag{
 			Name:        "tracing-enabled",
 			Usage:       "Enable sending traces",

--- a/thumbnails/pkg/command/root.go
+++ b/thumbnails/pkg/command/root.go
@@ -63,6 +63,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -121,6 +122,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Thumbnails.Supervised = true
 	}
+	cfg.Thumbnails.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Thumbnails,
 	}

--- a/thumbnails/pkg/config/config.go
+++ b/thumbnails/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/thumbnails/pkg/flagset/flagset.go
+++ b/thumbnails/pkg/flagset/flagset.go
@@ -27,6 +27,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"THUMBNAILS_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
+		&cli.StringFlag{
 			Name:        "log-level",
 			Usage:       "Set logging level",
 			EnvVars:     []string{"THUMBNAILS_LOG_LEVEL", "OCIS_LOG_LEVEL"},

--- a/web/pkg/command/root.go
+++ b/web/pkg/command/root.go
@@ -55,6 +55,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -113,6 +114,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Web.Supervised = true
 	}
+	cfg.Web.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.Web,
 	}

--- a/web/pkg/config/config.go
+++ b/web/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/web/pkg/flagset/flagset.go
+++ b/web/pkg/flagset/flagset.go
@@ -47,6 +47,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"WEB_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
+		&cli.StringFlag{
 			Name:        "config-file",
 			Value:       "",
 			Usage:       "Path to config file",

--- a/webdav/pkg/command/root.go
+++ b/webdav/pkg/command/root.go
@@ -61,6 +61,7 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Level(cfg.Log.Level),
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
+		log.File(cfg.Log.File),
 	)
 }
 
@@ -119,6 +120,7 @@ func NewSutureService(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.WebDAV.Supervised = true
 	}
+	cfg.WebDAV.Log.File = cfg.Log.File
 	return SutureService{
 		cfg: cfg.WebDAV,
 	}

--- a/webdav/pkg/config/config.go
+++ b/webdav/pkg/config/config.go
@@ -7,6 +7,7 @@ type Log struct {
 	Level  string
 	Pretty bool
 	Color  bool
+	File   string
 }
 
 // Debug defines the available debug configuration.

--- a/webdav/pkg/flagset/flagset.go
+++ b/webdav/pkg/flagset/flagset.go
@@ -23,6 +23,12 @@ func HealthWithConfig(cfg *config.Config) []cli.Flag {
 func ServerWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
+			Name:        "log-file",
+			Usage:       "Enable log to file",
+			EnvVars:     []string{"WEBDAV_LOG_FILE", "OCIS_LOG_FILE"},
+			Destination: &cfg.Log.File,
+		},
+		&cli.StringFlag{
 			Name:        "log-level",
 			Usage:       "Set logging level",
 			EnvVars:     []string{"WEBDAV_LOG_LEVEL", "OCIS_LOG_LEVEL"},


### PR DESCRIPTION
When running supervised, support for configuring all logs to a single log file:

`OCIS_LOG_FILE=/Users/foo/bar/ocis.log MICRO_REGISTRY=etcd bin/ocis server`

Supports directing log from single extensions to a log file:

`PROXY_LOG_FILE=/Users/foo/bar/proxy.log MICRO_REGISTRY=etcd bin/ocis proxy`

## TODO

- [x] add changelog
- [x] add documentation

## Docs

OCIS File Logging

Design Choices:
- if the file does not exist, the command aborts and exits with status 1.
- Pretty logs are only available in the console.
- When running with pretty logs, writing to file is disabled.

Use Cases
- start default runtime extensions: `OCIS_LOG_FILE=/Users/foo/bar/ocis OCIS_LOG_PRETTY=true OCIS_LOG_COLOR=true bin/ocis server`
    - every default extension log is written to foo/bar/ocis.log.
- start an extension using the single binary redirecting log output to a dedicated log file: `OCIS_LOG_FILE=/Users/foo/bar/proxy.log OCIS_LOG_PRETTY=true OCIS_LOG_COLOR=true bin/ocis proxy`
    - all logs only for the proxy extension are written to foo/bar/proxy.log.
- start an extension without the single binary: `PROXY_LOG_FILE=/Users/foo/bar/proxy.log go run cmd/proxy/main.go server`
    - all logs only for the proxy extension are written to foo/bar/proxy.log.
- start an extension with `ocis run proxy`
    - not yet supported.
