### PR TITLE
Fix error handling in GetUsers

### DIFF
--- a/changelog/unreleased/graph-getusers-err.md
+++ b/changelog/unreleased/graph-getusers-err.md
@@ -1,0 +1,6 @@
+Bugfix: Fix error handling in GraphAPI GetUsers call
+
+A missing return statement caused GetUsers to return misleading results when
+the identity backend returned an error.
+
+https://github.com/owncloud/ocis/pull/3357

--- a/graph/pkg/service/v0/users.go
+++ b/graph/pkg/service/v0/users.go
@@ -46,6 +46,7 @@ func (g Graph) GetUsers(w http.ResponseWriter, r *http.Request) {
 		} else {
 			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		}
+		return
 	}
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, &listResponse{Value: users})


### PR DESCRIPTION
A missing return statement caused GetUsers to return missleading results
when the identity backend returned an error.