### PR TITLE
add developer ssh access to continously deployed instances

### DIFF
--- a/deployments/continuous-deployment-config/cs3_users_ocis/latest.yml
+++ b/deployments/continuous-deployment-config/cs3_users_ocis/latest.yml
@@ -17,6 +17,16 @@
     - "*.ocis-cs3-users.latest.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/cs3_users_ocis/released.yml
+++ b/deployments/continuous-deployment-config/cs3_users_ocis/released.yml
@@ -17,6 +17,16 @@
     - "*.ocis-cs3-users.released.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_hello/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_hello/latest.yml
@@ -17,6 +17,16 @@
     - "*.ocis-s3.latest.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_keycloak/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_keycloak/latest.yml
@@ -17,6 +17,16 @@
     - "*.ocis-keycloak.latest.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_keycloak/released.yml
+++ b/deployments/continuous-deployment-config/ocis_keycloak/released.yml
@@ -17,6 +17,16 @@
     - "*.ocis-keycloak.released.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_s3/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_s3/latest.yml
@@ -17,6 +17,16 @@
     - "*.ocis-hello.latest.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_traefik/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_traefik/latest.yml
@@ -17,6 +17,16 @@
     - "*.ocis-traefik.latest.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_traefik/released.yml
+++ b/deployments/continuous-deployment-config/ocis_traefik/released.yml
@@ -17,6 +17,16 @@
     - "*.ocis-traefik.released.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_wopi/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_wopi/latest.yml
@@ -17,6 +17,16 @@
     - "*.ocis-wopi.latest.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git

--- a/deployments/continuous-deployment-config/ocis_wopi/released.yml
+++ b/deployments/continuous-deployment-config/ocis_wopi/released.yml
@@ -17,6 +17,16 @@
     - "*.ocis-wopi.released.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
This adds developer ssh access to continuously deployed instances, eg:
`ssh admin@ocis.ocis-traefik.latest.owncloud.works`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Possible after https://github.com/owncloud-devops/continuous-deployment/pull/21/files
- same as https://github.com/owncloud/web/pull/5765

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provide SSH access to continuously deployed instances to a wider audience to investigate, debug, ...