### PR TITLE
[docs-only] Add release guides for accounts & settings, fix issue link in settings/package.json

### DIFF
--- a/docs/extensions/accounts/releasing.md
+++ b/docs/extensions/accounts/releasing.md
@@ -8,11 +8,16 @@ geekdocFilePath: releasing.md
 
 {{< toc >}}
 
+## Requirements
+
+You need a working installation of [the Go programming language](https://golang.org/) installed to build the assets for a working release.
+
 ## Releasing
 
-After adding changes to the Accounts package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
+After adding changes to the accounts package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
 
-To achieve this, you have to run a Go command and add the results to your PR.
+To achieve this, you have to run a Go command and add the results to your PR. The preferred way to do this is to run `make generate` in the root 
+of the repository and then commit the resulting changes to your branch/PR. See below for a way to _only_ build the accounts extension assets.
 
 ### Package Hierarchy
 

--- a/docs/extensions/accounts/releasing.md
+++ b/docs/extensions/accounts/releasing.md
@@ -1,0 +1,27 @@
+---
+title: "Releasing"
+weight: 70
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/extensions/accounts
+geekdocFilePath: releasing.md
+---
+
+{{< toc >}}
+
+## Releasing
+
+After adding changes to the Accounts package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
+
+To achieve this, you have run a Go command and add the results to your PR.
+
+### Package Hierarchy
+
+- [ocis](https://githug.com/owncloud/ocis)
+    - [ocis-accounts](https://github.com/owncloud/ocis/tree/master/accounts)
+
+#### Updating ocis-accounts
+
+1. Make sure you are inside the [ocis repository](https://github.com/owncloud/ocis) and on your feature branch
+2. Change into accounts' asset package folder via `cd accounts/pkg/assets`
+3. Inside `accounts/pkg/assets`, run `go generate`. The output should look something like this: `accounts: embed.go - YYY/MM/DD ... to write [./embed.go] from config file ...`
+4. Commit your changes, push them and [create a PR](https://github.com/owncloud/ocis/pulls)

--- a/docs/extensions/accounts/releasing.md
+++ b/docs/extensions/accounts/releasing.md
@@ -17,16 +17,9 @@ You need a working installation of [the Go programming language](https://golang.
 After adding changes to the accounts package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
 
 To achieve this, you have to run a Go command and add the results to your PR. The preferred way to do this is to run `make generate` in the root 
-of the repository and then commit the resulting changes to your branch/PR. See below for a way to _only_ build the accounts extension assets.
+of the repository and then commit the resulting changes to your branch/PR.
 
 ### Package Hierarchy
 
 - [ocis](https://github.com/owncloud/ocis)
     - [ocis-accounts](https://github.com/owncloud/ocis/tree/master/accounts)
-
-#### Updating ocis-accounts
-
-1. Make sure you are inside the [ocis repository](https://github.com/owncloud/ocis) and on your feature branch
-2. Change into accounts' asset package folder via `cd accounts/pkg/assets`
-3. Inside `accounts/pkg/assets`, run `go generate`. The output should look something like this: `accounts: embed.go - YYY/MM/DD ... to write [./embed.go] from config file ...`
-4. Commit your changes, push them and [create a PR](https://github.com/owncloud/ocis/pulls)

--- a/docs/extensions/accounts/releasing.md
+++ b/docs/extensions/accounts/releasing.md
@@ -21,7 +21,7 @@ of the repository and then commit the resulting changes to your branch/PR. See b
 
 ### Package Hierarchy
 
-- [ocis](https://githug.com/owncloud/ocis)
+- [ocis](https://github.com/owncloud/ocis)
     - [ocis-accounts](https://github.com/owncloud/ocis/tree/master/accounts)
 
 #### Updating ocis-accounts

--- a/docs/extensions/accounts/releasing.md
+++ b/docs/extensions/accounts/releasing.md
@@ -12,7 +12,7 @@ geekdocFilePath: releasing.md
 
 After adding changes to the Accounts package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
 
-To achieve this, you have run a Go command and add the results to your PR.
+To achieve this, you have to run a Go command and add the results to your PR.
 
 ### Package Hierarchy
 

--- a/docs/extensions/settings/releasing.md
+++ b/docs/extensions/settings/releasing.md
@@ -1,0 +1,27 @@
+---
+title: "Releasing"
+weight: 70
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/extensions/settings
+geekdocFilePath: releasing.md
+---
+
+{{< toc >}}
+
+## Releasing
+
+After adding changes to the Settings package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
+
+To achieve this, you have run a Go command and add the results to your PR.
+
+### Package Hierarchy
+
+- [ocis](https://githug.com/owncloud/ocis)
+    - [ocis-settings](https://github.com/owncloud/ocis/tree/master/settings)
+
+#### Updating ocis-settings
+
+1. Make sure you are inside the [ocis repository](https://github.com/owncloud/ocis) and on your feature branch
+2. Change into settings' asset package folder via `cd settings/pkg/assets`
+3. Inside `settings/pkg/assets`, run `go generate`. The output should look something like this: `settings: embed.go - YYY/MM/DD ... to write [./embed.go] from config file ...`
+4. Commit your changes, push them and [create a PR](https://github.com/owncloud/ocis/pulls)

--- a/docs/extensions/settings/releasing.md
+++ b/docs/extensions/settings/releasing.md
@@ -8,11 +8,16 @@ geekdocFilePath: releasing.md
 
 {{< toc >}}
 
+## Requirements
+
+You need a working installation of [the Go programming language](https://golang.org/) installed to build the assets for a working release.
+
 ## Releasing
 
-After adding changes to the Settings package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
+After adding changes to the settings package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
 
-To achieve this, you have run a Go command and add the results to your PR.
+To achieve this, you have to run a Go command and add the results to your PR. The preferred way to do this is to run `make generate` in the root 
+of the repository and then commit the resulting changes to your branch/PR. See below for a way to _only_ build the settings extension assets.
 
 ### Package Hierarchy
 

--- a/docs/extensions/settings/releasing.md
+++ b/docs/extensions/settings/releasing.md
@@ -21,7 +21,7 @@ of the repository and then commit the resulting changes to your branch/PR. See b
 
 ### Package Hierarchy
 
-- [ocis](https://githug.com/owncloud/ocis)
+- [ocis](https://github.com/owncloud/ocis)
     - [ocis-settings](https://github.com/owncloud/ocis/tree/master/settings)
 
 #### Updating ocis-settings

--- a/docs/extensions/settings/releasing.md
+++ b/docs/extensions/settings/releasing.md
@@ -17,16 +17,9 @@ You need a working installation of [the Go programming language](https://golang.
 After adding changes to the settings package within oCIS and testing them locally, you want to update the compiled assets to the oCIS binary. 
 
 To achieve this, you have to run a Go command and add the results to your PR. The preferred way to do this is to run `make generate` in the root 
-of the repository and then commit the resulting changes to your branch/PR. See below for a way to _only_ build the settings extension assets.
+of the repository and then commit the resulting changes to your branch/PR.
 
 ### Package Hierarchy
 
 - [ocis](https://github.com/owncloud/ocis)
     - [ocis-settings](https://github.com/owncloud/ocis/tree/master/settings)
-
-#### Updating ocis-settings
-
-1. Make sure you are inside the [ocis repository](https://github.com/owncloud/ocis) and on your feature branch
-2. Change into settings' asset package folder via `cd settings/pkg/assets`
-3. Inside `settings/pkg/assets`, run `go generate`. The output should look something like this: `settings: embed.go - YYY/MM/DD ... to write [./embed.go] from config file ...`
-4. Commit your changes, push them and [create a PR](https://github.com/owncloud/ocis/pulls)

--- a/docs/extensions/web/releasing.md
+++ b/docs/extensions/web/releasing.md
@@ -16,7 +16,7 @@ To update this package within all the deliveries, we need to update the package 
 
 ### Package Hierarchy
 
-- [ocis](https://githug.com/owncloud/ocis)
+- [ocis](https://github.com/owncloud/ocis)
     - [ocis-web](https://github.com/owncloud/ocis/tree/master/web)
       - [ocis-pkg](https://github.com/owncloud/ocis/tree/master/ocis-pkg)
       - [ownCloud Web](https://github.com/owncloud/web)

--- a/settings/package.json
+++ b/settings/package.json
@@ -8,7 +8,7 @@
   "author": "ownCloud GmbH <devops@owncloud.com>",
   "repository": "https://github.com/owncloud/ocis-settings.git",
   "bugs": {
-    "url": "https://github.com/owncloud/ocis/settings/issues",
+    "url": "https://github.com/owncloud/ocis/issues",
     "email": "support@owncloud.com"
   },
   "scripts": {


### PR DESCRIPTION
## Description
Within the `v1.5.0` release of oCIS, I had to work on the `accounts` and `settings` extensions and almost forgot adding their respective `embed.go` files to Git. After searching for a while and requesting help from @fschade I managed to do so, but documenting this in written form will help both outside contributors as well as team members in the future.

## Types of changes
- [X] Documentation enhancement
