### PR TITLE
fix enforce_admins

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -42,7 +42,7 @@ branches:
         strict: false
         contexts:
           - continuous-integration/drone/pr
-      enforce_admins: false
+      enforce_admins: null
       restrictions:
         users: []
         teams:


### PR DESCRIPTION
Translation sync is not allowed to push to oCIS master branch:

```
latest: Pulling from plugins/git-action
--
2 | Digest: sha256:491ee1e85144d8a47dfd1eece5484dcb847f7ceb2a98f8daaadb8485778aa2d7
3 | Status: Image is up to date for plugins/git-action:latest
4 | + git push origin master:master
5 | Warning: Permanently added 'github.com,140.82.121.4' (RSA) to the list of known hosts.
6 | remote: error: GH006: Protected branch update failed for refs/heads/master.
7 | remote: error: Required status check "continuous-integration/drone/pr" is expected. At least 1 approving review is required by reviewers with write access.
8 | To github.com:owncloud/ocis.git
9 | ! [remote rejected]   master -> master (protected branch hook declined)
10 | error: failed to push some refs to 'git@github.com:owncloud/ocis.git'
11 | 2021/04/29 12:08:11 exit status 1
```

This should be due `enforce_admins` is set to `false` in .github/settings.yml but in order to disable it it must be set to `null` (https://github.com/apps/settings)