### PR TITLE
[full-ci][tests-only] Bump commit ids for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,7 +1,7 @@
 # The test runner source for API tests
-CORE_COMMITID=370fd807e464dcc5cb9619a8890107424254dfa6
+CORE_COMMITID=7d3b29708162facd5ba0291cd8a934eca09de6a2
 CORE_BRANCH=master
 
 # The test runner source for UI tests
-WEB_COMMITID=0e5a4b4990fc0edb69013122df42785774883e79
+WEB_COMMITID=e50b5cad7cbb2e13e269896e0ffffd798e5bb656
 WEB_BRANCH=master


### PR DESCRIPTION
## Description
This PR bumps core  and web commit ids to the latest

## Related Issue
- Part of  https://github.com/owncloud/QA/issues/689