### PR TITLE
OIDC: fallback to "email" if IDP doesn't provide "preferred_username" claim

### DIFF
--- a/changelog/unreleased/user-claim-fallback.md
+++ b/changelog/unreleased/user-claim-fallback.md
@@ -1,0 +1,6 @@
+Change: OIDC: fallback if IDP doesn't provide "preferred_username" claim
+
+Some IDPs don't add the "preferred_username" claim. Fallback to the "email"
+claim in that case
+
+https://github.com/owncloud/ocis/issues/2644

--- a/proxy/pkg/user/backend/accounts.go
+++ b/proxy/pkg/user/backend/accounts.go
@@ -123,8 +123,12 @@ func (a accountsServiceBackend) CreateUserFromClaims(ctx context.Context, claims
 		}
 	}
 	if req.Account.PreferredName, ok = claims[oidc.PreferredUsername].(string); !ok {
-		a.logger.Warn().Msg("Missing preferred_username claim")
-	} else {
+		a.logger.Warn().Msg("Missing preferred_username claim, falling back to email")
+		if req.Account.PreferredName, ok = claims[oidc.Email].(string); !ok {
+			a.logger.Debug().Msg("Missing email claim as well")
+		}
+	}
+	if req.Account.PreferredName != "" {
 		// also use as on premises samaccount name
 		req.Account.OnPremisesSamAccountName = req.Account.PreferredName
 	}


### PR DESCRIPTION
Some IDPs (e.g. Authelia) don't add the "preferred_username" claim.
Fallback to the "email" claim in that case.

Fixes: #2644

To fully work, this needs: https://github.com/cs3org/reva/pull/2314