### PR TITLE
[deployment-examples] streamline configuration

### DIFF
--- a/deployments/examples/cs3_users_ocis/config/ocis/proxy-config.json
+++ b/deployments/examples/cs3_users_ocis/config/ocis/proxy-config.json
@@ -62,6 +62,10 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/app/",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/data",
           "backend": "http://localhost:9140"
         },

--- a/deployments/examples/ocis_keycloak/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_keycloak/config/ocis/entrypoint-override.sh
@@ -5,34 +5,23 @@ set -e
 ocis server&
 sleep 10
 
-# stop builtin idp since we use Keycloak as a replacement
+# stop builtin IDP since we use Keycloak as a replacement
 ocis kill idp
 
 echo "##################################################"
 echo "change default secrets:"
 
-# REVA
-REVA_USER_UUID=$(ocis accounts list | grep " | Reva Inter " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
-echo "  Reva user UUID: $REVA_USER_UUID"
-ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD $REVA_USER_UUID
+ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD bc596f3c-c955-4328-80a0-60d018b4ad57 # REVA
 
-echo "default secrets changed"
 echo "##################################################"
 
 echo "##################################################"
-echo "delete demo users" # demo users are provided by keycloak
+echo "delete demo users" # users are provided by keycloak
 
 set +e # accounts can only delete once, so it will fail the second time
-# IDP
-IDP_USER_UUID=$(ocis accounts list | grep "| Kopano IDP " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
-echo "  IDP user UUID: $IDP_USER_UUID"
-ocis accounts remove $IDP_USER_UUID
-
-ocis accounts remove 4c510ada-c86b-4815-8820-42cdf82c3d51
-ocis accounts remove ddc2004c-0977-11eb-9d3f-a793888cd0f8
-ocis accounts remove 932b4540-8d16-481e-8ef4-588e4b6b151c
-ocis accounts remove 058bff95-6708-4fe5-91e4-9ea3d377588b
-ocis accounts remove f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c
+# only admin, IDP and REVA user will be created because of ACCOUNTS_DEMO_USERS_AND_GROUPS=false
+ocis accounts remove  820ba2a1-3f54-4538-80a4-2d73007e30bf # IDP user
+ocis accounts remove ddc2004c-0977-11eb-9d3f-a793888cd0f8 # admin
 set -e
 
 echo "##################################################"

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: false # don't generate demo users
       # change default secrets
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}

--- a/proxy/config/proxy-example-migration.json
+++ b/proxy/config/proxy-example-migration.json
@@ -77,6 +77,10 @@
           "backend": "http://localhost:9120"
         },
         {
+          "endpoint": "/app/",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/graph-explorer/",
           "backend": "http://localhost:9135"
         },

--- a/proxy/config/proxy-example-regex.json
+++ b/proxy/config/proxy-example-regex.json
@@ -12,12 +12,42 @@
       "selector_cookie_name": "owncloud-selector",
       "default_policy": "oc10",
       "matches_policies": [
-        {"priority": 10, "property": "mail", "match": "marie@example.org", "policy": "ocis"},
-        {"priority": 20, "property": "mail", "match": "[^@]+@example.org", "policy": "oc10"},
-        {"priority": 30, "property": "username", "match": "(einstein|feynman)", "policy": "ocis"},
-        {"priority": 40, "property": "username", "match": ".+", "policy": "oc10"},
-        {"priority": 50, "property": "id", "match": "4c510ada-c86b-4815-8820-42cdf82c3d51", "policy": "ocis"},
-        {"priority": 60, "property": "id", "match": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c", "policy": "oc10"}
+        {
+          "priority": 10,
+          "property": "mail",
+          "match": "marie@example.org",
+          "policy": "ocis"
+        },
+        {
+          "priority": 20,
+          "property": "mail",
+          "match": "[^@]+@example.org",
+          "policy": "oc10"
+        },
+        {
+          "priority": 30,
+          "property": "username",
+          "match": "(einstein|feynman)",
+          "policy": "ocis"
+        },
+        {
+          "priority": 40,
+          "property": "username",
+          "match": ".+",
+          "policy": "oc10"
+        },
+        {
+          "priority": 50,
+          "property": "id",
+          "match": "4c510ada-c86b-4815-8820-42cdf82c3d51",
+          "policy": "ocis"
+        },
+        {
+          "priority": 60,
+          "property": "id",
+          "match": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+          "policy": "oc10"
+        }
       ],
       "unauthenticated_policy": "oc10"
     }
@@ -78,6 +108,10 @@
         },
         {
           "endpoint": "/data",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/app/",
           "backend": "http://localhost:9140"
         },
         {

--- a/proxy/config/proxy-example.json
+++ b/proxy/config/proxy-example.json
@@ -67,6 +67,10 @@
           "backend": "http://localhost:9140"
         },
         {
+					"endpoint": "/app/",
+					"backend":  "http://localhost:9140"
+				},
+        {
           "endpoint": "/graph/",
           "backend": "http://localhost:9120"
         },

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -300,10 +300,6 @@ func defaultPolicies() []config.Policy {
 					Backend:  "http://localhost:9110",
 				},
 				{
-					Endpoint: "/app/",
-					Backend:  "http://localhost:9140",
-				},
-				{
 					Endpoint: "/ocs/",
 					Backend:  "http://localhost:9140",
 				},
@@ -334,6 +330,10 @@ func defaultPolicies() []config.Policy {
 				},
 				{
 					Endpoint: "/data",
+					Backend:  "http://localhost:9140",
+				},
+				{
+					Endpoint: "/app/",
 					Backend:  "http://localhost:9140",
 				},
 				{


### PR DESCRIPTION
## Description
- add app provider route to all proxy configurations (and move it to the same position)
- use ACCOUNTS_DEMO_USERS_AND_GROUPS where applicable, remove only admin and IDP demo users where needed
- remove accounts / change password by static account id (without `accounts list | grep ... | egrep ...` magic)

