### PR TITLE
fix: redirect invalid links to oC Web (#2493)

### DIFF
--- a/changelog/unreleased/fix-redirect-invalid-links-to-oC-web.md
+++ b/changelog/unreleased/fix-redirect-invalid-links-to-oC-web.md
@@ -1,0 +1,6 @@
+Bugfix: redirect invalid links to oC Web
+
+Invalid links ending with a slash(eg. https://foo.bar/index.php/apps/pdfviewer/) have not been redirected to ownCloud Web. Instead the former 404 not found status page was displayed.
+
+https://github.com/owncloud/ocis/pull/2493
+https://github.com/owncloud/ocis/pull/2512


### PR DESCRIPTION
## Description
Invalid links ending with a slash have not been redirected after #2493. This is cared of in this PR.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/pull/2493

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
