### PR TITLE
[tests-only] Investigate 1999

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=3f14092c4128248e3bc1aa532ee3e6115f5ff8c5
+CORE_COMMITID=b3d5ad5466ab63731d99984fc6d0be683777c9a7
 CORE_BRANCH=adjust-reShareUpdate-test
 
 # The test runner source for UI tests

--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=e8d1281774bb07d5e5195013ca83ceb515dd7e6d
-CORE_BRANCH=master
+CORE_COMMITID=3f14092c4128248e3bc1aa532ee3e6115f5ff8c5
+CORE_BRANCH=adjust-reShareUpdate-test
 
 # The test runner source for UI tests
 WEB_COMMITID=9b4f4cec4fee6e028898ffe661dd7f16996f234e

--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=b3d5ad5466ab63731d99984fc6d0be683777c9a7
+CORE_COMMITID=173ee1e16fd4cd06373c27cbcdc9dfdd08a3632c
 CORE_BRANCH=adjust-reShareUpdate-test
 
 # The test runner source for UI tests


### PR DESCRIPTION
Investigation of issue #1999 

1) Reverse order of examples - the failing test is the same scenario, for `ocs_api_version` 2. The scenario for `ocs_api_version` 1 now comes after it, and still passes.
2) Remove other scenarios from apiShareReshareToShares3 -  the failing test is the same scenario, for `ocs_api_version` 2. The scenario for `ocs_api_version` 1 comes after it, and still passes.
3) Remove scenarios from apiShareReshareToShares1 and 2 - https://drone.owncloud.com/owncloud/ocis/4842/33/7 - the failing test is now the first one in the pipeline, and it still fails with the same 500 status. So the problem is not caused by the leftovers of some previous scenario.