### PR TITLE
graph: Allow PATCH on user without 'mail' in body

### DIFF
--- a/changelog/unreleased/graph-patch-mail.md
+++ b/changelog/unreleased/graph-patch-mail.md
@@ -1,0 +1,6 @@
+Bugfix: Fix request validation on GraphAPI User updates
+
+Fix PATCH on graph/v1.0/users when no 'mail' attribute
+is present in the request body
+
+https://github.com/owncloud/ocis/issues/3167

--- a/graph/pkg/service/v0/users.go
+++ b/graph/pkg/service/v0/users.go
@@ -180,11 +180,12 @@ func (g Graph) PatchUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mail := changes.GetMail()
-	if !isValidEmail(mail) {
-		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
-			fmt.Sprintf("'%s' is not a valid email address", mail))
-		return
+	if mail, ok := changes.GetMailOk(); ok {
+		if !isValidEmail(*mail) {
+			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
+				fmt.Sprintf("'%s' is not a valid email address", *mail))
+			return
+		}
 	}
 
 	u, err := g.identityBackend.UpdateUser(r.Context(), nameOrID, *changes)


### PR DESCRIPTION
## Description
Skip the mail validator if 'mail' attribute is not present in the request.

## Related Issue
See https://github.com/owncloud/ocis/issues/3167#issuecomment-1076296242

## How Has This Been Tested?
- manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
