### PR TITLE
Fix s3ng metadata storage

### DIFF
--- a/changelog/unreleased/fix-s3ng-metadata-storage.md
+++ b/changelog/unreleased/fix-s3ng-metadata-storage.md
@@ -1,0 +1,6 @@
+Bugfix: Fix using s3ng as the metadata storage backend
+
+It is now possible to use s3ng as the metadata storage backend.
+
+https://github.com/owncloud/ocis/pull/2807
+https://github.com/owncloud/ocis/issues/2668

--- a/storage/pkg/command/storagedrivers/home.go
+++ b/storage/pkg/command/storagedrivers/home.go
@@ -115,15 +115,18 @@ func HomeDrivers(cfg *config.Config) map[string]interface{} {
 			"bucket":     cfg.Reva.UserStorage.S3.Bucket,
 		},
 		"s3ng": map[string]interface{}{
-			"root":          cfg.Reva.UserStorage.S3NG.Root,
-			"enable_home":   true,
-			"user_layout":   cfg.Reva.UserStorage.S3NG.UserLayout,
-			"share_folder":  cfg.Reva.UserStorage.S3NG.ShareFolder,
-			"s3.region":     cfg.Reva.UserStorage.S3NG.Region,
-			"s3.access_key": cfg.Reva.UserStorage.S3NG.AccessKey,
-			"s3.secret_key": cfg.Reva.UserStorage.S3NG.SecretKey,
-			"s3.endpoint":   cfg.Reva.UserStorage.S3NG.Endpoint,
-			"s3.bucket":     cfg.Reva.UserStorage.S3NG.Bucket,
+			"root":                cfg.Reva.UserStorage.S3NG.Root,
+			"enable_home":         true,
+			"user_layout":         cfg.Reva.UserStorage.S3NG.UserLayout,
+			"treetime_accounting": true,
+			"treesize_accounting": true,
+			"owner":               cfg.Reva.UserStorage.S3NG.ServiceUserUUID, // the accounts service system account uuid
+			"share_folder":        cfg.Reva.UserStorage.S3NG.ShareFolder,
+			"s3.region":           cfg.Reva.UserStorage.S3NG.Region,
+			"s3.access_key":       cfg.Reva.UserStorage.S3NG.AccessKey,
+			"s3.secret_key":       cfg.Reva.UserStorage.S3NG.SecretKey,
+			"s3.endpoint":         cfg.Reva.UserStorage.S3NG.Endpoint,
+			"s3.bucket":           cfg.Reva.UserStorage.S3NG.Bucket,
 		},
 	}
 }

--- a/storage/pkg/command/storagedrivers/metadata.go
+++ b/storage/pkg/command/storagedrivers/metadata.go
@@ -64,14 +64,17 @@ func MetadataDrivers(cfg *config.Config) map[string]interface{} {
 			"bucket":     cfg.Reva.MetadataStorage.S3.Bucket,
 		},
 		"s3ng": map[string]interface{}{
-			"root":          cfg.Reva.MetadataStorage.S3NG.Root,
-			"enable_home":   false,
-			"user_layout":   cfg.Reva.MetadataStorage.S3NG.UserLayout,
-			"s3.region":     cfg.Reva.MetadataStorage.S3NG.Region,
-			"s3.access_key": cfg.Reva.MetadataStorage.S3NG.AccessKey,
-			"s3.secret_key": cfg.Reva.MetadataStorage.S3NG.SecretKey,
-			"s3.endpoint":   cfg.Reva.MetadataStorage.S3NG.Endpoint,
-			"s3.bucket":     cfg.Reva.MetadataStorage.S3NG.Bucket,
+			"root":                cfg.Reva.MetadataStorage.S3NG.Root,
+			"enable_home":         false,
+			"user_layout":         cfg.Reva.MetadataStorage.S3NG.UserLayout,
+			"treetime_accounting": false,
+			"treesize_accounting": false,
+			"owner":               cfg.Reva.MetadataStorage.S3NG.ServiceUserUUID, // the accounts service system account uuid
+			"s3.region":           cfg.Reva.MetadataStorage.S3NG.Region,
+			"s3.access_key":       cfg.Reva.MetadataStorage.S3NG.AccessKey,
+			"s3.secret_key":       cfg.Reva.MetadataStorage.S3NG.SecretKey,
+			"s3.endpoint":         cfg.Reva.MetadataStorage.S3NG.Endpoint,
+			"s3.bucket":           cfg.Reva.MetadataStorage.S3NG.Bucket,
 		},
 	}
 }

--- a/storage/pkg/command/storagedrivers/user.go
+++ b/storage/pkg/command/storagedrivers/user.go
@@ -117,15 +117,18 @@ func UserDrivers(cfg *config.Config) map[string]interface{} {
 			"prefix":      cfg.Reva.UserStorage.S3.Root,
 		},
 		"s3ng": map[string]interface{}{
-			"root":          cfg.Reva.UserStorage.S3NG.Root,
-			"enable_home":   false,
-			"user_layout":   cfg.Reva.UserStorage.S3NG.UserLayout,
-			"share_folder":  cfg.Reva.UserStorage.S3NG.ShareFolder,
-			"s3.region":     cfg.Reva.UserStorage.S3NG.Region,
-			"s3.access_key": cfg.Reva.UserStorage.S3NG.AccessKey,
-			"s3.secret_key": cfg.Reva.UserStorage.S3NG.SecretKey,
-			"s3.endpoint":   cfg.Reva.UserStorage.S3NG.Endpoint,
-			"s3.bucket":     cfg.Reva.UserStorage.S3NG.Bucket,
+			"root":                cfg.Reva.UserStorage.S3NG.Root,
+			"enable_home":         false,
+			"user_layout":         cfg.Reva.UserStorage.S3NG.UserLayout,
+			"share_folder":        cfg.Reva.UserStorage.S3NG.ShareFolder,
+			"treetime_accounting": true,
+			"treesize_accounting": true,
+			"owner":               cfg.Reva.UserStorage.S3NG.ServiceUserUUID, // the accounts service system account uuid
+			"s3.region":           cfg.Reva.UserStorage.S3NG.Region,
+			"s3.access_key":       cfg.Reva.UserStorage.S3NG.AccessKey,
+			"s3.secret_key":       cfg.Reva.UserStorage.S3NG.SecretKey,
+			"s3.endpoint":         cfg.Reva.UserStorage.S3NG.Endpoint,
+			"s3.bucket":           cfg.Reva.UserStorage.S3NG.Bucket,
 		},
 	}
 }

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -713,7 +713,12 @@ func DefaultConfig() *Config {
 						UserLayout:  "{{.Id.OpaqueId}}",
 						EnableHome:  false,
 					},
-					Region: "default",
+					ServiceUserUUID: "95cb8724-03b2-11eb-a0a6-c33ef8ef53ad",
+					Region:          "default",
+					AccessKey:       "",
+					SecretKey:       "",
+					Endpoint:        "",
+					Bucket:          "",
 				},
 				OCIS: DriverOCIS{
 					DriverCommon: DriverCommon{

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -344,11 +344,12 @@ type DriverS3 struct {
 type DriverS3NG struct {
 	DriverCommon
 
-	Region    string `ocisConfig:"region"`
-	AccessKey string `ocisConfig:"access_key"`
-	SecretKey string `ocisConfig:"secret_key"`
-	Endpoint  string `ocisConfig:"endpoint"`
-	Bucket    string `ocisConfig:"bucket"`
+	ServiceUserUUID string `ocisConfig:"service_user_uuid"`
+	Region          string `ocisConfig:"region"`
+	AccessKey       string `ocisConfig:"access_key"`
+	SecretKey       string `ocisConfig:"secret_key"`
+	Endpoint        string `ocisConfig:"endpoint"`
+	Bucket          string `ocisConfig:"bucket"`
 }
 
 // OIDC defines the available OpenID Connect configuration.
@@ -655,11 +656,12 @@ func DefaultConfig() *Config {
 						UserLayout:  "{{.Id.OpaqueId}}",
 						EnableHome:  false,
 					},
-					Region:    "default",
-					AccessKey: "",
-					SecretKey: "",
-					Endpoint:  "",
-					Bucket:    "",
+					ServiceUserUUID: "95cb8724-03b2-11eb-a0a6-c33ef8ef53ad",
+					Region:          "default",
+					AccessKey:       "",
+					SecretKey:       "",
+					Endpoint:        "",
+					Bucket:          "",
 				},
 				OCIS: DriverOCIS{
 					DriverCommon: DriverCommon{
@@ -2231,6 +2233,10 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 		{
 			EnvVars:     []string{"STORAGE_METADATA_DRIVER_S3NG_LAYOUT"},
 			Destination: &cfg.Reva.MetadataStorage.S3NG.UserLayout,
+		},
+		{
+			EnvVars:     []string{"STORAGE_METADATA_DRIVER_S3NG_SERVICE_USER_UUID"},
+			Destination: &cfg.Reva.MetadataStorage.S3NG.ServiceUserUUID,
 		},
 		{
 			EnvVars:     []string{"STORAGE_METADATA_DRIVER_S3NG_REGION"},

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -2094,6 +2094,10 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 			Destination: &cfg.Reva.UserStorage.S3NG.UserLayout,
 		},
 		{
+			EnvVars:     []string{"STORAGE_USERS_DRIVER_S3NG_SERVICE_USER_UUID"},
+			Destination: &cfg.Reva.UserStorage.S3NG.ServiceUserUUID,
+		},
+		{
 			EnvVars:     []string{"STORAGE_USERS_DRIVER_S3NG_SHARE_FOLDER"},
 			Destination: &cfg.Reva.UserStorage.S3NG.ShareFolder,
 		},


### PR DESCRIPTION

## Description
The s3ng config for the metadata storage was missing the account service information so the permissions were not set up correctly. 

This commit fixes the configuration so that s3ng can be used for the metadata storage as well.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/2668

## How Has This Been Tested?

Manual testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
