### PR TITLE
Fixes for /ocs/cloud/users when using the CS3 user backend

### DIFF
--- a/ocis-pkg/roles/manager.go
+++ b/ocis-pkg/roles/manager.go
@@ -67,3 +67,21 @@ func (m *Manager) FindPermissionByID(ctx context.Context, roleIDs []string, perm
 	}
 	return nil
 }
+
+// FindRoleIdsForUser returns all roles that are assigned to the supplied userid
+func (m *Manager) FindRoleIDsForUser(ctx context.Context, userID string) ([]string, error) {
+	req := &settingssvc.ListRoleAssignmentsRequest{AccountUuid: userID}
+	assignmentResponse, err := m.roleService.ListRoleAssignments(ctx, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	roleIDs := make([]string, 0, len(assignmentResponse.Assignments))
+
+	for _, assignment := range assignmentResponse.Assignments {
+		roleIDs = append(roleIDs, assignment.RoleId)
+	}
+
+	return roleIDs, nil
+}

--- a/ocs/pkg/service/v0/groups.go
+++ b/ocs/pkg/service/v0/groups.go
@@ -30,6 +30,11 @@ func (o Ocs) ListUserGroups(w http.ResponseWriter, r *http.Request) {
 	}
 	var account *accountsmsg.Account
 
+	if o.config.AccountBackend == "cs3" {
+		o.mustRender(w, r, response.DataRender(&data.Groups{}))
+		return
+	}
+
 	// short circuit if there is a user already in the context
 	if u, ok := revactx.ContextGetUser(r.Context()); ok {
 		// we are not sure whether the current user in the context is the admin or the authenticated user.


### PR DESCRIPTION
## Description
This PR includes two workaround to get the CS3 backend for the ocs API to a somewhat working state. With this we'd no longer need to switch to the reva implemenation of ocs, e.g. when using an external LDAP server.

## Related Issue
- Partial Fix for #2646

## Motivation and Context
When using an external LDAP server we currently have to adjust the proxy configuration to point to the reva implemation of the ocs API. With this fix this should no longer be needed. I aware that these are mainly workarounds, but as we (at least to my understanding) agreed on removing the /ocs/cloud/users and ./groups services in the (not so long) run, I think they should be good enough. (btw, the /users/userid/groups implementation in reva also just returns an empty list, so we're not loosing anything here)

## How Has This Been Tested?
manually using the WebUI / curl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
