### PR TITLE
[docs-only] Add note about OIDC discovery redirect for Keycloak

### DIFF
--- a/docs/ocis/deployment/ocis_keycloak.md
+++ b/docs/ocis/deployment/ocis_keycloak.md
@@ -17,7 +17,8 @@ geekdocFilePath: ocis_keycloak.md
 
 [Find this example on GitHub](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_keycloak)
 
-The docker stack consists 4 containers. One of them is Traefik, a proxy which is terminating ssl and forwards the requests to oCIS in the internal docker network.
+The docker stack consists 4 containers. One of them is Traefik, a proxy which is terminating ssl and forwards the requests to oCIS in the internal docker network. It
+is also responsible for redirecting requests on the OIDC discovery endpoints (e.g. `.well-known/openid-configuration`) to the correct destination in Keycloak.
 
 Keycloak add two containers: Keycloak itself and a PostgreSQL as database. Keycloak will be configured as oCIS' IDP instead of the internal IDP [LibreGraph Connect]({{< ref "../../extensions/idp" >}})
 


### PR DESCRIPTION
## Description
Using an external OIDC IDP means that, that IDP also needs to serve  the OIDC discovery information.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes: https://github.com/owncloud/ocis/issues/2676
