### PR TITLE
[Tests-Only] Updated core commit id to the latest up to 2020/04/21

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=0fd7346bfb7de34ed9c9b6ca22bf1f90ac50eb1d
+CORE_COMMITID=6b06806ae2876cf78e9de9ede68042068be2414f
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
With this PR:
- core commit ID as testrunner is updated to the latest up to the date of PR creation.
- part of https://github.com/owncloud/QA/issues/662