### PR TITLE
Remove -i flag on build

### DIFF
--- a/.make/go.mk
+++ b/.make/go.mk
@@ -11,11 +11,7 @@ else
 	UNAME := $(shell uname -s)
 endif
 
-ifeq ($(UNAME), Darwin)
-	GOBUILD ?= go build -i
-else
-	GOBUILD ?= go build
-endif
+GOBUILD ?= go build
 
 SOURCES ?= $(shell find . -name "*.go" -type f -not -path "./node_modules/*")
 


### PR DESCRIPTION
As per go 1.17:

> The -i flag is deprecated. Compiled packages are cached automatically.

