### PR TITLE
Announce resharing as false in capabilities

### DIFF
--- a/changelog/unreleased/storage-disable-resharing.md
+++ b/changelog/unreleased/storage-disable-resharing.md
@@ -1,0 +1,5 @@
+Bugfix: Don't announce resharing via capabilities
+
+oCIS / Reva is not capable of resharing, yet. We've set the resharing capability to false, so that clients have a chance to react accordingly.
+
+https://github.com/owncloud/ocis/pull/2690

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -244,7 +244,7 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 							"dav":   map[string]interface{}{},
 							"files_sharing": map[string]interface{}{
 								"api_enabled":                       true,
-								"resharing":                         true,
+								"resharing":                         false,
 								"group_sharing":                     true,
 								"auto_accept_share":                 true,
 								"share_with_group_members_only":     true,


### PR DESCRIPTION
## Description
oCIS / Reva is not capable of resharing, yet. This PR sets the resharing capability to false, so that clients have a chance to react accordingly. At the moment ownCloud Web uses a hardcoded hack to get around this. Announcing the capability correctly will allow us to streamline code in Web.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
