### PR TITLE
Rework of PR#755

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -501,7 +501,7 @@ def coreApiTests(ctx, part_number = 1, number_of_parts = 1, storage = 'owncloud'
         'environment' : {
           'TEST_SERVER_URL': 'https://ocis-server:9200',
           'OCIS_REVA_DATA_ROOT': '%s' % ('/srv/app/tmp/ocis/owncloud/data/' if storage == 'owncloud' else ''),
-          'DELETE_USER_DATA_CMD': '%s' % ('' if storage == 'owncloud' else 'rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'),
+          #'DELETE_USER_DATA_CMD': '%s' % ('' if storage == 'owncloud' else 'rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'),
           'SKELETON_DIR': '/srv/app/tmp/testing/data/apiSkeleton',
           'OCIS_SKELETON_STRATEGY': '%s' % ('copy' if storage == 'owncloud' else 'upload'),
           'TEST_OCIS':'true',

--- a/.drone.star
+++ b/.drone.star
@@ -454,7 +454,7 @@ def localApiTests(ctx, storage = 'owncloud', suite = 'apiBugDemonstration', acco
         'environment' : {
           'TEST_SERVER_URL': 'https://ocis-server:9200',
           'OCIS_REVA_DATA_ROOT': '%s' % ('/srv/app/tmp/ocis/owncloud/data/' if storage == 'owncloud' else ''),
-          'DELETE_USER_DATA_CMD': '%s' % ('' if storage == 'owncloud' else 'rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'),
+          #'DELETE_USER_DATA_CMD': '%s' % ('' if storage == 'owncloud' else 'rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'),
           'SKELETON_DIR': '/srv/app/tmp/testing/data/apiSkeleton',
           'OCIS_SKELETON_STRATEGY': '%s' % ('copy' if storage == 'owncloud' else 'upload'),
           'TEST_OCIS':'true',

--- a/.drone.star
+++ b/.drone.star
@@ -454,7 +454,6 @@ def localApiTests(ctx, storage = 'owncloud', suite = 'apiBugDemonstration', acco
         'environment' : {
           'TEST_SERVER_URL': 'https://ocis-server:9200',
           'OCIS_REVA_DATA_ROOT': '%s' % ('/srv/app/tmp/ocis/owncloud/data/' if storage == 'owncloud' else ''),
-          #'DELETE_USER_DATA_CMD': '%s' % ('' if storage == 'owncloud' else 'rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'),
           'SKELETON_DIR': '/srv/app/tmp/testing/data/apiSkeleton',
           'OCIS_SKELETON_STRATEGY': '%s' % ('copy' if storage == 'owncloud' else 'upload'),
           'TEST_OCIS':'true',
@@ -501,7 +500,6 @@ def coreApiTests(ctx, part_number = 1, number_of_parts = 1, storage = 'owncloud'
         'environment' : {
           'TEST_SERVER_URL': 'https://ocis-server:9200',
           'OCIS_REVA_DATA_ROOT': '%s' % ('/srv/app/tmp/ocis/owncloud/data/' if storage == 'owncloud' else ''),
-          #'DELETE_USER_DATA_CMD': '%s' % ('' if storage == 'owncloud' else 'rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'),
           'SKELETON_DIR': '/srv/app/tmp/testing/data/apiSkeleton',
           'OCIS_SKELETON_STRATEGY': '%s' % ('copy' if storage == 'owncloud' else 'upload'),
           'TEST_OCIS':'true',

--- a/changelog/unreleased/ocs-user-deprovisioning.md
+++ b/changelog/unreleased/ocs-user-deprovisioning.md
@@ -5,7 +5,7 @@ Use the CS3 API and Reva to deprovision users completely.
 Two new environment variables introduced:
 ```
 OCS_IDM_ADDRESS
-STORAGE_USERS_DRIVER
+OCS_STORAGE_USERS_DRIVER
 ```
 
 `OCS_IDM_ADDRESS` is also an alias for `OCIS_URL`; allows the OCS service to mint jwt tokens for the authenticated user that will be read by the reva authentication middleware.

--- a/changelog/unreleased/ocs-user-deprovisioning.md
+++ b/changelog/unreleased/ocs-user-deprovisioning.md
@@ -1,0 +1,15 @@
+Enhancement: User Deprovisioning for the OCS API
+
+Use the CS3 API and Reva to deprovision users completely.
+
+Two new environment variables introduced:
+```
+OCS_IDM_ADDRESS
+STORAGE_USERS_DRIVER
+```
+
+`OCS_IDM_ADDRESS` is also an alias for `OCIS_URL`; allows the OCS service to mint jwt tokens for the authenticated user that will be read by the reva authentication middleware.
+
+`STORAGE_USERS_DRIVER` determines how a user is deprovisioned. This kind of behavior is needed since every storage driver deals with deleting differently.
+
+https://github.com/owncloud/ocis/pull/1962

--- a/changelog/unreleased/ocs-user-deprovisioning.md
+++ b/changelog/unreleased/ocs-user-deprovisioning.md
@@ -10,6 +10,6 @@ OCS_STORAGE_USERS_DRIVER
 
 `OCS_IDM_ADDRESS` is also an alias for `OCIS_URL`; allows the OCS service to mint jwt tokens for the authenticated user that will be read by the reva authentication middleware.
 
-`STORAGE_USERS_DRIVER` determines how a user is deprovisioned. This kind of behavior is needed since every storage driver deals with deleting differently.
+`OCS_STORAGE_USERS_DRIVER` determines how a user is deprovisioned. This kind of behavior is needed since every storage driver deals with deleting differently.
 
 https://github.com/owncloud/ocis/pull/1962

--- a/ocs/go.mod
+++ b/ocs/go.mod
@@ -22,12 +22,14 @@ require (
 	github.com/owncloud/ocis/proxy v0.0.0-20210412105747-9b95e9b1191b
 	github.com/owncloud/ocis/settings v0.0.0-20210413063522-955bd60edf33
 	github.com/owncloud/ocis/store v0.0.0-20210413063522-955bd60edf33
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.10.0
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
 	github.com/thejerf/suture/v4 v4.0.0
 	go.opencensus.io v0.23.0
 	google.golang.org/genproto v0.0.0-20210207032614-bba0dbe2a9ea
+	google.golang.org/grpc v1.37.0 // indirect
 	google.golang.org/protobuf v1.26.0
 )
 

--- a/ocs/pkg/config/config.go
+++ b/ocs/pkg/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	Service            Service
 	AccountBackend     string
 	RevaAddress        string
+	StorageUsersDriver string
 	IdentityManagement IdentityManagement
 
 	Context    context.Context

--- a/ocs/pkg/config/config.go
+++ b/ocs/pkg/config/config.go
@@ -45,17 +45,25 @@ type TokenManager struct {
 	JWTSecret string
 }
 
+// IdentityManagement keeps track of the OIDC address. This is because Reva requisite of uniqueness for users
+// is based in the combination of IDP hostname + UserID. For more information see:
+// https://github.com/cs3org/reva/blob/4fd0229f13fae5bc9684556a82dbbd0eced65ef9/pkg/storage/utils/decomposedfs/node/node.go#L856-L865
+type IdentityManagement struct {
+	Address string
+}
+
 // Config combines all available configuration parts.
 type Config struct {
-	File           string
-	Log            Log
-	Debug          Debug
-	HTTP           HTTP
-	Tracing        Tracing
-	TokenManager   TokenManager
-	Service        Service
-	AccountBackend string
-	RevaAddress    string
+	File               string
+	Log                Log
+	Debug              Debug
+	HTTP               HTTP
+	Tracing            Tracing
+	TokenManager       TokenManager
+	Service            Service
+	AccountBackend     string
+	RevaAddress        string
+	IdentityManagement IdentityManagement
 
 	Context    context.Context
 	Supervised bool

--- a/ocs/pkg/flagset/flagset.go
+++ b/ocs/pkg/flagset/flagset.go
@@ -176,7 +176,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Name:        "users-driver",
 			Value:       flags.OverrideDefaultString(cfg.StorageUsersDriver, "ocis"),
 			Usage:       "storage driver for users mount: eg. local, eos, owncloud, ocis or s3",
-			EnvVars:     []string{"STORAGE_USERS_DRIVER"},
+			EnvVars:     []string{"OCS_STORAGE_USERS_DRIVER", "STORAGE_USERS_DRIVER"},
 			Destination: &cfg.StorageUsersDriver,
 		},
 	}

--- a/ocs/pkg/flagset/flagset.go
+++ b/ocs/pkg/flagset/flagset.go
@@ -172,6 +172,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:       "keeps track of the IDM Address. Needed because of Reva requisite of uniqueness for users",
 			Destination: &cfg.IdentityManagement.Address,
 		},
+		&cli.StringFlag{
+			Name:        "users-driver",
+			Value:       flags.OverrideDefaultString(cfg.StorageUsersDriver, "ocis"),
+			Usage:       "storage driver for users mount: eg. local, eos, owncloud, ocis or s3",
+			EnvVars:     []string{"STORAGE_USERS_DRIVER"},
+			Destination: &cfg.StorageUsersDriver,
+		},
 	}
 }
 

--- a/ocs/pkg/flagset/flagset.go
+++ b/ocs/pkg/flagset/flagset.go
@@ -165,6 +165,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"OCS_REVA_GATEWAY_ADDR"},
 			Destination: &cfg.RevaAddress,
 		},
+		&cli.StringFlag{
+			Name:        "idm-address",
+			Value:       flags.OverrideDefaultString(cfg.IdentityManagement.Address, "https://localhost:9200"),
+			EnvVars:     []string{"OCS_IDM_ADDRESS", "OCIS_URL"},
+			Usage:       "keeps track of the IDM Address. Needed because of Reva requisite of uniqueness for users",
+			Destination: &cfg.IdentityManagement.Address,
+		},
 	}
 }
 

--- a/ocs/pkg/service/v0/users.go
+++ b/ocs/pkg/service/v0/users.go
@@ -455,14 +455,14 @@ func (o Ocs) DeleteUser(w http.ResponseWriter, r *http.Request) {
 // TODO(refs) this to ocis-pkg ... we are minting tokens all over the place ... or use a service? ... like reva?
 func (o Ocs) mintTokenForUser(ctx context.Context, account *accounts.Account) (string, error) {
 	tm, _ := jwt.New(map[string]interface{}{
-		"secret":  "Pive-Fumkiu4", // TODO(refs) this MUST not be hardcoded
+		"secret":  o.config.TokenManager.JWTSecret,
 		"expires": int64(60),
 	})
 
 	u := &revauser.User{
 		Id: &revauser.UserId{
 			OpaqueId: account.Id,
-			Idp:      "https://localhost:9200", // TODO(refs) this MUST not be hardcoded
+			Idp:      o.config.IdentityManagement.Address,
 		},
 		Groups: []string{},
 		Opaque: &types.Opaque{

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -1562,8 +1562,6 @@ special character username not valid
 -   [apiProvisioning-v2/enableUser.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/enableUser.feature#L20)
 -   [apiProvisioning-v2/getUser.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/getUser.feature#L34)
 -   [apiProvisioning-v2/getUser.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/getUser.feature#L35)
--   [apiTrashbin/trashbinFilesFolders.feature:201](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L201)
--   [apiTrashbin/trashbinFilesFolders.feature:202](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L202)
 -   [apiTrashbin/trashbinFilesFolders.feature:246](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L246)
 -   [apiTrashbin/trashbinFilesFolders.feature:247](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L247)
 -   [apiTrashbin/trashbinFilesFolders.feature:248](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L248)


### PR DESCRIPTION
Use the CS3 API and Reva to deprovision users completely.

Two new environment variables introduced:
```
OCS_IDM_ADDRESS
OCS_STORAGE_USERS_DRIVER
```

`OCS_IDM_ADDRESS` is also an alias for `OCIS_URL`; allows the OCS service to mint jwt tokens for the authenticated user that will be read by the reva authentication middleware.

`OCS_STORAGE_USERS_DRIVER` determines how a user is deprovisioned. This kind of behavior is needed since every storage driver deals with deleting differently.

This is being tested with:

```console
make test-acceptance-api \
TEST_SERVER_URL=https://localhost:9200 \
TEST_OCIS=true \
SKELETON_DIR=/Users/aunger/code/owncloud/core/apps/testing/data/apiSkeleton \
BEHAT_FEATURE=tests/acceptance/features/apiBugDemonstration/apiWebdavPreviews-previews.feature \
PATH_TO_CORE=/Users/aunger/code/owncloud/core
```

TODO:
- [x] Add PR description
- [x] Do we want to opt with this solution or instead use the StorageSpaces API?
- [x] Does this work with the owncloud driver? Does it have to?