### PR TITLE
graph: Assign new user the default user role

### DIFF
--- a/accounts/pkg/service/v0/accounts.go
+++ b/accounts/pkg/service/v0/accounts.go
@@ -746,7 +746,7 @@ func validateAccountEmail(serviceID string, a *accountsmsg.Account) error {
 // We want to allow email addresses as usernames so they show up when using them in ACLs on storages that allow integration with our glauth LDAP service
 // so we are adding a few restrictions from https://stackoverflow.com/questions/6949667/what-are-the-real-rules-for-linux-usernames-on-centos-6-and-rhel-6
 // names should not start with numbers
-var usernameRegex = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*(@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)*$")
+var usernameRegex = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*(@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)*$")
 
 func isValidUsername(e string) bool {
 	if len(e) < 1 && len(e) > 254 {
@@ -756,7 +756,7 @@ func isValidUsername(e string) bool {
 }
 
 // regex from https://www.w3.org/TR/2016/REC-html51-20161101/sec-forms.html#valid-e-mail-address
-var emailRegex = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+var emailRegex = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
 func isValidEmail(e string) bool {
 	if len(e) < 3 && len(e) > 254 {

--- a/graph/pkg/service/v0/graph.go
+++ b/graph/pkg/service/v0/graph.go
@@ -11,6 +11,7 @@ import (
 	"github.com/owncloud/ocis/graph/pkg/config"
 	"github.com/owncloud/ocis/graph/pkg/identity"
 	"github.com/owncloud/ocis/ocis-pkg/log"
+	settingssvc "github.com/owncloud/ocis/protogen/gen/ocis/services/settings/v0"
 	"google.golang.org/grpc"
 )
 
@@ -66,6 +67,7 @@ type Graph struct {
 	identityBackend      identity.Backend
 	gatewayClient        GatewayClient
 	httpClient           HTTPClient
+	roleService          settingssvc.RoleService
 	spacePropertiesCache *ttlcache.Cache
 }
 

--- a/graph/pkg/service/v0/service.go
+++ b/graph/pkg/service/v0/service.go
@@ -116,17 +116,19 @@ func NewService(opts ...Option) Service {
 		svc.httpClient = options.HTTPClient
 	}
 
-	roleService := options.RoleService
-	if roleService == nil {
-		roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient)
+	if options.RoleService == nil {
+		svc.roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient)
+	} else {
+		svc.roleService = options.RoleService
 	}
+
 	roleManager := options.RoleManager
 	if roleManager == nil {
 		m := roles.NewManager(
 			roles.CacheSize(1024),
 			roles.CacheTTL(time.Hour),
 			roles.Logger(options.Logger),
-			roles.RoleService(roleService),
+			roles.RoleService(svc.roleService),
 		)
 		roleManager = &m
 	}


### PR DESCRIPTION
## Description
Similar to what the accounts service is doing, all new users get
the User role assigned now. Otherwise creating the user's personal space
 upon login is not working.

This also add validation for the username an mail address the GraphAPI endpoints that allow updating attributes and fixes the valid mail regex in the accounts service.

## Related Issue
- Partial Fixes #3247 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manual
 
## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
