### PR TITLE
fix: remove need for external ocis-net network

### DIFF
--- a/changelog/unreleased/fix-network-on-individual-services.md
+++ b/changelog/unreleased/fix-network-on-individual-services.md
@@ -1,4 +1,4 @@
-Bugfix: Network configuration in individiual_services example.
+Bugfix: Network configuration in individiual_services example
 
 Tidy up the deployments/examples/ocis_individual_services example so that the instructions work.
 

--- a/changelog/unreleased/fix-network-on-individual-services.md
+++ b/changelog/unreleased/fix-network-on-individual-services.md
@@ -1,0 +1,5 @@
+Bugfix: Network configuration in individiual_services example.
+
+Tidy up the deployments/examples/ocis_individual_services example so that the instructions work.
+
+https://github.com/owncloud/ocis/pull/3238

--- a/deployments/examples/ocis_individual_services/docker-compose.yml
+++ b/deployments/examples/ocis_individual_services/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - proxy
@@ -90,7 +90,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - nats-server
@@ -111,7 +111,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - /bin/sh
       - /entrypoint-override.sh
@@ -145,7 +145,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - glauth
@@ -168,7 +168,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - idp
@@ -194,7 +194,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - ocs
@@ -222,7 +222,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - settings
@@ -247,7 +247,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - store
@@ -269,7 +269,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - thumbnails
@@ -296,7 +296,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - web
@@ -320,7 +320,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - webdav
@@ -343,7 +343,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - graph
@@ -369,7 +369,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-metadata
@@ -402,7 +402,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-auth-basic
@@ -426,7 +426,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-auth-machine
@@ -450,7 +450,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-auth-bearer
@@ -474,7 +474,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-shares
@@ -501,7 +501,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-users
@@ -535,7 +535,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-public-link
@@ -559,7 +559,7 @@ services:
     deploy:
       replicas: 1
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-sharing
@@ -592,7 +592,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-userprovider
@@ -623,7 +623,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-groupprovider
@@ -654,7 +654,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-frontend
@@ -684,7 +684,7 @@ services:
     deploy:
       replicas: ${OCIS_SCALE:-1}
     networks:
-      ocis-net: null
+      ocis-net:
     entrypoint:
       - ocis
       - storage-gateway
@@ -731,4 +731,3 @@ volumes:
 
 networks:
   ocis-net:
-    external: true


### PR DESCRIPTION
## Description
Tidy up the `deployments/examples/ocis_individual_services` example so that the instructions work.

## Motivation and Context
No need for manually creating a network via `docker create network ocis-net` (not in example instructions).

## How Has This Been Tested?
Tested in Windows 10 / WSL 2 Ubuntu and works as expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
