### PR TITLE
Fix linter issue

### DIFF
--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -63,7 +63,8 @@ func NewService(opts ...Option) Service {
 		var tlsConf *tls.Config
 		if options.Config.Identity.LDAP.Insecure {
 			tlsConf = &tls.Config{
-				InsecureSkipVerify: true,
+				//nolint:gosec // We need the ability to run with "insecure" (dev/testing)
+				InsecureSkipVerify: options.Config.Identity.LDAP.Insecure,
 			}
 		}
 


### PR DESCRIPTION
Silence the warning about Insecure being true. `Insecure` is not our default configuration, but need it to work in some cases.

