### PR TITLE
Adjust UserGroupFilter default to match latest reva changes

### DIFF
--- a/storage/pkg/config/defaultconfig.go
+++ b/storage/pkg/config/defaultconfig.go
@@ -33,7 +33,7 @@ func DefaultConfig() *Config {
 				UserFilter:           "(&(objectclass=posixAccount)(|(ownclouduuid={{.OpaqueId}})(cn={{.OpaqueId}})))",
 				UserAttributeFilter:  "(&(objectclass=posixAccount)({{attr}}={{value}}))",
 				UserFindFilter:       "(&(objectclass=posixAccount)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))",
-				UserGroupFilter:      "(&(objectclass=posixGroup)(cn={{.}}*))", // FIXME (&(objectclass=posixGroup)(ownclouduuid={{.OpaqueId}}*)) in reva the template is executed with a string. IIRC rhaferkamp mentioned this
+				UserGroupFilter:      "(&(objectclass=posixGroup)(cn={{query}}*))",
 				GroupFilter:          "(&(objectclass=posixGroup)(|(ownclouduuid={{.OpaqueId}})(cn={{.OpaqueId}})))",
 				GroupAttributeFilter: "(&(objectclass=posixGroup)({{attr}}={{value}}))",
 				GroupFindFilter:      "(&(objectclass=posixGroup)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))",


### PR DESCRIPTION
## Description

With https://github.com/cs3org/reva/pull/2436 the groupfilter setting
for the user provider was adjusted to no longer use a go-template value
as the input. Adjust our default to match those changes. For details
see:
https://github.com/cs3org/reva/blob/edge/changelog/unreleased/ldap-usergroupfilter-template.md
