### PR TITLE
Runtime port and host configurable

### DIFF
--- a/changelog/unreleased/runtime-address-configurable.md
+++ b/changelog/unreleased/runtime-address-configurable.md
@@ -1,6 +1,6 @@
 Enhancement: Runtime Hostname and Port are now configurable
 
-Without any configuration the ocis runtime will start on `localhost:6060` unless specified otherwise. Usage:
+Without any configuration the ocis runtime will start on `localhost:9250` unless specified otherwise. Usage:
 
 - `OCIS_RUNTIME_PORT=6061 bin/ocis server`
   - overrides the oCIS runtime and starts on port 6061

--- a/changelog/unreleased/runtime-address-configurable.md
+++ b/changelog/unreleased/runtime-address-configurable.md
@@ -1,0 +1,17 @@
+Enhancement: Runtime Hostname and Port are now configurable
+
+Without any configuration the ocis runtime will start on `localhost:6060` unless specified otherwise. Usage:
+
+- `OCIS_RUNTIME_PORT=6061 bin/ocis server`
+  - overrides the oCIS runtime and starts on port 6061
+- `OCIS_RUNTIME_PORT=6061 bin/ocis list`
+  - lists running extensions for the runtime on `localhost:6061`
+
+All subcommands are updated and expected to work with the following environment variables:
+
+```
+OCIS_RUNTIME_HOST
+OCIS_RUNTIME_PORT
+```
+
+https://github.com/owncloud/ocis/pull/1822

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -68,6 +68,12 @@ const (
 
 type Mode int
 
+// Runtime configures the oCIS runtime when running in supervised mode.
+type Runtime struct {
+	Port string
+	Host string
+}
+
 // Config combines all available configuration parts.
 type Config struct {
 	Mode Mode
@@ -80,6 +86,7 @@ type Config struct {
 	GRPC         GRPC
 	Tracing      Tracing
 	TokenManager TokenManager
+	Runtime      Runtime
 
 	Accounts      *accounts.Config
 	GLAuth        *glauth.Config

--- a/ocis/pkg/command/kill.go
+++ b/ocis/pkg/command/kill.go
@@ -22,7 +22,7 @@ func KillCommand(cfg *config.Config) *cli.Command {
 			&cli.StringFlag{
 				Name:        "hostname",
 				Value:       "localhost",
-				EnvVars:     []string{"OCIS_RUNTIME_HOSTNAME"},
+				EnvVars:     []string{"OCIS_RUNTIME_HOST"},
 				Destination: &cfg.Runtime.Host,
 			},
 			&cli.StringFlag{

--- a/ocis/pkg/command/kill.go
+++ b/ocis/pkg/command/kill.go
@@ -20,18 +20,20 @@ func KillCommand(cfg *config.Config) *cli.Command {
 		Category: "Runtime",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "hostname",
-				Value:   "localhost",
-				EnvVars: []string{"OCIS_RUNTIME_HOSTNAME"},
+				Name:        "hostname",
+				Value:       "localhost",
+				EnvVars:     []string{"OCIS_RUNTIME_HOSTNAME"},
+				Destination: &cfg.Runtime.Host,
 			},
 			&cli.StringFlag{
-				Name:    "port",
-				Value:   "6060",
-				EnvVars: []string{"OCIS_RUNTIME_PORT"},
+				Name:        "port",
+				Value:       "6060",
+				EnvVars:     []string{"OCIS_RUNTIME_PORT"},
+				Destination: &cfg.Runtime.Port,
 			},
 		},
 		Action: func(c *cli.Context) error {
-			client, err := rpc.DialHTTP("tcp", net.JoinHostPort("localhost", "6060"))
+			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
 				log.Fatal("dialing:", err)
 			}

--- a/ocis/pkg/command/kill.go
+++ b/ocis/pkg/command/kill.go
@@ -27,7 +27,7 @@ func KillCommand(cfg *config.Config) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "port",
-				Value:       "6060",
+				Value:       "9250",
 				EnvVars:     []string{"OCIS_RUNTIME_PORT"},
 				Destination: &cfg.Runtime.Port,
 			},

--- a/ocis/pkg/command/list.go
+++ b/ocis/pkg/command/list.go
@@ -19,18 +19,20 @@ func ListCommand(cfg *config.Config) *cli.Command {
 		Category: "Runtime",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "hostname",
-				Value:   "localhost",
-				EnvVars: []string{"OCIS_RUNTIME_HOSTNAME"},
+				Name:        "hostname",
+				Value:       "localhost",
+				EnvVars:     []string{"OCIS_RUNTIME_HOSTNAME"},
+				Destination: &cfg.Runtime.Host,
 			},
 			&cli.StringFlag{
-				Name:    "port",
-				Value:   "6060",
-				EnvVars: []string{"OCIS_RUNTIME_PORT"},
+				Name:        "port",
+				Value:       "6060",
+				EnvVars:     []string{"OCIS_RUNTIME_PORT"},
+				Destination: &cfg.Runtime.Port,
 			},
 		},
 		Action: func(c *cli.Context) error {
-			client, err := rpc.DialHTTP("tcp", net.JoinHostPort("localhost", "6060"))
+			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
 				log.Fatal("dialing:", err)
 			}

--- a/ocis/pkg/command/list.go
+++ b/ocis/pkg/command/list.go
@@ -26,7 +26,7 @@ func ListCommand(cfg *config.Config) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "port",
-				Value:       "6060",
+				Value:       "9250",
 				EnvVars:     []string{"OCIS_RUNTIME_PORT"},
 				Destination: &cfg.Runtime.Port,
 			},

--- a/ocis/pkg/command/list.go
+++ b/ocis/pkg/command/list.go
@@ -21,7 +21,7 @@ func ListCommand(cfg *config.Config) *cli.Command {
 			&cli.StringFlag{
 				Name:        "hostname",
 				Value:       "localhost",
-				EnvVars:     []string{"OCIS_RUNTIME_HOSTNAME"},
+				EnvVars:     []string{"OCIS_RUNTIME_HOST"},
 				Destination: &cfg.Runtime.Host,
 			},
 			&cli.StringFlag{

--- a/ocis/pkg/command/run.go
+++ b/ocis/pkg/command/run.go
@@ -23,7 +23,7 @@ func RunCommand(cfg *config.Config) *cli.Command {
 			&cli.StringFlag{
 				Name:        "hostname",
 				Value:       "localhost",
-				EnvVars:     []string{"OCIS_RUNTIME_HOSTNAME"},
+				EnvVars:     []string{"OCIS_RUNTIME_HOST"},
 				Destination: &cfg.Runtime.Host,
 			},
 			&cli.StringFlag{

--- a/ocis/pkg/command/run.go
+++ b/ocis/pkg/command/run.go
@@ -21,18 +21,20 @@ func RunCommand(cfg *config.Config) *cli.Command {
 		Category: "Runtime",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "hostname",
-				Value:   "localhost",
-				EnvVars: []string{"OCIS_RUNTIME_HOSTNAME"},
+				Name:        "hostname",
+				Value:       "localhost",
+				EnvVars:     []string{"OCIS_RUNTIME_HOSTNAME"},
+				Destination: &cfg.Runtime.Host,
 			},
 			&cli.StringFlag{
-				Name:    "port",
-				Value:   "6060",
-				EnvVars: []string{"OCIS_RUNTIME_PORT"},
+				Name:        "port",
+				Value:       "6060",
+				EnvVars:     []string{"OCIS_RUNTIME_PORT"},
+				Destination: &cfg.Runtime.Port,
 			},
 		},
 		Action: func(c *cli.Context) error {
-			client, err := rpc.DialHTTP("tcp", net.JoinHostPort("localhost", "6060"))
+			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
 				log.Fatal("dialing:", err)
 			}

--- a/ocis/pkg/command/run.go
+++ b/ocis/pkg/command/run.go
@@ -28,7 +28,7 @@ func RunCommand(cfg *config.Config) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "port",
-				Value:       "6060",
+				Value:       "9250",
 				EnvVars:     []string{"OCIS_RUNTIME_PORT"},
 				Destination: &cfg.Runtime.Port,
 			},

--- a/ocis/pkg/flagset/flagset.go
+++ b/ocis/pkg/flagset/flagset.go
@@ -84,7 +84,7 @@ func RootWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "runtime-port",
-			Value:       "6060",
+			Value:       "9250",
 			Usage:       "Configures which port the runtime starts",
 			EnvVars:     []string{"OCIS_RUNTIME_PORT"},
 			Destination: &cfg.Runtime.Port,

--- a/ocis/pkg/flagset/flagset.go
+++ b/ocis/pkg/flagset/flagset.go
@@ -82,6 +82,20 @@ func RootWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"OCIS_JWT_SECRET"},
 			Destination: &cfg.TokenManager.JWTSecret,
 		},
+		&cli.StringFlag{
+			Name:        "runtime-port",
+			Value:       "6060",
+			Usage:       "Configures which port the runtime starts",
+			EnvVars:     []string{"OCIS_RUNTIME_PORT"},
+			Destination: &cfg.Runtime.Port,
+		},
+		&cli.StringFlag{
+			Name:        "runtime-host",
+			Value:       "localhost",
+			Usage:       "Configures the host where the runtime process is running",
+			EnvVars:     []string{"OCIS_RUNTIME_HOST"},
+			Destination: &cfg.Runtime.Host,
+		},
 	}
 }
 

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -149,8 +149,7 @@ func Start(o ...Option) error {
 	halt := make(chan os.Signal, 1)
 	signal.Notify(halt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 
-	// TODO(refs) change default port
-	l, err := net.Listen("tcp", fmt.Sprintf("%v:%v", "localhost", "6060"))
+	l, err := net.Listen("tcp", net.JoinHostPort(s.cfg.Runtime.Host, s.cfg.Runtime.Port))
 	if err != nil {
 		s.Log.Fatal().Err(err)
 	}
@@ -158,8 +157,7 @@ func Start(o ...Option) error {
 	defer func() {
 		if r := recover(); r != nil {
 			reason := strings.Builder{}
-			// TODO(refs) change default port
-			if _, err := net.Dial("localhost", "6060"); err != nil {
+			if _, err := net.Dial("tcp", net.JoinHostPort(s.cfg.Runtime.Host, s.cfg.Runtime.Port)); err != nil {
 				reason.WriteString("runtime address already in use")
 			}
 


### PR DESCRIPTION
## What?

Without any configuration the ocis runtime will start on `localhost:6060` unless specified otherwise. Usage:

- `OCIS_RUNTIME_PORT=6061 bin/ocis server`
  - overrides the oCIS runtime and starts on port 6061
- `OCIS_RUNTIME_PORT=6061 bin/ocis list`
  - lists running extensions for the runtime on `localhost:6061`

All subcommands are updated and expected to work with the following environment variables:

```
OCIS_RUNTIME_HOST
OCIS_RUNTIME_PORT
```

