### PR TITLE
Expose configuration for the reva archiver

### DIFF
--- a/changelog/unreleased/expose-reva-archiver.md
+++ b/changelog/unreleased/expose-reva-archiver.md
@@ -1,0 +1,5 @@
+Enhancement: Expose the reva archiver in OCIS
+
+The reva archiver can now be accessed through the storage frontend service
+
+https://github.com/owncloud/ocis/pull/2509

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -291,7 +291,7 @@ func defaultPolicies() []config.Policy {
 					Backend:  "http://localhost:9130",
 				},
 				{
-					Endpoint: "/archiver/",
+					Endpoint: "/archiver",
 					Backend:  "http://localhost:9140",
 				},
 				{
@@ -384,7 +384,7 @@ func defaultPolicies() []config.Policy {
 					Backend:  "http://localhost:9130",
 				},
 				{
-					Endpoint: "/archiver/",
+					Endpoint: "/archiver",
 					Backend:  "http://localhost:9140",
 				},
 				{

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -291,6 +291,10 @@ func defaultPolicies() []config.Policy {
 					Backend:  "http://localhost:9130",
 				},
 				{
+					Endpoint: "/archiver/",
+					Backend:  "http://localhost:9140",
+				},
+				{
 					Type:     config.RegexRoute,
 					Endpoint: "/ocs/v[12].php/cloud/(users?|groups)", // we have `user`, `users` and `groups` in ocis-ocs
 					Backend:  "http://localhost:9110",
@@ -378,6 +382,10 @@ func defaultPolicies() []config.Policy {
 				{
 					Endpoint: "/signin/",
 					Backend:  "http://localhost:9130",
+				},
+				{
+					Endpoint: "/archiver/",
+					Backend:  "http://localhost:9140",
 				},
 				{
 					Endpoint:    "/ocs/",

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -147,6 +147,13 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 					"timeout":                86400,
 					"insecure":               true,
 				},
+				"archiver": map[string]interface{}{
+					"prefix":        cfg.Reva.Frontend.ArchiverPrefix,
+					"timeout":       86400,
+					"insecure":      true,
+					"max_num_files": cfg.Reva.Archiver.MaxNumFiles,
+					"max_size":      cfg.Reva.Archiver.MaxSize,
+				},
 				"datagateway": map[string]interface{}{
 					"prefix":                 cfg.Reva.Frontend.DatagatewayPrefix,
 					"transfer_shared_secret": cfg.Reva.TransferSecret,

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -132,6 +132,7 @@ type FrontendPort struct {
 	Port
 
 	AppProviderPrefix       string
+	ArchiverPrefix          string
 	DatagatewayPrefix       string
 	OCDavPrefix             string
 	OCSPrefix               string
@@ -401,6 +402,12 @@ type OCDav struct {
 	DavFilesNamespace string
 }
 
+// Archiver defines the available archiver configuration.
+type Archiver struct {
+	MaxNumFiles int64
+	MaxSize     int64
+}
+
 // Reva defines the available reva configuration.
 type Reva struct {
 	// JWTSecret used to sign jwt tokens between services
@@ -412,6 +419,7 @@ type Reva struct {
 	UserGroupRest   UserGroupRest
 	UserOwnCloudSQL UserOwnCloudSQL
 	OCDav           OCDav
+	Archiver        Archiver
 	Storages        StorageConfig
 	// Ports are used to configure which services to start on which port
 	Frontend          FrontendPort

--- a/storage/pkg/flagset/frontend.go
+++ b/storage/pkg/flagset/frontend.go
@@ -57,6 +57,23 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.Reva.OCDav.DavFilesNamespace,
 		},
 
+		// Archiver
+
+		&cli.Int64Flag{
+			Name:        "archiver-max-num-files",
+			Value:       flags.OverrideDefaultInt64(cfg.Reva.Archiver.MaxNumFiles, 10000),
+			Usage:       "Maximum number of files to be included in the archiver",
+			EnvVars:     []string{"STORAGE_ARCHIVER_MAX_NUM_FILES"},
+			Destination: &cfg.Reva.Archiver.MaxNumFiles,
+		},
+		&cli.Int64Flag{
+			Name:        "archiver-max-size",
+			Value:       flags.OverrideDefaultInt64(cfg.Reva.Archiver.MaxSize, 1073741824), // 1GB
+			Usage:       "Maximum size for the sum of the sizes of all the files included in the archive",
+			EnvVars:     []string{"STORAGE_ARCHIVER_MAX_SIZE"},
+			Destination: &cfg.Reva.Archiver.MaxSize,
+		},
+
 		// Services
 
 		// Frontend
@@ -97,6 +114,13 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:       "approvider prefix",
 			EnvVars:     []string{"STORAGE_FRONTEND_APPPROVIDER_PREFIX"},
 			Destination: &cfg.Reva.Frontend.AppProviderPrefix,
+		},
+		&cli.StringFlag{
+			Name:        "archiver-prefix",
+			Value:       flags.OverrideDefaultString(cfg.Reva.Frontend.ArchiverPrefix, "archiver"),
+			Usage:       "archiver prefix",
+			EnvVars:     []string{"STORAGE_FRONTEND_ARCHIVER_PREFIX"},
+			Destination: &cfg.Reva.Frontend.ArchiverPrefix,
 		},
 		&cli.StringFlag{
 			Name:        "datagateway-prefix",


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Expose the reva archiver configuration

## Related Issue
https://github.com/owncloud/ocis/issues/2507

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Access ocis with the admin user
2. Create folder "zzz" and upload some files there
3. Connect to the archiver service:
    1. Assuming you've started a basic ocis installation with `ocis server`
    2. In the same host
```
root@f13b05e8714d:/# curl -v -u admin:admin -JO http://localhost:9140/archiver?dir=/home/zzz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:9140...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9140 (#0)
* Server auth using Basic with user 'admin'
> GET /archiver?dir=/home/zzz HTTP/1.1
> Host: localhost:9140
> Authorization: Basic YWRtaW46YWRtaW4=
> User-Agent: curl/7.68.0
> Accept: */*
> 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Disposition: attachment; filename="zzz.tar"
< Content-Transfer-Encoding: binary
< Vary: Origin
< X-Access-Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZXZhIiwiZXhwIjoxNjMxNzk4NDYxLCJpYXQiOjE2MzE3MTIwNjEsImlzcyI6Imh0dHBzOi8vb2Npcy5qcC5zb2xpZGdlYXIucHJ2IiwidXNlciI6eyJpZCI6eyJpZHAiOiJodHRwczovL29jaXMuanAuc29saWRnZWFyLnBydiIsIm9wYXF1ZV9pZCI6ImRkYzIwMDRjLTA5NzctMTFlYi05ZDNmLWE3OTM4ODhjZDBmOCIsInR5cGUiOjF9LCJ1c2VybmFtZSI6ImFkbWluIiwibWFpbCI6ImFkbWluQGV4YW1wbGUub3JnIiwiZGlzcGxheV9uYW1lIjoiQWRtaW4iLCJ1aWRfbnVtYmVyIjoyMDAwNCwiZ2lkX251bWJlciI6MzAwMDB9LCJzY29wZSI6eyJ1c2VyIjp7InJlc291cmNlIjp7ImRlY29kZXIiOiJqc29uIiwidmFsdWUiOiJleUp3WVhSb0lqb2lMeUo5In0sInJvbGUiOjF9fX0.jf3Fxy5FGRLLKLss_gi8yxZ1MVof2-S3g17z4xtL_KA
< Date: Wed, 15 Sep 2021 13:21:02 GMT
< Content-Type: application/octet-stream
< Transfer-Encoding: chunked
< 
{ [3248 bytes data]
100 6782k    0 6782k    0     0  9566k      0 --:--:-- --:--:-- --:--:-- 9552k
* Connection #0 to host localhost left intact
curl: Saved to filename 'zzz.tar'
```

The tar file is downloaded and contains the files that were present in the folder.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
