### PR TITLE
[deployment examples] redirect oCIS users from oC10 login to oC Web

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/config/ocis/proxy-config.dist.json
+++ b/deployments/examples/oc10_ocis_parallel/config/ocis/proxy-config.dist.json
@@ -55,6 +55,14 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/index.php/login",
+          "backend": "http://localhost:9100"
+        },
+        {
+          "endpoint": "/login",
+          "backend": "http://localhost:9100"
+        },
+        {
           "endpoint": "/data",
           "backend": "http://localhost:9140"
         },


### PR DESCRIPTION
## Description
Migration deployment:
If  a users opens a `/index.php/login` or `/login` bookmark and is already migrated to oCIS, the user will not be gracefully redirected to the login screen / oC Web. Therefore I added a forward to the Web extension for these paths, which will then do a redirect.

You can try out the bug behavior on: https://cloud.oc10-ocis-parallel.latest.owncloud.works. Log in as einstein and see that you use oCIS. Then navigate to https://cloud.oc10-ocis-parallel.latest.owncloud.works/index.php/login and see that you are stuck.

After this PR you will be redirected to oC Web when you follow the second link