### PR TITLE
Fix CreateHome for external users

### DIFF
--- a/storage/pkg/config/defaults/defaultconfig.go
+++ b/storage/pkg/config/defaults/defaultconfig.go
@@ -266,7 +266,7 @@ func DefaultConfig() *config.Config {
 				},
 				CommitShareToStorageGrant:  true,
 				CommitShareToStorageRef:    true,
-				DisableHomeCreationOnLogin: false,
+				DisableHomeCreationOnLogin: true,
 				ShareFolder:                "Shares",
 				LinkGrants:                 "",
 				HomeMapping:                "",


### PR DESCRIPTION
## Description

External users, when logging in for the first time, have no role
assigned and are unable to create their home because that requires the
create-space permission. This assigns users that don't have a role assigned
to the default user role and persists that assignment in the settings
service so that CreateHome can pick it up when checking permissions
later.

This also disables the auto creation of the user's home in the reva
auth provider (i.e. when using basic auth) as the role assignement has
not happenend at that point. So the home creation will now always happen
in the CreateHome middleware in the proxy.

## How Has This Been Tested?
- manually
- 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
