### PR TITLE
update plugins/s3:1 to plugins/s3:latest

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -282,7 +282,7 @@ def testOcisModule(ctx, module):
         },
         {
             "name": "scan-result-cache",
-            "image": "plugins/s3:1",
+            "image": "plugins/s3:latest",
             "settings": {
                 "endpoint": {
                     "from_secret": "cache_s3_endpoint",
@@ -1111,7 +1111,7 @@ def binaryRelease(ctx, name):
             },
             {
                 "name": "upload",
-                "image": "plugins/s3:1",
+                "image": "plugins/s3:latest",
                 "pull": "always",
                 "settings": settings,
                 "when": {


### PR DESCRIPTION
## Description

`plugins/s3:1` has an outdated CA store - it was build 2018-09-18. Therefore we got this error:

```
RequestError: send request failed
caused by: Put ******/cache/owncloud/ocis/e4bb5b8bef0527a312437b64cda97cc715e3ab5d-6950/cache/checkstyle/accounts_checkstyle.xml: x509: certificate has expired or is not yet valid
```

`plugins/s3:latest` is just 4 months old and therefore has a valid CA store...

Was caused by https://community.letsencrypt.org/t/help-thread-for-dst-root-ca-x3-expiration-september-2021/149190
