### PR TITLE
fix oC10 oCIS parallel deployment

### DIFF
--- a/deployments/continuous-deployment-config/oc10_ocis_parallel/latest.yml
+++ b/deployments/continuous-deployment-config/oc10_ocis_parallel/latest.yml
@@ -17,6 +17,7 @@
     - "*.oc10-ocis-parallel.latest.owncloud.works"
 
   vars:
+    os_env_umask: 022 # https://github.com/dev-sec/ansible-collection-hardening/blob/master/roles/os_hardening/README.md#variables
     ssh_authorized_keys:
       - https://github.com/butonic.keys
       - https://github.com/C0rby.keys


### PR DESCRIPTION
## Description
Set a "normal" umask of `022` instead of a hardened `027` to make the oCIS entrypoint script executable after a git clone. This affects only our continuously deployed example since we apply host os hardening before deploying the example.