### PR TITLE
tests: Run ocis container as root for testsuite

### DIFF
--- a/tests/acceptance/docker/src/ocis-image.yml
+++ b/tests/acceptance/docker/src/ocis-image.yml
@@ -1,3 +1,4 @@
 services:
   ocis-server:
     image: owncloud/ocis:$OCIS_IMAGE_TAG
+    user: root


### PR DESCRIPTION
For running the acceptance tests in docker we setup a volume that is
shared between the ocis and oc10/testsuite container. Since ocis needs
to be able to write to that volume we're switching it to run as root.

Closes #2497

I am not really happy with this solution. It would be nicer to find a way to setup the permission of the volume so that the default user of the ocis container could actually write there. But I didn't really find a good way for that.
