### PR TITLE
[full-ci] set demo users to default off

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1627,6 +1627,8 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "OCIS_LOG_LEVEL": "error",
             "SETTINGS_DATA_PATH": "/srv/app/tmp/ocis/settings",
             "OCIS_INSECURE": "true",
+            "ACCOUNTS_DEMO_USERS_AND_GROUPS": True,  # deprecated, remove after switching to LibreIDM
+            "IDM_CREATE_DEMO_USERS": True,
         }
     else:
         user = "33:33"
@@ -1707,6 +1709,8 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "OCIS_MACHINE_AUTH_API_KEY": "change-me-please",
             "OCIS_INSECURE": "true",
             "PROXY_ENABLE_BASIC_AUTH": "true",
+            "ACCOUNTS_DEMO_USERS_AND_GROUPS": True,  # deprecated, remove after switching to LibreIDM
+            "IDM_CREATE_DEMO_USERS": True,
         }
 
     # Pass in "default" accounts_hash_difficulty to not set this environment variable.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,9 @@
                 "PROXY_ENABLE_BASIC_AUTH": "true",
                 // set insecure options because we don't have valid certificates in dev environments
                 "OCIS_INSECURE": "true",
+                // demo users
+                "ACCOUNTS_DEMO_USERS_AND_GROUPS": "true",
+                "IDM_CREATE_DEMO_USERS": "true"
                 // OCIS_RUN_EXTENSIONS allows to start a subset of extensions even in the supervised mode
                 //"OCIS_RUN_EXTENSIONS": "settings,storage-metadata,glauth,graph,graph-explorer,idp,ocs,store,thumbnails,web,webdav,storage-frontend,storage-gateway,storage-userprovider,storage-groupprovider,storage-authbasic,storage-authbearer,storage-authmachine,storage-users,storage-shares,storage-public-link,storage-appprovider,storage-sharing,accounts,proxy",
             }

--- a/accounts/pkg/config/defaults/defaultconfig.go
+++ b/accounts/pkg/config/defaults/defaultconfig.go
@@ -49,7 +49,7 @@ func DefaultConfig() *config.Config {
 			JWTSecret: "Pive-Fumkiu4",
 		},
 		HashDifficulty:     11,
-		DemoUsersAndGroups: true,
+		DemoUsersAndGroups: false,
 		Repo: config.Repo{
 			Backend: "CS3",
 			Disk: config.Disk{

--- a/changelog/unreleased/no-demo-users.md
+++ b/changelog/unreleased/no-demo-users.md
@@ -1,0 +1,6 @@
+Change: Don't create demo users by default
+
+As we are coming closer to the first beta, we need to disable the creation of the demo users by default.
+
+https://github.com/owncloud/ocis/pull/3474
+https://github.com/owncloud/ocis/issues/3181

--- a/deployments/examples/oc10_ocis_parallel/.env
+++ b/deployments/examples/oc10_ocis_parallel/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=false
+
 ### Traefik settings ###
 TRAEFIK_LOG_LEVEL=
 # Serve Treafik dashboard. Defaults to "false".

--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -124,6 +124,9 @@ services:
       OCIS_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
     volumes:
       - ./config/ocis/proxy.yaml:/etc/ocis/proxy.yaml
       - ocis-data:/var/lib/ocis

--- a/deployments/examples/ocis_hello/.env
+++ b/deployments/examples/ocis_hello/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=true
+
 ### Traefik settings ###
 # Serve Treafik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_hello/docker-compose.yml
+++ b/deployments/examples/ocis_hello/docker-compose.yml
@@ -68,6 +68,9 @@ services:
       OCIS_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/web-config.dist.json:/config/web-config.dist.json

--- a/deployments/examples/ocis_individual_services/.env
+++ b/deployments/examples/ocis_individual_services/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=true
+
 ### Traefik settings ###
 # Serve Treafik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_individual_services/docker-compose.yml
+++ b/deployments/examples/ocis_individual_services/docker-compose.yml
@@ -134,6 +134,8 @@ services:
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
 
       ACCOUNTS_JWT_SECRET: ${OCIS_METADATA_JWT_SECRET:-Pive-Fumkiu4}
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
     volumes:
       - ./config/accounts/entrypoint-override.sh:/entrypoint-override.sh
     logging:

--- a/deployments/examples/ocis_keycloak/.env
+++ b/deployments/examples/ocis_keycloak/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=false
+
 ### Traefik settings ###
 # Serve Treafik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -63,7 +63,9 @@ services:
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
-      ACCOUNTS_DEMO_USERS_AND_GROUPS: "false" # don't generate demo users
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
       # change default secrets
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
       STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}

--- a/deployments/examples/ocis_ldap/.env
+++ b/deployments/examples/ocis_ldap/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=true
+
 ### Traefik settings ###
 # Serve Treafik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -88,6 +88,9 @@ services:
       OCIS_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/web-config.dist.json:/config/web-config.dist.json

--- a/deployments/examples/ocis_s3/.env
+++ b/deployments/examples/ocis_s3/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=true
+
 ### Traefik settings ###
 # Serve Treafik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_s3/docker-compose.yml
+++ b/deployments/examples/ocis_s3/docker-compose.yml
@@ -72,6 +72,9 @@ services:
       OCIS_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-data:/var/lib/ocis

--- a/deployments/examples/ocis_traefik/.env
+++ b/deployments/examples/ocis_traefik/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=true
+
 ### Traefik settings ###
 # Serve Treafik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       OCIS_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-data:/var/lib/ocis

--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -2,6 +2,10 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
+# The demo users should not be created on a production instance
+# because their passwords are public
+DEMO_USERS=true
+
 ### Traefik settings ###
 # Serve Treafik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       OCIS_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
+      # demo users
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-false}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/mimetypes.json:/var/tmp/ocis/app-config/mimetypes.json

--- a/docs/ocis/deployment/_index.md
+++ b/docs/ocis/deployment/_index.md
@@ -50,8 +50,7 @@ You can change it by setting the `OCIS_MACHINE_AUTH_API_KEY` environment variabl
 {{< hint info >}}
 Before deleting the demo users mentioned below, you must create a new account for yourself and assign it to the administrator role.
 
-To skip the generation of demo users in the first place, run the inital setup step with an additional environment variable.
-`ACCOUNTS_DEMO_USERS_AND_GROUPS=false ./bin/ocis server` generates only the admin, and one user for IDP and Reva respectively.
+By default, oCIS doesn't create any demo users. During the first startup, it generates only the admin and one user for IDP and Reva respectively.
 {{< /hint >}}
 
 oCIS ships with a few demo users besides the system users:

--- a/docs/ocis/getting-started/_index.md
+++ b/docs/ocis/getting-started/_index.md
@@ -42,8 +42,8 @@ curl https://download.owncloud.com/ocis/ocis/stable/1.19.1/ocis-1.19.1-linux-amd
 # make binary executable
 chmod +x ocis
 
-# run
-OCIS_INSECURE=true ./ocis server
+# run with demo users
+OCIS_INSECURE=true ACCOUNTS_DEMO_USERS_AND_GROUPS=true ./ocis server
 ```
 
 The default primary storage location is `~/.ocis` or `/var/lib/ocis` depending on the packaging format and your operating system user. You can change that value by configuration.
@@ -64,11 +64,15 @@ The `latest` tag always reflects the current master branch.
 
 ```console
 docker pull owncloud/ocis
-docker run --rm -ti -p 9200:9200 -e OCIS_INSECURE=true owncloud/ocis
+docker run --rm -ti -p 9200:9200 -e OCIS_INSECURE=true -e ACCOUNTS_DEMO_USERS_AND_GROUPS=true owncloud/ocis
 ```
 
 {{< hint info >}}
 When you're using oCIS with self-signed certificates, you need to set the environment variable `OCIS_INSECURE=true`, in order to make oCIS work.
+{{< /hint >}}
+
+{{< hint warming >}}
+When you're creating the [demo users]({{< ref "./demo-users" >}}) by setting `ACCOUNTS_DEMO_USERS_AND_GROUPS=true`, you need to be sure that this instance is not used in prodution because the passwords are public.
 {{< /hint >}}
 
 {{< hint warning >}}

--- a/docs/ocis/getting-started/demo-users.md
+++ b/docs/ocis/getting-started/demo-users.md
@@ -7,11 +7,11 @@ geekdocEditPath: edit/master/docs/ocis/getting-started
 geekdocFilePath: demo-users.md
 ---
 
-As long as oCIS is released as [technology preview]({{< ref "../release_roadmap#release_roadmap" >}}) it will come with default demo users. These enable you to do quick testing and developing.
+oCIS has the option to create demo users during the first startup. These enable you to do quick testing and developing.
 
 {{< hint info >}}
-To skip the generation of demo users, run the inital setup step with an additional environment variable.
-`ACCOUNTS_DEMO_USERS_AND_GROUPS=false ./bin/ocis server` generates only the admin, and one user for IDP and Reva respectively.
+To create the demo users, run the inital setup step with an additional environment variable.
+`ACCOUNTS_DEMO_USERS_AND_GROUPS=true ./bin/ocis server` will generate the demo users listed in the table below. By default, it only generates the admin and one user for IDP and Reva respectively.
 {{< /hint >}}
 
 Following users are available in the demo set:

--- a/idm/pkg/config/defaults/defaultconfig.go
+++ b/idm/pkg/config/defaults/defaultconfig.go
@@ -21,7 +21,7 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "idm",
 		},
-		CreateDemoUsers: true,
+		CreateDemoUsers: false,
 		ServiceUserPasswords: config.ServiceUserPasswords{
 			IdmAdmin: "idm",
 			Idp:      "idp",


### PR DESCRIPTION
## Description
Disable the creation of the demo users by default

## Tasks

- [x]  Default value should be `false`
- [x] adjust CI
- [x] adjust Demo Deployments
- [x] adjust DevDocs

## Related Issue
- Fixes #3181 

## Motivation and Context

- Strengthen the security

## How Has This Been Tested?
- CI
- Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change, it changes the default behavior
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
