### PR TITLE
deployment examples: switch to http internally

### DIFF
--- a/deployments/examples/cs3_users_ocis/docker-compose.yml
+++ b/deployments/examples/cs3_users_ocis/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - "--entryPoints.https.address=:443"
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"
       - "--providers.docker.exposedByDefault=false"
-      - "--serversTransport.insecureSkipVerify=true" # oCIS uses self generated certificate
     ports:
       - "80:80"
       - "443:443"
@@ -74,6 +73,7 @@ services:
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # change default secrets
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
     volumes:
@@ -91,7 +91,6 @@ services:
       - "traefik.http.routers.ocis-secure.tls.certresolver=http"
       - "traefik.http.routers.ocis-secure.service=ocis"
       - "traefik.http.services.ocis.loadbalancer.server.port=9200"
-      - "traefik.http.services.ocis.loadbalancer.server.scheme=https"
     logging:
       driver: "local"
     restart: always

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - "--entryPoints.https.address=:443"
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"
       - "--providers.docker.exposedByDefault=false"
-      - "--serversTransport.insecureSkipVerify=true" # oCIS uses self generated certificate
     ports:
       - "80:80"
       - "443:443"
@@ -63,6 +62,7 @@ services:
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # change default secrets
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
@@ -82,7 +82,6 @@ services:
       - "traefik.http.routers.ocis-secure.tls.certresolver=http"
       - "traefik.http.routers.ocis-secure.service=ocis"
       - "traefik.http.services.ocis.loadbalancer.server.port=9200"
-      - "traefik.http.services.ocis.loadbalancer.server.scheme=https"
     logging:
       driver: "local"
     restart: always

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - "--entryPoints.https.address=:443"
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"
       - "--providers.docker.exposedByDefault=false"
-      - "--serversTransport.insecureSkipVerify=true" # oCIS uses self generated certificate
     ports:
       - "80:80"
       - "443:443"
@@ -53,6 +52,7 @@ services:
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # change default secrets
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
@@ -72,7 +72,6 @@ services:
       - "traefik.http.routers.ocis-secure.tls.certresolver=http"
       - "traefik.http.routers.ocis-secure.service=ocis"
       - "traefik.http.services.ocis.loadbalancer.server.port=9200"
-      - "traefik.http.services.ocis.loadbalancer.server.scheme=https"
     logging:
       driver: "local"
     restart: always

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       - "--entryPoints.https.address=:443"
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"
       - "--providers.docker.exposedByDefault=false"
-      - "--serversTransport.insecureSkipVerify=true" # oCIS uses self generated certificate
     ports:
       - "80:80"
       - "443:443"
@@ -56,6 +55,7 @@ services:
       OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # change default secrets
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
@@ -81,7 +81,6 @@ services:
       - "traefik.http.routers.ocis-secure.tls.certresolver=http"
       - "traefik.http.routers.ocis-secure.service=ocis"
       - "traefik.http.services.ocis.loadbalancer.server.port=9200"
-      - "traefik.http.services.ocis.loadbalancer.server.scheme=https"
     logging:
       driver: "local"
     restart: always


### PR DESCRIPTION
## Description

For the deployment examples we switched to HTTPS internally in https://github.com/owncloud/ocis/commit/3eb9e122a4b90ddd1d82bdacbe34a3f8f86c0926#diff-82183c58020714d66867eb24da3765200d315ec2508b7816916567ce534142c7 because there was some configuration dependency whether oCIS runs with https or http and we wanted to stick as close to the default configuration as possible:
```
THUMBNAILS_WEBDAVSOURCE_BASEURL: http://localhost:9200/remote.php/webdav/
```

The need to set THUMBNAILS_WEBDAVSOURCE_BASEURL was removed in #1898 so we can use http internally again.

Using http between oCIS has the advantage that we don't have to set `insecureSkipVerify` on Traefik.
