### PR TITLE
reduce drives in listing of graph /me/drives API

### DIFF
--- a/changelog/unreleased/graph-me-drives.md
+++ b/changelog/unreleased/graph-me-drives.md
@@ -1,0 +1,6 @@
+Change: Reduce drives in graph /me/drives API
+
+Reduced the drives in the graph `/me/drives` API to only the drives the user has access to.
+The endpoint `/drives` will list all drives when the user has the permission. 
+
+https://github.com/owncloud/ocis/pull/3629

--- a/extensions/graph/pkg/service/v0/drives.go
+++ b/extensions/graph/pkg/service/v0/drives.go
@@ -31,8 +31,19 @@ import (
 	merrors "go-micro.dev/v4/errors"
 )
 
-// GetDrives implements the Service interface.
+// GetDrives lists all drives the current user has access to
 func (g Graph) GetDrives(w http.ResponseWriter, r *http.Request) {
+	g.getDrives(w, r, false)
+}
+
+// GetAllDrives lists all drives, including other user's drives, if the current
+// user has the permission.
+func (g Graph) GetAllDrives(w http.ResponseWriter, r *http.Request) {
+	g.getDrives(w, r, true)
+}
+
+// getDrives implements the Service interface.
+func (g Graph) getDrives(w http.ResponseWriter, r *http.Request, unrestricted bool) {
 	sanitizedPath := strings.TrimPrefix(r.URL.Path, "/graph/v1.0/")
 	// Parse the request with odata parser
 	odataReq, err := godata.ParseRequest(r.Context(), sanitizedPath, r.URL.Query())
@@ -41,7 +52,10 @@ func (g Graph) GetDrives(w http.ResponseWriter, r *http.Request) {
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
-	g.logger.Info().Interface("query", r.URL.Query()).Msg("Calling GetDrives")
+	g.logger.Debug().
+		Interface("query", r.URL.Query()).
+		Bool("unrestricted", unrestricted).
+		Msg("Calling getDrives")
 	ctx := r.Context()
 
 	filters, err := generateCs3Filters(odataReq)
@@ -50,7 +64,7 @@ func (g Graph) GetDrives(w http.ResponseWriter, r *http.Request) {
 		errorcode.NotSupported.Render(w, r, http.StatusNotImplemented, err.Error())
 		return
 	}
-	res, err := g.ListStorageSpacesWithFilters(ctx, filters)
+	res, err := g.ListStorageSpacesWithFilters(ctx, filters, unrestricted)
 	switch {
 	case err != nil:
 		g.logger.Error().Err(err).Msg(ListStorageSpacesTransportErr)
@@ -106,7 +120,7 @@ func (g Graph) GetSingleDrive(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	filters := []*storageprovider.ListStorageSpacesRequest_Filter{listStorageSpacesIDFilter(driveID)}
-	res, err := g.ListStorageSpacesWithFilters(ctx, filters)
+	res, err := g.ListStorageSpacesWithFilters(ctx, filters, true)
 	switch {
 	case err != nil:
 		g.logger.Error().Err(err).Msg(ListStorageSpacesTransportErr)
@@ -398,7 +412,7 @@ func (g Graph) formatDrives(ctx context.Context, baseURL *url.URL, storageSpaces
 }
 
 // ListStorageSpacesWithFilters List Storage Spaces using filters
-func (g Graph) ListStorageSpacesWithFilters(ctx context.Context, filters []*storageprovider.ListStorageSpacesRequest_Filter) (*storageprovider.ListStorageSpacesResponse, error) {
+func (g Graph) ListStorageSpacesWithFilters(ctx context.Context, filters []*storageprovider.ListStorageSpacesRequest_Filter, unrestricted bool) (*storageprovider.ListStorageSpacesResponse, error) {
 	client := g.GetGatewayClient()
 
 	permissions := make(map[string]struct{}, 1)
@@ -422,6 +436,10 @@ func (g Graph) ListStorageSpacesWithFilters(ctx context.Context, filters []*stor
 			"permissions": {
 				Decoder: "json",
 				Value:   value,
+			},
+			"unrestricted": {
+				Decoder: "plain",
+				Value:   []byte(strconv.FormatBool(unrestricted)),
 			},
 		}},
 		Filters: filters,

--- a/extensions/graph/pkg/service/v0/service.go
+++ b/extensions/graph/pkg/service/v0/service.go
@@ -173,7 +173,7 @@ func NewService(opts ...Option) Service {
 					account.JWTSecret(options.Config.TokenManager.JWTSecret)),
 				)
 				r.Route("/drives", func(r chi.Router) {
-					r.Get("/", svc.GetDrives)
+					r.Get("/", svc.GetAllDrives)
 					r.Post("/", svc.CreateDrive)
 					r.Route("/{driveID}", func(r chi.Router) {
 						r.Patch("/", svc.UpdateDrive)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.3.2
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde
-	github.com/cs3org/reva/v2 v2.0.0-20220427203355-0164880ac7d3
+	github.com/cs3org/reva/v2 v2.0.0-20220429105953-71d0c17a5e8f
 	github.com/disintegration/imaging v1.6.2
 	github.com/glauth/glauth/v2 v2.0.0-20211021011345-ef3151c28733
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBW
 github.com/boombuler/barcode v1.0.1 h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
+github.com/c0rby/reva/v2 v2.0.0-20220429095703-bbac276f2cb4 h1:NAAz/6zTxFa0RBui856DKPIi4cF5jU7FHcbX+n25DM0=
+github.com/c0rby/reva/v2 v2.0.0-20220429095703-bbac276f2cb4/go.mod h1:2e/4HcIy54Mic3V7Ow0bz4n5dkZU0dHIZSWomFe5vng=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -318,10 +320,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde h1:WrD9O8ZaWvsm0
 github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva v1.18.0 h1:MbPS5ZAa8RzKcTxAVeSDdISB3XXqLIxqB03BTN5ReBY=
 github.com/cs3org/reva v1.18.0/go.mod h1:e5VDUDu4vVWIeVkZcW//n6UZzhGGMa+Tz/whCiX3N6o=
-github.com/cs3org/reva/v2 v2.0.0-20220427133111-618964eed515 h1:8pPCLxNXVz/q7PMM6Zq1lff3P8SFAu8/CXwB2eA21xc=
-github.com/cs3org/reva/v2 v2.0.0-20220427133111-618964eed515/go.mod h1:2e/4HcIy54Mic3V7Ow0bz4n5dkZU0dHIZSWomFe5vng=
-github.com/cs3org/reva/v2 v2.0.0-20220427203355-0164880ac7d3 h1:6sKjGI0AUW5tBXWBduaBoc+9sNYZWQR894G0oFCbus0=
-github.com/cs3org/reva/v2 v2.0.0-20220427203355-0164880ac7d3/go.mod h1:2e/4HcIy54Mic3V7Ow0bz4n5dkZU0dHIZSWomFe5vng=
+github.com/cs3org/reva/v2 v2.0.0-20220429105953-71d0c17a5e8f h1:UH9T67KTeWfKCmUQcR8jNSPDSoXaEjS6zkFykILO13w=
+github.com/cs3org/reva/v2 v2.0.0-20220429105953-71d0c17a5e8f/go.mod h1:2e/4HcIy54Mic3V7Ow0bz4n5dkZU0dHIZSWomFe5vng=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1145,7 +1145,7 @@ class SpacesContext implements Context {
 		$results = [];
 		if ($multistatusResults !== null) {
 			foreach ($multistatusResults as $multistatusResult) {
-				$entryPath = $multistatusResult['value'][0]['value'];
+				$entryPath = urldecode($multistatusResult['value'][0]['value']);
 				$entryName = \str_replace($topWebDavPath, "", $entryPath);
 				$entryName = \rawurldecode($entryName);
 				$entryName = \trim($entryName, "/");


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Reduced the drives in the graph `/me/drives` API to only the drives the user has access to.
The endpoint `/drives` will list all drives when the user has the permission. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The clients want a list of drives the current user can access. The listing for managing spaces can still be done via the `/drives` endpoint.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: locally with the graph-explorer


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
