### PR TITLE
[deployment examples] switch to Keycloak legacy (Wildfly)

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -203,7 +203,8 @@ services:
     restart: always
 
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    # Keycloak WildFly distribution, Quarkus is not ready yet for automatic setup https://github.com/keycloak/keycloak/issues/10216
+    image: quay.io/keycloak/keycloak:legacy
     networks:
       ocis-net:
     entrypoint: ["/bin/sh", "/opt/jboss/tools/docker-entrypoint-override.sh"]

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -101,7 +101,8 @@ services:
     restart: always
 
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    # Keycloak WildFly distribution, Quarkus is not ready yet for automatic setup https://github.com/keycloak/keycloak/issues/10216
+    image: quay.io/keycloak/keycloak:legacy
     networks:
       ocis-net:
     entrypoint: ["/bin/sh", "/opt/jboss/tools/docker-entrypoint-override.sh"]


### PR DESCRIPTION
## Description
Keycloak switch to Quarkus with their v17 release (instead of Wildfly). The Quarkus based docker images don't support automatic setup yet (https://github.com/keycloak/keycloak/issues/10216). Therefore this PR changes the Keycloak Docker Tag from `latest` to `legacy`, to stay on the Wildfly based distribution for now (it will be supported until June 2022).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes broken deployment examples using Keycloak

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
