### PR TITLE
update reva to v1.12

### DIFF
--- a/changelog/unreleased/update-reva.md
+++ b/changelog/unreleased/update-reva.md
@@ -1,0 +1,22 @@
+Enhancement: Update reva to v1.12
+
+* Enhancement cs3org/reva#1803: Introduce new webdav spaces endpoint
+* Bugfix cs3org/reva#1819: Disable notifications
+* Enhancement cs3org/reva#1861: Add support for runtime plugins
+* Bugfix cs3org/reva#1913: Logic to restore files to readonly nodes
+* Enhancement cs3org/reva#1946: Add share manager that connects to oc10 databases
+* Bugfix cs3org/reva#1954: Fix response format of the sharees API
+* Bugfix cs3org/reva#1956: Fix trashbin listing with depth 0
+* Bugfix cs3org/reva#1957: Fix etag propagation on deletes
+* Bugfix cs3org/reva#1960: Return the updated share after updating
+* Bugfix cs3org/reva#1965 cs3org/reva#1967: Fix the file target of user and group shares
+* Bugfix cs3org/reva#1980: Propagate the etag after restoring a file version
+* Enhancement cs3org/reva#1984: Replace OpenCensus with OpenTelemetry
+* Bugfix cs3org/reva#1985: Add quota stubs
+* Bugfix cs3org/reva#1987: Fix windows build
+* Bugfix cs3org/reva#1990: Increase oc10 compatibility of owncloudsql
+* Bugfix cs3org/reva#1992: Check if symlink exists instead of spamming the console
+* Bugfix cs3org/reva#1993: fix owncloudsql GetMD
+
+
+https://github.com/owncloud/ocis/pull/2423

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.1.0
 	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/cs3org/go-cs3apis v0.0.0-20210802070913-970eec344e59
-	github.com/cs3org/reva v1.11.1-0.20210817090727-aaf1fb8b8ead
+	github.com/cs3org/reva v1.12.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/glauth/glauth v1.1.3-0.20210729125545-b9aecdfcac31
 	github.com/go-chi/chi v4.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -292,8 +292,8 @@ github.com/crewjam/saml v0.4.5/go.mod h1:qCJQpUtZte9R1ZjUBcW8qtCNlinbO363ooNl02S
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20210802070913-970eec344e59 h1:cj9HxIbmbGn+HPpFP8nZ8oaNUsoFa0+cheCO8FUNoMc=
 github.com/cs3org/go-cs3apis v0.0.0-20210802070913-970eec344e59/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva v1.11.1-0.20210817090727-aaf1fb8b8ead h1:PxM0x/X/0roxieoKoKIYAfF1uNeX2vHiOJXCv18/lgc=
-github.com/cs3org/reva v1.11.1-0.20210817090727-aaf1fb8b8ead/go.mod h1:Fx2PHTX2Y3s/aNG/APpCbmttg5STWnxjD4DpnqdwjQc=
+github.com/cs3org/reva v1.12.0 h1:31Z+9+rLXUHRP3K6U3LK2wWLJUuicFjeFc2iZGg7rWE=
+github.com/cs3org/reva v1.12.0/go.mod h1:Fx2PHTX2Y3s/aNG/APpCbmttg5STWnxjD4DpnqdwjQc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -595,12 +595,6 @@ cannot share a folder with create permission
 -   [apiTrashbin/trashbinSharingToShares.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L63)
 -   [apiTrashbin/trashbinSharingToShares.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L64)
 
-#### [Restoring a file to read-only received folder returns incorrect status code](https://github.com/owncloud/ocis/issues/2143)
--   [apiTrashbin/trashbinSharingToShares.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L82)
--   [apiTrashbin/trashbinSharingToShares.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L83)
--   [apiTrashbin/trashbinSharingToShares.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L102)
--   [apiTrashbin/trashbinSharingToShares.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L103)
-
 #### [changing user quota gives ocs status 103 / cannot set user quota using the ocs endpoint](https://github.com/owncloud/product/issues/247)
 _getting and setting quota_
 -   [apiMain/quota.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L10)


### PR DESCRIPTION
Updating reva for the upcoming release.
This is just a preparation, later today when reva has been tagged I'll update to the tagged version.

- [x] Change reva version to 1.12