### PR TITLE
Prevent race condition on starting an already running service

### DIFF
--- a/changelog/unreleased/closed-channel-bug.md
+++ b/changelog/unreleased/closed-channel-bug.md
@@ -1,0 +1,7 @@
+Bugfix: Panic when service fails to start
+
+Tags: runtime
+
+When attempting to run a service through the runtime that is currently running and fails to start, a race condition still redirect os Interrupt signals to a closed channel.
+
+https://github.com/owncloud/ocis/pull/2252

--- a/ocis-pkg/sync/trap.go
+++ b/ocis-pkg/sync/trap.go
@@ -16,7 +16,6 @@ func Trap(gr *run.Group, cancel context.CancelFunc) {
 		<-stop
 		return nil
 	}, func(err error) {
-		close(stop)
 		cancel()
 	})
 }

--- a/storage/pkg/command/authbasic.go
+++ b/storage/pkg/command/authbasic.go
@@ -78,7 +78,7 @@ func AuthBasic(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.AuthBasic.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/authbearer.go
+++ b/storage/pkg/command/authbearer.go
@@ -73,7 +73,7 @@ func AuthBearer(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.AuthBearer.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/gateway.go
+++ b/storage/pkg/command/gateway.go
@@ -96,7 +96,7 @@ func Gateway(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.Gateway.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/groups.go
+++ b/storage/pkg/command/groups.go
@@ -84,7 +84,7 @@ func Groups(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.Groups.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/sharing.go
+++ b/storage/pkg/command/sharing.go
@@ -92,7 +92,7 @@ func Sharing(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.Sharing.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/storagehome.go
+++ b/storage/pkg/command/storagehome.go
@@ -86,7 +86,7 @@ func StorageHome(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.StorageHome.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/storagepubliclink.go
+++ b/storage/pkg/command/storagepubliclink.go
@@ -68,7 +68,7 @@ func StoragePublicLink(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.StoragePublicLink.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/storageusers.go
+++ b/storage/pkg/command/storageusers.go
@@ -86,7 +86,7 @@ func StorageUsers(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.StorageUsers.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 

--- a/storage/pkg/command/users.go
+++ b/storage/pkg/command/users.go
@@ -85,7 +85,7 @@ func Users(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			if !cfg.Reva.StorageMetadata.Supervised {
+			if !cfg.Reva.Users.Supervised {
 				sync.Trap(&gr, cancel)
 			}
 


### PR DESCRIPTION
When attempting to run a service through the runtime that is currently running and fails to start, a race condition still redirect os Interrupt signals to a closed channel.

## Steps to reproduce:

1. `ocis server`
2. `ocis run proxy`
3. `ctrl+c` on step 1

You should see a panic message on screen:

![image](https://user-images.githubusercontent.com/6905948/124286898-b45fab00-db4f-11eb-9ff1-3ca757df9bb2.png)

Not cool.