### PR TITLE
fix opening images in media viewer for some usernames

### DIFF
--- a/changelog/unreleased/fix-mediaviewer-url-encoded.md
+++ b/changelog/unreleased/fix-mediaviewer-url-encoded.md
@@ -1,0 +1,5 @@
+Bugfix: Fix opening images in media viewer for some usernames
+
+We've fixed the opening of images in the media viewer for user names containing special characters (eg. `@`) which will be URL-escaped. Before this fix users could not see the image in the media viewer. Now the user name is correctly escaped and the user can view the image in the media viewer.
+
+https://github.com/owncloud/ocis/pull/2738

--- a/webdav/pkg/dav/requests/thumbnail.go
+++ b/webdav/pkg/dav/requests/thumbnail.go
@@ -66,10 +66,15 @@ func ParseThumbnailRequest(r *http.Request) (*ThumbnailRequest, error) {
 // So using the URLParam function is not possible.
 func extractFilePath(r *http.Request) (string, error) {
 	user := chi.URLParam(r, "user")
+	user, err := url.QueryUnescape(user)
+	if err != nil {
+		return "", errors.New("could not unescape user")
+	}
 	if user != "" {
 		parts := strings.SplitN(r.URL.Path, user, 2)
 		return parts[1], nil
 	}
+
 	token := chi.URLParam(r, "token")
 	if token != "" {
 		parts := strings.SplitN(r.URL.Path, token, 2)


### PR DESCRIPTION
## Description
Users with a username like `foo@baz.test` can not view images in the media viewer. This PR fixes that.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
some oCIS installations might use email addresses as username.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
