### PR TITLE
unifiy go version

### DIFF
--- a/docs/ocis/development/getting-started.md
+++ b/docs/ocis/development/getting-started.md
@@ -16,7 +16,7 @@ So we are trying to reflect this in the tooling. It should be kept simple and qu
 
 Besides standard development tools like git and a text editor, you need the following software for development:
 
-- Go >= v1.15 ([install instructions](https://golang.org/doc/install))
+- Go >= v1.16 ([install instructions](https://golang.org/doc/install))
 - Yarn ([install instructions](https://classic.yarnpkg.com/en/docs/install))
 - docker ([install instructions](https://docs.docker.com/get-docker/))
 - docker-compose ([install instructions](https://docs.docker.com/compose/install/))

--- a/graph-explorer/go.mod
+++ b/graph-explorer/go.mod
@@ -1,6 +1,6 @@
 module github.com/owncloud/ocis/graph-explorer
 
-go 1.13
+go 1.16
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1

--- a/graph/go.mod
+++ b/graph/go.mod
@@ -1,6 +1,6 @@
 module github.com/owncloud/ocis/graph
 
-go 1.13
+go 1.16
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
docs state that a developer needs at least Go 1.15 but actually it is 1.16. Graph and Graph Explorer should also use Go 1.16 for consistency reasons, since all other extensions are using this version too.
