### PR TITLE
Rename `APP_PROVIDER_BASIC_*` environment variables

### DIFF
--- a/changelog/unreleased/change-rename-app-provider-env.md
+++ b/changelog/unreleased/change-rename-app-provider-env.md
@@ -1,0 +1,8 @@
+Change: Rename `APP_PROVIDER_BASIC_*` environment variables
+
+We've renamed the `APP_PROVIDER_BASIC_*` to `APP_PROVIDER_*` since
+the `_BASIC_` part is a copy and paste error. Now all app provider
+environment variables are consistently starting with `APP_PROVIDER_*`.
+
+https://github.com/owncloud/ocis/pull/2812
+https://github.com/owncloud/ocis/pull/2811

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -1082,19 +1082,19 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 		// app provider
 
 		{
-			EnvVars:     []string{"APP_PROVIDER_DEBUG_ADDR", "APP_PROVIDER_BASIC_DEBUG_ADDR"}, // TODO: remove env containing _BASIC_
+			EnvVars:     []string{"APP_PROVIDER_DEBUG_ADDR"},
 			Destination: &cfg.Reva.AppProvider.DebugAddr,
 		},
 		{
-			EnvVars:     []string{"APP_PROVIDER_GRPC_NETWORK", "APP_PROVIDER_BASIC_GRPC_NETWORK"}, // TODO: remove env containing _BASIC_
+			EnvVars:     []string{"APP_PROVIDER_GRPC_NETWORK"},
 			Destination: &cfg.Reva.AppProvider.GRPCNetwork,
 		},
 		{
-			EnvVars:     []string{"APP_PROVIDER_GRPC_ADDR", "APP_PROVIDER_BASIC_GRPC_ADDR"}, // TODO: remove env containing _BASIC_
+			EnvVars:     []string{"APP_PROVIDER_GRPC_ADDR"},
 			Destination: &cfg.Reva.AppProvider.GRPCAddr,
 		},
 		{
-			EnvVars:     []string{"APP_PROVIDER_EXTERNAL_ADDR", "APP_PROVIDER_BASIC_EXTERNAL_ADDR"}, // TODO: remove env containing _BASIC_
+			EnvVars:     []string{"APP_PROVIDER_EXTERNAL_ADDR"},
 			Destination: &cfg.Reva.AppProvider.ExternalAddr,
 		},
 		{


### PR DESCRIPTION
## Description
this PR removes all `APP_PROVIDER_BASIC_*` environment variables. Their `APP_PROVIDER_*` replacements have been added in #2811 .

These two PRs together are performing a rename.
