### PR TITLE
lower TUS max chunk size from infinite to 0.1 GB

### DIFF
--- a/changelog/unreleased/lower-tus-chunk-size.md
+++ b/changelog/unreleased/lower-tus-chunk-size.md
@@ -1,0 +1,6 @@
+Enhancement: Lower TUS max chunk size
+
+We've lowered the TUS max chunk size from infinite to 0.1GB so that chunking actually happens.
+
+https://github.com/owncloud/ocis/pull/2584
+https://github.com/cs3org/reva/pull/2136

--- a/storage/pkg/flagset/frontend.go
+++ b/storage/pkg/flagset/frontend.go
@@ -191,7 +191,7 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:        "upload-max-chunk-size",
-			Value:       flags.OverrideDefaultInt(cfg.Reva.UploadMaxChunkSize, 0),
+			Value:       flags.OverrideDefaultInt(cfg.Reva.UploadMaxChunkSize, 1e+8), // 0.1 GB
 			Usage:       "Max chunk size in bytes to advertise to clients through capabilities, or 0 for unlimited",
 			EnvVars:     []string{"STORAGE_FRONTEND_UPLOAD_MAX_CHUNK_SIZE"},
 			Destination: &cfg.Reva.UploadMaxChunkSize,


### PR DESCRIPTION
## Description
We've lowered the TUS max chunk size from infinite to 0.1GB so that chunking actually happens.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needs https://github.com/cs3org/reva/pull/2136
- Related to #1205, https://github.com/cs3org/reva/pull/1941

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
