### PR TITLE
Api tests for space

### DIFF
--- a/tests/acceptance/features/apiSpaces/ListSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/ListSpaces.feature
@@ -1,7 +1,7 @@
 @api @skipOnOcV10
 Feature: List and create spaces
   As a user
-  I want to be able to work with personal and project spaces to collaborate with individuals and teams
+  I want to be able to work with personal and project spaces
 
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
@@ -12,31 +12,33 @@ Feature: List and create spaces
   Scenario: Alice request her space via the Graph api, she expects a 200 code and the correct data in the response
     When user "Alice" lists all available spaces via the GraphApi
     Then the HTTP status code should be "200"
-    And the json responded should contain these key and value pairs
-      | key          | value        |
-      | driveType    | personal     |
-      | name         | Alice Hansen |
-      | quota@@@used | 0            |
+    And the json responded should contain a space "Alice Hansen" with these key and value pairs:
+      | key              | value        |
+      | driveType        | personal     |
+      | id               | %space_id%   |
+      | name             | Alice Hansen |
+      | quota@@@state    | normal       |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
 
-  Scenario: Alice requests her space via webDav api, she expects a 207 code 
+  Scenario: Alice requests her space via webDav api, she expects a 207 code
     When user "Alice" lists all available spaces via the GraphApi
-    And user "Alice" lists the content of the space with the name "Alice Hansen" using the WebDav Api 
+    And user "Alice" lists the content of the space with the name "Alice Hansen" using the WebDav Api
     Then the HTTP status code should be "207"
 
-  Scenario: Alice tryes to create Space via Graph api without right, she expects a response of 401
+  Scenario: Alice tries to create Space via Graph api without permission, she expects a response of 401
     When user "Alice" creates a space "Project Mars" of type "project" with the default quota using the GraphApi
     Then the HTTP status code should be "401"
 
-  Scenario: Alice creates Space via Graph api with defaul quota, she expects a 201 code the correct data and that space exists
+  Scenario: Alice creates Space via Graph api with default quota, she expects a 201 code the correct data and that space exists
     Given the administrator gives "Alice" the role "Admin" using the settings api
     When user "Alice" creates a space "Project Mars" of type "project" with the default quota using the GraphApi
     Then the HTTP status code should be "201"
-    And the json responded should contain these key and value pairs
-      | key           | value        |
-      | driveType     | project      |
-      | name          | Project Mars |
-      | quota@@@total | 1000000000   | 
-
+    And the json responded should contain a space "Project Mars" with these key and value pairs:
+      | key              | value        |
+      | driveType        | project      |
+      | name             | Project Mars |
+      | quota@@@total    | 1000000000   |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
     When user "Alice" lists all available spaces via the GraphApi
     And user "Alice" lists the content of the space with the name "Project Mars" using the WebDav Api
     Then the propfind result of the space should contain these entries:
@@ -46,13 +48,14 @@ Feature: List and create spaces
     Given the administrator gives "Alice" the role "Admin" using the settings api
     When user "Alice" creates a space "Project Venus" of type "project" with quota "2000" using the GraphApi
     Then the HTTP status code should be "201"
-    And the json responded should contain these key and value pairs
-      | key           | value         |
-      | driveType     | project       |
-      | name          | Project Venus |
-      | quota@@@total | 2000          | 
-    
-  Scenario: Alice creates folder via WebDav api in space, she expects a 201 code and she checks that folder exists
+    And the json responded should contain a space "Project Venus" with these key and value pairs:
+      | key              | value         |
+      | driveType        | project       |
+      | name             | Project Venus |
+      | quota@@@total    | 2000          |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+
+  Scenario: Alice creates folder via Graph api in space, she expects a 201 code and she checks that folder exists
     Given the administrator gives "Alice" the role "Admin" using the settings api
     When user "Alice" creates a space "Project Venus" of type "project" with quota "2000" using the GraphApi
     And user "Alice" lists all available spaces via the GraphApi
@@ -61,4 +64,3 @@ Feature: List and create spaces
     When user "Alice" lists the content of the space with the name "Project Venus" using the WebDav Api
     Then the propfind result of the space should contain these entries:
       | mainFolder/        |
-    


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
 
- Split one test into several.
- Added quota check.
- Added "create a folder in space" test

### Test Step Documentation

```gherkin
And the json responded should contain a space "Alice Hansen" with these key and value pairs:
      | key              | value        |
      | driveType        | personal     |
      | id               | %space_id%   |
      | name             | Alice Hansen |
      | quota@@@state    | normal       |
      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
```

- I added the `%space_id%` variable to the SpacesContext. Kudos to @individual-it and @phil-davis for that flexible framework.
- I used `@@@` as a separator for a multi-dimensional array like in other places (capabilities, ShareAPI) 


## Motivation and Context

Create a Foundation of testing steps that can be extended in the future

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
