### PR TITLE
Fix naming of the user- and groupprovider services

### DIFF
--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -103,8 +103,8 @@ func NewService(options ...Option) (*Service, error) {
 	s.ServicesRegistry["webdav"] = webdav.NewSutureService
 	s.ServicesRegistry["storage-frontend"] = storage.NewFrontend
 	s.ServicesRegistry["storage-gateway"] = storage.NewGateway
-	s.ServicesRegistry["storage-users-provider"] = storage.NewUsersProviderService
-	s.ServicesRegistry["storage-groupsprovider"] = storage.NewGroupsProvider
+	s.ServicesRegistry["storage-userprovider"] = storage.NewUserProvider
+	s.ServicesRegistry["storage-groupprovider"] = storage.NewGroupProvider
 	s.ServicesRegistry["storage-authbasic"] = storage.NewAuthBasic
 	s.ServicesRegistry["storage-authbearer"] = storage.NewAuthBearer
 	s.ServicesRegistry["storage-home"] = storage.NewStorageHome

--- a/storage/pkg/command/groups.go
+++ b/storage/pkg/command/groups.go
@@ -156,22 +156,22 @@ func groupsConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]inter
 	}
 }
 
-// GroupsProvider allows for the storage-groupsprovider command to be embedded and supervised by a suture supervisor tree.
-type GroupsProvider struct {
+// GroupProvider allows for the storage-groupprovider command to be embedded and supervised by a suture supervisor tree.
+type GroupProvider struct {
 	cfg *config.Config
 }
 
-// NewGroupsProvider creates a new storage.GroupsProvider
-func NewGroupsProvider(cfg *ociscfg.Config) suture.Service {
+// NewGroupProvider creates a new storage.GroupProvider
+func NewGroupProvider(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Storage.Reva.Groups.Supervised = true
 	}
-	return GroupsProvider{
+	return GroupProvider{
 		cfg: cfg.Storage,
 	}
 }
 
-func (s GroupsProvider) Serve(ctx context.Context) error {
+func (s GroupProvider) Serve(ctx context.Context) error {
 	s.cfg.Reva.Groups.Context = ctx
 	f := &flag.FlagSet{}
 	for k := range Groups(s.cfg).Flags {

--- a/storage/pkg/command/users.go
+++ b/storage/pkg/command/users.go
@@ -159,22 +159,22 @@ func usersConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]interf
 	return rcfg
 }
 
-// UsersProviderService allows for the storage-userprovider command to be embedded and supervised by a suture supervisor tree.
-type UsersProviderService struct {
+// UserProvider allows for the storage-userprovider command to be embedded and supervised by a suture supervisor tree.
+type UserProvider struct {
 	cfg *config.Config
 }
 
-// NewUsersProviderService creates a new storage.UsersProviderService
-func NewUsersProviderService(cfg *ociscfg.Config) suture.Service {
+// NewUserProvider creates a new storage.UserProvider
+func NewUserProvider(cfg *ociscfg.Config) suture.Service {
 	if cfg.Mode == 0 {
 		cfg.Storage.Reva.Users.Supervised = true
 	}
-	return UsersProviderService{
+	return UserProvider{
 		cfg: cfg.Storage,
 	}
 }
 
-func (s UsersProviderService) Serve(ctx context.Context) error {
+func (s UserProvider) Serve(ctx context.Context) error {
 	s.cfg.Reva.Users.Context = ctx
 	f := &flag.FlagSet{}
 	for k := range Users(s.cfg).Flags {


### PR DESCRIPTION
The services ared called "storage-userprovider" and "-groupprovider".
The 'ocis help' output was missleading. This also renames the structs
accordingly.
