### PR TITLE
[tests-only] apiTests: getting readmi file and spaceImage file

### DIFF
--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -17,12 +17,12 @@ Feature: Change data of space
     Then the HTTP status code should be "200"
     When user "Alice" lists all available spaces via the GraphApi
     Then the json responded should contain a space "Project Death Star" with these key and value pairs:
-      | key              | value                            |
-      | driveType        | project                          |
-      | name             | Project Death Star               |
+      | key              | value                                              |
+      | driveType        | project                                            |
+      | name             | Project Death Star                                 |
       | description      | The Death Star is a fictional mobile space station |
-      | quota@@@total    | 20                               |
-      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id% |
+      | quota@@@total    | 20                                                 |
+      | root@@@webDavUrl | %base_url%/dav/spaces/%space_id%                   |
 
   Scenario: An admin user can increase the quota of a Space via the Graph API
     Given user "Alice" has created a space "Project Earth" of type "project" with quota "20"
@@ -30,9 +30,9 @@ Feature: Change data of space
     Then the HTTP status code should be "200"
     When user "Alice" lists all available spaces via the GraphApi
     Then the json responded should contain a space "Project Earth" with these key and value pairs:
-      | key              | value         |
-      | name             | Project Earth |
-      | quota@@@total    | 100           |
+      | key           | value         |
+      | name          | Project Earth |
+      | quota@@@total | 100           |
 
 
   Scenario: An user set readme file as description of the space via the Graph API
@@ -48,29 +48,76 @@ Feature: Change data of space
       | special@@@0@@@size                 | 17                  |
       | special@@@0@@@name                 | readme.md           |
       | special@@@0@@@specialFolder@@@name | readme              |
-      | special@@@0@@@file@@@mimeType       | text/markdown       |
-      | special@@@0@@@id                   | %file_id%            |
+      | special@@@0@@@file@@@mimeType      | text/markdown       |
+      | special@@@0@@@id                   | %file_id%           |
       | special@@@0@@@eTag                 | %eTag%              |
+    And for user "Alice" folder ".space/" of the space "add special section" should contain these entries:
+      | readme.md |
+    And for user "Alice" the content of the file ".space/readme.md" of the space "add special section" should be "space description"
 
 
   Scenario Outline: An user set image file as space image of the space via the Graph API
     Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
     And user "Alice" has created a folder ".space" in space "add special section"
-    And user "Alice" has uploaded a file inside space "add special section" with content "" to "<fileName>"
-    When user "Alice" sets the file "<fileName>" as a space image in a special section of the "add special section" space
+    And user "Alice" has uploaded a file inside space "add special section" with content "" to ".space/<fileName>"
+    When user "Alice" sets the file ".space/<fileName>" as a space image in a special section of the "add special section" space
     Then the HTTP status code should be "200"
     When user "Alice" lists all available spaces via the GraphApi
-    Then the json responded should contain a space "add special section" owned by "Alice" with description file "<fileName>" with these key and value pairs:
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/<fileName>" with these key and value pairs:
       | key                                | value               |
       | name                               | add special section |
       | special@@@0@@@size                 | 0                   |
       | special@@@0@@@name                 | <nameInResponse>    |
       | special@@@0@@@specialFolder@@@name | image               |
-      | special@@@0@@@file@@@mimeType       | <mimeType>          |
-      | special@@@0@@@id                   | %file_id%            |
+      | special@@@0@@@file@@@mimeType      | <mimeType>          |
+      | special@@@0@@@id                   | %file_id%           |
       | special@@@0@@@eTag                 | %eTag%              |
+    And for user "Alice" folder ".space/" of the space "add special section" should contain these entries:
+      | <fileName> |
     Examples:
-      | fileName                | nameInResponse  | mimeType   |
-      | .space/spaceImage.jpeg | spaceImage.jpeg | image/jpeg |
-      | .space/spaceImage.png  | spaceImage.png  | image/png  |
-      | .space/spaceImage.gif  | spaceImage.gif  | image/gif  |
+      | fileName        | nameInResponse  | mimeType   |
+      | spaceImage.jpeg | spaceImage.jpeg | image/jpeg |
+      | spaceImage.png  | spaceImage.png  | image/png  |
+      | spaceImage.gif  | spaceImage.gif  | image/gif  |
+
+
+  Scenario: An user set new readme file as description of the space via the Graph API
+    Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
+    And user "Alice" has created a folder ".space" in space "add special section"
+    And user "Alice" has uploaded a file inside space "add special section" with content "space description" to ".space/readme.md"
+    And user "Alice" has set the file ".space/readme.md" as a description in a special section of the "add special section" space
+    When user "Alice" has uploaded a file inside space "add special section" with content "new space description" to ".space/newReadme.md"
+    And user "Alice" sets the file ".space/newReadme.md" as a description in a special section of the "add special section" space
+    Then the HTTP status code should be "200"
+    And for user "Alice" the content of the file ".space/newReadme.md" of the space "add special section" should be "new space description"
+    When user "Alice" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/newReadme.md" with these key and value pairs:
+      | key                                | value               |
+      | name                               | add special section |
+      | special@@@0@@@size                 | 21                  |
+      | special@@@0@@@name                 | newReadme.md        |
+      | special@@@0@@@specialFolder@@@name | readme              |
+      | special@@@0@@@file@@@mimeType      | text/markdown       |
+      | special@@@0@@@id                   | %file_id%           |
+      | special@@@0@@@eTag                 | %eTag%              |
+
+
+  Scenario: An user set new image file as space image of the space via the Graph API
+    Given user "Alice" has created a space "add special section" with the default quota using the GraphApi
+    And user "Alice" has created a folder ".space" in space "add special section"
+    And user "Alice" has uploaded a file inside space "add special section" with content "" to ".space/spaceImage.jpeg"
+    And user "Alice" has set the file ".space/spaceImage.jpeg" as a space image in a special section of the "add special section" space
+    When user "Alice" has uploaded a file inside space "add special section" with content "" to ".space/newSpaceImage.png"
+    And user "Alice" sets the file ".space/newSpaceImage.png" as a space image in a special section of the "add special section" space
+    Then the HTTP status code should be "200"
+    When user "Alice" lists all available spaces via the GraphApi
+    Then the json responded should contain a space "add special section" owned by "Alice" with description file ".space/newSpaceImage.png" with these key and value pairs:
+      | key                                | value               |
+      | name                               | add special section |
+      | special@@@0@@@size                 | 0                   |
+      | special@@@0@@@name                 | newSpaceImage.png   |
+      | special@@@0@@@specialFolder@@@name | image               |
+      | special@@@0@@@file@@@mimeType      | image/png           |
+      | special@@@0@@@id                   | %file_id%           |
+      | special@@@0@@@eTag                 | %eTag%              |
+      

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * ownCloud
  *
@@ -19,6 +21,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
@@ -218,12 +221,12 @@ class SpacesContext implements Context {
 	 * @param string $spaceName
 	 * @param string $fileName
 	 *
-	 * @return array
+	 * @return ResponseInterface
 	 */
-	public function getFileData(string $user, string $spaceName, string $fileName): array {
+	public function getFileData(string $user, string $spaceName, string $fileName): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$fullUrl = $this->baseUrl . "/remote.php/dav/spaces/" . $space["id"] . "/" . $fileName;
-		
+
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$fullUrl,
@@ -238,7 +241,7 @@ class SpacesContext implements Context {
 			200,
 			"file $fileName not found"
 		);
-		return $this->featureContext->getResponse()->getHeaders();
+		return $this->featureContext->getResponse();
 	}
 
 	/**
@@ -251,7 +254,7 @@ class SpacesContext implements Context {
 	 * @return string
 	 */
 	public function getFileId(string $user, string $spaceName, string $fileName): string {
-		$fileData = $this->getFileData($user, $spaceName, $fileName);
+		$fileData = $this->getFileData($user, $spaceName, $fileName)->getHeaders();
 		return $fileData["Oc-Fileid"][0];
 	}
 
@@ -265,7 +268,7 @@ class SpacesContext implements Context {
 	 * @return string
 	 */
 	public function getETag(string $user, string $spaceName, string $fileName): string {
-		$fileData = $this->getFileData($user, $spaceName, $fileName);
+		$fileData = $this->getFileData($user, $spaceName, $fileName)->getHeaders();
 		return $fileData["Etag"][0];
 	}
 
@@ -818,6 +821,28 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @Then /^for user "([^"]*)" the content of the file "([^"]*)" of the space "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string    $user
+	 * @param string    $file
+	 * @param string    $spaceName
+	 * @param string    $fileContent
+	 *
+	 * @return void
+	 *
+	 * @throws Exception|GuzzleException
+	 */
+	public function checkFileContent(
+		string $user,
+		string $file,
+		string $spaceName,
+		string $fileContent
+	): void {
+		$actualFileContent = $this->getFileData($user, $spaceName, $file)->getBody()->getContents();
+		Assert::assertEquals($fileContent, $actualFileContent, "$file does not contain $fileContent");
+	}
+
+	/**
 	 * @Then /^the json responded should contain a space "([^"]*)" (?:|(?:owned by|granted to) "([^"]*)" )(?:|(?:with description file|with space image) "([^"]*)" )with these key and value pairs:$/
 	 *
 	 * @param string $spaceName
@@ -846,25 +871,25 @@ class SpacesContext implements Context {
 					[
 						"code" => "%space_id%",
 						"function" =>
-							[$this, "getSpaceIdByNameFromResponse"],
+						[$this, "getSpaceIdByNameFromResponse"],
 						"parameter" => [$spaceName]
 					],
 					[
 						"code" => "%user_id%",
 						"function" =>
-							[$this, "getUserIdByUserName"],
+						[$this, "getUserIdByUserName"],
 						"parameter" => [$userName]
 					],
 					[
 						"code" => "%file_id%",
 						"function" =>
-							[$this, "getFileId"],
+						[$this, "getFileId"],
 						"parameter" => [$userName, $spaceName, $fileName]
 					],
 					[
 						"code" => "%eTag%",
 						"function" =>
-							[$this, "getETag"],
+						[$this, "getETag"],
 						"parameter" => [$userName, $spaceName, $fileName]
 					],
 				]
@@ -903,7 +928,7 @@ class SpacesContext implements Context {
 		Assert::assertIsArray($spaceAsArray = $this->getSpaceByNameFromResponse($spaceName), "No space with name $spaceName found");
 		$permissions = $spaceAsArray["root"]["permissions"];
 		$userId = $this->getUserIdByUserName($userName);
-		
+
 		$userRole = "";
 		foreach ($permissions as $permission) {
 			foreach ($permission["grantedTo"] as $grantedTo) {
@@ -1407,6 +1432,31 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" has set the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/
+	 *
+	 * @param string $user
+	 * @param string $file
+	 * @param string $type
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function userHasUpdatedSpaceSpecialSection(
+		string $user,
+		string $file,
+		string $type,
+		string $spaceName
+	): void {
+		$this->updateSpaceSpecialSection($user, $file, $type, $spaceName);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			200,
+			"Expected response status code should be 200"
+		);
+	}
+
+	/**
 	 * Send Graph Update Space Request
 	 *
 	 * @param  string $user
@@ -1635,7 +1685,7 @@ class SpacesContext implements Context {
 		$rows["password"] = \array_key_exists("password", $rows) ? $rows["password"] : null;
 		$rows["name"] = \array_key_exists("name", $rows) ? $rows["name"] : null;
 		$rows["expireDate"] = \array_key_exists("expireDate", $rows) ? $rows["expireDate"] : null;
-		
+
 		$body = [
 			"space_ref" => $space['id'] . "/" . $rows["path"],
 			"shareType" => $rows["shareType"],


### PR DESCRIPTION
Created test:
- check the contents of the readmi file
- space image check
- set a new readmi file description
- set a new space image

I added test after bug with url https://github.com/owncloud/ocis/issues/3419.  The test passes, despite the url error, because we strictly set the url in the test. 



