### PR TITLE
Use ocis registry for refresh

### DIFF
--- a/changelog/unreleased/fix-use-configured-registry
+++ b/changelog/unreleased/fix-use-configured-registry
@@ -1,0 +1,5 @@
+Bugfix: External storage registration used wrong config
+
+The go-micro registry-singleton ignores the ocis configuration and defaults to mdns
+
+https://github.com/owncloud/ocis/pull/2120

--- a/storage/pkg/service/external/external.go
+++ b/storage/pkg/service/external/external.go
@@ -19,10 +19,10 @@ func RegisterGRPCEndpoint(ctx context.Context, serviceID, uuid, addr string, log
 		Address:  addr,
 		Metadata: make(map[string]string),
 	}
-	r := oregistry.GetRegistry()
+	ocisRegistry := oregistry.GetRegistry()
 
 	node.Metadata["broker"] = broker.String()
-	node.Metadata["registry"] = r.String()
+	node.Metadata["registry"] = ocisRegistry.String()
 	node.Metadata["server"] = "grpc"
 	node.Metadata["transport"] = "grpc"
 	node.Metadata["protocol"] = "grpc"
@@ -37,7 +37,7 @@ func RegisterGRPCEndpoint(ctx context.Context, serviceID, uuid, addr string, log
 	logger.Info().Msgf("registering external service %v@%v", node.Id, node.Address)
 
 	rOpts := []registry.RegisterOption{registry.RegisterTTL(time.Minute)}
-	if err := r.Register(service, rOpts...); err != nil {
+	if err := ocisRegistry.Register(service, rOpts...); err != nil {
 		logger.Fatal().Err(err).Msgf("Registration error for external service %v", serviceID)
 	}
 
@@ -48,14 +48,14 @@ func RegisterGRPCEndpoint(ctx context.Context, serviceID, uuid, addr string, log
 			select {
 			case <-t.C:
 				logger.Debug().Interface("service", service).Msg("refreshing external service-registration")
-				err := registry.Register(service, rOpts...)
+				err := ocisRegistry.Register(service, rOpts...)
 				if err != nil {
 					logger.Error().Err(err).Msgf("registration error for external service %v", serviceID)
 				}
 			case <-ctx.Done():
 				logger.Debug().Interface("service", service).Msg("unregistering")
 				t.Stop()
-				err := registry.Deregister(service)
+				err := ocisRegistry.Deregister(service)
 				if err != nil {
 					logger.Err(err).Msgf("Error unregistering external service %v", serviceID)
 				}


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The go-micro registry-singleton ignores the ocis config and defaults to mdns

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2119

## Motivation and Context
The storage was always advertised via mdns, ignoring the registry configuration

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
