### PR TITLE
switch from micro/cli/v2 to urfave/cli/v2

### DIFF
--- a/accounts/pkg/command/add_account.go
+++ b/accounts/pkg/command/add_account.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
+	"github.com/urfave/cli/v2"
 )
 
 // AddAccount command creates a new account

--- a/accounts/pkg/command/inspect_account.go
+++ b/accounts/pkg/command/inspect_account.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
+	"github.com/urfave/cli/v2"
 )
 
 // InspectAccount command shows detailed information about a specific account.

--- a/accounts/pkg/command/list_accounts.go
+++ b/accounts/pkg/command/list_accounts.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
+	"github.com/urfave/cli/v2"
 )
 
 // ListAccounts command lists all accounts

--- a/accounts/pkg/command/rebuild_index.go
+++ b/accounts/pkg/command/rebuild_index.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
 	merrors "github.com/asim/go-micro/v3/errors"
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	index "github.com/owncloud/ocis/accounts/pkg/proto/v0"
+	"github.com/urfave/cli/v2"
 )
 
 // RebuildIndex rebuilds the entire configured index.

--- a/accounts/pkg/command/remove_account.go
+++ b/accounts/pkg/command/remove_account.go
@@ -5,10 +5,10 @@ import (
 	"os"
 
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
+	"github.com/urfave/cli/v2"
 )
 
 // RemoveAccount command deletes an existing account.

--- a/accounts/pkg/command/root.go
+++ b/accounts/pkg/command/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
 	"github.com/owncloud/ocis/accounts/pkg/version"
@@ -14,6 +13,7 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/accounts/pkg/command/server.go
+++ b/accounts/pkg/command/server.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
@@ -15,6 +14,7 @@ import (
 	"github.com/owncloud/ocis/accounts/pkg/server/http"
 	svc "github.com/owncloud/ocis/accounts/pkg/service/v0"
 	"github.com/owncloud/ocis/accounts/pkg/tracing"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entry point for the server command.

--- a/accounts/pkg/command/update_account.go
+++ b/accounts/pkg/command/update_account.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/asim/go-micro/plugins/client/grpc/v3"
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
+	"github.com/urfave/cli/v2"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 

--- a/accounts/pkg/command/version.go
+++ b/accounts/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/accounts/pkg/flagset/flagset.go
+++ b/accounts/pkg/flagset/flagset.go
@@ -1,10 +1,10 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/accounts/pkg/server/grpc/option.go
+++ b/accounts/pkg/server/grpc/option.go
@@ -3,11 +3,11 @@ package grpc
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/metrics"
 	svc "github.com/owncloud/ocis/accounts/pkg/service/v0"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/accounts/pkg/server/http/option.go
+++ b/accounts/pkg/server/http/option.go
@@ -3,11 +3,11 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/metrics"
 	svc "github.com/owncloud/ocis/accounts/pkg/service/v0"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/glauth/pkg/command/health.go
+++ b/glauth/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/glauth/pkg/config"
 	"github.com/owncloud/ocis/glauth/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/glauth/pkg/command/root.go
+++ b/glauth/pkg/command/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/glauth/pkg/config"
 	"github.com/owncloud/ocis/glauth/pkg/flagset"
 	"github.com/owncloud/ocis/glauth/pkg/version"
@@ -14,6 +13,7 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-glauth command.

--- a/glauth/pkg/command/server.go
+++ b/glauth/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	glauthcfg "github.com/glauth/glauth/pkg/config"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/glauth/pkg/config"
@@ -17,6 +16,7 @@ import (
 	pkgcrypto "github.com/owncloud/ocis/ocis-pkg/crypto"
 	"github.com/owncloud/ocis/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/glauth/pkg/flagset/flagset.go
+++ b/glauth/pkg/flagset/flagset.go
@@ -3,10 +3,10 @@ package flagset
 import (
 	"path"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/glauth/pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	pkgos "github.com/owncloud/ocis/ocis-pkg/os"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/asim/go-micro/plugins/wrapper/breaker/gobreaker/v3 v3.0.0-20210812172626-c7195aae9817
 	github.com/asim/go-micro/plugins/wrapper/monitoring/prometheus/v3 v3.0.0-20210812172626-c7195aae9817
 	github.com/asim/go-micro/plugins/wrapper/trace/opencensus/v3 v3.0.0-20210812172626-c7195aae9817
-	github.com/asim/go-micro/v3 v3.6.0
+	github.com/asim/go-micro/v3 v3.6.1-0.20210924081004-8c39b1e1204d
 	github.com/blevesearch/bleve/v2 v2.1.0
 	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/cs3org/go-cs3apis v0.0.0-20210922150613-cb9e3c99f8de
@@ -38,7 +38,6 @@ require (
 	github.com/justinas/alice v1.2.0
 	github.com/libregraph/lico v0.34.1-0.20210803054646-b584e0372224
 	github.com/mennanov/fieldmask-utils v0.4.0
-	github.com/micro/cli/v2 v2.1.2
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484
 	github.com/nmcclain/ldap v0.0.0-20210720162743-7f8d1e44eeba
@@ -55,6 +54,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/thejerf/suture/v4 v4.0.1
+	github.com/urfave/cli/v2 v2.3.0
 	github.com/yaegashi/msgraph.go v0.1.4
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/asim/go-micro/plugins/wrapper/trace/opencensus/v3 v3.0.0-202108121726
 github.com/asim/go-micro/v3 v3.5.1/go.mod h1:OJ5DnUQmoEVQTNbKRstR7/krtYJI+QaBe/XeN5MZkqE=
 github.com/asim/go-micro/v3 v3.5.2-0.20210629124054-4929a7c16ecc/go.mod h1:cNGIIYQcp0qy+taNYmrBdaIHeqMWHV5ZH/FfQzfOyE8=
 github.com/asim/go-micro/v3 v3.5.2-0.20210630062103-c13bb07171bc/go.mod h1:cNGIIYQcp0qy+taNYmrBdaIHeqMWHV5ZH/FfQzfOyE8=
-github.com/asim/go-micro/v3 v3.6.0 h1:I6UVJBpBtWNKCjWf0dRpZznRCW9TR4DXjV4wieyGhK0=
-github.com/asim/go-micro/v3 v3.6.0/go.mod h1:cNGIIYQcp0qy+taNYmrBdaIHeqMWHV5ZH/FfQzfOyE8=
+github.com/asim/go-micro/v3 v3.6.1-0.20210924081004-8c39b1e1204d h1:EAmpwVkQtiT3yD286sYUs6VqZglabLq/DqfowID83F4=
+github.com/asim/go-micro/v3 v3.6.1-0.20210924081004-8c39b1e1204d/go.mod h1:Vr4N4czAznfz3gPqKUznocbo5l0knZRIpzh5+0Hml7I=
 github.com/aws/aws-sdk-go v1.20.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
@@ -768,7 +768,6 @@ github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103 h1:Z/i1e+gTZrmcGeZy
 github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103/go.mod h1:o9YPB5aGP8ob35Vy6+vyq3P3bWe7NQWzf+JLiXCiMaE=
 github.com/mennanov/fieldmask-utils v0.4.0 h1:MvXJgV4em1j0u2Aw2Wwd/ES8alZE9vN5FSB1SYiJ6vM=
 github.com/mennanov/fieldmask-utils v0.4.0/go.mod h1:lah2lHczE2ff+7SqnNKpB+YzaO7M3h5iNO4LgPTJheM=
-github.com/micro/cli/v2 v2.1.2 h1:43J1lChg/rZCC1rvdqZNFSQDrGT7qfMrtp6/ztpIkEM=
 github.com/micro/cli/v2 v2.1.2/go.mod h1:EguNh6DAoWKm9nmk+k/Rg0H3lQnDxqzu5x5srOtGtYg=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -1103,7 +1102,9 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=

--- a/graph-explorer/pkg/command/health.go
+++ b/graph-explorer/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/graph-explorer/pkg/config"
 	"github.com/owncloud/ocis/graph-explorer/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/graph-explorer/pkg/command/root.go
+++ b/graph-explorer/pkg/command/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/graph-explorer/pkg/config"
 	"github.com/owncloud/ocis/graph-explorer/pkg/flagset"
 	"github.com/owncloud/ocis/graph-explorer/pkg/version"
@@ -14,6 +13,7 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the graph-explorer command.

--- a/graph-explorer/pkg/command/server.go
+++ b/graph-explorer/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/graph-explorer/pkg/config"
 	"github.com/owncloud/ocis/graph-explorer/pkg/flagset"
@@ -13,6 +12,7 @@ import (
 	"github.com/owncloud/ocis/graph-explorer/pkg/server/http"
 	"github.com/owncloud/ocis/graph-explorer/pkg/tracing"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/graph-explorer/pkg/flagset/flagset.go
+++ b/graph-explorer/pkg/flagset/flagset.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/graph-explorer/pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/graph-explorer/pkg/server/http/option.go
+++ b/graph-explorer/pkg/server/http/option.go
@@ -3,10 +3,10 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
-	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/graph-explorer/pkg/config"
 	"github.com/owncloud/ocis/graph-explorer/pkg/metrics"
+	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/graph/pkg/command/health.go
+++ b/graph/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/graph/pkg/config"
 	"github.com/owncloud/ocis/graph/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/graph/pkg/command/root.go
+++ b/graph/pkg/command/root.go
@@ -8,13 +8,13 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/thejerf/suture/v4"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/graph/pkg/config"
 	"github.com/owncloud/ocis/graph/pkg/flagset"
 	"github.com/owncloud/ocis/graph/pkg/version"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/spf13/viper"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-graph command.

--- a/graph/pkg/command/server.go
+++ b/graph/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/graph/pkg/config"
 	"github.com/owncloud/ocis/graph/pkg/flagset"
@@ -13,6 +12,7 @@ import (
 	"github.com/owncloud/ocis/graph/pkg/server/http"
 	"github.com/owncloud/ocis/graph/pkg/tracing"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/graph/pkg/flagset/flagset.go
+++ b/graph/pkg/flagset/flagset.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/graph/pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/graph/pkg/server/http/option.go
+++ b/graph/pkg/server/http/option.go
@@ -3,10 +3,10 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/graph/pkg/config"
 	"github.com/owncloud/ocis/graph/pkg/metrics"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/idp/pkg/command/health.go
+++ b/idp/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/idp/pkg/config"
 	"github.com/owncloud/ocis/idp/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/idp/pkg/command/root.go
+++ b/idp/pkg/command/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/idp/pkg/config"
 	"github.com/owncloud/ocis/idp/pkg/flagset"
 	"github.com/owncloud/ocis/idp/pkg/version"
@@ -14,6 +13,7 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-idp command.

--- a/idp/pkg/command/server.go
+++ b/idp/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/idp/pkg/config"
 	"github.com/owncloud/ocis/idp/pkg/flagset"
@@ -13,6 +12,7 @@ import (
 	"github.com/owncloud/ocis/idp/pkg/server/http"
 	"github.com/owncloud/ocis/idp/pkg/tracing"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/idp/pkg/command/version.go
+++ b/idp/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/idp/pkg/config"
 	"github.com/owncloud/ocis/idp/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/idp/pkg/flagset/flagset.go
+++ b/idp/pkg/flagset/flagset.go
@@ -3,10 +3,10 @@ package flagset
 import (
 	"path"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/idp/pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	pkgos "github.com/owncloud/ocis/ocis-pkg/os"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/idp/pkg/server/http/option.go
+++ b/idp/pkg/server/http/option.go
@@ -3,10 +3,10 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/idp/pkg/config"
 	"github.com/owncloud/ocis/idp/pkg/metrics"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/ocis-pkg/indexer/test/test.go
+++ b/ocis-pkg/indexer/test/test.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	mcfg "github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 func init() {

--- a/ocis-pkg/service/grpc/option.go
+++ b/ocis-pkg/service/grpc/option.go
@@ -3,8 +3,8 @@ package grpc
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/ocis-pkg/service/http/option.go
+++ b/ocis-pkg/service/http/option.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/ocis/pkg/command/accounts.go
+++ b/ocis/pkg/command/accounts.go
@@ -1,15 +1,16 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/accounts/pkg/command"
 	svcconfig "github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/flagset"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
+	"github.com/urfave/cli/v2"
 )
 
 // AccountsCommand is the entrypoint for the accounts command.

--- a/ocis/pkg/command/common.go
+++ b/ocis/pkg/command/common.go
@@ -1,6 +1,6 @@
 package command
 
-import "github.com/micro/cli/v2"
+import "github.com/urfave/cli/v2"
 
 func handleOriginalAction(c *cli.Context, cmd *cli.Command) error {
 

--- a/ocis/pkg/command/glauth.go
+++ b/ocis/pkg/command/glauth.go
@@ -1,13 +1,13 @@
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/glauth/pkg/command"
 	svcconfig "github.com/owncloud/ocis/glauth/pkg/config"
 	"github.com/owncloud/ocis/glauth/pkg/flagset"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
+	"github.com/urfave/cli/v2"
 )
 
 // GLAuthCommand is the entrypoint for the glauth command.

--- a/ocis/pkg/command/health.go
+++ b/ocis/pkg/command/health.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/flagset"
 	"github.com/owncloud/ocis/ocis/pkg/register"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/ocis/pkg/command/idp.go
+++ b/ocis/pkg/command/idp.go
@@ -1,13 +1,13 @@
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/idp/pkg/command"
 	svcconfig "github.com/owncloud/ocis/idp/pkg/config"
 	"github.com/owncloud/ocis/idp/pkg/flagset"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
+	"github.com/urfave/cli/v2"
 )
 
 // IDPCommand is the entrypoint for the idp command.

--- a/ocis/pkg/command/kill.go
+++ b/ocis/pkg/command/kill.go
@@ -7,9 +7,9 @@ import (
 	"net/rpc"
 	"os"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
+	"github.com/urfave/cli/v2"
 )
 
 // KillCommand is the entrypoint for the kill command.

--- a/ocis/pkg/command/list.go
+++ b/ocis/pkg/command/list.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"net/rpc"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
+	"github.com/urfave/cli/v2"
 )
 
 // ListCommand is the entrypoint for the list command.

--- a/ocis/pkg/command/ocs.go
+++ b/ocis/pkg/command/ocs.go
@@ -1,15 +1,16 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/ocs/pkg/command"
 	svcconfig "github.com/owncloud/ocis/ocs/pkg/config"
 	"github.com/owncloud/ocis/ocs/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // OCSCommand is the entrypoint for the ocs command.

--- a/ocis/pkg/command/proxy.go
+++ b/ocis/pkg/command/proxy.go
@@ -1,15 +1,16 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/proxy/pkg/command"
 	svcconfig "github.com/owncloud/ocis/proxy/pkg/config"
 	"github.com/owncloud/ocis/proxy/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // ProxyCommand is the entry point for the proxy command.

--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/flagset"

--- a/ocis/pkg/command/run.go
+++ b/ocis/pkg/command/run.go
@@ -7,7 +7,7 @@ import (
 	"net/rpc"
 	"os"
 
-	cli "github.com/micro/cli/v2"
+	cli "github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"

--- a/ocis/pkg/command/server.go
+++ b/ocis/pkg/command/server.go
@@ -1,3 +1,4 @@
+//go:build !simple
 // +build !simple
 
 package command
@@ -5,11 +6,11 @@ package command
 import (
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/flagset"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/runtime"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/ocis/pkg/command/settings.go
+++ b/ocis/pkg/command/settings.go
@@ -1,15 +1,16 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/settings/pkg/command"
 	svcconfig "github.com/owncloud/ocis/settings/pkg/config"
 	"github.com/owncloud/ocis/settings/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // SettingsCommand is the entry point for the settings command.

--- a/ocis/pkg/command/storageappprovider.go
+++ b/ocis/pkg/command/storageappprovider.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageAppProviderCommand is the entrypoint for the reva-app-provider command.

--- a/ocis/pkg/command/storageauthbasic.go
+++ b/ocis/pkg/command/storageauthbasic.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageAuthBasicCommand is the entrypoint for the reva-auth-basic command.

--- a/ocis/pkg/command/storageauthbearer.go
+++ b/ocis/pkg/command/storageauthbearer.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageAuthBearerCommand is the entrypoint for the reva-auth-bearer command.

--- a/ocis/pkg/command/storagefrontend.go
+++ b/ocis/pkg/command/storagefrontend.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageFrontendCommand is the entrypoint for the reva-frontend command.

--- a/ocis/pkg/command/storagegateway.go
+++ b/ocis/pkg/command/storagegateway.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageGatewayCommand is the entrypoint for the reva-gateway command.

--- a/ocis/pkg/command/storagegroupprovider.go
+++ b/ocis/pkg/command/storagegroupprovider.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageGroupProviderCommand is the entrypoint for the storage-groupprovider command.

--- a/ocis/pkg/command/storagehome.go
+++ b/ocis/pkg/command/storagehome.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageHomeCommand is the entrypoint for the storage-home command.

--- a/ocis/pkg/command/storagemetadata.go
+++ b/ocis/pkg/command/storagemetadata.go
@@ -1,12 +1,12 @@
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageMetadataCommand is the entrypoint for the storage-metadata command.

--- a/ocis/pkg/command/storagepubliclink.go
+++ b/ocis/pkg/command/storagepubliclink.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StoragePublicLinkCommand is the entrypoint for the reva-storage-oc command.

--- a/ocis/pkg/command/storagesharing.go
+++ b/ocis/pkg/command/storagesharing.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageSharingCommand is the entrypoint for the reva-sharing command.

--- a/ocis/pkg/command/storageuserprovider.go
+++ b/ocis/pkg/command/storageuserprovider.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageUserProviderCommand is the entrypoint for the storage-userprovider command.

--- a/ocis/pkg/command/storageusers.go
+++ b/ocis/pkg/command/storageusers.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/storage/pkg/command"
 	svcconfig "github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageUsersCommand is the entrypoint for the storage-users command.

--- a/ocis/pkg/command/store.go
+++ b/ocis/pkg/command/store.go
@@ -1,15 +1,16 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/store/pkg/command"
 	svcconfig "github.com/owncloud/ocis/store/pkg/config"
 	"github.com/owncloud/ocis/store/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // StoreCommand is the entrypoint for the ocs command.

--- a/ocis/pkg/command/thumbnails.go
+++ b/ocis/pkg/command/thumbnails.go
@@ -1,14 +1,15 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/thumbnails/pkg/command"
 	"github.com/owncloud/ocis/thumbnails/pkg/flagset"
+	"github.com/urfave/cli/v2"
 
 	svcconfig "github.com/owncloud/ocis/thumbnails/pkg/config"
 )

--- a/ocis/pkg/command/version.go
+++ b/ocis/pkg/command/version.go
@@ -5,11 +5,11 @@ import (
 	"os"
 
 	mreg "github.com/asim/go-micro/v3/registry"
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis/pkg/register"
+	"github.com/urfave/cli/v2"
 )
 
 // VersionCommand is the entrypoint for the version command.

--- a/ocis/pkg/command/web.go
+++ b/ocis/pkg/command/web.go
@@ -1,12 +1,12 @@
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/web/pkg/command"
 	svcconfig "github.com/owncloud/ocis/web/pkg/config"
 	"github.com/owncloud/ocis/web/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // WebCommand is the entrypoint for the web command.

--- a/ocis/pkg/command/webdav.go
+++ b/ocis/pkg/command/webdav.go
@@ -1,15 +1,16 @@
+//go:build !simple
 // +build !simple
 
 package command
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis/pkg/register"
 	"github.com/owncloud/ocis/ocis/pkg/version"
 	"github.com/owncloud/ocis/webdav/pkg/command"
 	svcconfig "github.com/owncloud/ocis/webdav/pkg/config"
 	"github.com/owncloud/ocis/webdav/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // WebDAVCommand is the entrypoint for the webdav command.

--- a/ocis/pkg/flagset/flagset.go
+++ b/ocis/pkg/flagset/flagset.go
@@ -1,8 +1,8 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/ocis/pkg/register/command.go
+++ b/ocis/pkg/register/command.go
@@ -1,8 +1,8 @@
 package register
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/ocis/pkg/runtime/options.go
+++ b/ocis/pkg/runtime/options.go
@@ -1,8 +1,8 @@
 package runtime
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Options is a runtime option

--- a/ocs/pkg/command/health.go
+++ b/ocs/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocs/pkg/config"
 	"github.com/owncloud/ocis/ocs/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/ocs/pkg/command/root.go
+++ b/ocs/pkg/command/root.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/ocs/pkg/config"
 	"github.com/owncloud/ocis/ocs/pkg/version"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-ocs command.

--- a/ocs/pkg/command/server.go
+++ b/ocs/pkg/command/server.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/ocs/pkg/config"
 	"github.com/owncloud/ocis/ocs/pkg/flagset"
 	"github.com/owncloud/ocis/ocs/pkg/metrics"
 	"github.com/owncloud/ocis/ocs/pkg/server/debug"
 	"github.com/owncloud/ocis/ocs/pkg/server/http"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/ocs/pkg/command/version.go
+++ b/ocs/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/ocs/pkg/config"
 	"github.com/owncloud/ocis/ocs/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/ocs/pkg/flagset/flagset.go
+++ b/ocs/pkg/flagset/flagset.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/ocs/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // HealthWithConfig applies cfg to the root flagset

--- a/ocs/pkg/server/http/option.go
+++ b/ocs/pkg/server/http/option.go
@@ -3,10 +3,10 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
+	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/ocs/pkg/config"
 	"github.com/owncloud/ocis/ocs/pkg/metrics"
-	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/proxy/pkg/command/health.go
+++ b/proxy/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/proxy/pkg/config"
 	"github.com/owncloud/ocis/proxy/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/proxy/pkg/command/root.go
+++ b/proxy/pkg/command/root.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/proxy/pkg/config"
@@ -15,6 +14,7 @@ import (
 	"github.com/owncloud/ocis/proxy/pkg/version"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-proxy command.

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/justinas/alice"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	acc "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocis-pkg/conversions"
@@ -32,6 +31,7 @@ import (
 	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 	settings "github.com/owncloud/ocis/settings/pkg/proto/v0"
 	storepb "github.com/owncloud/ocis/store/pkg/proto/v0"
+	"github.com/urfave/cli/v2"
 	"golang.org/x/oauth2"
 )
 

--- a/proxy/pkg/command/version.go
+++ b/proxy/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/proxy/pkg/config"
 	"github.com/owncloud/ocis/proxy/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -3,10 +3,10 @@ package flagset
 import (
 	"path"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	pkgos "github.com/owncloud/ocis/ocis-pkg/os"
 	"github.com/owncloud/ocis/proxy/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/proxy/pkg/server/http/option.go
+++ b/proxy/pkg/server/http/option.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 
 	"github.com/justinas/alice"
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/proxy/pkg/config"
 	"github.com/owncloud/ocis/proxy/pkg/metrics"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/settings/pkg/command/health.go
+++ b/settings/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/settings/pkg/config"
 	"github.com/owncloud/ocis/settings/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/settings/pkg/command/root.go
+++ b/settings/pkg/command/root.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/settings/pkg/config"
@@ -15,6 +14,7 @@ import (
 	"github.com/owncloud/ocis/settings/pkg/version"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-settings command.

--- a/settings/pkg/command/server.go
+++ b/settings/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/settings/pkg/config"
@@ -14,6 +13,7 @@ import (
 	"github.com/owncloud/ocis/settings/pkg/server/grpc"
 	"github.com/owncloud/ocis/settings/pkg/server/http"
 	"github.com/owncloud/ocis/settings/pkg/tracing"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/settings/pkg/command/version.go
+++ b/settings/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/settings/pkg/config"
 	"github.com/owncloud/ocis/settings/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/settings/pkg/flagset/flagset.go
+++ b/settings/pkg/flagset/flagset.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/settings/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/settings/pkg/server/grpc/option.go
+++ b/settings/pkg/server/grpc/option.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/settings/pkg/config"
 	"github.com/owncloud/ocis/settings/pkg/metrics"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/settings/pkg/server/http/option.go
+++ b/settings/pkg/server/http/option.go
@@ -3,10 +3,10 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/settings/pkg/config"
 	"github.com/owncloud/ocis/settings/pkg/metrics"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/storage/pkg/command/appprovider.go
+++ b/storage/pkg/command/appprovider.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
@@ -17,6 +16,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // AppProvider is the entrypoint for the app provider command.

--- a/storage/pkg/command/authbasic.go
+++ b/storage/pkg/command/authbasic.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
@@ -18,6 +17,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // AuthBasic is the entrypoint for the auth-basic command.

--- a/storage/pkg/command/authbearer.go
+++ b/storage/pkg/command/authbearer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
@@ -17,6 +16,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // AuthBearer is the entrypoint for the auth-bearer command.

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/conversions"
@@ -21,6 +20,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Frontend is the entrypoint for the frontend command.

--- a/storage/pkg/command/gateway.go
+++ b/storage/pkg/command/gateway.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
@@ -24,6 +23,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/service/external"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Gateway is the entrypoint for the gateway command.

--- a/storage/pkg/command/groups.go
+++ b/storage/pkg/command/groups.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
@@ -18,6 +17,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Groups is the entrypoint for the sharing command.

--- a/storage/pkg/command/health.go
+++ b/storage/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/storage/pkg/command/root.go
+++ b/storage/pkg/command/root.go
@@ -4,12 +4,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
 	"github.com/owncloud/ocis/storage/pkg/version"
 	"github.com/spf13/viper"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the storage command.

--- a/storage/pkg/command/sharing.go
+++ b/storage/pkg/command/sharing.go
@@ -13,13 +13,13 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/flagset"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Sharing is the entrypoint for the sharing command.

--- a/storage/pkg/command/storagehome.go
+++ b/storage/pkg/command/storagehome.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/config"
@@ -18,6 +17,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageHome is the entrypoint for the storage-home command.

--- a/storage/pkg/command/storagemetadata.go
+++ b/storage/pkg/command/storagemetadata.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/config"
@@ -19,6 +18,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/service/external"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageMetadata the entrypoint for the storage-storage-metadata command.

--- a/storage/pkg/command/storagepubliclink.go
+++ b/storage/pkg/command/storagepubliclink.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
@@ -17,6 +16,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // StoragePublicLink is the entrypoint for the reva-storage-public-link command.

--- a/storage/pkg/command/storageusers.go
+++ b/storage/pkg/command/storageusers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
@@ -17,6 +16,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageUsers is the entrypoint for the storage-users command.

--- a/storage/pkg/command/users.go
+++ b/storage/pkg/command/users.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cs3org/reva/cmd/revad/runtime"
 	"github.com/gofrs/uuid"
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
@@ -18,6 +17,7 @@ import (
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Users is the entrypoint for the sharing command.

--- a/storage/pkg/flagset/appprovider.go
+++ b/storage/pkg/flagset/appprovider.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // AppProviderWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/authbasic.go
+++ b/storage/pkg/flagset/authbasic.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // AuthBasicWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/authbearer.go
+++ b/storage/pkg/flagset/authbearer.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // AuthBearerWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/debug.go
+++ b/storage/pkg/flagset/debug.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // DebugWithConfig applies common debug config cfg to the flagset

--- a/storage/pkg/flagset/drivereos.go
+++ b/storage/pkg/flagset/drivereos.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // DriverEOSWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/driverlocal.go
+++ b/storage/pkg/flagset/driverlocal.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // DriverLocalWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/driverocis.go
+++ b/storage/pkg/flagset/driverocis.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // DriverOCISWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/driverowncloud.go
+++ b/storage/pkg/flagset/driverowncloud.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // DriverOwnCloudWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/driverowncloudsql.go
+++ b/storage/pkg/flagset/driverowncloudsql.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // DriverOwnCloudSQLWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/drivers3ng.go
+++ b/storage/pkg/flagset/drivers3ng.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // DriverS3NGWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/frontend.go
+++ b/storage/pkg/flagset/frontend.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // FrontendWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/gateway.go
+++ b/storage/pkg/flagset/gateway.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // GatewayWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/groups.go
+++ b/storage/pkg/flagset/groups.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // GroupsWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/health.go
+++ b/storage/pkg/flagset/health.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // HealthWithConfig applies cfg to the health flagset

--- a/storage/pkg/flagset/ldap.go
+++ b/storage/pkg/flagset/ldap.go
@@ -3,10 +3,10 @@ package flagset
 import (
 	"path"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	pkgos "github.com/owncloud/ocis/ocis-pkg/os"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // LDAPWithConfig applies LDAP cfg to the flagset

--- a/storage/pkg/flagset/rest.go
+++ b/storage/pkg/flagset/rest.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // RestWithConfig applies REST user/group provider cfg to the flagset

--- a/storage/pkg/flagset/root.go
+++ b/storage/pkg/flagset/root.go
@@ -1,8 +1,8 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/secret.go
+++ b/storage/pkg/flagset/secret.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // SecretWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/sharing.go
+++ b/storage/pkg/flagset/sharing.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // SharingWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/sharingsql.go
+++ b/storage/pkg/flagset/sharingsql.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // SharingSQLWithConfig applies the Sharing SQL driver cfg to the flagset

--- a/storage/pkg/flagset/storagehome.go
+++ b/storage/pkg/flagset/storagehome.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageHomeWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/storagemetadata.go
+++ b/storage/pkg/flagset/storagemetadata.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageMetadata applies cfg to the root flagset

--- a/storage/pkg/flagset/storagepubliclink.go
+++ b/storage/pkg/flagset/storagepubliclink.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // StoragePublicLink applies cfg to the root flagset

--- a/storage/pkg/flagset/storageusers.go
+++ b/storage/pkg/flagset/storageusers.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // StorageUsersWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/tracing.go
+++ b/storage/pkg/flagset/tracing.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // TracingWithConfig applies cfg to the root flagset

--- a/storage/pkg/flagset/users.go
+++ b/storage/pkg/flagset/users.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/storage/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // UsersWithConfig applies cfg to the root flagset

--- a/store/pkg/command/health.go
+++ b/store/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/store/pkg/config"
 	"github.com/owncloud/ocis/store/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/store/pkg/command/root.go
+++ b/store/pkg/command/root.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/store/pkg/config"
@@ -15,6 +14,7 @@ import (
 	"github.com/owncloud/ocis/store/pkg/version"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-store command.

--- a/store/pkg/command/server.go
+++ b/store/pkg/command/server.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/store/pkg/config"
 	"github.com/owncloud/ocis/store/pkg/flagset"
 	"github.com/owncloud/ocis/store/pkg/metrics"
 	"github.com/owncloud/ocis/store/pkg/server/debug"
 	"github.com/owncloud/ocis/store/pkg/server/grpc"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/store/pkg/command/version.go
+++ b/store/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/store/pkg/config"
 	"github.com/owncloud/ocis/store/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/store/pkg/flagset/flagset.go
+++ b/store/pkg/flagset/flagset.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/store/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/store/pkg/server/grpc/option.go
+++ b/store/pkg/server/grpc/option.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/store/pkg/config"
 	"github.com/owncloud/ocis/store/pkg/metrics"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/thumbnails/pkg/command/health.go
+++ b/thumbnails/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/thumbnails/pkg/config"
 	"github.com/owncloud/ocis/thumbnails/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/thumbnails/pkg/command/root.go
+++ b/thumbnails/pkg/command/root.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/thumbnails/pkg/config"
 	"github.com/owncloud/ocis/thumbnails/pkg/version"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-thumbnails command.

--- a/thumbnails/pkg/command/server.go
+++ b/thumbnails/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/thumbnails/pkg/config"
@@ -13,6 +12,7 @@ import (
 	"github.com/owncloud/ocis/thumbnails/pkg/server/debug"
 	"github.com/owncloud/ocis/thumbnails/pkg/server/grpc"
 	"github.com/owncloud/ocis/thumbnails/pkg/tracing"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/thumbnails/pkg/command/version.go
+++ b/thumbnails/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/thumbnails/pkg/config"
 	"github.com/owncloud/ocis/thumbnails/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/thumbnails/pkg/flagset/flagset.go
+++ b/thumbnails/pkg/flagset/flagset.go
@@ -3,8 +3,8 @@ package flagset
 import (
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/thumbnails/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // HealthWithConfig applies cfg to the root flagset

--- a/thumbnails/pkg/server/grpc/option.go
+++ b/thumbnails/pkg/server/grpc/option.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/thumbnails/pkg/config"
 	"github.com/owncloud/ocis/thumbnails/pkg/metrics"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/web/pkg/command/health.go
+++ b/web/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/web/pkg/config"
 	"github.com/owncloud/ocis/web/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/web/pkg/command/root.go
+++ b/web/pkg/command/root.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/web/pkg/config"
 	"github.com/owncloud/ocis/web/pkg/version"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the web command.

--- a/web/pkg/command/server.go
+++ b/web/pkg/command/server.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/web/pkg/config"
@@ -15,6 +14,7 @@ import (
 	"github.com/owncloud/ocis/web/pkg/server/debug"
 	"github.com/owncloud/ocis/web/pkg/server/http"
 	"github.com/owncloud/ocis/web/pkg/tracing"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/web/pkg/flagset/flagset.go
+++ b/web/pkg/flagset/flagset.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/web/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // RootWithConfig applies cfg to the root flagset

--- a/web/pkg/server/http/option.go
+++ b/web/pkg/server/http/option.go
@@ -3,10 +3,10 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/web/pkg/config"
 	"github.com/owncloud/ocis/web/pkg/metrics"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.

--- a/webdav/pkg/command/health.go
+++ b/webdav/pkg/command/health.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/webdav/pkg/config"
 	"github.com/owncloud/ocis/webdav/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // Health is the entrypoint for the health command.

--- a/webdav/pkg/command/root.go
+++ b/webdav/pkg/command/root.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 
-	"github.com/micro/cli/v2"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/webdav/pkg/config"
 	"github.com/owncloud/ocis/webdav/pkg/version"
 	"github.com/spf13/viper"
 	"github.com/thejerf/suture/v4"
+	"github.com/urfave/cli/v2"
 )
 
 // Execute is the entry point for the ocis-webdav command.

--- a/webdav/pkg/command/server.go
+++ b/webdav/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/micro/cli/v2"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/webdav/pkg/config"
@@ -13,6 +12,7 @@ import (
 	"github.com/owncloud/ocis/webdav/pkg/server/debug"
 	"github.com/owncloud/ocis/webdav/pkg/server/http"
 	"github.com/owncloud/ocis/webdav/pkg/tracing"
+	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.

--- a/webdav/pkg/command/version.go
+++ b/webdav/pkg/command/version.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/registry"
 
-	"github.com/micro/cli/v2"
 	tw "github.com/olekukonko/tablewriter"
 	"github.com/owncloud/ocis/webdav/pkg/config"
 	"github.com/owncloud/ocis/webdav/pkg/flagset"
+	"github.com/urfave/cli/v2"
 )
 
 // PrintVersion prints the service versions of all running instances.

--- a/webdav/pkg/flagset/flagset.go
+++ b/webdav/pkg/flagset/flagset.go
@@ -1,9 +1,9 @@
 package flagset
 
 import (
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/flags"
 	"github.com/owncloud/ocis/webdav/pkg/config"
+	"github.com/urfave/cli/v2"
 )
 
 // HealthWithConfig applies cfg to the root flagset

--- a/webdav/pkg/server/http/option.go
+++ b/webdav/pkg/server/http/option.go
@@ -3,10 +3,10 @@ package http
 import (
 	"context"
 
-	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"github.com/owncloud/ocis/webdav/pkg/config"
 	"github.com/owncloud/ocis/webdav/pkg/metrics"
+	"github.com/urfave/cli/v2"
 )
 
 // Option defines a single option function.


### PR DESCRIPTION
## Description
switch from micro/cli/v2 to urfave/cli/v2 because go-micro also has done it in https://github.com/asim/go-micro/pull/2224

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- like https://github.com/asim/go-micro/pull/2224

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- not at all

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
