### PR TITLE
Remove obsolete loadConfig

### DIFF
--- a/accounts/ui/store/index.js
+++ b/accounts/ui/store/index.js
@@ -10,7 +10,6 @@ import { RoleService_ListRoles } from '../client/settings'
 import { injectAuthToken } from '../helpers/auth'
 
 const state = {
-  config: null,
   initialized: false,
   failed: false,
   accounts: {},
@@ -19,7 +18,6 @@ const state = {
 }
 
 const getters = {
-  config: state => state.config,
   isInitialized: state => state.initialized,
   hasFailed: state => state.failed,
   getAccountsSorted: state => {
@@ -36,9 +34,6 @@ const getters = {
 }
 
 const mutations = {
-  LOAD_CONFIG (state, config) {
-    state.config = config
-  },
   SET_INITIALIZED (state, value) {
     state.initialized = value
   },
@@ -81,10 +76,6 @@ const mutations = {
 }
 
 const actions = {
-  loadConfig ({ commit }, config) {
-    commit('LOAD_CONFIG', config)
-  },
-
   async initialize ({ commit, dispatch, getters }) {
     await Promise.all([
       dispatch('fetchAccounts'),

--- a/settings/ui/store/index.js
+++ b/settings/ui/store/index.js
@@ -8,13 +8,11 @@ import axios from 'axios'
 import keyBy from 'lodash-es/keyBy'
 
 const state = {
-  config: null,
   initialized: false,
   bundles: {}
 }
 
 const getters = {
-  config: state => state.config,
   initialized: state => state.initialized,
   extensions: state => {
     return [...new Set(Object.values(state.bundles).map(bundle => bundle.extension))].sort()
@@ -36,17 +34,9 @@ const mutations = {
   SET_BUNDLES (state, bundles) {
     state.bundles = keyBy(bundles, 'id')
   },
-  LOAD_CONFIG (state, config) {
-    state.config = config
-  }
 }
 
 const actions = {
-  // Used by ocis-web.
-  loadConfig ({ commit }, config) {
-    commit('LOAD_CONFIG', config)
-  },
-
   async initialize ({ commit, dispatch }) {
     await dispatch('fetchBundles')
     commit('SET_INITIALIZED', true)

--- a/settings/ui/store/index.js
+++ b/settings/ui/store/index.js
@@ -33,7 +33,7 @@ const mutations = {
   },
   SET_BUNDLES (state, bundles) {
     state.bundles = keyBy(bundles, 'id')
-  },
+  }
 }
 
 const actions = {


### PR DESCRIPTION
I did not test this, but grepping for `loadConfig`, `LOAD_CONFIG` or simply `config` I could not find any usage of the app config.

Config handling has been refactored in oC Web, so this code is basically dead.

See https://github.com/owncloud/web/issues/3726