### PR TITLE
enable users to list all spaces

### DIFF
--- a/changelog/unreleased/list-all-spaces.md
+++ b/changelog/unreleased/list-all-spaces.md
@@ -1,0 +1,5 @@
+Enhancement: Add API to list all spaces
+
+Added a graph endpoint to enable users with the `list-all-spaces` permission to list all spaces.
+
+https://github.com/owncloud/ocis/pull/2692

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.2.1
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/cs3org/go-cs3apis v0.0.0-20211018122138-391b29bd7803
-	github.com/cs3org/reva v1.15.0
+	github.com/cs3org/reva v1.15.1-0.20211027114107-4879bf6be97a
 	github.com/disintegration/imaging v1.6.2
 	github.com/glauth/glauth/v2 v2.0.0-20211021011345-ef3151c28733
 	github.com/go-chi/chi/v5 v5.0.4

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/crewjam/saml v0.4.5/go.mod h1:qCJQpUtZte9R1ZjUBcW8qtCNlinbO363ooNl02S
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20211018122138-391b29bd7803 h1:R/6llgTNKxQQ7GaSTgFn6Fp8N50wIlagmdR7WY5LntM=
 github.com/cs3org/go-cs3apis v0.0.0-20211018122138-391b29bd7803/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva v1.15.0 h1:06Nso0/2ySmt/bXbXip/QQ1bUPwBUuqYm2zJXrYiR2A=
-github.com/cs3org/reva v1.15.0/go.mod h1:Pwo2bbUCXDfGPIxh1392/a7393H7S+roP7ccip67wTI=
+github.com/cs3org/reva v1.15.1-0.20211027114107-4879bf6be97a h1:rg00QAtWaC4vQMWJzp6m5UQfO1WgBg9g9tXz8jvjGtA=
+github.com/cs3org/reva v1.15.1-0.20211027114107-4879bf6be97a/go.mod h1:Pwo2bbUCXDfGPIxh1392/a7393H7S+roP7ccip67wTI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -58,6 +58,7 @@ func NewService(opts ...Option) Service {
 					account.JWTSecret(options.Config.TokenManager.JWTSecret)),
 				)
 				r.Route("/drives", func(r chi.Router) {
+					r.Get("/", svc.GetDrives)
 					r.Post("/", svc.CreateDrive)
 				})
 				r.Route("/Drive({firstSegmentIdentifier})", func(r chi.Router) {

--- a/settings/pkg/service/v0/settings.go
+++ b/settings/pkg/service/v0/settings.go
@@ -29,6 +29,11 @@ const (
 	// SetSpaceQuotaPermissionName is the hardcoded setting name for the set space quota permission
 	SetSpaceQuotaPermissionName string = "set-space-quota"
 
+	// ListAllSpacesPermissionID is the hardcoded setting UUID for the list all spaces permission
+	ListAllSpacesPermissionID string = "016f6ddd-9501-4a0a-8ebe-64a20ee8ec82"
+	// ListAllSpacesPermissionName is the hardcoded setting name for the list all spaces permission
+	ListAllSpacesPermissionName string = "list-all-spaces"
+
 	// CreateSpacePermissionID is the hardcoded setting UUID for the create space permission
 	CreateSpacePermissionID string = "79e13b30-3e22-11eb-bc51-0b9f0bad9a58"
 	// CreateSpacePermissionName is the hardcoded setting name for the create space permission
@@ -373,6 +378,24 @@ func generatePermissionRequests() []*settings.AddSettingToBundleRequest {
 				Value: &settings.Setting_PermissionValue{
 					PermissionValue: &settings.Permission{
 						Operation:  settings.Permission_OPERATION_READWRITE,
+						Constraint: settings.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+		},
+		{
+			BundleId: BundleUUIDRoleAdmin,
+			Setting: &settings.Setting{
+				Id:          ListAllSpacesPermissionID,
+				Name:        ListAllSpacesPermissionName,
+				DisplayName: "List All Spaces",
+				Description: "This permission allows list all spaces.",
+				Resource: &settings.Resource{
+					Type: settings.Resource_TYPE_SYSTEM,
+				},
+				Value: &settings.Setting_PermissionValue{
+					PermissionValue: &settings.Permission{
+						Operation:  settings.Permission_OPERATION_READ,
 						Constraint: settings.Permission_CONSTRAINT_ALL,
 					},
 				},


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added a new permission `list-all-spaces` and a new endpoint to list all spaces.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some users should be able to list all spaces so they can maintain them. (Update quota, etc.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally via the graph explorer


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes

