### PR TITLE
Add missing weight to header to fix menu sorting

### DIFF
--- a/docs/ocis/adr/0016-files-metadata.md
+++ b/docs/ocis/adr/0016-files-metadata.md
@@ -1,5 +1,10 @@
 ---
 title: "16. Storage for Files Metadata"
+weight: 16
+date: 2022-03-02T00:00:00+01:00
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/ocis/adr
+geekdocFilePath: 0016-files-metadata.md
 ---
 
 * Status: proposed


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds a missing weight to the markdown header of `ocs/ocis/adr/0016-files-metadata.md`to fix the navigation menu order.

## How Has This Been Tested?

manual


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
