### PR TITLE
Get rid of hardcoded admin user uuid

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1660,7 +1660,7 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "name": "wait-for-ocis-server",
             "image": OC_CI_ALPINE,
             "commands": [
-                "curl -k -u admin:admin --fail --retry-connrefused --retry 10 --retry-all-errors 'https://ocis-server:9200/graph/v1.0/users/ddc2004c-0977-11eb-9d3f-a793888cd0f8'",
+                "curl -k -u admin:admin --fail --retry-connrefused --retry 10 --retry-all-errors 'https://ocis-server:9200/graph/v1.0/users/admin'",
             ],
             "depends_on": depends_on,
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,7 @@
                 "IDP_LDAP_BIND_PASSWORD": "some-ldap-idp-password",
                 // admin user default password
                 "IDM_ADMIN_PASSWORD": "admin",
+                "ADMIN_USER_ID": "admin",
                 // demo users
                 "IDM_CREATE_DEMO_USERS": "true",
                 // metadata storage

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,14 +15,16 @@
                 "OCIS_LOG_LEVEL": "debug",
                 "OCIS_LOG_PRETTY": "true",
                 "OCIS_LOG_COLOR": "true",
-                // enable basic auth for dev setup so that we can use curl for testing
-                "PROXY_ENABLE_BASIC_AUTH": "true",
+                // user id of "admin", for user creation and admin role assignement
+                "OCIS_ADMIN_USER_ID": "admin-user-id",
                 // set insecure options because we don't have valid certificates in dev environments
                 "OCIS_INSECURE": "true",
                 // set some hardcoded secrets
                 "OCIS_JWT_SECRET": "some-ocis-jwt-secret",
-                "STORAGE_TRANSFER_SECRET": "some-ocis-transfer-secret",
                 "OCIS_MACHINE_AUTH_API_KEY": "some-ocis-machine-auth-api-key",
+                "STORAGE_TRANSFER_SECRET": "some-ocis-transfer-secret",
+                // enable basic auth for dev setup so that we can use curl for testing
+                "PROXY_ENABLE_BASIC_AUTH": "true",
                 // idm ldap
                 "IDM_SVC_PASSWORD": "some-ldap-idm-password",
                 "GRAPH_LDAP_BIND_PASSWORD": "some-ldap-idm-password",
@@ -36,7 +38,6 @@
                 "IDP_LDAP_BIND_PASSWORD": "some-ldap-idp-password",
                 // admin user default password
                 "IDM_ADMIN_PASSWORD": "admin",
-                "ADMIN_USER_ID": "admin",
                 // demo users
                 "IDM_CREATE_DEMO_USERS": "true",
                 // metadata storage

--- a/changelog/unreleased/change-ocis-init.md
+++ b/changelog/unreleased/change-ocis-init.md
@@ -1,10 +1,12 @@
 Change: Introduce `ocis init` and remove all default secrets
 
-We've removed all default secrets. This means you can't start oCIS any longer
-without setting these via environment variable or configuration file.
+We've removed all default secrets and the hardcoded UUID of the user `admin`.
+This means you can't start oCIS any longer without setting these via
+environment variable or configuration file.
 
 In order to make this easy for you, we introduced a new command: `ocis init`.
 You can run this command before starting oCIS with `ocis server` and it will
 bootstrap you a configuration file for a secure oCIS instance.
 
 https://github.com/owncloud/ocis/pull/3551
+https://github.com/owncloud/ocis/issues/3524

--- a/extensions/idm/ldif/base.ldif.tmpl
+++ b/extensions/idm/ldif/base.ldif.tmpl
@@ -29,7 +29,7 @@ cn: admin
 displayName: Admin
 description: An admin for this oCIS instance.
 mail: admin@example.org
-ownCloudUUID: ddc2004c-0977-11eb-9d3f-a793888cd0f8
+ownCloudUUID: {{ .ID }}
 {{ else -}}
 dn: uid={{ .Name }},ou=sysusers,o=libregraph-idm
 objectClass: account

--- a/extensions/idm/pkg/command/server.go
+++ b/extensions/idm/pkg/command/server.go
@@ -90,12 +90,14 @@ func bootstrap(logger log.Logger, cfg *config.Config, srvcfg server.Config) erro
 	type svcUser struct {
 		Name     string
 		Password string
+		ID       string
 	}
 
 	serviceUsers := []svcUser{
 		{
 			Name:     "admin",
 			Password: cfg.ServiceUserPasswords.OcisAdmin,
+			ID:       cfg.Commons.AdminUserID,
 		},
 		{
 			Name:     "libregraph",

--- a/extensions/idm/pkg/config/parser/parse.go
+++ b/extensions/idm/pkg/config/parser/parse.go
@@ -33,6 +33,10 @@ func ParseConfig(cfg *config.Config) error {
 }
 
 func Validate(cfg *config.Config) error {
+	if cfg.AdminUserID == "" {
+		return shared.MissingAdminUserID(cfg.Service.Name)
+	}
+
 	if cfg.ServiceUserPasswords.Idm == "" {
 		return shared.MissingServiceUserPassword(cfg.Service.Name, "IDM")
 	}
@@ -44,6 +48,7 @@ func Validate(cfg *config.Config) error {
 	if cfg.ServiceUserPasswords.Idp == "" {
 		return shared.MissingServiceUserPassword(cfg.Service.Name, "IDP")
 	}
+
 	if cfg.ServiceUserPasswords.Reva == "" {
 		return shared.MissingServiceUserPassword(cfg.Service.Name, "REVA")
 	}

--- a/extensions/settings/pkg/config/parser/parse.go
+++ b/extensions/settings/pkg/config/parser/parse.go
@@ -41,5 +41,9 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingMachineAuthApiKeyError(cfg.Service.Name)
 	}
 
+	if cfg.AdminUserID == "" {
+		return shared.MissingAdminUserID(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/extensions/settings/pkg/service/v0/service.go
+++ b/extensions/settings/pkg/service/v0/service.go
@@ -126,7 +126,7 @@ func (g Service) RegisterDefaultRoles() {
 		}
 	}
 
-	for _, req := range defaultRoleAssignments() {
+	for _, req := range g.defaultRoleAssignments() {
 		if _, err := g.manager.WriteRoleAssignment(req.AccountUuid, req.RoleId); err != nil {
 			g.logger.Error().Err(err).Msg("failed to register role assignment")
 		}

--- a/extensions/settings/pkg/service/v0/settings.go
+++ b/extensions/settings/pkg/service/v0/settings.go
@@ -532,14 +532,14 @@ func generatePermissionRequests() []*settingssvc.AddSettingToBundleRequest {
 	}
 }
 
-func defaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
+func (g Service) defaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
 	return []*settingsmsg.UserRoleAssignment{
 		// default admin users
 		{
 			AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b", // demo user "moss"
 			RoleId:      BundleUUIDRoleAdmin,
 		}, {
-			AccountUuid: "ddc2004c-0977-11eb-9d3f-a793888cd0f8",
+			AccountUuid: g.config.Commons.AdminUserID,
 			RoleId:      BundleUUIDRoleAdmin,
 		},
 		// default users with role "user"

--- a/extensions/settings/pkg/service/v0/settings.go
+++ b/extensions/settings/pkg/service/v0/settings.go
@@ -536,16 +536,10 @@ func defaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
 	return []*settingsmsg.UserRoleAssignment{
 		// default admin users
 		{
-			AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b",
+			AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b", // demo user "moss"
 			RoleId:      BundleUUIDRoleAdmin,
 		}, {
 			AccountUuid: "ddc2004c-0977-11eb-9d3f-a793888cd0f8",
-			RoleId:      BundleUUIDRoleAdmin,
-		}, {
-			AccountUuid: "820ba2a1-3f54-4538-80a4-2d73007e30bf",
-			RoleId:      BundleUUIDRoleAdmin,
-		}, {
-			AccountUuid: "bc596f3c-c955-4328-80a0-60d018b4ad57",
 			RoleId:      BundleUUIDRoleAdmin,
 		},
 		// default users with role "user"

--- a/extensions/settings/pkg/store/defaults/defaults.go
+++ b/extensions/settings/pkg/store/defaults/defaults.go
@@ -1,6 +1,7 @@
 package defaults
 
 import (
+	"github.com/owncloud/ocis/extensions/settings/pkg/config"
 	settingsmsg "github.com/owncloud/ocis/protogen/gen/ocis/messages/settings/v0"
 )
 
@@ -496,14 +497,14 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 }
 
 // DefaultRoleAssignments returns (as one might guess) the default role assignments
-func DefaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
+func DefaultRoleAssignments(cfg *config.Config) []*settingsmsg.UserRoleAssignment {
 	return []*settingsmsg.UserRoleAssignment{
 		// default admin users
 		{
 			AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b", // demo user "moss"
 			RoleId:      BundleUUIDRoleAdmin,
 		}, {
-			AccountUuid: "ddc2004c-0977-11eb-9d3f-a793888cd0f8",
+			AccountUuid: cfg.Commons.AdminUserID,
 			RoleId:      BundleUUIDRoleAdmin,
 		},
 		// default users with role "user"

--- a/extensions/settings/pkg/store/defaults/defaults.go
+++ b/extensions/settings/pkg/store/defaults/defaults.go
@@ -500,16 +500,10 @@ func DefaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
 	return []*settingsmsg.UserRoleAssignment{
 		// default admin users
 		{
-			AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b",
+			AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b", // demo user "moss"
 			RoleId:      BundleUUIDRoleAdmin,
 		}, {
 			AccountUuid: "ddc2004c-0977-11eb-9d3f-a793888cd0f8",
-			RoleId:      BundleUUIDRoleAdmin,
-		}, {
-			AccountUuid: "820ba2a1-3f54-4538-80a4-2d73007e30bf",
-			RoleId:      BundleUUIDRoleAdmin,
-		}, {
-			AccountUuid: "bc596f3c-c955-4328-80a0-60d018b4ad57",
 			RoleId:      BundleUUIDRoleAdmin,
 		},
 		// default users with role "user"

--- a/extensions/settings/pkg/store/metadata/assignments.go
+++ b/extensions/settings/pkg/store/metadata/assignments.go
@@ -14,7 +14,7 @@ import (
 // ListRoleAssignments loads and returns all role assignments matching the given assignment identifier.
 func (s *Store) ListRoleAssignments(accountUUID string) ([]*settingsmsg.UserRoleAssignment, error) {
 	if s.mdc == nil {
-		return defaultRoleAssignments(accountUUID), nil
+		return s.defaultRoleAssignments(accountUUID), nil
 	}
 	s.Init()
 	ctx := context.TODO()
@@ -92,9 +92,9 @@ func (s *Store) RemoveRoleAssignment(assignmentID string) error {
 	return fmt.Errorf("assignmentID '%s' not found", assignmentID)
 }
 
-func defaultRoleAssignments(accID string) []*settingsmsg.UserRoleAssignment {
+func (s *Store) defaultRoleAssignments(accID string) []*settingsmsg.UserRoleAssignment {
 	var assmnts []*settingsmsg.UserRoleAssignment
-	for _, r := range defaults.DefaultRoleAssignments() {
+	for _, r := range defaults.DefaultRoleAssignments(s.cfg) {
 		if r.AccountUuid == accID {
 			assmnts = append(assmnts, r)
 		}

--- a/extensions/settings/pkg/store/metadata/assignments_test.go
+++ b/extensions/settings/pkg/store/metadata/assignments_test.go
@@ -5,8 +5,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/owncloud/ocis/extensions/settings/pkg/config/defaults"
 	olog "github.com/owncloud/ocis/ocis-pkg/log"
+	"github.com/owncloud/ocis/ocis-pkg/shared"
 	settingsmsg "github.com/owncloud/ocis/protogen/gen/ocis/messages/settings/v0"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +20,6 @@ var (
 	s = &Store{
 		Logger: logger,
 		l:      &sync.Mutex{},
-		cfg:    defaults.DefaultConfig(),
 	}
 
 	logger = olog.NewLogger(
@@ -89,6 +90,11 @@ var (
 )
 
 func init() {
+	s.cfg = defaults.DefaultConfig()
+	s.cfg.Commons = &shared.Commons{
+		AdminUserID: uuid.Must(uuid.NewV4()).String(),
+	}
+
 	_ = NewMDC(s)
 	setupRoles()
 }

--- a/extensions/settings/pkg/store/metadata/store.go
+++ b/extensions/settings/pkg/store/metadata/store.go
@@ -123,7 +123,7 @@ func (s *Store) initMetadataClient(mdc MetadataClient) error {
 		}
 	}
 
-	for _, p := range defaults.DefaultRoleAssignments() {
+	for _, p := range defaults.DefaultRoleAssignments(s.cfg) {
 		accountUUID := p.AccountUuid
 		roleID := p.RoleId
 		err = mdc.MakeDirIfNotExist(ctx, accountPath(accountUUID))

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	MachineAuthAPIKey string               `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY"`
 	TransferSecret    string               `yaml:"transfer_secret" env:"STORAGE_TRANSFER_SECRET"`
 	SystemUserID      string               `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID"`
+	AdminUserID       string               `yaml:"admin_user_id" env:"ADMIN_USER_ID"`
 	Runtime           Runtime              `yaml:"runtime"`
 
 	Accounts          *accounts.Config      `yaml:"accounts"`

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	MachineAuthAPIKey string               `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY"`
 	TransferSecret    string               `yaml:"transfer_secret" env:"STORAGE_TRANSFER_SECRET"`
 	SystemUserID      string               `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID"`
-	AdminUserID       string               `yaml:"admin_user_id" env:"ADMIN_USER_ID"`
+	AdminUserID       string               `yaml:"admin_user_id" env:"OCIS_ADMIN_USER_ID"`
 	Runtime           Runtime              `yaml:"runtime"`
 
 	Accounts          *accounts.Config      `yaml:"accounts"`

--- a/ocis-pkg/config/parser/parse.go
+++ b/ocis-pkg/config/parser/parse.go
@@ -98,6 +98,11 @@ func EnsureCommons(cfg *config.Config) {
 	if cfg.SystemUserID != "" {
 		cfg.Commons.SystemUserID = cfg.SystemUserID
 	}
+
+	// copy admin user id to the commons part if set
+	if cfg.AdminUserID != "" {
+		cfg.Commons.AdminUserID = cfg.AdminUserID
+	}
 }
 
 func Validate(cfg *config.Config) error {

--- a/ocis-pkg/config/parser/parse.go
+++ b/ocis-pkg/config/parser/parse.go
@@ -122,5 +122,9 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingSystemUserID("ocis")
 	}
 
+	if cfg.AdminUserID == "" {
+		return shared.MissingAdminUserID("ocis")
+	}
+
 	return nil
 }

--- a/ocis-pkg/shared/errors.go
+++ b/ocis-pkg/shared/errors.go
@@ -53,3 +53,11 @@ func MissingSystemUserID(service string) error {
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
+
+func MissingAdminUserID(service string) error {
+	return fmt.Errorf("The admin user ID has not been configured for %s. "+
+		"Make sure your %s config contains the proper values "+
+		"(e.g. by running ocis init or setting it manually in "+
+		"the config/corresponding environment variable).",
+		service, defaults.BaseConfigPath())
+}

--- a/ocis-pkg/shared/shared_types.go
+++ b/ocis-pkg/shared/shared_types.go
@@ -45,4 +45,5 @@ type Commons struct {
 	MachineAuthAPIKey string        `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY"`
 	TransferSecret    string        `yaml:"transfer_secret,omitempty" env:"REVA_TRANSFER_SECRET"`
 	SystemUserID      string        `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID"`
+	AdminUserID       string        `yaml:"admin_user_id" env:"ADMIN_USER_ID"`
 }

--- a/ocis-pkg/shared/shared_types.go
+++ b/ocis-pkg/shared/shared_types.go
@@ -45,5 +45,5 @@ type Commons struct {
 	MachineAuthAPIKey string        `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY"`
 	TransferSecret    string        `yaml:"transfer_secret,omitempty" env:"REVA_TRANSFER_SECRET"`
 	SystemUserID      string        `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID"`
-	AdminUserID       string        `yaml:"admin_user_id" env:"ADMIN_USER_ID"`
+	AdminUserID       string        `yaml:"admin_user_id" env:"OCIS_ADMIN_USER_ID"`
 }

--- a/ocis/pkg/init/init.go
+++ b/ocis/pkg/init/init.go
@@ -100,6 +100,7 @@ type OcisConfig struct {
 	MachineAuthApiKey string       `yaml:"machine_auth_api_key"`
 	TransferSecret    string       `yaml:"transfer_secret"`
 	SystemUserID      string       `yaml:"system_user_id"`
+	AdminUserID       string       `yaml:"admin_user_id"`
 	Graph             GraphExtension
 	Idp               LdapBasedExtension
 	Idm               IdmExtension
@@ -162,6 +163,7 @@ func CreateConfig(insecure, forceOverwrite bool, configPath, adminPassword strin
 	}
 
 	systemUserID := uuid.Must(uuid.NewV4()).String()
+	adminUserID := uuid.Must(uuid.NewV4()).String()
 
 	idmServicePassword, err := generators.GenerateRandomPassword(passwordLength)
 	if err != nil {
@@ -203,6 +205,7 @@ func CreateConfig(insecure, forceOverwrite bool, configPath, adminPassword strin
 		MachineAuthApiKey: machineAuthApiKey,
 		TransferSecret:    revaTransferSecret,
 		SystemUserID:      systemUserID,
+		AdminUserID:       adminUserID,
 		Idm: IdmExtension{
 			ServiceUserPasswords: ServiceUserPasswordsSettings{
 				AdminPassword: ocisAdminServicePassword,


### PR DESCRIPTION
The UUID is generated by `ocs init` now and stored in the config file. To avoid that every ocis install uses the same UUID

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3524
