### PR TITLE
Change the links to use "_" instead of "."

### DIFF
--- a/protogen/docs/GRPC.tmpl
+++ b/protogen/docs/GRPC.tmpl
@@ -1,7 +1,7 @@
 ---
 {{- $package := (index .Files 0).Package }}
 title: "{{ $package }}"
-url: /grpc_apis/{{ $package }}
+url: /grpc_apis/{{ $package | replace "." "_" }}
 date: {{ now | date "2006-01-02T15:04:05Z07:00" }}
 weight: 50
 geekdocRepo: https://github.com/owncloud/ocis
@@ -27,7 +27,7 @@ geekdocRepo: https://github.com/owncloud/ocis
 {{- $loca := printf "#%s" (.LongType | lower | replace "." "") -}}
 {{- if and (hasPrefix "ocis." .LongType) (ge (len $filenameParts) 3) -}}
 	{{- $ltypeSpl := .LongType | splitList "." -}}
-	{{- $ltypePkg := slice $ltypeSpl 0 (sub (len $ltypeSpl) 1) | join "." -}}
+	{{- $ltypePkg := slice $ltypeSpl 0 (sub (len $ltypeSpl) 1) | join "_" -}}
 	{{- $loca = printf "/grpc_apis/%s/#%s" $ltypePkg (.Type | lower) -}}
 {{- end -}}
 | {{.Name}} | [{{.LongType}}]({{ $loca }}) | {{.Label}} | {{ .Description | replace "\n" "<br>" }}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end }} |
@@ -74,12 +74,12 @@ geekdocRepo: https://github.com/owncloud/ocis
 {{- $respLoca := printf "#%s" (.ResponseLongType | lower | replace "." "") -}}
 {{- if and (hasPrefix ".ocis." .RequestLongType) (ge (len $filenameParts) 3) }}
 	{{- $ltypeSpl := .RequestLongType | substr 1 -1 | splitList "." -}}
-	{{- $ltypePkg := slice $ltypeSpl 0 (sub (len $ltypeSpl) 1) | join "." -}}
+	{{- $ltypePkg := slice $ltypeSpl 0 (sub (len $ltypeSpl) 1) | join "_" -}}
 	{{- $reqLoca = printf "/grpc_apis/%s/#%s" $ltypePkg (.RequestType | lower) -}}
 {{- end -}}
 {{- if and (hasPrefix ".ocis." .ResponseLongType) (ge (len $filenameParts) 3) }}
 	{{- $ltypeSpl := .ResponseLongType | substr 1 -1 | splitList "." -}}
-	{{- $ltypePkg := slice $ltypeSpl 0 (sub (len $ltypeSpl) 1) | join "." -}}
+	{{- $ltypePkg := slice $ltypeSpl 0 (sub (len $ltypeSpl) 1) | join "_" -}}
 	{{- $respLoca = printf "/grpc_apis/%s/#%s" $ltypePkg (.ResponseType | lower) -}}
 {{- end -}}
 | {{.Name}} | [{{.RequestLongType}}]({{ $reqLoca }}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}]({{ $respLoca }}){{if .ResponseStreaming}} stream{{end}} | {{ .Description | replace "\n" "<br>" }} |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
It seems that owncloud.dev have some trouble with some of the links in the documentation containing `.`. This PR will replace those `.` with `_`

## Related Issue
No opened issue

## Motivation and Context
Clicking in the faulty links downloads a file instead of showing the contents. This is a bad behavior that needs to be fixed.

## How Has This Been Tested?
It's working with hugo. Checked by cloning the repo, run `make docs-serve` and finally access the link.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
