### PR TITLE
make yaml tags always use underscore

### DIFF
--- a/extensions/proxy/pkg/config/config.go
+++ b/extensions/proxy/pkg/config/config.go
@@ -53,7 +53,7 @@ type Route struct {
 	Backend string `yaml:"backend"`
 	// Service name to look up in the registry
 	Service     string `yaml:"service"`
-	ApacheVHost bool   `yaml:"apache-vhost"`
+	ApacheVHost bool   `yaml:"apache_vhost"`
 }
 
 // RouteType defines the type of a route

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -73,17 +73,17 @@ type Config struct {
 	Runtime           Runtime              `yaml:"runtime"`
 
 	Accounts          *accounts.Config      `yaml:"accounts"`
-	AppProvider       *appProvider.Config   `yaml:"app-provider"`
-	AppRegistry       *appRegistry.Config   `yaml:"app-registry"`
+	AppProvider       *appProvider.Config   `yaml:"app_provider"`
+	AppRegistry       *appRegistry.Config   `yaml:"app_registry"`
 	Audit             *audit.Config         `yaml:"audit"`
-	AuthBasic         *authbasic.Config     `yaml:"auth-basic"`
-	AuthBearer        *authbearer.Config    `yaml:"auth-bearer"`
-	AuthMachine       *authmachine.Config   `yaml:"auth-machine"`
+	AuthBasic         *authbasic.Config     `yaml:"auth_basic"`
+	AuthBearer        *authbearer.Config    `yaml:"auth_bearer"`
+	AuthMachine       *authmachine.Config   `yaml:"auth_machine"`
 	Frontend          *frontend.Config      `yaml:"frontend"`
 	Gateway           *gateway.Config       `yaml:"gateway"`
 	GLAuth            *glauth.Config        `yaml:"glauth"`
 	Graph             *graph.Config         `yaml:"graph"`
-	GraphExplorer     *graphExplorer.Config `yaml:"graph-explorer"`
+	GraphExplorer     *graphExplorer.Config `yaml:"graph_explorer"`
 	Group             *group.Config         `yaml:"group"`
 	IDM               *idm.Config           `yaml:"idm"`
 	IDP               *idp.Config           `yaml:"idp"`
@@ -94,10 +94,10 @@ type Config struct {
 	Proxy             *proxy.Config         `yaml:"proxy"`
 	Settings          *settings.Config      `yaml:"settings"`
 	Sharing           *sharing.Config       `yaml:"sharing"`
-	StorageSystem     *storagesystem.Config `yaml:"storage-system"`
-	StoragePublicLink *storagepublic.Config `yaml:"storage-public"`
-	StorageShares     *storageshares.Config `yaml:"storage-shares"`
-	StorageUsers      *storageusers.Config  `yaml:"storage-users"`
+	StorageSystem     *storagesystem.Config `yaml:"storage_system"`
+	StoragePublicLink *storagepublic.Config `yaml:"storage_public"`
+	StorageShares     *storageshares.Config `yaml:"storage_shares"`
+	StorageUsers      *storageusers.Config  `yaml:"storage_users"`
 	Store             *store.Config         `yaml:"store"`
 	Thumbnails        *thumbnails.Config    `yaml:"thumbnails"`
 	User              *user.Config          `yaml:"user"`

--- a/ocis/pkg/init/init.go
+++ b/ocis/pkg/init/init.go
@@ -105,12 +105,12 @@ type OcisConfig struct {
 	Idm               IdmExtension
 	Proxy             InsecureProxyExtension
 	Frontend          FrontendExtension
-	AuthBasic         AuthbasicExtension  `yaml:"auth-basic"`
-	AuthBearer        AuthbearerExtension `yaml:"auth-bearer"`
+	AuthBasic         AuthbasicExtension  `yaml:"auth_basic"`
+	AuthBearer        AuthbearerExtension `yaml:"auth_bearer"`
 	User              UserAndGroupExtension
 	Group             UserAndGroupExtension
-	StorageMetadata   DataProviderInsecureSettings `yaml:"storage-system"`
-	StorageUsers      DataProviderInsecureSettings `yaml:"storage-users"`
+	StorageMetadata   DataProviderInsecureSettings `yaml:"storage_system"`
+	StorageUsers      DataProviderInsecureSettings `yaml:"storage_users"`
 	Ocdav             InsecureExtension
 	Thumbnails        ThumbNailExtension
 }


### PR DESCRIPTION
We are going to treat yaml tags as lower case env vars. There should never be a `-` in the yaml tag. This PR changes all `-` to `_`, even when that will prevent finding service names like `auth-basic` when grepping the config, because it will be called `auth_basic`. The same applies to env vars where the prefix is `AUTH_BASIC_` for all env vars of the `auth-basic` service.