### PR TITLE
[docs-only] Add doc on running parallel deployment tests locally

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/.env
+++ b/deployments/examples/oc10_ocis_parallel/.env
@@ -58,3 +58,8 @@ KEYCLOAK_ADMIN_PASSWORD=
 # you need uncomment following line. Please see documentation at
 # https://owncloud.dev/ocis/deployment/monitoring-tracing/
 #COMPOSE_FILE=docker-compose.yml:monitoring_tracing/docker-compose-additions.yml
+
+# If you want to use the testsuite with this stack,
+# you need uncomment following line. Please see documentation at
+# https://owncloud.dev/ocis/development/testing/
+#COMPOSE_FILE=docker-compose.yml:testing/docker-compose-additions.yml

--- a/deployments/examples/oc10_ocis_parallel/config/oc10/10-custom-config.sh
+++ b/deployments/examples/oc10_ocis_parallel/config/oc10/10-custom-config.sh
@@ -37,9 +37,4 @@ gomplate \
 occ market:upgrade --major web
 occ app:enable web
 
-# enable testing app
-echo "Cloning and enabling testing app..."
-git clone --depth 1 https://github.com/owncloud/testing.git /var/www/owncloud/apps/testing
-occ app:enable testing
-
 true

--- a/deployments/examples/oc10_ocis_parallel/config/oc10/10-custom-config.sh
+++ b/deployments/examples/oc10_ocis_parallel/config/oc10/10-custom-config.sh
@@ -37,4 +37,9 @@ gomplate \
 occ market:upgrade --major web
 occ app:enable web
 
+# enable testing app
+echo "Cloning and enabling testing app..."
+git clone --depth 1 https://github.com/owncloud/testing.git /var/www/owncloud/apps/testing
+occ app:enable testing
+
 true

--- a/deployments/examples/oc10_ocis_parallel/config/oc10/11-testing-app.sh
+++ b/deployments/examples/oc10_ocis_parallel/config/oc10/11-testing-app.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# enable testing app
+echo "Cloning and enabling testing app..."
+git clone --depth 1 https://github.com/owncloud/testing.git /var/www/owncloud/apps/testing
+occ app:enable testing
+
+true

--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -123,6 +123,7 @@ services:
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:
       - ./config/ocis/proxy.json:/etc/ocis/proxy.json
@@ -144,8 +145,6 @@ services:
     image: owncloud/server:${OC10_DOCKER_TAG:-latest}
     networks:
       ocis-net:
-    ports:
-      - 8080:8080
     environment:
       # make ownCloud Web the default frontend
       OWNCLOUD_DEFAULT_APP: ${OWNCLOUD_DEFAULT_APP:-files} # can be switched to "web"
@@ -251,8 +250,6 @@ services:
     image: osixia/openldap:latest
     networks:
       ocis-net:
-    ports:
-      - 636:636
     command: --copy-service --loglevel debug
     environment:
       LDAP_TLS_VERIFY_CLIENT: never

--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       STORAGE_USERS_DRIVER_OWNCLOUDSQL_REDIS_ADDR: redis:6379 # TODO: redis is not yet supported
       # ownCloudSQL sharing driver
       STORAGE_SHARING_USER_DRIVER: oc10-sql
-      STORAGE_SHARING_USER_SQL_USERNAME:  owncloud
+      STORAGE_SHARING_USER_SQL_USERNAME: owncloud
       STORAGE_SHARING_USER_SQL_PASSWORD: owncloud
       STORAGE_SHARING_USER_SQL_HOST: oc10-db
       STORAGE_SHARING_USER_SQL_PORT: 3306
@@ -123,6 +123,7 @@ services:
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:
       - ./config/ocis/proxy.json:/etc/ocis/proxy.json
       - ocis-data:/var/lib/ocis
@@ -143,6 +144,8 @@ services:
     image: owncloud/server:${OC10_DOCKER_TAG:-latest}
     networks:
       ocis-net:
+    ports:
+      - 8080:8080
     environment:
       # make ownCloud Web the default frontend
       OWNCLOUD_DEFAULT_APP: ${OWNCLOUD_DEFAULT_APP:-files} # can be switched to "web"
@@ -248,6 +251,8 @@ services:
     image: osixia/openldap:latest
     networks:
       ocis-net:
+    ports:
+      - 636:636
     command: --copy-service --loglevel debug
     environment:
       LDAP_TLS_VERIFY_CLIENT: never

--- a/deployments/examples/oc10_ocis_parallel/testing/docker-compose-additions.yml
+++ b/deployments/examples/oc10_ocis_parallel/testing/docker-compose-additions.yml
@@ -4,7 +4,7 @@ version: "3.7"
 services:
   ocis:
     environment:
-      PROXY_ENABLE_BASIC_AUTH: true
+      PROXY_ENABLE_BASIC_AUTH: "true"
 
   oc10:
     ports:

--- a/deployments/examples/oc10_ocis_parallel/testing/docker-compose-additions.yml
+++ b/deployments/examples/oc10_ocis_parallel/testing/docker-compose-additions.yml
@@ -1,0 +1,17 @@
+---
+version: "3.7"
+
+services:
+  ocis:
+    environment:
+      PROXY_ENABLE_BASIC_AUTH: true
+
+  oc10:
+    ports:
+      - 8080:8080
+    volumes:
+      - ./config/oc10/11-testing-app.sh:/etc/pre_server.d/11-testing-app.sh
+
+  openldap:
+    ports:
+      - 636:636

--- a/deployments/examples/ocis_hello/docker-compose.yml
+++ b/deployments/examples/ocis_hello/docker-compose.yml
@@ -66,6 +66,8 @@ services:
       SETTINGS_GRPC_ADDR: 0.0.0.0:9191
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
+      PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/web-config.dist.json:/config/web-config.dist.json

--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
+      PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/web-config.dist.json:/config/web-config.dist.json

--- a/deployments/examples/ocis_s3/docker-compose.yml
+++ b/deployments/examples/ocis_s3/docker-compose.yml
@@ -70,6 +70,8 @@ services:
       STORAGE_USERS_DRIVER_S3NG_BUCKET: ${MINIO_BUCKET:-ocis-bucket}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
+      PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-data:/var/lib/ocis

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
+      PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-data:/var/lib/ocis

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -54,7 +54,6 @@ services:
       - /bin/sh
       - /entrypoint-override.sh
     environment:
-      PROXY_ENABLE_BASIC_AUTH: "true"
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
@@ -70,6 +69,8 @@ services:
       STORAGE_APP_REGISTRY_MIMETYPES_JSON: /var/tmp/ocis/app-config/mimetypes.json
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
+      PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/mimetypes.json:/var/tmp/ocis/app-config/mimetypes.json

--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -166,3 +166,50 @@ If you want to work on a specific issue
 5. go back to 2. and repeat till the tests are passing.
 6. remove those tests from the expected failures file
 7. make a PR that has the fixed code, and the relevant lines removed from the expected failures file.
+
+## Running tests for parallel deployment
+
+### Setup the parallel deployment environment
+
+Instruction on setup is available [here](https://owncloud.dev/ocis/deployment/oc10_ocis_parallel/#local-setup)
+
+Start the docker stack with the following command:
+
+```bash
+PROXY_ENABLE_BASIC_AUTH=true docker-compose up -d
+```
+
+**NOTE**: `PROXY_ENABLE_BASIC_AUTH=true` is required as the tests use basic auth.
+
+### Getting the test helpers
+
+All the test helpers are located in the core repo.
+
+```bash
+git clone https://github.com/owncloud/core.git
+```
+
+### Run the acceptance tests
+
+Run the acceptance tests with the following command from the root of the oCIS repository:
+
+```bash
+make test-paralleldeployment-api \
+TEST_SERVER_URL="https://cloud.owncloud.test" \
+TEST_OC10_URL="http://localhost:8080" \
+TEST_PARALLEL_DEPLOYMENT=true \
+TEST_OCIS=true \
+TEST_WITH_LDAP=true \
+PATH_TO_CORE="<path_to_core>" \
+SKELETON_DIR="<path_to_core>/apps/testing/data/apiSkeleton"
+```
+
+Replace `<path_to_core>` with the actual path to the root directory of core repo that you have cloned earlier.
+
+In order to run a single test, use `BEHAT_FEATURE` environment variable.
+
+```bash
+make test-paralleldeployment-api \
+... \
+BEHAT_FEATURE="tests/parallelDeployAcceptance/features/apiShareManagement/acceptShares.feature"
+```

--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -173,13 +173,16 @@ If you want to work on a specific issue
 
 Instruction on setup is available [here](https://owncloud.dev/ocis/deployment/oc10_ocis_parallel/#local-setup)
 
+Edit the `.env` file and uncomment this line:
+```
+COMPOSE_FILE=docker-compose.yml:testing/docker-compose-additions.yml
+```
+
 Start the docker stack with the following command:
 
 ```bash
-PROXY_ENABLE_BASIC_AUTH=true docker-compose up -d
+docker-compose up -d
 ```
-
-**NOTE**: `PROXY_ENABLE_BASIC_AUTH=true` is required as the tests use basic auth.
 
 ### Getting the test helpers
 


### PR DESCRIPTION
## Description
This adds documentation on how to run the acceptance tests for parallel deployment setup locally.

## Related Issue
- Closes  https://github.com/owncloud/ocis/issues/3097

## Motivation and Context
Guide to  run parallel deployment tests locally

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
