### PR TITLE
fix: make groups index case sensitive

### DIFF
--- a/accounts/pkg/service/v0/index.go
+++ b/accounts/pkg/service/v0/index.go
@@ -63,11 +63,11 @@ func recreateContainers(idx *indexer.Indexer, cfg *config.Config) error {
 	}
 
 	// Groups
-	if err := idx.AddIndex(&proto.Group{}, "OnPremisesSamAccountName", "Id", "groups", "unique", nil, true); err != nil {
+	if err := idx.AddIndex(&proto.Group{}, "OnPremisesSamAccountName", "Id", "groups", "unique", nil, false); err != nil {
 		return err
 	}
 
-	if err := idx.AddIndex(&proto.Group{}, "DisplayName", "Id", "groups", "non_unique", nil, true); err != nil {
+	if err := idx.AddIndex(&proto.Group{}, "DisplayName", "Id", "groups", "non_unique", nil, false); err != nil {
 		return err
 	}
 

--- a/changelog/unreleased/fix-groups-index.md
+++ b/changelog/unreleased/fix-groups-index.md
@@ -1,0 +1,5 @@
+Bugfix: Change the groups index to be case sensitive 
+
+Groups are considered to be case sensitive. The index must handle them case sensitive too otherwise we will have undeterministic behavior while editing or deleting groups.
+
+https://github.com/owncloud/ocis/pull/2109


### PR DESCRIPTION
When multiple groups are created like:
`group1` `Group1` and `GROUP1` they are separate groups for the accounts service but the index saw them as the same group.

First noticed it in the reva update PR: https://github.com/owncloud/ocis/pull/2104
The tests were failing because of this 'bug'.