### PR TITLE
[tests-only] first fixes

### DIFF
--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -120,14 +120,14 @@ help:
 .PHONY: test-ocis-feature-ocis-storage
 test-ocis-feature-ocis-storage: ## test a ocis feature with oCIS storage, useage: make ... BEHAT_FEATURE='tests/acceptance/features/apiBugDemonstration/apiAuthOcs-ocsDELETEAuth.feature:7'
 	@TEST_SOURCE=ocis \
-	STORAGE=ocis \
+	STORAGE_DRIVER=ocis \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: test-ocis-feature-s3ng-storage
 test-ocis-feature-s3ng-storage: ## test a ocis feature with s3ng storage, useage: make ... BEHAT_FEATURE='tests/acceptance/features/apiOcisSpecific/apiAuthOcs-ocsDELETEAuth.feature:7'
 	@TEST_SOURCE=ocis \
-	STORAGE=s3ng \
+	STORAGE_DRIVER=s3ng \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	START_CEPH=1 \
 	$(MAKE) --no-print-directory testSuite
@@ -135,21 +135,21 @@ test-ocis-feature-s3ng-storage: ## test a ocis feature with s3ng storage, useage
 .PHONY: test-ocis-feature-owncloud-storage
 test-ocis-feature-owncloud-storage: ## test a ocis feature with oc10 storage, useage: make ... BEHAT_FEATURE='tests/acceptance/features/apiBugDemonstration/apiAuthOcs-ocsDELETEAuth.feature:7'
 	@TEST_SOURCE=ocis \
-	STORAGE=owncloud \
+	STORAGE_DRIVER=owncloud \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: test-oc10-feature-ocis-storage
 test-oc10-feature-ocis-storage: ## test a oC10 feature with oCIS storage, useage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAuth/cors.feature'
 	@TEST_SOURCE=oc10 \
-	STORAGE=ocis \
+	STORAGE_DRIVER=ocis \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: test-oc10-feature-s3ng-storage
 test-oc10-feature-s3ng-storage: ## test a oC10 feature with s3ng storage, useage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAuth/cors.feature'
 	@TEST_SOURCE=oc10 \
-	STORAGE=s3ng \
+	STORAGE_DRIVER=s3ng \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	START_CEPH=1 \
 	$(MAKE) --no-print-directory testSuite
@@ -157,42 +157,42 @@ test-oc10-feature-s3ng-storage: ## test a oC10 feature with s3ng storage, useage
 .PHONY: test-oc10-feature-owncloud-storage
 test-oc10-feature-owncloud-storage: ## test a oC10 feature with oc10 storage, useage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAuth/cors.feature'
 	@TEST_SOURCE=oc10 \
-	STORAGE=owncloud \
+	STORAGE_DRIVER=owncloud \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: localApiTests-apiBugDemonstration-owncloud
 localApiTests-apiBugDemonstration-owncloud: ## run apiBugDemonstration test suite with owncloud storage
 	@TEST_SOURCE=oc10 \
-	STORAGE=owncloud \
+	STORAGE_DRIVER=owncloud \
 	BEHAT_SUITE=apiBugDemonstration \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: localApiTests-apiAccountsHashDifficulty-owncloud
 localApiTests-apiAccountsHashDifficulty-owncloud: ## run apiAccountsHashDifficulty test suite with owncloud storage
 	@TEST_SOURCE=ocis \
-	STORAGE=owncloud \
+	STORAGE_DRIVER=owncloud \
 	BEHAT_SUITE=apiAccountsHashDifficulty \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: localApiTests-apiBugDemonstration-ocis
 localApiTests-apiBugDemonstration-ocis: ## run apiBugDemonstration test suite with ocis storage
 	@TEST_SOURCE=ocis \
-	STORAGE=ocis \
+	STORAGE_DRIVER=ocis \
 	BEHAT_SUITE=apiBugDemonstration \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: localApiTests-apiAccountsHashDifficulty-ocis
 localApiTests-apiAccountsHashDifficulty-ocis: ## run apiAccountsHashDifficulty test suite with ocis storage
 	@TEST_SOURCE=ocis \
-	STORAGE=ocis \
+	STORAGE_DRIVER=ocis \
 	BEHAT_SUITE=apiAccountsHashDifficulty \
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: localApiTests-apiOcisSpecific-s3ng
 localApiTests-apiOcisSpecific-s3ng: ## run apiOcisSPecific test suite with s3ng storage
 	@TEST_SOURCE=ocis \
-	STORAGE=s3ng \
+	STORAGE_DRIVER=s3ng \
 	BEHAT_SUITE=apiOcisSpecific \
 	START_CEPH=1 \
 	$(MAKE) --no-print-directory testSuite
@@ -201,7 +201,7 @@ localApiTests-apiOcisSpecific-s3ng: ## run apiOcisSPecific test suite with s3ng 
 .PHONY: localApiTests-apiBasic-s3ng
 localApiTests-apiBasic-s3ng: ## run apiBasic test suite with s3ng storage
 	@TEST_SOURCE=ocis \
-	STORAGE=s3ng \
+	STORAGE_DRIVER=s3ng \
 	BEHAT_SUITE=apiBasic \
 	START_CEPH=1 \
 	$(MAKE) --no-print-directory testSuite
@@ -211,7 +211,7 @@ targets = $(addprefix Core-API-Tests-owncloud-storage-,$(PARTS))
 $(targets):
 	@$(eval RUN_PART=$(shell echo "$@" | tr -dc '0-9'))
 	@TEST_SOURCE=oc10 \
-	STORAGE=owncloud \
+	STORAGE_DRIVER=owncloud \
 	RUN_PART=$(RUN_PART) \
 	$(MAKE) --no-print-directory testSuite
 
@@ -220,7 +220,7 @@ targets = $(addprefix Core-API-Tests-ocis-storage-,$(PARTS))
 $(targets):
 	@$(eval RUN_PART=$(shell echo "$@" | tr -dc '0-9'))
 	@TEST_SOURCE=oc10 \
-	STORAGE=ocis \
+	STORAGE_DRIVER=ocis \
 	RUN_PART=$(RUN_PART) \
 	$(MAKE) --no-print-directory testSuite
 
@@ -233,7 +233,7 @@ testSuite: clean-docker-container
 	fi; \
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 	COMPOSE_FILE=$(COMPOSE_FILE) \
-	STORAGE=$(STORAGE) \
+	STORAGE_DRIVER=$(STORAGE_DRIVER) \
 	TEST_SOURCE=$(TEST_SOURCE) \
 	OCIS_IMAGE_TAG=$(OCIS_IMAGE_TAG) \
 	BEHAT_SUITE=$(BEHAT_SUITE) \
@@ -256,20 +256,19 @@ clean-docker-container: ## clean docker containers created during acceptance tes
 	DIVIDE_INTO_NUM_PARTS="" \
 	OCIS_IMAGE_TAG="" \
 	RUN_PART="" \
-	STORAGE="" \
+	STORAGE_DRIVER="" \
 	TEST_SOURCE="" \
 	docker-compose down --remove-orphans
 
 .PHONY: clean-docker-volumes
 clean-docker-volumes: ## clean docker volumes created during acceptance tests
 	@COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
-	STORAGE=$(STORAGE) \
 	COMPOSE_FILE=$(COMPOSE_FILE) \
 	BEHAT_SUITE="" \
 	DIVIDE_INTO_NUM_PARTS="" \
 	OCIS_IMAGE_TAG="" \
 	RUN_PART="" \
-	STORAGE="" \
+	STORAGE_DRIVER="" \
 	TEST_SOURCE="" \
 	docker-compose down --remove-orphans -v
 

--- a/tests/acceptance/docker/src/acceptance.yml
+++ b/tests/acceptance/docker/src/acceptance.yml
@@ -7,9 +7,11 @@ services:
       PATH_TO_CORE: /srv/app/testrunner
       SKELETON_DIR: /srv/app/tmp/testing/data/apiSkeleton
       TEST_OCIS: "true"
+      RUN_ON_OCIS: "true"
       TEST_SERVER_URL: https://ocis-server:9200
       TESTING_DIR: /srv/app/tmp/testing
 
+      STORAGE_DRIVER: $STORAGE
       STORAGE: $STORAGE
       TEST_SOURCE: $TEST_SOURCE
       BEHAT_SUITE: ${BEHAT_SUITE:-}

--- a/tests/acceptance/docker/src/acceptance.yml
+++ b/tests/acceptance/docker/src/acceptance.yml
@@ -11,8 +11,7 @@ services:
       TEST_SERVER_URL: https://ocis-server:9200
       TESTING_DIR: /srv/app/tmp/testing
 
-      STORAGE_DRIVER: $STORAGE
-      STORAGE: $STORAGE
+      STORAGE_DRIVER: $STORAGE_DRIVER
       TEST_SOURCE: $TEST_SOURCE
       BEHAT_SUITE: ${BEHAT_SUITE:-}
       BEHAT_FEATURE: ${BEHAT_FEATURE:-}

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -8,19 +8,13 @@ services:
       STORAGE_METADATA_ROOT: /srv/app/tmp/ocis/metadata
       STORAGE_DRIVER_OWNCLOUD_DATADIR: /srv/app/tmp/ocis/owncloud/data
       STORAGE_DRIVER_OWNCLOUD_REDIS_ADDR: redis:6379
-      STORAGE_LDAP_IDP: https://ocis-server:9200
-      STORAGE_OIDC_ISSUER: https://ocis-server:9200
-      PROXY_OIDC_ISSUER: https://ocis-server:9200
       STORAGE_HOME_DATA_SERVER_URL: http://ocis-server:9155/data
-      STORAGE_DATAGATEWAY_PUBLIC_URL: https://ocis-server:9200/data
       STORAGE_USERS_DATA_SERVER_URL: http://ocis-server:9158/data
-      STORAGE_FRONTEND_PUBLIC_URL: https://ocis-server:9200
       STORAGE_SHARING_USER_JSON_FILE: /srv/app/tmp/ocis/shares.json
+      SETTINGS_DATA_PATH: "/srv/app/tmp/ocis/settings"
       PROXY_ENABLE_BASIC_AUTH: "true"
-      PHOENIX_WEB_CONFIG: /drone/src/ocis/tests/config/drone/ocis-config.json
-      IDP_IDENTIFIER_REGISTRATION_CONF: /drone/src/ocis/tests/config/drone/identifier-registration.yml
-      IDP_ISS: https://ocis-server:9200
-      IDP_TLS: "true"
+      WEB_UI_CONFIG: /drone/src/tests/config/drone/ocis-config.json
+      IDP_IDENTIFIER_REGISTRATION_CONF: /drone/src/tests/config/drone/identifier-registration.yml
       ACCOUNTS_HASH_DIFFICULTY: 4
       # s3ng specific settings
       STORAGE_DRIVER_S3NG_ENDPOINT: http://ceph:8080
@@ -29,7 +23,7 @@ services:
       STORAGE_DRIVER_S3NG_SECRET_KEY: test
       STORAGE_DRIVER_S3NG_BUCKET: test
     volumes:
-      - ../../../config:/drone/src/ocis/tests/config
+      - ../../../config:/drone/src/tests/config
       - oCISownCloud10testsuite:/srv
 
 volumes:

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -1,8 +1,9 @@
 services:
   ocis-server:
     environment:
-      STORAGE_HOME_DRIVER: $STORAGE
-      STORAGE_USERS_DRIVER: $STORAGE
+      OCIS_URL: "https://ocis-server:9200"
+      STORAGE_HOME_DRIVER: $STORAGE_DRIVER
+      STORAGE_USERS_DRIVER: $STORAGE_DRIVER
       STORAGE_DRIVER_OCIS_ROOT: /srv/app/tmp/ocis/storage/users
       STORAGE_DRIVER_LOCAL_ROOT: /srv/app/tmp/ocis/local/root
       STORAGE_METADATA_ROOT: /srv/app/tmp/ocis/metadata

--- a/tests/acceptance/docker/src/run-tests.sh
+++ b/tests/acceptance/docker/src/run-tests.sh
@@ -26,13 +26,13 @@ fi
 
 if [ "$TEST_SOURCE" = "oc10" ]
 then
-    if [ "$STORAGE" = "owncloud" ]
+    if [ "$STORAGE_DRIVER" = "owncloud" ]
     then
         export OCIS_REVA_DATA_ROOT='/srv/app/tmp/ocis/owncloud/data/'
         export BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~comments-app-required&&~@federation-app-required&&~@notifications-app-required&&~systemtags-app-required&&~@local_storage&&~@skipOnOcis-OC-Storage'
         export OCIS_SKELETON_STRATEGY='copy'
         export EXPECTED_FAILURES_FILE='/drone/src/tests/acceptance/expected-failures-API-on-OWNCLOUD-storage.md'
-    elif [ "$STORAGE" = "ocis" ]
+    elif [ "$STORAGE_DRIVER" = "ocis" ]
     then
         export OCIS_REVA_DATA_ROOT=''
         export BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~comments-app-required&&~@federation-app-required&&~@notifications-app-required&&~systemtags-app-required&&~@local_storage&&~@skipOnOcis-OCIS-Storage'
@@ -48,18 +48,17 @@ then
 elif [ "$TEST_SOURCE" = "ocis" ]
 then
 
-    if [ "$STORAGE" = "owncloud" ]
+    if [ "$STORAGE_DRIVER" = "owncloud" ]
     then
         export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOcis-OC-Storage'
         export OCIS_REVA_DATA_ROOT='/srv/app/tmp/ocis/owncloud/data/'
         export OCIS_SKELETON_STRATEGY='copy'
-    elif [ "$STORAGE" = "ocis" ]
+    elif [ "$STORAGE_DRIVER" = "ocis" ]
     then
         export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOcis-OCIS-Storage'
-        #export OCIS_REVA_DATA_ROOT='/srv/app/tmp/ocis/owncloud/data'
         export OCIS_REVA_DATA_ROOT=''
         export OCIS_SKELETON_STRATEGY='upload'
-    elif [ "$STORAGE" = "s3ng" ]
+    elif [ "$STORAGE_DRIVER" = "s3ng" ]
     then
         export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOcis-S3NG-Storage'
         export OCIS_REVA_DATA_ROOT=''
@@ -89,16 +88,6 @@ else
     unset BEHAT_FEATURE
 fi
 
-echo "#################"
-echo "#################"
-echo "#################"
-echo "#################"
-printenv
-echo "#################"
-echo "#################"
-echo "#################"
-echo "#################"
-
 ## RUN TEST
 
 if [ "$TEST_SOURCE" = "oc10" ]
@@ -108,7 +97,7 @@ elif [ "$TEST_SOURCE" = "ocis" ]
 then
     cd $OCIS_ROOT
     sleep 10
-    make -C /drone/src test-acceptance-api
+    make test-acceptance-api
 else
     echo "non existing TEST_SOURCE selected"
     exit 1

--- a/tests/acceptance/docker/src/run-tests.sh
+++ b/tests/acceptance/docker/src/run-tests.sh
@@ -29,14 +29,12 @@ then
     if [ "$STORAGE" = "owncloud" ]
     then
         export OCIS_REVA_DATA_ROOT='/srv/app/tmp/ocis/owncloud/data/'
-        export DELETE_USER_DATA_CMD=''
         export BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~comments-app-required&&~@federation-app-required&&~@notifications-app-required&&~systemtags-app-required&&~@local_storage&&~@skipOnOcis-OC-Storage'
         export OCIS_SKELETON_STRATEGY='copy'
         export EXPECTED_FAILURES_FILE='/drone/src/tests/acceptance/expected-failures-API-on-OWNCLOUD-storage.md'
     elif [ "$STORAGE" = "ocis" ]
     then
         export OCIS_REVA_DATA_ROOT=''
-        export DELETE_USER_DATA_CMD='rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'
         export BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~comments-app-required&&~@federation-app-required&&~@notifications-app-required&&~systemtags-app-required&&~@local_storage&&~@skipOnOcis-OCIS-Storage'
         export OCIS_SKELETON_STRATEGY='upload'
         export EXPECTED_FAILURES_FILE='/drone/src/tests/acceptance/expected-failures-API-on-OCIS-storage.md'
@@ -52,20 +50,18 @@ then
 
     if [ "$STORAGE" = "owncloud" ]
     then
-        export BEHAT_FILTER_TAGS='~@skipOnOcis-OC-Storage'
-        export DELETE_USER_DATA_CMD=''
+        export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOcis-OC-Storage'
         export OCIS_REVA_DATA_ROOT='/srv/app/tmp/ocis/owncloud/data/'
         export OCIS_SKELETON_STRATEGY='copy'
     elif [ "$STORAGE" = "ocis" ]
     then
-        export BEHAT_FILTER_TAGS='~@skipOnOcis-OCIS-Storage'
-        export DELETE_USER_DATA_CMD='rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'
+        export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOcis-OCIS-Storage'
+        #export OCIS_REVA_DATA_ROOT='/srv/app/tmp/ocis/owncloud/data'
         export OCIS_REVA_DATA_ROOT=''
         export OCIS_SKELETON_STRATEGY='upload'
     elif [ "$STORAGE" = "s3ng" ]
     then
-        export BEHAT_FILTER_TAGS='~@skipOnOcis-S3NG-Storage'
-        export DELETE_USER_DATA_CMD='rm -rf /srv/app/tmp/ocis/storage/users/nodes/root/* /srv/app/tmp/ocis/storage/users/nodes/*-*-*-*'
+        export BEHAT_FILTER_TAGS='~@skip&&~@skipOnOcis-S3NG-Storage'
         export OCIS_REVA_DATA_ROOT=''
         export OCIS_SKELETON_STRATEGY='upload'
     else
@@ -89,7 +85,19 @@ then
     unset DIVIDE_INTO_NUM_PARTS
     unset RUN_PART
     unset EXPECTED_FAILURES_FILE
+else
+    unset BEHAT_FEATURE
 fi
+
+echo "#################"
+echo "#################"
+echo "#################"
+echo "#################"
+printenv
+echo "#################"
+echo "#################"
+echo "#################"
+echo "#################"
 
 ## RUN TEST
 
@@ -100,7 +108,7 @@ elif [ "$TEST_SOURCE" = "ocis" ]
 then
     cd $OCIS_ROOT
     sleep 10
-    make test-acceptance-api
+    make -C /drone/src test-acceptance-api
 else
     echo "non existing TEST_SOURCE selected"
     exit 1


### PR DESCRIPTION
## Description
Fix acceptance test setup which can be run by devs locally in docker

## Motivation and Context
CI and oCIS has changed a lot and the docker based acceptence test setup for devs has not gotten much love.  

## How Has This Been Tested?
- run tests `make -C tests/acceptance/docker <xxx> OCIS_IMAGE_TAG=1.6.0` where <xxx> is:
   - [x] test-ocis-feature-ocis-storage
   - [x] test-ocis-feature-owncloud-storage
   - [x] test-oc10-feature-ocis-storage BEHAT_FEATURE='tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature:97'
   - [x] test-oc10-feature-owncloud-storage BEHAT_FEATURE='tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature:56'
   - [x]  localApiTests-apiBugDemonstration-owncloud
   - [x] localApiTests-apiAccountsHashDifficulty-owncloud
   - [x] localApiTests-apiBugDemonstration-ocis
   - [x] localApiTests-apiAccountsHashDifficulty-ocis
   - [x] Core-API-Tests-owncloud-storage-1
   - [x] Core-API-Tests-ocis-storage-1
- respectively check that `make -C tests/acceptance/docker show-test-logs` reports no unexpected failures / passes

