### PR TITLE
add more proxy routes for thumbnails

### DIFF
--- a/changelog/unreleased/fix-thumbnails-dav.md
+++ b/changelog/unreleased/fix-thumbnails-dav.md
@@ -1,0 +1,10 @@
+Bugfix: Thumbnails for `/dav/xxx?preview=1` requests
+
+We've added the thumbnail rendering for `/dav/xxx?preview=1` requests, which was previously not supported because of missing routes. It now returns the same thumbnails as for
+`/remote.php/dav/xxx?preview=1`.
+
+We've also ensured that `/remote.php/webdav/xxx?preview=1` and `/webdav/xxx?preview=1` will be
+routed to the correct service and always return a 404 Not Found, because Thumbnails are currently
+not implemented for that route.
+
+https://github.com/owncloud/ocis/pull/3567

--- a/changelog/unreleased/fix-thumbnails-dav.md
+++ b/changelog/unreleased/fix-thumbnails-dav.md
@@ -1,10 +1,6 @@
 Bugfix: Thumbnails for `/dav/xxx?preview=1` requests
 
-We've added the thumbnail rendering for `/dav/xxx?preview=1` requests, which was previously not supported because of missing routes. It now returns the same thumbnails as for
+We've added the thumbnail rendering for `/dav/xxx?preview=1`, `/remote.php/webdav/{relative path}?preview=1` and `/webdav/{relative path}?preview=1` requests, which was previously not supported because of missing routes. It now returns the same thumbnails as for
 `/remote.php/dav/xxx?preview=1`.
-
-We've also ensured that `/remote.php/webdav/xxx?preview=1` and `/webdav/xxx?preview=1` will be
-routed to the correct service and always return a 404 Not Found, because Thumbnails are currently
-not implemented for that route.
 
 https://github.com/owncloud/ocis/pull/3567

--- a/extensions/proxy/pkg/config/config.go
+++ b/extensions/proxy/pkg/config/config.go
@@ -45,15 +45,15 @@ type Policy struct {
 
 // Route defines forwarding routes
 type Route struct {
-	Type RouteType `yaml:"type"`
+	Type RouteType `yaml:"type,omitempty"`
 	// Method optionally limits the route to this HTTP method
-	Method   string `yaml:"method"`
-	Endpoint string `yaml:"endpoint"`
+	Method   string `yaml:"method,omitempty"`
+	Endpoint string `yaml:"endpoint,omitempty"`
 	// Backend is a static URL to forward the request to
-	Backend string `yaml:"backend"`
+	Backend string `yaml:"backend,omitempty"`
 	// Service name to look up in the registry
-	Service     string `yaml:"service"`
-	ApacheVHost bool   `yaml:"apache_vhost"`
+	Service     string `yaml:"service,omitempty"`
+	ApacheVHost bool   `yaml:"apache_vhost,omitempty"`
 }
 
 // RouteType defines the type of a route

--- a/extensions/proxy/pkg/config/defaults/defaultconfig.go
+++ b/extensions/proxy/pkg/config/defaults/defaultconfig.go
@@ -107,6 +107,16 @@ func DefaultPolicies() []config.Policy {
 					Backend:  "http://localhost:9115", // TODO use registry?
 				},
 				{
+					Type:     config.QueryRoute,
+					Endpoint: "/dav/?preview=1",
+					Backend:  "http://localhost:9115",
+				},
+				{
+					Type:     config.QueryRoute,
+					Endpoint: "/webdav/?preview=1",
+					Backend:  "http://localhost:9115",
+				},
+				{
 					Endpoint: "/remote.php/",
 					Service:  "ocdav",
 				},

--- a/extensions/proxy/pkg/middleware/basic_auth.go
+++ b/extensions/proxy/pkg/middleware/basic_auth.go
@@ -115,6 +115,7 @@ func (m basicAuth) isPublicLink(req *http.Request) bool {
 	}
 
 	publicPaths := []string{
+		"/dav/public-files/",
 		"/remote.php/dav/public-files/",
 		"/remote.php/ocs/apps/files_sharing/api/v1/tokeninfo/unprotected",
 		"/ocs/v1.php/cloud/capabilities",

--- a/extensions/webdav/pkg/constants/constants.go
+++ b/extensions/webdav/pkg/constants/constants.go
@@ -1,0 +1,8 @@
+package constants
+
+type contextKey int
+
+const (
+	ContextKeyID contextKey = iota
+	ContextKeyPath
+)

--- a/extensions/webdav/pkg/dav/requests/thumbnail.go
+++ b/extensions/webdav/pkg/dav/requests/thumbnail.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/owncloud/ocis/extensions/webdav/pkg/constants"
+	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/constants"
 )
 
 const (
@@ -47,7 +47,11 @@ func ParseThumbnailRequest(r *http.Request) (*ThumbnailRequest, error) {
 		return nil, errors.New("invalid file path")
 	}
 
-	id := ctx.Value(constants.ContextKeyID).(string)
+	id := ""
+	v := ctx.Value(constants.ContextKeyID)
+	if v != nil {
+		id = v.(string)
+	}
 
 	q := r.URL.Query()
 	width, height, err := parseDimensions(q)

--- a/extensions/webdav/pkg/service/v0/service.go
+++ b/extensions/webdav/pkg/service/v0/service.go
@@ -78,6 +78,21 @@ func NewService(opts ...Option) (Service, error) {
 		r.Get("/remote.php/dav/public-files/{token}/*", svc.PublicThumbnail)
 		r.Head("/remote.php/dav/public-files/{token}/*", svc.PublicThumbnailHead)
 
+		r.Get("/remote.php/webdav/spaces/{id}/*", svc.SpacesThumbnail)
+		r.Get("/remote.php/webdav/files/{id}/*", svc.Thumbnail)
+		r.Get("/remote.php/webdav/public-files/{token}/*", svc.PublicThumbnail)
+		r.Head("/remote.php/webdav/public-files/{token}/*", svc.PublicThumbnailHead)
+
+		r.Get("/dav/spaces/{id}/*", svc.SpacesThumbnail)
+		r.Get("/dav/files/{id}/*", svc.Thumbnail)
+		r.Get("/dav/public-files/{token}/*", svc.PublicThumbnail)
+		r.Head("/dav/public-files/{token}/*", svc.PublicThumbnailHead)
+
+		r.Get("/webdav/spaces/{id}/*", svc.SpacesThumbnail)
+		r.Get("/webdav/files/{id}/*", svc.Thumbnail)
+		r.Get("/webdav/public-files/{token}/*", svc.PublicThumbnail)
+		r.Head("/webdav/public-files/{token}/*", svc.PublicThumbnailHead)
+
 		// r.MethodFunc("REPORT", "/remote.php/dav/files/{id}/*", svc.Search)
 
 		// This is a workaround for the go-chi concurrent map read write issue.

--- a/extensions/webdav/pkg/service/v0/service.go
+++ b/extensions/webdav/pkg/service/v0/service.go
@@ -5,10 +5,7 @@ import (
 	"encoding/xml"
 	"io"
 	"net/http"
-<<<<<<< HEAD
-=======
 	"net/url"
->>>>>>> 60f1081e8 (implement thumbnails also for webdav and non remote.php routes)
 	"path"
 	"path/filepath"
 	"strings"
@@ -18,27 +15,19 @@ import (
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/templates"
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	merrors "go-micro.dev/v4/errors"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/config"
+	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/constants"
+	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/dav/requests"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
-
-	"github.com/go-chi/chi/v5"
-<<<<<<< HEAD
-	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/config"
-	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/dav/requests"
 	thumbnailsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/thumbnails/v0"
 	searchsvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/search/v0"
 	thumbnailssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/thumbnails/v0"
-=======
-	"github.com/owncloud/ocis/extensions/webdav/pkg/config"
-	"github.com/owncloud/ocis/extensions/webdav/pkg/constants"
-	"github.com/owncloud/ocis/extensions/webdav/pkg/dav/requests"
-	thumbnailsmsg "github.com/owncloud/ocis/protogen/gen/ocis/messages/thumbnails/v0"
-	thumbnailssvc "github.com/owncloud/ocis/protogen/gen/ocis/services/thumbnails/v0"
->>>>>>> 60f1081e8 (implement thumbnails also for webdav and non remote.php routes)
 )
 
 const (
@@ -114,7 +103,7 @@ func NewService(opts ...Option) (Service, error) {
 			r.Get("/remote.php/webdav/*", http.NotFound)
 			r.Get("/webdav/*", http.NotFound)
 		})
-		
+
 		// r.MethodFunc("REPORT", "/remote.php/dav/files/{id}/*", svc.Search)
 
 		// This is a workaround for the go-chi concurrent map read write issue.


### PR DESCRIPTION
## Description
adds more routes to the proxy for thumbnail previews.

also adds omitempty to the routes config struct, to slim down the configuration example in https://owncloud.dev/extensions/proxy/configuration/

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis/issues/3558

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
