### PR TITLE
use selfhosted icons in oCIS WOPI deployment example

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1554,8 +1554,11 @@ def skipIfUnchanged(ctx, type):
         return []
 
     base = [
-        "^docs/.*",
+        "^.github/.*",
+        "^.vscode/.*",
         "^changelog/.*",
+        "^docs/.*",
+        "^deployments/.*",
     ]
     unit = [
         ".*_test.go$",

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       APP_PROVIDER_DRIVER: wopi
       APP_PROVIDER_WOPI_DRIVER_APP_NAME: Collabora
-      APP_PROVIDER_WOPI_DRIVER_APP_ICON_URI: https://www.collaboraoffice.com/wp-content/uploads/2019/01/CP-icon.png
+      APP_PROVIDER_WOPI_DRIVER_APP_ICON_URI: https://${COLLABORA_DOMAIN:-collabora.owncloud.test}/favicon.ico
       APP_PROVIDER_WOPI_DRIVER_APP_URL: https://${COLLABORA_DOMAIN:-collabora.owncloud.test}
       APP_PROVIDER_WOPI_DRIVER_INSECURE: "${INSECURE:-false}"
       APP_PROVIDER_WOPI_DRIVER_IOP_SECRET: ${WOPI_IOP_SECRET:-LoremIpsum123}
@@ -123,7 +123,7 @@ services:
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       APP_PROVIDER_DRIVER: wopi
       APP_PROVIDER_WOPI_DRIVER_APP_NAME: OnlyOffice
-      APP_PROVIDER_WOPI_DRIVER_APP_ICON_URI: https://www.pikpng.com/pngl/m/343-3435764_onlyoffice-desktop-editors-onlyoffice-logo-clipart.png
+      APP_PROVIDER_WOPI_DRIVER_APP_ICON_URI: https://${ONLYOFFICE_DOMAIN:-onlyoffice.owncloud.test}/web-apps/apps/documenteditor/main/resources/img/favicon.ico
       APP_PROVIDER_WOPI_DRIVER_APP_URL: https://${ONLYOFFICE_DOMAIN:-onlyoffice.owncloud.test}
       APP_PROVIDER_WOPI_DRIVER_INSECURE: "${INSECURE:-false}"
       APP_PROVIDER_WOPI_DRIVER_IOP_SECRET: ${WOPI_IOP_SECRET:-LoremIpsum123}
@@ -152,7 +152,7 @@ services:
       APP_PROVIDER_DRIVER: wopi
       APP_PROVIDER_WOPI_DRIVER_APP_NAME: CodiMD
       APP_PROVIDER_WOPI_DRIVER_APP_API_KEY: ${CODIMD_SECRET:-LoremIpsum456}
-      APP_PROVIDER_WOPI_DRIVER_APP_ICON_URI: https://avatars.githubusercontent.com/u/67865462?v=4
+      APP_PROVIDER_WOPI_DRIVER_APP_ICON_URI: https://${CODIMD_DOMAIN:-codimd.owncloud.test}/favicon.png
       APP_PROVIDER_WOPI_DRIVER_APP_URL: https://${CODIMD_DOMAIN:-codimd.owncloud.test}
       APP_PROVIDER_WOPI_DRIVER_INSECURE: "${INSECURE:-false}"
       APP_PROVIDER_WOPI_DRIVER_IOP_SECRET: ${WOPI_IOP_SECRET:-LoremIpsum123}


### PR DESCRIPTION
## Description
use self hosted icons for office apps in oCIS WOPI deployment example

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-  Same as https://github.com/owncloud/web/pull/6000

## Motivation and Context
Don't fetch the image from a third party
