### PR TITLE
add new file url of the app provider to the ocs capabilities

### DIFF
--- a/changelog/unreleased/enhancement-add-new-file-capability.md
+++ b/changelog/unreleased/enhancement-add-new-file-capability.md
@@ -1,0 +1,8 @@
+Enhancement: add new file url of the app provider to the ocs capabilities
+
+We've added the new file capability of the app provider to the ocs capabilities, so that
+clients can discover this url analogous to the app list and file open urls.
+
+https://github.com/owncloud/ocis/pull/2884
+https://github.com/cs3org/reva/pull/2379
+https://github.com/owncloud/web/pull/5890#issuecomment-993905242

--- a/docs/extensions/storage/apps.md
+++ b/docs/extensions/storage/apps.md
@@ -24,7 +24,8 @@ The capabilities endpoint (eg. `https://localhost:9200/ocs/v1.php/cloud/capabili
               "enabled": true,
               "version": "1.0.0",
               "apps_url": "/app/list",
-              "open_url": "/app/open"
+              "open_url": "/app/open",
+              "new_url": "/app/new"
             }
           ]
         }

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -61,6 +61,7 @@ type AppProvider struct {
 	WopiDriver   WopiDriver `ocisConfig:"wopi_driver"`
 	AppsURL      string     `ocisConfig:"apps_url"`
 	OpenURL      string     `ocisConfig:"open_url"`
+	NewURL       string     `ocisConfig:"new_url"`
 }
 
 type WopiDriver struct {
@@ -938,6 +939,7 @@ func DefaultConfig() *Config {
 				WopiDriver:   WopiDriver{},
 				AppsURL:      "/app/list",
 				OpenURL:      "/app/open",
+				NewURL:       "/app/new",
 			},
 			Configs:                     nil,
 			UploadMaxChunkSize:          1e+8,
@@ -1316,6 +1318,10 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 		{
 			EnvVars:     []string{"STORAGE_FRONTEND_APP_PROVIDER_OPEN_URL"},
 			Destination: &cfg.Reva.AppProvider.OpenURL,
+		},
+		{
+			EnvVars:     []string{"STORAGE_FRONTEND_APP_PROVIDER_NEW_URL"},
+			Destination: &cfg.Reva.AppProvider.NewURL,
 		},
 
 		// gateway


### PR DESCRIPTION
## Description
We've added the new file capability of the app provider to the ocs capabilities, so that
clients can discover this url analogous to the app list and file open urls.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needs https://github.com/cs3org/reva/pull/2379 first
- Needed by https://github.com/owncloud/web/pull/5890#issuecomment-993905242

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
