### PR TITLE
[docs-only] Fix typo and update http->https, port numbers

### DIFF
--- a/docs/ocis/deployment/basic-remote-setup.md
+++ b/docs/ocis/deployment/basic-remote-setup.md
@@ -18,7 +18,7 @@ If you need to access oCIS running in a docker container, on a VM or a remote ma
 Upon first start of the oCIS fullstack server with `./bin/ocis server` it will generate a file `identifier-registration.yml` in the config folder in your current working directory. This file is used to configure the built-in identity provider and therefore contains the OpenID Connect issuer and also information about relying parties, for example ownCloud Web and our desktop and mobile applications.
 
 {{< hint warning >}}
-The `identifier-registration.yml` file will only be generated if does not exist. If you want to change certain environment variables like `OCIS_URL`, please delete this file first before doing so. Otherwise your changes will not be applied correctly and you will run into errors.
+The `identifier-registration.yml` file will only be generated if it does not exist yet. If you want to change certain environment variables like `OCIS_URL`, please delete this file first before doing so. Otherwise your changes will not be applied correctly and you will run into errors.
 {{< /hint >}}
 
 {{< hint warning >}}

--- a/docs/ocis/development/extensions.md
+++ b/docs/ocis/development/extensions.md
@@ -31,10 +31,10 @@ TAGS=simple make generate build
 
 `bin/ocis server`
 
-Open the browser at http://localhost:9100
+Open the browser at https://localhost:9200
 
 1. You land on the login screen. click login
-2. You are redirected to an idp at https://localhost:9200/oauth2/auth with a login mask. Use `einstein:relativity`to login (one of the three demo users)
+2. You are redirected to an idp at https://localhost:9200/signin/v1/identifier with a login mask. Use `einstein:relativity` (one of the three demo users) to log in 
 3. You are redirected to http://localhost:9100/#/hello the ocis-hello app
 4. Replace `World` with something else and submit. You should see `Hello %something else%`
 

--- a/docs/ocis/development/extensions.md
+++ b/docs/ocis/development/extensions.md
@@ -34,7 +34,7 @@ TAGS=simple make generate build
 Open the browser at http://localhost:9100
 
 1. You land on the login screen. click login
-2. You are redirected to an idp at http://localhost:9140/oauth2/auth with a login mask. Use `einstein:relativity`to login (one of the three demo users)
+2. You are redirected to an idp at https://localhost:9200/oauth2/auth with a login mask. Use `einstein:relativity`to login (one of the three demo users)
 3. You are redirected to http://localhost:9100/#/hello the ocis-hello app
 4. Replace `World` with something else and submit. You should see `Hello %something else%`
 
@@ -132,12 +132,12 @@ This is what hello is: copy and extend!
 
 ```json
 {
-  "server": "http://localhost:9140",
+  "server": "https://localhost:9200",
   "theme": "owncloud",
   "version": "0.1.0",
   "openIdConnect": {
-    "metadata_url": "http://localhost:9140/.well-known/openid-configuration",
-    "authority": "http://localhost:9140",
+    "metadata_url": "https://localhost:9200/.well-known/openid-configuration",
+    "authority": "https://localhost:9200",
     "client_id": "web",
     "response_type": "code",
     "scope": "openid profile email"


### PR DESCRIPTION
## Description
Fixed a typo and updated the `config.json` docs for extension development to reference correct ports.

## How Has This Been Tested?
- Docs only

## Types of changes
- [X] Docs only (no source changes)
