### PR TITLE
no error logging on unsupported files for thumbnailer

### DIFF
--- a/changelog/unreleased/fix-thumbnail-logging.md
+++ b/changelog/unreleased/fix-thumbnail-logging.md
@@ -1,0 +1,7 @@
+Bugfix: Fix error logging when there is no thumbnail for a file
+
+We've fixed the behavior of the logging when there is no thumbnail for a file
+(because the filetype is not supported for thumbnail generation).
+Previously the WebDAV service always issues an error log in this case. Now, we don't log this event any more.
+
+https://github.com/owncloud/ocis/pull/2702

--- a/webdav/pkg/service/v0/service.go
+++ b/webdav/pkg/service/v0/service.go
@@ -45,9 +45,9 @@ func NewService(opts ...Option) Service {
 	m.Use(options.Middleware...)
 
 	svc := Webdav{
-		config: options.Config,
-		log:    options.Logger,
-		mux:    m,
+		config:           options.Config,
+		log:              options.Logger,
+		mux:              m,
 		thumbnailsClient: thumbnails.NewThumbnailService("com.owncloud.api.thumbnails", grpc.DefaultClient),
 	}
 
@@ -62,9 +62,9 @@ func NewService(opts ...Option) Service {
 
 // Webdav defines implements the business logic for Service.
 type Webdav struct {
-	config *config.Config
-	log    log.Logger
-	mux    *chi.Mux
+	config           *config.Config
+	log              log.Logger
+	mux              *chi.Mux
 	thumbnailsClient thumbnails.ThumbnailService
 }
 
@@ -96,16 +96,18 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 	if err != nil {
-		g.log.Error().Err(err).Msg("could not get thumbnail")
 		e := merrors.Parse(err.Error())
 		switch e.Code {
 		case http.StatusNotFound:
+			// StatusNotFound is expected for unsupported files
 			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
+			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(err.Error()))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
+		g.log.Error().Err(err).Msg("could not get thumbnail")
 		return
 	}
 
@@ -139,16 +141,18 @@ func (g Webdav) PublicThumbnail(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 	if err != nil {
-		g.log.Error().Err(err).Msg("could not get thumbnail")
 		e := merrors.Parse(err.Error())
 		switch e.Code {
 		case http.StatusNotFound:
+			// StatusNotFound is expected for unsupported files
 			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
+			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(err.Error()))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
+		g.log.Error().Err(err).Msg("could not get thumbnail")
 		return
 	}
 
@@ -185,14 +189,15 @@ func (g Webdav) PublicThumbnailHead(w http.ResponseWriter, r *http.Request) {
 		e := merrors.Parse(err.Error())
 		switch e.Code {
 		case http.StatusNotFound:
+			// StatusNotFound is expected for unsupported files
 			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
+			return
 		case http.StatusBadRequest:
-			g.log.Error().Err(err).Msg("could not get thumbnail")
 			renderError(w, r, errBadRequest(err.Error()))
 		default:
-			g.log.Error().Err(err).Msg("could not get thumbnail")
 			renderError(w, r, errInternalError(err.Error()))
 		}
+		g.log.Error().Err(err).Msg("could not get thumbnail")
 		return
 	}
 


### PR DESCRIPTION

## Description
Bugfix: Fix error logging when there is no thumbnail for a file

We've fixed the behavior of the logging when there is no thumbnail for a file
(because the filetype is not supported for thumbnail generation).
Previously the WebDAV service always issues an error log in this case. Now, we don't log this event any **more.**

## Related Issue

## Motivation and Context
Reduce error logging on production instances, to see real errors.

## How Has This Been Tested?
- 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
