### PR TITLE
[deployment examples] make archiver work for deployment examples with custom proxy config

### DIFF
--- a/deployments/examples/cs3_users_ocis/config/ocis/proxy-config.json
+++ b/deployments/examples/cs3_users_ocis/config/ocis/proxy-config.json
@@ -66,6 +66,10 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/archiver",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/data",
           "backend": "http://localhost:9140"
         },

--- a/deployments/examples/oc10_ocis_parallel/config/ocis/proxy-config.dist.json
+++ b/deployments/examples/oc10_ocis_parallel/config/ocis/proxy-config.dist.json
@@ -63,6 +63,14 @@
           "backend": "http://localhost:9120"
         },
         {
+          "endpoint": "/app/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/archiver",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/graph-explorer/",
           "backend": "http://localhost:9135"
         },

--- a/deployments/examples/ocis_hello/config/ocis/proxy-config.json
+++ b/deployments/examples/ocis_hello/config/ocis/proxy-config.json
@@ -66,6 +66,14 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/app/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/archiver",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/graph/",
           "backend": "http://localhost:9120"
         },

--- a/proxy/config/proxy-example-migration.json
+++ b/proxy/config/proxy-example-migration.json
@@ -81,6 +81,10 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/archiver",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/graph-explorer/",
           "backend": "http://localhost:9135"
         },

--- a/proxy/config/proxy-example-regex.json
+++ b/proxy/config/proxy-example-regex.json
@@ -115,6 +115,10 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/archiver",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/graph/",
           "backend": "http://localhost:9120"
         },

--- a/proxy/config/proxy-example.json
+++ b/proxy/config/proxy-example.json
@@ -67,9 +67,13 @@
           "backend": "http://localhost:9140"
         },
         {
-					"endpoint": "/app/",
-					"backend":  "http://localhost:9140"
-				},
+          "endpoint": "/app/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/archiver",
+          "backend": "http://localhost:9140"
+        },
         {
           "endpoint": "/graph/",
           "backend": "http://localhost:9120"


### PR DESCRIPTION
## Description
Some deployment examples miss the archiver and / or the app endpoint. These are added in this PR.