### PR TITLE
[tests-only] ApiTests: sharing subItems inside of space

### DIFF
--- a/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature
@@ -1,13 +1,13 @@
 @api @skipOnOcV10
 Feature: Share a file or folder that is inside a space
-  As an user with manager space role
-  I want to be able to share the data inside the space
+      As an user with manager space role
+      I want to be able to share the data inside the space
 
-  | role        | permissions |
-  | viewer      |      1      |
-  | uploader    |      4      |
-  | contributor |      5      |
-  | editor      |     15      |
+      | role        | permissions |
+      | viewer      | 1           |
+      | uploader    | 4           |
+      | contributor | 5           |
+      | editor      | 15          |
 
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
@@ -24,70 +24,69 @@ Feature: Share a file or folder that is inside a space
     And user "Alice" has uploaded a file inside space "share sub-item" with content "some content" to "folder/file.txt"
 
 
-  Scenario Outline: An user-owner can share an entrity inside project space to another user with role:
-    When user "Alice" shares the following entity "<entity>" inside of space "share sub-item" with user "Brian" with role "<role>"
+  Scenario Outline: An user-owner can share a folder inside project space to another user with role:
+    When user "Alice" shares the following entity "folder" inside of space "share sub-item" with user "Brian" with role "<role>"
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the OCS status message should be "OK"
+    And user "Brian" accepts share "/folder" offered by user "Alice" using the sharing API
+    And as "Brian" folder "Shares/folder" should exist
     Examples:
-      | entity         | role       | statusCode |
-      | folder         | viewer     |    200     |
-      | folder         | editor     |    200     |
-      | folder/file.txt | viewer     |    200     |
-      | folder/file.txt | editor     |    200     |
-     
+      | role   |
+      | viewer |
+      | editor |
 
-  Scenario Outline: An user participant of the project space tries to share an entity to another user
+
+  Scenario Outline: An user-owner can share a file inside project space to another user with role:
+    When user "Alice" shares the following entity "folder/file.txt" inside of space "share sub-item" with user "Brian" with role "<role>"
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    And user "Brian" accepts share "/file.txt" offered by user "Alice" using the sharing API
+    Then as "Brian" file "Shares/file.txt" should exist
+    Examples:
+      | role   |
+      | viewer |
+      | editor |
+
+
+  Scenario Outline: An user participant of the project space with manager role can share a folder to another user
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "manager"
+    When user "Brian" shares the following entity "folder" inside of space "share sub-item" with user "Bob" with role "<role>"
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    And user "Bob" accepts share "/folder" offered by user "Brian" using the sharing API
+    And as "Bob" folder "Shares/folder" should exist
+    Examples:
+      | role   |
+      | viewer |
+      | editor |
+
+
+  Scenario Outline: An user participant of the project space with manager role can share a file to another user
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "manager"
+    When user "Brian" shares the following entity "folder/file.txt" inside of space "share sub-item" with user "Bob" with role "<role>"
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    And user "Bob" accepts share "/file.txt" offered by user "Brian" using the sharing API
+    Then as "Bob" file "Shares/file.txt" should exist
+    Examples:
+      | role   |
+      | viewer |
+      | editor |
+
+
+  Scenario Outline: An user participant of the project space without space manager role cannot share an entity to another user
     Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
     When user "Brian" shares the following entity "<entity>" inside of space "share sub-item" with user "Bob" with role "editor"
     Then the HTTP status code should be "<statusCode>"
     And the OCS status code should be "<statusCode>"
+    And the OCS status message should be "<statusMessage>"
     Examples:
-      | entity         | spaceRole  | statusCode |
-      | folder         | manager    |    200     |
-      | folder/file.txt | manager    |    200     |
-      | folder         | editor     |    404     |
-      | folder/file.txt | editor     |    404     |
-      | folder/file.txt | viewer     |    404     |
-      | folder         | viewer     |    404     |
-
-
-  Scenario Outline: An user-owner can share an entrity inside project space via public link
-    When user "Alice" creates a public link share inside of space "share sub-item" with settings:
-      | path        | <entity>                 |
-      | shareType   |     3                    |
-      | permissions | <permissions>            |
-      | password    | <password>               |
-      | name        | <name>                   |
-      | expireDate  | 2042-03-25T23:59:59+0100 |
-    Then the HTTP status code should be "200"
-    And the OCS status code should be "200"
-    Examples:
-      | entity         | permissions | password | name | expireDate               |
-      | folder         |      1      |    123   | link | 2042-03-25T23:59:59+0100 |
-      | folder         |      4      |          |      |                          |
-      | folder         |      5      |    200   |      | 2042-03-25T23:59:59+0100 |
-      | folder         |      15     |          | link |                          |
-      | folder/file.txt |      1      |    123   | link | 2042-03-25T23:59:59+0100 |
-      
-  
-  Scenario Outline: An user participant of the project space tries to share an entrity inside project space via public link
-    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
-    When user "Brian" creates a public link share inside of space "share sub-item" with settings:
-      | path        |  <entity>                |
-      | shareType   | 3                        |
-      | permissions | 1                        |
-      | password    | 123                      |
-      | name        | public link              |
-      | expireDate  | 2042-03-25T23:59:59+0100 |
-    Then the HTTP status code should be "<statusCode>"
-    And the OCS status code should be "<statusCode>"
-    Examples:
-      | entity         | spaceRole | statusCode |
-      | folder         | manager   |    200     |
-      | folder         | editor    |    404     |
-      | folder         | viewer    |    404     |
-      | folder/file.txt | manager   |    200     |
-      | folder/file.txt | editor    |    404     |
-      | folder/file.txt | viewer    |    404     |
-      
+      | entity          | spaceRole | statusCode | statusMessage       |
+      | folder          | editor    | 404        | No share permission |
+      | folder/file.txt | editor    | 404        | No share permission |
+      | folder/file.txt | viewer    | 404        | No share permission |
+      | folder          | viewer    | 404        | No share permission |

--- a/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature
@@ -1,0 +1,93 @@
+@api @skipOnOcV10
+Feature: Share a file or folder that is inside a space
+  As an user with manager space role
+  I want to be able to share the data inside the space
+
+  | role        | permissions |
+  | viewer      |      1      |
+  | uploader    |      4      |
+  | contributor |      5      |
+  | editor      |     15      |
+
+  Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
+  See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Bob      |
+    And the administrator has given "Alice" the role "Admin" using the settings api
+    And user "Alice" has created a space "share sub-item" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder" in space "share sub-item"
+    And user "Alice" has uploaded a file inside space "share sub-item" with content "some content" to "folder/file.txt"
+
+
+  Scenario Outline: An user-owner can share an entrity inside project space to another user with role:
+    When user "Alice" shares the following entity "<entity>" inside of space "share sub-item" with user "Brian" with role "<role>"
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    Examples:
+      | entity         | role       | statusCode |
+      | folder         | viewer     |    200     |
+      | folder         | editor     |    200     |
+      | folder/file.txt | viewer     |    200     |
+      | folder/file.txt | editor     |    200     |
+     
+
+  Scenario Outline: An user participant of the project space tries to share an entity to another user
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
+    When user "Brian" shares the following entity "<entity>" inside of space "share sub-item" with user "Bob" with role "editor"
+    Then the HTTP status code should be "<statusCode>"
+    And the OCS status code should be "<statusCode>"
+    Examples:
+      | entity         | spaceRole  | statusCode |
+      | folder         | manager    |    200     |
+      | folder/file.txt | manager    |    200     |
+      | folder         | editor     |    404     |
+      | folder/file.txt | editor     |    404     |
+      | folder/file.txt | viewer     |    404     |
+      | folder         | viewer     |    404     |
+
+
+  Scenario Outline: An user-owner can share an entrity inside project space via public link
+    When user "Alice" creates a public link share inside of space "share sub-item" with settings:
+      | path        | <entity>                 |
+      | shareType   |     3                    |
+      | permissions | <permissions>            |
+      | password    | <password>               |
+      | name        | <name>                   |
+      | expireDate  | 2042-03-25T23:59:59+0100 |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    Examples:
+      | entity         | permissions | password | name | expireDate               |
+      | folder         |      1      |    123   | link | 2042-03-25T23:59:59+0100 |
+      | folder         |      4      |          |      |                          |
+      | folder         |      5      |    200   |      | 2042-03-25T23:59:59+0100 |
+      | folder         |      15     |          | link |                          |
+      | folder/file.txt |      1      |    123   | link | 2042-03-25T23:59:59+0100 |
+      
+  
+  Scenario Outline: An user participant of the project space tries to share an entrity inside project space via public link
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
+    When user "Brian" creates a public link share inside of space "share sub-item" with settings:
+      | path        |  <entity>                |
+      | shareType   | 3                        |
+      | permissions | 1                        |
+      | password    | 123                      |
+      | name        | public link              |
+      | expireDate  | 2042-03-25T23:59:59+0100 |
+    Then the HTTP status code should be "<statusCode>"
+    And the OCS status code should be "<statusCode>"
+    Examples:
+      | entity         | spaceRole | statusCode |
+      | folder         | manager   |    200     |
+      | folder         | editor    |    404     |
+      | folder         | viewer    |    404     |
+      | folder/file.txt | manager   |    200     |
+      | folder/file.txt | editor    |    404     |
+      | folder/file.txt | viewer    |    404     |
+      

--- a/tests/acceptance/features/apiSpaces/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpaces/shareSubItemOfSpaceViaPublicLink.feature
@@ -1,0 +1,86 @@
+@api @skipOnOcV10
+Feature: Share a file or folder that is inside a space via public link
+      As an user with manager space role
+      I want to be able to share the data inside the space via public link
+
+      | role        | permissions |
+      | viewer      | 1           |
+      | uploader    | 4           |
+      | contributor | 5           |
+      | editor      | 15          |
+
+  Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
+  See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Bob      |
+    And the administrator has given "Alice" the role "Admin" using the settings api
+    And user "Alice" has created a space "share sub-item" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder" in space "share sub-item"
+    And user "Alice" has uploaded a file inside space "share sub-item" with content "some content" to "folder/file.txt"
+
+
+  Scenario Outline: An user-owner can share an entrity inside project space via public link
+    When user "Alice" creates a public link share inside of space "share sub-item" with settings:
+      | path        | <entity>      |
+      | shareType   | 3             |
+      | permissions | <permissions> |
+      | password    | <password>    |
+      | name        | <name>        |
+      | expireDate  | <expireDate>  |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    And the fields of the last response to user "Alice" should include
+      | path | /<entity> |
+    Examples:
+      | entity          | permissions | password | name | expireDate               |
+      | folder          | 1           | 123      | link | 2042-03-25T23:59:59+0100 |
+      | folder          | 4           |          |      |                          |
+      | folder          | 5           | 200      |      | 2042-03-25T23:59:59+0100 |
+      | folder          | 15          |          | link |                          |
+      | folder/file.txt | 1           | 123      | link | 2042-03-25T23:59:59+0100 |
+
+
+  Scenario Outline: An user participant of the project space with space manager role can share an entrity inside project space via public link
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "manager"
+    When user "Brian" creates a public link share inside of space "share sub-item" with settings:
+      | path        | <entity>                 |
+      | shareType   | 3                        |
+      | permissions | 1                        |
+      | password    | 123                      |
+      | name        | public link              |
+      | expireDate  | 2042-03-25T23:59:59+0100 |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    And the fields of the last response to user "Alice" should include
+      | path | /<entity> |
+    Examples:
+      | entity          |
+      | folder          |
+      | folder/file.txt |
+
+
+  Scenario Outline: An user participant of the project space without space manager role cannot share an entrity inside project space via public link
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
+    When user "Brian" creates a public link share inside of space "share sub-item" with settings:
+      | path        | <entity>                 |
+      | shareType   | 3                        |
+      | permissions | 1                        |
+      | password    | 123                      |
+      | name        | public link              |
+      | expireDate  | 2042-03-25T23:59:59+0100 |
+    Then the HTTP status code should be "404"
+    And the OCS status code should be "404"
+    And the OCS status message should be "No share permission"
+    Examples:
+      | entity          | spaceRole |
+      | folder          | editor    |
+      | folder          | viewer    |
+      | folder/file.txt | editor    |
+      | folder/file.txt | viewer    |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1566,6 +1566,95 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" shares the following entity "([^"]*)" inside of space "([^"]*)" with user "([^"]*)" with role "([^"]*)"$/
+	 *
+	 * @param  string $user
+	 * @param  string $entity
+	 * @param  string $spaceName
+	 * @param  string $userRecipient
+	 * @param  string $role
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function sendShareEntityInsideOfSpaceRequest(
+		string $user,
+		string $entity,
+		string $spaceName,
+		string $userRecipient,
+		string $role
+	): void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$body = [
+			"space_ref" => $space['id'] . "/" . $entity,
+			"shareType" => 0,
+			"shareWith" => $userRecipient,
+			"role" => $role
+		];
+
+		$fullUrl = $this->baseUrl . "/ocs/v2.php/apps/files_sharing/api/v1/shares";
+
+		$this->featureContext->setResponse(
+			HttpRequestHelper::post(
+				$fullUrl,
+				"",
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				[],
+				$body
+			)
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" creates a public link share inside of space "([^"]*)" with settings:$/
+	 *
+	 * @param  string $user
+	 * @param  string $spaceName
+	 * @param TableNode|null $table
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function createPublicLinkToEntityInsideOfSpaceRequest(
+		string $user,
+		string $spaceName,
+		?TableNode $table
+	): void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$rows = $table->getRowsHash();
+
+		$rows["path"] = \array_key_exists("path", $rows) ? $rows["path"] : null;
+		$rows["shareType"] = \array_key_exists("shareType", $rows) ? $rows["shareType"] : null;
+		$rows["permissions"] = \array_key_exists("permissions", $rows) ? $rows["permissions"] : null;
+		$rows["password"] = \array_key_exists("password", $rows) ? $rows["password"] : null;
+		$rows["name"] = \array_key_exists("name", $rows) ? $rows["name"] : null;
+		$rows["expireDate"] = \array_key_exists("expireDate", $rows) ? $rows["expireDate"] : null;
+		
+		$body = [
+			"space_ref" => $space['id'] . "/" . $rows["path"],
+			"shareType" => $rows["shareType"],
+			"permissions" => $rows["permissions"],
+			"password" => $rows["password"],
+			"name" => $rows["name"],
+			"expireDate" => $rows["expireDate"]
+		];
+
+		$fullUrl = $this->baseUrl . "/ocs/v2.php/apps/files_sharing/api/v1/shares";
+
+		$this->featureContext->setResponse(
+			HttpRequestHelper::post(
+				$fullUrl,
+				"",
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				[],
+				$body
+			)
+		);
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has shared a space "([^"]*)" to user "([^"]*)" with role "([^"]*)"$/
 	 *
 	 * @param  string $user

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -57,6 +57,11 @@ class SpacesContext implements Context {
 	private array $createdSpaces;
 
 	/**
+	 * @var string
+	 */
+	private $ocsApiUrl = '/ocs/v2.php/apps/files_sharing/api/v1/shares';
+
+	/**
 	 * @param string $spaceName
 	 *
 	 * @return string name of the user that created the space
@@ -1551,7 +1556,7 @@ class SpacesContext implements Context {
 			"role" => $role // role overrides the permissions parameter
 		];
 
-		$fullUrl = $this->baseUrl . "/ocs/v2.php/apps/files_sharing/api/v1/shares";
+		$fullUrl = $this->baseUrl . $this->ocsApiUrl;
 
 		$this->featureContext->setResponse(
 			HttpRequestHelper::post(
@@ -1592,7 +1597,7 @@ class SpacesContext implements Context {
 			"role" => $role
 		];
 
-		$fullUrl = $this->baseUrl . "/ocs/v2.php/apps/files_sharing/api/v1/shares";
+		$fullUrl = $this->baseUrl . $this->ocsApiUrl;
 
 		$this->featureContext->setResponse(
 			HttpRequestHelper::post(
@@ -1640,7 +1645,7 @@ class SpacesContext implements Context {
 			"expireDate" => $rows["expireDate"]
 		];
 
-		$fullUrl = $this->baseUrl . "/ocs/v2.php/apps/files_sharing/api/v1/shares";
+		$fullUrl = $this->baseUrl . $this->ocsApiUrl;
 
 		$this->featureContext->setResponse(
 			HttpRequestHelper::post(
@@ -1698,7 +1703,7 @@ class SpacesContext implements Context {
 		string $userRecipient
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
-		$fullUrl = $this->baseUrl . "/ocs/v2.php/apps/files_sharing/api/v1/shares/" . $space['id'] . "?shareWith=" . $userRecipient;
+		$fullUrl = $this->baseUrl . $this->ocsApiUrl . "/" . $space['id'] . "?shareWith=" . $userRecipient;
 
 		$this->featureContext->setResponse(
 			HttpRequestHelper::delete(


### PR DESCRIPTION
added tests sharing subItems inside of the space:
- via sharing
- via public link

Only users with the **manager space role** can be able to share resources within the space
Users with editor and viewer space role cannot be able to share resources within the space. 
They get 404 Error with "No share permission" message. for client would certainly be better to get 403. 
code here:
https://github.com/cs3org/reva/blob/9e040c93d60ec5faf6c8b0347ce9ecf8d6c6ab70/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go#L192-L196