### PR TITLE
fix STORAGE_TRANSFER_SECRET usage in deployment examples

### DIFF
--- a/deployments/examples/cs3_users_ocis/.env
+++ b/deployments/examples/cs3_users_ocis/.env
@@ -20,7 +20,7 @@ OCIS_DOMAIN=
 # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
 OCIS_JWT_SECRET=
 # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-OCIS_TRANSFER_SECRET=
+STORAGE_TRANSFER_SECRET=
 
 
 ### LDAP server settings ###

--- a/deployments/examples/cs3_users_ocis/docker-compose.yml
+++ b/deployments/examples/cs3_users_ocis/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # change default secrets
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
-      OCIS_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
+      STORAGE_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/web-config.dist.json:/config/web-config.dist.json

--- a/deployments/examples/ocis_hello/.env
+++ b/deployments/examples/ocis_hello/.env
@@ -24,7 +24,7 @@ STORAGE_LDAP_BIND_PASSWORD=
 # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
 OCIS_JWT_SECRET=
 # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-OCIS_TRANSFER_SECRET=
+STORAGE_TRANSFER_SECRET=
 
 ### oCIS Hello settings ###
 # oCIS Hello version. Defaults to "latest"

--- a/deployments/examples/ocis_hello/docker-compose.yml
+++ b/deployments/examples/ocis_hello/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
-      OCIS_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
+      STORAGE_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
       # web ui
       WEB_UI_CONFIG: "/var/tmp/ocis/.config/web-config.json"
       # proxy

--- a/deployments/examples/ocis_keycloak/.env
+++ b/deployments/examples/ocis_keycloak/.env
@@ -26,7 +26,7 @@ STORAGE_LDAP_BIND_PASSWORD=
 # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
 OCIS_JWT_SECRET=
 # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-OCIS_TRANSFER_SECRET=
+STORAGE_TRANSFER_SECRET=
 
 ### Keycloak ###
 # Domain of Keycloak, where you can find the managment and authentication frontend. Defaults to "keycloak.owncloud.test"

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
-      OCIS_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
+      STORAGE_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-data:/var/tmp/ocis

--- a/deployments/examples/ocis_s3/.env
+++ b/deployments/examples/ocis_s3/.env
@@ -24,7 +24,7 @@ STORAGE_LDAP_BIND_PASSWORD=
 # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
 OCIS_JWT_SECRET=
 # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-OCIS_TRANSFER_SECRET=
+STORAGE_TRANSFER_SECRET=
 
 ### MINIO / S3 settings ###
 # Domain of MinIO where the Web UI is accessible. Defaults to "minio.owncloud.test".

--- a/deployments/examples/ocis_s3/docker-compose.yml
+++ b/deployments/examples/ocis_s3/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
-      OCIS_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
+      STORAGE_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
       # activate s3ng storage driver
       STORAGE_HOME_DRIVER: s3ng
       STORAGE_USERS_DRIVER: s3ng

--- a/deployments/examples/ocis_traefik/.env
+++ b/deployments/examples/ocis_traefik/.env
@@ -24,7 +24,7 @@ STORAGE_LDAP_BIND_PASSWORD=
 # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
 OCIS_JWT_SECRET=
 # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-OCIS_TRANSFER_SECRET=
+STORAGE_TRANSFER_SECRET=
 
 # If you want to use debugging and tracing with this stack,
 # you need uncomment following line. Please see documentation at

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
-      OCIS_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
+      STORAGE_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-data:/var/tmp/ocis

--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -24,7 +24,7 @@ STORAGE_LDAP_BIND_PASSWORD=
 # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
 OCIS_JWT_SECRET=
 # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-OCIS_TRANSFER_SECRET=
+STORAGE_TRANSFER_SECRET=
 
 ### Wopi server settings ###
 # oCIS Wopi server version. Defaults to "latest"

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
-      OCIS_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
+      STORAGE_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
       # web ui
       WEB_UI_CONFIG: "/var/tmp/ocis/.config/web-config.json"
       # proxy

--- a/docs/ocis/deployment/ocis_hello.md
+++ b/docs/ocis/deployment/ocis_hello.md
@@ -74,7 +74,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
       # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
       OCIS_JWT_SECRET=
       # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-      OCIS_TRANSFER_SECRET=
+      STORAGE_TRANSFER_SECRET=
 
       ### oCIS Hello settings ###
       # oCIS Hello version. Defaults to "latest"

--- a/docs/ocis/deployment/ocis_keycloak.md
+++ b/docs/ocis/deployment/ocis_keycloak.md
@@ -77,7 +77,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
   # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
   OCIS_JWT_SECRET=
   # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-  OCIS_TRANSFER_SECRET=
+  STORAGE_TRANSFER_SECRET=
 
   ### Keycloak ###
   # Domain of Keycloak, where you can find the management and authentication frontend. Defaults to "keycloak.owncloud.test"

--- a/docs/ocis/deployment/ocis_s3.md
+++ b/docs/ocis/deployment/ocis_s3.md
@@ -76,7 +76,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
       # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
       OCIS_JWT_SECRET=
       # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-      OCIS_TRANSFER_SECRET=
+      STORAGE_TRANSFER_SECRET=
 
       ### MINIO / S3 settings ###
       # Domain of MinIO where the Web UI is accessible. Defaults to "minio.owncloud.test".

--- a/docs/ocis/deployment/ocis_traefik.md
+++ b/docs/ocis/deployment/ocis_traefik.md
@@ -71,7 +71,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
   # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
   OCIS_JWT_SECRET=
   # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-  OCIS_TRANSFER_SECRET=
+  STORAGE_TRANSFER_SECRET=
   ```
 
   You are installing oCIS on a server and Traefik will obtain valid certificates for you so please remove `INSECURE=true` or set it to `false`.

--- a/docs/ocis/deployment/ocis_wopi.md
+++ b/docs/ocis/deployment/ocis_wopi.md
@@ -79,7 +79,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
     # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
     OCIS_JWT_SECRET=
     # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-    OCIS_TRANSFER_SECRET=
+    STORAGE_TRANSFER_SECRET=
 
     ### Wopi server settings ###
     # oCIS Wopi server version. Defaults to "latest"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`STORAGE_TRANSFER_SECRET` hasn't been set properly since the wrong env variable has been exposed to oCIS

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
