### PR TITLE
[tests-only] [full-ci] Bump core commit id to include PR 39793 getPersonalSpaceIdForUser changes

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=20bf0ed4f460b55c68e10fbdfeeaa98284ee0a01
+CORE_COMMITID=93d081488afcba12abb709765dd0baa3aa3eb56d
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
Bumps the core commit id for tests in master branch. Gets the code from https://github.com/owncloud/core/pull/39793 running in CI for the edge branch.
, 
This is similar to https://github.com/cs3org/reva/pull/2556 and https://github.com/cs3org/reva/pull/2557

The core test code changes should not be really relevant her in oCIS, because the test code uses the graph API end points to fins out space ids. But the commit id bump makes sure that there is no accidental side-effect.