### PR TITLE
idp: Check if CA cert if present

### DIFF
--- a/changelog/unreleased/idp-cert-wait.md
+++ b/changelog/unreleased/idp-cert-wait.md
@@ -1,0 +1,8 @@
+Bugfix: idp: Check if CA certificate if present
+
+Upon first start with the default configurtation the idm service creates
+a server certificate, that might not be finished before the idp service
+is starting. Add a check to idp similar to what the user, group, and
+auth-providers implement.
+
+https://github.com/owncloud/ocis/issues/3623


### PR DESCRIPTION
Upon first start with the default configurtation the idm service creates
a server certificate, that might not be finished before the idp service
is starting. Add a check to idp similar to what the user, group, and
auth-providers implement.

Fixes: #3623
