### PR TITLE
idp: Create parent directories if they don't exist

### DIFF
--- a/changelog/unreleased/idp-parent-dir.md
+++ b/changelog/unreleased/idp-parent-dir.md
@@ -1,0 +1,6 @@
+Bugfix: Create parent directories for idp configuration
+
+The parent directories of the identifier-registration.yaml config file might
+not exist when starting idp. Create them, when that is the case.
+
+https://github.com/owncloud/ocis/issues/2667

--- a/idp/pkg/service/v0/service.go
+++ b/idp/pkg/service/v0/service.go
@@ -73,7 +73,7 @@ func createConfigsIfNotExist(assets http.FileSystem, filePath, ocisURL string) e
 
 	folder := path.Dir(filePath)
 	if _, err := os.Stat(folder); os.IsNotExist(err) {
-		if err := os.Mkdir(folder, 0700); err != nil {
+		if err := os.MkdirAll(folder, 0700); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description

The parent directories of the identifier-registration.yaml config file might
not exist when starting idp. So instead of creating just the top most
directory use MkdirAll to also create the parents.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
