### PR TITLE
Add service user for settings service

### DIFF
--- a/idm/ldif/base.ldif.tmpl
+++ b/idm/ldif/base.ldif.tmpl
@@ -22,3 +22,18 @@ uid: {{ .Name }}
 userPassword:: {{ .Password }}
 
 {{ end -}}
+
+## Service user for the settings service
+dn: uid=95cb8724-03b2-11eb-a0a6-c33ef8ef53ad,ou=users,o=libregraph-idm
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: ownCloud
+objectClass: person
+objectClass: top
+uid: 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad
+givenName: 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad
+sn: 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad
+cn: 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad
+displayName: 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad
+ownCloudUUID: 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad
+


### PR DESCRIPTION
## Description

This is a quick workaround to make the settings service work with idm after b7c934b1b1. We need to to provide a better 
solution for service users like that (they shouldn't need to be present in ldap)

## Related Issue
See: https://github.com/owncloud/ocis/issues/3343
