### PR TITLE
[full-ci] remove the owncloud storage driver

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1413,7 +1413,6 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "STORAGE_HOME_DRIVER": "%s" % (storage),
             "STORAGE_USERS_DRIVER": "%s" % (storage),
             "STORAGE_USERS_DRIVER_LOCAL_ROOT": "/srv/app/tmp/ocis/local/root",
-            "STORAGE_USERS_DRIVER_OWNCLOUD_DATADIR": "/srv/app/tmp/ocis/owncloud/data",
             "STORAGE_USERS_DRIVER_OCIS_ROOT": "/srv/app/tmp/ocis/storage/users",
             "STORAGE_METADATA_DRIVER_OCIS_ROOT": "/srv/app/tmp/ocis/storage/metadata",
             "STORAGE_SHARING_USER_JSON_FILE": "/srv/app/tmp/ocis/shares.json",
@@ -1465,7 +1464,7 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "STORAGE_LDAP_USERATTRIBUTEFILTER": "(&(objectclass=posixAccount)(objectclass=owncloud)({{attr}}={{value}}))",
             "STORAGE_LDAP_USERFILTER": "(&(objectclass=posixAccount)(objectclass=owncloud)(|(ownclouduuid={{.OpaqueId}})(uid={{.OpaqueId}})))",
             "STORAGE_LDAP_USERFINDFILTER": "(&(objectclass=posixAccount)(objectclass=owncloud)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))",
-            # ownCloud storage driver
+            # ownCloudSQL storage driver
             "STORAGE_HOME_DRIVER": "owncloudsql",
             "STORAGE_USERS_DRIVER": "owncloudsql",
             "STORAGE_METADATA_DRIVER": "ocis",
@@ -1480,7 +1479,7 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBNAME": "owncloud",
             # TODO: redis is not yet supported
             "STORAGE_USERS_DRIVER_OWNCLOUDSQL_REDIS_ADDR": "redis:6379",
-            # ownCloud sharing driver
+            # ownCloudSQL sharing driver
             "STORAGE_SHARING_USER_DRIVER": "oc10-sql",
             "STORAGE_SHARING_USER_SQL_USERNAME": "owncloud",
             "STORAGE_SHARING_USER_SQL_PASSWORD": "owncloud",

--- a/changelog/unreleased/change-remove-owncloud-storage-driver.md
+++ b/changelog/unreleased/change-remove-owncloud-storage-driver.md
@@ -1,0 +1,10 @@
+Change: remove the ownCloud storage driver
+
+We've removed the ownCloud storage driver because it was no longer
+maintained after the ownCloud SQL storage driver was added.
+
+If you have been using the ownCloud storage driver, please switch
+to the ownCloud SQL storage driver which brings you more features and
+is under active maintenance.
+
+https://github.com/owncloud/ocis/pull/3072

--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       STORAGE_LDAP_USERATTRIBUTEFILTER: "(&(objectclass=posixAccount)(objectclass=owncloud)({{attr}}={{value}}))"
       STORAGE_LDAP_USERFILTER: "(&(objectclass=posixAccount)(objectclass=owncloud)(|(ownclouduuid={{.OpaqueId}})(uid={{.OpaqueId}})))"
       STORAGE_LDAP_USERFINDFILTER: "(&(objectclass=posixAccount)(objectclass=owncloud)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))"
-      # ownCloud storage driver
+      # ownCloudSQL storage driver
       STORAGE_USERS_DRIVER: owncloudsql
       STORAGE_METADATA_DRIVER: ocis # keep metadata on ocis storage since this are only small files atm
       STORAGE_USERS_DRIVER_OWNCLOUDSQL_DATADIR: /mnt/data/files
@@ -100,7 +100,7 @@ services:
       STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBPORT: 3306
       STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBNAME: owncloud
       STORAGE_USERS_DRIVER_OWNCLOUDSQL_REDIS_ADDR: redis:6379 # TODO: redis is not yet supported
-      # ownCloud sharing driver
+      # ownCloudSQL sharing driver
       STORAGE_SHARING_USER_DRIVER: oc10-sql
       STORAGE_SHARING_USER_SQL_USERNAME:  owncloud
       STORAGE_SHARING_USER_SQL_PASSWORD: owncloud

--- a/docs/ocis/deployment/oc10_ocis_parallel.md
+++ b/docs/ocis/deployment/oc10_ocis_parallel.md
@@ -20,7 +20,7 @@ geekdocFilePath: oc10_ocis_parallel.md
   - ownCloud 10 is configured to synchronize users from the LDAP server
   - ownCloud 10 is used to use OpenID Connect for authentication with Keycloak
 - oCIS running behind Traefik as reverse proxy
-  - oCIS is using the ownCloud storage driver on the same files and same database as ownCloud 10
+  - oCIS is using the ownCloudSQL storage driver on the same files and same database as ownCloud 10
   - oCIS is using Keycloak as OpenID Connect provider
   - oCIS is using the LDAP server as user backend
 - All requests to both oCIS and oC10 are routed through the oCIS proxy and will be routed based on an OIDC claim to one of them. Therefore admins can change on a user basis in the LDAP which backend is used.

--- a/storage/pkg/command/storagedrivers/user.go
+++ b/storage/pkg/command/storagedrivers/user.go
@@ -75,16 +75,6 @@ func UserDrivers(cfg *config.Config) map[string]interface{} {
 			"share_folder": cfg.Reva.UserStorage.Local.ShareFolder,
 			"user_layout":  cfg.Reva.UserStorage.Local.UserLayout,
 		},
-		"owncloud": map[string]interface{}{
-			"datadirectory":   cfg.Reva.UserStorage.OwnCloud.Root,
-			"upload_info_dir": cfg.Reva.UserStorage.OwnCloud.UploadInfoDir,
-			"share_folder":    cfg.Reva.UserStorage.OwnCloud.ShareFolder,
-			"user_layout":     cfg.Reva.UserStorage.OwnCloud.UserLayout,
-			"redis":           cfg.Reva.UserStorage.OwnCloud.Redis,
-			"enable_home":     false,
-			"scan":            cfg.Reva.UserStorage.OwnCloud.Scan,
-			"userprovidersvc": cfg.Reva.Users.Endpoint,
-		},
 		"owncloudsql": map[string]interface{}{
 			"datadirectory":   cfg.Reva.UserStorage.OwnCloudSQL.Root,
 			"upload_info_dir": cfg.Reva.UserStorage.OwnCloudSQL.UploadInfoDir,

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -218,7 +218,6 @@ type PublicStorage struct {
 type StorageConfig struct {
 	EOS         DriverEOS         `ocisConfig:"eos"`
 	Local       DriverCommon      `ocisConfig:"local"`
-	OwnCloud    DriverOwnCloud    `ocisConfig:"owncloud"`
 	OwnCloudSQL DriverOwnCloudSQL `ocisConfig:"owncloud_sql"`
 	S3          DriverS3          `ocisConfig:"s3"`
 	S3NG        DriverS3NG        `ocisConfig:"s3ng"`
@@ -304,15 +303,6 @@ type DriverOCIS struct {
 	DriverCommon
 
 	ServiceUserUUID string `ocisConfig:"service_user_uuid"`
-}
-
-// DriverOwnCloud defines the available ownCloud storage driver configuration.
-type DriverOwnCloud struct {
-	DriverCommon
-
-	UploadInfoDir string `ocisConfig:"upload_info_dir"`
-	Redis         string `ocisConfig:"redis"`
-	Scan          bool   `ocisConfig:"scan"`
 }
 
 // DriverOwnCloudSQL defines the available ownCloudSQL storage driver configuration.
@@ -583,10 +573,6 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 		{
 			EnvVars:     []string{"STORAGE_USERS_DRIVER"},
 			Destination: &cfg.Reva.StorageUsers.Driver,
-		},
-		{
-			EnvVars:     []string{"STORAGE_USERS_DRIVER_OWNCLOUD_DATADIR"},
-			Destination: &cfg.Reva.UserStorage.OwnCloud.Root,
 		},
 		{
 			EnvVars:     []string{"STORAGE_USERS_DRIVER_OCIS_ROOT"},
@@ -1535,29 +1521,6 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 			EnvVars:     []string{"STORAGE_USERS_DRIVER_OCIS_SERVICE_USER_UUID"},
 			Destination: &cfg.Reva.UserStorage.OCIS.ServiceUserUUID,
 		},
-
-		// driver owncloud
-		{
-			EnvVars:     []string{"STORAGE_USERS_DRIVER_OWNCLOUD_UPLOADINFO_DIR"},
-			Destination: &cfg.Reva.UserStorage.OwnCloud.UploadInfoDir,
-		},
-		{
-			EnvVars:     []string{"STORAGE_USERS_DRIVER_OWNCLOUD_SHARE_FOLDER"},
-			Destination: &cfg.Reva.UserStorage.OwnCloud.ShareFolder,
-		},
-		{
-			EnvVars:     []string{"STORAGE_USERS_DRIVER_OWNCLOUD_SCAN"},
-			Destination: &cfg.Reva.UserStorage.OwnCloud.Scan,
-		},
-		{
-			EnvVars:     []string{"STORAGE_USERS_DRIVER_OWNCLOUD_REDIS_ADDR"},
-			Destination: &cfg.Reva.UserStorage.OwnCloud.Redis,
-		},
-		{
-			EnvVars:     []string{"STORAGE_USERS_DRIVER_OWNCLOUD_LAYOUT"},
-			Destination: &cfg.Reva.UserStorage.OwnCloud.UserLayout,
-		},
-
 		// driver owncloud sql
 		{
 			EnvVars:     []string{"STORAGE_USERS_DRIVER_OWNCLOUDSQL_DATADIR"},

--- a/storage/pkg/config/defaultconfig.go
+++ b/storage/pkg/config/defaultconfig.go
@@ -112,17 +112,6 @@ func DefaultConfig() *Config {
 					UserLayout:  "{{.Username}}",
 					EnableHome:  false,
 				},
-				OwnCloud: DriverOwnCloud{
-					DriverCommon: DriverCommon{
-						Root:        path.Join(defaults.BaseDataPath(), "storage", "owncloud"),
-						ShareFolder: defaultShareFolder,
-						UserLayout:  defaultUserLayout,
-						EnableHome:  false,
-					},
-					UploadInfoDir: path.Join(defaults.BaseDataPath(), "storage", "uploadinfo"),
-					Redis:         ":6379",
-					Scan:          true,
-				},
 				OwnCloudSQL: DriverOwnCloudSQL{
 					DriverCommon: DriverCommon{
 						Root:        path.Join(defaults.BaseDataPath(), "storage", "owncloud"),
@@ -196,7 +185,6 @@ func DefaultConfig() *Config {
 				Local: DriverCommon{
 					Root: path.Join(defaults.BaseDataPath(), "storage", "local", "metadata"),
 				},
-				OwnCloud:    DriverOwnCloud{},
 				OwnCloudSQL: DriverOwnCloudSQL{},
 				S3: DriverS3{
 					DriverCommon: DriverCommon{},

--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -66,9 +66,6 @@ help:
 	@echo -e "${GREEN}Run full ownCloud test suites against oCIS with s3ng storage:${RESET}\n"
 	@echo -e "\tmake Core-API-Tests-s3ng-storage-${RED}X${RESET}\t\t${BLUE}run test suite number X, where ${RED}X = 1 .. 10${RESET}"
 	@echo
-	@echo -e "${GREEN}Run full ownCloud test suites against oCIS with ownCloud storage:${RESET}\n"
-	@echo -e "\tmake Core-API-Tests-owncloud-storage-${RED}X${RESET}\t\t${BLUE}run test suite number X, where ${RED}X = 1 .. 10${RESET}"
-	@echo
 	@echo -e "${GREEN}Run an oCIS feature test against oCIS with oCIS storage:${RESET}\n"
 	@echo -e "\tmake test-ocis-feature-ocis-storage ${YELLOW}BEHAT_FEATURE='...'${RESET}\t${BLUE}run single feature test${RESET}"
 	@echo
@@ -80,9 +77,6 @@ help:
 	@echo
 	@echo -e "\twhere ${YELLOW}BEHAT_FEATURE='...'${RESET} contains a relative path to the feature definition."
 	@echo -e "\texample: ${RED}tests/acceptance/features/apiAccountsHashDifficulty/addUser.feature${RESET}"
-	@echo
-	@echo -e "${GREEN}Run an oCIS feature test against oCIS with owncloud storage:${RESET}\n"
-	@echo -e "\tmake test-ocis-feature-owncloud-storage ${YELLOW}BEHAT_FEATURE='...'${RESET}\t${BLUE}run single feature test${RESET}"
 	@echo
 	@echo -e "\twhere ${YELLOW}BEHAT_FEATURE='...'${RESET} contains a relative path to the feature definition."
 	@echo -e "\texample: ${RED}tests/acceptance/features/apiAccountsHashDifficulty/addUser.feature${RESET}"
@@ -98,9 +92,6 @@ help:
 	@echo
 	@echo -e "\twhere ${YELLOW}BEHAT_FEATURE='...'${RESET} contains a relative path to the feature definition."
 	@echo -e "\texample: ${RED}tests/acceptance/features/apiAuth/cors.feature${RESET}"
-	@echo
-	@echo -e "${GREEN}Run an ownCloud feature test against oCIS with owncloud storage:${RESET}\n"
-	@echo -e "\tmake test-oc10-feature-owncloud-storage ${YELLOW}BEHAT_FEATURE='...'${RESET}\t${BLUE}run single feature test${RESET}"
 	@echo
 	@echo -e "\twhere ${YELLOW}BEHAT_FEATURE='...'${RESET} contains a relative path to the feature definition."
 	@echo -e "\texample: ${RED}tests/acceptance/features/apiAuth/cors.feature${RESET}"
@@ -130,13 +121,6 @@ test-ocis-feature-s3ng-storage: ## test a ocis feature with s3ng storage, usage:
 	START_CEPH=1 \
 	$(MAKE) --no-print-directory testSuite
 
-.PHONY: test-ocis-feature-owncloud-storage
-test-ocis-feature-owncloud-storage: ## test a ocis feature with oc10 storage, usage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAccountsHashDifficulty/addUser.feature:10'
-	@TEST_SOURCE=ocis \
-	STORAGE_DRIVER=owncloud \
-	BEHAT_FEATURE=$(BEHAT_FEATURE) \
-	$(MAKE) --no-print-directory testSuite
-
 .PHONY: test-oc10-feature-ocis-storage
 test-oc10-feature-ocis-storage: ## test a oC10 feature with oCIS storage, usage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAuth/cors.feature'
 	@TEST_SOURCE=oc10 \
@@ -152,13 +136,6 @@ test-oc10-feature-s3ng-storage: ## test a oC10 feature with s3ng storage, usage:
 	START_CEPH=1 \
 	$(MAKE) --no-print-directory testSuite
 
-.PHONY: test-oc10-feature-owncloud-storage
-test-oc10-feature-owncloud-storage: ## test a oC10 feature with oc10 storage, usage: make ... BEHAT_FEATURE='tests/acceptance/features/apiAuth/cors.feature'
-	@TEST_SOURCE=oc10 \
-	STORAGE_DRIVER=owncloud \
-	BEHAT_FEATURE=$(BEHAT_FEATURE) \
-	$(MAKE) --no-print-directory testSuite
-
 .PHONY: localApiTests-apiAccountsHashDifficulty-owncloud
 localApiTests-apiAccountsHashDifficulty-owncloud: ## run apiAccountsHashDifficulty test suite with owncloud storage
 	@TEST_SOURCE=ocis \
@@ -171,15 +148,6 @@ localApiTests-apiAccountsHashDifficulty-ocis: ## run apiAccountsHashDifficulty t
 	@TEST_SOURCE=ocis \
 	STORAGE_DRIVER=ocis \
 	BEHAT_SUITE=apiAccountsHashDifficulty \
-	$(MAKE) --no-print-directory testSuite
-
-targets = $(addprefix Core-API-Tests-owncloud-storage-,$(PARTS))
-.PHONY: $(targets)
-$(targets):
-	@$(eval RUN_PART=$(shell echo "$@" | tr -dc '0-9'))
-	@TEST_SOURCE=oc10 \
-	STORAGE_DRIVER=owncloud \
-	RUN_PART=$(RUN_PART) \
 	$(MAKE) --no-print-directory testSuite
 
 targets = $(addprefix Core-API-Tests-ocis-storage-,$(PARTS))

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -6,7 +6,6 @@ services:
       OCIS_URL: "https://ocis-server:9200"
       STORAGE_USERS_DRIVER: $STORAGE_DRIVER
       STORAGE_USERS_DRIVER_LOCAL_ROOT: /srv/app/tmp/ocis/local/root
-      STORAGE_USERS_DRIVER_OWNCLOUD_DATADIR: /srv/app/tmp/ocis/owncloud/data
       STORAGE_USERS_DRIVER_OCIS_ROOT: /srv/app/tmp/ocis/storage/users
       STORAGE_METADATA_DRIVER_OCIS_ROOT: /srv/app/tmp/ocis/storage/metadata
       STORAGE_SHARING_USER_JSON_FILE: /srv/app/tmp/ocis/shares.json


### PR DESCRIPTION
## Description
We've removed the ownCloud storage driver because it was no longer
maintained after the ownCloud SQL storage driver was added.

If you have been using the ownCloud storage driver, please switch
to the ownCloud SQL storage driver which brings you more features and
is under active maintenance.


## Related Issue
- Found in https://github.com/owncloud/ocis/issues/2969
- REVA part: https://github.com/cs3org/reva/pull/2495
