### PR TITLE
[tests-only] apiTests. restoring disabled space

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -23,5 +23,5 @@
 
 #### [Viewer and editor has the possibility to disable the space](https://github.com/owncloud/ocis/issues/3031)
 -   [apiSpaces/removeSpaceObjects.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature#L121)
--   [apiSpaces/deleteSpaces.feature:60](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/deleteSpaces.feature#L60)
--   [apiSpaces/deleteSpaces.feature:71](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/deleteSpaces.feature#L71)
+-   [apiSpaces/deleteSpaces.feature:73](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/deleteSpaces.feature#L73)
+-   [apiSpaces/deleteSpaces.feature:84](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/deleteSpaces.feature#L84)

--- a/tests/acceptance/features/apiSpaces/deleteSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/deleteSpaces.feature
@@ -8,8 +8,11 @@ Feature: Disabling and deleting space
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
 
   Background:
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Bob      |
     And the administrator has given "Alice" the role "Admin" using the settings api
 
 
@@ -20,10 +23,20 @@ Feature: Disabling and deleting space
     Then the HTTP status code should be "204"
     When user "Alice" lists all available spaces via the GraphApi
     Then the json responded should contain a space "disable a space" with these key and value pairs:
-      | key  | value           |
-      | name | disable a space |
+      | key                    | value           |
+      | name                   | disable a space |
+      | root@@@deleted@@@state | trashed         |
+    
+
+   Scenario: Participants without a manager role cannot see the disabled space
+    Given user "Alice" has created a space "cannot see space" of type "project" with quota "10"
+    And user "Alice" has shared a space "cannot see space" to user "Brian" with role "editor"
+    And user "Alice" has shared a space "cannot see space" to user "Bob" with role "viewer"
+    And user "Alice" has disabled a space "cannot see space"  
     When user "Brian" lists all available spaces via the GraphApi
-    Then the json responded should not contain a space with name "disable a space"
+    Then the json responded should not contain a space with name "cannot see space"
+    When user "Bob" lists all available spaces via the GraphApi
+    Then the json responded should not contain a space with name "cannot see space"
 
 
   Scenario: An owner can delete a disabled Space via the webDav API

--- a/tests/acceptance/features/apiSpaces/restoreSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaces.feature
@@ -1,0 +1,56 @@
+@api @skipOnOcV10
+Feature: Restoring space
+  As a manager of space
+  I want to be able to restore a disabled space.
+  Only manager can restore disabled space
+  The restored space must be visible to the other participants without loss of data
+
+  Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
+  See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Bob      |
+    And the administrator has given "Alice" the role "Admin" using the settings api
+
+
+  Scenario: An owner can restore a Space via the Graph API
+    Given user "Alice" has created a space "restore a space" of type "project" with quota "10"
+    And user "Alice" has disabled a space "restore a space"
+    When user "Alice" restores a disabled space "restore a space"
+    Then the HTTP status code should be "200"
+
+
+  Scenario: Participants can see the data after the space is restored
+    Given user "Alice" has created a space "data exists" of type "project" with quota "10"
+    And user "Alice" has created a folder "mainFolder" in space "data exists"
+    And user "Alice" has uploaded a file inside space "data exists" with content "example" to "test.txt"
+    And user "Alice" has shared a space "data exists" to user "Brian" with role "editor"
+    And user "Alice" has shared a space "data exists" to user "Bob" with role "viewer"
+    And user "Alice" has disabled a space "data exists"
+    When user "Alice" restores a disabled space "data exists"
+    Then for user "Alice" the space "data exists" should contain these entries:
+      | test.txt         |
+      | mainFolder       |
+    And for user "Brian" the space "data exists" should contain these entries:
+      | test.txt         |
+      | mainFolder       |
+    And for user "Bob" the space "data exists" should contain these entries:
+      | test.txt         |
+      | mainFolder       |
+
+
+  Scenario: Participants can create data in the space after restoring
+    Given user "Alice" has created a space "create data in restored space" of type "project" with quota "10"
+    And user "Alice" has shared a space "create data in restored space" to user "Brian" with role "editor"
+    And user "Alice" has disabled a space "create data in restored space"
+    And user "Alice" has restored a disabled space "create data in restored space"
+    When user "Brian" creates a folder "mainFolder" in space "create data in restored space" using the WebDav Api
+    And user "Brian" uploads a file inside space "create data in restored space" with content "test" to "test.txt" using the WebDAV API
+    Then for user "Brian" the space "create data in restored space" should contain these entries:
+      | test.txt         |
+      | mainFolder       |
+    

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1482,4 +1482,56 @@ class SpacesContext implements Context {
 			)
 		);
 	}
+
+	/**
+	 * @When /^user "([^"]*)" restores a disabled space "([^"]*)"$/
+	 *
+	 * @param  string $user
+	 * @param  string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function sendRestoreSpaceRequest(
+		string $user,
+		string $spaceName
+	): void {
+		$header = ["restore" => true];
+		$body = '{}';
+		$space = $this->getSpaceByName($user, $spaceName);
+		$fullUrl = $this->baseUrl . "/graph/v1.0/drives/" . $space["id"];
+
+		$this->featureContext->setResponse(
+			HttpRequestHelper::sendRequest(
+				$fullUrl,
+				"",
+				'PATCH',
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				$header,
+				$body
+			)
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" has restored a disabled space "([^"]*)"$/
+	 *
+	 * @param  string $user
+	 * @param  string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userHasRestoredSpaceRequest(
+		string $user,
+		string $spaceName
+	): void {
+		$this->sendRestoreSpaceRequest($user, $spaceName);
+		$expectedHTTPStatus = "200";
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+            $expectedHTTPStatus,
+			"Expected response status code should be $expectedHTTPStatus"
+		);
+	}
 }


### PR DESCRIPTION
- added api test: restoring disabled space
- added test that only user with manager permissions can see the disabled space
- added check,  if the space is disabled, it is displayed in the response:

```
 "root": {
      "deleted": {
      "state": "trashed
     },
```
