### PR TITLE
[tests-only][full-ci]Add expected failure for spaces tests on  apiWebDavEtagpropagation2 suite

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=87a93ca67de6e6807b7561ee48897a0dd61b88d2
+CORE_COMMITID=1303a296e5f2c843345babd05c8413e01d764959
 CORE_BRANCH=master
 
 # The test runner source for UI tests

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -1218,6 +1218,14 @@ And other missing implementation of favorites
 - [apiWebdavEtagPropagation1/deleteFileFolder.feature:151](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature#L151)
 - [apiWebdavEtagPropagation1/deleteFileFolder.feature:188](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature#L188)
 - [apiWebdavEtagPropagation1/deleteFileFolder.feature:225](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature#L225)
+- [apiWebdavEtagPropagation2/copyFileFolder.feature:188](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature#L188)
+- [apiWebdavEtagPropagation2/copyFileFolder.feature:231](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature#L231)
+- [apiWebdavEtagPropagation2/createFolder.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature#L82)
+- [apiWebdavEtagPropagation2/createFolder.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature#L112)
+- [apiWebdavEtagPropagation2/upload.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature#L82)
+- [apiWebdavEtagPropagation2/upload.feature:111](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature#L111)
+- [apiWebdavEtagPropagation2/upload.feature:141](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature#L141)
+- [apiWebdavEtagPropagation2/upload.feature:171](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature#L171)
 
 #### [WWW-Authenticate header for unauthenticated requests is not clear](https://github.com/owncloud/ocis/issues/2285)
 Scenario Outline: Unauthenticated call


### PR DESCRIPTION
## Description
This PR adds spaces tests to the expected failures files after the tests related to the spaces added in apiWebDavEtagpropagation2 suites.

## Related Issue
- https://github.com/owncloud/ocis/issues/3075
- https://github.com/owncloud/core/pull/39744
- https://github.com/owncloud/QA/issues/715

## How Has This Been Tested?
- CI
- Locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)
