### PR TITLE
[tests-only] temporarily disable parallel deployment tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -59,7 +59,7 @@ config = {
             "suites": [
                 "apiShareManagement",
             ],
-            "skip": False,
+            "skip": True,
             "earlyFail": True,
             "cron": "nightly",
         },
@@ -67,7 +67,7 @@ config = {
             "suites": [
                 "apiWebdavOperations",
             ],
-            "skip": False,
+            "skip": True,
             "earlyFail": True,
             "cron": "nightly",
         },
@@ -251,7 +251,7 @@ def testPipelines(ctx):
     if "skip" not in config["settingsUITests"] or not config["settingsUITests"]["skip"]:
         pipelines.append(settingsUITests(ctx))
 
-    if "parallelApiTests" in config:
+    if "skip" not in config["parallelApiTests"] or not config["parallelApiTests"]["skip"]:
         pipelines += parallelDeployAcceptancePipeline(ctx)
 
     return pipelines


### PR DESCRIPTION
## Description
Since REVA edge was introduced to oCIS yesterday, we can't use the owncloudSql storage driver for now, because it lacks an implementation.

Missing function:

https://github.com/cs3org/reva/blob/edge/pkg/storage/fs/owncloudsql/owncloudsql.go#L1953-L1956

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
