### PR TITLE
[full-ci] Bugfix: Disallow creation of a group with empty name via the OCS api

### DIFF
--- a/changelog/unreleased/fix-create-group-without-name.md
+++ b/changelog/unreleased/fix-create-group-without-name.md
@@ -1,0 +1,10 @@
+Bugfix: Disallow creation of a group with empty name via the OCS api
+
+We've fixed the behavior for group creation on the OCS api, where it was
+possible to create a group with an empty name. This was is not possible
+on oC10 and is therefore also forbidden on oCIS to keep compatibility.
+This PR forbids the creation and also ensures the correct status codef
+or both OCS v1 and OCS v2 apis.
+
+https://github.com/owncloud/ocis/pull/2825
+https://github.com/owncloud/ocis/issues/2823

--- a/changelog/unreleased/fix-create-group-without-name.md
+++ b/changelog/unreleased/fix-create-group-without-name.md
@@ -3,8 +3,8 @@ Bugfix: Disallow creation of a group with empty name via the OCS api
 We've fixed the behavior for group creation on the OCS api, where it was
 possible to create a group with an empty name. This was is not possible
 on oC10 and is therefore also forbidden on oCIS to keep compatibility.
-This PR forbids the creation and also ensures the correct status codef
-or both OCS v1 and OCS v2 apis.
+This PR forbids the creation and also ensures the correct status code
+for both OCS v1 and OCS v2 apis.
 
 https://github.com/owncloud/ocis/pull/2825
 https://github.com/owncloud/ocis/issues/2823

--- a/ocs/pkg/middleware/requireuser.go
+++ b/ocs/pkg/middleware/requireuser.go
@@ -10,18 +10,25 @@ import (
 )
 
 // RequireUser middleware is used to require a user in context
-func RequireUser() func(next http.Handler) http.Handler {
+func RequireUser(opts ...Option) func(next http.Handler) http.Handler {
+	opt := newOptions(opts...)
+
+	mustRender := func(w http.ResponseWriter, r *http.Request, renderer render.Renderer) {
+		if err := render.Render(w, r, renderer); err != nil {
+			opt.Logger.Err(err).Msgf("failed to write response for ocs request %s on %s", r.Method, r.URL)
+		}
+	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 			u, ok := revactx.ContextGetUser(r.Context())
 			if !ok {
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaUnauthorized.StatusCode, "Unauthorized")))
+				mustRender(w, r, response.ErrRender(data.MetaUnauthorized.StatusCode, "Unauthorized"))
 				return
 			}
 			if u.Id == nil || u.Id.OpaqueId == "" {
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "user is missing an id")))
+				mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "user is missing an id"))
 				return
 			}
 

--- a/ocs/pkg/service/v0/config.go
+++ b/ocs/pkg/service/v0/config.go
@@ -3,18 +3,17 @@ package svc
 import (
 	"net/http"
 
-	"github.com/go-chi/render"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/data"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/response"
 )
 
 // GetConfig renders the ocs config endpoint
 func (o Ocs) GetConfig(w http.ResponseWriter, r *http.Request) {
-	mustNotFail(render.Render(w, r, response.DataRender(&data.ConfigData{
+	o.mustRender(w, r, response.DataRender(&data.ConfigData{
 		Version: "1.7",  // TODO get from env
 		Website: "ocis", // TODO get from env
 		Host:    "",     // TODO get from FRONTEND config
 		Contact: "",     // TODO get from env
 		SSL:     "true", // TODO get from env
-	})))
+	}))
 }

--- a/ocs/pkg/service/v0/groups.go
+++ b/ocs/pkg/service/v0/groups.go
@@ -11,7 +11,6 @@ import (
 
 	revactx "github.com/cs3org/reva/pkg/ctx"
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/render"
 	accounts "github.com/owncloud/ocis/accounts/pkg/proto/v0"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/data"
 	"github.com/owncloud/ocis/ocs/pkg/service/v0/response"
@@ -41,7 +40,7 @@ func (o Ocs) ListUserGroups(w http.ResponseWriter, r *http.Request) {
 			span.SetAttributes(attribute.StringSlice("groups", u.Groups))
 
 			if len(u.Groups) > 0 {
-				mustNotFail(render.Render(w, r, response.DataRender(&data.Groups{Groups: u.Groups})))
+				o.mustRender(w, r, response.DataRender(&data.Groups{Groups: u.Groups}))
 				return
 			}
 		}
@@ -57,9 +56,9 @@ func (o Ocs) ListUserGroups(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			merr := merrors.FromError(err)
 			if merr.Code == http.StatusNotFound {
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested user could not be found")))
+				o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested user could not be found"))
 			} else {
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+				o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 			}
 			o.logger.Error().Err(err).Str("userid", userid).Msg("could not get list of user groups")
 			return
@@ -98,26 +97,31 @@ func (o Ocs) ListUserGroups(w http.ResponseWriter, r *http.Request) {
 
 	span.SetAttributes(attribute.StringSlice("groups", groups))
 
-	mustNotFail(render.Render(w, r, response.DataRender(&data.Groups{Groups: groups})))
+	o.mustRender(w, r, response.DataRender(&data.Groups{Groups: groups}))
 }
 
 // AddToGroup adds a user to a group
 func (o Ocs) AddToGroup(w http.ResponseWriter, r *http.Request) {
-	mustNotFail(r.ParseForm())
+	err := r.ParseForm()
+	if err != nil {
+		o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "Could not parse form from request"))
+		return
+	}
+
 	userid := chi.URLParam(r, "userid")
 	groupid := r.PostForm.Get("groupid")
 
 	if groupid == "" {
-		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "empty group assignment: unspecified group")))
+		o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "empty group assignment: unspecified group"))
 		return
 	}
 	account, err := o.fetchAccountByUsername(r.Context(), userid)
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested user could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested user could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		return
 	}
@@ -127,9 +131,9 @@ func (o Ocs) AddToGroup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		return
 	}
@@ -142,16 +146,16 @@ func (o Ocs) AddToGroup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		o.logger.Error().Err(err).Str("userid", account.Id).Str("groupid", group.Id).Msg("could not add user to group")
 		return
 	}
 
 	o.logger.Debug().Str("userid", account.Id).Str("groupid", group.Id).Msg("added user to group")
-	mustNotFail(render.Render(w, r, response.DataRender(struct{}{})))
+	o.mustRender(w, r, response.DataRender(struct{}{}))
 }
 
 // RemoveFromGroup removes a user from a group
@@ -165,23 +169,23 @@ func (o Ocs) RemoveFromGroup(w http.ResponseWriter, r *http.Request) {
 	// read it manually
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, err.Error())))
+		o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, err.Error()))
 		return
 	}
 	if err = r.Body.Close(); err != nil {
-		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+		o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		return
 	}
 
 	values, err := url.ParseQuery(string(body))
 	if err != nil {
-		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, err.Error())))
+		o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, err.Error()))
 		return
 	}
 
 	groupid := values.Get("groupid")
 	if groupid == "" {
-		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "no group id")))
+		o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "no group id"))
 		return
 	}
 
@@ -197,9 +201,9 @@ func (o Ocs) RemoveFromGroup(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			merr := merrors.FromError(err)
 			if merr.Code == http.StatusNotFound {
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, "The requested user could not be found")))
+				o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, "The requested user could not be found"))
 			} else {
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+				o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 			}
 			o.logger.Error().Err(err).Str("userid", userid).Msg("could not get list of user groups")
 			return
@@ -211,9 +215,9 @@ func (o Ocs) RemoveFromGroup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		return
 	}
@@ -226,16 +230,16 @@ func (o Ocs) RemoveFromGroup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		o.logger.Error().Err(err).Str("userid", account.Id).Str("groupid", group.Id).Msg("could not remove user from group")
 		return
 	}
 
 	o.logger.Debug().Str("userid", account.Id).Str("groupid", group.Id).Msg("removed user from group")
-	mustNotFail(render.Render(w, r, response.DataRender(struct{}{})))
+	o.mustRender(w, r, response.DataRender(struct{}{}))
 }
 
 // ListGroups lists all groups
@@ -252,7 +256,7 @@ func (o Ocs) ListGroups(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		o.logger.Err(err).Msg("could not list users")
-		mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, "could not list users")))
+		o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, "could not list users"))
 		return
 	}
 
@@ -268,7 +272,7 @@ func (o Ocs) ListGroups(w http.ResponseWriter, r *http.Request) {
 
 	span.SetAttributes(attribute.StringSlice("groups", groups))
 
-	mustNotFail(render.Render(w, r, response.DataRender(&data.Groups{Groups: groups})))
+	o.mustRender(w, r, response.DataRender(&data.Groups{Groups: groups}))
 }
 
 // AddGroup adds a group
@@ -283,7 +287,7 @@ func (o Ocs) AddGroup(w http.ResponseWriter, r *http.Request) {
 		if response.APIVersion(r.Context()) == "2" {
 			code = data.MetaBadRequest.StatusCode
 		}
-		render.Render(w, r, response.ErrRender(code, "No groupid or display name provided"))
+		o.mustRender(w, r, response.ErrRender(code, "No groupid or display name provided"))
 		return
 	}
 
@@ -299,7 +303,7 @@ func (o Ocs) AddGroup(w http.ResponseWriter, r *http.Request) {
 	if gid != "" {
 		gidNumber, err = strconv.ParseInt(gid, 10, 64)
 		if err != nil {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "Cannot use the gidnumber provided")))
+			o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, "Cannot use the gidnumber provided"))
 			o.logger.Error().Err(err).Str("gid", gid).Str("groupid", groupid).Msg("Cannot use the gidnumber provided")
 			return
 		}
@@ -318,17 +322,17 @@ func (o Ocs) AddGroup(w http.ResponseWriter, r *http.Request) {
 		merr := merrors.FromError(err)
 		switch merr.Code {
 		case http.StatusBadRequest:
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, merr.Detail)))
+			o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, merr.Detail))
 		case http.StatusConflict:
 			if response.APIVersion(r.Context()) == "2" {
 				// it seems the application framework sets the ocs status code to the httpstatus code, which affects the provisioning api
 				// see https://github.com/owncloud/core/blob/b9ff4c93e051c94adfb301545098ae627e52ef76/lib/public/AppFramework/OCSController.php#L142-L150
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, merr.Detail)))
+				o.mustRender(w, r, response.ErrRender(data.MetaBadRequest.StatusCode, merr.Detail))
 			} else {
-				mustNotFail(render.Render(w, r, response.ErrRender(data.MetaInvalidInput.StatusCode, merr.Detail)))
+				o.mustRender(w, r, response.ErrRender(data.MetaInvalidInput.StatusCode, merr.Detail))
 			}
 		default:
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		o.logger.Error().Err(err).Str("groupid", groupid).Msg("could not add group")
 		// TODO check error if group already existed
@@ -336,7 +340,7 @@ func (o Ocs) AddGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	o.logger.Debug().Interface("group", group).Msg("added group")
 
-	mustNotFail(render.Render(w, r, response.DataRender(struct{}{})))
+	o.mustRender(w, r, response.DataRender(struct{}{}))
 }
 
 // DeleteGroup deletes a group
@@ -348,9 +352,9 @@ func (o Ocs) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		return
 	}
@@ -362,16 +366,16 @@ func (o Ocs) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		o.logger.Error().Err(err).Str("groupid", group.Id).Msg("could not remove group")
 		return
 	}
 
 	o.logger.Debug().Str("groupid", group.Id).Msg("removed group")
-	mustNotFail(render.Render(w, r, response.DataRender(struct{}{})))
+	o.mustRender(w, r, response.DataRender(struct{}{}))
 }
 
 // GetGroupMembers lists all members of a group
@@ -384,9 +388,9 @@ func (o Ocs) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		return
 	}
@@ -396,9 +400,9 @@ func (o Ocs) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		merr := merrors.FromError(err)
 		if merr.Code == http.StatusNotFound {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found")))
+			o.mustRender(w, r, response.ErrRender(data.MetaNotFound.StatusCode, "The requested group could not be found"))
 		} else {
-			mustNotFail(render.Render(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error())))
+			o.mustRender(w, r, response.ErrRender(data.MetaServerError.StatusCode, err.Error()))
 		}
 		o.logger.Error().Err(err).Str("groupid", group.Id).Msg("could not get list of members")
 		return
@@ -410,7 +414,7 @@ func (o Ocs) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	o.logger.Error().Err(err).Int("count", len(members)).Str("groupid", groupid).Msg("listing group members")
-	mustNotFail(render.Render(w, r, response.DataRender(&data.Users{Users: members})))
+	o.mustRender(w, r, response.DataRender(&data.Users{Users: members}))
 }
 
 func isValidUUID(uuid string) bool {
@@ -430,10 +434,4 @@ func (o Ocs) fetchGroupByName(ctx context.Context, name string) (*accounts.Group
 		return res.Groups[0], nil
 	}
 	return nil, merrors.NotFound("", "The requested group could not be found")
-}
-
-func mustNotFail(err error) {
-	if err != nil {
-		panic(err)
-	}
 }

--- a/ocs/pkg/service/v0/groups.go
+++ b/ocs/pkg/service/v0/groups.go
@@ -283,7 +283,7 @@ func (o Ocs) AddGroup(w http.ResponseWriter, r *http.Request) {
 		if response.APIVersion(r.Context()) == "2" {
 			code = data.MetaBadRequest.StatusCode
 		}
-		mustNotFail(render.Render(w, r, response.ErrRender(code, "No groupid or display name provided")))
+		render.Render(w, r, response.ErrRender(code, "No groupid or display name provided"))
 		return
 	}
 

--- a/ocs/pkg/service/v0/response/version.go
+++ b/ocs/pkg/service/v0/response/version.go
@@ -80,7 +80,7 @@ func VersionCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		version := chi.URLParam(r, "version")
 		if version == "" {
-			mustNotFail(render.Render(w, r, ErrRender(data.MetaBadRequest.StatusCode, "unknown ocs api version")))
+			_ = render.Render(w, r, ErrRender(data.MetaBadRequest.StatusCode, "unknown ocs api version"))
 			return
 		}
 		w.Header().Set("Ocs-Api-Version", version)
@@ -89,10 +89,4 @@ func VersionCtx(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), apiVersionKey, version)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
-}
-
-func mustNotFail(err error) {
-	if err != nil {
-		panic(err)
-	}
 }

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -983,10 +983,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiProvisioningGroups-v1/addGroup.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature#L134)
 -   [apiProvisioningGroups-v2/addGroup.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature#L129)
 
-#### [creating a group with empty name doesn't give an error](https://github.com/owncloud/ocis/issues/2823)
--   [apiProvisioningGroups-v1/addGroup.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature#L181)
--   [apiProvisioningGroups-v2/addGroup.feature:177](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature#L177)
-
 #### [cannot create group with '/'](https://github.com/owncloud/product/issues/285)
 -   [apiProvisioningGroups-v1/addToGroup.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature#L82)
 -   [apiProvisioningGroups-v1/deleteGroup.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature#L85)


### PR DESCRIPTION
## Description
We've fixed the behavior for group creation on the OCS api, where it was
possible to create a group with an empty name. This was is not possible
on oC10 and is therefore also forbidden on oCIS to keep compatibility.
This PR forbids the creation and also ensures the correct status codef
or both OCS v1 and OCS v2 apis.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/2823

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
