### PR TITLE
improve runtime connect error messages

### DIFF
--- a/ocis/pkg/command/kill.go
+++ b/ocis/pkg/command/kill.go
@@ -35,7 +35,7 @@ func KillCommand(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
-				log.Fatalf("Failed to connect to the runtime. Is the runtime running and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
+				log.Fatalf("Failed to connect to the runtime. Has the runtime been started and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
 			}
 
 			var arg1 int

--- a/ocis/pkg/command/kill.go
+++ b/ocis/pkg/command/kill.go
@@ -35,7 +35,7 @@ func KillCommand(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
-				log.Fatal("dialing:", err)
+				log.Fatalf("Failed to connect to the runtime. Is the runtime running and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
 			}
 
 			var arg1 int

--- a/ocis/pkg/command/list.go
+++ b/ocis/pkg/command/list.go
@@ -34,7 +34,7 @@ func ListCommand(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
-				log.Fatalf("Failed to connect to the runtime. Is the runtime running and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
+				log.Fatalf("Failed to connect to the runtime. Has the runtime been started and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
 			}
 
 			var arg1 string

--- a/ocis/pkg/command/list.go
+++ b/ocis/pkg/command/list.go
@@ -34,7 +34,7 @@ func ListCommand(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
-				log.Fatal("dialing:", err)
+				log.Fatalf("Failed to connect to the runtime. Is the runtime running and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
 			}
 
 			var arg1 string

--- a/ocis/pkg/command/run.go
+++ b/ocis/pkg/command/run.go
@@ -36,7 +36,7 @@ func RunCommand(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
-				log.Fatal("dialing:", err)
+				log.Fatalf("Failed to connect to the runtime. Is the runtime running and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
 			}
 
 			var reply int

--- a/ocis/pkg/command/run.go
+++ b/ocis/pkg/command/run.go
@@ -36,7 +36,7 @@ func RunCommand(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			client, err := rpc.DialHTTP("tcp", net.JoinHostPort(cfg.Runtime.Host, cfg.Runtime.Port))
 			if err != nil {
-				log.Fatalf("Failed to connect to the runtime. Is the runtime running and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
+				log.Fatalf("Failed to connect to the runtime. Has the runtime been started and did you configure the right runtime address (\"%s\")", cfg.Runtime.Host+":"+cfg.Runtime.Port)
 			}
 
 			var reply int


### PR DESCRIPTION
## Description
Improves the error message for following commands if the runtime is not started / reachable:
- ocis list
- ocis kill
- ocis run

The error message now looks like this: `Failed to connect to the runtime. Is the runtime running and did you configure the right runtime address ("localhost:9250")`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [Fix error message when the runtime has not started but you file a command for it](https://github.com/owncloud/ocis/issues/3458)

## Motivation and Context
Make oCIS commands more human friendly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
