### PR TITLE
check changelog also on [docs-only] PRs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -149,7 +149,7 @@ def main(ctx):
     elif (ctx.build.event == "pull_request" and "[docs-only]" in ctx.build.title) or \
          (ctx.build.event != "pull_request" and "[docs-only]" in (ctx.build.title + ctx.build.message)):
         # [docs-only] is not taken from PR messages, but from commit messages
-        pipelines = [docs(ctx)]
+        pipelines = [docs(ctx), changelog(ctx)]
 
     else:
         test_pipelines.append(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
PRs with [docs-only]  in their title do currently not check the changelog. This is a very short task and should be run on all PRs since adding an invalid changelog item would fail the CI on master after merging the PR.

This PR already demonstrates, that now the changelog step is run on [docs-only] PRs, too. (since it got the keyword in the title).