### PR TITLE
Make config dir configurable via `OCIS_CONFIG_DIR` env var

### DIFF
--- a/changelog/unreleased/make-config-dir-configurable.md
+++ b/changelog/unreleased/make-config-dir-configurable.md
@@ -1,0 +1,5 @@
+Enhancement: make config dir configurable
+
+We have added an `OCIS_CONFIG_DIR` environment variable the will take precedence over the default `/etc/ocis`, `~/.ocis` and `.config` locations. When it is set the default locations will be ignored and only the configuration files in that directory will be read.
+
+https://github.com/owncloud/ocis/pull/3440

--- a/ocis-pkg/config/helpers.go
+++ b/ocis-pkg/config/helpers.go
@@ -31,14 +31,23 @@ var (
 func DefaultConfigSources(filename string, drivers []string) []string {
 	var sources []string
 
-	for i := range defaultLocations {
-		dirFS := os.DirFS(defaultLocations[i])
+	locations := []string{}
+	if os.Getenv("OCIS_CONFIG_DIR") != "" {
+		// only use the configured config dir
+		locations = append(locations, os.Getenv("OCIS_CONFIG_DIR"))
+	} else {
+		// merge config from all default locations
+		locations = append(locations, defaultLocations...)
+	}
+
+	for i := range locations {
+		dirFS := os.DirFS(locations[i])
 		pattern := filename + ".*"
 		matched, _ := fs.Glob(dirFS, pattern)
 		if len(matched) > 0 {
 			// prepend path to results
 			for j := 0; j < len(matched); j++ {
-				matched[j] = filepath.Join(defaultLocations[i], matched[j])
+				matched[j] = filepath.Join(locations[i], matched[j])
 			}
 		}
 		sources = append(sources, matched...)

--- a/ocis-pkg/config/helpers.go
+++ b/ocis-pkg/config/helpers.go
@@ -32,7 +32,8 @@ func DefaultConfigSources(filename string, drivers []string) []string {
 	var sources []string
 
 	locations := []string{}
-	if os.Getenv("OCIS_CONFIG_DIR") != "" {
+	if v := os.Getenv("OCIS_CONFIG_DIR"); v != "" {
+	    locations = append(locations, v)
 		// only use the configured config dir
 		locations = append(locations, os.Getenv("OCIS_CONFIG_DIR"))
 	} else {


### PR DESCRIPTION
We have added an `OCIS_CONFIG_DIR` environment variable the will take precedence over the default `/etc/ocis`, `~/.ocis` and `.config` locations. When it is set the default locations will be ignored and only the configuration files in that directory will be read.
