### PR TITLE
use insecure ldap for deployment examples

### DIFF
--- a/deployments/examples/cs3_users_ocis/docker-compose.yml
+++ b/deployments/examples/cs3_users_ocis/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       PROXY_ACCOUNT_BACKEND_TYPE: cs3
       STORAGE_LDAP_HOSTNAME: ldap-server
       STORAGE_LDAP_PORT: 636
+      STORAGE_LDAP_INSECURE: "true"
       STORAGE_LDAP_BASE_DN: "dc=owncloud,dc=com"
       STORAGE_LDAP_BIND_DN: "cn=admin,dc=owncloud,dc=com"
       STORAGE_LDAP_BIND_PASSWORD: ${LDAP_ADMIN_PASSWORD:-admin}

--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       # LDAP bind
       STORAGE_LDAP_HOSTNAME: openldap
       STORAGE_LDAP_PORT: 636
+      STORAGE_LDAP_INSECURE: "true"
       STORAGE_LDAP_BIND_DN: "cn=admin,dc=owncloud,dc=com"
       STORAGE_LDAP_BIND_PASSWORD: ${LDAP_ADMIN_PASSWORD:-admin}
       # LDAP user settings


### PR DESCRIPTION
## Description
set `STORAGE_LDAP_INSECURE` for LDAP and oC10 / oCIS parallel deployment examples to make them work again.
