### PR TITLE
[full-ci] update reva to 756bdced1d22

### DIFF
--- a/accounts/pkg/storage/cs3.go
+++ b/accounts/pkg/storage/cs3.go
@@ -16,6 +16,7 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
@@ -67,7 +68,7 @@ func (r CS3Repo) WriteAccount(ctx context.Context, a *proto.Account) (err error)
 		return err
 	}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	if err := r.makeRootDirIfNotExist(ctx, accountsFolder); err != nil {
 		return err
 	}
@@ -104,7 +105,7 @@ func (r CS3Repo) LoadAccounts(ctx context.Context, a *[]*proto.Account) (err err
 		return err
 	}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	res, err := r.storageProvider.ListContainer(ctx, &provider.ListContainerRequest{
 		Ref: &provider.Reference{
 			Path: path.Join("/meta", accountsFolder),
@@ -154,7 +155,7 @@ func (r CS3Repo) DeleteAccount(ctx context.Context, id string) (err error) {
 		return err
 	}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 
 	resp, err := r.storageProvider.Delete(ctx, &provider.DeleteRequest{
 		Ref: &provider.Reference{
@@ -181,7 +182,7 @@ func (r CS3Repo) WriteGroup(ctx context.Context, g *proto.Group) (err error) {
 		return err
 	}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	if err := r.makeRootDirIfNotExist(ctx, groupsFolder); err != nil {
 		return err
 	}
@@ -218,7 +219,7 @@ func (r CS3Repo) LoadGroups(ctx context.Context, g *[]*proto.Group) (err error) 
 		return err
 	}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	res, err := r.storageProvider.ListContainer(ctx, &provider.ListContainerRequest{
 		Ref: &provider.Reference{
 			Path: path.Join("/meta", groupsFolder),
@@ -268,7 +269,7 @@ func (r CS3Repo) DeleteGroup(ctx context.Context, id string) (err error) {
 		return err
 	}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 
 	resp, err := r.storageProvider.Delete(ctx, &provider.DeleteRequest{
 		Ref: &provider.Reference{
@@ -371,7 +372,7 @@ func (d dataProviderClient) put(url string, body io.Reader, token string) (*http
 		return nil, err
 	}
 
-	req.Header.Add("x-access-token", token)
+	req.Header.Add(revactx.TokenHeader, token)
 	return d.client.Do(req)
 }
 
@@ -381,6 +382,6 @@ func (d dataProviderClient) get(url string, token string) (*http.Response, error
 		return nil, err
 	}
 
-	req.Header.Add("x-access-token", token)
+	req.Header.Add(revactx.TokenHeader, token)
 	return d.client.Do(req)
 }

--- a/changelog/1.10.0_2021-08-06/update-reva-v1.11.1-0.20210809134415-3fe79c870fb5.md
+++ b/changelog/1.10.0_2021-08-06/update-reva-v1.11.1-0.20210809134415-3fe79c870fb5.md
@@ -2,6 +2,14 @@ Enhancement: update REVA
 
 Update REVA from v1.10.1-0.20210730095301-fcb7a30a44a6 to v1.11.1-0.20210809134415-3fe79c870fb5
 * Fix cs3org/reva#1978: Fix owner type is optional
+* Fix cs3org/reva#1965: fix value of file_target in shares
+* Fix cs3org/reva#1960: fix updating shares in the memory share manager
+* Fix cs3org/reva#1956: fix trashbin listing with depth 0
+* Fix cs3org/reva#1957: fix etag propagation on deletes
+* Enh cs3org/reva#1861: [WIP] Runtime plugins
+* Fix cs3org/reva#1954: fix response format of the sharees API
+* Fix cs3org/reva#1819: Remove notifications key from ocs response
+* Enh cs3org/reva#1946: Add a share manager that connects to oc10 databases
 * Fix cs3org/reva#1899: Fix chunked uploads for new versions
 * Fix cs3org/reva#1906: Fix copy over existing resource
 * Fix cs3org/reva#1891: Delete Shared Resources as Receiver

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/blevesearch/bleve v1.0.9
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/go-cs3apis v0.0.0-20210802070913-970eec344e59
-	github.com/cs3org/reva v1.11.1-0.20210809134415-3fe79c870fb5
+	github.com/cs3org/reva v1.11.1-0.20210812105259-756bdced1d22
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/disintegration/imaging v1.6.2
@@ -42,7 +42,7 @@ require (
 	github.com/iancoleman/strcase v0.1.3
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/justinas/alice v1.2.0
-	github.com/libregraph/lico v0.34.1-0.20210803054646-b584e0372224 // indirect
+	github.com/libregraph/lico v0.34.1-0.20210803054646-b584e0372224
 	github.com/mennanov/fieldmask-utils v0.3.3
 	github.com/micro/cli/v2 v2.1.2
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,10 @@ github.com/crewjam/saml v0.4.5/go.mod h1:qCJQpUtZte9R1ZjUBcW8qtCNlinbO363ooNl02S
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20210802070913-970eec344e59 h1:cj9HxIbmbGn+HPpFP8nZ8oaNUsoFa0+cheCO8FUNoMc=
 github.com/cs3org/go-cs3apis v0.0.0-20210802070913-970eec344e59/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva v1.11.1-0.20210809134415-3fe79c870fb5 h1:JFBmuZwnsShEuAA3U6BL+AY8mwKc5NnKUB7WkCeD5+8=
-github.com/cs3org/reva v1.11.1-0.20210809134415-3fe79c870fb5/go.mod h1:9DgwsoB4cqlPaEC3hT7/NCdgJO7T1bY3kpxvWXc1DkA=
+github.com/cs3org/reva v1.11.1-0.20210811142901-ec4099da830e h1:/gJanj5PuKzY51Z2Cp01DjHT2U1HLnEUSDrMf9kC7b8=
+github.com/cs3org/reva v1.11.1-0.20210811142901-ec4099da830e/go.mod h1:9DgwsoB4cqlPaEC3hT7/NCdgJO7T1bY3kpxvWXc1DkA=
+github.com/cs3org/reva v1.11.1-0.20210812105259-756bdced1d22 h1:RZxu/fWJiTmu8fT6pWfu0fdKq7ZUXAZI4TndUfiUIYI=
+github.com/cs3org/reva v1.11.1-0.20210812105259-756bdced1d22/go.mod h1:9DgwsoB4cqlPaEC3hT7/NCdgJO7T1bY3kpxvWXc1DkA=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d h1:SwD98825d6bdB+pEuTxWOXiSjBrHdOl/UVp75eI7JT8=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -365,7 +367,6 @@ github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 h1:gclg6gY70GLy
 github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
 github.com/go-acme/lego/v3 v3.4.0/go.mod h1:xYbLDuxq3Hy4bMUT1t9JIuz6GWIWb3m5X+TeTHYaT7M=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
-github.com/go-asn1-ber/asn1-ber v1.4.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-asn1-ber/asn1-ber v1.5.1 h1:pDbRAunXzIUXfx4CB2QJFv5IuPiuoW+sWvr/Us009o8=
 github.com/go-asn1-ber/asn1-ber v1.5.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
@@ -955,7 +956,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/prometheus/procfs v0.0.10/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
@@ -1755,8 +1755,6 @@ sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
-stash.kopano.io/kc/konnect v0.34.0 h1:aKjZpLu8fvrrqVvNU9b2vKZOn8lUusXLoycLWgMi3o0=
-stash.kopano.io/kc/konnect v0.34.0/go.mod h1:GV6AxroXyHte83EsiJXA5ZygzofQ48zXCJ3qX9bK1JY=
 stash.kopano.io/kgol/kcc-go/v5 v5.0.1 h1:urR9hOR6TnTKjGkzZKac/a9cA8ws1WecWLTgiYubLQw=
 stash.kopano.io/kgol/kcc-go/v5 v5.0.1/go.mod h1:0ZmjWapy3zp+TAjZI6iCrcfh+BthZbB2WM1VfhDgNB4=
 stash.kopano.io/kgol/ksurveyclient-go v0.6.0/go.mod h1:LJMDQBROS2oXxBN04eSI6j1KhgWlqMFd8xKjXV4Irtw=

--- a/graph/pkg/middleware/auth.go
+++ b/graph/pkg/middleware/auth.go
@@ -4,9 +4,8 @@ import (
 	"net/http"
 
 	"github.com/cs3org/reva/pkg/auth/scope"
-	"github.com/cs3org/reva/pkg/token"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
-	"github.com/cs3org/reva/pkg/user"
 	"github.com/owncloud/ocis/graph/pkg/service/v0/errorcode"
 	"github.com/owncloud/ocis/ocis-pkg/account"
 	"google.golang.org/grpc/metadata"
@@ -68,9 +67,9 @@ func Auth(opts ...account.Option) func(http.Handler) http.Handler {
 				return
 			}
 
-			ctx = token.ContextSetToken(ctx, t)
-			ctx = user.ContextSetUser(ctx, u)
-			ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+			ctx = revactx.ContextSetToken(ctx, t)
+			ctx = revactx.ContextSetUser(ctx, u)
+			ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/graph/pkg/service/v0/users.go
+++ b/graph/pkg/service/v0/users.go
@@ -6,7 +6,7 @@ import (
 
 	cs3 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	cs3rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
-	"github.com/cs3org/reva/pkg/user"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 	"github.com/owncloud/ocis/graph/pkg/service/v0/errorcode"
@@ -63,7 +63,7 @@ func (g Graph) UserCtx(next http.Handler) http.Handler {
 // GetMe implements the Service interface.
 func (g Graph) GetMe(w http.ResponseWriter, r *http.Request) {
 
-	u, ok := user.ContextGetUser(r.Context())
+	u, ok := revactx.ContextGetUser(r.Context())
 	if !ok {
 		g.logger.Error().Msg("user not in context")
 		errorcode.ServiceNotAvailable.Render(w, r, http.StatusInternalServerError, "user not in context")

--- a/ocis-pkg/indexer/index/cs3/autoincrement.go
+++ b/ocis-pkg/indexer/index/cs3/autoincrement.go
@@ -18,6 +18,7 @@ import (
 
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
@@ -363,7 +364,7 @@ func (idx *Autoincrement) getAuthenticatedContext(ctx context.Context) (context.
 	if err != nil {
 		return nil, err
 	}
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	return ctx, nil
 }
 

--- a/ocis-pkg/indexer/index/cs3/non_unique.go
+++ b/ocis-pkg/indexer/index/cs3/non_unique.go
@@ -14,6 +14,7 @@ import (
 
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
@@ -106,7 +107,7 @@ func (idx *NonUnique) Init() error {
 	if err != nil {
 		return err
 	}
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, tk)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, tk)
 
 	if err := idx.makeDirIfNotExists(ctx, idx.indexBaseDir); err != nil {
 		return err
@@ -374,7 +375,7 @@ func (idx *NonUnique) getAuthenticatedContext(ctx context.Context) (context.Cont
 	if err != nil {
 		return nil, err
 	}
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	return ctx, nil
 }
 

--- a/ocis-pkg/indexer/index/cs3/unique.go
+++ b/ocis-pkg/indexer/index/cs3/unique.go
@@ -16,6 +16,7 @@ import (
 
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
@@ -112,7 +113,7 @@ func (idx *Unique) Init() error {
 	if err != nil {
 		return err
 	}
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, tk)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, tk)
 
 	if err := idx.makeDirIfNotExists(ctx, idx.indexBaseDir); err != nil {
 		return err
@@ -188,7 +189,7 @@ func (idx *Unique) Remove(id string, v string) error {
 	}
 
 	deletePath := path.Join("/meta", idx.indexRootDir, v)
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	resp, err := idx.storageProvider.Delete(ctx, &provider.DeleteRequest{
 		Ref: &provider.Reference{
 			Path: deletePath,
@@ -237,7 +238,7 @@ func (idx *Unique) Search(pattern string) ([]string, error) {
 		return nil, err
 	}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	res, err := idx.storageProvider.ListContainer(ctx, &provider.ListContainerRequest{
 		Ref: &provider.Reference{
 			Path: path.Join("/meta", idx.indexRootDir),
@@ -350,7 +351,7 @@ func (idx *Unique) getAuthenticatedContext(ctx context.Context) (context.Context
 	if err != nil {
 		return nil, err
 	}
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 	return ctx, nil
 }
 

--- a/ocis-pkg/middleware/account.go
+++ b/ocis-pkg/middleware/account.go
@@ -3,12 +3,13 @@ package middleware
 import (
 	"context"
 	"encoding/json"
-	"github.com/cs3org/reva/pkg/auth/scope"
 	"net/http"
 
+	"github.com/cs3org/reva/pkg/auth/scope"
+
 	"github.com/asim/go-micro/v3/metadata"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
-	"github.com/cs3org/reva/pkg/user"
 	"github.com/owncloud/ocis/ocis-pkg/account"
 )
 
@@ -65,7 +66,7 @@ func ExtractAccountUUID(opts ...account.Option) func(http.Handler) http.Handler 
 			}
 
 			// store user in context for request
-			ctx := user.ContextSetUser(r.Context(), u)
+			ctx := revactx.ContextSetUser(r.Context(), u)
 
 			// Important: user.Id.OpaqueId is the AccountUUID. Set this way in the account uuid middleware in ocis-proxy.
 			// https://github.com/owncloud/ocis-proxy/blob/ea254d6036592cf9469d757d1295e0c4309d1e63/pkg/middleware/account_uuid.go#L109

--- a/ocs/pkg/middleware/requireselforadmin.go
+++ b/ocs/pkg/middleware/requireselforadmin.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/cs3org/reva/pkg/user"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 	accounts "github.com/owncloud/ocis/accounts/pkg/service/v0"
@@ -19,7 +19,7 @@ func RequireSelfOrAdmin(opts ...Option) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			u, ok := user.ContextGetUser(r.Context())
+			u, ok := revactx.ContextGetUser(r.Context())
 			if !ok {
 				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaUnauthorized.StatusCode, "Unauthorized")))
 				return

--- a/ocs/pkg/middleware/requireuser.go
+++ b/ocs/pkg/middleware/requireuser.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/cs3org/reva/pkg/user"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/render"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/data"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/response"
@@ -15,7 +15,7 @@ func RequireUser() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			u, ok := user.ContextGetUser(r.Context())
+			u, ok := revactx.ContextGetUser(r.Context())
 			if !ok {
 				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaUnauthorized.StatusCode, "Unauthorized")))
 				return

--- a/ocs/pkg/service/v0/groups.go
+++ b/ocs/pkg/service/v0/groups.go
@@ -9,12 +9,10 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/cs3org/reva/pkg/user"
-
 	merrors "github.com/asim/go-micro/v3/errors"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
-
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/data"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/response"
@@ -27,7 +25,7 @@ func (o Ocs) ListUserGroups(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	// short circuit if there is a user already in the context
-	if u, ok := user.ContextGetUser(r.Context()); ok {
+	if u, ok := revactx.ContextGetUser(r.Context()); ok {
 		// we are not sure whether the current user in the context is the admin or the authenticated user.
 		if u.Username == userid {
 			// the OCS API is a REST API and it uses the username to look for groups. If the id from the user in the context

--- a/ocs/pkg/service/v0/users.go
+++ b/ocs/pkg/service/v0/users.go
@@ -9,18 +9,16 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cs3org/reva/pkg/auth/scope"
-
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
 	merrors "github.com/asim/go-micro/v3/errors"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	revauser "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/auth/scope"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
-	"github.com/cs3org/reva/pkg/user"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
@@ -37,7 +35,7 @@ import (
 func (o Ocs) GetSelf(w http.ResponseWriter, r *http.Request) {
 	var account *accounts.Account
 	var err error
-	u, ok := user.ContextGetUser(r.Context())
+	u, ok := revactx.ContextGetUser(r.Context())
 	if !ok || u.Id == nil || u.Id.OpaqueId == "" {
 		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "user is missing an id")))
 		return
@@ -373,7 +371,7 @@ func (o Ocs) DeleteUser(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		ctx := metadata.AppendToOutgoingContext(r.Context(), token.TokenHeader, t)
+		ctx := metadata.AppendToOutgoingContext(r.Context(), revactx.TokenHeader, t)
 
 		gwc, err := pool.GetGatewayServiceClient(o.config.RevaAddress)
 		if err != nil {
@@ -603,7 +601,7 @@ func (o Ocs) DisableUser(w http.ResponseWriter, r *http.Request) {
 // The signing key is part of the user settings and is used by the proxy to authenticate requests
 // Currently, the username is used as the OC-Credential
 func (o Ocs) GetSigningKey(w http.ResponseWriter, r *http.Request) {
-	u, ok := user.ContextGetUser(r.Context())
+	u, ok := revactx.ContextGetUser(r.Context())
 	if !ok {
 		//o.logger.Error().Msg("missing user in context")
 		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "missing user in context")))

--- a/proxy/pkg/middleware/account_resolver_test.go
+++ b/proxy/pkg/middleware/account_resolver_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	"github.com/cs3org/reva/pkg/token"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/ocis-pkg/oidc"
 	"github.com/owncloud/ocis/proxy/pkg/config"
@@ -29,7 +29,7 @@ func TestTokenIsAddedWithMailClaim(t *testing.T) {
 
 	sut.ServeHTTP(rw, req)
 
-	token := req.Header.Get(token.TokenHeader)
+	token := req.Header.Get(revactx.TokenHeader)
 	assert.NotEmpty(t, token)
 	assert.Contains(t, token, "eyJ")
 }
@@ -47,7 +47,7 @@ func TestTokenIsAddedWithUsernameClaim(t *testing.T) {
 
 	sut.ServeHTTP(rw, req)
 
-	token := req.Header.Get(token.TokenHeader)
+	token := req.Header.Get(revactx.TokenHeader)
 	assert.NotEmpty(t, token)
 
 	assert.Contains(t, token, "eyJ")
@@ -73,7 +73,7 @@ func TestUnauthorizedOnUserNotFound(t *testing.T) {
 
 	sut.ServeHTTP(rw, req)
 
-	token := req.Header.Get(token.TokenHeader)
+	token := req.Header.Get(revactx.TokenHeader)
 	assert.Empty(t, token)
 	assert.Equal(t, http.StatusUnauthorized, rw.Code)
 }
@@ -87,7 +87,7 @@ func TestUnauthorizedOnUserDisabled(t *testing.T) {
 
 	sut.ServeHTTP(rw, req)
 
-	token := req.Header.Get(token.TokenHeader)
+	token := req.Header.Get(revactx.TokenHeader)
 	assert.Empty(t, token)
 	assert.Equal(t, http.StatusUnauthorized, rw.Code)
 }
@@ -100,7 +100,7 @@ func TestInternalServerErrorOnMissingMailAndUsername(t *testing.T) {
 
 	sut.ServeHTTP(rw, req)
 
-	token := req.Header.Get(token.TokenHeader)
+	token := req.Header.Get(revactx.TokenHeader)
 	assert.Empty(t, token)
 	assert.Equal(t, http.StatusInternalServerError, rw.Code)
 }

--- a/proxy/pkg/middleware/create_home.go
+++ b/proxy/pkg/middleware/create_home.go
@@ -6,8 +6,9 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	tokenPkg "github.com/cs3org/reva/pkg/token"
+	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"google.golang.org/grpc/metadata"
@@ -38,7 +39,7 @@ func CreateHome(optionSetters ...Option) func(next http.Handler) http.Handler {
 type createHome struct {
 	next              http.Handler
 	logger            log.Logger
-	tokenManager      tokenPkg.Manager
+	tokenManager      token.Manager
 	revaGatewayClient gateway.GatewayAPIClient
 }
 
@@ -52,7 +53,7 @@ func (m createHome) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// we need to pass the token to authenticate the CreateHome request.
 	//ctx := tokenpkg.ContextSetToken(r.Context(), token)
-	ctx := metadata.AppendToOutgoingContext(req.Context(), tokenPkg.TokenHeader, token)
+	ctx := metadata.AppendToOutgoingContext(req.Context(), revactx.TokenHeader, token)
 
 	createHomeReq := &provider.CreateHomeRequest{}
 	createHomeRes, err := m.revaGatewayClient.CreateHome(ctx, createHomeReq)

--- a/proxy/pkg/middleware/signed_url_auth.go
+++ b/proxy/pkg/middleware/signed_url_auth.go
@@ -6,15 +6,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	revauser "github.com/cs3org/reva/pkg/user"
-	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/proxy/pkg/config"
+	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 	store "github.com/owncloud/ocis/store/pkg/proto/v0"
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -54,7 +54,7 @@ func (m signedURLAuth) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 
-	ctx := revauser.ContextSetUser(req.Context(), user)
+	ctx := revactx.ContextSetUser(req.Context(), user)
 
 	req = req.WithContext(ctx)
 
@@ -164,7 +164,7 @@ func (m signedURLAuth) urlIsExpired(query url.Values, now func() time.Time) (exp
 }
 
 func (m signedURLAuth) signatureIsValid(req *http.Request) (ok bool, err error) {
-	u := revauser.ContextMustGetUser(req.Context())
+	u := revactx.ContextMustGetUser(req.Context())
 	signingKey, err := m.getSigningKey(req.Context(), u.Id.OpaqueId)
 	if err != nil {
 		m.logger.Error().Err(err).Msg("could not retrieve signing key")

--- a/proxy/pkg/proxy/policy/selector.go
+++ b/proxy/pkg/proxy/policy/selector.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
-	revauser "github.com/cs3org/reva/pkg/user"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocis-pkg/oidc"
 	"github.com/owncloud/ocis/proxy/pkg/config"
@@ -220,7 +220,7 @@ func NewRegexSelector(cfg *config.RegexSelectorConf) Selector {
 		}
 
 		// if no cookie is present, try to route by selector
-		if u, ok := revauser.ContextGetUser(r.Context()); ok {
+		if u, ok := revactx.ContextGetUser(r.Context()); ok {
 			for i := range regexRules {
 				switch regexRules[i].property {
 				case "mail":

--- a/proxy/pkg/proxy/policy/selector_test.go
+++ b/proxy/pkg/proxy/policy/selector_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/asim/go-micro/v3/client"
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	revauser "github.com/cs3org/reva/pkg/user"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocis-pkg/oidc"
 	"github.com/owncloud/ocis/proxy/pkg/config"
@@ -173,15 +173,15 @@ func TestRegexSelector(t *testing.T) {
 
 	var tests = []testCase{
 		{"unauthenticated", context.Background(), "unauthenticated"},
-		{"default", revauser.ContextSetUser(context.Background(), &userv1beta1.User{}), "default"},
-		{"mail-ocis", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Mail: "marie@example.org"}), "ocis"},
-		{"mail-oc10", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Mail: "einstein@example.org"}), "oc10"},
-		{"username-einstein", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Username: "einstein"}), "ocis"},
-		{"username-feynman", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Username: "feynman"}), "ocis"},
-		{"username-marie", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Username: "marie"}), "oc10"},
-		{"id-nil", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{}}), "default"},
-		{"id-1", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51"}}), "ocis"},
-		{"id-2", revauser.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"}}), "oc10"},
+		{"default", revactx.ContextSetUser(context.Background(), &userv1beta1.User{}), "default"},
+		{"mail-ocis", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Mail: "marie@example.org"}), "ocis"},
+		{"mail-oc10", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Mail: "einstein@example.org"}), "oc10"},
+		{"username-einstein", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Username: "einstein"}), "ocis"},
+		{"username-feynman", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Username: "feynman"}), "ocis"},
+		{"username-marie", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Username: "marie"}), "oc10"},
+		{"id-nil", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{}}), "default"},
+		{"id-1", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51"}}), "ocis"},
+		{"id-2", revactx.ContextSetUser(context.Background(), &userv1beta1.User{Id: &userv1beta1.UserId{OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"}}), "oc10"},
 	}
 
 	for _, tc := range tests {

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -289,6 +289,10 @@ func defaultPolicies() []config.Policy {
 					Backend:  "http://localhost:9140",
 				},
 				{
+					Endpoint: "/ocs/v[12].php/cloud/users/signing-key",
+					Backend:  "http://localhost:9110",
+				},
+				{
 					Type:     config.QueryRoute,
 					Endpoint: "/remote.php/?preview=1",
 					Backend:  "http://localhost:9115",

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -5,9 +5,6 @@ Basic file management like up and download, move, copy, properties, trash, versi
 
 #### [Version count is 1 more than on oC10](https://github.com/owncloud/ocis/issues/1633)
 
-#### [Implement Versions Feature for ocis storage](https://github.com/owncloud/product/issues/210)
--   [apiWebdavEtagPropagation2/restoreVersion.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreVersion.feature#L10)
-
 #### [PUT request with missing parent must return status code 409](https://github.com/owncloud/ocis/issues/824)
 
 #### [invalid file-names should not be created using the TUS protocol](https://github.com/owncloud/ocis/issues/1001)

--- a/thumbnails/pkg/service/v0/service.go
+++ b/thumbnails/pkg/service/v0/service.go
@@ -11,7 +11,7 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	"github.com/cs3org/reva/pkg/token"
+	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/thumbnails/pkg/preprocessor"
 	v0proto "github.com/owncloud/ocis/thumbnails/pkg/proto/v0"
@@ -201,7 +201,7 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *v0proto.GetThumb
 }
 
 func (g Thumbnail) stat(path, auth string) (*provider.StatResponse, error) {
-	ctx := metadata.AppendToOutgoingContext(context.Background(), token.TokenHeader, auth)
+	ctx := metadata.AppendToOutgoingContext(context.Background(), revactx.TokenHeader, auth)
 
 	req := &provider.StatRequest{
 		Ref: &provider.Reference{


### PR DESCRIPTION
Update REVA from v1.11.1-0.20210809134415-3fe79c870fb5 to v1.11.1-0.20210812105259-756bdced1d22
* Enh cs3org/reva#1803: /dav/spaces endpoint
* Fix cs3org/reva#1987: fix windows build
* Fix cs3org/reva#1985: Quota stubs
* Cha cs3org/reva#1982: Move user context methods into separate package
* Fix cs3org/reva#1980: propagate after restoring a file version

The change moves Token and User related Context functions and headers to the new `github.com/cs3org/reva/pkg/ctx` package.