### PR TITLE
fix spaces thumbnails

### DIFF
--- a/changelog/unreleased/spaces-thumbnails.md
+++ b/changelog/unreleased/spaces-thumbnails.md
@@ -3,3 +3,4 @@ Enhancement: Thumbnails in spaces
 Added support for thumbnails in spaces.
 
 https://github.com/owncloud/ocis/pull/3219
+https://github.com/owncloud/ocis/pull/3235

--- a/thumbnails/pkg/thumbnail/imgsource/cs3.go
+++ b/thumbnails/pkg/thumbnail/imgsource/cs3.go
@@ -52,7 +52,8 @@ func (s CS3) Get(ctx context.Context, path string) (io.ReadCloser, error) {
 				StorageId: spaceID,
 				OpaqueId:  spaceID,
 			},
-			Path: path,
+			// Spaces requests need relative paths.
+			Path: "." + path,
 		}
 	} else {
 		ref = &provider.Reference{


### PR DESCRIPTION
When requesting files using spaces references, the path needs to be relative. I thought it was working, when I tested it because I was using files which were already in the thumbnails service cache. The thumbnails service never had to load these files from the storage and that's why I never encountered this issue.

Lesson learned: when working with the thumbnailer, clear the thumbnails cache!