### PR TITLE
[full-ci] update reva to v1.9

### DIFF
--- a/accounts/go.mod
+++ b/accounts/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/asim/go-micro/plugins/client/grpc/v3 v3.0.0-20210408173139-0d57213d3f5c
 	github.com/asim/go-micro/v3 v3.5.1-0.20210217182006-0f0ace1a44a9
 	github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887
-	github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02
+	github.com/cs3org/reva v1.9.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/gofrs/uuid v3.3.0+incompatible

--- a/accounts/go.sum
+++ b/accounts/go.sum
@@ -317,8 +317,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887 h1:X5Se3M/kbh9w6
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/changelog/unreleased/update-reva-v1.8.1-0.20210622125952-b54b15943d02.md
+++ b/changelog/unreleased/update-reva-v1.8.1-0.20210622125952-b54b15943d02.md
@@ -1,3 +1,0 @@
-Enhancement: update REVA to v1.8.1-0.20210622125952-b54b15943d02
-
-https://github.com/owncloud/ocis/pull/2205

--- a/changelog/unreleased/update-reva-v1.9.md
+++ b/changelog/unreleased/update-reva-v1.9.md
@@ -1,0 +1,18 @@
+Enhancement: update REVA to v1.9
+
+This update includes
+* [set Content-Type correctly](https://github.com/cs3org/reva/pull/1750)
+* [Return file checksum available from the metadata for the EOS driver](https://github.com/cs3org/reva/pull/1755)
+* [Sort share entries alphabetically](https://github.com/cs3org/reva/pull/1772)
+* [Initial work on the owncloudsql driver](https://github.com/cs3org/reva/pull/1710)
+* [Add user ID cache warmup to EOS storage driver](https://github.com/cs3org/reva/pull/1774)
+* [Use UidNumber and GidNumber fields in User objects](https://github.com/cs3org/reva/pull/1573)
+* [EOS GRPC interface](https://github.com/cs3org/reva/pull/1471)
+* [switch references](https://github.com/cs3org/reva/pull/1721)
+* [remove user's uuid from trashbin file key](https://github.com/cs3org/reva/pull/1793)
+* [fix restore behavior of the trashbin API](https://github.com/cs3org/reva/pull/1795)
+* [eosfs: add arbitrary metadata support](https://github.com/cs3org/reva/pull/1811)
+
+https://github.com/owncloud/ocis/pull/2205
+https://github.com/owncloud/ocis/pull/2210
+

--- a/glauth/go.sum
+++ b/glauth/go.sum
@@ -304,8 +304,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210325133324-32b03d75a535/go.mod h1:UXha4T
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887 h1:X5Se3M/kbh9w6LZQvyLS7djAGKcWGzmaY6IOa7Talpk=
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/graph-explorer/go.sum
+++ b/graph-explorer/go.sum
@@ -305,8 +305,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/graph/go.mod
+++ b/graph/go.mod
@@ -8,7 +8,7 @@ require (
 	contrib.go.opencensus.io/exporter/zipkin v0.1.2
 	github.com/asim/go-micro/v3 v3.5.1-0.20210217182006-0f0ace1a44a9
 	github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887
-	github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02
+	github.com/cs3org/reva v1.9.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/go-ldap/ldap/v3 v3.3.0

--- a/graph/go.sum
+++ b/graph/go.sum
@@ -305,8 +305,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/idp/go.sum
+++ b/idp/go.sum
@@ -305,8 +305,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/ocis-pkg/go.mod
+++ b/ocis-pkg/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/asim/go-micro/v3 v3.5.1-0.20210217182006-0f0ace1a44a9
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887
-	github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02
+	github.com/cs3org/reva v1.9.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/iancoleman/strcase v0.1.3
 	github.com/justinas/alice v1.2.0

--- a/ocis-pkg/go.sum
+++ b/ocis-pkg/go.sum
@@ -309,8 +309,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210104105209-0d3ecb3453dc/go.mod h1:UXha4T
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887 h1:X5Se3M/kbh9w6LZQvyLS7djAGKcWGzmaY6IOa7Talpk=
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/ocis/go.sum
+++ b/ocis/go.sum
@@ -311,8 +311,8 @@ github.com/crewjam/saml v0.4.5/go.mod h1:qCJQpUtZte9R1ZjUBcW8qtCNlinbO363ooNl02S
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887 h1:X5Se3M/kbh9w6LZQvyLS7djAGKcWGzmaY6IOa7Talpk=
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d h1:SwD98825d6bdB+pEuTxWOXiSjBrHdOl/UVp75eI7JT8=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=

--- a/ocs/go.mod
+++ b/ocs/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/asim/go-micro/plugins/client/grpc/v3 v3.0.0-20210408173139-0d57213d3f5c
 	github.com/asim/go-micro/v3 v3.5.1-0.20210217182006-0f0ace1a44a9
 	github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887
-	github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02
+	github.com/cs3org/reva v1.9.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/golang/protobuf v1.5.2

--- a/ocs/go.sum
+++ b/ocs/go.sum
@@ -312,8 +312,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210325133324-32b03d75a535/go.mod h1:UXha4T
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887 h1:X5Se3M/kbh9w6LZQvyLS7djAGKcWGzmaY6IOa7Talpk=
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/onlyoffice/go.sum
+++ b/onlyoffice/go.sum
@@ -305,8 +305,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/asim/go-micro/v3 v3.5.1-0.20210217182006-0f0ace1a44a9
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887
-	github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02
+	github.com/cs3org/reva v1.9.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/justinas/alice v1.2.0
 	github.com/micro/cli/v2 v2.1.2

--- a/proxy/go.sum
+++ b/proxy/go.sum
@@ -302,8 +302,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210325133324-32b03d75a535/go.mod h1:UXha4T
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887 h1:X5Se3M/kbh9w6LZQvyLS7djAGKcWGzmaY6IOa7Talpk=
 github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/settings/go.sum
+++ b/settings/go.sum
@@ -313,8 +313,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/asim/go-micro/v3 v3.5.1-0.20210217182006-0f0ace1a44a9
-	github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02
+	github.com/cs3org/reva v1.9.0
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/micro/cli/v2 v2.1.2
 	github.com/oklog/run v1.1.0

--- a/storage/go.sum
+++ b/storage/go.sum
@@ -313,8 +313,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/store/go.sum
+++ b/store/go.sum
@@ -323,8 +323,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d h1:SwD98825d6bdB+pEuTxWOXiSjBrHdOl/UVp75eI7JT8=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -17,26 +17,9 @@ Basic file management like up and download, move, copy, properties, trash, versi
 -   [apiTrashbin/trashbinFilesFolders.feature:278](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L278)
 -   [apiTrashbin/trashbinFilesFolders.feature:279](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L279)
 
-#### [cannot restore to a different file-name](https://github.com/owncloud/ocis/issues/1122)
--   [apiTrashbin/trashbinRestore.feature:108](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L108)
--   [apiTrashbin/trashbinRestore.feature:109](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L109)
--   [apiTrashbin/trashbinRestore.feature:110](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L110)
--   [apiTrashbin/trashbinRestore.feature:111](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L111)
-
 #### [trash-bin restore move does not send back Etag and other headers](https://github.com/owncloud/ocis/issues/1121)
--   [apiTrashbin/trashbinRestore.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L34)
--   [apiTrashbin/trashbinRestore.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L35)
 -   [apiTrashbin/trashbinRestore.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L130)
 -   [apiTrashbin/trashbinRestore.feature:131](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L131)
-
-#### [cannot restore to a different file-name](https://github.com/owncloud/ocis/issues/1122)
-#### [trash-bin restore move does not send back Etag and other headers](https://github.com/owncloud/ocis/issues/1121)
--   [apiTrashbin/trashbinRestore.feature:88](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L88)
--   [apiTrashbin/trashbinRestore.feature:89](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L89)
--   [apiTrashbin/trashbinRestore.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L90)
--   [apiTrashbin/trashbinRestore.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L91)
--   [apiTrashbin/trashbinRestore.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L92)
--   [apiTrashbin/trashbinRestore.feature:93](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L93)
 
 #### [cannot restore to a different file-name](https://github.com/owncloud/ocis/issues/1122)
 -   [apiTrashbin/trashbinRestore.feature:309](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L309)

--- a/tests/acceptance/expected-failures-API-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OWNCLOUD-storage.md
@@ -30,21 +30,6 @@ The following scenarios fail on OWNCLOUD storage but not on OCIS storage:
 -   [apiTrashbin/trashbinRestore.feature:110](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L110)
 -   [apiTrashbin/trashbinRestore.feature:111](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L111)
 
-#### [trash-bin restore move does not send back Etag and other headers](https://github.com/owncloud/ocis/issues/1121)
--   [apiTrashbin/trashbinRestore.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L34)
--   [apiTrashbin/trashbinRestore.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L35)
--   [apiTrashbin/trashbinRestore.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L130)
--   [apiTrashbin/trashbinRestore.feature:131](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L131)
-
-#### [cannot restore to a different file-name](https://github.com/owncloud/ocis/issues/1122)
-#### [trash-bin restore move does not send back Etag and other headers](https://github.com/owncloud/ocis/issues/1121)
--   [apiTrashbin/trashbinRestore.feature:88](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L88)
--   [apiTrashbin/trashbinRestore.feature:89](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L89)
--   [apiTrashbin/trashbinRestore.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L90)
--   [apiTrashbin/trashbinRestore.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L91)
--   [apiTrashbin/trashbinRestore.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L92)
--   [apiTrashbin/trashbinRestore.feature:93](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L93)
-
 #### [cannot restore to a different file-name](https://github.com/owncloud/ocis/issues/1122)
 -   [apiTrashbin/trashbinRestore.feature:309](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L309)
 -   [apiTrashbin/trashbinRestore.feature:310](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L310)

--- a/thumbnails/go.mod
+++ b/thumbnails/go.mod
@@ -8,7 +8,7 @@ require (
 	contrib.go.opencensus.io/exporter/zipkin v0.1.2
 	github.com/asim/go-micro/v3 v3.5.1-0.20210217182006-0f0ace1a44a9
 	github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887
-	github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02
+	github.com/cs3org/reva v1.9.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/golang/protobuf v1.5.2

--- a/thumbnails/go.sum
+++ b/thumbnails/go.sum
@@ -311,8 +311,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/web/go.sum
+++ b/web/go.sum
@@ -305,8 +305,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/webdav/go.sum
+++ b/webdav/go.sum
@@ -311,8 +311,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20210614143420-5ee2eb1e7887/go.mod h1:UXha4T
 github.com/cs3org/reva v1.1.0/go.mod h1:fBzTrNuAKdQ62ybjpdu8nyhBin90/3/3s6DGQDCdBp4=
 github.com/cs3org/reva v1.5.2-0.20210212085611-d8aa2eb3ec9c/go.mod h1:24c68Ys3h7srGohymDKSXakN4OrhzABJoKFoMeSIBvk=
 github.com/cs3org/reva v1.6.1-0.20210329145723-ed244aac4ddc/go.mod h1:exwJqEJ8lVVnmdY0GrGwuPRQ018xUU9mKVXQBiO0ZlQ=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02 h1:5mG6FRIK8/9zwUVzuO0rVZ6ej0E+husMcEookZa1xi4=
-github.com/cs3org/reva v1.8.1-0.20210622125952-b54b15943d02/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
+github.com/cs3org/reva v1.9.0 h1:CJ4T/YZwTX6zOqnupbrxgOw7fyQt3T4kqDChRS06Mkw=
+github.com/cs3org/reva v1.9.0/go.mod h1:2D2Bq4hjcwibIELp6qQXm6woofJGHdTqZ8nPSH1IUPU=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This update includes
* [set Content-Type correctly](https://github.com/cs3org/reva/pull/1750)
* [Return file checksum available from the metadata for the EOS driver](https://github.com/cs3org/reva/pull/1755)
* [Sort share entries alphabetically](https://github.com/cs3org/reva/pull/1772)
* [Initial work on the owncloudsql driver](https://github.com/cs3org/reva/pull/1710)
* [Add user ID cache warmup to EOS storage driver](https://github.com/cs3org/reva/pull/1774)
* [Use UidNumber and GidNumber fields in User objects](https://github.com/cs3org/reva/pull/1573)
* [EOS GRPC interface](https://github.com/cs3org/reva/pull/1471)
* [switch references](https://github.com/cs3org/reva/pull/1721)
* [remove user's uuid from trashbin file key](https://github.com/cs3org/reva/pull/1793)
* [fix restore behavior of the trashbin API](https://github.com/cs3org/reva/pull/1795)
* [eosfs: add arbitrary metadata support](https://github.com/cs3org/reva/pull/1811)