### PR TITLE
change default path for thumbnails

### DIFF
--- a/changelog/unreleased/change-default-path-for-thumbnails.md
+++ b/changelog/unreleased/change-default-path-for-thumbnails.md
@@ -1,0 +1,6 @@
+Enhancement: change default path for thumbnails
+
+Changes the default path for thumbnails from `<os tmp dir>/ocis-thumbnails` to `/var/tmp/ocis/thumbnails`
+
+https://github.com/owncloud/ocis/pull/1892
+https://github.com/owncloud/ocis/issues/1891

--- a/thumbnails/pkg/flagset/flagset.go
+++ b/thumbnails/pkg/flagset/flagset.go
@@ -1,9 +1,6 @@
 package flagset
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 
 	"github.com/micro/cli/v2"
@@ -140,7 +137,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "filesystemstorage-root",
-			Value:       flags.OverrideDefaultString(cfg.Thumbnail.FileSystemStorage.RootDirectory, filepath.Join(os.TempDir(), "ocis-thumbnails/")),
+			Value:       "/var/tmp/ocis/thumbnails",
 			Usage:       "Root path of the filesystem storage directory",
 			EnvVars:     []string{"THUMBNAILS_FILESYSTEMSTORAGE_ROOT"},
 			Destination: &cfg.Thumbnail.FileSystemStorage.RootDirectory,

--- a/thumbnails/pkg/thumbnail/storage/filesystem.go
+++ b/thumbnails/pkg/thumbnail/storage/filesystem.go
@@ -132,7 +132,7 @@ func (s *FileSystem) createUserDir(username string) (string, error) {
 }
 
 // linkImageToUserDir links the stored images to the user directory.
-// The goal is to minimize disk usage by linking to the images if they already exist and avoid file duplicaiton.
+// The goal is to minimize disk usage by linking to the images if they already exist and avoid file duplication.
 func (s *FileSystem) linkImageToUserDir(key string, userDir string) error {
 	imgRootDir := s.rootDir(key)
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Changes the default path for thumbnails from `<os tmp dir>/ocis-thumbnails` to `/var/tmp/ocis/thumbnails`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1891 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As requested in #1891 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
