### PR TITLE
[tests-only] Bump core commit id to include cofre PR 39914

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=8fc353d79e7c0de1e137220c2422efcfe2ac5b89
+CORE_COMMITID=87d2f9a69a11838b9b591a09da4d13f860dd4a31
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
## Description
Gets test changes from https://github.com/owncloud/core/pull/39914 running in oCIS CI.

## Related Issue
https://github.com/owncloud/QA/issues/735

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
