### PR TITLE
[deployment-example] add owncloud scope to default scopes in the parallel deployment

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/config/keycloak/owncloud-realm.dist.json
+++ b/deployments/examples/oc10_ocis_parallel/config/keycloak/owncloud-realm.dist.json
@@ -1358,7 +1358,7 @@
       }
     } ]
   } ],
-  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins" ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "owncloud" ],
   "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
   "browserSecurityHeaders" : {
     "contentSecurityPolicyReportOnly" : "",


### PR DESCRIPTION
## Description
Adds the "owncloud" scope as a default scope to all clients.

![image](https://user-images.githubusercontent.com/34452982/156761101-e638c16f-f345-48c4-b287-72b497869590.png)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
