### PR TITLE
reduce hash difficulty in CI and of demo users

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -269,10 +269,10 @@ def testPipelines(ctx):
     if "skip" not in config["cs3ApiTests"] or not config["cs3ApiTests"]["skip"]:
         pipelines += [cs3ApiTests(ctx, "ocis", "default")]
     if "skip" not in config["localApiTests"] or not config["localApiTests"]["skip"]:
-        pipelines += [
-            localApiTests(ctx, "ocis", "apiAccountsHashDifficulty", "default"),
-            localApiTests(ctx, "ocis", "apiSpaces", "default"),
-            localApiTests(ctx, "ocis", "apiArchiver", "default"),
+        pipelines = [
+            localApiTests(ctx, "ocis", "apiAccountsHashDifficulty"),
+            localApiTests(ctx, "ocis", "apiSpaces"),
+            localApiTests(ctx, "ocis", "apiArchiver"),
         ]
 
     if "skip" not in config["apiTests"] or not config["apiTests"]["skip"]:
@@ -2129,7 +2129,7 @@ def parallelDeployAcceptancePipeline(ctx):
                          fixSharedDataPermissions() +
                          ocisServer(
                              "ocis",
-                             "default",
+                             4,
                              [stepVolumeOC10OCISData, stepVolumeOCISConfig],
                              ["fix-shared-data-permissions"],
                              True,

--- a/accounts/pkg/service/v0/service.go
+++ b/accounts/pkg/service/v0/service.go
@@ -196,7 +196,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                20000,
 			GidNumber:                30000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2a$11$4WNffzgU/WrIRiDnwu8OnOwgOIIUqR/2Ptvp7WJAQCTSgSrylyuvC",
+				Password: "$2a$04$L.Rkpa0/nOhF3SsFo.QY9uzjMG8zB9a8dZP./LZBCDgsiuI8w10Em",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{
@@ -215,7 +215,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                20001,
 			GidNumber:                30000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2a$11$Wu2XcDnE6G2No8C88FVWluNHyXuQQi0cHzSe82Vni8AdwIO12fphC",
+				Password: "$2a$04$AZd1k6OVpzP7E4hw5.ysFuuL2.XjjgakAuRs2zdBvIMizF0KaZkNG",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{
@@ -234,7 +234,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                20002,
 			GidNumber:                30000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2a$11$6Lak4zh1xUkpObg2rrOotOTdQYGj2Uu/sowcVLhub.8qYIr.CxzEW",
+				Password: "$2a$04$aeVYaBH3LCTj9DviV6Y4xO2reoEzY9vnc7a5/0mhJWQUDtPqPINme",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{
@@ -254,7 +254,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                20003,
 			GidNumber:                30000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2a$11$jvI6PHuvrimpcCHzL2Q2WOqfm1FGdYAuSYZBDahr/B48fpiFxyDy2",
+				Password: "$2a$04$la2yFV6N.pPySwHnLIxyAuBCJ2t/DxWfXJGnIooA9Ebb3.lSTKXby",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{
@@ -270,7 +270,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                20004,
 			GidNumber:                30000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2a$11$En9VIUtqOdDyUl.LuUq2KeuBb5A2n8zE0lkJ2v6IDRSaOamhNq6Uu",
+				Password: "$2a$04$zqpfwdtBUDg89cpltxd.9ef7ZMzsor1BLCJyTEcdoitmEuS3Hr/Q6",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{
@@ -286,7 +286,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                20005,
 			GidNumber:                30000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2a$11$6SIBlZ.8BzjBsDTRrThUyuz6OvP.XLo7101oFiwHHB.jufKGS9.Ji",
+				Password: "$2a$04$j0//gOyZ3xg/WtMOk4XUaOMJ1r5niD3paPcFh1O/PNr8pL7yC8rhG",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{
@@ -306,7 +306,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                10000,
 			GidNumber:                15000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2y$12$ywfGLDPsSlBTVZU0g.2GZOPO8Wap3rVOpm8e3192VlytNdGWH7x72",
+				Password: "$2a$04$TiuPj61Lkwt9hPOj4UUdwO.fupKBO3gpMv1EoXo0XF8Z8L9rFN8Nm",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{
@@ -322,7 +322,7 @@ func (s Service) createDefaultAccounts(withDemoAccounts bool) (err error) {
 			UidNumber:                10001,
 			GidNumber:                15000,
 			PasswordProfile: &accountsmsg.PasswordProfile{
-				Password: "$2a$11$40xzy3rO8Tq4j2VkFbKz8Ow19BRaqaixEjAR0IbvQXxtOvMtkjwzy",
+				Password: "$2a$04$.cYhDMMXsvoCJzH9rX0eKev7fsLZwUv.VsRn66iaCXj2KlgpzHu3a",
 			},
 			AccountEnabled: true,
 			MemberOf: []*accountsmsg.Group{


### PR DESCRIPTION
I don't think that the high hash difficulty is in any way relevant for CI and that we can save some time by reducing it.
Also reduced the hash difficulty for the demo users in case any of them is used in the CI. 

This doesn't introduce any security risk since a production setup shouldn't use the demo users nor the default passwords.