### PR TITLE
[full-ci] Update reva to  v1.13.1-0.20211001063718-477bb18843a9

### DIFF
--- a/changelog/unreleased/update-reva-to-477bb18843a97c6e392dd316e8735ccbe44f16ed.md
+++ b/changelog/unreleased/update-reva-to-477bb18843a97c6e392dd316e8735ccbe44f16ed.md
@@ -1,0 +1,23 @@
+Enhancement: Update reva to v1.13.1-0.20211001063718-477bb18843a9
+
+This update includes:
+
+* Bugfix [cs3org/reva#2076](https://github.com/cs3org/reva/pull/2076): Fix chi routing
+* Bugfix [cs3org/reva#2077](https://github.com/cs3org/reva/pull/2077): Fix concurrent registration of mimetypes
+* Bugfix [cs3org/reva#2074](https://github.com/cs3org/reva/pull/2074): Fix Stat() for eos storage provider
+* Bugfix [cs3org/reva#2072](https://github.com/cs3org/reva/pull/2072): Fix denial shares being visible on Shared-with-me page
+* Bugfix [cs3org/reva#2073](https://github.com/cs3org/reva/pull/2073): Fix opening a readonly filetype with WOPI
+* Bugfix [cs3org/reva#2114](https://github.com/cs3org/reva/pull/2114): Fix apps as default while registering and skip unset mimetypes
+* Security [cs3org/reva#2093](https://github.com/cs3org/reva/pull/2093): Limit the data exposed to resourceinfo and publicshare scopes
+* Security [cs3org/reva#2053](https://github.com/cs3org/reva/pull/2053): Use safer defaults for TLS verification on LDAP connections
+* Enhancement [cs3org/reva#1989](https://github.com/cs3org/reva/pull/1989): Implement url translation for legacy urls
+* Enhancement [cs3org/reva#2075](https://github.com/cs3org/reva/pull/2075): Make owncloudsql leverage existing filecache index
+* Enhancement [cs3org/reva#2090](https://github.com/cs3org/reva/pull/2090): Add space name during listStorageSpaces on decomposedfs
+* Enhancement [cs3org/reva#2088](https://github.com/cs3org/reva/pull/2088): Add archiver and app provider capabilities
+* Enhancement [cs3org/reva#2106](https://github.com/cs3org/reva/pull/2106): Add max num files and max size to the archiver capabilities
+* Enhancement [cs3org/reva#2067](https://github.com/cs3org/reva/pull/2067): Extend AppRegistry and AppProvider
+* Enhancement [cs3org/reva#2095](https://github.com/cs3org/reva/pull/2095): Whitelist apps via AppRegistry and AppProvider
+* Enhancement [cs3org/reva#2115](https://github.com/cs3org/reva/pull/2115): Reduce code duplication in LDAP related drivers
+* Enhancement [cs3org/reva#2100](https://github.com/cs3org/reva/pull/2100): Resource id based archiver for zip/tar downloads
+
+https://github.com/owncloud/ocis/pull/2566

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.1.0
 	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/cs3org/go-cs3apis v0.0.0-20210922150613-cb9e3c99f8de
-	github.com/cs3org/reva v1.13.1-0.20210930071148-6823079c1702
+	github.com/cs3org/reva v1.13.1-0.20211001063718-477bb18843a9
 	github.com/disintegration/imaging v1.6.2
 	github.com/glauth/glauth v1.1.3-0.20210729125545-b9aecdfcac31
 	github.com/go-chi/chi/v5 v5.0.4

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/crewjam/saml v0.4.5/go.mod h1:qCJQpUtZte9R1ZjUBcW8qtCNlinbO363ooNl02S
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20210922150613-cb9e3c99f8de h1:N+AI8wz7yhDDqHDuq9EGaqQoFhAOi9XW37xt0ormflw=
 github.com/cs3org/go-cs3apis v0.0.0-20210922150613-cb9e3c99f8de/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva v1.13.1-0.20210930071148-6823079c1702 h1:/z6evkFEnUOHg/1BaWGoaLmvd+zQIUn7SGZVn9aYtho=
-github.com/cs3org/reva v1.13.1-0.20210930071148-6823079c1702/go.mod h1:fLBEUChifLlv/b2cmkOB5E4jeD7xvyXbD6yZ6G4va0s=
+github.com/cs3org/reva v1.13.1-0.20211001063718-477bb18843a9 h1:0R1Gk+pIOyZpz4h1Ts/Fal9XAumC9162ppKM+QByb/w=
+github.com/cs3org/reva v1.13.1-0.20211001063718-477bb18843a9/go.mod h1:fLBEUChifLlv/b2cmkOB5E4jeD7xvyXbD6yZ6G4va0s=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=


### PR DESCRIPTION
## Description
This PR updates cs3org/reva to v1.13.1-0.20211001063718-477bb18843a9

## How Has This Been Tested?
- full CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
