### PR TITLE
accounts now uses the same reva jwt secret as the metadata storage

### DIFF
--- a/accounts/pkg/config/config.go
+++ b/accounts/pkg/config/config.go
@@ -56,7 +56,6 @@ type Disk struct {
 // CS3 is the cs3 implementation of the storage.
 type CS3 struct {
 	ProviderAddr string `ocisConfig:"provider_addr" env:"ACCOUNTS_STORAGE_CS3_PROVIDER_ADDR"`
-	JWTSecret    string `ocisConfig:"jwt_secret" env:"ACCOUNTS_STORAGE_CS3_JWT_SECRET"`
 }
 
 // ServiceUser defines the user required for EOS.

--- a/accounts/pkg/config/defaultconfig.go
+++ b/accounts/pkg/config/defaultconfig.go
@@ -46,7 +46,6 @@ func DefaultConfig() *Config {
 			},
 			CS3: CS3{
 				ProviderAddr: "localhost:9215",
-				JWTSecret:    "Pive-Fumkiu4",
 			},
 		},
 		Index: Index{

--- a/accounts/pkg/service/v0/service.go
+++ b/accounts/pkg/service/v0/service.go
@@ -136,7 +136,7 @@ func configFromSvc(cfg *config.Config) (*idxcfg.Config, error) {
 			Backend: cfg.Repo.Backend,
 			CS3: idxcfg.CS3{
 				ProviderAddr: cfg.Repo.CS3.ProviderAddr,
-				JWTSecret:    cfg.Repo.CS3.JWTSecret,
+				JWTSecret:    cfg.TokenManager.JWTSecret,
 			},
 		}
 	default:

--- a/changelog/unreleased/fix-accounts-metadata-jwt-token.md
+++ b/changelog/unreleased/fix-accounts-metadata-jwt-token.md
@@ -1,0 +1,8 @@
+Bugfix: use same jwt secret for accounts as for metadata storage
+
+We've the metadata storage uses the same jwt secret as all other REVA services.
+Therefore the accounts service needs to use the same secret.
+
+Secrets are documented here: https://owncloud.dev/ocis/deployment/#change-default-secrets
+
+https://github.com/owncloud/ocis/pull/3081


### PR DESCRIPTION
## Description
Bugfix: use same jwt secret for accounts as for metadata storage

We've the metadata storage uses the same jwt secret as all other REVA services.
Therefore the accounts service needs to use the same secret.

Secrets are documented here: https://owncloud.dev/ocis/deployment/#change-default-secrets

## Motivation and Context
Start oCIS with following environment variables:
```
OCIS_JWT_SECRET: "random-756"
STORAGE_TRANSFER_SECRET: "random-987"
OCIS_MACHINE_AUTH_API_KEY: "random-123"
```
and the accounts service can't write / read from the metadata storage...