### PR TITLE
[tests-only][full-ci]Remove a test scenario from expected to fail file

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=2987544bfd6f6823df68f6ea392ba41c1ea4f07c
-CORE_BRANCH=acceptance-test-changes-waiting-2021-11
+CORE_COMMITID=8f0575dda6a23643f51e97321fa8de34a093e5dc
+CORE_BRANCH=bug-demo-test-webdav-put
 
 # The test runner source for UI tests
 WEB_COMMITID=ed4a8b32240b59666a6c2b162d95b50ff7191eb8

--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=8f0575dda6a23643f51e97321fa8de34a093e5dc
-CORE_BRANCH=bug-demo-test-webdav-put
+CORE_COMMITID=38ee68e6358443e980ba5e7036cf1fb554443814
+CORE_BRANCH=acceptance-test-changes-waiting-2021-11
 
 # The test runner source for UI tests
 WEB_COMMITID=ed4a8b32240b59666a6c2b162d95b50ff7191eb8

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -1482,6 +1482,3 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 ### [Content-type is not multipart/byteranges when downloading file with Range Header](https://github.com/owncloud/ocis/issues/2677)
 -   [apiWebdavOperations/downloadFile.feature:169](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L169)
 -   [apiWebdavOperations/downloadFile.feature:170](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L170)
-
-### [send PUT requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis/issues/2759)
--   [apiAuthWebDav/webDavPUTAuth.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature#L40)


### PR DESCRIPTION
## Description
This core PR https://github.com/owncloud/core/pull/39598 adds a bug demonstration test for core and the current OCIS behavior is okay. This PR removes the working OCIS test from the expected to fail file. 

## Related Issue
https://github.com/owncloud/QA/issues/703 and https://github.com/owncloud/core/issues/39597

## How Has This Been Tested?
- CI
- Locally


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
