### PR TITLE
fix env variable for metadata user ID

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,8 @@
                 "IDM_ADMIN_PASSWORD": "admin",
                 // demo users
                 "IDM_CREATE_DEMO_USERS": "true",
+                // metadata storage
+                "METADATA_USER_ID": "some-metadata-user-id"
                 // OCIS_RUN_EXTENSIONS allows to start a subset of extensions even in the supervised mode
                 //"OCIS_RUN_EXTENSIONS": "settings,storage-metadata,glauth,graph,graph-explorer,idp,ocs,store,thumbnails,web,webdav,storage-frontend,storage-gateway,storage-userprovider,storage-groupprovider,storage-authbasic,storage-authbearer,storage-authmachine,storage-users,storage-shares,storage-public-link,storage-appprovider,storage-sharing,accounts,proxy,ocdav",
             }

--- a/changelog/unreleased/metadata-gateway.md
+++ b/changelog/unreleased/metadata-gateway.md
@@ -3,3 +3,4 @@ Enhancement: wrap metadata storage with dedicated reva gateway
 We wrapped the metadata storage in a minimal reva instance with a dedicated gateway, including static storage registry, static auth registry, in memory userprovider, machine authprovider and demo permissions service. This allows us to preconfigure the service user for the ocis settings service, share and public share providers.
 
 https://github.com/owncloud/ocis/pull/3602
+https://github.com/owncloud/ocis/pull/3647

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	TokenManager      *shared.TokenManager `yaml:"token_manager"`
 	MachineAuthAPIKey string               `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY"`
 	TransferSecret    string               `yaml:"transfer_secret" env:"STORAGE_TRANSFER_SECRET"`
-	MetadataUserID    string               `yaml:"metadata_user_id"`
+	MetadataUserID    string               `yaml:"metadata_user_id" env:"METADATA_USER_ID"`
 	Runtime           Runtime              `yaml:"runtime"`
 
 	Audit             *audit.Config           `yaml:"audit"`


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

`METADATA_USER_ID` was not routed to the env variable in the single process use case. 
Also added it to the launch.json

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
