### PR TITLE
disable DCR for oCIS with Traefik example

### DIFF
--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
+      IDP_ALLOW_DYNAMIC_CLIENT_REGISTRATION: false # DCR not reliable with konnectd https://github.com/owncloud/openidconnect/issues/142
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-data:/var/tmp/ocis


### PR DESCRIPTION
## Description
disable DCR for oCIS with Traefik example since according to @michaelstingl Konnectd does not have Dynamic Client Registration at the moment (https://github.com/owncloud/openidconnect/issues/142)
