### PR TITLE
Change outdated documentation ("owncloud" driver is not the default)

### DIFF
--- a/docs/extensions/storage/storagedrivers.md
+++ b/docs/extensions/storage/storagedrivers.md
@@ -141,7 +141,7 @@ To provide the other storage aspects we plan to implement a FUSE overlay filesys
 The owncloud storage driver was used for testing purposes early on. For a parallel deployment focus has shifted to the owncloudsql.
 {{< /hint >}}
 
-This is the current default storage driver. While it implements the file tree (using redis, including id based lookup), ETag propagation, trash, versions and sharing (including expiry) using the data directory layout of ownCloud 10 it has [known limitations](https://github.com/owncloud/core/issues/28095) that cannot be fixed without changing the actual layout on disk.
+While this storage driver implements the file tree (using redis, including id based lookup), ETag propagation, trash, versions and sharing (including expiry) using the data directory layout of ownCloud 10 it has [known limitations](https://github.com/owncloud/core/issues/28095) that cannot be fixed without changing the actual layout on disk.
 
 To setup it up properly in a distributed fashion, the storage-home and the storage-oc need to share the same underlying FS. Their "data" counterparts also need access to the same shared FS.
 For a simple docker-compose setup, you can create a volume which will be used by the "storage-storage-home", "storage-storage-home-data", "storage-storage-oc" and "storage-storage-oc-data" containers. Using the `owncloud/ocis` docker image, the volume would need to be hooked in the `/var/lib/ocis` folder inside the containers.


### PR DESCRIPTION
Very simple docs fix stating **owncloud** is the default storage driver (incorrect) off the back of raising [this issue](https://github.com/owncloud/ocis/issues/2969) and seeing [this update](https://github.com/owncloud/ocis/commit/7803ad5fbdde0cbb8a8cf7dd89ef4066708398bf) earlier today.