### PR TITLE
feat(public-token): get public-token from query string

### DIFF
--- a/proxy/pkg/middleware/public_share_auth.go
+++ b/proxy/pkg/middleware/public_share_auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -53,8 +52,6 @@ func PublicShareAuth(opts ...Option) func(next http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-
-			fmt.Println("########################################################", authResp.Token)
 
 			r.Header.Add(headerRevaAccessToken, authResp.Token)
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
due the need for web to retrieve binaries like archives it is needed to authenticate the request by the query string also.
This only is needed in cases where no explicit header mutation is possible, for example `window.location = url?public-token=foo`

## Related Issue
- Extends #2536

## Motivation and Context
be able to auth requests with the url only

## How Has This Been Tested?
- local installation
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
