### PR TITLE
Update password enforcement & expiration date capabilities for public links

### DIFF
--- a/changelog/unreleased/update-linkshare-capabilities.md
+++ b/changelog/unreleased/update-linkshare-capabilities.md
@@ -1,0 +1,5 @@
+Enhancement: Update linkshare capabilities
+
+We have updated the capabilities regarding password enforcement and expiration dates of public links. They were previously hardcoded in a way that didn't reflect the actual backend functionality anymore.
+
+https://github.com/owncloud/ocis/pull/3579

--- a/extensions/storage/pkg/command/frontend.go
+++ b/extensions/storage/pkg/command/frontend.go
@@ -254,15 +254,15 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 									"multiple":             true,
 									"supports_upload_only": true,
 									"password": map[string]interface{}{
-										"enforced": true,
+										"enforced": false,
 										"enforced_for": map[string]interface{}{
-											"read_only":   true,
-											"read_write":  true,
-											"upload_only": true,
+											"read_only":   false,
+											"read_write":  false,
+											"upload_only": false,
 										},
 									},
 									"expire_date": map[string]interface{}{
-										"enabled": false,
+										"enabled": true,
 									},
 									"can_edit": true,
 								},


### PR DESCRIPTION
## Description
We discovered while working on https://github.com/owncloud/web/pull/6749 that oCIS announces passwords as enforced (which they aren't) and expiration dates as not enabled (which they are) for public links. This PR updates capabilities so we can cleanup the web frontend implementation which has relied on weird workarounds before