### PR TITLE
reduce hacky reference handling in thumbnailer

### DIFF
--- a/changelog/unreleased/new-space-id-functions.md
+++ b/changelog/unreleased/new-space-id-functions.md
@@ -3,3 +3,4 @@ Change: Use new space ID util functions
 Changed code to use the new space ID util functions so that everything works with the new spaces ID format.
 
 https://github.com/owncloud/ocis/pull/3648
+https://github.com/owncloud/ocis/pull/3669

--- a/extensions/thumbnails/pkg/service/grpc/v0/service.go
+++ b/extensions/thumbnails/pkg/service/grpc/v0/service.go
@@ -256,20 +256,16 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context,
 func (g Thumbnail) stat(path, auth string) (*provider.StatResponse, error) {
 	ctx := metadata.AppendToOutgoingContext(context.Background(), revactx.TokenHeader, auth)
 
-	var ref *provider.Reference
-	if strings.Contains(path, "!") {
-		parsed, err := storagespace.ParseReference(path)
-		if err != nil {
-			return nil, err
-		}
-		ref = &parsed
-	} else {
-		ref = &provider.Reference{
+	ref, err := storagespace.ParseReference(path)
+	if err != nil {
+		// If the path is not a spaces reference try to handle it like a plain
+		// path reference.
+		ref = provider.Reference{
 			Path: path,
 		}
 	}
 
-	req := &provider.StatRequest{Ref: ref}
+	req := &provider.StatRequest{Ref: &ref}
 	rsp, err := g.cs3Client.Stat(ctx, req)
 	if err != nil {
 		g.logger.Error().Err(err).Str("path", path).Msg("could not stat file")

--- a/extensions/webdav/pkg/service/v0/service.go
+++ b/extensions/webdav/pkg/service/v0/service.go
@@ -124,7 +124,7 @@ func (g Webdav) SpacesThumbnail(w http.ResponseWriter, r *http.Request) {
 	}
 	t := r.Header.Get(TokenHeader)
 
-	fullPath := tr.Identifier + "!" + tr.Filepath
+	fullPath := tr.Identifier + tr.Filepath
 	rsp, err := g.thumbnailsClient.GetThumbnail(r.Context(), &thumbnailssvc.GetThumbnailRequest{
 		Filepath:      strings.TrimLeft(tr.Filepath, "/"),
 		ThumbnailType: extensionToThumbnailType(strings.TrimLeft(tr.Extension, ".")),


### PR DESCRIPTION
Fix thumbnails requests with full spaces reference (`<providerid>$<spaceid>!<nodeid>`).