### PR TITLE
fix cs3 users deployment example

### DIFF
--- a/deployments/examples/cs3_users_ocis/docker-compose.yml
+++ b/deployments/examples/cs3_users_ocis/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       PROXY_CONFIG_FILE: "/var/tmp/ocis/.config/proxy-config.json"
       # General oCIS config
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS


### PR DESCRIPTION
## Description
Currently the CS3 users deployment example does not work on our continuous deployment since `OCIS_DOMAIN` is missing for the web config.json templating. 

Therefore we have `https://ocis.owncloud.test` in the config.json, even if the domain is different: https://ocis.ocis-cs3-users.latest.owncloud.works/config.json
