### PR TITLE
remove warning from parallel deployment docs

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/config/oc10/10-custom-config.sh
+++ b/deployments/examples/oc10_ocis_parallel/config/oc10/10-custom-config.sh
@@ -6,7 +6,8 @@ gomplate \
   -f /etc/templates/oidc.config.php \
   -o ${OWNCLOUD_VOLUME_CONFIG}/oidc.config.php
 
-occ market:upgrade --major openidconnect # we need a release including https://github.com/owncloud/openidconnect/pull/180
+# we need at least version 2.1.0 of the oenidconnect app
+occ market:upgrade --major openidconnect
 occ app:enable openidconnect
 
 # user LDAP

--- a/docs/ocis/deployment/oc10_ocis_parallel.md
+++ b/docs/ocis/deployment/oc10_ocis_parallel.md
@@ -9,10 +9,6 @@ geekdocFilePath: oc10_ocis_parallel.md
 
 {{< toc >}}
 
-{{< hint warning >}}
-This deployment example currently has known issues. See [github.com/owncloud/ocis/issues/2549](https://github.com/owncloud/ocis/issues/2549) for more information.
-{{< /hint >}}
-
 ## Overview
 
 - This setup reflects [stage 6 of the oC10 to oCIS migration plan]({{< ref "migration#stage-6-parallel-deployment" >}})


### PR DESCRIPTION
## Description
oC10 OpenID Connect app 2.1.0 was released and includes the changes needed for the parallel deployment. Therefore we can remove the incompleteness warning from the docs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2549 
