### PR TITLE
[docs-only] Add warning about firewall configuration.

### DIFF
--- a/docs/ocis/getting-started.md
+++ b/docs/ocis/getting-started.md
@@ -36,7 +36,7 @@ chmod +x ocis
 The default primary storage location is `/var/tmp/ocis`. You can change that value by configuration.
 
 {{< hint warning >}}
-oCIS internally uses mDNS. If your system has a firewall, make sure mDNS is allowed in your active zone.
+oCIS by default relies on Multicast DNS (mDNS), usually via avahi-daemon. If your system has a firewall, make sure mDNS is allowed in your active zone.
 {{< /hint >}}
 
 

--- a/docs/ocis/getting-started.md
+++ b/docs/ocis/getting-started.md
@@ -35,6 +35,10 @@ chmod +x ocis
 
 The default primary storage location is `/var/tmp/ocis`. You can change that value by configuration.
 
+{{< hint warning >}}
+oCIS internally uses mDNS. If your system has a firewall, make sure mDNS is allowed in your active zone.
+{{< /hint >}}
+
 
 ### Docker
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Adds a short warning about firewall. An activated firewall that does not allow mDNS breaks oCIS.
