### PR TITLE
add spa fileserver to the web service

### DIFF
--- a/changelog/unreleased/enhancement-web-cache-control.md
+++ b/changelog/unreleased/enhancement-web-cache-control.md
@@ -1,0 +1,6 @@
+Enhancement: Re-Enabling web cache control
+
+We've re-enable browser caching headers (`Expires` and `Last-Modified`) for the web service, this was disabled due to a problem in the fileserver used before.
+Since we're now using our own fileserver implementation this works again and is enabled by default.
+
+https://github.com/owncloud/ocis/pull/3109

--- a/changelog/unreleased/enhancement-web-spa-fileserver.md
+++ b/changelog/unreleased/enhancement-web-spa-fileserver.md
@@ -1,0 +1,6 @@
+Enhancement: Add SPA conform fileserver fow web
+
+We've added an SPA conform fileserver to the web service.
+It enables web to use vue's history mode and behaves like nginx try_files.
+
+https://github.com/owncloud/ocis/pull/3109

--- a/changelog/unreleased/enhancement-web-spa-fileserver.md
+++ b/changelog/unreleased/enhancement-web-spa-fileserver.md
@@ -1,4 +1,4 @@
-Enhancement: Add SPA conform fileserver fow web
+Enhancement: Add SPA conform fileserver for web
 
 We've added an SPA conform fileserver to the web service.
 It enables web to use vue's history mode and behaves like nginx try_files.

--- a/storage/pkg/command/groups.go
+++ b/storage/pkg/command/groups.go
@@ -32,6 +32,7 @@ func Groups(cfg *config.Config) *cli.Command {
 			tracing.Configure(cfg, logger)
 			gr := run.Group{}
 			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			// pre-create folders
 			if cfg.Reva.Groups.Driver == "json" && cfg.Reva.Groups.JSON != "" {
@@ -40,9 +41,8 @@ func Groups(cfg *config.Config) *cli.Command {
 				}
 			}
 
-			uuid := uuid.Must(uuid.NewV4())
-			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+uuid.String()+".pid")
-			defer cancel()
+			cuuid := uuid.Must(uuid.NewV4())
+			pidFile := path.Join(os.TempDir(), "revad-"+c.Command.Name+"-"+cuuid.String()+".pid")
 
 			rcfg := groupsConfigFromStruct(c, cfg)
 

--- a/web/pkg/assets/server.go
+++ b/web/pkg/assets/server.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
-	"strings"
 )
 
 type fileServer struct {
@@ -20,12 +19,8 @@ func FileServer(root http.FileSystem) http.Handler {
 }
 
 func (f *fileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	upath := r.URL.Path
-	if !strings.HasPrefix(upath, "/") {
-		upath = "/" + upath
-		r.URL.Path = upath
-	}
-	upath = path.Clean(upath)
+	upath := path.Clean(path.Join("/", r.URL.Path))
+	r.URL.Path = upath
 
 	asset, err := f.root.Open(upath)
 	if err != nil {

--- a/web/pkg/assets/server.go
+++ b/web/pkg/assets/server.go
@@ -53,7 +53,7 @@ func (f *fileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_, _ = buf.ReadFrom(asset)
 	}
 
-	w.Write(buf.Bytes())
+	_, _ = w.Write(buf.Bytes())
 }
 
 func withBase(w io.Writer, r io.Reader, base string) error {
@@ -65,7 +65,7 @@ func withBase(w io.Writer, r io.Reader, base string) error {
 				Type: html.ElementNode,
 				Data: "base",
 				Attr: []html.Attribute{
-					html.Attribute{
+					{
 						Key: "href",
 						Val: base,
 					},

--- a/web/pkg/assets/server.go
+++ b/web/pkg/assets/server.go
@@ -1,0 +1,85 @@
+package assets
+
+import (
+	"bytes"
+	"golang.org/x/net/html"
+	"io"
+	"mime"
+	"net/http"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type fileServer struct {
+	root http.FileSystem
+}
+
+func FileServer(root http.FileSystem) http.Handler {
+	return &fileServer{root}
+}
+
+func (f *fileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	upath := r.URL.Path
+	if !strings.HasPrefix(upath, "/") {
+		upath = "/" + upath
+		r.URL.Path = upath
+	}
+	upath = path.Clean(upath)
+
+	asset, err := f.root.Open(upath)
+	if err != nil {
+		r.URL.Path = "/index.html"
+		f.ServeHTTP(w, r)
+		return
+	}
+	defer asset.Close()
+
+	s, _ := asset.Stat()
+	if s.IsDir() {
+		r.URL.Path = "/index.html"
+		f.ServeHTTP(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", mime.TypeByExtension(filepath.Ext(s.Name())))
+
+	buf := new(bytes.Buffer)
+
+	switch s.Name() {
+	case "index.html", "oidc-callback.html", "oidc-silent-redirect.html":
+		_ = withBase(buf, asset, "/")
+	default:
+		_, _ = buf.ReadFrom(asset)
+	}
+
+	w.Write(buf.Bytes())
+}
+
+func withBase(w io.Writer, r io.Reader, base string) error {
+	doc, _ := html.Parse(r)
+	var parse func(*html.Node)
+	parse = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "head" {
+			n.InsertBefore(&html.Node{
+				Type: html.ElementNode,
+				Data: "base",
+				Attr: []html.Attribute{
+					html.Attribute{
+						Key: "href",
+						Val: base,
+					},
+				},
+			}, n.FirstChild)
+
+			return
+		}
+
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			parse(c)
+		}
+	}
+	parse(doc)
+
+	return html.Render(w, doc)
+}


### PR DESCRIPTION
## Description
Adding a custom fileServer implementation was neede due the requirement of having nice and clean URLs without a hash `http://foo.tld/#foo/bar`. To get a more detailed insight please read [6277](https://github.com/owncloud/web/issues/6277).

The implementation behaves similar to the nginx try_files setting and always falls back to the index.html file if a requested resource is not found.

It also injects a  `base` tag into the html files which is needed for web to sniff what mode to use (`hash` or `history`).
We cannot get rid of the `hash` mode for now because we still use it in oc10 and maybe in custom deployments.

A nice side effect is that we're now able to re-enable cache headers for the web service.


## Related Issue
- Fixes https://github.com/owncloud/web/issues/6277
- Fixes https://github.com/owncloud/ocis/issues/1094
- belongs https://github.com/owncloud/web/pull/6363

## Motivation and Context
... nice URLS

## How Has This Been Tested?
- we acceptance tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
