### PR TITLE
update gologr

### DIFF
--- a/glauth/pkg/mlogr/mlogr.go
+++ b/glauth/pkg/mlogr/mlogr.go
@@ -14,23 +14,28 @@ const traceVerbosity = 8
 
 // New returns a logr.Logger which is implemented by the log.
 func New(l *plog.Logger) logr.Logger {
-	return logger{
+	sink := logSink{
 		l:         l,
 		verbosity: 0,
 		prefix:    "glauth",
 		values:    nil,
 	}
+
+	return logr.New(sink)
 }
 
-// logger is a logr.Logger that uses the ocis-pkg log.
-type logger struct {
+func (l logSink) Init(info logr.RuntimeInfo) {
+}
+
+// logSink is a logr.LogSink that uses the ocis-pkg log.
+type logSink struct {
 	l         *plog.Logger
 	verbosity int
 	prefix    string
 	values    []interface{}
 }
 
-func (l logger) clone() logger {
+func (l logSink) clone() logSink {
 	out := l
 	out.values = copySlice(l.values)
 	return out
@@ -71,8 +76,8 @@ func add(e *zerolog.Event, keysAndVals []interface{}) {
 	}
 }
 
-func (l logger) Info(msg string, keysAndVals ...interface{}) {
-	if l.Enabled() {
+func (l logSink) Info(level int, msg string, kvList ...interface{}) {
+	if l.Enabled(level) {
 		var e *zerolog.Event
 		if l.verbosity < debugVerbosity {
 			e = l.l.Info()
@@ -86,16 +91,16 @@ func (l logger) Info(msg string, keysAndVals ...interface{}) {
 			e.Str("name", l.prefix)
 		}
 		add(e, l.values)
-		add(e, keysAndVals)
+		add(e, kvList)
 		e.Msg(msg)
 	}
 }
 
-func (l logger) Enabled() bool {
+func (l logSink) Enabled(level int) bool {
 	return true
 }
 
-func (l logger) Error(err error, msg string, keysAndVals ...interface{}) {
+func (l logSink) Error(err error, msg string, keysAndVals ...interface{}) {
 	e := l.l.Error().Err(err)
 	if l.prefix != "" {
 		e.Str("name", l.prefix)
@@ -105,18 +110,10 @@ func (l logger) Error(err error, msg string, keysAndVals ...interface{}) {
 	e.Msg(msg)
 }
 
-func (l logger) V(verbosity int) logr.InfoLogger {
-	//new := l.clone()
-	//new.level = level
-	//return new
-	l.verbosity = verbosity
-	return l
-}
-
-// WithName returns a new logr.Logger with the specified name appended. zerologr
+// WithName returns a new logr.LogSink with the specified name appended. zerologr
 // uses '/' characters to separate name elements.  Callers should not pass '/'
 // in the provided name string, but this library does not actually enforce that.
-func (l logger) WithName(name string) logr.Logger {
+func (l logSink) WithName(name string) logr.LogSink {
 	nl := l.clone()
 	if len(l.prefix) > 0 {
 		nl.prefix = l.prefix + "/"
@@ -124,11 +121,10 @@ func (l logger) WithName(name string) logr.Logger {
 	nl.prefix += name
 	return nl
 }
-func (l logger) WithValues(kvList ...interface{}) logr.Logger {
+func (l logSink) WithValues(kvList ...interface{}) logr.LogSink {
 	nl := l.clone()
 	nl.values = append(nl.values, kvList...)
 	return nl
 }
 
-var _ logr.Logger = logger{}
-var _ logr.InfoLogger = logger{}
+var _ logr.LogSink = logSink{}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/go-chi/cors v1.2.0
 	github.com/go-chi/render v1.0.1
 	github.com/go-ldap/ldap/v3 v3.4.1
-	github.com/go-logr/logr v0.4.0
+	github.com/go-logr/logr v1.2.2
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -415,6 +415,8 @@ github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNV
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=


### PR DESCRIPTION
## Description
Updates github.com/go-logr/logr, since that is needed for newer versions of REVA (because of  go.opentelemetry.io/otel v1.3.0)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Closes https://github.com/owncloud/ocis/pull/2873
- Unblocks https://github.com/owncloud/ocis/pull/2870
