### PR TITLE
configure "gatewaysvc" everywhere

### DIFF
--- a/storage/pkg/command/appprovider.go
+++ b/storage/pkg/command/appprovider.go
@@ -92,6 +92,7 @@ func appProviderConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]
 		},
 		"shared": map[string]interface{}{
 			"jwt_secret": cfg.Reva.JWTSecret,
+			"gatewaysvc": cfg.Reva.Gateway.Endpoint,
 		},
 		"grpc": map[string]interface{}{
 			"network": cfg.Reva.AppProvider.GRPCNetwork,

--- a/storage/pkg/command/authbasic.go
+++ b/storage/pkg/command/authbasic.go
@@ -103,6 +103,7 @@ func authBasicConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]in
 		},
 		"shared": map[string]interface{}{
 			"jwt_secret": cfg.Reva.JWTSecret,
+			"gatewaysvc": cfg.Reva.Gateway.Endpoint,
 		},
 		"grpc": map[string]interface{}{
 			"network": cfg.Reva.AuthBasic.GRPCNetwork,

--- a/storage/pkg/command/authbearer.go
+++ b/storage/pkg/command/authbearer.go
@@ -94,6 +94,7 @@ func authBearerConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]i
 		},
 		"shared": map[string]interface{}{
 			"jwt_secret": cfg.Reva.JWTSecret,
+			"gatewaysvc": cfg.Reva.Gateway.Endpoint,
 		},
 		"grpc": map[string]interface{}{
 			"network": cfg.Reva.AuthBearer.GRPCNetwork,

--- a/storage/pkg/command/users.go
+++ b/storage/pkg/command/users.go
@@ -110,6 +110,7 @@ func usersConfigFromStruct(c *cli.Context, cfg *config.Config) map[string]interf
 		},
 		"shared": map[string]interface{}{
 			"jwt_secret": cfg.Reva.JWTSecret,
+			"gatewaysvc": cfg.Reva.Gateway.Endpoint,
 		},
 		"grpc": map[string]interface{}{
 			"network": cfg.Reva.Users.GRPCNetwork,

--- a/storage/pkg/flagset/users.go
+++ b/storage/pkg/flagset/users.go
@@ -145,6 +145,16 @@ func UsersWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"STORAGE_USERPROVIDER_OWNCLOUDSQL_ENABLE_MEDIAL_SEARCH"},
 			Destination: &cfg.Reva.UserOwnCloudSQL.EnableMedialSearch,
 		},
+
+		// Gateway
+
+		&cli.StringFlag{
+			Name:        "gateway-url",
+			Value:       flags.OverrideDefaultString(cfg.Reva.Gateway.Endpoint, "localhost:9142"),
+			Usage:       "URL to use for the storage gateway service",
+			EnvVars:     []string{"STORAGE_GATEWAY_ENDPOINT"},
+			Destination: &cfg.Reva.Gateway.Endpoint,
+		},
 	}
 
 	flags = append(flags, TracingWithConfig(cfg)...)


### PR DESCRIPTION
## Description
configure "gatewaysvc" everywhere, like done in https://github.com/owncloud/ocis/pull/2562/files

## Related Issue
- oCIS fails in CI with `{"level":"error","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 0.0.0.0:19000: connect: connection refused\"","time":"2021-10-05T01:05:59Z","message":"could not listUserShares"}`
