### PR TITLE
Align service naming

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1654,7 +1654,7 @@ def ocisServerWithAccounts(storage, accounts_hash_difficulty = 4, volumes = [], 
         "IDP_LDAP_LOGIN_ATTRIBUTE": "uid",
         "PROXY_ACCOUNT_BACKEND_TYPE": "accounts",
         "OCS_ACCOUNT_BACKEND_TYPE": "accounts",
-        "OCIS_RUN_EXTENSIONS": "settings,storage-metadata,graph,graph-explorer,ocs,store,thumbnails,web,webdav,storage-frontend,storage-gateway,storage-userprovider,storage-groupprovider,storage-authbasic,storage-authbearer,storage-authmachine,storage-users,storage-shares,storage-public-link,storage-appprovider,storage-sharing,proxy,idp,nats,accounts,glauth,ocdav",
+        "OCIS_RUN_EXTENSIONS": "settings,storage-metadata,graph,graph-explorer,ocs,store,thumbnails,web,webdav,frontend,gateway,user,group,auth-basic,auth-bearer,auth-machine,storage-users,storage-shares,storage-publiclink,appprovider,sharing,proxy,idp,nats,accounts,glauth,ocdav",
         "OCIS_INSECURE": "true",
         "PROXY_ENABLE_BASIC_AUTH": "true",
         "IDP_INSECURE": "true",
@@ -1787,7 +1787,7 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "OCIS_STORAGE_READ_ONLY": "false",
             # General oCIS config
             # OCIS_RUN_EXTENSIONS specifies to start all extensions except glauth, idp and accounts. These are replaced by external services
-            "OCIS_RUN_EXTENSIONS": "settings,storage-metadata,graph,graph-explorer,ocs,store,thumbnails,web,webdav,storage-frontend,storage-gateway,storage-userprovider,storage-groupprovider,storage-authbasic,storage-authbearer,storage-authmachine,storage-users,storage-shares,storage-public-link,storage-appprovider,storage-sharing,proxy,nats,ocdav",
+            "OCIS_RUN_EXTENSIONS": "settings,storage-metadata,graph,graph-explorer,ocs,store,thumbnails,web,webdav,frontend,gateway,user,group,auth-basic,auth-bearer,auth-machine,storage-users,storage-shares,storage-publiclink,appprovider,sharing,proxy,nats,ocdav",
             "OCIS_LOG_LEVEL": "info",
             "OCIS_URL": OCIS_URL,
             "PROXY_TLS": "true",

--- a/changelog/unreleased/align-service-naming.md
+++ b/changelog/unreleased/align-service-naming.md
@@ -1,0 +1,6 @@
+Enhancement: align service naming
+
+We now reflect the configured service names when listing them in the ocis runtime
+
+https://github.com/owncloud/ocis/pull/3606
+https://github.com/owncloud/ocis/issues/3603

--- a/extensions/group/pkg/config/defaults/defaultconfig.go
+++ b/extensions/group/pkg/config/defaults/defaultconfig.go
@@ -28,7 +28,7 @@ func DefaultConfig() *config.Config {
 			Protocol: "tcp",
 		},
 		Service: config.Service{
-			Name: "user",
+			Name: "group",
 		},
 		GroupMembersCacheExpiration: 5,
 		GatewayEndpoint:             "127.0.0.1:9142",

--- a/extensions/storage-shares/pkg/config/defaults/defaultconfig.go
+++ b/extensions/storage-shares/pkg/config/defaults/defaultconfig.go
@@ -29,7 +29,7 @@ func DefaultConfig() *config.Config {
 			Protocol: "tcp",
 		},
 		Service: config.Service{
-			Name: "storage-metadata",
+			Name: "storage-shares",
 		},
 		GatewayEndpoint:        "127.0.0.1:9142",
 		JWTSecret:              "Pive-Fumkiu4",

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -76,7 +76,7 @@ type Config struct {
 	Accounts          *accounts.Config        `yaml:"accounts"`
 	GLAuth            *glauth.Config          `yaml:"glauth"`
 	Graph             *graph.Config           `yaml:"graph"`
-	GraphExplorer     *graphExplorer.Config   `yaml:"graph_explorer"`
+	GraphExplorer     *graphExplorer.Config   `yaml:"graph-explorer"`
 	IDP               *idp.Config             `yaml:"idp"`
 	IDM               *idm.Config             `yaml:"idm"`
 	Nats              *nats.Config            `yaml:"nats"`
@@ -87,17 +87,17 @@ type Config struct {
 	Settings          *settings.Config        `yaml:"settings"`
 	Gateway           *gateway.Config         `yaml:"gateway"`
 	Frontend          *frontend.Config        `yaml:"frontend"`
-	AuthBasic         *authbasic.Config       `yaml:"auth_basic"`
-	AuthBearer        *authbearer.Config      `yaml:"auth_bearer"`
-	AuthMachine       *authmachine.Config     `yaml:"auth_machine"`
+	AuthBasic         *authbasic.Config       `yaml:"auth-basic"`
+	AuthBearer        *authbearer.Config      `yaml:"auth-bearer"`
+	AuthMachine       *authmachine.Config     `yaml:"auth-machine"`
 	User              *user.Config            `yaml:"user"`
 	Group             *group.Config           `yaml:"group"`
-	AppProvider       *appprovider.Config     `yaml:"app_provider"`
+	AppProvider       *appprovider.Config     `yaml:"appprovider"`
 	Sharing           *sharing.Config         `yaml:"sharing"`
-	StorageMetadata   *storagemetadata.Config `yaml:"storage_metadata"`
-	StoragePublicLink *storagepublic.Config   `yaml:"storage_public"`
-	StorageUsers      *storageusers.Config    `yaml:"storage_users"`
-	StorageShares     *storageshares.Config   `yaml:"storage_shares"`
+	StorageMetadata   *storagemetadata.Config `yaml:"storage-metadata"`
+	StoragePublicLink *storagepublic.Config   `yaml:"storage-public"`
+	StorageUsers      *storageusers.Config    `yaml:"storage-users"`
+	StorageShares     *storageshares.Config   `yaml:"storage-shares"`
 	OCDav             *ocdav.Config           `yaml:"ocdav"`
 	Store             *store.Config           `yaml:"store"`
 	Thumbnails        *thumbnails.Config      `yaml:"thumbnails"`

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -106,37 +106,37 @@ func NewService(options ...Option) (*Service, error) {
 		cfg:          opts.Config,
 	}
 
-	s.ServicesRegistry["settings"] = settings.NewSutureService
-	s.ServicesRegistry["nats"] = nats.NewSutureService
-	s.ServicesRegistry["storage-metadata"] = storagemetadata.NewStorageMetadata
-	s.ServicesRegistry["glauth"] = glauth.NewSutureService
-	s.ServicesRegistry["graph"] = graph.NewSutureService
-	s.ServicesRegistry["graph-explorer"] = graphExplorer.NewSutureService
-	s.ServicesRegistry["idm"] = idm.NewSutureService
-	s.ServicesRegistry["ocs"] = ocs.NewSutureService
-	s.ServicesRegistry["store"] = store.NewSutureService
-	s.ServicesRegistry["thumbnails"] = thumbnails.NewSutureService
-	s.ServicesRegistry["web"] = web.NewSutureService
-	s.ServicesRegistry["webdav"] = webdav.NewSutureService
-	s.ServicesRegistry["storage-frontend"] = frontend.NewFrontend
-	s.ServicesRegistry["ocdav"] = ocdav.NewOCDav
-	s.ServicesRegistry["storage-gateway"] = gateway.NewGateway
-	s.ServicesRegistry["storage-userprovider"] = user.NewUserProvider
-	s.ServicesRegistry["storage-groupprovider"] = group.NewGroupProvider
-	s.ServicesRegistry["storage-authbasic"] = authbasic.NewAuthBasic
-	s.ServicesRegistry["storage-authbearer"] = authbearer.NewAuthBearer
-	s.ServicesRegistry["storage-authmachine"] = authmachine.NewAuthMachine
-	s.ServicesRegistry["storage-users"] = storageusers.NewStorageUsers
-	s.ServicesRegistry["storage-shares"] = storageshares.NewStorageShares
-	s.ServicesRegistry["storage-public-link"] = storagepublic.NewStoragePublicLink
-	s.ServicesRegistry["storage-appprovider"] = appprovider.NewAppProvider
-	s.ServicesRegistry["notifications"] = notifications.NewSutureService
+	s.ServicesRegistry[opts.Config.Settings.Service.Name] = settings.NewSutureService
+	s.ServicesRegistry[opts.Config.Nats.Service.Name] = nats.NewSutureService
+	s.ServicesRegistry[opts.Config.StorageMetadata.Service.Name] = storagemetadata.NewStorageMetadata
+	s.ServicesRegistry[opts.Config.GLAuth.Service.Name] = glauth.NewSutureService
+	s.ServicesRegistry[opts.Config.Graph.Service.Name] = graph.NewSutureService
+	s.ServicesRegistry[opts.Config.GraphExplorer.Service.Name] = graphExplorer.NewSutureService
+	s.ServicesRegistry[opts.Config.IDM.Service.Name] = idm.NewSutureService
+	s.ServicesRegistry[opts.Config.OCS.Service.Name] = ocs.NewSutureService
+	s.ServicesRegistry[opts.Config.Store.Service.Name] = store.NewSutureService
+	s.ServicesRegistry[opts.Config.Thumbnails.Service.Name] = thumbnails.NewSutureService
+	s.ServicesRegistry[opts.Config.Web.Service.Name] = web.NewSutureService
+	s.ServicesRegistry[opts.Config.WebDAV.Service.Name] = webdav.NewSutureService
+	s.ServicesRegistry[opts.Config.Frontend.Service.Name] = frontend.NewFrontend
+	s.ServicesRegistry[opts.Config.OCDav.Service.Name] = ocdav.NewOCDav
+	s.ServicesRegistry[opts.Config.Gateway.Service.Name] = gateway.NewGateway
+	s.ServicesRegistry[opts.Config.User.Service.Name] = user.NewUserProvider
+	s.ServicesRegistry[opts.Config.Group.Service.Name] = group.NewGroupProvider
+	s.ServicesRegistry[opts.Config.AuthBasic.Service.Name] = authbasic.NewAuthBasic
+	s.ServicesRegistry[opts.Config.AuthBearer.Service.Name] = authbearer.NewAuthBearer
+	s.ServicesRegistry[opts.Config.AuthMachine.Service.Name] = authmachine.NewAuthMachine
+	s.ServicesRegistry[opts.Config.StorageUsers.Service.Name] = storageusers.NewStorageUsers
+	s.ServicesRegistry[opts.Config.StorageShares.Service.Name] = storageshares.NewStorageShares
+	s.ServicesRegistry[opts.Config.StoragePublicLink.Service.Name] = storagepublic.NewStoragePublicLink
+	s.ServicesRegistry[opts.Config.AppProvider.Service.Name] = appprovider.NewAppProvider
+	s.ServicesRegistry[opts.Config.Notifications.Service.Name] = notifications.NewSutureService
 
 	// populate delayed services
-	s.Delayed["storage-sharing"] = sharing.NewSharing
-	s.Delayed["accounts"] = accounts.NewSutureService
-	s.Delayed["proxy"] = proxy.NewSutureService
-	s.Delayed["idp"] = idp.NewSutureService
+	s.Delayed[opts.Config.Sharing.Service.Name] = sharing.NewSharing
+	s.Delayed[opts.Config.Accounts.Service.Name] = accounts.NewSutureService
+	s.Delayed[opts.Config.Proxy.Service.Name] = proxy.NewSutureService
+	s.Delayed[opts.Config.IDP.Service.Name] = idp.NewSutureService
 
 	return s, nil
 }


### PR DESCRIPTION
We now reflect the configured service names when listing them in the ocis runtime.

Follow up PRs:
- [ ] rename `storage-metadata` -> just `metadata`
- [ ] rename ocis commands to reflect changed names, eg `storageapprovider.go` -> `approvider.go` with the command name `storage-app-provider` -> `app-provider`
- always use the correct service names in the `.drone.star` file `OCIS_RUN_EXTENSIONS`

partly fixes https://github.com/owncloud/ocis/issues/3603