### PR TITLE
switch to owncloudci/wait-for

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1341,10 +1341,10 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes=[]):
     },
     {
       'name': 'wait-for-ocis-server',
-      'image': 'thegeeklab/wait-for:latest',
+      'image': 'owncloudci/wait-for:latest',
       'pull': 'always',
       'commands': [
-        'wait-for ocis-server:9200 -t 300',
+        'wait-for -it ocis-server:9200 -t 300',
       ],
     },
   ]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
replaces `thegeeklab/wait-for:latest` with `owncloudci/wait-for:latest`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Was not really needed but we needed to maintain our own wait-for for https://github.com/owncloud-docker/ubuntu/pull/56, so we also can use it for our CI purposes.
