### PR TITLE
add password reset link to login page

### DIFF
--- a/changelog/unreleased/password-reset-link.md
+++ b/changelog/unreleased/password-reset-link.md
@@ -1,0 +1,7 @@
+Enhancement: Add password reset link to login page
+
+Added a configurable passwort reset link to the login page.
+It can be set via `IDP_PASSWORD_RESET_URI`. If the option is not set
+the link will not be shown.
+
+https://github.com/owncloud/ocis/pull/3329

--- a/idp/pkg/config/service.go
+++ b/idp/pkg/config/service.go
@@ -2,5 +2,6 @@ package config
 
 // Service defines the available service configuration.
 type Service struct {
-	Name string `ocisConfig:"-" yaml:"-"`
+	Name             string `ocisConfig:"-" yaml:"-"`
+	PasswordResetURI string `ocisConfig:"password_reset_uri" env:"IDP_PASSWORD_RESET_URI" desc:"The URI where a user can reset their password."`
 }

--- a/idp/pkg/service/v0/service.go
+++ b/idp/pkg/service/v0/service.go
@@ -214,6 +214,8 @@ func (idp IDP) Index() http.HandlerFunc {
 	nonce := rndm.GenerateRandomString(32)
 	indexHTML = bytes.Replace(indexHTML, []byte("__CSP_NONCE__"), []byte(nonce), 1)
 
+	indexHTML = bytes.Replace(indexHTML, []byte("__PASSWORD_RESET_LINK__"), []byte(idp.config.Service.PasswordResetURI), 1)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write(indexHTML); err != nil {

--- a/idp/ui/public/index.html
+++ b/idp/ui/public/index.html
@@ -13,6 +13,6 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    <main id="root" class="oc-login-bg" data-path-prefix="__PATH_PREFIX__"></main>
+    <main id="root" class="oc-login-bg" data-path-prefix="__PATH_PREFIX__" passwort-reset-link="__PASSWORD_RESET_LINK__"></main>
   </body>
 </html>

--- a/idp/ui/src/containers/Login/Login.js
+++ b/idp/ui/src/containers/Login/Login.js
@@ -9,6 +9,7 @@ import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import green from '@material-ui/core/colors/green';
 import Typography from '@material-ui/core/Typography';
+import Link from '@material-ui/core/Link';
 
 import TextInput from '../../components/TextInput'
 
@@ -55,7 +56,8 @@ class Login extends React.PureComponent {
   }
 
   render() {
-    const { loading, errors, classes, username } = this.props;
+    const { loading, errors, classes, username, passwordResetLink } = this.props;
+    const loginFailed = errors.http;
     const hasError = errors.http || errors.username || errors.password;
     const errorMessage = errors.http
       ? <ErrorMessage error={errors.http}></ErrorMessage>
@@ -109,6 +111,8 @@ class Login extends React.PureComponent {
               {hasError && <Typography id="oc-login-error-message" variant="subtitle2" component="span" color="error"
                                        className={classes.message}>{errorMessage}</Typography>}
               <div className={classes.wrapper}>
+                {loginFailed && passwordResetLink && <Link id="oc-login-password-reset" href={passwordResetLink} variant="subtitle2">{"Reset password?"}</Link>}
+                <br />
                 <Button
                     type="submit"
                     color="primary"
@@ -150,6 +154,7 @@ Login.propTypes = {
   loading: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
   password: PropTypes.string.isRequired,
+  passwordResetLink: PropTypes.string.isRequired,
   errors: PropTypes.object.isRequired,
   hello: PropTypes.object,
   query: PropTypes.object.isRequired,
@@ -160,7 +165,7 @@ Login.propTypes = {
 
 const mapStateToProps = (state) => {
   const { loading, username, password, errors} = state.login;
-  const { hello, query } = state.common;
+  const { hello, query, passwordResetLink } = state.common;
 
   return {
     loading,
@@ -168,7 +173,8 @@ const mapStateToProps = (state) => {
     password,
     errors,
     hello,
-    query
+    query,
+    passwordResetLink
   };
 };
 

--- a/idp/ui/src/reducers/common.js
+++ b/idp/ui/src/reducers/common.js
@@ -20,13 +20,24 @@ const defaultPathPrefix = (() => {
   return pathPrefix;
 })();
 
+const defaultPasswordResetLink = (() => {
+  const root = document.getElementById('root');
+  let link = root ? root.getAttribute('passwort-reset-link') : null;
+  if (!link || link === '__PASSWORD_RESET_LINK__') {
+    // Not replaced, probably we are running in debug mode or whatever. Use sane default.
+    link = '';
+  }
+  return link;
+})();
+
 const defaultState = {
   hello: null,
   error: null,
   flow: flow,
   query: query,
   updateAvailable: false,
-  pathPrefix: defaultPathPrefix
+  pathPrefix: defaultPathPrefix,
+  passwordResetLink: defaultPasswordResetLink
 };
 
 function commonReducer(state = defaultState, action) {


### PR DESCRIPTION
Added a configurable passwort reset link to the login page.
It can be set via `IDP_PASSWORD_RESET_URI`. If the option is not set, the link will not be shown.

It looks like this:
![image](https://user-images.githubusercontent.com/5579653/158601859-08ed1f8b-dae8-4c5c-9347-e5afd18374c1.png)
