### PR TITLE
Enable user-management webui

### DIFF
--- a/changelog/unreleased/libregraph-idm-switch.md
+++ b/changelog/unreleased/libregraph-idm-switch.md
@@ -1,0 +1,9 @@
+Change: Switched default configuration to use libregraph/idm
+
+We switched the default configuration of oCIS to use the "idm" service (based
+on libregraph/idm) as the standard source for user and group information. The
+accounts and glauth services are no longer enabled by default and will be
+removed with an upcoming release.
+
+https://github.com/owncloud/ocis/pull/3331
+https://github.com/owncloud/ocis/pull/3633

--- a/extensions/web/pkg/config/defaults/defaultconfig.go
+++ b/extensions/web/pkg/config/defaults/defaultconfig.go
@@ -50,7 +50,7 @@ func DefaultConfig() *config.Config {
 					ResponseType: "code",
 					Scope:        "openid profile email",
 				},
-				Apps: []string{"files", "search", "preview", "text-editor", "pdf-viewer", "external"},
+				Apps: []string{"files", "search", "preview", "text-editor", "pdf-viewer", "external", "user-management"},
 			},
 		},
 	}

--- a/extensions/web/pkg/service/v0/service.go
+++ b/extensions/web/pkg/service/v0/service.go
@@ -85,10 +85,6 @@ func (p Web) getPayload() (payload []byte, err error) {
 					ID:   "settings",
 					Path: "/settings.js",
 				},
-				{
-					ID:   "accounts",
-					Path: "/accounts.js",
-				},
 			}
 		}
 


### PR DESCRIPTION
The switch to libregraph/idm happend we can enable the new UI.