### PR TITLE
fix app provider "new url" capability

### DIFF
--- a/changelog/unreleased/enhancement-add-new-file-capability.md
+++ b/changelog/unreleased/enhancement-add-new-file-capability.md
@@ -4,5 +4,6 @@ We've added the new file capability of the app provider to the ocs capabilities,
 clients can discover this url analogous to the app list and file open urls.
 
 https://github.com/owncloud/ocis/pull/2884
+https://github.com/owncloud/ocis/pull/2907
 https://github.com/cs3org/reva/pull/2379
 https://github.com/owncloud/web/pull/5890#issuecomment-993905242

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -71,6 +71,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 					"version":  "1.0.0",
 					"apps_url": cfg.Reva.AppProvider.AppsURL,
 					"open_url": cfg.Reva.AppProvider.OpenURL,
+					"new_url":  cfg.Reva.AppProvider.NewURL,
 				},
 			}
 


### PR DESCRIPTION
## Description
Fix of https://github.com/owncloud/ocis/pull/2884 and https://github.com/cs3org/reva/pull/2379, since "new_url" was added as option, but was not hooked up in the oCIS frontend part...

After this fix we get:
```bash
curl -k 'https://localhost:9200/ocs/v1.php/cloud/capabilities?format=json' -u einstein:relativity | jq '.ocs.data.capabilities.files.app_providers'
```

```json
[
  {
    "enabled": true,
    "version": "1.0.0",
    "apps_url": "/app/list",
    "open_url": "/app/open",
    "new_url": "/app/new"
  }
]
```

Unblocks https://github.com/owncloud/web/pull/5890