### PR TITLE
Spaces filters

### DIFF
--- a/changelog/unreleased/spaces-filters.md
+++ b/changelog/unreleased/spaces-filters.md
@@ -1,0 +1,6 @@
+Enhancement: Add filter by driveType and id to /me/drives
+
+We added two possible filter terms (driveType, id) to the /me/drives endpoint on the graph api. These can be used with the odata query parameter "$filter".
+We only support the "eq" operator for now.
+
+https://github.com/owncloud/ocis/pull/2946

--- a/graph/pkg/service/v0/drives.go
+++ b/graph/pkg/service/v0/drives.go
@@ -69,7 +69,7 @@ func (g Graph) GetDrives(w http.ResponseWriter, r *http.Request) {
 	filters, err := generateCs3Filters(odataReq)
 	if err != nil {
 		g.logger.Err(err).Interface("query", r.URL.Query()).Msg("query error")
-		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		errorcode.NotSupported.Render(w, r, http.StatusNotImplemented, err.Error())
 		return
 	}
 	res, err := client.ListStorageSpaces(ctx, &storageprovider.ListStorageSpacesRequest{

--- a/graph/pkg/service/v0/drives.go
+++ b/graph/pkg/service/v0/drives.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/CiscoM31/godata"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	cs3rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
@@ -31,6 +32,14 @@ import (
 
 // GetDrives implements the Service interface.
 func (g Graph) GetDrives(w http.ResponseWriter, r *http.Request) {
+	sanitized := strings.TrimPrefix(r.URL.Path, "/graph/v1.0/")
+	// Parse the request with odata parser
+	odataReq, err := godata.ParseRequest(r.Context(), sanitized, r.URL.Query())
+	if err != nil {
+		g.logger.Err(err).Msg("unable to parse odata request")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		return
+	}
 	g.logger.Info().Msg("Calling GetDrives")
 	ctx := r.Context()
 
@@ -64,7 +73,7 @@ func (g Graph) GetDrives(w http.ResponseWriter, r *http.Request) {
 				Value:   value,
 			},
 		}},
-		// TODO add filters?
+		Filters: generateCs3Filters(odataReq),
 	})
 	switch {
 	case err != nil:
@@ -552,4 +561,31 @@ func canSetSpaceQuota(ctx context.Context, user *userv1beta1.User) (bool, error)
 		return false, err
 	}
 	return true, nil
+}
+
+func generateCs3Filters(request *godata.GoDataRequest) []*storageprovider.ListStorageSpacesRequest_Filter {
+	var filters []*storageprovider.ListStorageSpacesRequest_Filter
+	if request.Query.Filter != nil && request.Query.Filter.Tree.Token.Value == "eq" {
+		switch request.Query.Filter.Tree.Children[0].Token.Value {
+		case "driveType":
+			filter1 := &storageprovider.ListStorageSpacesRequest_Filter{
+				Type: storageprovider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE,
+				Term: &storageprovider.ListStorageSpacesRequest_Filter_SpaceType{
+					SpaceType: strings.Trim(request.Query.Filter.Tree.Children[1].Token.Value, "'"),
+				},
+			}
+			filters = append(filters, filter1)
+		case "id":
+			filter2 := &storageprovider.ListStorageSpacesRequest_Filter{
+				Type: storageprovider.ListStorageSpacesRequest_Filter_TYPE_ID,
+				Term: &storageprovider.ListStorageSpacesRequest_Filter_Id{
+					Id: &storageprovider.StorageSpaceId{
+						OpaqueId: strings.Trim(request.Query.Filter.Tree.Children[1].Token.Value, "'"),
+					},
+				},
+			}
+			filters = append(filters, filter2)
+		}
+	}
+	return filters
 }

--- a/graph/pkg/service/v0/drives.go
+++ b/graph/pkg/service/v0/drives.go
@@ -571,30 +571,32 @@ func canSetSpaceQuota(ctx context.Context, user *userv1beta1.User) (bool, error)
 
 func generateCs3Filters(request *godata.GoDataRequest) ([]*storageprovider.ListStorageSpacesRequest_Filter, error) {
 	var filters []*storageprovider.ListStorageSpacesRequest_Filter
-	if request.Query.Filter != nil && request.Query.Filter.Tree.Token.Value == "eq" {
-		switch request.Query.Filter.Tree.Children[0].Token.Value {
-		case "driveType":
-			filter1 := &storageprovider.ListStorageSpacesRequest_Filter{
-				Type: storageprovider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE,
-				Term: &storageprovider.ListStorageSpacesRequest_Filter_SpaceType{
-					SpaceType: strings.Trim(request.Query.Filter.Tree.Children[1].Token.Value, "'"),
-				},
-			}
-			filters = append(filters, filter1)
-		case "id":
-			filter2 := &storageprovider.ListStorageSpacesRequest_Filter{
-				Type: storageprovider.ListStorageSpacesRequest_Filter_TYPE_ID,
-				Term: &storageprovider.ListStorageSpacesRequest_Filter_Id{
-					Id: &storageprovider.StorageSpaceId{
-						OpaqueId: strings.Trim(request.Query.Filter.Tree.Children[1].Token.Value, "'"),
+	if request.Query.Filter != nil {
+		if request.Query.Filter.Tree.Token.Value == "eq" {
+			switch request.Query.Filter.Tree.Children[0].Token.Value {
+			case "driveType":
+				filter1 := &storageprovider.ListStorageSpacesRequest_Filter{
+					Type: storageprovider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE,
+					Term: &storageprovider.ListStorageSpacesRequest_Filter_SpaceType{
+						SpaceType: strings.Trim(request.Query.Filter.Tree.Children[1].Token.Value, "'"),
 					},
-				},
+				}
+				filters = append(filters, filter1)
+			case "id":
+				filter2 := &storageprovider.ListStorageSpacesRequest_Filter{
+					Type: storageprovider.ListStorageSpacesRequest_Filter_TYPE_ID,
+					Term: &storageprovider.ListStorageSpacesRequest_Filter_Id{
+						Id: &storageprovider.StorageSpaceId{
+							OpaqueId: strings.Trim(request.Query.Filter.Tree.Children[1].Token.Value, "'"),
+						},
+					},
+				}
+				filters = append(filters, filter2)
 			}
-			filters = append(filters, filter2)
+		} else {
+			err := fmt.Errorf("unsupported filter operand: %s", request.Query.Filter.Tree.Token.Value)
+			return nil, err
 		}
-	} else {
-		err := fmt.Errorf("unsupported filter operand: %s", request.Query.Filter.Tree.Token.Value)
-		return nil, err
 	}
 	return filters, nil
 }

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -37,11 +37,7 @@ Feature: List and create spaces
       | quota@@@state    | normal       |
       | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
     And the json responded should not contain a space with name "Shares Jail"
-    And the json responded should contain spaces of type "personal"
     And the json responded should only contain spaces of type "personal"
-    And the json responded should not contain spaces of type "project"
-    And the json responded should not contain spaces of type "virtual"
-    And the json responded should not contain spaces of type "public"
 
   Scenario: An ordinary user will not see any space when using a filter for project
     When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'project'"

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -19,6 +19,35 @@ Feature: List and create spaces
       | name             | Alice Hansen |
       | quota@@@state    | normal       |
       | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+    And the json responded should contain a space "Shares Jail" with these key and value pairs:
+      | key              | value        |
+      | driveType        | virtual     |
+      | id               | %space_id%   |
+      | name             | Shares Jail |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+
+  Scenario: An ordinary user can request information about their Space via the Graph API using a filter
+    When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'personal'"
+    Then the HTTP status code should be "200"
+    And the json responded should contain a space "Alice Hansen" with these key and value pairs:
+      | key              | value        |
+      | driveType        | personal     |
+      | id               | %space_id%   |
+      | name             | Alice Hansen |
+      | quota@@@state    | normal       |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+    And the json responded should not contain a space with name "Shares Jail"
+    And the json responded should contain spaces of type "personal"
+    And the json responded should only contain spaces of type "personal"
+    And the json responded should not contain spaces of type "project"
+    And the json responded should not contain spaces of type "virtual"
+    And the json responded should not contain spaces of type "public"
+
+  Scenario: An ordinary user will not see any space when using a filter for project
+    When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'project'"
+    Then the HTTP status code should be "200"
+    And the json responded should not contain a space with name "Alice Hansen"
+    And the json responded should not contain spaces of type "personal"
 
   Scenario: An ordinary user can access their Space via the webDav API
     When user "Alice" lists all available spaces via the GraphApi


### PR DESCRIPTION
## Description

This adds two possible filter terms (driveType, id) to the /me/drives endpoint on the graph api. These can be used with the odata query parameter "$filter".

We only support the "eq" operator for now.

This is leveraging the `spaces-registry` branch and needs to be rebased after that one has been merged.

## Examples

### Filter by Id
```sh
curl -L -X GET "https://localhost:9200/graph/v1.0/me/drives?$filter=id eq 'f98b7cc7-15ba-4715-9d16-23a746dfe648'" \
-H "Authorization: Basic YWRtaW46YWRtaW4="
```

### Filter by type
```sh
curl -L -X GET "https://localhost:9200/graph/v1.0/me/drives?$filter=driveType eq 'project'" \
-H "Authorization: Basic YWRtaW46YWRtaW4="
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- curl
- needs API tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
