### PR TITLE
Add support for user creation and deletion to GraphAPI (LDAP backend)

### DIFF
--- a/graph/pkg/config/config.go
+++ b/graph/pkg/config/config.go
@@ -34,9 +34,10 @@ type Spaces struct {
 }
 
 type LDAP struct {
-	URI          string `ocisConfig:"uri" env:"GRAPH_LDAP_URI"`
-	BindDN       string `ocisConfig:"bind_dn" env:"GRAPH_LDAP_BIND_DN"`
-	BindPassword string `ocisConfig:"bind_password" env:"GRAPH_LDAP_BIND_PASSWORD"`
+	URI           string `ocisConfig:"uri" env:"GRAPH_LDAP_URI"`
+	BindDN        string `ocisConfig:"bind_dn" env:"GRAPH_LDAP_BIND_DN"`
+	BindPassword  string `ocisConfig:"bind_password" env:"GRAPH_LDAP_BIND_PASSWORD"`
+	UseServerUUID bool   `ocisConfig:"use_server_uuid" env:"GRAPH_LDAP_SERVER_UUID"`
 
 	UserBaseDN               string `ocisConfig:"user_base_dn" env:"GRAPH_LDAP_USER_BASE_DN"`
 	UserSearchScope          string `ocisConfig:"user_search_scope" env:"GRAPH_LDAP_USER_SCOPE"`

--- a/graph/pkg/config/config.go
+++ b/graph/pkg/config/config.go
@@ -38,6 +38,7 @@ type LDAP struct {
 	BindDN        string `ocisConfig:"bind_dn" env:"GRAPH_LDAP_BIND_DN"`
 	BindPassword  string `ocisConfig:"bind_password" env:"GRAPH_LDAP_BIND_PASSWORD"`
 	UseServerUUID bool   `ocisConfig:"use_server_uuid" env:"GRAPH_LDAP_SERVER_UUID"`
+	WriteEnabled  bool   `ocisConfig:"write_enabled" env:"GRAPH_LDAP_SERVER_WRITE_ENABLED"`
 
 	UserBaseDN               string `ocisConfig:"user_base_dn" env:"GRAPH_LDAP_USER_BASE_DN"`
 	UserSearchScope          string `ocisConfig:"user_search_scope" env:"GRAPH_LDAP_USER_SCOPE"`

--- a/graph/pkg/config/defaultconfig.go
+++ b/graph/pkg/config/defaultconfig.go
@@ -31,6 +31,7 @@ func DefaultConfig() *Config {
 				URI:                      "ldap://localhost:9125",
 				BindDN:                   "",
 				BindPassword:             "",
+				UseServerUUID:            false,
 				UserBaseDN:               "ou=users,dc=ocis,dc=test",
 				UserSearchScope:          "sub",
 				UserFilter:               "(objectClass=inetOrgPerson)",
@@ -39,12 +40,12 @@ func DefaultConfig() *Config {
 				UserNameAttribute:        "uid",
 				// FIXME: switch this to some more widely available attribute by default
 				//        ideally this needs to	be constant for the lifetime of a users
-				UserIDAttribute:    "entryUUID",
+				UserIDAttribute:    "owncloudUUID",
 				GroupBaseDN:        "ou=groups,dc=ocis,dc=test",
 				GroupSearchScope:   "sub",
 				GroupFilter:        "(objectclass=groupOfNames)",
 				GroupNameAttribute: "cn",
-				GroupIDAttribute:   "cn",
+				GroupIDAttribute:   "owncloudUUID",
 			},
 		},
 	}

--- a/graph/pkg/config/defaultconfig.go
+++ b/graph/pkg/config/defaultconfig.go
@@ -33,13 +33,13 @@ func DefaultConfig() *Config {
 				BindPassword:             "",
 				UserBaseDN:               "ou=users,dc=ocis,dc=test",
 				UserSearchScope:          "sub",
-				UserFilter:               "(objectClass=posixaccount)",
+				UserFilter:               "(objectClass=inetOrgPerson)",
 				UserEmailAttribute:       "mail",
 				UserDisplayNameAttribute: "displayName",
 				UserNameAttribute:        "uid",
 				// FIXME: switch this to some more widely available attribute by default
 				//        ideally this needs to	be constant for the lifetime of a users
-				UserIDAttribute:    "ownclouduuid",
+				UserIDAttribute:    "entryUUID",
 				GroupBaseDN:        "ou=groups,dc=ocis,dc=test",
 				GroupSearchScope:   "sub",
 				GroupFilter:        "(objectclass=groupOfNames)",

--- a/graph/pkg/config/defaultconfig.go
+++ b/graph/pkg/config/defaultconfig.go
@@ -32,6 +32,7 @@ func DefaultConfig() *Config {
 				BindDN:                   "",
 				BindPassword:             "",
 				UseServerUUID:            false,
+				WriteEnabled:             false,
 				UserBaseDN:               "ou=users,dc=ocis,dc=test",
 				UserSearchScope:          "sub",
 				UserFilter:               "(objectClass=inetOrgPerson)",

--- a/graph/pkg/identity/backend.go
+++ b/graph/pkg/identity/backend.go
@@ -9,6 +9,9 @@ import (
 )
 
 type Backend interface {
+	// CreateUser creates a given user in the identity backend.
+	CreateUser(ctx context.Context, user libregraph.User) (*libregraph.User, error)
+
 	GetUser(ctx context.Context, nameOrId string) (*libregraph.User, error)
 	GetUsers(ctx context.Context, queryParam url.Values) ([]*libregraph.User, error)
 

--- a/graph/pkg/identity/backend.go
+++ b/graph/pkg/identity/backend.go
@@ -12,6 +12,9 @@ type Backend interface {
 	// CreateUser creates a given user in the identity backend.
 	CreateUser(ctx context.Context, user libregraph.User) (*libregraph.User, error)
 
+	// DeleteUser deletes a given user, identified by username or id, from the backend
+	DeleteUser(ctx context.Context, nameOrId string) error
+
 	GetUser(ctx context.Context, nameOrId string) (*libregraph.User, error)
 	GetUsers(ctx context.Context, queryParam url.Values) ([]*libregraph.User, error)
 

--- a/graph/pkg/identity/backend.go
+++ b/graph/pkg/identity/backend.go
@@ -15,6 +15,9 @@ type Backend interface {
 	// DeleteUser deletes a given user, identified by username or id, from the backend
 	DeleteUser(ctx context.Context, nameOrId string) error
 
+	// UpdateUser applies changes to given user, identified by username or id
+	UpdateUser(ctx context.Context, nameOrId string, user libregraph.User) (*libregraph.User, error)
+
 	GetUser(ctx context.Context, nameOrId string) (*libregraph.User, error)
 	GetUsers(ctx context.Context, queryParam url.Values) ([]*libregraph.User, error)
 

--- a/graph/pkg/identity/cs3.go
+++ b/graph/pkg/identity/cs3.go
@@ -20,6 +20,11 @@ type CS3 struct {
 	Logger *log.Logger
 }
 
+// CreateUser implements the Backend Interface. It's currently not supported for the CS3 backend
+func (i *CS3) CreateUser(ctx context.Context, user libregraph.User) (*libregraph.User, error) {
+	return nil, errorcode.New(errorcode.NotSupported, "not implemented")
+}
+
 func (i *CS3) GetUser(ctx context.Context, userID string) (*libregraph.User, error) {
 	client, err := pool.GetGatewayServiceClient(i.Config.Address)
 	if err != nil {

--- a/graph/pkg/identity/cs3.go
+++ b/graph/pkg/identity/cs3.go
@@ -30,6 +30,11 @@ func (i *CS3) DeleteUser(ctx context.Context, nameOrID string) error {
 	return errorcode.New(errorcode.NotSupported, "not implemented")
 }
 
+// UpdateUser implements the Backend Interface. It's currently not suported for the CS3 backend
+func (i *CS3) UpdateUser(ctx context.Context, nameOrID string, user libregraph.User) (*libregraph.User, error) {
+	return nil, errorcode.New(errorcode.NotSupported, "not implemented")
+}
+
 func (i *CS3) GetUser(ctx context.Context, userID string) (*libregraph.User, error) {
 	client, err := pool.GetGatewayServiceClient(i.Config.Address)
 	if err != nil {

--- a/graph/pkg/identity/cs3.go
+++ b/graph/pkg/identity/cs3.go
@@ -25,6 +25,11 @@ func (i *CS3) CreateUser(ctx context.Context, user libregraph.User) (*libregraph
 	return nil, errorcode.New(errorcode.NotSupported, "not implemented")
 }
 
+// DeleteUser implements the Backend Interface. It's currently not supported for the CS3 backend
+func (i *CS3) DeleteUser(ctx context.Context, nameOrID string) error {
+	return errorcode.New(errorcode.NotSupported, "not implemented")
+}
+
 func (i *CS3) GetUser(ctx context.Context, userID string) (*libregraph.User, error) {
 	client, err := pool.GetGatewayServiceClient(i.Config.Address)
 	if err != nil {

--- a/graph/pkg/identity/ldap/reconnect.go
+++ b/graph/pkg/identity/ldap/reconnect.go
@@ -162,8 +162,13 @@ func (c ConnWithReconnect) ExternalBind() error {
 	return ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
 }
 
-func (c ConnWithReconnect) Add(*ldap.AddRequest) error {
-	return ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+func (c ConnWithReconnect) Add(a *ldap.AddRequest) error {
+	conn, err := c.GetConnection()
+	if err != nil {
+		return err
+	}
+
+	return conn.Add(a)
 }
 
 func (c ConnWithReconnect) Del(*ldap.DelRequest) error {

--- a/graph/pkg/identity/ldap/reconnect.go
+++ b/graph/pkg/identity/ldap/reconnect.go
@@ -171,8 +171,13 @@ func (c ConnWithReconnect) Add(a *ldap.AddRequest) error {
 	return conn.Add(a)
 }
 
-func (c ConnWithReconnect) Del(*ldap.DelRequest) error {
-	return ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+func (c ConnWithReconnect) Del(d *ldap.DelRequest) error {
+	conn, err := c.GetConnection()
+	if err != nil {
+		return err
+	}
+
+	return conn.Del(d)
 }
 
 func (c ConnWithReconnect) Modify(*ldap.ModifyRequest) error {

--- a/graph/pkg/identity/ldap/reconnect.go
+++ b/graph/pkg/identity/ldap/reconnect.go
@@ -180,16 +180,31 @@ func (c ConnWithReconnect) Del(d *ldap.DelRequest) error {
 	return conn.Del(d)
 }
 
-func (c ConnWithReconnect) Modify(*ldap.ModifyRequest) error {
-	return ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+func (c ConnWithReconnect) Modify(m *ldap.ModifyRequest) error {
+	conn, err := c.GetConnection()
+	if err != nil {
+		return err
+	}
+
+	return conn.Modify(m)
 }
 
-func (c ConnWithReconnect) ModifyDN(*ldap.ModifyDNRequest) error {
-	return ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+func (c ConnWithReconnect) ModifyDN(m *ldap.ModifyDNRequest) error {
+	conn, err := c.GetConnection()
+	if err != nil {
+		return err
+	}
+
+	return conn.ModifyDN(m)
 }
 
-func (c ConnWithReconnect) ModifyWithResult(*ldap.ModifyRequest) (*ldap.ModifyResult, error) {
-	return nil, ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+func (c ConnWithReconnect) ModifyWithResult(m *ldap.ModifyRequest) (*ldap.ModifyResult, error) {
+	conn, err := c.GetConnection()
+	if err != nil {
+		return nil, err
+	}
+
+	return conn.ModifyWithResult(m)
 }
 
 func (c ConnWithReconnect) Compare(dn, attribute, value string) (bool, error) {

--- a/graph/pkg/service/v0/instrument.go
+++ b/graph/pkg/service/v0/instrument.go
@@ -48,3 +48,8 @@ func (i instrument) PostUser(w http.ResponseWriter, r *http.Request) {
 func (i instrument) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	i.next.DeleteUser(w, r)
 }
+
+// PatchUser implements the Service interface.
+func (i instrument) PatchUser(w http.ResponseWriter, r *http.Request) {
+	i.next.PatchUser(w, r)
+}

--- a/graph/pkg/service/v0/instrument.go
+++ b/graph/pkg/service/v0/instrument.go
@@ -34,7 +34,17 @@ func (i instrument) GetUsers(w http.ResponseWriter, r *http.Request) {
 	i.next.GetUsers(w, r)
 }
 
-// GetUsers implements the Service interface.
+// GetUser implements the Service interface.
 func (i instrument) GetUser(w http.ResponseWriter, r *http.Request) {
 	i.next.GetUser(w, r)
+}
+
+// PostUser implements the Service interface.
+func (i instrument) PostUser(w http.ResponseWriter, r *http.Request) {
+	i.next.PostUser(w, r)
+}
+
+// DeleteUser implements the Service interface.
+func (i instrument) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	i.next.DeleteUser(w, r)
 }

--- a/graph/pkg/service/v0/logging.go
+++ b/graph/pkg/service/v0/logging.go
@@ -38,3 +38,13 @@ func (l logging) GetUsers(w http.ResponseWriter, r *http.Request) {
 func (l logging) GetUser(w http.ResponseWriter, r *http.Request) {
 	l.next.GetUser(w, r)
 }
+
+// PostUser implements the Service interface.
+func (l logging) PostUser(w http.ResponseWriter, r *http.Request) {
+	l.next.PostUser(w, r)
+}
+
+// DeleteUser implements the Service interface.
+func (l logging) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	l.next.DeleteUser(w, r)
+}

--- a/graph/pkg/service/v0/logging.go
+++ b/graph/pkg/service/v0/logging.go
@@ -48,3 +48,8 @@ func (l logging) PostUser(w http.ResponseWriter, r *http.Request) {
 func (l logging) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	l.next.DeleteUser(w, r)
 }
+
+// PatchUser implements the Service interface.
+func (l logging) PatchUser(w http.ResponseWriter, r *http.Request) {
+	l.next.PatchUser(w, r)
+}

--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -67,6 +67,7 @@ func NewService(opts ...Option) Service {
 			})
 			r.Route("/users", func(r chi.Router) {
 				r.Get("/", svc.GetUsers)
+				r.Post("/", svc.PostUser)
 				r.Route("/{userID}", func(r chi.Router) {
 					r.Get("/", svc.GetUser)
 				})

--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -70,6 +70,7 @@ func NewService(opts ...Option) Service {
 				r.Post("/", svc.PostUser)
 				r.Route("/{userID}", func(r chi.Router) {
 					r.Get("/", svc.GetUser)
+					r.Delete("/", svc.DeleteUser)
 				})
 			})
 			r.Route("/groups", func(r chi.Router) {

--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -20,6 +20,7 @@ type Service interface {
 	GetUser(http.ResponseWriter, *http.Request)
 	PostUser(http.ResponseWriter, *http.Request)
 	DeleteUser(http.ResponseWriter, *http.Request)
+	PatchUser(http.ResponseWriter, *http.Request)
 }
 
 // NewService returns a service implementation for Service.
@@ -73,6 +74,7 @@ func NewService(opts ...Option) Service {
 				r.Route("/{userID}", func(r chi.Router) {
 					r.Get("/", svc.GetUser)
 					r.Delete("/", svc.DeleteUser)
+					r.Patch("/", svc.PatchUser)
 				})
 			})
 			r.Route("/groups", func(r chi.Router) {

--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -18,6 +18,8 @@ type Service interface {
 	GetMe(http.ResponseWriter, *http.Request)
 	GetUsers(http.ResponseWriter, *http.Request)
 	GetUser(http.ResponseWriter, *http.Request)
+	PostUser(http.ResponseWriter, *http.Request)
+	DeleteUser(http.ResponseWriter, *http.Request)
 }
 
 // NewService returns a service implementation for Service.

--- a/graph/pkg/service/v0/tracing.go
+++ b/graph/pkg/service/v0/tracing.go
@@ -44,3 +44,8 @@ func (t tracing) PostUser(w http.ResponseWriter, r *http.Request) {
 func (t tracing) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	t.next.DeleteUser(w, r)
 }
+
+// PatchUser implements the Service interface.
+func (t tracing) PatchUser(w http.ResponseWriter, r *http.Request) {
+	t.next.PatchUser(w, r)
+}

--- a/graph/pkg/service/v0/tracing.go
+++ b/graph/pkg/service/v0/tracing.go
@@ -34,3 +34,13 @@ func (t tracing) GetUsers(w http.ResponseWriter, r *http.Request) {
 func (t tracing) GetUser(w http.ResponseWriter, r *http.Request) {
 	t.next.GetUser(w, r)
 }
+
+// PostUser implements the Service interface.
+func (t tracing) PostUser(w http.ResponseWriter, r *http.Request) {
+	t.next.PostUser(w, r)
+}
+
+// DeleteUser implements the Service interface.
+func (t tracing) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	t.next.DeleteUser(w, r)
+}

--- a/graph/pkg/service/v0/users.go
+++ b/graph/pkg/service/v0/users.go
@@ -97,6 +97,32 @@ func (g Graph) GetUser(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, user)
 }
 
+func (g Graph) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	userID := chi.URLParam(r, "userID")
+	userID, err := url.PathUnescape(userID)
+	if err != nil {
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping user id failed")
+	}
+
+	if userID == "" {
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing user id")
+		return
+	}
+
+	err = g.identityBackend.DeleteUser(r.Context(), userID)
+
+	if err != nil {
+		var errcode errorcode.Error
+		if errors.As(err, &errcode) {
+			errcode.Render(w, r)
+		} else {
+			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		}
+	}
+	render.Status(r, http.StatusNoContent)
+	render.NoContent(w, r)
+}
+
 func isNilOrEmpty(s *string) bool {
 	return s == nil || *s == ""
 }

--- a/graph/pkg/service/v0/users.go
+++ b/graph/pkg/service/v0/users.go
@@ -60,6 +60,14 @@ func (g Graph) PostUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Disallow user-supplied IDs. It's supposed to be readonly. We're either
+	// generating them in the backend ourselves or rely on the Backend's
+	// storage (e.g. LDAP) to provide a unique ID.
+	if !isNilOrEmpty(u.Id) {
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "user id is a read-only attribute")
+		return
+	}
+
 	if u, err = g.identityBackend.CreateUser(r.Context(), *u); err != nil {
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
## Description
Sending a POST request to /graph/v1.0/users with this body:
```
{
  "displayName": "Test User",
  "mail": "test@example.org",
  "onPremisesSamAccountName": "test",
  "passwordProfile": {
    "password": "secret"
  }
}
```

Will create the user `test`. The call will respond with the just created user (including the server generated ID:
```
{
    "displayName": "Test User",
    "id": "2b7f0f9c-0739-103c-926e-03e52584738a",
    "mail": "test@example.org",
    "onPremisesSamAccountName": "test"
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

//cc @refs 