### PR TITLE
fix fork handling for the unit test result upload

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -361,7 +361,7 @@ def uploadScanResults(ctx):
     if ctx.build.source_repo:
         fork_handling = [
             "git remote add fork https://github.com/%s.git" % (ctx.build.source_repo),
-            "git pull fork",
+            "git fetch fork",
         ]
 
     return {

--- a/.drone.star
+++ b/.drone.star
@@ -357,7 +357,12 @@ def uploadScanResults(ctx):
             "SONAR_PULL_REQUEST_KEY": "%s" % (ctx.build.ref.replace("refs/pull/", "").split("/")[0]),
         })
 
-    repo_slug = ctx.build.source_repo if ctx.build.source_repo else ctx.repo.slug
+    fork_handling = []
+    if ctx.build.source_repo:
+        fork_handling = [
+            "git remote add fork https://github.com/%s.git" % (ctx.build.source_repo),
+            "git pull fork",
+        ]
 
     return {
         "kind": "pipeline",
@@ -375,9 +380,13 @@ def uploadScanResults(ctx):
                 "name": "clone",
                 "image": "alpine/git:latest",
                 "commands": [
-                    "git clone https://github.com/%s.git ." % (repo_slug),
-                    "git checkout $DRONE_COMMIT",
-                ],
+                                # Always use the owncloud/ocis repository as base to have an up to date default branch.
+                                # This is needed for the skipIfUnchanged step, since it references a commit on master (which could be absent on a fork)
+                                "git clone https://github.com/%s.git ." % (ctx.repo.slug),
+                            ] + fork_handling +
+                            [
+                                "git checkout $DRONE_COMMIT",
+                            ],
             },
         ] + skipIfUnchanged(ctx, "unit-tests") + [
             {

--- a/.drone.star
+++ b/.drone.star
@@ -358,7 +358,7 @@ def uploadScanResults(ctx):
         })
 
     fork_handling = []
-    if ctx.build.source_repo:
+    if ctx.build.source_repo != "" and ctx.build.source_repo != ctx.repo.slug:
         fork_handling = [
             "git remote add fork https://github.com/%s.git" % (ctx.build.source_repo),
             "git fetch fork",


### PR DESCRIPTION

## Description
Unit test result upload needs a custom clone step without a merge to master of the PR branch. Threfore we cloned the source repo of the branch. But when a fork has an outdated default branch, we may not find the target commit ID of the PR. Therefore we now always clone owncloud/ocis and just add the fork (if it is a fork) as an additional remote, in order to get the PR commit.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Makes pipline of https://github.com/owncloud/ocis/pull/2989 green
