### PR TITLE
Add favorites capability

### DIFF
--- a/changelog/unreleased/favorites-capability.md
+++ b/changelog/unreleased/favorites-capability.md
@@ -1,0 +1,5 @@
+Enhancement: Favorites capability
+
+We've added a capability for the storage frontend which can be used to announce to clients whether or not favorites are supported. By default this is disabled because the listing of favorites doesn't survive service restarts at the moment.
+
+https://github.com/owncloud/ocis/pull/2599

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -83,6 +83,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 				"versioning":        true,
 				"archivers":         archivers,
 				"app_providers":     appProviders,
+				"favorites":         cfg.Reva.Frontend.Favorites,
 			}
 
 			if cfg.Reva.DefaultUploadProtocol == "tus" {

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -149,6 +149,7 @@ type FrontendPort struct {
 	AppProviderPrefix       string
 	ArchiverPrefix          string
 	DatagatewayPrefix       string
+	Favorites               bool
 	OCDavPrefix             string
 	OCSPrefix               string
 	OCSSharePrefix          string

--- a/storage/pkg/flagset/frontend.go
+++ b/storage/pkg/flagset/frontend.go
@@ -129,6 +129,13 @@ func FrontendWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"STORAGE_FRONTEND_DATAGATEWAY_PREFIX"},
 			Destination: &cfg.Reva.Frontend.DatagatewayPrefix,
 		},
+		&cli.BoolFlag{
+			Name:        "favorites",
+			Value:       flags.OverrideDefaultBool(cfg.Reva.Frontend.Favorites, false),
+			Usage:       "announces favorites support to clients",
+			EnvVars:     []string{"STORAGE_FRONTEND_FAVORITES"},
+			Destination: &cfg.Reva.Frontend.Favorites,
+		},
 		&cli.StringFlag{
 			Name:        "ocdav-prefix",
 			Value:       flags.OverrideDefaultString(cfg.Reva.Frontend.OCDavPrefix, ""),


### PR DESCRIPTION
## Description
This PR adds a capability for `files.favorites` which is used to announce favorites support to clients. By default it's disabled for now because the implementation of the REPORT request doesn't allow service restarts as of now (there's no re-indexing of favorites, yet).

## Motivation and Context
Allow to use the experimental state of favorites.

## How Has This Been Tested?
- manually tested, since this is "only" a new capability.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
