### PR TITLE
Add "insecure" flag to graph LDAP backend

### DIFF
--- a/graph/pkg/config/config.go
+++ b/graph/pkg/config/config.go
@@ -37,6 +37,7 @@ type Spaces struct {
 
 type LDAP struct {
 	URI           string `ocisConfig:"uri" env:"GRAPH_LDAP_URI"`
+	Insecure      bool   `ocisConfig:"insecure" env:"OCIS_INSECURE;GRAPH_LDAP_INSECURE"`
 	BindDN        string `ocisConfig:"bind_dn" env:"GRAPH_LDAP_BIND_DN"`
 	BindPassword  string `ocisConfig:"bind_password" env:"GRAPH_LDAP_BIND_PASSWORD"`
 	UseServerUUID bool   `ocisConfig:"use_server_uuid" env:"GRAPH_LDAP_SERVER_UUID"`

--- a/graph/pkg/config/defaultconfig.go
+++ b/graph/pkg/config/defaultconfig.go
@@ -30,6 +30,7 @@ func DefaultConfig() *Config {
 			Backend: "cs3",
 			LDAP: LDAP{
 				URI:                      "ldap://localhost:9125",
+				Insecure:                 false,
 				BindDN:                   "",
 				BindPassword:             "",
 				UseServerUUID:            false,

--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -59,10 +59,21 @@ func NewService(opts ...Option) Service {
 		}
 	case "ldap":
 		var err error
+
+		var tlsConf *tls.Config
+		if options.Config.Identity.LDAP.Insecure {
+			tlsConf = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		}
+
 		conn := ldap.NewLDAPWithReconnect(&options.Logger,
-			options.Config.Identity.LDAP.URI,
-			options.Config.Identity.LDAP.BindDN,
-			options.Config.Identity.LDAP.BindPassword,
+			ldap.Config{
+				URI:          options.Config.Identity.LDAP.URI,
+				BindDN:       options.Config.Identity.LDAP.BindDN,
+				BindPassword: options.Config.Identity.LDAP.BindPassword,
+				TLSConfig:    tlsConf,
+			},
 		)
 		if backend, err = identity.NewLDAPBackend(conn, options.Config.Identity.LDAP, &options.Logger); err != nil {
 			options.Logger.Error().Msgf("Error initializing LDAP Backend: '%s'", err)


### PR DESCRIPTION
To allow skipping TLS Certificate verification in development environments.

