### PR TITLE
improve quota handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,3 +275,5 @@ require (
 
 // we need to use a fork to make the windows build pass
 replace github.com/pkg/xattr => github.com/micbar/xattr v0.4.6-0.20220215112335-88e74d648fb7
+
+replace github.com/cs3org/reva/v2 => github.com/c0rby/reva/v2 v2.0.0-20220323083042-7816427c9126

--- a/go.mod
+++ b/go.mod
@@ -276,4 +276,4 @@ require (
 // we need to use a fork to make the windows build pass
 replace github.com/pkg/xattr => github.com/micbar/xattr v0.4.6-0.20220215112335-88e74d648fb7
 
-replace github.com/cs3org/reva/v2 => github.com/c0rby/reva/v2 v2.0.0-20220323083042-7816427c9126
+replace github.com/cs3org/reva/v2 => github.com/c0rby/reva/v2 v2.0.0-20220323142736-9bae5440c0c2

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBW
 github.com/boombuler/barcode v1.0.1 h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
+github.com/c0rby/reva/v2 v2.0.0-20220323083042-7816427c9126 h1:NFbMNgd44MMocvUq23X/8MpNDzwIoN34/T0EARaozGU=
+github.com/c0rby/reva/v2 v2.0.0-20220323083042-7816427c9126/go.mod h1:XNtK1HEClNzmz5vyQa2DUw4KH3oqBjQoEsV1LhAGlV0=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -335,8 +337,6 @@ github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD9
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20220126114148-64c025ccdd19 h1:1jqPH58jCxvbaJ9WLIJ7W2/m622bWS6ChptzljSG6IQ=
 github.com/cs3org/go-cs3apis v0.0.0-20220126114148-64c025ccdd19/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva/v2 v2.0.0-20220321093112-25cedab9f739 h1:GD8ZoMqRKclM0dP5hjSMXals9vRWHPH2hOeBruCuQlg=
-github.com/cs3org/reva/v2 v2.0.0-20220321093112-25cedab9f739/go.mod h1:XNtK1HEClNzmz5vyQa2DUw4KH3oqBjQoEsV1LhAGlV0=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBW
 github.com/boombuler/barcode v1.0.1 h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
-github.com/c0rby/reva/v2 v2.0.0-20220323083042-7816427c9126 h1:NFbMNgd44MMocvUq23X/8MpNDzwIoN34/T0EARaozGU=
-github.com/c0rby/reva/v2 v2.0.0-20220323083042-7816427c9126/go.mod h1:XNtK1HEClNzmz5vyQa2DUw4KH3oqBjQoEsV1LhAGlV0=
+github.com/c0rby/reva/v2 v2.0.0-20220323142736-9bae5440c0c2 h1:A0mQD68G9KudTbegyH1rKqrAlf3VpFe0dGJ1mXIpexw=
+github.com/c0rby/reva/v2 v2.0.0-20220323142736-9bae5440c0c2/go.mod h1:XNtK1HEClNzmz5vyQa2DUw4KH3oqBjQoEsV1LhAGlV0=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=

--- a/graph/pkg/service/v0/drives.go
+++ b/graph/pkg/service/v0/drives.go
@@ -601,7 +601,7 @@ func (g Graph) getDriveQuota(ctx context.Context, space *storageprovider.Storage
 	}
 
 	var t int64
-	if total != 0 || (total == 0 && remaining == 0) {
+	if total != 0 {
 		// A quota was set
 		qta.Total = &total
 		t = total

--- a/graph/pkg/service/v0/drives.go
+++ b/graph/pkg/service/v0/drives.go
@@ -584,16 +584,33 @@ func (g Graph) getDriveQuota(ctx context.Context, space *storageprovider.Storage
 		return nil, err
 	}
 
+	var remaining int64
+	if res.Opaque != nil {
+		m := res.Opaque.Map
+		if e, ok := m["remaining"]; ok {
+			remaining, _ = strconv.ParseInt(string(e.Value), 10, 64)
+		}
+	}
+
 	total := int64(res.TotalBytes)
 
 	used := int64(res.UsedBytes)
-	remaining := total - used
 	qta := libregraph.Quota{
 		Remaining: &remaining,
-		Total:     &total,
 		Used:      &used,
 	}
-	state := calculateQuotaState(total, used)
+
+	var t int64
+	if total != 0 || (total == 0 && remaining == 0) {
+		// A quota was set
+		qta.Total = &total
+		t = total
+	} else {
+		// Quota was not set
+		// Use remaining bytes to calculate state
+		t = remaining
+	}
+	state := calculateQuotaState(t, used)
 	qta.State = &state
 
 	return &qta, nil


### PR DESCRIPTION
`Total` is now only the specified quota. If no quota was set then total will be omitted.
`Remaining` is either:
* The available disk space if no quota was set or if the disk space is smaller than `Total`
* `Total - Used` if quota was set

If 0 is set as quota value then this is seen as "unlimited", `Total` will be omitted from the response.
This way the quota can be unrestricted again.