### PR TITLE
allow requesting capabilities from password protected links

### DIFF
--- a/changelog/unreleased/fix-capabilities-for-public-links.md
+++ b/changelog/unreleased/fix-capabilities-for-public-links.md
@@ -1,0 +1,7 @@
+Bugfix: Capabilities for password protected public links
+
+Allow password protected public links to request capabilities.
+
+https://github.com/owncloud/ocis/pull/3229
+https://github.com/owncloud/web/pull/6471
+https://github.com/owncloud/web/issues/5863

--- a/proxy/pkg/middleware/basic_auth_test.go
+++ b/proxy/pkg/middleware/basic_auth_test.go
@@ -1,3 +1,40 @@
 package middleware
 
+import (
+	"net/http/httptest"
+	"testing"
+)
+
 /**/
+
+func TestBasicAuth__isPublicLink(t *testing.T) {
+	tests := []struct {
+		url      string
+		username string
+		expected bool
+	}{
+		{url: "/remote.php/dav/public-files/", username: "", expected: false},
+		{url: "/remote.php/dav/public-files/", username: "abc", expected: false},
+		{url: "/remote.php/dav/public-files/", username: "private", expected: false},
+		{url: "/remote.php/dav/public-files/", username: "public", expected: true},
+		{url: "/ocs/v1.php/cloud/capabilities", username: "", expected: false},
+		{url: "/ocs/v1.php/cloud/capabilities", username: "abc", expected: false},
+		{url: "/ocs/v1.php/cloud/capabilities", username: "private", expected: false},
+		{url: "/ocs/v1.php/cloud/capabilities", username: "public", expected: true},
+		{url: "/ocs/v1.php/cloud/users/admin", username: "public", expected: false},
+	}
+	ba := basicAuth{}
+
+	for _, tt := range tests {
+		req := httptest.NewRequest("", tt.url, nil)
+
+		if tt.username != "" {
+			req.SetBasicAuth(tt.username, "")
+		}
+
+		result := ba.isPublicLink(req)
+		if result != tt.expected {
+			t.Errorf("with %s expected %t got %t", tt.url, tt.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
## Description
Requesting capabilities from password protected links wasn't possible.

## Related Issue
- requirement for https://github.com/owncloud/web/pull/6471
- requested by: https://github.com/owncloud/web/issues/5863

## Motivation and Context
allow public links with password protection to request capabilities.

## How Has This Been Tested?
- tests added
- 
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)