### PR TITLE
Allow reva to use safer TLS defaults for LDAP

### DIFF
--- a/changelog/unreleased/reva-ldap-tls.md
+++ b/changelog/unreleased/reva-ldap-tls.md
@@ -1,0 +1,10 @@
+Enhancement: TLS config options for ldap in reva
+
+We added the new config options "ldap-cacert" and "ldap-insecure" to the auth-,
+users- and groups-provider services to be able to do proper TLS configuration
+for the LDAP clients. "ldap-cacert" is by default configured to add the bundled
+glauth LDAP servers certificate to the trusted set for the LDAP clients.
+"ldap-insecure" is set to "false" by default and can be used to disable
+certificate checks (only advisable for development and test enviroments).
+
+https://github.com/owncloud/ocis/pull/2492

--- a/storage/pkg/command/authbasic.go
+++ b/storage/pkg/command/authbasic.go
@@ -114,6 +114,8 @@ func authBasicConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]in
 						"ldap": map[string]interface{}{
 							"hostname":      cfg.Reva.LDAP.Hostname,
 							"port":          cfg.Reva.LDAP.Port,
+							"cacert":        cfg.Reva.LDAP.CACert,
+							"insecure":      cfg.Reva.LDAP.Insecure,
 							"base_dn":       cfg.Reva.LDAP.BaseDN,
 							"loginfilter":   cfg.Reva.LDAP.LoginFilter,
 							"bind_username": cfg.Reva.LDAP.BindDN,

--- a/storage/pkg/command/groups.go
+++ b/storage/pkg/command/groups.go
@@ -118,6 +118,8 @@ func groupsConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]inter
 						"ldap": map[string]interface{}{
 							"hostname":        cfg.Reva.LDAP.Hostname,
 							"port":            cfg.Reva.LDAP.Port,
+							"cacert":          cfg.Reva.LDAP.CACert,
+							"insecure":        cfg.Reva.LDAP.Insecure,
 							"base_dn":         cfg.Reva.LDAP.BaseDN,
 							"groupfilter":     cfg.Reva.LDAP.GroupFilter,
 							"attributefilter": cfg.Reva.LDAP.GroupAttributeFilter,

--- a/storage/pkg/command/users.go
+++ b/storage/pkg/command/users.go
@@ -121,6 +121,8 @@ func usersConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]interf
 						"ldap": map[string]interface{}{
 							"hostname":        cfg.Reva.LDAP.Hostname,
 							"port":            cfg.Reva.LDAP.Port,
+							"cacert":          cfg.Reva.LDAP.CACert,
+							"insecure":        cfg.Reva.LDAP.Insecure,
 							"base_dn":         cfg.Reva.LDAP.BaseDN,
 							"userfilter":      cfg.Reva.LDAP.UserFilter,
 							"attributefilter": cfg.Reva.LDAP.UserAttributeFilter,

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -332,6 +332,8 @@ type OIDC struct {
 type LDAP struct {
 	Hostname             string
 	Port                 int
+	CACert               string
+	Insecure             bool
 	BaseDN               string
 	LoginFilter          string
 	UserFilter           string

--- a/storage/pkg/flagset/ldap.go
+++ b/storage/pkg/flagset/ldap.go
@@ -1,8 +1,11 @@
 package flagset
 
 import (
+	"path"
+
 	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
+	pkgos "github.com/owncloud/ocis/ocis-pkg/os"
 	"github.com/owncloud/ocis/storage/pkg/config"
 )
 
@@ -22,6 +25,20 @@ func LDAPWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:       "LDAP port",
 			EnvVars:     []string{"STORAGE_LDAP_PORT"},
 			Destination: &cfg.Reva.LDAP.Port,
+		},
+		&cli.StringFlag{
+			Name:        "ldap-cacert",
+			Value:       flags.OverrideDefaultString(cfg.Reva.LDAP.CACert, path.Join(pkgos.MustUserConfigDir("ocis", "ldap"), "ldap.crt")),
+			Usage:       "Path to a trusted Certificate file (in PEM format) for the LDAP Connection",
+			EnvVars:     []string{"STORAGE_LDAP_CACERT"},
+			Destination: &cfg.Reva.LDAP.CACert,
+		},
+		&cli.BoolFlag{
+			Name:        "ldap-insecure",
+			Value:       flags.OverrideDefaultBool(cfg.Reva.LDAP.Insecure, false),
+			Usage:       "Disable TLS certificate and hostname validation",
+			EnvVars:     []string{"STORAGE_LDAP_INSECURE"},
+			Destination: &cfg.Reva.LDAP.Insecure,
 		},
 		&cli.StringFlag{
 			Name:        "ldap-base-dn",


### PR DESCRIPTION
Reva is moving away from the hardcoded "insecure" setting for LDAP (see https://github.com/cs3org/reva/pull/2053)
connections. For this to happend ocis needs some adjustments. In order to avoid an "insecure" by default config in ocis this commit adds the new parameters "insecure" and "cacert" to the LDAP configuration for the auth-, user- and groups-provider. To make the out of the box experience as smooth as possible the default setting for "cacert" points to the certificate that is generated for glauth on startup.

To avoid any hickup with the CI this should ideally be merged together with (or before) the changes from https://github.com/cs3org/reva/pull/2053 reach this repo.
