### PR TITLE
use micro registry in reva

### DIFF
--- a/ocis-pkg/registry/reva.go
+++ b/ocis-pkg/registry/reva.go
@@ -1,7 +1,12 @@
 package registry
 
 import (
+	"time"
+
 	revareg "github.com/cs3org/reva/pkg/registry"
+	"github.com/owncloud/ocis/ocis-pkg/version"
+	"go-micro.dev/v4/broker"
+	"go-micro.dev/v4/registry"
 	microreg "go-micro.dev/v4/registry"
 )
 
@@ -19,6 +24,11 @@ func (r RevaRegistry) Add(s revareg.Service) error {
 	nodes := []*microreg.Node{}
 
 	for _, n := range s.Nodes() {
+		meta := n.Metadata()
+
+		meta["broker"] = broker.String()
+		meta["registry"] = microreg.String()
+
 		node := microreg.Node{
 			Address:  n.Address(),
 			Id:       n.ID(),
@@ -28,11 +38,13 @@ func (r RevaRegistry) Add(s revareg.Service) error {
 	}
 
 	svc := &microreg.Service{
-		Name:  s.Name(),
-		Nodes: nodes,
+		Name:    s.Name(),
+		Version: version.String,
+		Nodes:   nodes,
 	}
+	rOpts := []registry.RegisterOption{registry.RegisterTTL(time.Minute)}
 
-	return r.r.Register(svc)
+	return r.r.Register(svc, rOpts...)
 }
 
 func (r RevaRegistry) GetService(serviceName string) (revareg.Service, error) {

--- a/ocis-pkg/registry/reva.go
+++ b/ocis-pkg/registry/reva.go
@@ -1,0 +1,100 @@
+package registry
+
+import (
+	revareg "github.com/cs3org/reva/pkg/registry"
+	microreg "go-micro.dev/v4/registry"
+)
+
+func GetRevaRegistry() RevaRegistry {
+	return RevaRegistry{
+		r: GetRegistry(),
+	}
+}
+
+type RevaRegistry struct {
+	r microreg.Registry
+}
+
+func (r RevaRegistry) Add(s revareg.Service) error {
+	nodes := []*microreg.Node{}
+
+	for _, n := range s.Nodes() {
+		node := microreg.Node{
+			Address:  n.Address(),
+			Id:       n.ID(),
+			Metadata: n.Metadata(),
+		}
+		nodes = append(nodes, &node)
+	}
+
+	svc := &microreg.Service{
+		Name:  s.Name(),
+		Nodes: nodes,
+	}
+
+	return r.r.Register(svc)
+}
+
+func (r RevaRegistry) GetService(serviceName string) (revareg.Service, error) {
+
+	services, err := r.r.GetService(serviceName)
+	if err != nil {
+		return Service{}, err
+	}
+
+	nodes := []Node{}
+
+	for _, svc := range services {
+		for _, nd := range svc.Nodes {
+			n := Node{
+				address:  nd.Address,
+				id:       nd.Id,
+				metadata: nd.Metadata,
+			}
+			nodes = append(nodes, n)
+		}
+	}
+
+	svc := Service{
+		name:  serviceName,
+		nodes: nodes,
+	}
+
+	return svc, nil
+
+}
+
+type Service struct {
+	name  string
+	nodes []Node
+}
+
+func (s Service) Name() string {
+	return s.name
+}
+
+func (s Service) Nodes() []revareg.Node {
+	nodes := []revareg.Node{}
+	for _, n := range s.nodes {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+type Node struct {
+	address  string
+	metadata map[string]string
+	id       string
+}
+
+func (n Node) Address() string {
+	return n.address
+}
+
+func (n Node) Metadata() map[string]string {
+	return n.metadata
+}
+
+func (n Node) ID() string {
+	return n.id
+}

--- a/storage/pkg/command/appprovider.go
+++ b/storage/pkg/command/appprovider.go
@@ -47,6 +47,7 @@ func AppProvider(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/appprovider.go
+++ b/storage/pkg/command/appprovider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
@@ -33,13 +34,27 @@ func AppProvider(cfg *config.Config) *cli.Command {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
+			serviceName := "appprovider"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 
 			rcfg := appProviderConfigFromStruct(c, cfg)
 
 			gr.Add(func() error {
-				runtime.RunWithOptions(rcfg, pidFile, runtime.WithLogger(&logger.Logger))
+				reg := oreg.GetRevaRegistry()
+
+				runtime.RunWithOptions(
+					rcfg,
+					pidFile,
+					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
+				)
 				return nil
 			}, func(_ error) {
 				logger.Info().

--- a/storage/pkg/command/authbasic.go
+++ b/storage/pkg/command/authbasic.go
@@ -58,6 +58,7 @@ func AuthBasic(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/authbearer.go
+++ b/storage/pkg/command/authbearer.go
@@ -46,6 +46,7 @@ func AuthBearer(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/authbearer.go
+++ b/storage/pkg/command/authbearer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
@@ -33,15 +34,25 @@ func AuthBearer(cfg *config.Config) *cli.Command {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
+			serviceName := "auth-bearer"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 			rcfg := authBearerConfigFromStruct(c, cfg)
 
 			gr.Add(func() error {
+				reg := oreg.GetRevaRegistry()
+
 				runtime.RunWithOptions(
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
 				)
 				return nil
 			}, func(_ error) {

--- a/storage/pkg/command/authmachine.go
+++ b/storage/pkg/command/authmachine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
@@ -33,15 +34,25 @@ func AuthMachine(cfg *config.Config) *cli.Command {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
+			serviceName := "auth-machine"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 			rcfg := authMachineConfigFromStruct(c, cfg)
 
 			gr.Add(func() error {
+				reg := oreg.GetRevaRegistry()
+
 				runtime.RunWithOptions(
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
 				)
 				return nil
 			}, func(_ error) {

--- a/storage/pkg/command/authmachine.go
+++ b/storage/pkg/command/authmachine.go
@@ -46,6 +46,7 @@ func AuthMachine(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -107,6 +107,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 					revaCfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/conversions"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
@@ -44,8 +45,9 @@ func Frontend(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
+			serviceName := "frontend"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 
 			// pregenerate list of valid localhost ports for the desktop redirect_uri
 			// TODO use custom scheme like "owncloud://localhost/user/callback" tracked in
@@ -99,7 +101,20 @@ func Frontend(cfg *config.Config) *cli.Command {
 			revaCfg := frontendConfigFromStruct(c, cfg, filesCfg)
 
 			gr.Add(func() error {
-				runtime.RunWithOptions(revaCfg, pidFile, runtime.WithLogger(&logger.Logger))
+				reg := oreg.GetRevaRegistry()
+
+				runtime.RunWithOptions(
+					revaCfg,
+					pidFile,
+					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
+				)
 				return nil
 			}, func(_ error) {
 				logger.Info().Str("server", c.Command.Name).Msg("Shutting down server")

--- a/storage/pkg/command/gateway.go
+++ b/storage/pkg/command/gateway.go
@@ -76,6 +76,12 @@ func Gateway(cfg *config.Config) *cli.Command {
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
 					runtime.WithRegistry(reg),
+					runtime.WithServiceName("gateway"),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
 				)
 				return nil
 			}, func(_ error) {

--- a/storage/pkg/command/gateway.go
+++ b/storage/pkg/command/gateway.go
@@ -15,12 +15,11 @@ import (
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/shared"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
-	"github.com/owncloud/ocis/ocis-pkg/version"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
-	"github.com/owncloud/ocis/storage/pkg/service/external"
 	"github.com/owncloud/ocis/storage/pkg/tracing"
 	"github.com/thejerf/suture/v4"
 	"github.com/urfave/cli/v2"
@@ -58,23 +57,25 @@ func Gateway(cfg *config.Config) *cli.Command {
 			defer cancel()
 
 			gr.Add(func() error {
-				err := external.RegisterGRPCEndpoint(
-					ctx,
-					"com.owncloud.storage",
-					uuid.String(),
-					cfg.Reva.Gateway.GRPCAddr,
-					version.String,
-					logger,
-				)
+				//err := external.RegisterGRPCEndpoint(
+				//	ctx,
+				//	"com.owncloud.storage",
+				//	uuid.String(),
+				//	cfg.Reva.Gateway.GRPCAddr,
+				//	version.String,
+				//	logger,
+				//)
 
-				if err != nil {
-					return err
-				}
+				//if err != nil {
+				//	return err
+				//}
+				reg := oreg.GetRevaRegistry()
 
 				runtime.RunWithOptions(
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
 				)
 				return nil
 			}, func(_ error) {

--- a/storage/pkg/command/gateway.go
+++ b/storage/pkg/command/gateway.go
@@ -46,29 +46,18 @@ func Gateway(cfg *config.Config) *cli.Command {
 			tracing.Configure(cfg, logger)
 			gr := run.Group{}
 			ctx, cancel := context.WithCancel(context.Background())
+			serviceName := "gateway"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 			rcfg := gatewayConfigFromStruct(c, cfg, logger)
 			logger.Debug().
-				Str("server", "gateway").
+				Str("server", serviceName).
 				Interface("reva-config", rcfg).
 				Msg("config")
 
 			defer cancel()
 
 			gr.Add(func() error {
-				//err := external.RegisterGRPCEndpoint(
-				//	ctx,
-				//	"com.owncloud.storage",
-				//	uuid.String(),
-				//	cfg.Reva.Gateway.GRPCAddr,
-				//	version.String,
-				//	logger,
-				//)
-
-				//if err != nil {
-				//	return err
-				//}
 				reg := oreg.GetRevaRegistry()
 
 				runtime.RunWithOptions(
@@ -76,7 +65,7 @@ func Gateway(cfg *config.Config) *cli.Command {
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
 					runtime.WithRegistry(reg),
-					runtime.WithServiceName("gateway"),
+					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),
 					runtime.WithNameSpaceConfig(map[string]string{
 						"grpc": "com.owncloud.api",

--- a/storage/pkg/command/gateway.go
+++ b/storage/pkg/command/gateway.go
@@ -64,6 +64,7 @@ func Gateway(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/groups.go
+++ b/storage/pkg/command/groups.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
@@ -40,17 +41,27 @@ func Groups(cfg *config.Config) *cli.Command {
 				}
 			}
 
+			serviceName := "groups"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 			defer cancel()
 
 			rcfg := groupsConfigFromStruct(c, cfg)
 
 			gr.Add(func() error {
+				reg := oreg.GetRevaRegistry()
+
 				runtime.RunWithOptions(
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
 				)
 				return nil
 			}, func(_ error) {

--- a/storage/pkg/command/groups.go
+++ b/storage/pkg/command/groups.go
@@ -55,6 +55,7 @@ func Groups(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/sharing.go
+++ b/storage/pkg/command/sharing.go
@@ -65,6 +65,7 @@ func Sharing(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/storagemetadata.go
+++ b/storage/pkg/command/storagemetadata.go
@@ -58,11 +58,13 @@ func StorageMetadata(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),
 					runtime.WithNameSpaceConfig(map[string]string{
-						//"grpc": "com.owncloud.api",
+						//TODO: which namespace to use??
+						// "grpc": "com.owncloud.api",
 						"grpc": "com.owncloud.storage",
 						"http": "com.owncloud.web",
 					}),

--- a/storage/pkg/command/storagepubliclink.go
+++ b/storage/pkg/command/storagepubliclink.go
@@ -47,6 +47,7 @@ func StoragePublicLink(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/storagepubliclink.go
+++ b/storage/pkg/command/storagepubliclink.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
@@ -34,14 +35,25 @@ func StoragePublicLink(cfg *config.Config) *cli.Command {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.Must(uuid.NewV4()).String()+".pid")
+			serviceName := "storage-public-link"
+			uuid := uuid.Must(uuid.NewV4())
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 			rcfg := storagePublicLinkConfigFromStruct(c, cfg)
 
 			gr.Add(func() error {
+				reg := oreg.GetRevaRegistry()
+
 				runtime.RunWithOptions(
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
 				)
 				return nil
 			}, func(_ error) {

--- a/storage/pkg/command/storageshares.go
+++ b/storage/pkg/command/storageshares.go
@@ -49,6 +49,7 @@ func StorageShares(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/storageusers.go
+++ b/storage/pkg/command/storageusers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/command/storagedrivers"
 	"github.com/owncloud/ocis/storage/pkg/config"
@@ -37,16 +38,26 @@ func StorageUsers(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
+			serviceName := "storage-users"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 
 			rcfg := storageUsersConfigFromStruct(c, cfg)
 
 			gr.Add(func() error {
+				reg := oreg.GetRevaRegistry()
+
 				runtime.RunWithOptions(
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
 				)
 				return nil
 			}, func(_ error) {

--- a/storage/pkg/command/storageusers.go
+++ b/storage/pkg/command/storageusers.go
@@ -51,6 +51,7 @@ func StorageUsers(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/users.go
+++ b/storage/pkg/command/users.go
@@ -62,6 +62,7 @@ func Users(cfg *config.Config) *cli.Command {
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithContext(ctx),
 					runtime.WithRegistry(reg),
 					runtime.WithServiceName(serviceName),
 					runtime.WithServiceUUID(uuid.String()),

--- a/storage/pkg/command/users.go
+++ b/storage/pkg/command/users.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/oklog/run"
 	ociscfg "github.com/owncloud/ocis/ocis-pkg/config"
+	oreg "github.com/owncloud/ocis/ocis-pkg/registry"
 	"github.com/owncloud/ocis/ocis-pkg/sync"
 	"github.com/owncloud/ocis/storage/pkg/config"
 	"github.com/owncloud/ocis/storage/pkg/server/debug"
@@ -44,8 +45,9 @@ func Users(cfg *config.Config) *cli.Command {
 				}
 			}
 
+			serviceName := "users"
 			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
+			pidFile := path.Join(os.TempDir(), "revad-"+serviceName+"-"+uuid.String()+".pid")
 
 			rcfg := usersConfigFromStruct(c, cfg)
 			logger.Debug().
@@ -54,10 +56,19 @@ func Users(cfg *config.Config) *cli.Command {
 				Msg("config")
 
 			gr.Add(func() error {
+				reg := oreg.GetRevaRegistry()
+
 				runtime.RunWithOptions(
 					rcfg,
 					pidFile,
 					runtime.WithLogger(&logger.Logger),
+					runtime.WithRegistry(reg),
+					runtime.WithServiceName(serviceName),
+					runtime.WithServiceUUID(uuid.String()),
+					runtime.WithNameSpaceConfig(map[string]string{
+						"grpc": "com.owncloud.api",
+						"http": "com.owncloud.web",
+					}),
 				)
 				return nil
 			}, func(_ error) {


### PR DESCRIPTION
## Description
Use the micro registry in reva

Current Problem:
- the registry is not used in reva:
  - that a service is registered on startup
  - that a service asks the registry when calling another service 

## Related Issue
- Follow up on https://github.com/cs3org/reva/pull/1509/files

## Motivation and Context
Use servicediscovery everywhere to make it consistent and to not configure hostnames / ips everywhere...
