### PR TITLE
[full-ci] Update web assets to v5.1.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -3,5 +3,5 @@ CORE_COMMITID=bed95a7ca2e7e155b9ec5e63740417bf0de324ba
 CORE_BRANCH=master
 
 # The test runner source for UI tests
-WEB_COMMITID=905b4e342db0202cdbaa8c21096bf87f179b25f6
+WEB_COMMITID=94532551d3d89d5d3eeee016e2f0aae9fe919fce
 WEB_BRANCH=master

--- a/changelog/unreleased/update-web-5.1.0.md
+++ b/changelog/unreleased/update-web-5.1.0.md
@@ -1,0 +1,8 @@
+Enhancement: Update ownCloud Web to v5.1.0
+
+Tags: web
+
+We updated ownCloud Web to v5.1.0. Please refer to the changelog (linked) for details on the web release.
+
+https://github.com/owncloud/ocis/pull/3202
+https://github.com/owncloud/web/releases/tag/v5.1.0

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,5 +1,6 @@
 SHELL := bash
 NAME := web
+WEB_ASSETS_VERSION = v5.1.0
 
 include ../.make/recursion.mk
 
@@ -28,8 +29,6 @@ ci-go-generate: # CI runs ci-node-generate automatically before this target
 
 .PHONY: ci-node-generate
 ci-node-generate: pull-assets
-
-WEB_ASSETS_VERSION = v5.0.0
 
 .PHONY: pull-assets
 pull-assets:


### PR DESCRIPTION
## Description
Brings web assets up to date for the most recent web release. Changelog:
https://github.com/owncloud/web/releases/tag/v5.1.0
Doesn't bring much value for oCIS, but let's still keep it up to date.
