### PR TITLE
enable spaces capability

### DIFF
--- a/changelog/unreleased/enhancement-spaces-capability.md
+++ b/changelog/unreleased/enhancement-spaces-capability.md
@@ -1,0 +1,6 @@
+Enhancement: Add spaces capability
+
+We've added the spaces capability with version 0.0.1 and enabled set to true.
+
+https://github.com/owncloud/ocis/pull/2930
+https://github.com/cs3org/reva/pull/2015

--- a/changelog/unreleased/enhancement-spaces-capability.md
+++ b/changelog/unreleased/enhancement-spaces-capability.md
@@ -2,5 +2,5 @@ Enhancement: Add spaces capability
 
 We've added the spaces capability with version 0.0.1 and enabled set to true.
 
-https://github.com/owncloud/ocis/pull/2930
+https://github.com/owncloud/ocis/pull/2931
 https://github.com/cs3org/reva/pull/2015

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -291,6 +291,10 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 									"incoming": true,
 								},
 							},
+							"spaces": map[string]interface{}{
+								"version": "0.0.1",
+								"enabled": true,
+							},
 						},
 						"version": map[string]interface{}{
 							"edition": "reva",


### PR DESCRIPTION
## Description
`curl -k 'https://localhost:9200/ocs/v1.php/cloud/capabilities?format=json' -u einstein:relativity | jq '.ocs.data.capabilities.spaces'`

gives

``` json
{
  "version": "0.0.1",
  "enabled": true
}
```


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Follow up on https://github.com/cs3org/reva/pull/2015

