### PR TITLE
add set space quota permission

### DIFF
--- a/changelog/unreleased/set-quota-permission.md
+++ b/changelog/unreleased/set-quota-permission.md
@@ -1,0 +1,5 @@
+Enhancement: add set space quota permission
+
+In preparation for the upcoming spaces features a `SetSpaceQuota` permission was added.
+
+https://github.com/owncloud/ocis/pull/2459

--- a/settings/pkg/service/v0/settings.go
+++ b/settings/pkg/service/v0/settings.go
@@ -24,6 +24,11 @@ const (
 	// SettingsManagementPermissionName is the hardcoded setting name for the settings management permission
 	SettingsManagementPermissionName string = "settings-management"
 
+	// SetSpaceQuotaPermissionID is the hardcoded setting UUID for the set space quota permission
+	SetSpaceQuotaPermissionID string = "4e6f9709-f9e7-44f1-95d4-b762d27b7896"
+	// SetSpaceQuotaPermissionName is the hardcoded setting name for the set space quota permission
+	SetSpaceQuotaPermissionName string = "set-space-quota"
+
 	settingUUIDProfileLanguage = "aa8cfbe5-95d4-4f7e-a032-c3c01f5f062f"
 
 	// AccountManagementPermissionID is the hardcoded setting UUID for the account management permission
@@ -327,6 +332,24 @@ func generatePermissionRequests() []*settings.AddSettingToBundleRequest {
 					PermissionValue: &settings.Permission{
 						Operation:  settings.Permission_OPERATION_READWRITE,
 						Constraint: settings.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+		},
+		{
+			BundleId: BundleUUIDRoleAdmin,
+			Setting: &settings.Setting{
+				Id:          SetSpaceQuotaPermissionID,
+				Name:        SetSpaceQuotaPermissionName,
+				DisplayName: "Set Space Quota",
+				Description: "This permission allows to manage space quotas.",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SYSTEM,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_READWRITE,
+						Constraint: settings.Permission_CONSTRAINT_ALL,
 					},
 				},
 			},


### PR DESCRIPTION
In preparation for the upcoming spaces features a `SetSpaceQuota` permission was added.

I'm not entirely sure about the permission to role assignment. Especially about the ResourceType:
```
BundleId: BundleUUIDRoleAdmin,
  Setting: &settings.Setting{
	Id:          SetSpaceQuotaPermissionID,
	Name:        SetSpaceQuotaPermissionName,
	DisplayName: "Set Space Quota",
	Description: "This permission allows to manage space quotas.",
	Resource: &settings.Resource{
		Type: settings.Resource_TYPE_SYSTEM,
	},
	Value: &settings.Setting_PermissionValue{
		PermissionValue: &settings.Permission{
			Operation:  settings.Permission_OPERATION_READWRITE,
			Constraint: settings.Permission_CONSTRAINT_ALL,
		},
	},
  },
```