### PR TITLE
Update Build Targets

### DIFF
--- a/.make/go.mk
+++ b/.make/go.mk
@@ -94,6 +94,9 @@ go-coverage:
 install: $(SOURCES)
 	go install -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/$(NAME)
 
+.PHONY: build-all
+build-all: build build-debug
+
 .PHONY: build
 build: $(BIN)/$(EXECUTABLE)
 

--- a/.make/go.mk
+++ b/.make/go.mk
@@ -95,7 +95,10 @@ install: $(SOURCES)
 	go install -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/$(NAME)
 
 .PHONY: build
-build: $(BIN)/$(EXECUTABLE) $(BIN)/$(EXECUTABLE)-debug
+build: $(BIN)/$(EXECUTABLE)
+
+.PHONY: build-debug
+build-debug: $(BIN)/$(EXECUTABLE)-debug
 
 $(BIN)/$(EXECUTABLE): $(SOURCES)
 	$(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)

--- a/changelog/unreleased/build-all-targets.md
+++ b/changelog/unreleased/build-all-targets.md
@@ -1,0 +1,8 @@
+Enhancement: Add new build targets
+
+Make build target `build` used to build a binary twice, the second occurrence having symbols for debugging. We split this step in two and added `build-all` and `build-debug` targets.
+
+- `build-all` now behaves as the previous `build` target, it will generate 2 binaries, one for debug.
+- `build-debug` will build a single binary for debugging.
+
+https://github.com/owncloud/ocis/pull/1824


### PR DESCRIPTION
## What?

Make build target `build` used to build a binary twice, the second occurrence having symbols for debugging. We split this step in two and added `build-all` and `build-debug` targets.

- `build-all` now behaves as the previous `build` target, it will generate 2 binaries, one for debug.
- `build-debug` will build a single binary for debugging.

