### PR TITLE
Add ocs cache warmup config and warn on protobuf ns conflicts

### DIFF
--- a/.make/go.mk
+++ b/.make/go.mk
@@ -42,8 +42,9 @@ ifndef DATE
 	DATE := $(shell date -u '+%Y%m%d')
 endif
 
-LDFLAGS += -s -w -X "$(IMPORT)/pkg/version.String=$(VERSION)" -X "$(IMPORT)/pkg/version.Date=$(DATE)"
-DEBUG_LDFLAGS += -X "$(IMPORT)/pkg/version.String=$(VERSION)" -X "$(IMPORT)/pkg/version.Date=$(DATE)"
+LDFLAGS += -X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -s -w -X "$(IMPORT)/pkg/version.String=$(VERSION)" -X "$(IMPORT)/pkg/version.Date=$(DATE)"
+DEBUG_LDFLAGS += -X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X "$(IMPORT)/pkg/version.String=$(VERSION)" -X "$(IMPORT)/pkg/version.Date=$(DATE)"
+
 GCFLAGS += all=-N -l
 
 .PHONY: all

--- a/changelog/unreleased/ocs-cache-warmup.md
+++ b/changelog/unreleased/ocs-cache-warmup.md
@@ -1,0 +1,3 @@
+Enhancement: Add ocs cache warmup config and warn on protobuf ns conflicts
+
+https://github.com/owncloud/ocis/pull/2328

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -156,9 +156,22 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 					"public_url":       cfg.Reva.Frontend.PublicURL,
 				},
 				"ocs": map[string]interface{}{
-					"share_prefix":   cfg.Reva.Frontend.OCSSharePrefix,
-					"home_namespace": cfg.Reva.Frontend.OCSHomeNamespace,
-					"prefix":         cfg.Reva.Frontend.OCSPrefix,
+					"share_prefix":            cfg.Reva.Frontend.OCSSharePrefix,
+					"home_namespace":          cfg.Reva.Frontend.OCSHomeNamespace,
+					"resource_info_cache_ttl": cfg.Reva.Frontend.OCSResourceInfoCacheTTL,
+					"prefix":                  cfg.Reva.Frontend.OCSPrefix,
+					"cache_warmup_driver":     cfg.Reva.Frontend.OCSCacheWarmupDriver,
+					"cache_warmup_drivers": map[string]interface{}{
+						"cbox": map[string]interface{}{
+							"db_username": cfg.Reva.Sharing.UserSQLUsername,
+							"db_password": cfg.Reva.Sharing.UserSQLPassword,
+							"db_host":     cfg.Reva.Sharing.UserSQLHost,
+							"db_port":     cfg.Reva.Sharing.UserSQLPort,
+							"db_name":     cfg.Reva.Sharing.UserSQLName,
+							"namespace":   cfg.Reva.Storages.EOS.Root,
+							"gatewaysvc":  cfg.Reva.Gateway.Endpoint,
+						},
+					},
 					"config": map[string]interface{}{
 						"version": "1.8",
 						"website": "reva",

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -109,13 +109,15 @@ type Groups struct {
 type FrontendPort struct {
 	Port
 
-	DatagatewayPrefix string
-	OCDavPrefix       string
-	OCSPrefix         string
-	OCSSharePrefix    string
-	OCSHomeNamespace  string
-	PublicURL         string
-	Middleware        Middleware
+	DatagatewayPrefix       string
+	OCDavPrefix             string
+	OCSPrefix               string
+	OCSSharePrefix          string
+	OCSHomeNamespace        string
+	PublicURL               string
+	OCSCacheWarmupDriver    string
+	OCSResourceInfoCacheTTL int
+	Middleware              Middleware
 }
 
 // Middleware configures reva middlewares.
@@ -147,7 +149,7 @@ type StoragePort struct {
 	// for HTTP ports with only one http service
 	HTTPPrefix string
 	TempFolder string
-	ReadOnly bool
+	ReadOnly   bool
 }
 
 // PublicStorage configures a public storage provider

--- a/storage/pkg/flagset/frontend.go
+++ b/storage/pkg/flagset/frontend.go
@@ -126,6 +126,20 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"STORAGE_FRONTEND_OCS_HOME_NAMESPACE"},
 			Destination: &cfg.Reva.Frontend.OCSHomeNamespace,
 		},
+		&cli.IntFlag{
+			Name:        "ocs-resource-info-cache-ttl",
+			Value:       flags.OverrideDefaultInt(cfg.Reva.Frontend.OCSResourceInfoCacheTTL, 0),
+			Usage:       "the TTL for statted resources in the share cache",
+			EnvVars:     []string{"STORAGE_FRONTEND_OCS_RESOURCE_INFO_CACHE_TTL"},
+			Destination: &cfg.Reva.Frontend.OCSResourceInfoCacheTTL,
+		},
+		&cli.StringFlag{
+			Name:        "ocs-cache-warmup-driver",
+			Value:       flags.OverrideDefaultString(cfg.Reva.Frontend.OCSCacheWarmupDriver, ""),
+			Usage:       "the driver to be used for warming up the share cache",
+			EnvVars:     []string{"STORAGE_FRONTEND_OCS_CACHE_WARMUP_DRIVER"},
+			Destination: &cfg.Reva.Frontend.OCSCacheWarmupDriver,
+		},
 		// Gateway
 
 		&cli.StringFlag{
@@ -183,6 +197,8 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 	flags = append(flags, TracingWithConfig(cfg)...)
 	flags = append(flags, DebugWithConfig(cfg)...)
 	flags = append(flags, SecretWithConfig(cfg)...)
+	flags = append(flags, SharingSQLWithConfig(cfg)...)
+	flags = append(flags, DriverEOSWithConfig(cfg)...)
 
 	return flags
 }


### PR DESCRIPTION
This PR introduces a couple of changes:
- Since v1.26.0, protobuf [panics](https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict) in case of namespace conflicts instead of warning. This does not allow us to integrate extensions in oCIS for which the proto bindings were generated separately, despite the fact that `go_package` was [different](https://github.com/cernbox/ocis-canary/blob/main/pkg/proto/v0/canary.proto#L5) for the extensions' protobufs. For the time being, we set this back to warn (like it was in the previous versions) until we can find a solution.
- We added a cache warmup strategy for the resources in the ocs layer. We stat every resource when a user lists their shares, which introduced a bit of latency. To handle that, we introduced a cache for these resources. This PR goes a bit further and adds a strategy through which we can populate the cache even before the first user request, further enhancing the user experience. Currently, we have only a single strategy for the CERNBox-specific drivers, I'll add a generic one as well.