### PR TITLE
Allow config parsing on supervise mode only with `run` subcommand

### DIFF
--- a/changelog/unreleased/config-parsing-run-subcommand.md
+++ b/changelog/unreleased/config-parsing-run-subcommand.md
@@ -1,0 +1,5 @@
+Enhancement: Parse config on supervised mode with run subcommand
+
+Currenntly it is not possible to parse a single config file from an extension when running on supervised mode.
+
+https://github.com/owncloud/ocis/pull/1931

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -76,6 +76,9 @@ type Runtime struct {
 
 // Config combines all available configuration parts.
 type Config struct {
+	// Mode is mostly used whenever we need to run an extension. The technical debt this introduces is in regards of
+	// what it does. Supervised (0) loads configuration from a unified config file because of known limitations of Viper; whereas
+	// Unsupervised (1) MUST parse config from all known sources.
 	Mode Mode
 	File string
 

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -194,6 +194,7 @@ func Start(o ...Option) error {
 // Start indicates the Service Controller to start a new supervised service as an OS thread.
 func (s *Service) Start(name string, reply *int) error {
 	swap := deepcopy.Copy(s.cfg)
+	swap.(*ociscfg.Config).Mode = ociscfg.UNSUPERVISED
 	if _, ok := s.ServicesRegistry[name]; ok {
 		*reply = 0
 		s.serviceToken[name] = append(s.serviceToken[name], s.Supervisor.Add(s.ServicesRegistry[name](swap.(*ociscfg.Config))))

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -114,11 +114,17 @@ func NewService(options ...Option) (*Service, error) {
 // Start an rpc service. By default the package scope Start will run all default extensions to provide with a working
 // oCIS instance.
 func Start(o ...Option) error {
+	// Start the runtime. Most likely this was called ONLY by the `ocis server` subcommand, but since we cannot protect
+	// from the caller, the previous statement holds truth.
+
 	// prepare a new rpc Service struct.
 	s, err := NewService(o...)
 	if err != nil {
 		return err
 	}
+
+	// notify goroutines that they are running on supervised mode
+	s.cfg.Mode = ociscfg.SUPERVISED
 
 	setMicroLogger()
 
@@ -129,14 +135,11 @@ func Start(o ...Option) error {
 		},
 	})
 
-	// reva storages have their own logging. For consistency sake the top level logging will be cascade to reva.
+	// reva storages have their own logging. For consistency sake the top level logging will cascade to reva.
 	s.cfg.Storage.Log.Color = s.cfg.Log.Color
 	s.cfg.Storage.Log.Level = s.cfg.Log.Level
 	s.cfg.Storage.Log.Pretty = s.cfg.Log.Pretty
 	s.cfg.Storage.Log.File = s.cfg.Log.File
-
-	// notify goroutines that they are running on supervised mode
-	s.cfg.Mode = ociscfg.SUPERVISED
 
 	if err := rpc.Register(s); err != nil {
 		if s != nil {
@@ -193,8 +196,12 @@ func Start(o ...Option) error {
 
 // Start indicates the Service Controller to start a new supervised service as an OS thread.
 func (s *Service) Start(name string, reply *int) error {
+	// RPC calls to a Service object will allow for parsing config. Mind that since the runtime is running on a different
+	// machine, the configuration needs to be present in the given machine. RPC does not yet allow providing a config
+	// during transport.
+	s.cfg.Mode = ociscfg.UNSUPERVISED
+
 	swap := deepcopy.Copy(s.cfg)
-	swap.(*ociscfg.Config).Mode = ociscfg.UNSUPERVISED
 	if _, ok := s.ServicesRegistry[name]; ok {
 		*reply = 0
 		s.serviceToken[name] = append(s.serviceToken[name], s.Supervisor.Add(s.ServicesRegistry[name](swap.(*ociscfg.Config))))


### PR DESCRIPTION
## What?

What the descriptions says. Currenntly it is not possible to parse a single config file from an extension when running on supervised mode.

a) global ocis config file on /etc/ocis/ocis.yaml with the contents:

```yaml
proxy:
  http:
    addr: "0.0.0.0:6200"
accounts:
  http:
    addr: "0.0.0.0:8888"
Storage:
  Reva:
    StorageMetadata:
      Port:
        HTTPAddr: "0.0.0.0:7777"
```

b) a proxy config file /etc/ocis/proxy.json with the contents:

```json
{
        "http": {
                "addr": "0.0.0.0:5200"
        },
        "debug": {
                "addr": "0.0.0.0:5201"
        }
}
```


Running everything:
1) run ocis server // What will happen? /etc/ocis/ocis.yaml will get parsed and all extensions will inherit their config from it
2) run ocis kill proxy // What will happen? supervised proxy will die
3) run ocis run proxy // What will happen? /etc/ocis/proxy.json gets parsed and the proxy subcommand will run with the changes (it will no longer run the values from /etc/ocis/ocis.yaml)
this works for me with the changes on this branch: https://github.com/owncloud/ocis/tree/parse-config-when-run

it also supports this use case:
1) run ocis server
2) run ocis run proxy
and you should end up with 2 proxy instances bound to different ports.

---

A known issue that needs to be considered is the following: What should we do when we have a global ocis.yaml config file configuring all services and individual config files i.e: proxy.yaml? What should be the outcome of the following sequence of commands:

1) `ocis server` // with a global ocis.yaml in preconfigured locations (it configures a proxy)
2) `ocis kill proxy` // with a single proxy.yaml in the expected preconfigured locations
3) `ocis run proxy`

What could we expect from running (3) ? Should the proxy config in the global ocis.yaml take precedence over the single more granular proxy.yaml? Should both be considered and have their values merged?

The conundrum here is that we wouldn't only be talking here about source priorities on ENV var vs. CLI vs. config file but also between config files.