### PR TITLE
[tests-only] Fix sharing tests in parallel deployment tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1954,13 +1954,10 @@ def pipelineSanityChecks(ctx, pipelines):
 """
 
 #images
-OC_OCIS = "owncloud/ocis:latest"
 OC_OC10 = "owncloud/server:10"
 OC_UBUNTU = "owncloud/ubuntu:18.04"
 MARIADB = "mariadb:10.6"
 OSIXIA_OPENLDAP = "osixia/openldap:latest"
-QUAY_IO_KEYCLOAK = "quay.io/keycloak/keycloak:latest"
-POSTGRES = "postgres:alpine"
 
 # configs
 OCIS_URL = "https://ocis-server:9200"

--- a/tests/parallelDeployAcceptance/expected-failures-API.md
+++ b/tests/parallelDeployAcceptance/expected-failures-API.md
@@ -1,5 +1,1 @@
 ## Scenarios that are expected to fail in parallel deployment
-
-#### [[WIP] Add a SharesStorageProvider and an oc10 sql share manager](https://github.com/owncloud/ocis/pull/2232)
-
-- [apiShareManagement/acceptShares.feature:22](https://github.com/owncloud/ocis/blob/master/tests/parallelDeployAcceptance/features/apiShareManagement/acceptShares.feature#L22)

--- a/tests/parallelDeployAcceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/parallelDeployAcceptance/features/apiShareManagement/acceptShares.feature
@@ -1,6 +1,3 @@
-# Sharing tests currently doesn't work
-# Accessing oc10 shares from ocis still WIP in PR #2232
-# https://github.com/owncloud/ocis/pull/2232
 @api
 Feature: sharing files and folders
   As a user
@@ -22,7 +19,7 @@ Feature: sharing files and folders
   Scenario: accept a pending share
     Given user "Alice" has shared folder "/textfile.txt" with user "Brian"
     And using "ocis" as owncloud selector
-    When user "Brian" accepts share "/textfile.txt" offered by user "Alice" using the sharing API
+    When user "Brian" accepts share "/Shares/textfile.txt" offered by user "Alice" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the sharing API should report to user "Brian" that these shares are in the accepted state


### PR DESCRIPTION
## Description
This PR fixes the sharing tests that were not working in parallel deployment pipelines

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/3069

## How Has This Been Tested?
- test environment: local & CI

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
