### PR TITLE
[docs-only] fix the directory path for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/ocis"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 2
 
   - package-ecosystem: "npm"


### PR DESCRIPTION
The repository now only holds one go.mod file at the root of the repository. Changed the path in the dependabot config to the repo root.