### PR TITLE
Use reva's Authenticate method instead of spawning token managers

### DIFF
--- a/changelog/unreleased/reva-auth-tokens.md
+++ b/changelog/unreleased/reva-auth-tokens.md
@@ -1,0 +1,11 @@
+Enhancement: Use reva's Authenticate method instead of spawning token managers
+
+When using the CS3 proxy backend, we previously obtained the user from reva's
+userprovider service and minted the token ourselves. This required maintaining
+a shared JWT secret between ocis and reva, as well duplication of logic. This
+PR delegates this logic by using the `Authenticate` method provided by the reva
+gateway service to obtain this token, making it an arbitrary, indestructible
+entry. Currently, the changes have been made to the proxy service but will be
+extended to others as well.
+
+https://github.com/owncloud/ocis/pull/2528

--- a/ocs/pkg/config/config.go
+++ b/ocs/pkg/config/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	AccountBackend     string
 	RevaAddress        string
 	StorageUsersDriver string
+	MachineAuthAPIKey  string
 	IdentityManagement IdentityManagement
 
 	Context    context.Context

--- a/ocs/pkg/flagset/flagset.go
+++ b/ocs/pkg/flagset/flagset.go
@@ -166,6 +166,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.RevaAddress,
 		},
 		&cli.StringFlag{
+			Name:        "machine-auth-api-key",
+			Value:       flags.OverrideDefaultString(cfg.MachineAuthAPIKey, "change-me-please"),
+			Usage:       "the API key to be used for the machine auth driver in reva",
+			EnvVars:     []string{"OCS_MACHINE_AUTH_API_KEY", "OCIS_MACHINE_AUTH_API_KEY"},
+			Destination: &cfg.MachineAuthAPIKey,
+		},
+		&cli.StringFlag{
 			Name:        "idm-address",
 			Value:       flags.OverrideDefaultString(cfg.IdentityManagement.Address, "https://localhost:9200"),
 			EnvVars:     []string{"OCS_IDM_ADDRESS", "OCIS_URL"},

--- a/ocs/pkg/service/v0/service.go
+++ b/ocs/pkg/service/v0/service.go
@@ -165,7 +165,7 @@ func (o Ocs) getCS3Backend() backend.UserBackend {
 	if err != nil {
 		o.logger.Fatal().Msgf("could not get reva client at address %s", o.config.RevaAddress)
 	}
-	return backend.NewCS3UserBackend(revaClient, nil, revaClient, o.logger)
+	return backend.NewCS3UserBackend(nil, revaClient, o.config.MachineAuthAPIKey, o.logger)
 }
 
 func (o Ocs) getGroupsService() accounts.GroupsService {

--- a/ocs/pkg/service/v0/users.go
+++ b/ocs/pkg/service/v0/users.go
@@ -736,7 +736,7 @@ func (o Ocs) fetchAccountByUsername(ctx context.Context, name string) (*accounts
 
 func (o Ocs) fetchAccountFromCS3Backend(ctx context.Context, name string) (*accounts.Account, error) {
 	backend := o.getCS3Backend()
-	u, err := backend.GetUserByClaims(ctx, "username", name, false)
+	u, _, err := backend.GetUserByClaims(ctx, "username", name, false)
 	if err != nil {
 		return nil, err
 	}

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -227,6 +227,7 @@ func loadMiddlewares(ctx context.Context, l log.Logger, cfg *config.Config) alic
 		middleware.AccountResolver(
 			middleware.Logger(l),
 			middleware.UserProvider(userProvider),
+			middleware.TokenManagerConfig(cfg.TokenManager),
 			middleware.UserOIDCClaim(cfg.UserOIDCClaim),
 			middleware.UserCS3Claim(cfg.UserCS3Claim),
 			middleware.AutoprovisionAccounts(cfg.AutoprovisionAccounts),
@@ -241,6 +242,7 @@ func loadMiddlewares(ctx context.Context, l log.Logger, cfg *config.Config) alic
 		// finally, trigger home creation when a user logs in
 		middleware.CreateHome(
 			middleware.Logger(l),
+			middleware.TokenManagerConfig(cfg.TokenManager),
 			middleware.RevaGatewayClient(revaClient),
 		),
 	)

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -121,8 +121,9 @@ type Config struct {
 	Reva                  Reva
 	PreSignedURL          PreSignedURL
 	AccountBackend        string
-	UserOIDCClaim             string
-	UserCS3Claim         string
+	UserOIDCClaim         string
+	UserCS3Claim          string
+	MachineAuthAPIKey     string
 	AutoprovisionAccounts bool
 	EnableBasicAuth       bool
 	InsecureBackends      bool

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -295,7 +295,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Name:        "machine-auth-api-key",
 			Value:       flags.OverrideDefaultString(cfg.MachineAuthAPIKey, "change-me-please"),
 			Usage:       "the API key to be used for the machine auth driver in reva",
-			EnvVars:     []string{"PROXY_MACHINE_AUTH_API_KEY"},
+			EnvVars:     []string{"PROXY_MACHINE_AUTH_API_KEY", "OCIS_MACHINE_AUTH_API_KEY"},
 			Destination: &cfg.MachineAuthAPIKey,
 		},
 

--- a/proxy/pkg/flagset/flagset.go
+++ b/proxy/pkg/flagset/flagset.go
@@ -291,6 +291,14 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.AccountBackend,
 		},
 
+		&cli.StringFlag{
+			Name:        "machine-auth-api-key",
+			Value:       flags.OverrideDefaultString(cfg.MachineAuthAPIKey, "change-me-please"),
+			Usage:       "the API key to be used for the machine auth driver in reva",
+			EnvVars:     []string{"PROXY_MACHINE_AUTH_API_KEY"},
+			Destination: &cfg.MachineAuthAPIKey,
+		},
+
 		// Reva Middlewares Config
 		&cli.StringSliceFlag{
 			Name:    "proxy-user-agent-lock-in",

--- a/proxy/pkg/middleware/basic_auth.go
+++ b/proxy/pkg/middleware/basic_auth.go
@@ -41,7 +41,7 @@ func BasicAuth(optionSetters ...Option) func(next http.Handler) http.Handler {
 
 				removeSuperfluousAuthenticate(w)
 				login, password, _ := req.BasicAuth()
-				user, err := h.userProvider.Authenticate(req.Context(), login, password)
+				user, _, err := h.userProvider.Authenticate(req.Context(), login, password)
 
 				// touch is a user agent locking guard, when touched changes to true it indicates the User-Agent on the
 				// request is configured to support only one challenge, it it remains untouched, there are no considera-

--- a/proxy/pkg/middleware/create_home.go
+++ b/proxy/pkg/middleware/create_home.go
@@ -8,8 +8,6 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/token"
-	"github.com/cs3org/reva/pkg/token/manager/jwt"
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	"google.golang.org/grpc/metadata"
 )
@@ -20,17 +18,9 @@ func CreateHome(optionSetters ...Option) func(next http.Handler) http.Handler {
 	logger := options.Logger
 
 	return func(next http.Handler) http.Handler {
-		tokenManager, err := jwt.New(map[string]interface{}{
-			"secret": options.TokenManagerConfig.JWTSecret,
-		})
-		if err != nil {
-			logger.Fatal().Err(err).Msgf("Could not initialize token-manager")
-		}
-
 		return &createHome{
 			next:              next,
 			logger:            logger,
-			tokenManager:      tokenManager,
 			revaGatewayClient: options.RevaGatewayClient,
 		}
 	}
@@ -39,7 +29,6 @@ func CreateHome(optionSetters ...Option) func(next http.Handler) http.Handler {
 type createHome struct {
 	next              http.Handler
 	logger            log.Logger
-	tokenManager      token.Manager
 	revaGatewayClient gateway.GatewayAPIClient
 }
 

--- a/proxy/pkg/middleware/options.go
+++ b/proxy/pkg/middleware/options.go
@@ -45,9 +45,9 @@ type Options struct {
 	// PreSignedURLConfig to configure the middleware
 	PreSignedURLConfig config.PreSignedURL
 	// UserOIDCClaim to read from the oidc claims
-	UserOIDCClaim             string
+	UserOIDCClaim string
 	// UserCS3Claim to use when looking up a user in the CS3 API
-	UserCS3Claim         string
+	UserCS3Claim string
 	// AutoprovisionAccounts when an accountResolver does not exist.
 	AutoprovisionAccounts bool
 	// EnableBasicAuth to allow basic auth

--- a/proxy/pkg/middleware/signed_url_auth.go
+++ b/proxy/pkg/middleware/signed_url_auth.go
@@ -48,7 +48,7 @@ func (m signedURLAuth) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	user, err := m.userProvider.GetUserByClaims(req.Context(), "username", req.URL.Query().Get("OC-Credential"), true)
+	user, _, err := m.userProvider.GetUserByClaims(req.Context(), "username", req.URL.Query().Get("OC-Credential"), true)
 	if err != nil {
 		m.logger.Error().Err(err).Msg("Could not get user by claim")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/proxy/pkg/user/backend/accounts.go
+++ b/proxy/pkg/user/backend/accounts.go
@@ -178,7 +178,7 @@ func (a *accountsServiceBackend) getAccount(ctx context.Context, query string) (
 	})
 
 	if err != nil {
-		a.logger.Error().Err(err).Str("query", query).Msgf("error fetching from accounts-service")
+		a.logger.Error().Err(err).Str("query", query).Msgf("error fetching from accounts-service %+v", a.tokenManager)
 		status = http.StatusInternalServerError
 		return
 	}

--- a/proxy/pkg/user/backend/accounts.go
+++ b/proxy/pkg/user/backend/accounts.go
@@ -66,17 +66,15 @@ func (a accountsServiceBackend) GetUserByClaims(ctx context.Context, claim, valu
 
 	user := a.accountToUser(account)
 
+	if withRoles {
+		if err := injectRoles(ctx, user, a.settingsRoleService); err != nil {
+			a.logger.Warn().Err(err).Msgf("Could not load roles... continuing without")
+		}
+	}
+
 	token, err := a.generateToken(ctx, user)
 	if err != nil {
 		return nil, "", err
-	}
-
-	if !withRoles {
-		return user, token, nil
-	}
-
-	if err := injectRoles(ctx, user, a.settingsRoleService); err != nil {
-		a.logger.Warn().Err(err).Msgf("Could not load roles... continuing without")
 	}
 
 	return user, token, nil
@@ -178,7 +176,7 @@ func (a *accountsServiceBackend) getAccount(ctx context.Context, query string) (
 	})
 
 	if err != nil {
-		a.logger.Error().Err(err).Str("query", query).Msgf("error fetching from accounts-service %+v", a.tokenManager)
+		a.logger.Error().Err(err).Str("query", query).Msgf("error fetching from accounts-service")
 		status = http.StatusInternalServerError
 		return
 	}

--- a/proxy/pkg/user/backend/backend.go
+++ b/proxy/pkg/user/backend/backend.go
@@ -23,8 +23,8 @@ var (
 
 // UserBackend allows the proxy to retrieve users from different user-backends (accounts-service, CS3)
 type UserBackend interface {
-	GetUserByClaims(ctx context.Context, claim, value string, withRoles bool) (*cs3.User, error)
-	Authenticate(ctx context.Context, username string, password string) (*cs3.User, error)
+	GetUserByClaims(ctx context.Context, claim, value string, withRoles bool) (*cs3.User, string, error)
+	Authenticate(ctx context.Context, username string, password string) (*cs3.User, string, error)
 	CreateUserFromClaims(ctx context.Context, claims map[string]interface{}) (*cs3.User, error)
 	GetUserGroups(ctx context.Context, userID string)
 }

--- a/proxy/pkg/user/backend/cs3.go
+++ b/proxy/pkg/user/backend/cs3.go
@@ -14,42 +14,48 @@ import (
 )
 
 type cs3backend struct {
-	userProvider        cs3.UserAPIClient
 	settingsRoleService settings.RoleService
 	authProvider        RevaAuthenticator
+	machineAuthAPIKey   string
 	logger              log.Logger
 }
 
 // NewCS3UserBackend creates a user-provider which fetches users from a CS3 UserBackend
-func NewCS3UserBackend(up cs3.UserAPIClient, rs settings.RoleService, ap RevaAuthenticator, logger log.Logger) UserBackend {
+func NewCS3UserBackend(rs settings.RoleService, ap RevaAuthenticator, machineAuthAPIKey string, logger log.Logger) UserBackend {
 	return &cs3backend{
-		userProvider:        up,
 		settingsRoleService: rs,
 		authProvider:        ap,
+		machineAuthAPIKey:   machineAuthAPIKey,
 		logger:              logger,
 	}
 }
 
-func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, withRoles bool) (*cs3.User, error) {
-	res, err := c.userProvider.GetUserByClaim(ctx, &cs3.GetUserByClaimRequest{
-		Claim: claim,
-		Value: value,
+func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, withRoles bool) (*cs3.User, string, error) {
+	// We only support authentication via username for now
+	if claim != "username" {
+		return nil, "", fmt.Errorf("claim: %s not supported", claim)
+	}
+
+	res, err := c.authProvider.Authenticate(ctx, &gateway.AuthenticateRequest{
+		Type:         "machine",
+		ClientId:     value,
+		ClientSecret: c.machineAuthAPIKey,
 	})
 
 	switch {
 	case err != nil:
-		return nil, fmt.Errorf("could not get user by claim %v with value %v: %w", claim, value, err)
+		return nil, "", fmt.Errorf("could not get user by claim %v with value %v: %w", claim, value, err)
 	case res.Status.Code != rpcv1beta1.Code_CODE_OK:
 		if res.Status.Code == rpcv1beta1.Code_CODE_NOT_FOUND {
-			return nil, ErrAccountNotFound
+			return nil, "", ErrAccountNotFound
 		}
-		return nil, fmt.Errorf("could not get user by claim %v with value %v : %w ", claim, value, err)
+		return nil, "", fmt.Errorf("could not get user by claim %v with value %v : %w ", claim, value, err)
 	}
 
 	user := res.User
 
 	if !withRoles {
-		return user, nil
+		return user, res.Token, nil
 	}
 
 	var roleIDs []string
@@ -82,10 +88,10 @@ func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, w
 		user.Opaque.Map["roles"] = enc
 	}
 
-	return res.User, nil
+	return user, res.Token, nil
 }
 
-func (c *cs3backend) Authenticate(ctx context.Context, username string, password string) (*cs3.User, error) {
+func (c *cs3backend) Authenticate(ctx context.Context, username string, password string) (*cs3.User, string, error) {
 	res, err := c.authProvider.Authenticate(ctx, &gateway.AuthenticateRequest{
 		Type:         "basic",
 		ClientId:     username,
@@ -94,12 +100,12 @@ func (c *cs3backend) Authenticate(ctx context.Context, username string, password
 
 	switch {
 	case err != nil:
-		return nil, fmt.Errorf("could not authenticate with username and password user: %s, %w", username, err)
+		return nil, "", fmt.Errorf("could not authenticate with username and password user: %s, %w", username, err)
 	case res.Status.Code != rpcv1beta1.Code_CODE_OK:
-		return nil, fmt.Errorf("could not authenticate with username and password user: %s, got code: %d", username, res.Status.Code)
+		return nil, "", fmt.Errorf("could not authenticate with username and password user: %s, got code: %d", username, res.Status.Code)
 	}
 
-	return res.User, nil
+	return res.User, res.Token, nil
 }
 
 func (c *cs3backend) CreateUserFromClaims(ctx context.Context, claims map[string]interface{}) (*cs3.User, error) {

--- a/proxy/pkg/user/backend/test/backend_mock.go
+++ b/proxy/pkg/user/backend/test/backend_mock.go
@@ -5,9 +5,10 @@ package test
 
 import (
 	"context"
-	"github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 	"sync"
+
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/owncloud/ocis/proxy/pkg/user/backend"
 )
 
 // Ensure, that UserBackendMock does implement UserBackend.
@@ -40,13 +41,13 @@ var _ backend.UserBackend = &UserBackendMock{}
 //     }
 type UserBackendMock struct {
 	// AuthenticateFunc mocks the Authenticate method.
-	AuthenticateFunc func(ctx context.Context, username string, password string) (*userv1beta1.User, error)
+	AuthenticateFunc func(ctx context.Context, username string, password string) (*userv1beta1.User, string, error)
 
 	// CreateUserFromClaimsFunc mocks the CreateUserFromClaims method.
 	CreateUserFromClaimsFunc func(ctx context.Context, claims map[string]interface{}) (*userv1beta1.User, error)
 
 	// GetUserByClaimsFunc mocks the GetUserByClaims method.
-	GetUserByClaimsFunc func(ctx context.Context, claim string, value string, withRoles bool) (*userv1beta1.User, error)
+	GetUserByClaimsFunc func(ctx context.Context, claim string, value string, withRoles bool) (*userv1beta1.User, string, error)
 
 	// GetUserGroupsFunc mocks the GetUserGroups method.
 	GetUserGroupsFunc func(ctx context.Context, userID string)
@@ -95,7 +96,7 @@ type UserBackendMock struct {
 }
 
 // Authenticate calls AuthenticateFunc.
-func (mock *UserBackendMock) Authenticate(ctx context.Context, username string, password string) (*userv1beta1.User, error) {
+func (mock *UserBackendMock) Authenticate(ctx context.Context, username string, password string) (*userv1beta1.User, string, error) {
 	if mock.AuthenticateFunc == nil {
 		panic("UserBackendMock.AuthenticateFunc: method is nil but UserBackend.Authenticate was just called")
 	}
@@ -169,7 +170,7 @@ func (mock *UserBackendMock) CreateUserFromClaimsCalls() []struct {
 }
 
 // GetUserByClaims calls GetUserByClaimsFunc.
-func (mock *UserBackendMock) GetUserByClaims(ctx context.Context, claim string, value string, withRoles bool) (*userv1beta1.User, error) {
+func (mock *UserBackendMock) GetUserByClaims(ctx context.Context, claim string, value string, withRoles bool) (*userv1beta1.User, string, error) {
 	if mock.GetUserByClaimsFunc == nil {
 		panic("UserBackendMock.GetUserByClaimsFunc: method is nil but UserBackend.GetUserByClaims was just called")
 	}

--- a/storage/pkg/command/authbearer.go
+++ b/storage/pkg/command/authbearer.go
@@ -101,7 +101,7 @@ func authBearerConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]i
 			// TODO build services dynamically
 			"services": map[string]interface{}{
 				"authprovider": map[string]interface{}{
-					"auth_manager": "oidc",
+					"auth_manager": cfg.Reva.AuthBearerConfig.Driver,
 					"auth_managers": map[string]interface{}{
 						"oidc": map[string]interface{}{
 							"issuer":     cfg.Reva.OIDC.Issuer,
@@ -110,6 +110,9 @@ func authBearerConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]i
 							"uid_claim":  cfg.Reva.OIDC.UIDClaim,
 							"gid_claim":  cfg.Reva.OIDC.GIDClaim,
 							"gatewaysvc": cfg.Reva.Gateway.Endpoint,
+						},
+						"machine": map[string]interface{}{
+							"api_key": cfg.Reva.AuthBearerConfig.MachineAuthAPIKey,
 						},
 					},
 				},

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -119,6 +119,13 @@ type Users struct {
 	UserGroupsCacheExpiration int
 }
 
+// AuthBearerConfig defines the available configuration for the bearer auth drivers.
+type AuthBearerConfig struct {
+	Port
+	Driver            string
+	MachineAuthAPIKey string
+}
+
 // Groups defines the available groups configuration.
 type Groups struct {
 	Port
@@ -423,6 +430,7 @@ type Reva struct {
 	Users             Users
 	Groups            Groups
 	AuthProvider      Users
+	AuthBearerConfig  AuthBearerConfig
 	AuthBasic         Port
 	AuthBearer        Port
 	Sharing           Sharing

--- a/storage/pkg/flagset/authbearer.go
+++ b/storage/pkg/flagset/authbearer.go
@@ -19,6 +19,15 @@ func AuthBearerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.Reva.AuthBearer.DebugAddr,
 		},
 
+		// Driver
+		&cli.StringFlag{
+			Name:        "auth-driver",
+			Value:       flags.OverrideDefaultString(cfg.Reva.AuthBearerConfig.Driver, "oidc"),
+			Usage:       "bearer auth driver: 'oidc' or 'machine'",
+			EnvVars:     []string{"STORAGE_AUTH_BEARER_DRIVER"},
+			Destination: &cfg.Reva.AuthBearerConfig.Driver,
+		},
+
 		// OIDC
 
 		&cli.StringFlag{
@@ -61,6 +70,16 @@ func AuthBearerWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:       "OIDC gid claim",
 			EnvVars:     []string{"STORAGE_OIDC_GID_CLAIM"},
 			Destination: &cfg.Reva.OIDC.GIDClaim,
+		},
+
+		// Machine Auth
+
+		&cli.StringFlag{
+			Name:        "machine-auth-api-key",
+			Value:       flags.OverrideDefaultString(cfg.Reva.AuthBearerConfig.MachineAuthAPIKey, "change-me-please"),
+			Usage:       "the API key to be used for the machine auth driver in reva",
+			EnvVars:     []string{"STORAGE_AUTH_BEARER_MACHINE_AUTH_API_KEY", "OCIS_MACHINE_AUTH_API_KEY"},
+			Destination: &cfg.Reva.AuthBearerConfig.MachineAuthAPIKey,
 		},
 
 		// Services


### PR DESCRIPTION
When using the CS3 proxy backend, we previously obtained the user from reva's userprovider service and minted the token ourselves. This required maintaining a shared JWT secret between ocis and reva, as well duplication of logic. This PR delegates this logic by using the `Authenticate` method provided by the reva gateway service to obtain this token, making it an arbitrary, indestructible entry. Currently, the changes have been made to the proxy service but will be extended to others as well.

Closes https://github.com/owncloud/ocis/issues/2525