### PR TITLE
use proper url path decode on the username

### DIFF
--- a/changelog/unreleased/fix-username-encoding.md
+++ b/changelog/unreleased/fix-username-encoding.md
@@ -1,0 +1,5 @@
+Bugfix: use proper url path decode on the username
+
+We now properly decode the username when reading it from a url parameter
+
+https://github.com/owncloud/ocis/pull/2511

--- a/ocs/pkg/middleware/requireselforadmin.go
+++ b/ocs/pkg/middleware/requireselforadmin.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"net/url"
 
 	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/chi/v5"
@@ -44,6 +45,11 @@ func RequireSelfOrAdmin(opts ...Option) func(next http.Handler) http.Handler {
 			// check if self management permission is present in roles of the authenticated account
 			if opt.RoleManager.FindPermissionByID(r.Context(), roleIDs, accounts.SelfManagementPermissionID) != nil {
 				userid := chi.URLParam(r, "userid")
+				var err error
+				if userid, err = url.PathUnescape(userid); err != nil {
+					mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "malformed username")))
+				}
+
 				if userid == "" || userid == u.Id.OpaqueId || userid == u.Username {
 					next.ServeHTTP(w, r)
 					return


### PR DESCRIPTION
We now properly decode the username when reading it from a url parameter

related to https://github.com/owncloud/ocis/pull/2302