### PR TITLE
Fix ocis admin creation for idm

### DIFF
--- a/idm/ldif/base.ldif.tmpl
+++ b/idm/ldif/base.ldif.tmpl
@@ -15,10 +15,27 @@ objectClass: organizationalUnit
 ou: groups
 
 {{ range . -}}
+{{ if eq .Name "admin" -}}
+dn: uid=admin,ou=users,o=libregraph-idm
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: ownCloud
+objectClass: person
+objectClass: top
+uid: admin
+givenName: Admin
+sn: Admin
+cn: admin
+displayName: Admin
+description: An admin for this oCIS instance.
+mail: admin@example.org
+ownCloudUUID: ddc2004c-0977-11eb-9d3f-a793888cd0f8
+{{ else -}}
 dn: uid={{ .Name }},ou=sysusers,o=libregraph-idm
 objectClass: account
 objectClass: simpleSecurityObject
 uid: {{ .Name }}
+{{ end -}}
 userPassword:: {{ .Password }}
 
 {{ end -}}

--- a/idm/ldif/demousers.ldif
+++ b/idm/ldif/demousers.ldif
@@ -66,23 +66,6 @@ ownCloudUUID: 058bff95-6708-4fe5-91e4-9ea3d377588b
 userPassword:: e0FSR09OMn0kYXJnb24yaWQkdj0xOSRtPTY1NTM2LHQ9MSxwPTIkZU0xaXR6amQ2dlNSSERx
  NlZCbXBlQSQxNzBhcTB3YjJZZ2NLU2cwWDhHY3l6ckZwMUllcGplMTNraDdVNjUyNXk4
 
-dn: uid=admin,ou=users,o=libregraph-idm
-objectClass: inetOrgPerson
-objectClass: organizationalPerson
-objectClass: ownCloud
-objectClass: person
-objectClass: top
-uid: admin
-givenName: Admin
-sn: Admin
-cn: admin
-displayName: Admin
-description: An admin for this oCIS instance.
-mail: admin@example.org
-ownCloudUUID: ddc2004c-0977-11eb-9d3f-a793888cd0f8
-userPassword:: e0FSR09OMn0kYXJnb24yaWQkdj0xOSRtPTY1NTM2LHQ9MSxwPTIkRXdwYUhJeVErcG9wdkcv
- Tk81R0o2USRNWHp4czNvdHBhOWp3S0hxc1lLMlZodzAralUxSFowMUNpOXducWZlT1pn
-
 dn: cn=users,ou=groups,o=libregraph-idm
 objectClass: groupOfNames
 objectClass: ownCloud

--- a/idm/pkg/command/server.go
+++ b/idm/pkg/command/server.go
@@ -90,8 +90,12 @@ func bootstrap(logger log.Logger, cfg *config.Config, srvcfg server.Config) erro
 
 	serviceUsers := []svcUser{
 		{
+			Name:     "admin",
+			Password: cfg.ServiceUserPasswords.OcisAdmin,
+		},
+		{
 			Name:     "libregraph",
-			Password: cfg.ServiceUserPasswords.IdmAdmin,
+			Password: cfg.ServiceUserPasswords.Idm,
 		},
 		{
 			Name:     "idp",
@@ -141,7 +145,6 @@ func bootstrap(logger log.Logger, cfg *config.Config, srvcfg server.Config) erro
 	}
 
 	bootstrapData := tmplWriter.String()
-
 	if cfg.CreateDemoUsers {
 		bootstrapData = bootstrapData + "\n" + idm.DemoUsersLDIF
 	}

--- a/idm/pkg/config/config.go
+++ b/idm/pkg/config/config.go
@@ -32,7 +32,8 @@ type Settings struct {
 }
 
 type ServiceUserPasswords struct {
-	IdmAdmin string `yaml:"admin_password" env:"IDM_ADMIN_PASSWORD" desc:"Password to set for the \"idm\" service users. Either cleartext or an argon2id hash"`
-	Reva     string `yaml:"reva_password" env:"IDM_REVASVC_PASSWORD" desc:"Password to set for the \"reva\" service users. Either cleartext or an argon2id hash"`
-	Idp      string `yaml:"idp_password" env:"IDM_IDPSVC_PASSWORD" desc:"Password to set for the \"idp\" service users. Either cleartext or an argon2id hash"`
+	OcisAdmin string `yaml:"admin_password" env:"IDM_ADMIN_PASSWORD" desc:"Password to set for the ocis \"admin\" user. Either cleartext or an argon2id hash"`
+	Idm       string `yaml:"idm_password" env:"IDM_SVC_PASSWORD" desc:"Password to set for the \"idm\" service user. Either cleartext or an argon2id hash"`
+	Reva      string `yaml:"reva_password" env:"IDM_REVASVC_PASSWORD" desc:"Password to set for the \"reva\" service user. Either cleartext or an argon2id hash"`
+	Idp       string `yaml:"idp_password" env:"IDM_IDPSVC_PASSWORD" desc:"Password to set for the \"idp\" service user. Either cleartext or an argon2id hash"`
 }

--- a/idm/pkg/config/defaults/defaultconfig.go
+++ b/idm/pkg/config/defaults/defaultconfig.go
@@ -23,9 +23,10 @@ func DefaultConfig() *config.Config {
 		},
 		CreateDemoUsers: false,
 		ServiceUserPasswords: config.ServiceUserPasswords{
-			IdmAdmin: "idm",
-			Idp:      "idp",
-			Reva:     "reva",
+			OcisAdmin: "admin",
+			Idm:       "idm",
+			Idp:       "idp",
+			Reva:      "reva",
 		},
 		IDM: config.Settings{
 			LDAPSAddr:    "127.0.0.1:9235",


### PR DESCRIPTION
The admin user was created as part of the demo user set. But we need the
admin to be created always.