### PR TITLE
[tests-only]  ApiTest. added Spacemanager role to tests

### DIFF
--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -1,30 +1,114 @@
 @api @skipOnOcV10
 Feature: Change data of space
-  As a user with admin rights
+  As an user-owner of the space or an user who is a participant with the role of manager or editor
   I want to be able to change the data of a created space (increase the quota, change name, etc.)
+  
+  system role:
+  | admin        |
+  | Spacemanager |
+  | user         |
+
+  sharing role:
+  | manager |
+  | editor  |
+  | viewer  |
+
+  Cases:
+  | user                                       | change spaceName | change description | change quota | set readme file | set space image |
+  | owner with the SpaceManager role           |        v         |          v         |      v       |       v        |        v        |
+  | participant-user with manager role         |        v         |          v         |      v       |       v        |        v        |
+  | participant-user with editor role          |        x         |          x         |      x       |       v        |        v        |
+  | participant-user with viewer role          |        x         |          x         |      x       |       x        |        x        |
+  | participant-SpaceManager with manager role |        v         |          v         |      v       |       v        |        v        |
+  | participant-SpaceManager with editor role  |        x         |          x         |      x       |       v        |        v        |
+  | participant-SpaceManager with viewer role  |        x         |          x         |      x       |       x        |        x        |
 
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
 
   Background:
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Bob      |
+    And the administrator has given "Alice" the role "Spacemanager" using the settings api
+    And the administrator has given "Brian" the role "Spacemanager" using the settings api
 
-  Scenario: An admin user can change the name and description of a Space via the Graph API
+  
+  Scenario: an owner of space changes the name of a Space via the Graph API
     Given user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
     When user "Alice" changes the name of the "Project Jupiter" space to "Project Death Star"
-    And user "Alice" changes the description of the "Project Death Star" space to "The Death Star is a fictional mobile space station"
     Then the HTTP status code should be "200"
     When user "Alice" lists all available spaces via the GraphApi
     Then the json responded should contain a space "Project Death Star" with these key and value pairs:
       | key              | value                            |
       | driveType        | project                          |
       | name             | Project Death Star               |
-      | description      | The Death Star is a fictional mobile space station |
       | quota@@@total    | 20                               |
       | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
 
-  Scenario: An admin user can increase the quota of a Space via the Graph API
+
+  Scenario Outline: <participant> with <systemRole> role changes the name of a Space via the Graph API
+    Given user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
+    And user "Alice" has shared a space "Project Jupiter" to user "<participant>" with role "<sharingRole>"
+    When user "<participant>" changes the name of the "Project Jupiter" space to "new space name"
+    Then the HTTP status code should be "<statusCode>"
+    When user "<participant>" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "<resultingName>" with these key and value pairs:
+      | key              | value                            |
+      | name             | <resultingName>                  |
+      | quota@@@total    | 20                               |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+    Examples:
+      | participant  | systemRole   | sharingRole | resultingName   | statusCode |
+      | Brian        | Spacemanager | manager     | new space name  |    200     |
+      | Brian        | Spacemanager | editor      | Project Jupiter |    403     |
+      | Brian        | Spacemanager | viewer      | Project Jupiter |    403     |
+      | Bob          | user         | manager     | new space name  |    200     |
+      | Bob          | user         | editor      | Project Jupiter |    403     |
+      | Bob          | user         | viewer      | Project Jupiter |    403     |
+
+
+  Scenario: an owner of the space changes the description of a Space via the Graph API
+    Given user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
+    When user "Alice" changes the description of the "Project Jupiter" space to "The Death Star is a fictional mobile space station"
+    Then the HTTP status code should be "200"
+    When user "Alice" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "Project Jupiter" with these key and value pairs:
+      | key              | value                            |
+      | driveType        | project                          |
+      | name             | Project Jupiter                  |
+      | description      | The Death Star is a fictional mobile space station |
+      | quota@@@total    | 20                               |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+    
+
+  Scenario Outline: <participant> with <systemRole> role changes the description of a Space via the Graph API
+    Given user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
+    And user "Alice" has shared a space "Project Jupiter" to user "<participant>" with role "<sharingRole>"
+    And user "Alice" has changed the description of the "Project Jupiter" space to "subtitle"
+    When user "<participant>" changes the description of the "Project Jupiter" space to "new subtitle"
+    Then the HTTP status code should be "<statusCode>"
+    When user "<participant>" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "Project Jupiter" with these key and value pairs:
+      | key              | value                            |
+      | driveType        | project                          |
+      | name             | Project Jupiter                  |
+      | description      | <descriptionName>                |
+      | quota@@@total    | 20                               |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+    Examples:
+      | participant  | systemRole   | sharingRole | descriptionName | statusCode |
+      | Brian        | Spacemanager | manager     | new subtitle    |    200     |
+      | Brian        | Spacemanager | editor      | subtitle        |    403     |
+      | Brian        | Spacemanager | viewer      | subtitle        |    403     |
+      | Bob          | user         | manager     | new subtitle    |    200     | 
+      | Bob          | user         | editor      | subtitle        |    403     |
+      | Bob          | user         | viewer      | subtitle        |    403     |
+
+
+  Scenario: an owner of the space increases the quota of a Space via the Graph API
     Given user "Alice" has created a space "Project Earth" of type "project" with quota "20"
     When user "Alice" changes the quota of the "Project Earth" space to "100"
     Then the HTTP status code should be "200"
@@ -33,9 +117,29 @@ Feature: Change data of space
       | key              | value         |
       | name             | Project Earth |
       | quota@@@total    | 100           |
+  
+
+  Scenario Outline: <participant> with <systemRole> role increases the quota of a Space via the Graph API
+    Given user "Alice" has created a space "Project Earth" of type "project" with quota "20"
+    And user "Alice" has shared a space "Project Earth" to user "<participant>" with role "<sharingRole>"
+    When user "<participant>" changes the quota of the "Project Earth" space to "100"
+    Then the HTTP status code should be "<statusCode>"
+    When user "<participant>" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "Project Earth" with these key and value pairs:
+      | key              | value         |
+      | name             | Project Earth |
+      | quota@@@total    | <quotaTotal>  |
+    Examples:
+      | participant  | systemRole   | sharingRole | quotaTotal | statusCode |
+      | Brian        | Spacemanager | manager     |     100    |    200     |
+      | Brian        | Spacemanager | editor      |     20     |    403     |
+      | Brian        | Spacemanager | viewer      |     20     |    403     |
+      | Bob          | user         | manager     |     100    |    200     |
+      | Bob          | user         | editor      |     20     |    401     |
+      | Bob          | user         | viewer      |     20     |    401     |
 
 
-  Scenario: An user set readme file as description of the space via the Graph API
+  Scenario: an owner of the space set readme file as description of the space via the Graph API
     Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
     And user "Alice" has created a folder ".space" in space "add special section"
     And user "Alice" has uploaded a file inside space "add special section" with content "space description" to ".space/readme.md"
@@ -53,24 +157,102 @@ Feature: Change data of space
       | special@@@0@@@eTag                 | %eTag%              |
 
 
-  Scenario Outline: An user set image file as space image of the space via the Graph API
+  Scenario: an owner of the space adds new file and set as description of the space via the Graph API
     Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
     And user "Alice" has created a folder ".space" in space "add special section"
-    And user "Alice" has uploaded a file inside space "add special section" with content "" to "<fileName>"
-    When user "Alice" sets the file "<fileName>" as a space image in a special section of the "add special section" space
+    And user "Alice" has uploaded a file inside space "add special section" with content "space description" to ".space/readme.md"
+    And user "Alice" has set the file ".space/readme.md" as a description in a special section of the "add special section" space
+    When user "Alice" uploads a file inside space "add special section" with content "new space description" to ".space/newReadme.md" using the WebDAV API
+    And user "Alice" sets the file ".space/newReadme.md" as a description in a special section of the "add special section" space
     Then the HTTP status code should be "200"
     When user "Alice" lists all available spaces via the GraphApi
-    Then the json responded should contain a space "add special section" owned by "Alice" with description file "<fileName>" with these key and value pairs:
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/newReadme.md" with these key and value pairs:
       | key                                | value               |
       | name                               | add special section |
+      | special@@@0@@@size                 | 21                  |
+      | special@@@0@@@name                 | newReadme.md        |
+      | special@@@0@@@specialFolder@@@name | readme              |
+      | special@@@0@@@file@@@mimeType       | text/markdown       |
+      | special@@@0@@@id                   | %file_id%            |
+      | special@@@0@@@eTag                 | %eTag%              |
+
+
+  Scenario Outline: <participant> with <systemRole> set new readme file as description of the space via the Graph API
+    Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
+    And user "Alice" has shared a space "add special section" to user "<participant>" with role "<sharingRole>"
+    And user "Alice" has created a folder ".space" in space "add special section"
+    And user "Alice" has uploaded a file inside space "add special section" with content "space description" to ".space/readme.md"
+    And user "Alice" has set the file ".space/readme.md" as a description in a special section of the "add special section" space
+    When user "Alice" has uploaded a file inside space "add special section" with content "new space description" to ".space/newReadme.md"
+    And user "<participant>" sets the file ".space/newReadme.md" as a description in a special section of the "add special section" space
+    Then the HTTP status code should be "<statusCode>"
+    When user "<participant>" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/<fileName>" with these key and value pairs:
+      | key                                | value               |
+      | name                               | add special section |
+      | special@@@0@@@size                 | <fileSize>           |
+      | special@@@0@@@name                 | <fileName>           |
+      | special@@@0@@@specialFolder@@@name | readme              |
+      | special@@@0@@@file@@@mimeType       | text/markdown       |
+      | special@@@0@@@id                   | %file_id%            |
+      | special@@@0@@@eTag                 | %eTag%              |
+    Examples:
+      | participant  | systemRole   | sharingRole | fileName      | fileSize | statusCode |
+      | Brian        | Spacemanager | manager     | newReadme.md |    21   |     200    |
+      | Brian        | Spacemanager | editor      | newReadme.md |    21   |     200    |
+      | Brian        | Spacemanager | viewer      | readme.md    |    17   |     403    |
+      | Bob          | user         | manager     | newReadme.md |    21   |     200    |
+      | Bob          | user         | editor      | newReadme.md |    21   |     200    |
+      | Bob          | user         | viewer      | readme.md    |    17   |     403    |
+
+
+  Scenario Outline: owner set image file as space image of the space via the Graph API
+    Given user "Alice" has created a space "add space image" with the default quota using the GraphApi
+    And user "Alice" has created a folder ".space" in space "add space image"
+    And user "Alice" has uploaded a file inside space "add space image" with content "" to ".space/<fileName>"
+    When user "Alice" sets the file ".space/<fileName>" as a space image in a special section of the "add space image" space
+    Then the HTTP status code should be "200"
+    When user "Alice" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "add space image" owned by "Alice" with description file ".space/<fileName>" with these key and value pairs:
+      | key                                | value               |
+      | name                               | add space image     |
       | special@@@0@@@size                 | 0                   |
-      | special@@@0@@@name                 | <nameInResponse>    |
+      | special@@@0@@@name                 | <fileName>           |
       | special@@@0@@@specialFolder@@@name | image               |
       | special@@@0@@@file@@@mimeType       | <mimeType>          |
       | special@@@0@@@id                   | %file_id%            |
       | special@@@0@@@eTag                 | %eTag%              |
     Examples:
-      | fileName                | nameInResponse  | mimeType   |
-      | .space/spaceImage.jpeg | spaceImage.jpeg | image/jpeg |
-      | .space/spaceImage.png  | spaceImage.png  | image/png  |
-      | .space/spaceImage.gif  | spaceImage.gif  | image/gif  |
+      | fileName         | nameInResponse  | mimeType   |
+      | spaceImage.jpeg | spaceImage.jpeg | image/jpeg |
+      | spaceImage.png  | spaceImage.png  | image/png  |
+      | spaceImage.gif  | spaceImage.gif  | image/gif  |
+
+
+  Scenario Outline: <participant> with <systemRole> set image file as space image of the space via the Graph API
+    Given user "Alice" has created a space "add space image" with the default quota using the GraphApi
+    And user "Alice" has shared a space "add space image" to user "<participant>" with role "<sharingRole>"
+    And user "Alice" has created a folder ".space" in space "add space image"
+    And user "Alice" has uploaded a file inside space "add space image" with content "" to ".space/spaceImage.jpeg"
+    And user "Alice" has set the file ".space/spaceImage.jpeg" as a space image in a special section of the "add space image" space
+    And user "Alice" has uploaded a file inside space "add space image" with content "" to ".space/newImage.jpeg"
+    When user "<participant>" sets the file ".space/newImage.jpeg" as a space image in a special section of the "add space image" space
+    Then the HTTP status code should be "<statusCode>"
+    When user "<participant>" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "add space image" owned by "Alice" with description file ".space/<fileName>" with these key and value pairs:
+      | key                                | value               |
+      | name                               | add space image     |
+      | special@@@0@@@size                 | 0                   |
+      | special@@@0@@@name                 | <fileName>           |
+      | special@@@0@@@specialFolder@@@name | image               |
+      | special@@@0@@@file@@@mimeType       | image/jpeg          |
+      | special@@@0@@@id                   | %file_id%            |
+      | special@@@0@@@eTag                 | %eTag%              |
+    Examples:
+      | participant  | systemRole   | sharingRole | statusCode | fileName         |
+      | Brian        | Spacemanager | manager     |     200    | newImage.jpeg   |
+      | Brian        | Spacemanager | editor      |     200    | newImage.jpeg   |
+      | Brian        | Spacemanager | viewer      |     403    | spaceImage.jpeg | 
+      | Bob          | user         | manager     |     200    | newImage.jpeg   |
+      | Bob          | user         | editor      |     200    | newImage.jpeg   |
+      | Bob          | user         | viewer      |     403    | spaceImage.jpeg |

--- a/tests/acceptance/features/apiSpaces/createSpace.feature
+++ b/tests/acceptance/features/apiSpaces/createSpace.feature
@@ -1,0 +1,41 @@
+@api @skipOnOcV10
+Feature: Create spaces
+  As a user with space manager role
+  I want to be able to create project spaces
+
+  Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
+  See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And the administrator has given "Alice" the role "Spacemanager" using the settings api
+
+
+  Scenario: An user without spacemanager role cannot create a Space via Graph API
+    When user "Brian" creates a space "Project Mars" of type "project" with the default quota using the GraphApi
+    Then the HTTP status code should be "401"
+
+
+  Scenario: An user with spacemanager role can create a Space via the Graph API with default quota
+    When user "Alice" creates a space "Project Mars" of type "project" with the default quota using the GraphApi
+    Then the HTTP status code should be "201"
+    And the json responded should contain a space "Project Mars" with these key and value pairs:
+      | key              | value        |
+      | driveType        | project      |
+      | name             | Project Mars |
+      | quota@@@total    | 1000000000   |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+
+
+  Scenario: An user with spacemanager role user can create a Space via the Graph API with certain quota
+    When user "Alice" creates a space "Project Venus" of type "project" with quota "2000" using the GraphApi
+    Then the HTTP status code should be "201"
+    And the json responded should contain a space "Project Venus" with these key and value pairs:
+      | key              | value         |
+      | driveType        | project       |
+      | name             | Project Venus |
+      | quota@@@total    | 2000          |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -1,5 +1,5 @@
 @api @skipOnOcV10
-Feature: List and create spaces
+Feature: List spaces
   As a user
   I want to be able to work with personal and project spaces
 
@@ -8,6 +8,7 @@ Feature: List and create spaces
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
+
 
   Scenario: An ordinary user can request information about their Space via the Graph API
     When user "Alice" lists all available spaces via the GraphApi
@@ -26,6 +27,7 @@ Feature: List and create spaces
       | name             | Shares Jail |
       | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
 
+
   Scenario: An ordinary user can request information about their Space via the Graph API using a filter
     When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'personal'"
     Then the HTTP status code should be "200"
@@ -39,42 +41,19 @@ Feature: List and create spaces
     And the json responded should not contain a space with name "Shares Jail"
     And the json responded should only contain spaces of type "personal"
 
+
   Scenario: An ordinary user will not see any space when using a filter for project
     When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'project'"
     Then the HTTP status code should be "200"
     And the json responded should not contain a space with name "Alice Hansen"
     And the json responded should not contain spaces of type "personal"
 
+
   Scenario: An ordinary user can access their Space via the webDav API
     When user "Alice" lists all available spaces via the GraphApi
     And user "Alice" lists the content of the space with the name "Alice Hansen" using the WebDav Api
     Then the HTTP status code should be "207"
 
-  Scenario: An ordinary user cannot create a Space via Graph API
-    When user "Alice" creates a space "Project Mars" of type "project" with the default quota using the GraphApi
-    Then the HTTP status code should be "401"
-
-  Scenario: An admin user can create a Space via the Graph API with default quota
-    Given the administrator has given "Alice" the role "Admin" using the settings api
-    When user "Alice" creates a space "Project Mars" of type "project" with the default quota using the GraphApi
-    Then the HTTP status code should be "201"
-    And the json responded should contain a space "Project Mars" with these key and value pairs:
-      | key              | value        |
-      | driveType        | project      |
-      | name             | Project Mars |
-      | quota@@@total    | 1000000000   |
-      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
-
-  Scenario: An admin user can create a Space via the Graph API with certain quota
-    Given the administrator has given "Alice" the role "Admin" using the settings api
-    When user "Alice" creates a space "Project Venus" of type "project" with quota "2000" using the GraphApi
-    Then the HTTP status code should be "201"
-    And the json responded should contain a space "Project Venus" with these key and value pairs:
-      | key              | value         |
-      | driveType        | project       |
-      | name             | Project Venus |
-      | quota@@@total    | 2000          |
-      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
 
   Scenario: A user can list his personal space via multiple endpoints
     When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'personal'"
@@ -91,16 +70,10 @@ Feature: List and create spaces
       | name             | Alice Hansen  |
       | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
 
+
   Scenario: A user can list his created spaces via multiple endpoints
-    Given the administrator has given "Alice" the role "Admin" using the settings api
-    When user "Alice" creates a space "Project Venus" of type "project" with quota "2000" using the GraphApi
-    Then the HTTP status code should be "201"
-    And the json responded should contain a space "Project Venus" with these key and value pairs:
-      | key              | value         |
-      | driveType        | project       |
-      | name             | Project Venus |
-      | quota@@@total    | 2000          |
-      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+    Given the administrator has given "Alice" the role "Spacemanager" using the settings api
+    And user "Alice" has created a space "Project Venus" of type "project" with quota "2000"
     When user "Alice" looks up the single space "Project Venus" via the GraphApi by using its id
     Then the json responded should contain a space "Project Venus" with these key and value pairs:
       | key              | value         |

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -13,7 +13,7 @@ Feature: State of the quota
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has given "Alice" the role "Spacemanager" using the settings api
 
 
   Scenario Outline: Quota information is returned in the list of spaces returned via the Graph API

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1329,6 +1329,29 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" has changed the description of the "([^"]*)" space to "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 * @param string $newName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function userHasUpdatedSpaceDescription(
+		string $user,
+		string $spaceName,
+		string $newDescription
+	): void {
+		$this->updateSpaceDescription($user, $spaceName, $newDescription);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			200,
+			"Expected response status code should be 200"
+		);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" changes the quota of the "([^"]*)" space to "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1398,6 +1421,31 @@ class SpacesContext implements Context {
 				$body,
 				$spaceId
 			)
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" has set the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/
+	 *
+	 * @param string $user
+	 * @param string $file
+	 * @param string $type
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function userHasUpdatedSpaceSpecialSection(
+		string $user,
+		string $file,
+		string $type,
+		string $spaceName
+	): void {
+		$this->updateSpaceSpecialSection($user, $file, $type, $spaceName);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			200,
+			"Expected response status code should be 200"
 		);
 	}
 


### PR DESCRIPTION
Previously, we used the admin role to create/change space. Now we have the Spacemanager role so I have changed some tests:

- added "Spacemanager" role to quota.feature
- splited "listSpaces.feature" and added "Spacemanager" role
- added tests to "changeSpace.feature" 

@pmaier1 before I create bug issue can you please check my cases table in code https://github.com/owncloud/ocis/pull/3324/files#diff-d239f57f83ba953c9bd7a0b6dac99e90770247371ac612bf6a2c6640b3e430e0R16-R24. It describes the behavior I expect

for example: participant-user with editor role can increase quota - I think it's bug
