### PR TITLE
[Tests-Only] remove DELETE_USER_DATA_CMD env from api tests running scripts

### DIFF
--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -118,7 +118,6 @@ make test-acceptance-api \
 TEST_SERVER_URL=https://localhost:9200 \
 TEST_OCIS=true \
 SKELETON_DIR=apps/testing/data/apiSkeleton \
-DELETE_USER_DATA_CMD='rm -rf /var/tmp/ocis/storage/users/nodes/root/* /var/tmp/ocis/storage/users/nodes/*-*-*-*' \
 BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS'
 ```
 
@@ -158,7 +157,6 @@ If you want to work on a specific issue
     make test-acceptance-api \
     TEST_SERVER_URL=https://localhost:9200 \
     TEST_OCIS=true \
-    DELETE_USER_DATA_CMD='rm -rf /var/tmp/ocis/storage/users/nodes/root/* /var/tmp/ocis/storage/users/nodes/*-*-*-*' \
     BEHAT_FEATURE='tests/acceptance/features/apiComments/comments.feature:123'
     ```
 


### PR DESCRIPTION
## Description
Remove `DELETE_USER_DATA_CMD` env used in API tests running scripts from testing docs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/2008

