### PR TITLE
return newly created space in response

### DIFF
--- a/changelog/unreleased/create-space-response.md
+++ b/changelog/unreleased/create-space-response.md
@@ -1,0 +1,6 @@
+Enhancement: Return the newly created space 
+
+Changed the response of the CreateSpace method to include the newly created space.
+
+https://github.com/owncloud/ocis/pull/2610
+https://github.com/cs3org/reva/pull/2158

--- a/graph/pkg/service/v0/drives.go
+++ b/graph/pkg/service/v0/drives.go
@@ -164,12 +164,12 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 	}
 	drive := msgraph.Drive{}
 	if err := json.NewDecoder(r.Body).Decode(&drive); err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Errorf("invalid schema definition").Error())
+		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, "invalid schema definition")
 		return
 	}
 	spaceName := *drive.Name
 	if spaceName == "" {
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, fmt.Errorf("invalid name").Error())
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "invalid name")
 		return
 	}
 
@@ -181,7 +181,7 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 	case "":
 		driveType = "project"
 	case "share":
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Errorf("drives of type share cannot be created via this api").Error())
+		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, "drives of type share cannot be created via this api")
 	}
 
 	var quota uint64
@@ -207,8 +207,24 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if resp.GetStatus().GetCode() != v1beta11.Code_CODE_OK {
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, fmt.Errorf("").Error())
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "")
 	}
+
+	wdu, err := url.Parse(g.config.Spaces.WebDavBase)
+	if err != nil {
+		g.logger.Error().Err(err).Msg("error parsing url")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	newDrive, err := cs3StorageSpaceToDrive(wdu, resp.StorageSpace)
+	if err != nil {
+		g.logger.Error().Err(err).Msg("error parsing url")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, newDrive)
 }
 
 func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
@@ -226,19 +242,19 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.FirstSegment.Identifier.Get() == "" {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Errorf("identifier cannot be empty").Error())
+		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, "identifier cannot be empty")
 		return
 	}
 
 	drive := msgraph.Drive{}
 	if err = json.NewDecoder(r.Body).Decode(&drive); err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Errorf("invalid request body: %v", r.Body).Error())
+		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", r.Body))
 		return
 	}
 
 	identifierParts := strings.Split(req.FirstSegment.Identifier.Get(), "!")
 	if len(identifierParts) != 2 {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Errorf("invalid resource id: %v", req.FirstSegment.Identifier.Get()).Error())
+		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid resource id: %v", req.FirstSegment.Identifier.Get()))
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 
@@ -262,13 +278,19 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	if drive.Quota.HasTotal() {
+		updateSpaceRequest.StorageSpace.Quota = &storageprovider.Quota{
+			QuotaMaxBytes: uint64(*drive.Quota.Total),
+		}
+	}
+
 	resp, err := client.UpdateStorageSpace(r.Context(), updateSpaceRequest)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 
 	if resp.GetStatus().GetCode() != v1beta11.Code_CODE_OK {
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, fmt.Errorf("").Error())
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "")
 	}
 
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added the newly created space in the response for CreateSpace and changed the response code to 201. Before the response was empty and returned a `200 OK`.

Requires this Reva change: https://github.com/cs3org/reva/pull/2158


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is compatible to what Microsoft is doing in the Graph API:
https://docs.microsoft.com/en-us/graph/api/user-post-users?view=graph-rest-1.0&tabs=http#response-1
https://docs.microsoft.com/en-us/graph/api/user-post-calendars?view=graph-rest-1.0&tabs=http#response-1

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally in the graph explorer


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
