### PR TITLE
publish git ref images

### DIFF
--- a/ocis/docker/manifest-git.tmpl
+++ b/ocis/docker/manifest-git.tmpl
@@ -1,0 +1,16 @@
+image: owncloud/ocis:git-{{build.commit}}
+manifests:
+  - image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    platform:
+      architecture: arm64
+      variant: v8
+      os: linux
+  - image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm
+    platform:
+      architecture: arm
+      variant: v6
+      os: linux


### PR DESCRIPTION
## Description
In addition to our `owncloud/ocis:latest` docker tag we also will create a `owncloud/ocis:git-<commit-sha>` tag. This enable one to easily pin the oCIS docker image to a git reference without messing around with docker digests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needed by #1900 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
