### PR TITLE
make default client respect the registry settings

### DIFF
--- a/changelog/unreleased/fix-default-client-registry-settings.md
+++ b/changelog/unreleased/fix-default-client-registry-settings.md
@@ -1,0 +1,6 @@
+Bugfix: Make the default grpc client use the registry settings
+
+We've fixed the default grpc client to use the registry settings. Previously it always
+used mdns.
+
+https://github.com/owncloud/ocis/pull/3041

--- a/ocis-pkg/service/grpc/service.go
+++ b/ocis-pkg/service/grpc/service.go
@@ -18,7 +18,11 @@ import (
 var DefaultClient = getDefaultGrpcClient()
 
 func getDefaultGrpcClient() client.Client {
+
+	reg := registry.GetRegistry()
+
 	return mgrpcc.NewClient(
+		client.Registry(reg),
 		client.Wrap(mbreaker.NewClientWrapper()),
 	)
 }


### PR DESCRIPTION

## Description
We've fixed the default grpc client to use the registry settings. Previously it always
used mdns.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
