### PR TITLE
[Tests-Only]Add earlyFail

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -389,6 +389,10 @@ def uploadScanResults(ctx):
 
 def localApiTests(ctx, storage = "owncloud", suite = "apiBugDemonstration", accounts_hash_difficulty = 4):
     earlyFail = config["localApiTests"]["earlyFail"] if "earlyFail" in config["localApiTests"] else False
+
+    if ("full-ci" in ctx.build.title.lower()):
+        earlyFail = False
+
     return {
         "kind": "pipeline",
         "type": "docker",
@@ -435,6 +439,10 @@ def localApiTests(ctx, storage = "owncloud", suite = "apiBugDemonstration", acco
 
 def coreApiTests(ctx, part_number = 1, number_of_parts = 1, storage = "owncloud", accounts_hash_difficulty = 4):
     earlyFail = config["apiTests"]["earlyFail"] if "earlyFail" in config["apiTests"] else False
+
+    if ("full-ci" in ctx.build.title.lower()):
+        earlyFail = False
+
     return {
         "kind": "pipeline",
         "type": "docker",
@@ -508,6 +516,9 @@ def uiTests(ctx):
 
     filterTags = params["filterTags"]
     earlyFail = params["earlyFail"]
+
+    if ("full-ci" in ctx.build.title.lower()):
+        earlyFail = False
 
     if ("full-ci" in ctx.build.title.lower() or ctx.build.event == "tag"):
         numberOfParts = params["numberOfParts"]
@@ -594,6 +605,10 @@ def uiTestPipeline(ctx, filterTags, earlyFail, runPart = 1, numberOfParts = 1, s
 
 def accountsUITests(ctx, storage = "ocis", accounts_hash_difficulty = 4):
     earlyFail = config["accountsUITests"]["earlyFail"] if "earlyFail" in config["accountsUITests"] else False
+
+    if ("full-ci" in ctx.build.title.lower()):
+        earlyFail = False
+
     return {
         "kind": "pipeline",
         "type": "docker",
@@ -659,6 +674,10 @@ def accountsUITests(ctx, storage = "ocis", accounts_hash_difficulty = 4):
 
 def settingsUITests(ctx, storage = "ocis", accounts_hash_difficulty = 4):
     earlyFail = config["settingsUITests"]["earlyFail"] if "earlyFail" in config["settingsUITests"] else False
+
+    if ("full-ci" in ctx.build.title.lower()):
+        earlyFail = False
+
     return {
         "kind": "pipeline",
         "type": "docker",


### PR DESCRIPTION
## Description
This PR enables fail-early system for tests running in CI.
When ever a test suite fails, it stops the particular build so that the resources are not wasted.
The drone.star is adjusted such that for the suites where earlyFail feature is set to True, any test failure in that suite stops the build. If we do not want the failing tests in a suite to stop the build, we can adjust `earlyFail: False` for the particular test suite.
Whenever a test suite fails, a github comment is generated which helps us identify which test failure actually stopped the build.

## Related Issue
- https://github.com/owncloud/QA/issues/672

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
