### PR TITLE
graph: Fix LDAP retry handling

### DIFF
--- a/changelog/unreleased/fix-ldapretry.md
+++ b/changelog/unreleased/fix-ldapretry.md
@@ -1,0 +1,6 @@
+Bugfix: Fix retry handling for LDAP connections
+
+We've fixed the handling of network issues (e.g. connection loss) during LDAP Write Operations
+to correcty retry the request.
+
+https://github.com/owncloud/ocis/issues/2974


### PR DESCRIPTION
The reconnect package was missing the retry loop for LDAP Write
Operations (add, delete, mod, modrdn)

Fixes: #2974