### PR TITLE
go embed / generate improvements

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -4,5 +4,6 @@ import (
 	"embed"
 )
 
+//go:generate make generate
 //go:embed assets/*
 var Assets embed.FS

--- a/glauth/Makefile
+++ b/glauth/Makefile
@@ -25,7 +25,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/graph-explorer/graph_explorer.go
+++ b/graph-explorer/graph_explorer.go
@@ -4,5 +4,6 @@ import (
 	"embed"
 )
 
+//go:generate make generate
 //go:embed assets/*
 var Assets embed.FS

--- a/graph/Makefile
+++ b/graph/Makefile
@@ -25,7 +25,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/idp/Makefile
+++ b/idp/Makefile
@@ -25,7 +25,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate: assets

--- a/idp/idp.go
+++ b/idp/idp.go
@@ -4,5 +4,6 @@ import (
 	"embed"
 )
 
+//go:generate make generate
 //go:embed assets/*
 var Assets embed.FS

--- a/ocis-pkg/Makefile
+++ b/ocis-pkg/Makefile
@@ -27,7 +27,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/ocis/Makefile
+++ b/ocis/Makefile
@@ -34,7 +34,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate: # ocis needs assets of all other modules

--- a/ocs/Makefile
+++ b/ocs/Makefile
@@ -25,7 +25,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -25,7 +25,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -4,5 +4,6 @@ import (
 	"embed"
 )
 
+//go:generate make generate
 //go:embed assets/*
 var Assets embed.FS

--- a/storage/Makefile
+++ b/storage/Makefile
@@ -25,7 +25,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/store/Makefile
+++ b/store/Makefile
@@ -26,7 +26,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: protobuf # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/thumbnails/Makefile
+++ b/thumbnails/Makefile
@@ -26,7 +26,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: protobuf # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:

--- a/web/web.go
+++ b/web/web.go
@@ -4,5 +4,6 @@ import (
 	"embed"
 )
 
+//go:generate make generate
 //go:embed assets/*
 var Assets embed.FS

--- a/web/web.go
+++ b/web/web.go
@@ -5,5 +5,4 @@ import (
 )
 
 //go:embed assets/*
-//go:embed assets/js/*
 var Assets embed.FS

--- a/webdav/Makefile
+++ b/webdav/Makefile
@@ -25,7 +25,6 @@ include ../.make/generate.mk
 
 .PHONY: ci-go-generate
 ci-go-generate: # CI runs ci-node-generate automatically before this target
-	@go generate ./...
 
 .PHONY: ci-node-generate
 ci-node-generate:


### PR DESCRIPTION
## Description
- simplify embed rule for Web (possible since https://github.com/owncloud/web/pull/5988 landed in Web 4.5.0)
- add `go:generate` step to all `go:embed` steps, so that one can use the `go generate ./...` command to get all assets
- don't run `go generate ./...` anymore in CI, since it is no longer needed (was needed for fileb0x only)
