### PR TITLE
[Runtime] Removed trap goroutine in favor of context propagation cancelation

### DIFF
--- a/accounts/pkg/command/server.go
+++ b/accounts/pkg/command/server.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/owncloud/ocis/ocis-pkg/log"
 
-	"github.com/owncloud/ocis/ocis-pkg/sync"
-
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/accounts/pkg/config"
 	"github.com/owncloud/ocis/accounts/pkg/metrics"
@@ -84,10 +82,6 @@ func Server(cfg *config.Config) *cli.Command {
 				logger.Info().Str("server", "grpc").Msg("shutting down server")
 				cancel()
 			})
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
-			}
 
 			return gr.Run()
 		},

--- a/changelog/unreleased/supervisor-stop-routine.md
+++ b/changelog/unreleased/supervisor-stop-routine.md
@@ -1,0 +1,5 @@
+Enhancement: Correct shutdown of services under runtime
+
+Supervised goroutines now shut themselves down on context cancellation propagation.
+
+https://github.com/owncloud/ocis/pull/2843

--- a/glauth/pkg/command/server.go
+++ b/glauth/pkg/command/server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/owncloud/ocis/glauth/pkg/tracing"
 	pkgcrypto "github.com/owncloud/ocis/ocis-pkg/crypto"
 	"github.com/owncloud/ocis/ocis-pkg/service/grpc"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/urfave/cli/v2"
 )
 
@@ -176,10 +175,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/graph-explorer/pkg/command/server.go
+++ b/graph-explorer/pkg/command/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/owncloud/ocis/graph-explorer/pkg/server/debug"
 	"github.com/owncloud/ocis/graph-explorer/pkg/server/http"
 	"github.com/owncloud/ocis/graph-explorer/pkg/tracing"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/urfave/cli/v2"
 )
 
@@ -93,10 +92,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/graph/pkg/command/server.go
+++ b/graph/pkg/command/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/owncloud/ocis/graph/pkg/server/debug"
 	"github.com/owncloud/ocis/graph/pkg/server/http"
 	"github.com/owncloud/ocis/graph/pkg/tracing"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/urfave/cli/v2"
 )
 
@@ -90,10 +89,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/idp/pkg/command/server.go
+++ b/idp/pkg/command/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/owncloud/ocis/idp/pkg/server/debug"
 	"github.com/owncloud/ocis/idp/pkg/server/http"
 	"github.com/owncloud/ocis/idp/pkg/tracing"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/urfave/cli/v2"
 )
 
@@ -94,10 +93,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/ocis/pkg/command/storagemetadata.go
+++ b/ocis/pkg/command/storagemetadata.go
@@ -13,7 +13,6 @@ func StorageMetadataCommand(cfg *config.Config) *cli.Command {
 		Name:     "storage-metadata",
 		Usage:    "Start storage and data service for metadata",
 		Category: "Extensions",
-		//Flags:    flagset.StorageMetadata(cfg.Storage),
 		Before: func(ctx *cli.Context) error {
 			return ParseStorageCommon(ctx, cfg)
 		},

--- a/ocis/pkg/runtime/cmd/run.go
+++ b/ocis/pkg/runtime/cmd/run.go
@@ -22,7 +22,8 @@ func Run(cfg *config.Config) *cobra.Command {
 				log.Fatal("dialing:", err)
 			}
 			var res int
-			if err := client.Call("Service.Start", &args[0], &res); err != nil {
+
+			if err = client.Call("Service.Start", &args[0], &res); err != nil {
 				log.Fatal(err)
 			}
 

--- a/ocs/pkg/command/server.go
+++ b/ocs/pkg/command/server.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/owncloud/ocis/ocs/pkg/tracing"
 
-	"github.com/owncloud/ocis/ocis-pkg/sync"
-
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/ocs/pkg/config"
 	"github.com/owncloud/ocis/ocs/pkg/metrics"
@@ -98,10 +96,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/proxy/pkg/command/server.go
+++ b/proxy/pkg/command/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	pkgmiddleware "github.com/owncloud/ocis/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/ocis-pkg/service/grpc"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/proxy/pkg/config"
 	"github.com/owncloud/ocis/proxy/pkg/cs3"
 	"github.com/owncloud/ocis/proxy/pkg/metrics"
@@ -136,10 +135,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/settings/pkg/command/server.go
+++ b/settings/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/oklog/run"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/settings/pkg/config"
 	"github.com/owncloud/ocis/settings/pkg/metrics"
 	"github.com/owncloud/ocis/settings/pkg/server/debug"
@@ -82,10 +81,6 @@ func Server(cfg *config.Config) *cli.Command {
 				_ = debugServer.Shutdown(ctx)
 				cancel()
 			})
-
-			if !cfg.Supervised {
-				sync.Trap(&servers, cancel)
-			}
 
 			return servers.Run()
 		},

--- a/store/pkg/command/server.go
+++ b/store/pkg/command/server.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/owncloud/ocis/store/pkg/tracing"
 
-	"github.com/owncloud/ocis/ocis-pkg/sync"
-
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/store/pkg/config"
 	"github.com/owncloud/ocis/store/pkg/metrics"
@@ -101,10 +99,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/thumbnails/pkg/command/server.go
+++ b/thumbnails/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/oklog/run"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/thumbnails/pkg/config"
 	"github.com/owncloud/ocis/thumbnails/pkg/metrics"
 	"github.com/owncloud/ocis/thumbnails/pkg/server/debug"
@@ -77,10 +76,6 @@ func Server(cfg *config.Config) *cli.Command {
 				_ = server.Shutdown(ctx)
 				cancel()
 			})
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
-			}
 
 			return gr.Run()
 		},

--- a/web/pkg/command/server.go
+++ b/web/pkg/command/server.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/oklog/run"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/web/pkg/config"
 	"github.com/owncloud/ocis/web/pkg/metrics"
 	"github.com/owncloud/ocis/web/pkg/server/debug"
@@ -122,10 +121,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()

--- a/webdav/pkg/command/server.go
+++ b/webdav/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/oklog/run"
-	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/webdav/pkg/config"
 	"github.com/owncloud/ocis/webdav/pkg/metrics"
 	"github.com/owncloud/ocis/webdav/pkg/server/debug"
@@ -98,10 +97,6 @@ func Server(cfg *config.Config) *cli.Command {
 					_ = server.Shutdown(ctx)
 					cancel()
 				})
-			}
-
-			if !cfg.Supervised {
-				sync.Trap(&gr, cancel)
 			}
 
 			return gr.Run()


### PR DESCRIPTION
Supervised goroutines now shut themselves down on context cancellation propagation. This method still does not stop reva go-routines, since the Reva runtime does not work with contexts.