### PR TITLE
add attr and tree as inspection / debugging tools to the docker image

### DIFF
--- a/ocis/docker/Dockerfile.linux.amd64
+++ b/ocis/docker/Dockerfile.linux.amd64
@@ -5,7 +5,7 @@ ARG REVISION=""
 
 RUN apk update && \
 	apk upgrade && \
-	apk add ca-certificates mailcap && \
+	apk add ca-certificates mailcap tree attr && \
 	rm -rf /var/cache/apk/* && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf
 

--- a/ocis/docker/Dockerfile.linux.arm
+++ b/ocis/docker/Dockerfile.linux.arm
@@ -5,7 +5,7 @@ ARG REVISION=""
 
 RUN apk update && \
 	apk upgrade && \
-	apk add ca-certificates mailcap && \
+	apk add ca-certificates mailcap tree attr && \
 	rm -rf /var/cache/apk/* && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf
 

--- a/ocis/docker/Dockerfile.linux.arm64
+++ b/ocis/docker/Dockerfile.linux.arm64
@@ -5,7 +5,7 @@ ARG REVISION=""
 
 RUN apk update && \
 	apk upgrade && \
-	apk add ca-certificates mailcap && \
+	apk add ca-certificates mailcap tree attr && \
 	rm -rf /var/cache/apk/* && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf
 


### PR DESCRIPTION
## Description
Adds `attr` and `tree` to the docker image, to have these tools at hand when you need them.

## Motivation and Context
When running oCIS I may want to inspect extended attributes:

```
~/storage/users/nodes $ getfattr -d -m '' f4fead7f-d43e-45e2-b998-1eb84577048e/
# file: f4fead7f-d43e-45e2-b998-1eb84577048e/
user.ocis.blobid=""
user.ocis.blobsize="0"
user.ocis.name="4c510ada-c86b-4815-8820-42cdf82c3d51"
user.ocis.owner.id="4c510ada-c86b-4815-8820-42cdf82c3d51"
user.ocis.owner.idp="https://ocis.owncloud.test"
user.ocis.owner.type="primary"
user.ocis.parentid="root"
user.ocis.propagation="1"
user.ocis.space.name="Albert Einstein"
user.ocis.tmtime="2021-11-15T12:03:13.921006821Z"
user.ocis.treesize="1028608"
```

And I want to have a way to see what files exist in a file tree.