### PR TITLE
Use decorator pattern and allow more methods to be decorated

### DIFF
--- a/thumbnails/pkg/server/grpc/server.go
+++ b/thumbnails/pkg/server/grpc/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/version"
 	thumbnailssvc "github.com/owncloud/ocis/protogen/gen/ocis/services/thumbnails/v0"
 	svc "github.com/owncloud/ocis/thumbnails/pkg/service/v0"
+	"github.com/owncloud/ocis/thumbnails/pkg/service/v0/decorators"
 	"github.com/owncloud/ocis/thumbnails/pkg/thumbnail/imgsource"
 	"github.com/owncloud/ocis/thumbnails/pkg/thumbnail/storage"
 )
@@ -30,7 +31,7 @@ func NewService(opts ...Option) grpc.Service {
 		options.Logger.Error().Err(err).Msg("could not get gateway client")
 		return grpc.Service{}
 	}
-	var thumbnail thumbnailssvc.ThumbnailServiceHandler
+	var thumbnail decorators.DecoratedService
 	{
 		thumbnail = svc.NewService(
 			svc.Config(options.Config),
@@ -45,9 +46,9 @@ func NewService(opts ...Option) grpc.Service {
 			svc.CS3Source(imgsource.NewCS3Source(tconf, gc)),
 			svc.CS3Client(gc),
 		)
-		thumbnail = svc.NewInstrument(thumbnail, options.Metrics)
-		thumbnail = svc.NewLogging(thumbnail, options.Logger)
-		thumbnail = svc.NewTracing(thumbnail)
+		thumbnail = decorators.NewInstrument(thumbnail, options.Metrics)
+		thumbnail = decorators.NewLogging(thumbnail, options.Logger)
+		thumbnail = decorators.NewTracing(thumbnail)
 	}
 
 	_ = thumbnailssvc.RegisterThumbnailServiceHandler(

--- a/thumbnails/pkg/service/v0/decorators/base.go
+++ b/thumbnails/pkg/service/v0/decorators/base.go
@@ -1,0 +1,59 @@
+package decorators
+
+import (
+	"context"
+
+	thumbnailssvc "github.com/owncloud/ocis/protogen/gen/ocis/services/thumbnails/v0"
+)
+
+// Interface acting as facade, holding all the interfaces that this
+// thumbnails microservice is expecting to implement.
+// For now, only the thumbnailssvc.ThumbnailServiceHandler is present,
+// but a future configsvc.ConfigServiceHandler is expected to be added here
+//
+// This interface will also act as the base interface to implement
+// a decorator pattern.
+type DecoratedService interface {
+	thumbnailssvc.ThumbnailServiceHandler
+}
+
+// Base type to implement the decorators. It will provide a basic implementation
+// by delegating to the decoratedService
+//
+// Expected implementations will be like:
+// ```
+// type MyDecorator struct {
+//   Decorator
+//   myCustomOpts *opts
+//   additionalSrv *srv
+// }
+//
+// func NewMyDecorator(next DecoratedService, customOpts *customOpts) DecoratedService {
+//   .....
+//   return MyDecorator{
+//     Decorator: Decorator{next: next},
+//     myCustomOpts: opts,
+//     additionalSrv: srv,
+//   }
+// }
+// ```
+type Decorator struct {
+	next DecoratedService
+}
+
+// Base implementation for the GetThumbnail (for the thumbnailssvc).
+// It will just delegate to the underlying decoratedService
+//
+// Your custom decorator is expected to overwrite this function,
+// but it MUST call the underlying decoratedService at some point
+// ```
+// func (d MyDecorator) GetThumbnail(ctx context.Context, req *thumbnailssvc.GetThumbnailRequest, resp *thumbnailssvc.GetThumbnailResponse) error {
+//   doSomething()
+//   err := d.next.GetThumbnail(ctx, req, resp)
+//   doAnotherThing()
+//   return err
+// }
+// ```
+func (deco Decorator) GetThumbnail(ctx context.Context, req *thumbnailssvc.GetThumbnailRequest, resp *thumbnailssvc.GetThumbnailResponse) error {
+	return deco.next.GetThumbnail(ctx, req, resp)
+}

--- a/thumbnails/pkg/service/v0/decorators/instrument.go
+++ b/thumbnails/pkg/service/v0/decorators/instrument.go
@@ -1,4 +1,4 @@
-package svc
+package decorators
 
 import (
 	"context"
@@ -9,15 +9,15 @@ import (
 )
 
 // NewInstrument returns a service that instruments metrics.
-func NewInstrument(next thumbnailssvc.ThumbnailServiceHandler, metrics *metrics.Metrics) thumbnailssvc.ThumbnailServiceHandler {
+func NewInstrument(next DecoratedService, metrics *metrics.Metrics) DecoratedService {
 	return instrument{
-		next:    next,
-		metrics: metrics,
+		Decorator: Decorator{next: next},
+		metrics:   metrics,
 	}
 }
 
 type instrument struct {
-	next    thumbnailssvc.ThumbnailServiceHandler
+	Decorator
 	metrics *metrics.Metrics
 }
 

--- a/thumbnails/pkg/service/v0/decorators/logging.go
+++ b/thumbnails/pkg/service/v0/decorators/logging.go
@@ -1,4 +1,4 @@
-package svc
+package decorators
 
 import (
 	"context"
@@ -9,15 +9,15 @@ import (
 )
 
 // NewLogging returns a service that logs messages.
-func NewLogging(next thumbnailssvc.ThumbnailServiceHandler, logger log.Logger) thumbnailssvc.ThumbnailServiceHandler {
+func NewLogging(next DecoratedService, logger log.Logger) DecoratedService {
 	return logging{
-		next:   next,
-		logger: logger,
+		Decorator: Decorator{next: next},
+		logger:    logger,
 	}
 }
 
 type logging struct {
-	next   thumbnailssvc.ThumbnailServiceHandler
+	Decorator
 	logger log.Logger
 }
 

--- a/thumbnails/pkg/service/v0/decorators/tracing.go
+++ b/thumbnails/pkg/service/v0/decorators/tracing.go
@@ -1,4 +1,4 @@
-package svc
+package decorators
 
 import (
 	"context"
@@ -11,14 +11,14 @@ import (
 )
 
 // NewTracing returns a service that instruments traces.
-func NewTracing(next thumbnailssvc.ThumbnailServiceHandler) thumbnailssvc.ThumbnailServiceHandler {
+func NewTracing(next DecoratedService) DecoratedService {
 	return tracing{
-		next: next,
+		Decorator: Decorator{next: next},
 	}
 }
 
 type tracing struct {
-	next thumbnailssvc.ThumbnailServiceHandler
+	Decorator
 }
 
 // GetThumbnail implements the ThumbnailServiceHandler interface.

--- a/thumbnails/pkg/service/v0/service.go
+++ b/thumbnails/pkg/service/v0/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/owncloud/ocis/ocis-pkg/log"
 	thumbnailssvc "github.com/owncloud/ocis/protogen/gen/ocis/services/thumbnails/v0"
 	"github.com/owncloud/ocis/thumbnails/pkg/preprocessor"
+	"github.com/owncloud/ocis/thumbnails/pkg/service/v0/decorators"
 	"github.com/owncloud/ocis/thumbnails/pkg/thumbnail"
 	"github.com/owncloud/ocis/thumbnails/pkg/thumbnail/imgsource"
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ import (
 )
 
 // NewService returns a service implementation for Service.
-func NewService(opts ...Option) thumbnailssvc.ThumbnailServiceHandler {
+func NewService(opts ...Option) decorators.DecoratedService {
 	options := newOptions(opts...)
 	logger := options.Logger
 	resolutions, err := thumbnail.ParseResolutions(options.Config.Thumbnail.Resolutions)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Implement a decorator pattern, allowing extension of the target interface. This means additional methods can be added in the interface in the future.

Thumbnail's instrument, logging and tracing files have been moved to the decorators package.

## Related Issue
No issue opened

## Motivation and Context
There are plans to for the thumbnails to implement a config service. With these changes, adding the implementation will be easier

## How Has This Been Tested?
Manually checked by uploading a file. No changes in the thumbnail service were detected

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
