### PR TITLE
Add profile_picture to user capabilities

### DIFF
--- a/changelog/unreleased/enhancement-user-profile-picture-capability
+++ b/changelog/unreleased/enhancement-user-profile-picture-capability
@@ -1,0 +1,7 @@
+Enhancement: Announce user profile picture capability
+
+Added a new capability (through https://github.com/cs3org/reva/pull/1694) to prevent 
+the web frontend from fetching (nonexistent) user avatar profile pictures which added 
+latency & console errors.
+
+https://github.com/owncloud/ocis/pull/2036

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -219,7 +219,8 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 									},
 								},
 								"user": map[string]interface{}{
-									"send_mail": true,
+									"send_mail":       true,
+									"profile_picture": false,
 								},
 								"user_enumeration": map[string]interface{}{
 									"enabled":            true,


### PR DESCRIPTION
## Description
~Needs a PR in `reva` merged and then the `reva` version to be updated, will finalize this PR once that's done~

Adds the newly introduced capability in the latest `reva` version to oCIS' capabilities

## Related Issue
- Fixes #2031 
