### PR TITLE
[tests-only] Add test step about 'space contains for user'

### DIFF
--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -16,7 +16,7 @@ Feature: Upload files into a space
     And user "Alice" lists all available spaces via the GraphApi
     And user "Alice" creates a folder "mainFolder" in space "Project Venus" using the WebDav Api
     Then the HTTP status code should be "201"
-    And the space "Project Venus" should contain these entries:
+    And for user "Alice" the space "Project Venus" should contain these entries:
       | mainFolder        |
 
   Scenario: Bob creates a folder via the Graph api in a space, he expects a 404 code and Alice checks that this folder does not exist
@@ -25,7 +25,7 @@ Feature: Upload files into a space
     And user "Alice" lists all available spaces via the GraphApi
     And user "Bob" creates a folder "forAlice" in space "Project Merkur" using the WebDav Api
     Then the HTTP status code should be "404"
-    And the space "Project Merkur" should not contain these entries:
+    And for user "Alice" the space "Project Merkur" should not contain these entries:
       | forAlice        |
 
   Scenario: Alice creates a folder via Graph api and uploads a file
@@ -36,7 +36,7 @@ Feature: Upload files into a space
     Then the HTTP status code should be "201"
     And user "Alice" uploads a file inside space "Project Moon" with content "Test" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the space "Project Moon" should contain these entries:
+    And for user "Alice" the space "Project Moon" should contain these entries:
       | NewFolder        |
       | test.txt         |
 
@@ -46,7 +46,7 @@ Feature: Upload files into a space
     And user "Alice" lists all available spaces via the GraphApi
     And user "Bob" uploads a file inside space "Project Pluto" with content "Test" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "404"
-    And the space "Project Pluto" should not contain these entries:
+    And for user "Alice" the space "Project Pluto" should not contain these entries:
       | test.txt        |
 
   Scenario: Alice creates uploads a file and checks her quota
@@ -61,8 +61,7 @@ Feature: Upload files into a space
     And user "Alice" lists all available spaces via the GraphApi
     And user "Alice" uploads a file inside space "Project Saturn" with content "Test" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    When user "Alice" lists the content of the space with the name "Project Saturn" using the WebDav Api
-    Then the propfind result of the space should contain these entries:
+    And for user "Alice" the space "Project Saturn" should contain these entries:
       | test.txt         |
     And user "Alice" lists all available spaces via the GraphApi
     And the json responded should contain a space "Project Saturn" with these key and value pairs:

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -585,6 +585,34 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @Then /^for user "([^"]*)" the space "([^"]*)" should (not|)\s?contain these (?:files|entries):$/
+	 *
+	 * @param string    $user
+	 * @param string    $spaceName
+	 * @param string    $shouldOrNot   (not|)
+	 * @param TableNode $expectedFiles
+	 *
+	 * @return void
+	 *
+	 * @throws Exception|GuzzleException
+	 */
+	public function usertheSpaceShouldContainEntries(
+		string $user,
+		string $spaceName,
+		string $shouldOrNot,
+		TableNode $expectedFiles
+	):void {
+		$this->theUserListsTheContentOfAPersonalSpaceRootUsingTheWebDAvApi(
+			$user,
+			$spaceName
+		);
+		$this->propfindResultShouldContainEntries(
+			$shouldOrNot,
+			$expectedFiles,
+		);
+	}
+
+	/**
 	 * @Then /^the json responded should contain a space "([^"]*)" with these key and value pairs:$/
 	 *
 	 * @param string $spaceName


### PR DESCRIPTION
## Description
This PR adds a test step:
```
    Then for user "Alice" the space "Project Venus" should contain these entries:
      | mainFolder        |
```

The step specifies the user. That will be specially useful when we have the functionality to grant users various access to a space. Then we can easily have test scenarios that check what different users can access resources in the pace.

I left the other step code for:
```
    Then the space "Project Venus" should contain these entries:
      | mainFolder        |
```

Because we will sometimes want to do a general check that some resource actually exists in a space, without mentioning a specific user. In that case the test code has to choose a username to authenticate the API request - currently it chooses the username that created the space (and in future it can do whatever seems best to achieve a check of the space at "admin" level)



## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
