### PR TITLE
support thumbnails in spaces

### DIFF
--- a/changelog/unreleased/spaces-thumbnails.md
+++ b/changelog/unreleased/spaces-thumbnails.md
@@ -1,0 +1,5 @@
+Enhancement: Thumbnails in spaces
+
+Added support for thumbnails in spaces.
+
+https://github.com/owncloud/ocis/pull/3219

--- a/thumbnails/pkg/service/v0/service.go
+++ b/thumbnails/pkg/service/v0/service.go
@@ -217,11 +217,24 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *thumbnailssvc.Ge
 func (g Thumbnail) stat(path, auth string) (*provider.StatResponse, error) {
 	ctx := metadata.AppendToOutgoingContext(context.Background(), revactx.TokenHeader, auth)
 
-	req := &provider.StatRequest{
-		Ref: &provider.Reference{
+	var ref *provider.Reference
+	if strings.Contains(path, "!") {
+		parts := strings.Split(path, "!")
+		spaceID, path := parts[0], parts[1]
+		ref = &provider.Reference{
+			ResourceId: &provider.ResourceId{
+				StorageId: spaceID,
+				OpaqueId:  spaceID,
+			},
 			Path: path,
-		},
+		}
+	} else {
+		ref = &provider.Reference{
+			Path: path,
+		}
 	}
+
+	req := &provider.StatRequest{Ref: ref}
 	rsp, err := g.cs3Client.Stat(ctx, req)
 	if err != nil {
 		g.logger.Error().Err(err).Str("path", path).Msg("could not stat file")

--- a/webdav/pkg/dav/requests/thumbnail.go
+++ b/webdav/pkg/dav/requests/thumbnail.go
@@ -33,13 +33,13 @@ type ThumbnailRequest struct {
 	Height int32
 	// In case of a public share the public link token.
 	PublicLinkToken string
-	// The username from the requested URL
-	Username string
+	// The Identifier from the requested URL
+	Identifier string
 }
 
 // ParseThumbnailRequest extracts all required parameters from a http request.
 func ParseThumbnailRequest(r *http.Request) (*ThumbnailRequest, error) {
-	fp, username, err := extractFilePath(r)
+	fp, id, err := extractFilePath(r)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func ParseThumbnailRequest(r *http.Request) (*ThumbnailRequest, error) {
 		Width:           int32(width),
 		Height:          int32(height),
 		PublicLinkToken: chi.URLParam(r, "token"),
-		Username:        username,
+		Identifier:      id,
 	}, nil
 }
 
@@ -68,16 +68,17 @@ func ParseThumbnailRequest(r *http.Request) (*ThumbnailRequest, error) {
 // User and filepath are dynamic and filepath can contain slashes
 // So using the URLParam function is not possible.
 func extractFilePath(r *http.Request) (string, string, error) {
-	user := chi.URLParam(r, "user")
-	user, err := url.QueryUnescape(user)
+	id := chi.URLParam(r, "id")
+	id, err := url.QueryUnescape(id)
 	if err != nil {
 		return "", "", errors.New("could not unescape user")
 	}
-	if user != "" {
-		parts := strings.SplitN(r.URL.Path, user, 2)
-		return parts[1], user, nil
+	if id != "" {
+		parts := strings.SplitN(r.URL.Path, id, 2)
+		return parts[1], id, nil
 	}
 
+	// This is for public links
 	token := chi.URLParam(r, "token")
 	if token != "" {
 		parts := strings.SplitN(r.URL.Path, token, 2)


### PR DESCRIPTION
Added support for thumbnails in spaces.

The thumbnail code in the webdav and thumbnails module feel a bit hacky now after many adjustments.
When we have some more time we should invest a bit of it to make the API of the thumbnails service better.
Maybe even consider a HTTP API for the thumbnails service since serving large content through GRPC is not recommended. (4 MB is already large for GRPC)

![Screenshot of a space with some images](https://user-images.githubusercontent.com/5579653/155171190-3a0bf7d5-7df9-4667-8e6b-b7e0b8e2cf79.png)
