### PR TITLE
rename space manager to space admin

### DIFF
--- a/docs/ocis/getting-started/demo-users.md
+++ b/docs/ocis/getting-started/demo-users.md
@@ -16,13 +16,13 @@ To skip the generation of demo users, run the inital setup step with an addition
 
 Following users are available in the demo set:
 
-| username  | password      | email                 | role                | groups                                                                  |
-| --------- | ------------- | --------------------- | ------------------- | ----------------------------------------------------------------------- |
-| admin     | admin         | admin@example.org     | admin               | users                                                                   |
-| einstein  | relativity    | einstein@example.org  | user                | users, philosophy-haters, physics-lovers, sailing-lovers, violin-haters |
-| marie     | radioactivity | marie@example.org     | user                | users, physics-lovers, polonium-lovers, radium-lovers                   |
-| moss      | vista         | moss@example.org      | admin               | users                                                                   |
-| richard   | superfluidity | richard@example.org   | user                | users, philosophy-haters, physics-lovers, quantum-lovers                |
-| katherine | gemini        | katherine@example.org | user, space-manager | users, sailing-lovers, physics-lovers, quantum-lovers                   |
+| username  | password      | email                 | role        | groups                                                                  |
+| --------- | ------------- | --------------------- | ----------- | ----------------------------------------------------------------------- |
+| admin     | admin         | admin@example.org     | admin       | users                                                                   |
+| einstein  | relativity    | einstein@example.org  | user        | users, philosophy-haters, physics-lovers, sailing-lovers, violin-haters |
+| marie     | radioactivity | marie@example.org     | user        | users, physics-lovers, polonium-lovers, radium-lovers                   |
+| moss      | vista         | moss@example.org      | admin       | users                                                                   |
+| richard   | superfluidity | richard@example.org   | user        | users, philosophy-haters, physics-lovers, quantum-lovers                |
+| katherine | gemini        | katherine@example.org | space admin | users, sailing-lovers, physics-lovers, quantum-lovers                   |
 
 You may also want to run oCIS with only your custom users by [deleting the demo users]({{< ref "../deployment#delete-demo-users" >}}).

--- a/settings/pkg/service/v0/settings.go
+++ b/settings/pkg/service/v0/settings.go
@@ -12,8 +12,8 @@ const (
 	// BundleUUIDRoleAdmin represents the admin role
 	BundleUUIDRoleAdmin = "71881883-1768-46bd-a24d-a356a2afdf7f"
 
-	// BundleUUIDRoleSpaceManager represents the space manager role
-	BundleUUIDRoleSpaceManager = "2aadd357-682c-406b-8874-293091995fdd"
+	// BundleUUIDRoleSpaceAdmin represents the space admin role
+	BundleUUIDRoleSpaceAdmin = "2aadd357-682c-406b-8874-293091995fdd"
 
 	// BundleUUIDRoleUser represents the user role.
 	BundleUUIDRoleUser = "d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11"
@@ -66,7 +66,7 @@ const (
 func generateBundlesDefaultRoles() []*settingsmsg.Bundle {
 	return []*settingsmsg.Bundle{
 		generateBundleAdminRole(),
-		generateBundleSpaceManagerRole(),
+		generateBundleSpaceAdminRole(),
 		generateBundleUserRole(),
 		generateBundleGuestRole(),
 		generateBundleProfileRequest(),
@@ -87,13 +87,13 @@ func generateBundleAdminRole() *settingsmsg.Bundle {
 	}
 }
 
-func generateBundleSpaceManagerRole() *settingsmsg.Bundle {
+func generateBundleSpaceAdminRole() *settingsmsg.Bundle {
 	return &settingsmsg.Bundle{
-		Id:          BundleUUIDRoleSpaceManager,
-		Name:        "spacemanager",
+		Id:          BundleUUIDRoleSpaceAdmin,
+		Name:        "spaceadmin",
 		Type:        settingsmsg.Bundle_TYPE_ROLE,
 		Extension:   "ocis-roles",
-		DisplayName: "Spacemanager",
+		DisplayName: "Space Admin",
 		Resource: &settingsmsg.Resource{
 			Type: settingsmsg.Resource_TYPE_SYSTEM,
 		},
@@ -442,7 +442,7 @@ func generatePermissionRequests() []*settingssvc.AddSettingToBundleRequest {
 			},
 		},
 		{
-			BundleId: BundleUUIDRoleSpaceManager,
+			BundleId: BundleUUIDRoleSpaceAdmin,
 			Setting: &settingsmsg.Setting{
 				Id:          CreateSpacePermissionID,
 				Name:        CreateSpacePermissionName,
@@ -460,7 +460,7 @@ func generatePermissionRequests() []*settingssvc.AddSettingToBundleRequest {
 			},
 		},
 		{
-			BundleId: BundleUUIDRoleSpaceManager,
+			BundleId: BundleUUIDRoleSpaceAdmin,
 			Setting: &settingsmsg.Setting{
 				Id:          SetSpaceQuotaPermissionID,
 				Name:        SetSpaceQuotaPermissionName,
@@ -478,7 +478,7 @@ func generatePermissionRequests() []*settingssvc.AddSettingToBundleRequest {
 			},
 		},
 		{
-			BundleId: BundleUUIDRoleSpaceManager,
+			BundleId: BundleUUIDRoleSpaceAdmin,
 			Setting: &settingsmsg.Setting{
 				Id:          ListAllSpacesPermissionID,
 				Name:        ListAllSpacesPermissionName,
@@ -496,7 +496,7 @@ func generatePermissionRequests() []*settingssvc.AddSettingToBundleRequest {
 			},
 		},
 		{
-			BundleId: BundleUUIDRoleSpaceManager,
+			BundleId: BundleUUIDRoleSpaceAdmin,
 			Setting: &settingsmsg.Setting{
 				Id:          "640e00d2-4df8-41bd-b1c2-9f30a01e0e99",
 				Name:        "language-readwrite",
@@ -514,7 +514,7 @@ func generatePermissionRequests() []*settingssvc.AddSettingToBundleRequest {
 			},
 		},
 		{
-			BundleId: BundleUUIDRoleSpaceManager,
+			BundleId: BundleUUIDRoleSpaceAdmin,
 			Setting: &settingsmsg.Setting{
 				Id:          SelfManagementPermissionID,
 				Name:        SelfManagementPermissionName,
@@ -581,17 +581,11 @@ func defaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
 		}, {
 			AccountUuid: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
 			RoleId:      BundleUUIDRoleUser,
-		}, {
-			AccountUuid: "932b4540-8d16-481e-8ef4-588e4b6b151c",
-			RoleId:      BundleUUIDRoleUser,
-		}, {
-			AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7",
-			RoleId:      BundleUUIDRoleUser,
 		},
-		// default users with role "spacemanager"
+		// default users with role "spaceadmin"
 		{
 			AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7",
-			RoleId:      BundleUUIDRoleSpaceManager,
+			RoleId:      BundleUUIDRoleSpaceAdmin,
 		},
 	}
 }

--- a/settings/pkg/store/defaults/defaults.go
+++ b/settings/pkg/store/defaults/defaults.go
@@ -8,6 +8,9 @@ const (
 	// BundleUUIDRoleAdmin represents the admin role
 	BundleUUIDRoleAdmin = "71881883-1768-46bd-a24d-a356a2afdf7f"
 
+	// BundleUUIDRoleSpaceAdmin represents the space admin role
+	BundleUUIDRoleSpaceAdmin = "2aadd357-682c-406b-8874-293091995fdd"
+
 	// BundleUUIDRoleUser represents the user role.
 	BundleUUIDRoleUser = "d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11"
 
@@ -66,6 +69,7 @@ func GenerateBundlesDefaultRoles() []*settingsmsg.Bundle {
 		generateBundleGuestRole(),
 		generateBundleProfileRequest(),
 		generateBundleMetadataRole(),
+		generateBundleSpaceAdminRole(),
 	}
 }
 
@@ -201,6 +205,112 @@ func generateBundleAdminRole() *settingsmsg.Bundle {
 					PermissionValue: &settingsmsg.Permission{
 						Operation:  settingsmsg.Permission_OPERATION_READ,
 						Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+		},
+	}
+}
+
+func generateBundleSpaceAdminRole() *settingsmsg.Bundle {
+	return &settingsmsg.Bundle{
+		Id:          BundleUUIDRoleSpaceAdmin,
+		Name:        "spaceadmin",
+		Type:        settingsmsg.Bundle_TYPE_ROLE,
+		Extension:   "ocis-roles",
+		DisplayName: "Space Admin",
+		Resource: &settingsmsg.Resource{
+			Type: settingsmsg.Resource_TYPE_SYSTEM,
+		},
+		Settings: []*settingsmsg.Setting{
+			{
+				Id:          SetSpaceQuotaPermissionID,
+				Name:        SetSpaceQuotaPermissionName,
+				DisplayName: "Set Space Quota",
+				Description: "This permission allows to manage space quotas.",
+				Resource: &settingsmsg.Resource{
+					Type: settingsmsg.Resource_TYPE_SYSTEM,
+				},
+				Value: &settingsmsg.Setting_PermissionValue{
+					PermissionValue: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+						Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+			{
+				Id:          CreateSpacePermissionID,
+				Name:        CreateSpacePermissionName,
+				DisplayName: "Create Space",
+				Description: "This permission allows to create new spaces.",
+				Resource: &settingsmsg.Resource{
+					Type: settingsmsg.Resource_TYPE_SYSTEM,
+				},
+				Value: &settingsmsg.Setting_PermissionValue{
+					PermissionValue: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+						Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+			{
+				Id:          ListAllSpacesPermissionID,
+				Name:        ListAllSpacesPermissionName,
+				DisplayName: "List All Spaces",
+				Description: "This permission allows list all spaces.",
+				Resource: &settingsmsg.Resource{
+					Type: settingsmsg.Resource_TYPE_SYSTEM,
+				},
+				Value: &settingsmsg.Setting_PermissionValue{
+					PermissionValue: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_READ,
+						Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+			{
+				Id:          "640e00d2-4df8-41bd-b1c2-9f30a01e0e99",
+				Name:        "language-readwrite",
+				DisplayName: "Permission to read and set the language (self)",
+				Resource: &settingsmsg.Resource{
+					Type: settingsmsg.Resource_TYPE_SETTING,
+					Id:   settingUUIDProfileLanguage,
+				},
+				Value: &settingsmsg.Setting_PermissionValue{
+					PermissionValue: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+						Constraint: settingsmsg.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+			{
+				Id:          SelfManagementPermissionID,
+				Name:        SelfManagementPermissionName,
+				DisplayName: "Self Management",
+				Description: "This permission gives access to self management.",
+				Resource: &settingsmsg.Resource{
+					Type: settingsmsg.Resource_TYPE_USER,
+					Id:   "me",
+				},
+				Value: &settingsmsg.Setting_PermissionValue{
+					PermissionValue: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+						Constraint: settingsmsg.Permission_CONSTRAINT_OWN,
+					},
+				},
+			},
+			{
+				Id:          CreateSpacePermissionID,
+				Name:        CreateSpacePermissionName,
+				DisplayName: "Create own Space",
+				Description: "This permission allows to create a space owned by the current user.",
+				Resource: &settingsmsg.Resource{
+					Type: settingsmsg.Resource_TYPE_SYSTEM, // TODO resource type space? self? me? own?
+				},
+				Value: &settingsmsg.Setting_PermissionValue{
+					PermissionValue: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_CREATE,
+						Constraint: settingsmsg.Permission_CONSTRAINT_OWN,
 					},
 				},
 			},
@@ -451,6 +561,11 @@ func DefaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
 		}, {
 			AccountUuid: "932b4540-8d16-481e-8ef4-588e4b6b151c",
 			RoleId:      BundleUUIDRoleUser,
+		},
+		// default users with role "spaceadmin"
+		{
+			AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7",
+			RoleId:      BundleUUIDRoleSpaceAdmin,
 		},
 	}
 }


### PR DESCRIPTION
## Description
The global "Space Manager" role is now called "Space Admin" to be different from the per space "Space Manager"
