### PR TITLE
ensure the same data on /ocs/v?.php/config like oC10 [full-ci]

### DIFF
--- a/changelog/unreleased/fix-ocs-config-values.md
+++ b/changelog/unreleased/fix-ocs-config-values.md
@@ -1,0 +1,6 @@
+Bugfix: ensure the same data on /ocs/v?.php/config like oC10
+
+We've fixed the returned values on the /ocs/v?.php/config endpoints,
+so that they now return the same values as an oC10 would do.
+
+https://github.com/owncloud/ocis/pull/3113

--- a/storage/pkg/command/frontend.go
+++ b/storage/pkg/command/frontend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"strconv"
@@ -97,11 +96,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 				}
 			}
 
-			revaCfg, err := frontendConfigFromStruct(c, cfg, filesCfg)
-			if err != nil {
-				logger.Error().Err(err).Msg("could not generate frontend configuration")
-				return err
-			}
+			revaCfg := frontendConfigFromStruct(c, cfg, filesCfg)
 
 			gr.Add(func() error {
 				runtime.RunWithOptions(revaCfg, pidFile, runtime.WithLogger(&logger.Logger))
@@ -144,12 +139,7 @@ func Frontend(cfg *config.Config) *cli.Command {
 }
 
 // frontendConfigFromStruct will adapt an oCIS config struct into a reva mapstructure to start a reva service.
-func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[string]interface{}) (map[string]interface{}, error) {
-	frontendURL, err := url.Parse(cfg.Reva.Frontend.PublicURL)
-	if err != nil {
-		return map[string]interface{}{}, err
-	}
-
+func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[string]interface{}) map[string]interface{} {
 	return map[string]interface{}{
 		"core": map[string]interface{}{
 			"max_cpus":             cfg.Reva.Users.MaxCPUs,
@@ -227,7 +217,7 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 					"config": map[string]interface{}{
 						"version": "1.7",
 						"website": "ownCloud",
-						"host":    frontendURL.Host + frontendURL.Path,
+						"host":    cfg.Reva.Frontend.PublicURL,
 						"contact": "",
 						"ssl":     "false",
 					},
@@ -318,7 +308,7 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 // loadUserAgent reads the user-agent-whitelist-lock-in, since it is a string flag, and attempts to construct a map of


### PR DESCRIPTION
## Description
together with https://github.com/cs3org/reva/pull/2692/files, we now return the same (weird / wrong) info as oC10:

oCIS /ocs/v2.php/config
```xml
<ocs>
  <meta>
    <status>ok</status>
    <statuscode>200</statuscode>
    <message>OK</message>
  </meta>
  <data>
    <version>1.7</version>
    <website>ownCloud</website>
    <host>localhost:9200</host>
    <contact/>
    <ssl>false</ssl>
  </data>
</ocs>
 ```

https://cloud.owncloud.com/ocs/v2.php/config:

```xml
<ocs>
  <meta>
    <status>ok</status>
    <statuscode>200</statuscode>
    <message/>
    <totalitems/>
    <itemsperpage/>
  </meta>
  <data>
    <version>1.7</version>
    <website>ownCloud</website>
    <host>cloud.owncloud.com</host>
    <contact/>
    <ssl>false</ssl>
  </data>
</ocs>
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to https://github.com/owncloud/ocis/issues/1338
