### PR TITLE
Make the project spaces capability configurable

### DIFF
--- a/changelog/unreleased/enhancement-spaces-capability.md
+++ b/changelog/unreleased/enhancement-spaces-capability.md
@@ -1,6 +1,7 @@
 Enhancement: Add spaces capability
 
-We've added the spaces capability with version 0.0.1 and enabled set to true.
+We've added the spaces capability with version 0.0.1 and enabled defaulting to true.
 
 https://github.com/owncloud/ocis/pull/2931
 https://github.com/cs3org/reva/pull/2015
+https://github.com/owncloud/ocis/pull/2965

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -294,7 +294,7 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 							},
 							"spaces": map[string]interface{}{
 								"version": "0.0.1",
-								"enabled": true,
+								"enabled": cfg.Reva.Frontend.ProjectSpaces,
 							},
 						},
 						"version": map[string]interface{}{

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -155,6 +155,7 @@ type FrontendPort struct {
 	ArchiverPrefix             string     `ocisConfig:"archiver_prefix"`
 	DatagatewayPrefix          string     `ocisConfig:"data_gateway_prefix"`
 	Favorites                  bool       `ocisConfig:"favorites"`
+	ProjectSpaces              bool       `ocisConfig:"project_spaces"`
 	OCDavInsecure              bool       `ocisConfig:"ocdav_insecure"`
 	OCDavPrefix                string     `ocisConfig:"ocdav_prefix"`
 	OCSPrefix                  string     `ocisConfig:"ocs_prefix"`
@@ -814,6 +815,10 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 		{
 			EnvVars:     []string{"STORAGE_FRONTEND_FAVORITES"},
 			Destination: &cfg.Reva.Frontend.Favorites,
+		},
+		{
+			EnvVars:     []string{"STORAGE_FRONTEND_PROJECT_SPACES"},
+			Destination: &cfg.Reva.Frontend.ProjectSpaces,
 		},
 		{
 			EnvVars:     []string{"STORAGE_FRONTEND_OCDAV_PREFIX"},

--- a/storage/pkg/config/defaultconfig.go
+++ b/storage/pkg/config/defaultconfig.go
@@ -239,6 +239,7 @@ func DefaultConfig() *Config {
 				ArchiverPrefix:             "archiver",
 				DatagatewayPrefix:          "data",
 				Favorites:                  false,
+				ProjectSpaces:              true,
 				OCDavInsecure:              false, // true?
 				OCDavPrefix:                "",
 				OCSPrefix:                  "ocs",


### PR DESCRIPTION
## Description
Some deployments don't want to show early stages of the spaces feature
set in the clients. It can now be disabled in the capabilities.

## Motivation and Context
Give admins the power to decide for their own if they want to announce the project spaces feature set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
