### PR TITLE
[tests-only] [full-ci] Bump core commit id to include new group name tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=5f98837bd95d75660fc9fbc9a8802f7db8793a89
+CORE_COMMITID=2987544bfd6f6823df68f6ea392ba41c1ea4f07c
 CORE_BRANCH=acceptance-test-changes-waiting-2021-11
 
 # The test runner source for UI tests

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -983,6 +983,14 @@ _ocs: api compatibility, return correct status code_
 -   [apiProvisioningGroups-v1/addGroup.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature#L134)
 -   [apiProvisioningGroups-v2/addGroup.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature#L129)
 
+#### [group names with space at the start or end should not be allowed](https://github.com/owncloud/ocis/issues/2876)
+-   [apiProvisioningGroups-v1/addGroup.feature:158](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature#L158)
+-   [apiProvisioningGroups-v1/addGroup.feature:166](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature#L166)
+-   [apiProvisioningGroups-v1/addGroup.feature:174](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature#L174)
+-   [apiProvisioningGroups-v2/addGroup.feature:154](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature#L154)
+-   [apiProvisioningGroups-v2/addGroup.feature:162](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature#L162)
+-   [apiProvisioningGroups-v2/addGroup.feature:170](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature#L170)
+
 #### [cannot create group with '/'](https://github.com/owncloud/product/issues/285)
 -   [apiProvisioningGroups-v1/addToGroup.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature#L82)
 -   [apiProvisioningGroups-v1/deleteGroup.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature#L85)


### PR DESCRIPTION
## Description
core PR https://github.com/owncloud/core/pull/39540 prohibits space at the start or end of a group name. It should be merged to core master after the 10.9.0 release process is finished.

That has been cherry-picked into core PR https://github.com/owncloud/core/pull/39514 so that the new and changed API test scenarios can be run from oCIS. Let's see the CI  results...

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
