### PR TITLE
[tests-only] [full-ci] Bump CORE_COMMITID to include core PR 39813

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=afae230f67daf971cda4a10d1b20cd846e87060b
+CORE_COMMITID=a0a4064c77a3576763885f83d57ca4c558348b8c
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/39813 enhanced the test code that checks the `status.php` end-point. Bump the CORE_COMMITID so that we run that code in CI.