### PR TITLE
add claims and regex policy selector

### DIFF
--- a/changelog/unreleased/claims-policy-selector.md
+++ b/changelog/unreleased/claims-policy-selector.md
@@ -1,0 +1,5 @@
+Enhancement: Proxy: Add claims policy selector
+
+Using the proxy config file, it is now possible to let let the IdP determine the routing policy by sending an `ocis.routing.policy` claim. Its value will be used to determine the set of routes for the logged in user.
+
+https://github.com/owncloud/ocis/pull/2248

--- a/ocis-pkg/oidc/claims.go
+++ b/ocis-pkg/oidc/claims.go
@@ -1,15 +1,16 @@
 package oidc
 
 const (
-	Iss = "iss"
-	Sub = "sub"
-	Email = "email"
-	Name = "name"
+	Iss               = "iss"
+	Sub               = "sub"
+	Email             = "email"
+	Name              = "name"
 	PreferredUsername = "preferred_username"
-	UIDNumber = "uidnumber"
-	GIDNumber = "gidnumber"
-	Groups = "groups"
-	OwncloudUUID = "ownclouduuid"
+	UIDNumber         = "uidnumber"
+	GIDNumber         = "gidnumber"
+	Groups            = "groups"
+	OwncloudUUID      = "ownclouduuid"
+	OcisRoutingPolicy = "ocis.routing.policy"
 )
 
 // The ProviderMetadata describes an idp.
@@ -192,4 +193,7 @@ type StandardClaims struct {
 
 	// OcisID is a unique, persistent, non reassignable user id
 	OcisID string `json:"ownclouduuid,omitempty"`
+
+	// OcisRoutingPolicy is used to specify the routing policy to use for the ocis proxy
+	OcisRoutingPolicy string `json:"ocis.routing.policy,omitempty"`
 }

--- a/proxy/config/proxy-example-migration.json
+++ b/proxy/config/proxy-example-migration.json
@@ -1,6 +1,7 @@
 {
-  "HTTP": {
-    "Namespace": "com.owncloud"
+  "http": {
+    "addr": "0.0.0.0:9200",
+    "root": "/"
   },
   "oidc": {
     "issuer": "https://localhost:9200",

--- a/proxy/config/proxy-example-regex.json
+++ b/proxy/config/proxy-example-regex.json
@@ -9,6 +9,7 @@
   },
   "policy_selector": {
     "regex": {
+      "selector_cookie_name": "owncloud-selector",
       "default_policy": "oc10",
       "matches_policies": [
         {"priority": 10, "property": "mail", "match": "marie@example.org", "policy": "ocis"},

--- a/proxy/config/proxy-example-regex.json
+++ b/proxy/config/proxy-example-regex.json
@@ -3,9 +3,22 @@
     "addr": "0.0.0.0:9200",
     "root": "/"
   },
+  "oidc": {
+    "issuer": "https://localhost:9200",
+    "insecure": true
+  },
   "policy_selector": {
-    "static": {
-      "policy": "ocis"
+    "regex": {
+      "default_policy": "oc10",
+      "matches_policies": [
+        {"priority": 10, "property": "mail", "match": "marie@example.org", "policy": "ocis"},
+        {"priority": 20, "property": "mail", "match": "[^@]+@example.org", "policy": "oc10"},
+        {"priority": 30, "property": "username", "match": "(einstein|feynman)", "policy": "ocis"},
+        {"priority": 40, "property": "username", "match": ".+", "policy": "oc10"},
+        {"priority": 50, "property": "id", "match": "4c510ada-c86b-4815-8820-42cdf82c3d51", "policy": "ocis"},
+        {"priority": 60, "property": "id", "match": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c", "policy": "oc10"}
+      ],
+      "unauthenticated_policy": "oc10"
     }
   },
   "policies": [
@@ -93,6 +106,60 @@
         {
           "endpoint": "/onlyoffice.js",
           "backend": "http://localhost:9220"
+        }
+      ]
+    },
+    {
+      "name": "oc10",
+      "routes": [
+        {
+          "endpoint": "/",
+          "backend": "http://localhost:9100"
+        },
+        {
+          "endpoint": "/.well-known/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/konnect/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/signin/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/ocs/",
+          "backend": "https://demo.owncloud.com",
+          "apache-vhost": true
+        },
+        {
+          "endpoint": "/remote.php/",
+          "backend": "https://demo.owncloud.com",
+          "apache-vhost": true
+        },
+        {
+          "endpoint": "/dav/",
+          "backend": "https://demo.owncloud.com",
+          "apache-vhost": true
+        },
+        {
+          "endpoint": "/webdav/",
+          "backend": "https://demo.owncloud.com",
+          "apache-vhost": true
+        },
+        {
+          "endpoint": "/status.php",
+          "backend": "https://demo.owncloud.com"
+        },
+        {
+          "endpoint": "/index.php/",
+          "backend": "https://demo.owncloud.com"
+        },
+        {
+          "endpoint": "/data",
+          "backend": "https://demo.owncloud.com",
+          "apache-vhost": true
         }
       ]
     }

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -221,6 +221,12 @@ func loadMiddlewares(ctx context.Context, l log.Logger, cfg *config.Config) alic
 			middleware.AutoprovisionAccounts(cfg.AutoprovisionAccounts),
 		),
 
+		middleware.SelectorCookie(
+			middleware.Logger(l),
+			middleware.UserProvider(userProvider),
+			middleware.PolicySelectorConfig(*cfg.PolicySelector),
+		),
+
 		// finally, trigger home creation when a user logs in
 		middleware.CreateHome(
 			middleware.Logger(l),

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -142,6 +142,7 @@ type PolicySelector struct {
 	Static    *StaticSelectorConf
 	Migration *MigrationSelectorConf
 	Claims    *ClaimsSelectorConf
+	Regex     *RegexSelectorConf
 }
 
 // StaticSelectorConf is the config for the static-policy-selector
@@ -171,6 +172,13 @@ type MigrationSelectorConf struct {
 type ClaimsSelectorConf struct {
 	DefaultPolicy         string `mapstructure:"default_policy"`
 	UnauthenticatedPolicy string `mapstructure:"unauthenticated_policy"`
+}
+
+// RegexSelectorConf is the config for the regex-selector
+type RegexSelectorConf struct {
+	DefaultPolicy         string                       `mapstructure:"default_policy"`
+	MatchesPolicies       map[string]map[string]string `mapstructure:"matches_policies"`
+	UnauthenticatedPolicy string                       `mapstructure:"unauthenticated_policy"`
 }
 
 // New initializes a new configuration

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -1,6 +1,8 @@
 package config
 
-import "context"
+import (
+	"context"
+)
 
 // Log defines the available logging configuration.
 type Log struct {
@@ -176,9 +178,15 @@ type ClaimsSelectorConf struct {
 
 // RegexSelectorConf is the config for the regex-selector
 type RegexSelectorConf struct {
-	DefaultPolicy         string                       `mapstructure:"default_policy"`
-	MatchesPolicies       map[string]map[string]string `mapstructure:"matches_policies"`
-	UnauthenticatedPolicy string                       `mapstructure:"unauthenticated_policy"`
+	DefaultPolicy         string          `mapstructure:"default_policy"`
+	MatchesPolicies       []RegexRuleConf `mapstructure:"matches_policies"`
+	UnauthenticatedPolicy string          `mapstructure:"unauthenticated_policy"`
+}
+type RegexRuleConf struct {
+	Priority int    `mapstructure:"priority"`
+	Property string `mapstructure:"property"`
+	Match    string `mapstructure:"match"`
+	Policy   string `mapstructure:"policy"`
 }
 
 // New initializes a new configuration

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -141,6 +141,7 @@ type OIDC struct {
 type PolicySelector struct {
 	Static    *StaticSelectorConf
 	Migration *MigrationSelectorConf
+	Claims    *ClaimsSelectorConf
 }
 
 // StaticSelectorConf is the config for the static-policy-selector
@@ -163,6 +164,12 @@ type PreSignedURL struct {
 type MigrationSelectorConf struct {
 	AccFoundPolicy        string `mapstructure:"acc_found_policy"`
 	AccNotFoundPolicy     string `mapstructure:"acc_not_found_policy"`
+	UnauthenticatedPolicy string `mapstructure:"unauthenticated_policy"`
+}
+
+// ClaimsSelectorConf is the config for the claims-selector
+type ClaimsSelectorConf struct {
+	DefaultPolicy         string `mapstructure:"default_policy"`
 	UnauthenticatedPolicy string `mapstructure:"unauthenticated_policy"`
 }
 

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -174,6 +174,7 @@ type MigrationSelectorConf struct {
 type ClaimsSelectorConf struct {
 	DefaultPolicy         string `mapstructure:"default_policy"`
 	UnauthenticatedPolicy string `mapstructure:"unauthenticated_policy"`
+	SelectorCookieName    string `mapstructure:"selector_cookie_name"`
 }
 
 // RegexSelectorConf is the config for the regex-selector
@@ -181,6 +182,7 @@ type RegexSelectorConf struct {
 	DefaultPolicy         string          `mapstructure:"default_policy"`
 	MatchesPolicies       []RegexRuleConf `mapstructure:"matches_policies"`
 	UnauthenticatedPolicy string          `mapstructure:"unauthenticated_policy"`
+	SelectorCookieName    string          `mapstructure:"selector_cookie_name"`
 }
 type RegexRuleConf struct {
 	Priority int    `mapstructure:"priority"`

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -254,7 +254,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "user-cs3-claim",
 			Value:       flags.OverrideDefaultString(cfg.UserCS3Claim, "mail"),
-			Usage:       "The claim to use when looking up a user in the CS3 API, eg. 'userid' or 'mail'",
+			Usage:       "The CS3 claim to use when looking up a user in the CS3 users API, eg. 'userid', 'username' or 'mail'",
 			EnvVars:     []string{"PROXY_USER_CS3_CLAIM"},
 			Destination: &cfg.UserCS3Claim,
 		},

--- a/proxy/pkg/middleware/account_resolver.go
+++ b/proxy/pkg/middleware/account_resolver.go
@@ -83,6 +83,8 @@ func (m accountResolver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			m.logger.Debug().Interface("claims", claims).Msg("Autoprovisioning user")
 			u, err = m.userProvider.CreateUserFromClaims(req.Context(), claims)
+			// TODO instead of creating an account create a personal storage via the CS3 admin api?
+			// see https://cs3org.github.io/cs3apis/#cs3.admin.user.v1beta1.CreateUserRequest
 		}
 
 		if errors.Is(err, backend.ErrAccountDisabled) {

--- a/proxy/pkg/middleware/account_resolver.go
+++ b/proxy/pkg/middleware/account_resolver.go
@@ -56,6 +56,7 @@ func (m accountResolver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	claims := oidc.FromContext(ctx)
 	u, ok := revauser.ContextGetUser(ctx)
+	// TODO what if an X-Access-Token is set? happens eg for download requests to the /data endpoint in the reva frontend
 
 	if claims == nil && !ok {
 		m.next.ServeHTTP(w, req)

--- a/proxy/pkg/middleware/options.go
+++ b/proxy/pkg/middleware/options.go
@@ -1,9 +1,10 @@
 package middleware
 
 import (
-	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 	"net/http"
 	"time"
+
+	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 
 	settings "github.com/owncloud/ocis/settings/pkg/proto/v0"
 
@@ -23,6 +24,8 @@ type Options struct {
 	Logger log.Logger
 	// TokenManagerConfig for communicating with the reva token manager
 	TokenManagerConfig config.TokenManager
+	// PolicySelectorConfig for using the policy selector
+	PolicySelector config.PolicySelector
 	// HTTPClient to use for communication with the oidcAuth provider
 	HTTPClient *http.Client
 	// AccountsClient for resolving accounts
@@ -79,6 +82,13 @@ func Logger(l log.Logger) Option {
 func TokenManagerConfig(cfg config.TokenManager) Option {
 	return func(o *Options) {
 		o.TokenManagerConfig = cfg
+	}
+}
+
+// PolicySelectorConfig provides a function to set the policy selector config option.
+func PolicySelectorConfig(cfg config.PolicySelector) Option {
+	return func(o *Options) {
+		o.PolicySelector = cfg
 	}
 }
 

--- a/proxy/pkg/middleware/selector_cookie.go
+++ b/proxy/pkg/middleware/selector_cookie.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/owncloud/ocis/ocis-pkg/oidc"
+	"github.com/owncloud/ocis/proxy/pkg/config"
+	"github.com/owncloud/ocis/proxy/pkg/proxy/policy"
+)
+
+// SelectorCookie provides a middleware which
+func SelectorCookie(optionSetters ...Option) func(next http.Handler) http.Handler {
+	options := newOptions(optionSetters...)
+	logger := options.Logger
+	policySelector := options.PolicySelector
+
+	return func(next http.Handler) http.Handler {
+		return &selectorCookie{
+			next:           next,
+			logger:         logger,
+			policySelector: policySelector,
+		}
+	}
+}
+
+type selectorCookie struct {
+	next           http.Handler
+	logger         log.Logger
+	policySelector config.PolicySelector
+}
+
+func (m selectorCookie) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if m.policySelector.Regex == nil && m.policySelector.Claims == nil {
+		// only set selector cookie for regex and claim selectors
+		m.next.ServeHTTP(w, req)
+		return
+	}
+
+	ctx := req.Context()
+	claims := oidc.FromContext(ctx)
+
+	selectorCookieName := ""
+	if m.policySelector.Regex != nil {
+		selectorCookieName = m.policySelector.Regex.SelectorCookieName
+	} else if m.policySelector.Claims != nil {
+		selectorCookieName = m.policySelector.Claims.SelectorCookieName
+	}
+
+	_, err := req.Cookie(selectorCookieName)
+	if err != nil {
+		// no cookie there - try to add one
+		if claims != nil {
+
+			selectorFunc, err := policy.LoadSelector(&m.policySelector)
+			if err != nil {
+				m.logger.Err(err)
+			}
+
+			selector, err := selectorFunc(ctx, req)
+			if err != nil {
+				m.logger.Err(err)
+			}
+
+			cookie := http.Cookie{
+				Name:     selectorCookieName,
+				Value:    selector,
+				Domain:   req.Host,
+				Path:     "/",
+				MaxAge:   60 * 60,
+				HttpOnly: true,
+			}
+			http.SetCookie(w, &cookie)
+		}
+	}
+
+	m.next.ServeHTTP(w, req)
+}

--- a/proxy/pkg/middleware/selector_cookie.go
+++ b/proxy/pkg/middleware/selector_cookie.go
@@ -37,9 +37,6 @@ func (m selectorCookie) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ctx := req.Context()
-	claims := oidc.FromContext(ctx)
-
 	selectorCookieName := ""
 	if m.policySelector.Regex != nil {
 		selectorCookieName = m.policySelector.Regex.SelectorCookieName
@@ -50,14 +47,14 @@ func (m selectorCookie) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	_, err := req.Cookie(selectorCookieName)
 	if err != nil {
 		// no cookie there - try to add one
-		if claims != nil {
+		if oidc.FromContext(req.Context()) != nil {
 
 			selectorFunc, err := policy.LoadSelector(&m.policySelector)
 			if err != nil {
 				m.logger.Err(err)
 			}
 
-			selector, err := selectorFunc(ctx, req)
+			selector, err := selectorFunc(req)
 			if err != nil {
 				m.logger.Err(err)
 			}

--- a/proxy/pkg/proxy/policy/selector.go
+++ b/proxy/pkg/proxy/policy/selector.go
@@ -169,7 +169,7 @@ func NewClaimsSelector(cfg *config.ClaimsSelectorConf) Selector {
 // NewRegexSelector selects the policy based on a user property
 // The policy for each case is configurable:
 // "policy_selector": {
-//    "migration": {
+//    "regex": {
 //      "matches_policies": [
 //        {"priority": 10, "property": "mail", "match": "marie@example.org", "policy": "ocis"},
 //        {"priority": 20, "property": "mail", "match": "[^@]+@example.org", "policy": "oc10"},

--- a/proxy/pkg/proxy/policy/selector.go
+++ b/proxy/pkg/proxy/policy/selector.go
@@ -176,7 +176,7 @@ func NewClaimsSelector(cfg *config.ClaimsSelectorConf) Selector {
 //        {"priority": 30, "property": "username", "match": "(einstein|feynman)", "policy": "ocis"},
 //        {"priority": 40, "property": "username", "match": ".+", "policy": "oc10"},
 //        {"priority": 50, "property": "id", "match": "4c510ada-c86b-4815-8820-42cdf82c3d51", "policy": "ocis"},
-//        {"priority": 60, "property": "id", "match": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c", "policy": "oc10"},
+//        {"priority": 60, "property": "id", "match": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c", "policy": "oc10"}
 //      ],
 //      "unauthenticated_policy": "oc10"
 //    }

--- a/proxy/pkg/proxy/policy/selector_test.go
+++ b/proxy/pkg/proxy/policy/selector_test.go
@@ -3,10 +3,11 @@ package policy
 import (
 	"context"
 	"fmt"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/asim/go-micro/v3/client"
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	revauser "github.com/cs3org/reva/pkg/user"
 	"github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocis-pkg/oidc"
 	"github.com/owncloud/ocis/proxy/pkg/config"
@@ -23,29 +24,32 @@ func TestLoadSelector(t *testing.T) {
 		AccNotFoundPolicy:     "not_found",
 		UnauthenticatedPolicy: "unauth",
 	}
+	ccfg := &config.ClaimsSelectorConf{}
+	rcfg := &config.RegexSelectorConf{}
 
 	table := []test{
 		{cfg: &config.PolicySelector{Static: sCfg, Migration: mcfg}, expectedErr: ErrMultipleSelectors},
+		{cfg: &config.PolicySelector{Static: sCfg, Claims: ccfg, Regex: rcfg}, expectedErr: ErrMultipleSelectors},
 		{cfg: &config.PolicySelector{}, expectedErr: ErrSelectorConfigIncomplete},
 		{cfg: &config.PolicySelector{Static: sCfg}, expectedErr: nil},
 		{cfg: &config.PolicySelector{Migration: mcfg}, expectedErr: nil},
+		{cfg: &config.PolicySelector{Claims: ccfg}, expectedErr: nil},
+		{cfg: &config.PolicySelector{Regex: rcfg}, expectedErr: nil},
 	}
 
 	for _, test := range table {
 		_, err := LoadSelector(test.cfg)
 		if err != test.expectedErr {
-			t.Fail()
+			t.Errorf("Unexpected error %v", err)
 		}
 	}
 }
 
 func TestStaticSelector(t *testing.T) {
-	ctx := context.Background()
-	req := httptest.NewRequest("GET", "https://example.org/foo", nil)
 	sel := NewStaticSelector(&config.StaticSelectorConf{Policy: "ocis"})
-
+	ctx := context.Background()
 	want := "ocis"
-	got, err := sel(ctx, req)
+	got, err := sel(ctx)
 	if got != want {
 		t.Errorf("Expected policy %v got %v", want, got)
 	}
@@ -57,7 +61,7 @@ func TestStaticSelector(t *testing.T) {
 	sel = NewStaticSelector(&config.StaticSelectorConf{Policy: "foo"})
 
 	want = "foo"
-	got, err = sel(ctx, req)
+	got, err = sel(ctx)
 	if got != want {
 		t.Errorf("Expected policy %v got %v", want, got)
 	}
@@ -67,7 +71,7 @@ func TestStaticSelector(t *testing.T) {
 	}
 }
 
-type testCase struct {
+type migrationTestCase struct {
 	AccSvcShouldReturnError bool
 	Claims                  map[string]interface{}
 	Expected                string
@@ -79,7 +83,7 @@ func TestMigrationSelector(t *testing.T) {
 		AccNotFoundPolicy:     "not_found",
 		UnauthenticatedPolicy: "unauth",
 	}
-	var tests = []testCase{
+	var tests = []migrationTestCase{
 		{true, map[string]interface{}{oidc.PreferredUsername: "Hans"}, "not_found"},
 		{true, map[string]interface{}{oidc.Email: "hans@example.test"}, "not_found"},
 		{false, map[string]interface{}{oidc.PreferredUsername: "Hans"}, "found"},
@@ -87,15 +91,11 @@ func TestMigrationSelector(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		//t.Run(fmt.Sprintf("#%v", k), func(t *testing.T) {
-		//	t.Parallel()
 		tc := tc
 		sut := NewMigrationSelector(&cfg, mockAccSvc(tc.AccSvcShouldReturnError))
-		r := httptest.NewRequest("GET", "https://example.com", nil)
-		ctx := oidc.NewContext(r.Context(), tc.Claims)
-		nr := r.WithContext(ctx)
+		ctx := oidc.NewContext(context.Background(), tc.Claims)
 
-		got, err := sut(ctx, nr)
+		got, err := sut(ctx)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -103,7 +103,6 @@ func TestMigrationSelector(t *testing.T) {
 		if got != tc.Expected {
 			t.Errorf("Expected Policy %v got %v", tc.Expected, got)
 		}
-		//})
 	}
 }
 
@@ -122,4 +121,75 @@ func mockAccSvc(retErr bool) proto.AccountsService {
 		},
 	}
 
+}
+
+type testCase struct {
+	Name     string
+	Context  context.Context
+	Expected string
+}
+
+func TestClaimsSelector(t *testing.T) {
+	sel := NewClaimsSelector(&config.ClaimsSelectorConf{
+		DefaultPolicy:         "default",
+		UnauthenticatedPolicy: "unauthenticated",
+	})
+
+	var tests = []testCase{
+		{"unatuhenticated", context.Background(), "unauthenticated"},
+		{"default", oidc.NewContext(context.Background(), map[string]interface{}{oidc.OcisRoutingPolicy: ""}), "default"},
+		{"claim-value", oidc.NewContext(context.Background(), map[string]interface{}{oidc.OcisRoutingPolicy: "ocis.routing.policy-value"}), "ocis.routing.policy-value"},
+	}
+	for _, tc := range tests {
+		got, err := sel(tc.Context)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if got != tc.Expected {
+			t.Errorf("Expected Policy %v got %v", tc.Expected, got)
+		}
+	}
+}
+
+func TestRegexSelector(t *testing.T) {
+	sel := NewRegexSelector(&config.RegexSelectorConf{
+		DefaultPolicy: "default",
+		MatchesPolicies: []config.RegexRuleConf{
+			{Priority: 10, Property: "mail", Match: "marie@example.org", Policy: "ocis"},
+			{Priority: 20, Property: "mail", Match: "[^@]+@example.org", Policy: "oc10"},
+			{Priority: 30, Property: "username", Match: "(einstein|feynman)", Policy: "ocis"},
+			{Priority: 40, Property: "username", Match: ".+", Policy: "oc10"},
+			{Priority: 50, Property: "id", Match: "4c510ada-c86b-4815-8820-42cdf82c3d51", Policy: "ocis"},
+			{Priority: 60, Property: "id", Match: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c", Policy: "oc10"},
+		},
+		UnauthenticatedPolicy: "unauthenticated",
+	})
+
+	var tests = []testCase{
+		{"unauthenticated", context.Background(), "unauthenticated"},
+		{"default", revauser.ContextSetUser(context.Background(), &userv1beta1.User{}), "default"},
+		{"mail-ocis", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Mail: "marie@example.org"}), "ocis"},
+		{"mail-oc10", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Mail: "einstein@example.org"}), "oc10"},
+		{"username-einstein", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Username: "einstein"}), "ocis"},
+		{"username-feynman", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Username: "feynman"}), "ocis"},
+		{"username-marie", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Username: "marie"}), "oc10"},
+		{"id-nil", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{}}), "default"},
+		{"id-1", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51"}}), "ocis"},
+		{"id-2", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"}}), "oc10"},
+	}
+
+	for _, tc := range tests {
+		tc := tc // capture range variable
+		t.Run(tc.Name, func(t *testing.T) {
+			got, err := sel(tc.Context)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if got != tc.Expected {
+				t.Errorf("Expected Policy %v got %v", tc.Expected, got)
+			}
+		})
+	}
 }

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -110,7 +110,7 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 }
 
 func (p *MultiHostReverseProxy) directorSelectionDirector(r *http.Request) {
-	pol, err := p.PolicySelector(r.Context(), r)
+	pol, err := p.PolicySelector(r.Context())
 	if err != nil {
 		p.logger.Error().Msgf("Error while selecting pol %v", err)
 		return

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -109,7 +109,7 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 }
 
 func (p *MultiHostReverseProxy) directorSelectionDirector(r *http.Request) {
-	pol, err := p.PolicySelector(r.Context())
+	pol, err := p.PolicySelector(r.Context(), r)
 	if err != nil {
 		p.logger.Error().Msgf("Error while selecting pol %v", err)
 		return

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -213,12 +212,12 @@ func (p *MultiHostReverseProxy) AddHost(policy string, target *url.URL, rt confi
 }
 
 func (p *MultiHostReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx := r.Context()
 	var span *trace.Span
 
 	// Start root span.
 	if p.config.Tracing.Enabled {
-		ctx, span = trace.StartSpan(context.Background(), r.URL.String())
+		ctx, span = trace.StartSpan(ctx, r.URL.String())
 		defer span.End()
 		p.propagator.SpanContextToRequest(span.SpanContext(), r)
 	}

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -66,7 +66,7 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 
 	if options.Config.PolicySelector == nil {
 		firstPolicy := options.Config.Policies[0].Name
-		rp.logger.Warn().Msgf("policy-selector not configured. Will always use first policy: '%v'", firstPolicy)
+		rp.logger.Warn().Str("policy", firstPolicy).Msg("policy-selector not configured. Will always use first policy")
 		options.Config.PolicySelector = &config.PolicySelector{
 			Static: &config.StaticSelectorConf{
 				Policy: firstPolicy,
@@ -91,9 +91,10 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 			uri, err := url.Parse(route.Backend)
 			if err != nil {
 				rp.logger.
-					Fatal().
+					Fatal(). // fail early on misconfiguration
 					Err(err).
-					Msgf("malformed url: %v", route.Backend)
+					Str("backend", route.Backend).
+					Msg("malformed url")
 			}
 
 			rp.logger.
@@ -109,16 +110,17 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 }
 
 func (p *MultiHostReverseProxy) directorSelectionDirector(r *http.Request) {
-	pol, err := p.PolicySelector(r.Context(), r)
+	pol, err := p.PolicySelector(r)
 	if err != nil {
-		p.logger.Error().Msgf("Error while selecting pol %v", err)
+		p.logger.Error().Err(err).Msg("Error while selecting pol")
 		return
 	}
 
 	if _, ok := p.Directors[pol]; !ok {
 		p.logger.
 			Error().
-			Msgf("policy %v is not configured", pol)
+			Str("policy", pol).
+			Msg("policy is not configured")
 		return
 	}
 
@@ -247,7 +249,7 @@ func (p MultiHostReverseProxy) queryRouteMatcher(endpoint string, target url.URL
 func (p *MultiHostReverseProxy) regexRouteMatcher(pattern string, target url.URL) bool {
 	matched, err := regexp.MatchString(pattern, target.String())
 	if err != nil {
-		p.logger.Warn().Err(err).Msgf("regex with pattern %s failed", pattern)
+		p.logger.Warn().Err(err).Str("pattern", pattern).Msg("regex with pattern failed")
 	}
 	return matched
 }


### PR DESCRIPTION
Using the proxy config file, it is now possible to let let the IdP determine the routing policy by sending an `ocis.routing.policy` claim or by matching username, email or id using regexes. 


- [x] tests
- [x] update changelog
- [ ] update docs

This PR can stand on its own. But the proxy and the docs need an overhaul in subsequent PRs:
- [ ] Configuring the policy selector is only possible via the config file
- [ ] The proxy should always use the cs3 api. get rid of configuration choices here
- [ ] We should use the cs3 api to authenticate requests ... yes it would mean more latency when authenticating, but we can cache the token afterwards. It would remove the duplicate code in the proxy and in the auth providers. This should allow us to actually get rid of several middlewares in here.
- [ ] when moving the oidc auth into reva we can do the claims mapping there, including custom porperties like `ocis.routing.policy` or `ocis.id`
