### PR TITLE
[tests-only] [full-ci] Bump CORE_COMMITID

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=e921ceb2563a717459401385a1d20fc2a22c132f
+CORE_COMMITID=5b738dfa70b5493cb305123ad1d1a2c3055863c0
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
## Description
Includes latest test code for API tests.

In particular PR https://github.com/owncloud/core/pull/39893 which added some extra options for LDAP-based testing. So this commit-id bump will confirm that the existing tests still work the same in oCIS.

## Related Issue
https://github.com/owncloud/QA/issues/735

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
