### PR TITLE
[tests-only][full-ci] bump web commit id upto 2022-01-07

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -3,5 +3,5 @@ CORE_COMMITID=09d584745d6cbd6aebc557d9b78f6130e9b99e2b
 CORE_BRANCH=master
 
 # The test runner source for UI tests
-WEB_COMMITID=bddf71ff51e2e092551dda82a134bc227073e09c
+WEB_COMMITID=af989fc505ddd5a0ee283ed19f8f23d1cd07410f
 WEB_BRANCH=master


### PR DESCRIPTION
## Description
- updates `owncloud/web` commit id for the tests


## Part of 
- https://github.com/owncloud/QA/issues/711