### PR TITLE
Do not make QA issues stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,7 @@ exemptLabels:
   - "Type:Bug"
   - "Type:Technical-Debt"
   - "Category:Research"
+  - "QA:team"
 # Label to use when marking an issue as stale
 staleLabel: "Status:Stale"
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
The stale bot has been finding issues labelled QA:team. Make those exempt from the stale bot - we can manage those ourselves.