### PR TITLE
Delete group memberships when deleting a user

### DIFF
--- a/changelog/unreleased/fix-ldap-del-usermembership.md
+++ b/changelog/unreleased/fix-ldap-del-usermembership.md
@@ -1,0 +1,6 @@
+Bugfix: Remove group memberships when deleting a user
+
+The LDAP backend in the graph API now takes care of removing a user's group
+membership when deleting the user.
+
+https://github.com/owncloud/ocis/issues/3027


### PR DESCRIPTION
## Description

Upon deleting a User from the LDAP backend, we also need to cleanup
the user's group memberships as LDAP itself doesn't make any promises
about referential integrity.

## Related Issue
- Fixes #3027
