### PR TITLE
[tests-only] ApiTest: set space image/description to space

### DIFF
--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -33,3 +33,39 @@ Feature: Change data of space
       | key              | value         |
       | name             | Project Earth |
       | quota@@@total    | 100           |
+
+
+  Scenario: An user set readme file as description of the space via the Graph API
+    Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
+    And user "Alice" has created a folder ".space" in space "add special section"
+    And user "Alice" has uploaded a file inside space "add special section" with content "space description" to ".space/readme.md"
+    When user "Alice" sets the file ".space/readme.md" as a description in a special section of the "add special section" space
+    Then the HTTP status code should be "200"
+    When user "Alice" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/readme.md" with these key and value pairs:
+      | key                                | value               |
+      | name                               | add special section |
+      | special@@@0@@@size                 | 17                  |
+      | special@@@0@@@name                 | readme.md           |
+      | special@@@0@@@specialFolder@@@name | readme              |
+      | special@@@0@@@file@@@mimeType       | text/markdown       |
+      | special@@@0@@@id                   | %file_id%            |
+      | special@@@0@@@eTag                 | %eTag%              |
+
+
+  Scenario: An user set jpeg file as space image of the space via the Graph API
+    Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
+    And user "Alice" has created a folder ".space" in space "add special section"
+    And user "Alice" has uploaded a file inside space "add special section" with content "" to ".space/spaceImage.jpeg"
+    When user "Alice" sets the file ".space/spaceImage.jpeg" as a space image in a special section of the "add special section" space
+    Then the HTTP status code should be "200"
+    When user "Alice" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/spaceImage.jpeg" with these key and value pairs:
+      | key                                | value               |
+      | name                               | add special section |
+      | special@@@0@@@size                 | 0                   |
+      | special@@@0@@@name                 | spaceImage.jpeg     |
+      | special@@@0@@@specialFolder@@@name | image              |
+      | special@@@0@@@file@@@mimeType       | image/jpeg          |
+      | special@@@0@@@id                   | %file_id%            |
+      | special@@@0@@@eTag                 | %eTag%              |

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -53,19 +53,24 @@ Feature: Change data of space
       | special@@@0@@@eTag                 | %eTag%              |
 
 
-  Scenario: An user set jpeg file as space image of the space via the Graph API
+  Scenario Outline: An user set image file as space image of the space via the Graph API
     Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
     And user "Alice" has created a folder ".space" in space "add special section"
-    And user "Alice" has uploaded a file inside space "add special section" with content "" to ".space/spaceImage.jpeg"
-    When user "Alice" sets the file ".space/spaceImage.jpeg" as a space image in a special section of the "add special section" space
+    And user "Alice" has uploaded a file inside space "add special section" with content "" to "<fileName>"
+    When user "Alice" sets the file "<fileName>" as a space image in a special section of the "add special section" space
     Then the HTTP status code should be "200"
     When user "Alice" lists all available spaces via the GraphApi
-    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/spaceImage.jpeg" with these key and value pairs:
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file "<fileName>" with these key and value pairs:
       | key                                | value               |
       | name                               | add special section |
       | special@@@0@@@size                 | 0                   |
-      | special@@@0@@@name                 | spaceImage.jpeg     |
-      | special@@@0@@@specialFolder@@@name | image              |
-      | special@@@0@@@file@@@mimeType       | image/jpeg          |
+      | special@@@0@@@name                 | <nameInResponse>    |
+      | special@@@0@@@specialFolder@@@name | image               |
+      | special@@@0@@@file@@@mimeType       | <mimeType>          |
       | special@@@0@@@id                   | %file_id%            |
       | special@@@0@@@eTag                 | %eTag%              |
+    Examples:
+      | fileName                | nameInResponse  | mimeType   |
+      | .space/spaceImage.jpeg | spaceImage.jpeg | image/jpeg |
+      | .space/spaceImage.png  | spaceImage.png  | image/png  |
+      | .space/spaceImage.gif  | spaceImage.gif  | image/gif  |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -229,6 +229,10 @@ class SpacesContext implements Context {
 				"{}"
 			)
 		);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			200,
+			"file $fileName not found"
+		);
 		return $this->featureContext->getResponse()->getHeaders();
 	}
 
@@ -268,7 +272,6 @@ class SpacesContext implements Context {
 	 * @return string
 	 */
 	public function getUserIdByUserName(string $userName): string {
-
 		$fullUrl = $this->baseUrl . "/api/v0/accounts/accounts-list";
 		$this->featureContext->setResponse(
 			HttpRequestHelper::post(
@@ -485,7 +488,7 @@ class SpacesContext implements Context {
 			$this->listMySpacesRequest(
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				"?". $query
+				"?" . $query
 			)
 		);
 	}
@@ -898,10 +901,11 @@ class SpacesContext implements Context {
 		
 		$userRole = "";
 		foreach ($permissions as $permission) {
-			foreach ($permission["grantedTo"] as $grantedTo)
-			if ($grantedTo["user"]["id"] === $userId) {
-				$userRole = $permission["roles"][0];
-			} 
+			foreach ($permission["grantedTo"] as $grantedTo) {
+				if ($grantedTo["user"]["id"] === $userId) {
+					$userRole = $permission["roles"][0];
+				}
+			}
 		}
 		Assert::assertEquals($userRole, $role, "the user $userName with the role $role could not be found");
 	}
@@ -943,18 +947,18 @@ class SpacesContext implements Context {
 			)
 		);
 		$matches = [];
-		foreach($spaces["value"] as $space) {
-			if($onlyOrNot === "not") {
+		foreach ($spaces["value"] as $space) {
+			if ($onlyOrNot === "not") {
 				Assert::assertNotEquals($space["driveType"], $type);
 			}
-			if($onlyOrNot === "only") {
+			if ($onlyOrNot === "only") {
 				Assert::assertEquals($space["driveType"], $type);
 			}
-			if($onlyOrNot === "" && $space["driveType"] === $type) {
+			if ($onlyOrNot === "" && $space["driveType"] === $type) {
 				$matches[] = $space;
 			}
 		}
-		if($onlyOrNot === "") {
+		if ($onlyOrNot === "") {
 			Assert::assertNotEmpty($matches);
 		}
 	}
@@ -1099,7 +1103,7 @@ class SpacesContext implements Context {
 	): void {
 		$exploded = explode('/', $folder);
 		$path = '';
-		for ($i = 0; $i < count($exploded); $i++) {
+		for ($i = 0; $i < \count($exploded); $i++) {
 			$path = $path . $exploded[$i] . '/';
 			$this->theUserCreatesAFolderToAnotherOwnerSpaceUsingTheGraphApi($user, $path, $spaceName);
 		};
@@ -1293,36 +1297,36 @@ class SpacesContext implements Context {
 	}
 
 	/**
-    	 * @When /^user "([^"]*)" changes the description of the "([^"]*)" space to "([^"]*)"$/
-    	 *
-    	 * @param string $user
-    	 * @param string $spaceName
-    	 * @param string $newName
-    	 *
-    	 * @return void
-    	 * @throws GuzzleException
-    	 * @throws Exception
-    	 */
-    	public function updateSpaceDescription(
-    		string $user,
-    		string $spaceName,
-    		string $newDescription
-    	): void {
-    		$space = $this->getSpaceByName($user, $spaceName);
-    		$spaceId = $space["id"];
+	 * @When /^user "([^"]*)" changes the description of the "([^"]*)" space to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 * @param string $newName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function updateSpaceDescription(
+		string $user,
+		string $spaceName,
+		string $newDescription
+	): void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$spaceId = $space["id"];
 
-    		$bodyData = ["description" => $newDescription];
-    		$body = json_encode($bodyData, JSON_THROW_ON_ERROR);
+		$bodyData = ["description" => $newDescription];
+		$body = json_encode($bodyData, JSON_THROW_ON_ERROR);
 
-    		$this->featureContext->setResponse(
-    			$this->sendUpdateSpaceRequest(
-    				$user,
-    				$this->featureContext->getPasswordForUser($user),
-    				$body,
-    				$spaceId
-    			)
-    		);
-    	}
+		$this->featureContext->setResponse(
+			$this->sendUpdateSpaceRequest(
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				$body,
+				$spaceId
+			)
+		);
+	}
 
 	/**
 	 * @When /^user "([^"]*)" changes the quota of the "([^"]*)" space to "([^"]*)"$/
@@ -1357,7 +1361,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sets the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/ 
+	 * @When /^user "([^"]*)" sets the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -1380,7 +1384,9 @@ class SpacesContext implements Context {
 
 		if ($type === "description") {
 			$type = "readme";
-		} else $type = "image";
+		} else {
+			$type = "image";
+		}
 
 		$bodyData = ["special" => [["specialFolder" => ["name" => "$type"], "id" => "$fileId"]]];
 		$body = json_encode($bodyData, JSON_THROW_ON_ERROR);
@@ -1580,10 +1586,10 @@ class SpacesContext implements Context {
 
 		$expectedHTTPStatus = "200";
 		$this->featureContext->theHTTPStatusCodeShouldBe(
-            $expectedHTTPStatus,
+			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus"
 		);
-        $expectedOCSStatus = "200";
+		$expectedOCSStatus = "200";
 		$this->ocsContext->theOCSStatusCodeShouldBe($expectedOCSStatus, "Expected OCS response status code $expectedOCSStatus");
 	}
 
@@ -1683,7 +1689,7 @@ class SpacesContext implements Context {
 		$this->sendDisableSpaceRequest($user, $spaceName);
 		$expectedHTTPStatus = "204";
 		$this->featureContext->theHTTPStatusCodeShouldBe(
-            $expectedHTTPStatus,
+			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus"
 		);
 	}
@@ -1784,7 +1790,7 @@ class SpacesContext implements Context {
 		$this->sendRestoreSpaceRequest($user, $spaceName);
 		$expectedHTTPStatus = "200";
 		$this->featureContext->theHTTPStatusCodeShouldBe(
-            $expectedHTTPStatus,
+			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -206,6 +206,61 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * The method finds file by fileName and spaceName and returns data of file wich contains in responseHeader
+	 * fileName contains the path, if the file is in the folder
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 * @param string $fileName
+	 *
+	 * @return array
+	 */
+	public function getFileData(string $user, string $spaceName, string $fileName): array {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$fullUrl = $this->baseUrl . "/remote.php/dav/spaces/" . $space["id"] . "/" . $fileName;
+		
+		$this->featureContext->setResponse(
+			HttpRequestHelper::get(
+				$fullUrl,
+				"",
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				[],
+				"{}"
+			)
+		);
+		return $this->featureContext->getResponse()->getHeaders();
+	}
+
+	/**
+	 * The method returns fileId
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 * @param string $fileName
+	 *
+	 * @return string
+	 */
+	public function getFileId(string $user, string $spaceName, string $fileName): string {
+		$fileData = $this->getFileData($user, $spaceName, $fileName);
+		return $fileData["Oc-Fileid"][0];
+	}
+
+	/**
+	 * The method returns eTag
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 * @param string $fileName
+	 *
+	 * @return string
+	 */
+	public function getETag(string $user, string $spaceName, string $fileName): string {
+		$fileData = $this->getFileData($user, $spaceName, $fileName);
+		return $fileData["Etag"][0];
+	}
+
+	/**
 	 * The method returns userId
 	 *
 	 * @param string $userName
@@ -755,7 +810,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the json responded should contain a space "([^"]*)" (?:|(?:owned by|granted to) "([^"]*)" )with these key and value pairs:$/
+	 * @Then /^the json responded should contain a space "([^"]*)" (?:|(?:owned by|granted to) "([^"]*)" )(?:|(?:with description file|with space image) "([^"]*)" )with these key and value pairs:$/
 	 *
 	 * @param string $spaceName
 	 * @param string $userName
@@ -767,6 +822,7 @@ class SpacesContext implements Context {
 	public function jsonRespondedShouldContain(
 		string $spaceName,
 		string $userName = '',
+		string $fileName = '',
 		TableNode $table
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
@@ -790,6 +846,18 @@ class SpacesContext implements Context {
 						"function" =>
 							[$this, "getUserIdByUserName"],
 						"parameter" => [$userName]
+					],
+					[
+						"code" => "%file_id%",
+						"function" =>
+							[$this, "getFileId"],
+						"parameter" => [$userName, $spaceName, $fileName]
+					],
+					[
+						"code" => "%eTag%",
+						"function" =>
+							[$this, "getETag"],
+						"parameter" => [$userName, $spaceName, $fileName]
 					],
 				]
 			);
@@ -1289,6 +1357,45 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" sets the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/ 
+	 *
+	 * @param string $user
+	 * @param string $file
+	 * @param string $type
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function updateSpaceSpecialSection(
+		string $user,
+		string $file,
+		string $type,
+		string $spaceName
+	): void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$spaceId = $space["id"];
+		$fileId = $this->getFileId($user, $spaceName, $file);
+
+		if ($type === "description") {
+			$type = "readme";
+		} else $type = "image";
+
+		$bodyData = ["special" => [["specialFolder" => ["name" => "$type"], "id" => "$fileId"]]];
+		$body = json_encode($bodyData, JSON_THROW_ON_ERROR);
+
+		$this->featureContext->setResponse(
+			$this->sendUpdateSpaceRequest(
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				$body,
+				$spaceId
+			)
+		);
+	}
+
+	/**
 	 * Send Graph Update Space Request
 	 *
 	 * @param  string $user
@@ -1334,6 +1441,36 @@ class SpacesContext implements Context {
 	): void {
 		$space = ["Name" => $spaceName, "driveType" => $spaceType, "quota" => ["total" => $quota]];
 		$body = json_encode($space);
+		$this->featureContext->setResponse(
+			$this->sendCreateSpaceRequest(
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				$body
+			)
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			201,
+			"Expected response status code should be 201 (Created)"
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" has created a space "([^"]*)" with the default quota using the GraphApi$/
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theUserHasCreatedASpaceByDefaultUsingTheGraphApi(
+		string $user,
+		string $spaceName
+	): void {
+		$space = ["Name" => $spaceName];
+		$body = json_encode($space, JSON_THROW_ON_ERROR);
 		$this->featureContext->setResponse(
 			$this->sendCreateSpaceRequest(
 				$user,


### PR DESCRIPTION
Created tests for method: 
PATCH `https://localhost:9200/graph/v1.0/drives/spaceId --data-raw '{"special":[{"specialFolder":{"name":"readme"},"id":"fileId"}]}'`

1. I create a readmi file or an image file in the .space folder
2. I add the file to a special section in space (using method PATCH)
3. I check that the files are added to the space response

<img width="522" alt="Screenshot 2022-03-08 at 23 37 04" src="https://user-images.githubusercontent.com/84779829/157337743-9da28cb1-69b2-4ae7-b9b4-3e2d5c9bc08e.png">
