### PR TITLE
Set english as default language

### DIFF
--- a/changelog/unreleased/set-english-default-dropdown.md
+++ b/changelog/unreleased/set-english-default-dropdown.md
@@ -1,0 +1,5 @@
+Bugfix: Set English as default language in the dropdown in the settings page
+
+The language dropdown didn't have a default language selected, and it was showing an empty value. Now it shows English instead.
+
+https://github.com/owncloud/ocis/pull/2465

--- a/settings/pkg/service/v0/settings.go
+++ b/settings/pkg/service/v0/settings.go
@@ -128,6 +128,7 @@ var languageSetting = settings.Setting_SingleChoiceValue{
 					},
 				},
 				DisplayValue: "English",
+				Default:      true,
 			},
 			{
 				Value: &settings.ListOptionValue{

--- a/settings/ui/tests/acceptance/features/settings.feature
+++ b/settings/ui/tests/acceptance/features/settings.feature
@@ -13,7 +13,7 @@ Feature: Set user specific settings
 	Scenario: Check the default settings
 		Given user "user1" has logged in using the webUI
 		And the user browses to the settings page
-		Then the setting "Language" should not have any value
+		Then the setting "Language" should have value "English"
 		When the user browses to the files page
 		Then the files menu should be listed in language "English"
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Show English as default language in the settings

## Related Issue
https://github.com/owncloud/ocis/issues/2126

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested in a fresh environment

1. Login with a user
2. Check the settings page

English is selected a language

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
