### PR TITLE
Fix claim selector based routing for basic auth

### DIFF
--- a/changelog/unreleased/fix-basic-auth-route-claim-selector.md
+++ b/changelog/unreleased/fix-basic-auth-route-claim-selector.md
@@ -1,0 +1,8 @@
+Bugfix: Fix claim selector based routing for basic auth
+
+We've fixed the claim selector based routing for requests using basic auth.
+Previously requests using basic auth have always been routed to the DefaultPolicy when using the claim selector despite the set cookie because the basic auth middleware fakes some OIDC claims.
+
+Now the cookie is checked before routing to the DefaultPolicy and therefore set cookie will also be respected for requests using basic auth.
+
+https://github.com/owncloud/ocis/pull/2779


### PR DESCRIPTION
## Description
We've fixed the claim selector based routing for requests using basic auth.
Previously requests using basic auth have always been routed to the DefaultPolicy
when using the claim selector despite the set cookie because the basic auth
middleware fakes some OIDC claims.

Now the cookie is checked before routing to the DefaultPolicy and therefore 
set cookie will also be respected for requests using basic auth.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Unblocks https://github.com/owncloud/ocis/issues/2387

## Motivation and Context
Using basic auth for testing the parallel deployment

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
