### PR TITLE
enable continous deployment for migration example

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1619,6 +1619,7 @@ def example_deploys(ctx):
         "ocis_wopi/latest.yml",
         "ocis_hello/latest.yml",
         "ocis_s3/latest.yml",
+        "oc10_ocis_parallel/latest.yml",
     ]
     released_configs = [
         "cs3_users_ocis/released.yml",


### PR DESCRIPTION
adding the deployment example was missed in #2302, since it only happens on master