### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/changelog/unreleased/change-replace-deprecated-substr
+++ b/changelog/unreleased/change-replace-deprecated-substr
@@ -1,0 +1,7 @@
+Change: Replace deprecated String.prototype.substr()
+
+We've replaced all occurrences of the deprecated String.prototype.substr()
+function with String.prototype.slice() which works similarly but isn't
+deprecated.
+
+https://github.com/owncloud/ocis/pull/3448

--- a/changelog/unreleased/enhancement-replace-deprecated-substr
+++ b/changelog/unreleased/enhancement-replace-deprecated-substr
@@ -1,4 +1,4 @@
-Change: Replace deprecated String.prototype.substr()
+Enhancement: Replace deprecated String.prototype.substr()
 
 We've replaced all occurrences of the deprecated String.prototype.substr()
 function with String.prototype.slice() which works similarly but isn't

--- a/idp/ui/src/containers/Login/Chooseaccount.js
+++ b/idp/ui/src/containers/Login/Chooseaccount.js
@@ -85,7 +85,7 @@ function Chooseaccount({ loading, errors, classes, hello, history, dispatch }) {
             className={classes.accountListItem}
             disabled={!!loading}
             onClick={(event) => logon(event)}
-          ><ListItemAvatar><Avatar>{username.substr(0, 1)}</Avatar></ListItemAvatar>
+          ><ListItemAvatar><Avatar>{username.slice(0, 1)}</Avatar></ListItemAvatar>
             <ListItemText className="oc-light" primary={username} />
           </ListItem>
           <ListItem

--- a/idp/ui_config/paths.js
+++ b/idp/ui_config/paths.js
@@ -14,7 +14,7 @@ const envPublicUrl = process.env.PUBLIC_URL;
 function ensureSlash(inputPath, needsSlash) {
   const hasSlash = inputPath.endsWith('/');
   if (hasSlash && !needsSlash) {
-    return inputPath.substr(0, inputPath.length - 1);
+    return inputPath.slice(0, -1);
   } else if (!hasSlash && needsSlash) {
     return `${inputPath}/`;
   } else {

--- a/settings/ui/components/SettingsBundle.vue
+++ b/settings/ui/components/SettingsBundle.vue
@@ -49,7 +49,7 @@ export default {
   methods: {
     ...mapActions('Settings', ['saveValue']),
     getSettingComponent (setting) {
-      return 'Setting' + setting.type[0].toUpperCase() + setting.type.substr(1)
+      return 'Setting' + setting.type[0].toUpperCase() + setting.type.slice(1)
     },
     getValue (setting) {
       return this.getSettingsValue({ settingId: setting.id })


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Related Issue


## Motivation and Context

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated

## How Has This Been Tested?

I tested the return of each statement to make sure it's still the same as before

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
