### PR TITLE
enable signature auth in public share auth middleware

### DIFF
--- a/changelog/unreleased/public-link-signature-auth.md
+++ b/changelog/unreleased/public-link-signature-auth.md
@@ -1,0 +1,5 @@
+Enhancement: Support signature auth in the public share auth middleware
+
+Enabled public share requests to be authenticated using the public share signature.
+
+https://github.com/owncloud/ocis/pull/2831


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added signature authentication to the public share auth middleware.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To support archive downloads in password protected public links we need some way to authenticate the requests.
We can't provide the password via the `Authorization` header because the download is triggered via browser mechanisms like `<a href=` and not via `fetch` or `XmlHttpRequests`.
Here the public share signature comes into play. To support archive downloads you can take the `signature` and `expiration` parameters from a files `downloadURL` and append them to the archive download url.

This could look like this:
```
curl -k 'https://localhost:9200/archiver?public-token=urxyrXobvuXYaFi&id=ZTFhNzNlZGUtNTQ5Yi00MjI2LWFiZGYtNDBlNjljYTgyMzBkOnVyeHlyWG9idnVYWWFGaS9hZGM1Nzc3MS0wNTI2LTQxYzgtYTk3Yy0wNDk5NWZjY2FkMzE=&id=ZTFhNzNlZGUtNTQ5Yi00MjI2LWFiZGYtNDBlNjljYTgyMzBkOnVyeHlyWG9idnVYWWFGaS82ZThiMmQ2NC03ZDAxLTRiMjctOTFkOC0yZjZlNTdmZThjZTk=&signature=eec4738af66435fd2075e0eb5542aa22e5630fb4733c76cf63ece90eac9887ee&expiration=2021-11-30T15:59:20%2b01:00' -o download.tar
```

There are some drawbacks though, like if there are no files, only folders,  in the current PROPFIND response then you don't have access to the signature and expiration. One way to solve that could be to add one or two new attributes to the PROPFIND root where we would add the signature and expiration. This way these values would always be present and accessible. Though this would divert from the behavior in ownCloud 10.

/cc @fschade

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally via curl

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes

