### PR TITLE
Spaces capability feature flags

### DIFF
--- a/changelog/unreleased/spaces-capabilities.md
+++ b/changelog/unreleased/spaces-capabilities.md
@@ -1,0 +1,5 @@
+Enhancement: Added `share_jail` and `projects` feature flags in spaces capability
+
+We've added feature flags to the `spaces` capability to indicate to clients which features are supposed to be shown to users.
+
+https://github.com/owncloud/ocis/pull/3626

--- a/changelog/unreleased/update-reva.md
+++ b/changelog/unreleased/update-reva.md
@@ -9,4 +9,5 @@ https://github.com/owncloud/ocis/pull/3570
 https://github.com/owncloud/ocis/pull/3601
 https://github.com/owncloud/ocis/pull/3605
 https://github.com/owncloud/ocis/pull/3611
-https://github.com/owncloud/ocis/pull/3621
+https://github.com/owncloud/ocis/issues/3621
+https://github.com/owncloud/ocis/pull/3637

--- a/extensions/frontend/pkg/command/command.go
+++ b/extensions/frontend/pkg/command/command.go
@@ -286,8 +286,10 @@ func frontendConfigFromStruct(c *cli.Context, cfg *config.Config, filesCfg map[s
 								},
 							},
 							"spaces": map[string]interface{}{
-								"version": "0.0.1",
-								"enabled": cfg.EnableProjectSpaces,
+								"version":    "0.0.1",
+								"enabled":    cfg.EnableProjectSpaces || cfg.EnableShareJail,
+								"projects":   cfg.EnableProjectSpaces,
+								"share_jail": cfg.EnableShareJail,
 							},
 						},
 						"version": map[string]interface{}{

--- a/extensions/frontend/pkg/config/config.go
+++ b/extensions/frontend/pkg/config/config.go
@@ -23,7 +23,8 @@ type Config struct {
 	SkipUserGroupsInToken bool `yaml:"skip_users_groups_in_token"`
 
 	EnableFavorites          bool   `yaml:"favorites"`
-	EnableProjectSpaces      bool   `yaml:"enable_project_spaces"`
+	EnableProjectSpaces      bool   `yaml:"enable_project_spaces" env:"FRONTEND_ENABLE_PROJECT_SPACES" desc:"Indicates to clients that project spaces are supposed to be made available."`
+	EnableShareJail          bool   `yaml:"enable_share_jail" env:"FRONTEND_ENABLE_SHARE_JAIL" desc:"Indicates to clients that the share jail is supposed to be used."`
 	UploadMaxChunkSize       int    `yaml:"upload_max_chunk_size"`
 	UploadHTTPMethodOverride string `yaml:"upload_http_method_override"`
 	DefaultUploadProtocol    string `yaml:"default_upload_protocol"`

--- a/extensions/frontend/pkg/config/defaults/defaultconfig.go
+++ b/extensions/frontend/pkg/config/defaults/defaultconfig.go
@@ -33,6 +33,7 @@ func DefaultConfig() *config.Config {
 		PublicURL:                "https://localhost:9200",
 		EnableFavorites:          false,
 		EnableProjectSpaces:      true,
+		EnableShareJail:          true,
 		UploadMaxChunkSize:       1e+8,
 		UploadHTTPMethodOverride: "",
 		DefaultUploadProtocol:    "tus",


### PR DESCRIPTION
## Description
Adds new `share_jail` and `projects` feature flags to the `spaces` capability.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/3615
- related https://github.com/cs3org/reva/pull/2795
- needed for https://github.com/owncloud/web/pull/6593

## Motivation and Context
Provide a switch to indicate to clients to still use the old user home webdav endpoint.

## How Has This Been Tested?
just in CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
