### PR TITLE
[tests-only] [full-ci] Bump core commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=2bd368c4c786e6c4bb079be91841d3766b039aab
+CORE_COMMITID=e921ceb2563a717459401385a1d20fc2a22c132f
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
This gets test code running from https://github.com/owncloud/core/pull/39887

Part of issue https://github.com/owncloud/QA/issues/731

CI passed - good, that means that I didn't introduce any test code regressions in core.