### PR TITLE
[tests-only] Refactor spaces API tests

### DIFF
--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -16,19 +16,16 @@ Feature: Upload files into a space
     And user "Alice" lists all available spaces via the GraphApi
     And user "Alice" creates a folder "mainFolder" in space "Project Venus" using the WebDav Api
     Then the HTTP status code should be "201"
-    When user "Alice" lists the content of the space with the name "Project Venus" using the WebDav Api
-    Then the propfind result of the space should contain these entries:
+    And the space "Project Venus" should contain these entries:
       | mainFolder        |
 
-  Scenario: Bob creates a folder via the Graph api in a space, he expects a 404 code and
-  Alice checks that this folder does not exist
+  Scenario: Bob creates a folder via the Graph api in a space, he expects a 404 code and Alice checks that this folder does not exist
     Given the administrator gives "Alice" the role "Admin" using the settings api
     When user "Alice" creates a space "Project Merkur" of type "project" with quota "2000" using the GraphApi
     And user "Alice" lists all available spaces via the GraphApi
     And user "Bob" creates a folder "forAlice" in space "Project Merkur" using the WebDav Api
     Then the HTTP status code should be "404"
-    When user "Alice" lists the content of the space with the name "Project Merkur" using the WebDav Api
-    Then the propfind result of the space should not contain these entries:
+    And the space "Project Merkur" should not contain these entries:
       | forAlice        |
 
   Scenario: Alice creates a folder via Graph api and uploads a file
@@ -39,20 +36,17 @@ Feature: Upload files into a space
     Then the HTTP status code should be "201"
     And user "Alice" uploads a file inside space "Project Moon" with content "Test" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    When user "Alice" lists the content of the space with the name "Project Moon" using the WebDav Api
-    Then the propfind result of the space should contain these entries:
+    And the space "Project Moon" should contain these entries:
       | NewFolder        |
       | test.txt         |
 
-  Scenario: Bob uploads a file via the Graph api in a space, he expects a 404 code and
-  Alice checks that this file does not exist
+  Scenario: Bob uploads a file via the Graph api in a space, he expects a 404 code and Alice checks that this file does not exist
     Given the administrator gives "Alice" the role "Admin" using the settings api
     When user "Alice" creates a space "Project Pluto" of type "project" with quota "2000" using the GraphApi
     And user "Alice" lists all available spaces via the GraphApi
     And user "Bob" uploads a file inside space "Project Pluto" with content "Test" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "404"
-    When user "Alice" lists the content of the space with the name "Project Pluto" using the WebDav Api
-    Then the propfind result of the space should not contain these entries:
+    And the space "Project Pluto" should not contain these entries:
       | test.txt        |
 
   Scenario: Alice creates uploads a file and checks her quota


### PR DESCRIPTION
## Description
We don't need to have 2 steps like this to check that a resource exists (or not) in a space:
```
When user "Alice" lists the content of the space with the name "Project Venus" using the WebDav Api
Then the propfind result of the space should contain these entries:
```

This PR refactors the code to use:
```
Then the space "Project Venus" should contain these entries:
```

I remember the username that created a space, so that the `Then` step can use that username when checking what resources exist (or not) in a space.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
