### PR TITLE
[full-ci] Fix image name for deploy pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1753,7 +1753,7 @@ def deploy(ctx, config, rebuild):
             },
             {
                 "name": "deploy",
-                "image": SELENIUM_STANDALONE_CHROME_DEBUG,
+                "image": OC_CI_DRONE_ANSIBLE,
                 "failure": "ignore",
                 "environment": {
                     "CONTINUOUS_DEPLOY_SERVERS_CONFIG": "../%s" % (config),


### PR DESCRIPTION
## Description
PR https://github.com/owncloud/ocis/pull/3347 has mistakenly used `selenium` docker image for `deploy` pipeline.
This fixes the image name

## Related Issue
Failing CI pipelines

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
