### PR TITLE
[tests-only] Bump core commit id to include recent SetupHelper core changes

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=13d7bda4a6e64c816e3897980ec20b1812d17423
+CORE_COMMITID=6a55f750d8a3f34c6c7772355f9281ffb8ffb4ca
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
Includes the core SetupHelper changes merged today in PR https://github.com/owncloud/core/pull/39505

It will be good to know the strict_types checking in that change passes when run in the oCIS environment.

Part of issue https://github.com/owncloud/QA/issues/699