### PR TITLE
ignore authentication header on status.php

### DIFF
--- a/changelog/unreleased/status_php_authentication.md
+++ b/changelog/unreleased/status_php_authentication.md
@@ -1,0 +1,9 @@
+Bugfix: Remove authentication from /status.php completely
+
+Despite requests without Authentication header being successful, requests with an
+invalid bearer token in the Authentication header were rejected in the proxy with
+an 401 unauthenticated. Now the Authentication header is completely ignored for the
+/status.php route.
+
+https://github.com/owncloud/ocis/pull/2188
+https://github.com/owncloud/client/issues/8538

--- a/proxy/pkg/middleware/oidc_auth.go
+++ b/proxy/pkg/middleware/oidc_auth.go
@@ -155,7 +155,7 @@ func (m oidcAuth) shouldServe(req *http.Request) bool {
 
 	// todo: looks dirty, check later
 	// TODO: make a PR to coreos/go-oidc for exposing userinfo endpoint on provider, see https://github.com/coreos/go-oidc/issues/248
-	for _, ignoringPath := range []string{"/konnect/v1/userinfo"} {
+	for _, ignoringPath := range []string{"/konnect/v1/userinfo", "/status.php"} {
 		if req.URL.Path == ignoringPath {
 			return false
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
`/status.php` is expected not to be authentication protected. This is currently true if you don't sent the `authorization` header. If you send an invalid or expired authorization header you will get an 401 unauthorized - so it is not really an unauthenticated endpoint. This PR adds the `/status.php` to the dirty ignore list which is already there because of `/konnect/v1/userinfo`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/client/issues/8538
