### PR TITLE
enable dependabot to merge PRs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -58,7 +58,8 @@ branches:
       enforce_admins: null
       restrictions:
         apps: []
-        users: []
+        users:
+          - dependabot
         teams:
           - ci
           - employees


### PR DESCRIPTION
## Description

Enable Dependabot to merge PRs after they got a review and CI was green.
This makes it possible to use the `@dependabot merge` comment on the PR, which will merge the PR after your CI passes on it