### PR TITLE
add hello and s3 deplyoment example

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1450,6 +1450,8 @@ def example_deploys(ctx):
         "ocis_keycloak/latest.yml",
         "ocis_traefik/latest.yml",
         "ocis_wopi/latest.yml",
+        "ocis_hello/latest.yml",
+        "ocis_s3/latest.yml",
     ]
     released_configs = [
         "cs3_users_ocis/released.yml",

--- a/deployments/continuous-deployment-config/ocis_hello/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_hello/latest.yml
@@ -1,0 +1,41 @@
+---
+- name: continuous-deployment-ocis-s3-latest
+  server:
+    server_type: cx21
+    image: ubuntu-20.04
+    location: nbg1
+    initial_ssh_key_names:
+      - owncloud-ocis@drone.owncloud.com
+    labels:
+      owner: wkloucek
+      for: oCIS-continuous-deployment-examples
+    rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
+
+  domains:
+    - "*.ocis-s3.latest.owncloud.works"
+
+  vars:
+    docker_compose_projects:
+      - name: ocis
+        git_url: https://github.com/owncloud/ocis.git
+        ref: master
+        docker_compose_path: deployments/examples/ocis_s3
+        env:
+          INSECURE: "false"
+          TRAEFIK_ACME_MAIL: wkloucek@owncloud.com
+          OCIS_DOCKER_TAG: latest
+          OCIS_DOMAIN: ocis.ocis-s3.latest.owncloud.works
+          MINIO_DOMAIN: minio.ocis-s3.latest.owncloud.works
+          COMPOSE_FILE: docker-compose.yml:monitoring_tracing/docker-compose-additions.yml
+      - name: monitoring
+        git_url: https://github.com/owncloud-devops/monitoring-tracing-client.git
+        ref: master
+        env:
+          NETWORK_NAME: ocis-net
+          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-s3.latest.owncloud.works
+          JAEGER_COLLECTOR: jaeger-collector.infra.owncloud.works:443
+          TELEGRAF_SPECIFIC_CONFIG: ocis_single_container
+          OCIS_URL: ocis.ocis-s3.latest.owncloud.works
+          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-s3-latest

--- a/deployments/continuous-deployment-config/ocis_s3/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_s3/latest.yml
@@ -1,0 +1,40 @@
+---
+- name: continuous-deployment-ocis-hello-latest
+  server:
+    server_type: cx21
+    image: ubuntu-20.04
+    location: nbg1
+    initial_ssh_key_names:
+      - owncloud-ocis@drone.owncloud.com
+    labels:
+      owner: wkloucek
+      for: oCIS-continuous-deployment-examples
+    rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
+
+  domains:
+    - "*.ocis-hello.latest.owncloud.works"
+
+  vars:
+    docker_compose_projects:
+      - name: ocis
+        git_url: https://github.com/owncloud/ocis.git
+        ref: master
+        docker_compose_path: deployments/examples/ocis_hello
+        env:
+          INSECURE: "false"
+          TRAEFIK_ACME_MAIL: wkloucek@owncloud.com
+          OCIS_DOCKER_TAG: latest
+          OCIS_DOMAIN: ocis.ocis-hello.latest.owncloud.works
+          COMPOSE_FILE: docker-compose.yml:monitoring_tracing/docker-compose-additions.yml
+      - name: monitoring
+        git_url: https://github.com/owncloud-devops/monitoring-tracing-client.git
+        ref: master
+        env:
+          NETWORK_NAME: ocis-net
+          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-hello.latest.owncloud.works
+          JAEGER_COLLECTOR: jaeger-collector.infra.owncloud.works:443
+          TELEGRAF_SPECIFIC_CONFIG: ocis_single_container
+          OCIS_URL: ocis.ocis-hello.latest.owncloud.works
+          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-hello-latest

--- a/deployments/examples/ocis_hello/.env
+++ b/deployments/examples/ocis_hello/.env
@@ -1,0 +1,34 @@
+# If you're on a internet facing server please comment out following line.
+# It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
+INSECURE=true
+
+### Traefik settings ###
+# Serve Treafik dashboard. Defaults to "false".
+TRAEFIK_DASHBOARD=
+# Domain of Traefik, where you can find the dashboard. Defaults to "traefik.owncloud.test"
+TRAEFIK_DOMAIN=
+# Basic authentication for the dashboard. Defaults to user "admin" and password "admin"
+TRAEFIK_BASIC_AUTH_USERS=
+# Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
+TRAEFIK_ACME_MAIL=
+
+### oCIS settings ###
+# oCIS version. Defaults to "latest"
+OCIS_DOCKER_TAG=
+# Domain of oCIS, where you can find the frontend. Defaults to "ocis.owncloud.test"
+OCIS_DOMAIN=
+# IDP LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "idp".
+IDP_LDAP_BIND_PASSWORD=
+# Storage LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "reva".
+STORAGE_LDAP_BIND_PASSWORD=
+# JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
+OCIS_JWT_SECRET=
+
+### oCIS Hello settings ###
+# oCIS Hello version. Defaults to "latest"
+OCIS_HELLO_DOCKER_TAG=
+
+# If you want to use debugging and tracing with this stack,
+# you need uncomment following line. Please see documentation at
+# https://owncloud.dev/ocis/deployment/monitoring-tracing/
+#COMPOSE_FILE=docker-compose.yml:monitoring_tracing/docker-compose-additions.yml

--- a/deployments/examples/ocis_hello/README.md
+++ b/deployments/examples/ocis_hello/README.md
@@ -1,0 +1,6 @@
+---
+document this deployment example in: docs/ocis/deployment/ocis_wopi.md
+---
+
+Please refer to [our documentation](https://owncloud.dev/ocis/deployment/ocis_wopi/)
+for instructions on how to deploy this scenario.

--- a/deployments/examples/ocis_hello/config/ocis/config.dist.json
+++ b/deployments/examples/ocis_hello/config/ocis/config.dist.json
@@ -1,0 +1,30 @@
+{
+  "server": "https://ocis.owncloud.test",
+  "theme": "owncloud",
+  "version": "0.1.0",
+  "openIdConnect": {
+    "metadata_url": "https://ocis.owncloud.test/.well-known/openid-configuration",
+    "authority": "https://ocis.owncloud.test",
+    "client_id": "web",
+    "response_type": "code",
+    "scope": "openid profile email"
+  },
+  "apps": ["files"],
+  "external_apps": [
+    {
+      "id": "settings",
+      "path": "/settings.js"
+    },
+    {
+      "id": "accounts",
+      "path": "/accounts.js"
+    },
+    {
+      "id": "hello",
+      "path": "/hello.js"
+    }
+  ],
+  "options": {
+    "hideSearchBar": true
+  }
+}

--- a/deployments/examples/ocis_hello/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_hello/config/ocis/entrypoint-override.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+cp /config/config.dist.json /config/config.json
+sed -i 's/ocis.owncloud.test/'${OCIS_DOMAIN:-ocis.owncloud.test}'/g' /config/config.json
+
+ocis server&
+sleep 10
+
+echo "##################################################"
+echo "change default secrets:"
+
+# IDP
+IDP_USER_UUID=$(ocis accounts list | grep "| Kopano IDP " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
+echo "  IDP user UUID: $IDP_USER_UUID"
+ocis accounts update --password $IDP_LDAP_BIND_PASSWORD $IDP_USER_UUID
+
+# REVA
+REVA_USER_UUID=$(ocis accounts list | grep " | Reva Inter " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
+echo "  Reva user UUID: $REVA_USER_UUID"
+ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD $REVA_USER_UUID
+
+echo "default secrets changed"
+echo "##################################################"
+
+ocis kill proxy
+sleep 10
+ocis proxy server # workaround for loading proxy configuration
+
+wait # wait for oCIS to exit

--- a/deployments/examples/ocis_hello/config/ocis/proxy-config.json
+++ b/deployments/examples/ocis_hello/config/ocis/proxy-config.json
@@ -1,0 +1,107 @@
+{
+  "HTTP": {
+    "Namespace": "com.owncloud"
+  },
+  "policy_selector": {
+    "static": {
+      "policy": "ocis"
+    }
+  },
+  "policies": [
+    {
+      "name": "ocis",
+      "routes": [
+        {
+          "endpoint": "/",
+          "backend": "http://localhost:9100"
+        },
+        {
+          "endpoint": "/.well-known/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/konnect/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/signin/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "type": "regex",
+          "endpoint": "/ocs/v[12].php/cloud/(users?|groups)",
+          "backend": "http://localhost:9110"
+        },
+        {
+          "endpoint": "/ocs/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "type": "query",
+          "endpoint": "/remote.php/?preview=1",
+          "backend": "http://localhost:9115"
+        },
+        {
+          "endpoint": "/remote.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/dav/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/webdav/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/status.php",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/index.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/data",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/graph/",
+          "backend": "http://localhost:9120"
+        },
+        {
+          "endpoint": "/graph-explorer/",
+          "backend": "http://localhost:9135"
+        },
+        {
+          "endpoint": "/api/v0/accounts",
+          "backend": "http://localhost:9181"
+        },
+        {
+          "endpoint": "/accounts.js",
+          "backend": "http://localhost:9181"
+        },
+        {
+          "endpoint": "/api/v0/settings",
+          "backend": "http://localhost:9190"
+        },
+        {
+          "endpoint": "/settings.js",
+          "backend": "http://localhost:9190"
+        },
+        {
+          "endpoint": "/onlyoffice.js",
+          "backend": "http://localhost:9220"
+        },
+        {
+          "endpoint": "/api/v0/greet",
+          "backend": "http://ocis-hello:9105"
+        },
+        {
+          "endpoint": "/hello.js",
+          "backend": "http://ocis-hello:9105"
+        }
+      ]
+    }
+  ]
+}

--- a/deployments/examples/ocis_hello/docker-compose.yml
+++ b/deployments/examples/ocis_hello/docker-compose.yml
@@ -1,0 +1,101 @@
+---
+version: "3.7"
+
+services:
+  traefik:
+    image: traefik:v2.4
+    networks:
+      ocis-net:
+        aliases:
+          - ${OCIS_DOMAIN:-ocis.owncloud.test}
+    command:
+      #- "--log.level=DEBUG"
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
+      - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
+      - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+      - "--api.dashboard=true"
+      - "--entryPoints.http.address=:80"
+      - "--entryPoints.https.address=:443"
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+      - "--providers.docker.exposedByDefault=false"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "certs:/certs"
+    labels:
+      - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
+      - "traefik.http.routers.traefik.entrypoints=http"
+      - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$apr1$4vqie50r$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
+      - "traefik.http.middlewares.traefik-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.traefik.middlewares=traefik-https-redirect"
+      - "traefik.http.routers.traefik-secure.entrypoints=https"
+      - "traefik.http.routers.traefik-secure.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.routers.traefik-secure.middlewares=traefik-auth"
+      - "traefik.http.routers.traefik-secure.tls=true"
+      - "traefik.http.routers.traefik-secure.tls.certresolver=http"
+      - "traefik.http.routers.traefik-secure.service=api@internal"
+    logging:
+      driver: "local"
+    restart: always
+
+  ocis:
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
+    networks:
+      ocis-net:
+    entrypoint:
+      - /bin/sh
+      - /entrypoint-override.sh
+    environment:
+      OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
+      OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
+      PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
+      # change default secrets
+      IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
+      STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
+      OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
+      # web ui
+      WEB_UI_CONFIG: "/config/config.json"
+      # proxy
+      PROXY_CONFIG_FILE: "/config/proxy-config.json"
+    volumes:
+      - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
+      - ./config/ocis/config.dist.json:/config/config.dist.json
+      - ./config/ocis/proxy-config.json:/config/proxy-config.json
+      - ocis-data:/var/tmp/ocis
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ocis.entrypoints=http"
+      - "traefik.http.routers.ocis.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.middlewares.ocis-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.ocis.middlewares=ocis-https-redirect"
+      - "traefik.http.routers.ocis-secure.entrypoints=https"
+      - "traefik.http.routers.ocis-secure.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.routers.ocis-secure.tls=true"
+      - "traefik.http.routers.ocis-secure.tls.certresolver=http"
+      - "traefik.http.routers.ocis-secure.service=ocis"
+      - "traefik.http.services.ocis.loadbalancer.server.port=9200"
+    logging:
+      driver: "local"
+    restart: always
+
+  ocis-hello:
+    image: owncloud/ocis-hello:${OCIS_HELLO_DOCKER_TAG:-latest}
+    networks:
+      ocis-net:
+    environment:
+      OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
+    logging:
+      driver: "local"
+    restart: always
+
+volumes:
+  certs:
+  ocis-data:
+
+networks:
+  ocis-net:

--- a/deployments/examples/ocis_hello/monitoring_tracing/docker-compose-additions.yml
+++ b/deployments/examples/ocis_hello/monitoring_tracing/docker-compose-additions.yml
@@ -1,0 +1,12 @@
+---
+version: "3.7"
+
+services:
+  ocis:
+    environment:
+      OCIS_TRACING_ENABLED: "true"
+      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+
+networks:
+  ocis-net:
+    external: true

--- a/deployments/examples/ocis_s3/.env
+++ b/deployments/examples/ocis_s3/.env
@@ -1,0 +1,40 @@
+# If you're on a internet facing server please comment out following line.
+# It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
+INSECURE=true
+
+### Traefik settings ###
+# Serve Treafik dashboard. Defaults to "false".
+TRAEFIK_DASHBOARD=
+# Domain of Traefik, where you can find the dashboard. Defaults to "traefik.owncloud.test"
+TRAEFIK_DOMAIN=
+# Basic authentication for the dashboard. Defaults to user "admin" and password "admin"
+TRAEFIK_BASIC_AUTH_USERS=
+# Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
+TRAEFIK_ACME_MAIL=
+
+### oCIS settings ###
+# oCIS version. Defaults to "latest"
+OCIS_DOCKER_TAG=
+# Domain of oCIS, where you can find the frontend. Defaults to "ocis.owncloud.test"
+OCIS_DOMAIN=
+# IDP LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "idp".
+IDP_LDAP_BIND_PASSWORD=
+# Storage LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "reva".
+STORAGE_LDAP_BIND_PASSWORD=
+# JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
+OCIS_JWT_SECRET=
+
+### MINIO / S3 settings ###
+# Domain of MinIO where the Web UI is accessible. Defaults to "minio.owncloud.test".
+MINIO_DOMAIN=
+# S3 bucket name, where oCIS stores its data in. Defaults to "ocis-bucket".
+MINIO_BUCKET=
+# S3 bucket access key, which oCIS uses to authenticate. Defaults to "ocis".
+MINIO_ACCESS_KEY=
+# S3 bucket access key secret, which oCIS uses to authenticate. Defaults to "ocis-secret-key".
+MINIO_SECRET_KEY=
+
+# If you want to use debugging and tracing with this stack,
+# you need uncomment following line. Please see documentation at
+# https://owncloud.dev/ocis/deployment/monitoring-tracing/
+#COMPOSE_FILE=docker-compose.yml:monitoring_tracing/docker-compose-additions.yml

--- a/deployments/examples/ocis_s3/README.md
+++ b/deployments/examples/ocis_s3/README.md
@@ -1,0 +1,6 @@
+---
+document this deployment example in: docs/ocis/deployment/ocis_traefik.md
+---
+
+Please refer to [our documentation](https://owncloud.dev/ocis/deployment/ocis_traefik/)
+for instructions on how to deploy this scenario.

--- a/deployments/examples/ocis_s3/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_s3/config/ocis/entrypoint-override.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+ocis server&
+sleep 10
+
+echo "##################################################"
+echo "change default secrets:"
+
+# IDP
+IDP_USER_UUID=$(ocis accounts list | grep "| Kopano IDP " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
+echo "  IDP user UUID: $IDP_USER_UUID"
+ocis accounts update --password $IDP_LDAP_BIND_PASSWORD $IDP_USER_UUID
+
+# REVA
+REVA_USER_UUID=$(ocis accounts list | grep " | Reva Inter " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
+echo "  Reva user UUID: $REVA_USER_UUID"
+ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD $REVA_USER_UUID
+
+echo "default secrets changed"
+echo "##################################################"
+
+wait # wait for oCIS to exit

--- a/deployments/examples/ocis_s3/docker-compose.yml
+++ b/deployments/examples/ocis_s3/docker-compose.yml
@@ -1,0 +1,124 @@
+---
+version: "3.7"
+
+services:
+  traefik:
+    image: traefik:v2.4
+    networks:
+      ocis-net:
+        aliases:
+          - ${OCIS_DOMAIN:-ocis.owncloud.test}
+    command:
+      #- "--log.level=DEBUG"
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
+      - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
+      - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+      - "--api.dashboard=true"
+      - "--entryPoints.http.address=:80"
+      - "--entryPoints.https.address=:443"
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+      - "--providers.docker.exposedByDefault=false"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "certs:/certs"
+    labels:
+      - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
+      - "traefik.http.routers.traefik.entrypoints=http"
+      - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$apr1$4vqie50r$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
+      - "traefik.http.middlewares.traefik-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.traefik.middlewares=traefik-https-redirect"
+      - "traefik.http.routers.traefik-secure.entrypoints=https"
+      - "traefik.http.routers.traefik-secure.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.routers.traefik-secure.middlewares=traefik-auth"
+      - "traefik.http.routers.traefik-secure.tls=true"
+      - "traefik.http.routers.traefik-secure.tls.certresolver=http"
+      - "traefik.http.routers.traefik-secure.service=api@internal"
+    logging:
+      driver: "local"
+    restart: always
+
+  ocis:
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
+    networks:
+      ocis-net:
+    entrypoint:
+      - /bin/sh
+      - /entrypoint-override.sh
+    environment:
+      OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
+      PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
+      # change default secrets
+      IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
+      STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
+      OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
+      # activate s3ng storage driver
+      STORAGE_HOME_DRIVER: s3ng
+      STORAGE_USERS_DRIVER: s3ng
+      STORAGE_METADATA_DRIVER: ocis # keep metadata on ocis storage since this are only small files atm
+      # s3ng specific settings
+      STORAGE_DRIVER_S3NG_ENDPOINT: http://minio:9000
+      STORAGE_DRIVER_S3NG_REGION: default
+      STORAGE_DRIVER_S3NG_ACCESS_KEY: ${MINIO_ACCESS_KEY:-ocis}
+      STORAGE_DRIVER_S3NG_SECRET_KEY: ${MINIO_SECRET_KEY:-ocis-secret-key}
+      STORAGE_DRIVER_S3NG_BUCKET: ${MINIO_BUCKET:-ocis-bucket}
+    volumes:
+      - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
+      - ocis-data:/var/tmp/ocis
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ocis.entrypoints=http"
+      - "traefik.http.routers.ocis.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.middlewares.ocis-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.ocis.middlewares=ocis-https-redirect"
+      - "traefik.http.routers.ocis-secure.entrypoints=https"
+      - "traefik.http.routers.ocis-secure.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.routers.ocis-secure.tls=true"
+      - "traefik.http.routers.ocis-secure.tls.certresolver=http"
+      - "traefik.http.routers.ocis-secure.service=ocis"
+      - "traefik.http.services.ocis.loadbalancer.server.port=9200"
+    logging:
+      driver: "local"
+    restart: always
+
+  minio:
+    image: minio/minio:latest
+    networks:
+      ocis-net:
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "mkdir -p /data/${MINIO_BUCKET:-ocis-bucket} && minio server /data"
+    volumes:
+      - minio-data:/data
+    environment:
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-ocis}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-ocis-secret-key}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.minio.entrypoints=http"
+      - "traefik.http.routers.minio.rule=Host(`${MINIO_DOMAIN:-minio.owncloud.test}`)"
+      - "traefik.http.middlewares.minio-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.minio.middlewares=minio-https-redirect"
+      - "traefik.http.routers.minio-secure.entrypoints=https"
+      - "traefik.http.routers.minio-secure.rule=Host(`${MINIO_DOMAIN:-minio.owncloud.test}`)"
+      - "traefik.http.routers.minio-secure.tls=true"
+      - "traefik.http.routers.minio-secure.tls.certresolver=http"
+      - "traefik.http.routers.minio-secure.service=minio"
+      - "traefik.http.services.minio.loadbalancer.server.port=9000"
+    logging:
+      driver: "local"
+    restart: always
+
+volumes:
+  certs:
+  ocis-data:
+  minio-data:
+
+networks:
+  ocis-net:

--- a/deployments/examples/ocis_s3/monitoring_tracing/docker-compose-additions.yml
+++ b/deployments/examples/ocis_s3/monitoring_tracing/docker-compose-additions.yml
@@ -1,0 +1,12 @@
+---
+version: "3.7"
+
+services:
+  ocis:
+    environment:
+      OCIS_TRACING_ENABLED: "true"
+      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+
+networks:
+  ocis-net:
+    external: true

--- a/docs/ocis/deployment/continuous_deployment.md
+++ b/docs/ocis/deployment/continuous_deployment.md
@@ -44,7 +44,6 @@ Credentials:
 
 - oCIS: [ocis.ocis-wopi.released.owncloud.works](https://ocis.ocis-wopi.released.owncloud.works)
 
-
 # oCIS with latest ownCloud Web
 
 Credentials:
@@ -73,6 +72,30 @@ Credentials:
 
 - oCIS: [ocis.ocis-keycloak.released.owncloud.works](https://ocis.ocis-keycloak.released.owncloud.works)
 - Keycloak: [keycloak.ocis-keycloak.released.owncloud.works](https://keycloak.ocis-keycloak.released.owncloud.works)
+
+# oCIS with Hello extension
+
+Credentials:
+
+- oCIS: see [default demo users]({{< ref "../getting-started#login-to-owncloud-web" >}})
+
+## Latest
+
+- oCIS: [ocis.ocis-hello.latest.owncloud.works](https://ocis.ocis-hello.latest.owncloud.works)
+
+# oCIS with S3 storage backend (MinIO)
+
+Credentials:
+
+- oCIS: see [default demo users]({{< ref "../getting-started#login-to-owncloud-web" >}})
+- MinIO:
+  - access key: ocis
+  - secret access key: ocis-secret-key
+
+## Latest
+
+- oCIS: [ocis.ocis-s3.latest.owncloud.works](https://ocis.ocis-s3.latest.owncloud.works)
+- MinIO: [minio.ocis-s3.latest.owncloud.works](https://minio.ocis-s3.latest.owncloud.works)
 
 # oCIS with CS3 users
 

--- a/docs/ocis/deployment/ocis_hello.md
+++ b/docs/ocis/deployment/ocis_hello.md
@@ -1,0 +1,125 @@
+---
+title: "oCIS with Hello extension"
+date: 2020-10-12T14:04:00+01:00
+weight: 24
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/ocis/deployment
+geekdocFilePath: ocis_wopi.md
+---
+
+{{< toc >}}
+
+## Overview
+
+- oCIS running behind Traefik as reverse proxy
+- oCIS Hello extension runs beside the main oCIS stack and providing the Hello functionality
+- Traefik generating self signed certificates for local setup or obtaining valid SSL certificates for a server setup
+
+[Find this example on GitHub](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_hello)
+
+The docker stack consists of 3 containers. One of them is Traefik, a proxy which is terminating SSL and forwards the requests to oCIS in the internal docker network.
+
+The next container is oCIS itself in a configuration like the [oCIS with Traefik example]({{< ref "ocis_traefik" >}}), except that for this example a custom proxy and web UI configuration is used to enable the oCIS Hello extension.
+
+The oCIS Hello extension is running in another container and enables you to use its' functionality from within ownCloud Web.
+
+## Server Deployment
+
+### Requirements
+
+- Linux server with docker and docker-compose installed
+- two domains set up and pointing to your server
+  - ocis.\* for serving oCIS
+  - traefik.\* for serving the Traefik dashboard
+
+See also [example server setup]({{< ref "preparing_server" >}})
+
+### Install oCIS and Traefik
+
+- Clone oCIS repository
+
+  `git clone https://github.com/owncloud/ocis.git`
+
+- Go to the deployment example
+
+  `cd ocis/deployment/examples/ocis_hello
+
+- Open the `.env` file in a text editor
+  The file by default looks like this:
+
+  ```bash
+      # If you're on a internet facing server please comment out following line.
+      # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
+      INSECURE=true
+
+      ### Traefik settings ###
+      # Serve Treafik dashboard. Defaults to "false".
+      TRAEFIK_DASHBOARD=
+      # Domain of Traefik, where you can find the dashboard. Defaults to "traefik.owncloud.test"
+      TRAEFIK_DOMAIN=
+      # Basic authentication for the dashboard. Defaults to user "admin" and password "admin"
+      TRAEFIK_BASIC_AUTH_USERS=
+      # Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
+      TRAEFIK_ACME_MAIL=
+
+      ### oCIS settings ###
+      # oCIS version. Defaults to "latest"
+      OCIS_DOCKER_TAG=
+      # Domain of oCIS, where you can find the frontend. Defaults to "ocis.owncloud.test"
+      OCIS_DOMAIN=
+      # IDP LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "idp".
+      IDP_LDAP_BIND_PASSWORD=
+      # Storage LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "reva".
+      STORAGE_LDAP_BIND_PASSWORD=
+      # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
+      OCIS_JWT_SECRET=
+
+      ### oCIS Hello settings ###
+      # oCIS Hello version. Defaults to "latest"
+      OCIS_HELLO_DOCKER_TAG=
+  ```
+
+  You are installing oCIS on a server and Traefik will obtain valid certificates for you so please remove `INSECURE=true` or set it to `false`.
+
+  If you want to use the Traefik dashboard, set TRAEFIK_DASHBOARD to `true` (default is `false` and therefore not active). If you activate it, you must set a domain for the Traefik dashboard in `TRAEFIK_DOMAIN=` eg. `TRAEFIK_DOMAIN=traefik.owncloud.test`.
+
+  The Traefik dashboard is secured by basic auth. Default credentials are the user `admin` with the password `admin`. To set your own credentials, generate a htpasswd (eg. by using [an online tool](https://htpasswdgenerator.de/) or a cli tool).
+
+  Traefik will issue certificates with LetsEncrypt and therefore you must set an email address in `TRAEFIK_ACME_MAIL=`.
+
+  By default oCIS will be started in the `latest` version. If you want to start a specific version of oCIS set the version to `OCIS_DOCKER_TAG=`. Available versions can be found on [Docker Hub](https://hub.docker.com/r/owncloud/ocis/tags?page=1&ordering=last_updated).
+
+  Set your domain for the oCIS frontend in `OCIS_DOMAIN=`, eg. `OCIS_DOMAIN=ocis.owncloud.test`.
+
+  You also must override three default secrets in `IDP_LDAP_BIND_PASSWORD`, `STORAGE_LDAP_BIND_PASSWORD` and `OCIS_JWT_SECRET` in order to secure your oCIS instance. Choose some random strings eg. from the output of `openssl rand -base64 32`. For more information see [secure an oCIS instance]({{< ref "./#secure-an-ocis-instance" >}}).
+
+  By default the oCIS Hello extension will be started in the `latest` version. If you want to start a specific version of oCIS Hello set the version to `OCIS_HELLO_DOCKER_TAG=`. Available versions can be found on [Docker Hub](https://hub.docker.com/r/owncloud/ocis-hello/tags?page=1&ordering=last_updated).
+
+  Now you have configured everything and can save the file.
+
+- Start the docker stack
+
+  `docker-compose up -d`
+
+- You now can visit oCIS and are able to switch to the Hello extension by using the application switcher on the top right corner of ownCloud Web.
+
+## Local setup
+
+For a more simple local ocis setup see [Getting started]({{< ref "../getting-started" >}})
+
+This docker stack can also be run locally. One downside is that Traefik can not obtain valid SSL certificates and therefore will create self signed ones. This means that your browser will show scary warnings. Another downside is that you can not point DNS entries to your localhost. So you have to add static host entries to your computer.
+
+On Linux and macOS you can add them to your `/etc/hosts` files like this:
+
+```
+127.0.0.1 ocis.owncloud.test
+127.0.0.1 traefik.owncloud.testt
+```
+
+After that you're ready to start the application stack:
+
+`docker-compose up -d`
+
+Open https://collabora.owncloud.test and https://wopisever.owncloud.test in your browser and accept the invalid certificate warning.
+
+Open https://ocis.owncloud.test in your browser and accept the invalid certificate warning. You are now able to switch to the Hello extension by using the application switcher on the top right corner of ownCloud Web.

--- a/docs/ocis/deployment/ocis_s3.md
+++ b/docs/ocis/deployment/ocis_s3.md
@@ -1,0 +1,135 @@
+---
+title: "oCIS with S3 storage backend (MinIO)"
+date: 2020-10-12T14:04:00+01:00
+weight: 24
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/ocis/deployment
+geekdocFilePath: ocis_wopi.md
+---
+
+{{< toc >}}
+
+## Overview
+
+* oCIS running behind Traefik as reverse proxy
+* MinIO as S3 compatible storage provider
+* oCIS is configured to use S3 as user storage provider
+* Traefik generating self signed certificates for local setup or obtaining valid SSL certificates for a server setup
+
+[Find this example on GitHub](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_wopi)
+
+The docker stack consists 3 containers. One of them is Traefik, a proxy which is terminating SSL and forwards the requests to oCIS in the internal docker network.
+
+The next container is oCIS itself in a configuration like the [oCIS with Traefik example]({{< ref "ocis_traefik" >}}), except that it will use S3 as user storage.
+
+The last container is MinIO, providing a S3 compatible API, where oCIS will store its' data.
+
+## Server Deployment
+
+### Requirements
+
+* Linux server with docker and docker-compose installed
+* Three domains set up and pointing to your server
+  - ocis.* for serving oCIS
+  - minio.* for accessing the MinIO S3 bucket in the browser
+  - traefik.* for serving the Traefik dashboard
+
+See also [example server setup]({{< ref "preparing_server" >}})
+
+
+### Install oCIS and Traefik
+
+* Clone oCIS repository
+
+  `git clone https://github.com/owncloud/ocis.git`
+
+* Go to the deployment example
+
+  `cd ocis/deployment/examples/ocis_s3
+
+* Open the `.env` file in a text editor
+  The file by default looks like this:
+  ```bash
+      # If you're on a internet facing server please comment out following line.
+      # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
+      INSECURE=true
+
+      ### Traefik settings ###
+      # Serve Treafik dashboard. Defaults to "false".
+      TRAEFIK_DASHBOARD=
+      # Domain of Traefik, where you can find the dashboard. Defaults to "traefik.owncloud.test"
+      TRAEFIK_DOMAIN=
+      # Basic authentication for the dashboard. Defaults to user "admin" and password "admin"
+      TRAEFIK_BASIC_AUTH_USERS=
+      # Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
+      TRAEFIK_ACME_MAIL=
+
+      ### oCIS settings ###
+      # oCIS version. Defaults to "latest"
+      OCIS_DOCKER_TAG=
+      # Domain of oCIS, where you can find the frontend. Defaults to "ocis.owncloud.test"
+      OCIS_DOMAIN=
+      # IDP LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "idp".
+      IDP_LDAP_BIND_PASSWORD=
+      # Storage LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "reva".
+      STORAGE_LDAP_BIND_PASSWORD=
+      # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
+      OCIS_JWT_SECRET=
+
+      ### MINIO / S3 settings ###
+      # Domain of MinIO where the Web UI is accessible. Defaults to "minio.owncloud.test".
+      MINIO_DOMAIN=
+      # S3 bucket name, where oCIS stores its data in. Defaults to "ocis-bucket".
+      MINIO_BUCKET=
+      # S3 bucket access key, which oCIS uses to authenticate. Defaults to "ocis".
+      MINIO_ACCESS_KEY=
+      # S3 bucket access key secret, which oCIS uses to authenticate. Defaults to "ocis-secret-key".
+      MINIO_SECRET_KEY=
+
+  ```
+
+  You are installing oCIS on a server and Traefik will obtain valid certificates for you so please remove `INSECURE=true` or set it to `false`.
+
+  If you want to use the Traefik dashboard, set TRAEFIK_DASHBOARD to `true` (default is `false` and therefore not active). If you activate it, you must set a domain for the Traefik dashboard in `TRAEFIK_DOMAIN=` eg. `TRAEFIK_DOMAIN=traefik.owncloud.test`.
+
+  The Traefik dashboard is secured by basic auth. Default credentials are the user `admin` with the password `admin`. To set your own credentials, generate a htpasswd (eg. by using [an online tool](https://htpasswdgenerator.de/) or a cli tool).
+
+  Traefik will issue certificates with LetsEncrypt and therefore you must set an email address in `TRAEFIK_ACME_MAIL=`.
+
+  By default oCIS will be started in the `latest` version. If you want to start a specific version of oCIS set the version to `OCIS_DOCKER_TAG=`. Available versions can be found on [Docker Hub](https://hub.docker.com/r/owncloud/ocis/tags?page=1&ordering=last_updated).
+
+  Set your domain for the oCIS frontend in `OCIS_DOMAIN=`, eg. `OCIS_DOMAIN=ocis.owncloud.test`.
+
+  You also must override three default secrets in `IDP_LDAP_BIND_PASSWORD`, `STORAGE_LDAP_BIND_PASSWORD` and `OCIS_JWT_SECRET` in order to secure your oCIS instance. Choose some random strings eg. from the output of `openssl rand -base64 32`. For more information see [secure an oCIS instance]({{< ref "./#secure-an-ocis-instance" >}}).
+
+  Set your domain for the MinIO frontend in `MINIO_DOMAIN=`, eg. `MINIO_DOMAIN=minio.owncloud.test`. If you are using other S3-compatible providers you need to configure the respective endpoint here.
+
+  If you like you can change the default name of the S3 bucket by setting `MINIO_BUCKET=` to a different value.
+
+  You also must override the S3 bucket credentials in `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` in order to secure your MinIO instance. Choose some random strings eg. from the output of `openssl rand -base64 32`.
+
+  Now you have configured everything and can save the file.
+
+* Start the docker stack
+
+  `docker-compose up -d`
+
+* You now can visit oCIS and are able to use it just normally. If you log into the web UI of MinIO, you will see blobs of files you uploaded.
+
+## Local setup
+For a more simple local ocis setup see [Getting started]({{< ref "../getting-started" >}})
+
+This docker stack can also be run locally. One downside is that Traefik can not obtain valid SSL certificates and therefore will create self signed ones. This means that your browser will show scary warnings. Another downside is that you can not point DNS entries to your localhost. So you have to add static host entries to your computer.
+
+On Linux and macOS you can add them to your `/etc/hosts` files like this:
+```
+127.0.0.1 ocis.owncloud.test
+127.0.0.1 traefik.owncloud.test
+127.0.0.1 minio.owncloud.test
+```
+
+After that you're ready to start the application stack:
+
+`docker-compose up -d`
+
+ Open https://ocis.owncloud.test in your browser and accept the invalid certificate warning. You now can use oCIS normally and should now upload a file. Open https://minio.owncloud.test in your browser and accept the invalid certificate warning, after that you will see blobs of files you have uploaded to oCIS.

--- a/docs/ocis/deployment/ocis_wopi.md
+++ b/docs/ocis/deployment/ocis_wopi.md
@@ -113,8 +113,6 @@ See also [example server setup]({{< ref "preparing_server" >}})
 
   Set your domain for the oCIS frontend in `OCIS_DOMAIN=`, eg. `OCIS_DOMAIN=ocis.owncloud.test`.
 
-  If you want to change the OIDC client id of th ownCloud Web frontend, you can do this by setting the name to `OCIS_OIDC_CLIENT_ID=`.
-
   You also must override three default secrets in `IDP_LDAP_BIND_PASSWORD`, `STORAGE_LDAP_BIND_PASSWORD` and `OCIS_JWT_SECRET` in order to secure your oCIS instance. Choose some random strings eg. from the output of `openssl rand -base64 32`. For more information see [secure an oCIS instance]({{< ref "./#secure-an-ocis-instance" >}}).
 
   By default the oCIS WOPI server extension will be started in the `latest` version. If you want to start a specific version of oCIS WOPI server set the version to `OCIS_WOPISERVER_DOCKER_TAG=`. Available versions can be found on [Docker Hub](https://hub.docker.com/r/owncloud/ocis-wopiserver/tags?page=1&ordering=last_updated).


### PR DESCRIPTION
## Description
add two new deployment examples and add them to the continuous deploymen:
- oCIS with S3 as user storage driver
- oCIS with Hello extension

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to showcase the S3 and Extension usecase.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://drone.owncloud.com/owncloud/ocis/5594