### PR TITLE
fix basic auth with custom user claim

### DIFF
--- a/changelog/unreleased/fix-basic-auth-with-custom-user-claim
+++ b/changelog/unreleased/fix-basic-auth-with-custom-user-claim
@@ -1,0 +1,7 @@
+Bugfix: Fix basic auth with custom user claim
+
+We've fixed authentication with basic if oCIS is configured to use a non-standard claim
+as user claim (`PROXY_USER_OIDC_CLAIM`). Prior to this bugfix the authentication always
+failed and is now working.
+
+https://github.com/owncloud/ocis/pull/2755

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -221,6 +221,7 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config)
 			middleware.UserProvider(userProvider),
 			middleware.OIDCIss(cfg.OIDC.Issuer),
 			middleware.UserOIDCClaim(cfg.UserOIDCClaim),
+			middleware.UserCS3Claim(cfg.UserCS3Claim),
 			middleware.CredentialsByUserAgent(cfg.Reva.Middleware.Auth.CredentialsByUserAgent),
 		),
 		middleware.SignedURLAuth(

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -220,6 +220,7 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config)
 			middleware.EnableBasicAuth(cfg.EnableBasicAuth),
 			middleware.UserProvider(userProvider),
 			middleware.OIDCIss(cfg.OIDC.Issuer),
+			middleware.UserOIDCClaim(cfg.UserOIDCClaim),
 			middleware.CredentialsByUserAgent(cfg.Reva.Middleware.Auth.CredentialsByUserAgent),
 		),
 		middleware.SignedURLAuth(

--- a/proxy/pkg/middleware/authentication.go
+++ b/proxy/pkg/middleware/authentication.go
@@ -126,6 +126,7 @@ func newBasicAuth(options Options) func(http.Handler) http.Handler {
 		EnableBasicAuth(options.EnableBasicAuth),
 		AccountsClient(options.AccountsClient),
 		OIDCIss(options.OIDCIss),
+		UserOIDCClaim(options.UserOIDCClaim),
 		CredentialsByUserAgent(options.CredentialsByUserAgent),
 	)
 }

--- a/proxy/pkg/middleware/authentication.go
+++ b/proxy/pkg/middleware/authentication.go
@@ -127,6 +127,7 @@ func newBasicAuth(options Options) func(http.Handler) http.Handler {
 		AccountsClient(options.AccountsClient),
 		OIDCIss(options.OIDCIss),
 		UserOIDCClaim(options.UserOIDCClaim),
+		UserCS3Claim(options.UserCS3Claim),
 		CredentialsByUserAgent(options.CredentialsByUserAgent),
 	)
 }

--- a/proxy/pkg/middleware/basic_auth.go
+++ b/proxy/pkg/middleware/basic_auth.go
@@ -84,11 +84,17 @@ func BasicAuth(optionSetters ...Option) func(next http.Handler) http.Handler {
 
 				// fake oidc claims
 				claims := map[string]interface{}{
-					oidc.OwncloudUUID:      user.Id.OpaqueId,
-					options.UserOIDCClaim:  user.Id.OpaqueId,
 					oidc.Iss:               user.Id.Idp,
 					oidc.PreferredUsername: user.Username,
 					oidc.Email:             user.Mail,
+					oidc.OwncloudUUID:      user.Id.OpaqueId,
+				}
+
+				if options.UserCS3Claim == "userid" {
+					// set the custom user claim only if users will be looked up by the the userid on the CS3api
+					// OpaqueId contains the userid configured in STORAGE_LDAP_USER_SCHEMA_UID
+					claims[options.UserOIDCClaim] = user.Id.OpaqueId
+
 				}
 
 				next.ServeHTTP(w, req.WithContext(oidc.NewContext(req.Context(), claims)))

--- a/proxy/pkg/middleware/basic_auth.go
+++ b/proxy/pkg/middleware/basic_auth.go
@@ -91,7 +91,7 @@ func BasicAuth(optionSetters ...Option) func(next http.Handler) http.Handler {
 				}
 
 				if options.UserCS3Claim == "userid" {
-					// set the custom user claim only if users will be looked up by the the userid on the CS3api
+					// set the custom user claim only if users will be looked up by the userid on the CS3api
 					// OpaqueId contains the userid configured in STORAGE_LDAP_USER_SCHEMA_UID
 					claims[options.UserOIDCClaim] = user.Id.OpaqueId
 

--- a/proxy/pkg/middleware/basic_auth.go
+++ b/proxy/pkg/middleware/basic_auth.go
@@ -85,6 +85,7 @@ func BasicAuth(optionSetters ...Option) func(next http.Handler) http.Handler {
 				// fake oidc claims
 				claims := map[string]interface{}{
 					oidc.OwncloudUUID:      user.Id.OpaqueId,
+					options.UserOIDCClaim:  user.Id.OpaqueId,
 					oidc.Iss:               user.Id.Idp,
 					oidc.PreferredUsername: user.Username,
 					oidc.Email:             user.Mail,


### PR DESCRIPTION
## Description
We've fixed authentication with basic if oCIS is configured to use a non-standard claim
as user claim (`PROXY_USER_OIDC_CLAIM`). Prior to this bugfix the authentication always
failed and is now working.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Unblocks https://github.com/owncloud/ocis/issues/2387

## Motivation and Context
Make basic auth login work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
