### PR TITLE
redirect to root when file not found

### DIFF
--- a/changelog/unreleased/redirect-invalid-links-to-oC-web.md
+++ b/changelog/unreleased/redirect-invalid-links-to-oC-web.md
@@ -1,0 +1,5 @@
+Enhancement: redirect invalid links to oC Web
+
+Invalid links (eg. https://foo.bar/index.php/apps/pdfviewer) will be redirect to ownCloud Web instead of displaying a blank page with a "not found" message.
+
+https://github.com/owncloud/ocis/pull/2493


### PR DESCRIPTION
## Description
Web owns the "/" route in oCIS proxy which will match everything not matching any other more specific route. All these requests will end in the static file serve block which just returns a 404 not found. Ideally we would display a dedicated not found page which is should be included in the static files. Until we have a site like this we can redirect requests to the root, from which oC Web is served. This helps people having non valid links (eg. oC 10 links like https://foo.bar/index.php/apps/pdfviewer...) to not beeing stuck to a blank page saying "not found".

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Redirect should be replaced with a proper not found page when available -> https://github.com/owncloud/web/issues/5804
 
## Motivation and Context
Bookmarked links from eg. ownCloud 10 which are no longer supported after an migration will lead to ownCloud web instead displaying a blank page (with the text "not found").

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
