### PR TITLE
move uint64s to beginning of struct to ensure they are 64-bit aligned

### DIFF
--- a/changelog/unreleased/fix-unaligned-atomic-operation-on-arm32.md
+++ b/changelog/unreleased/fix-unaligned-atomic-operation-on-arm32.md
@@ -1,0 +1,7 @@
+Bugfix: Fixes "unaligned 64-bit atomic operation" panic on 32-bit ARM
+
+sync/cache had uint64s that were not 64-bit aligned causing panics
+on 32-bit systems during atomic access
+
+https://github.com/owncloud/ocis/pull/1888
+https://github.com/owncloud/ocis/issues/1887

--- a/ocis-pkg/sync/cache.go
+++ b/ocis-pkg/sync/cache.go
@@ -8,10 +8,11 @@ import (
 
 // Cache is a barebones cache implementation.
 type Cache struct {
+	// capacity and length have to be the first words
+	// in order to be 64-aligned on 32-bit architectures.
+	capacity, length uint64 // access atomically
 	entries  sync.Map
 	pool     sync.Pool
-	capacity uint64
-	length   uint64
 }
 
 // CacheEntry represents an entry on the cache. You can type assert on V.


### PR DESCRIPTION
## Description
This fixes an "unaligned 64-bit atomic operation" panic on 32-bit ARM, (in my case a Raspberry Pi 4, running 32-bit Raspbian).

The panic happens (at least) during the first login after a service (re)start.

This issue has been spotted in other Golang projects too. (e.g. https://github.com/census-instrumentation/opencensus-go/commit/01b39586f932bbb0b4e1cb6499e454c470e9138b)

The Golang project documents this at https://golang.org/pkg/sync/atomic/#pkg-note-BUG mentioning it is the "caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically" and "The first word in (...) an allocated struct (...) can be relied upon to be 64-bit aligned"

## Related Issue
- Fixes issue #1887 

## Motivation and Context
It fixes a crash on 32-bit ARM (and likely other 32-bit systems).

## How Has This Been Tested?
- Repeated the following multiple times without the fix: Restart ocis server (kubernetes pod) and attempt to login with a web browser with "einstein:relativity". Panic was repeatable every time.
- Then build a new docker image with the fix
- And again repeated multiple times: Restart ocis server and attempt login as einstein. Panic no longer repeatable.
- (Note: the Kubernetes pod was technically not "restarted" but essentially recreated each time because there is no restart in Kubernetes. However, because /var/tmp/ocis were mounted-in as a volume and server.{key,crt} and ldap.(key,crt} were also supplied from the outside in (secrets mounted into the pod), this should in effect amount to a restart).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
