### PR TITLE
Add permission checks to `users` and `groups` Graph API

### DIFF
--- a/graph/pkg/middleware/requireadmin.go
+++ b/graph/pkg/middleware/requireadmin.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"net/http"
+
+	revactx "github.com/cs3org/reva/pkg/ctx"
+	accounts "github.com/owncloud/ocis/accounts/pkg/service/v0"
+	"github.com/owncloud/ocis/graph/pkg/service/v0/errorcode"
+	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/owncloud/ocis/ocis-pkg/roles"
+)
+
+// RequireAdmin middleware is used to require the user in context to be an admin / have account management permissions
+func RequireAdmin(rm *roles.Manager, logger log.Logger) func(next http.Handler) http.Handler {
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			u, ok := revactx.ContextGetUser(r.Context())
+			if !ok {
+				errorcode.AccessDenied.Render(w, r, http.StatusUnauthorized, "Unauthorized")
+				return
+			}
+			if u.Id == nil || u.Id.OpaqueId == "" {
+				errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "user is missing an id")
+				return
+			}
+			// get roles from context
+			roleIDs, ok := roles.ReadRoleIDsFromContext(r.Context())
+			if !ok {
+				logger.Debug().Str("userid", u.Id.OpaqueId).Msg("No roles in context, contacting settings service")
+				var err error
+				roleIDs, err = rm.FindRoleIDsForUser(r.Context(), u.Id.OpaqueId)
+				if err != nil {
+					logger.Err(err).Str("userid", u.Id.OpaqueId).Msg("failed to get roles for user")
+					errorcode.AccessDenied.Render(w, r, http.StatusUnauthorized, "Unauthorized")
+					return
+				}
+				if len(roleIDs) == 0 {
+					errorcode.AccessDenied.Render(w, r, http.StatusUnauthorized, "Unauthorized")
+					return
+				}
+			}
+
+			// check if permission is present in roles of the authenticated account
+			if rm.FindPermissionByID(r.Context(), roleIDs, accounts.AccountManagementPermissionID) != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			errorcode.AccessDenied.Render(w, r, http.StatusUnauthorized, "Unauthorized")
+		})
+	}
+}

--- a/graph/pkg/service/v0/option.go
+++ b/graph/pkg/service/v0/option.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/owncloud/ocis/graph/pkg/config"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/owncloud/ocis/ocis-pkg/roles"
+	settingssvc "github.com/owncloud/ocis/protogen/gen/ocis/services/settings/v0"
 )
 
 // Option defines a single option function.
@@ -17,6 +19,8 @@ type Options struct {
 	Middleware    []func(http.Handler) http.Handler
 	GatewayClient GatewayClient
 	HTTPClient    HTTPClient
+	RoleService   settingssvc.RoleService
+	RoleManager   *roles.Manager
 }
 
 // newOptions initializes the available default options.
@@ -62,5 +66,19 @@ func WithGatewayClient(val GatewayClient) Option {
 func WithHTTPClient(val HTTPClient) Option {
 	return func(o *Options) {
 		o.HTTPClient = val
+	}
+}
+
+// RoleService provides a function to set the RoleService option.
+func RoleService(val settingssvc.RoleService) Option {
+	return func(o *Options) {
+		o.RoleService = val
+	}
+}
+
+// RoleManager provides a function to set the RoleManager option.
+func RoleManager(val *roles.Manager) Option {
+	return func(o *Options) {
+		o.RoleManager = val
 	}
 }


### PR DESCRIPTION
Only users with the account management permission should be able to
create, update or delete users. This also restricts access to the APIs
that allow listing all Groups/all Users.

Fixes #3177
 
