### PR TITLE
Fix docker-compose ocis_keycloak example

### DIFF
--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
-      ACCOUNTS_DEMO_USERS_AND_GROUPS: false # don't generate demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "false" # don't generate demo users
       # change default secrets
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}


### PR DESCRIPTION
docker-compose doesn't like bare boolean values in the `environment`
section. From the compose-file docs:
Any boolean values (true, false, yes, no) need to be enclosed in quotes to
ensure they are not converted to True or False by the YML parser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
