### PR TITLE
[full-ci] Use new icons and bump ODS to 12.0.0(-alpha) in accounts/settings

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -3,5 +3,5 @@ CORE_COMMITID=a37efb60db92923398de7efef1abb173d13a9afb
 CORE_BRANCH=master
 
 # The test runner source for UI tests
-WEB_COMMITID=bddf71ff51e2e092551dda82a134bc227073e09c
+WEB_COMMITID=a64487f5f7f4637051a1ffc7e24f8447bb2e13cf
 WEB_BRANCH=master

--- a/accounts/package.json
+++ b/accounts/package.json
@@ -80,7 +80,7 @@
     "xml-js": "^1.6.11"
   },
   "peerDependencies": {
-    "owncloud-design-system": "^11.0.0"
+    "owncloud-design-system": "12.0.0-alpha7"
   },
   "packageManager": "yarn@3.1.0"
 }

--- a/accounts/ui/app.js
+++ b/accounts/ui/app.js
@@ -11,7 +11,7 @@ function $gettext (msg) {
 const appInfo = {
   name: $gettext('Accounts'),
   id: 'accounts',
-  icon: 'text-vcard',
+  icon: 'team',
   isFileEditor: false,
   extensions: []
 }

--- a/accounts/ui/components/App.vue
+++ b/accounts/ui/components/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <main class="uk-flex uk-flex-column uk-height-1-1" id="accounts-app">
+    <main class="uk-flex uk-flex-column uk-height-1-1 oc-px-s" id="accounts-app">
       <template v-if="isInitialized">
         <h1 class="oc-invisible-sr">
           <translate>Accounts</translate>
@@ -21,7 +21,7 @@
       </template>
       <template v-else-if="hasFailed">
         <oc-alert variation="warning" no-close class="oc-m" id="accounts-list-loading-failed">
-          <oc-icon name="warning" variation="warning" class="uk-float-left oc-mr-s" />
+          <oc-icon name="error-warning" variation="warning" class="uk-float-left oc-mr-s" />
           <translate>You don't have permissions to manage accounts.</translate>
         </oc-alert>
       </template>

--- a/accounts/ui/components/accounts/AccountsCreate.vue
+++ b/accounts/ui/components/accounts/AccountsCreate.vue
@@ -65,7 +65,7 @@
           gap-size="small"
           @click="setFormInProgress(true)"
         >
-          <oc-icon name="add" />
+          <oc-icon name="user-add" />
           <translate>Create new account</translate>
         </oc-button>
       </div>

--- a/accounts/ui/components/accounts/AccountsListRow.vue
+++ b/accounts/ui/components/accounts/AccountsListRow.vue
@@ -21,7 +21,7 @@
       <oc-button :id="`accounts-roles-select-trigger-${account.id}`" class="accounts-roles-select-trigger" appearance="outline">
         <span class="uk-flex uk-flex-middle accounts-roles-current-role">
           {{ currentRole ? currentRole.displayName : $gettext('Select role') }}
-          <oc-icon name="expand_more" aria-hidden="true" />
+          <oc-icon name="arrow-down-s" aria-hidden="true" />
         </span>
       </oc-button>
       <oc-drop
@@ -48,14 +48,14 @@
       <oc-icon
         v-if="account.accountEnabled"
         key="account-icon-enabled"
-        name="ready"
+        name="user-follow"
         variation="success"
         :aria-label="$gettext('Account is activated')"
         class="accounts-status-indicator-enabled"
       />
       <oc-icon
         v-else
-        name="deprecated"
+        name="user-unfollow"
         key="account-icon-disabled"
         variation="danger"
         :aria-label="$gettext('Account is blocked')"

--- a/accounts/yarn.lock
+++ b/accounts/yarn.lock
@@ -8347,7 +8347,7 @@ __metadata:
     vuex: ^3.5.1
     xml-js: ^1.6.11
   peerDependencies:
-    owncloud-design-system: ^11.0.0
+    owncloud-design-system: 12.0.0-alpha7
   languageName: unknown
   linkType: soft
 

--- a/changelog/unreleased/enhancement-redesign-accounts-settings.md
+++ b/changelog/unreleased/enhancement-redesign-accounts-settings.md
@@ -1,0 +1,6 @@
+Enhancement: Redesign accounts & settings
+
+We've updated the UIs of the accounts and settings services, 
+following the web service redesign (and changes in the available icons).
+
+https://github.com/owncloud/ocis/pull/2929

--- a/settings/package.json
+++ b/settings/package.json
@@ -80,6 +80,6 @@
     "xml-js": "^1.6.11"
   },
   "peerDependencies": {
-    "owncloud-design-system": "^11.0.0"
+    "owncloud-design-system": "12.0.0-alpha7"
   }
 }

--- a/settings/ui/app.js
+++ b/settings/ui/app.js
@@ -11,7 +11,7 @@ function $gettext (msg) {
 const appInfo = {
   name: $gettext('Settings'),
   id: 'settings',
-  icon: 'application',
+  icon: 'settings-4',
   isFileEditor: false,
   extensions: []
 }

--- a/settings/ui/components/SettingsApp.vue
+++ b/settings/ui/components/SettingsApp.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="oc-p">
-    <main class="uk-flex uk-flex-column" id="settings-app">
+    <main class="uk-flex uk-flex-column oc-px-s" id="settings-app">
       <template v-if="initialized">
         <oc-alert v-if="extensions.length === 0" variation="primary" no-close>
           <p class="uk-flex uk-flex-middle">
-            <oc-icon name="info" class="oc-mr-s" />
+            <oc-icon name="information" class="oc-mr-s" />
             <translate>No settings available</translate>
           </p>
         </oc-alert>

--- a/tests/config/drone/ocis-config.json
+++ b/tests/config/drone/ocis-config.json
@@ -1,29 +1,32 @@
 {
-    "server": "https://ocis-server:9200",
-    "theme": "https://ocis-server:9200/themes/owncloud/theme.json",
-    "version": "0.1.0",
-    "openIdConnect": {
-        "metadata_url": "https://ocis-server:9200/.well-known/openid-configuration",
-        "authority": "https://ocis-server:9200",
-        "client_id": "web",
-        "response_type": "code",
-        "scope": "openid profile email"
+  "server": "https://ocis-server:9200",
+  "theme": "https://ocis-server:9200/themes/owncloud/theme.json",
+  "version": "0.1.0",
+  "openIdConnect": {
+    "metadata_url": "https://ocis-server:9200/.well-known/openid-configuration",
+    "authority": "https://ocis-server:9200",
+    "client_id": "web",
+    "response_type": "code",
+    "scope": "openid profile email"
+  },
+  "options": {
+    "displayResourcesLazy": false
+  },
+  "apps": [
+    "files",
+    "draw-io",
+    "markdown-editor",
+    "media-viewer",
+    "search"
+  ],
+  "external_apps": [
+    {
+      "id": "settings",
+      "path": "https://ocis-server:9200/settings.js"
     },
-    "apps": [
-        "files",
-        "draw-io",
-        "markdown-editor",
-        "media-viewer",
-	"search"
-    ],
-    "external_apps": [
-        {
-            "id": "settings",
-            "path": "https://ocis-server:9200/settings.js"
-        },
-        {
-            "id": "accounts",
-            "path": "https://ocis-server:9200/accounts.js"
-        }
-    ]
+    {
+      "id": "accounts",
+      "path": "https://ocis-server:9200/accounts.js"
+    }
+  ]
 }


### PR DESCRIPTION
## Description
Necessary updates in accounts & settings UIs since we're changing available icons in the ODS

## Checklist:
- Perhaps needs a `web` commit ID bump after https://github.com/owncloud/web/pull/6142 is merged

## TODO:
- [ ] settings ui should get this icon https://github.com/Remix-Design/RemixIcon/blob/master/icons/Design/tools-line.svg according to https://github.com/owncloud/web/issues/6256