### PR TITLE
doc fixes

### DIFF
--- a/docs/helpers/adoc-generator.go.tmpl
+++ b/docs/helpers/adoc-generator.go.tmpl
@@ -15,7 +15,7 @@ import (
     {{- end}})
 
 type ConfigField struct {
-	Name         string
+	EnvVars      []string
 	DefaultValue string
 	Type         string
 	Description  string
@@ -86,8 +86,9 @@ func GetAnnotatedVariables(s interface{}) []ConfigField {
 			if !ok {
 				continue
 			}
-			v := fmt.Sprintf("%v", value.Interface())
-			fields = append(fields, ConfigField{Name: strings.ReplaceAll(env, ";", " +\n"), DefaultValue: v, Description: desc, Type: value.Type().Name()})
+			v := fmt.Sprintf("%v", value.Interface())			
+			td := strings.Split(env, ";")
+			fields = append(fields, ConfigField{EnvVars: td, DefaultValue: v, Description: desc, Type: value.Type().Name()})
 		case reflect.Ptr:
 			// PolicySelectors in the Proxy are being skipped atm
 			// they are not configurable via env vars, if that changes

--- a/docs/helpers/environment-variable-docs-generator.go.tmpl
+++ b/docs/helpers/environment-variable-docs-generator.go.tmpl
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"io/ioutil"
 	"log"
 	"os"
@@ -76,7 +77,7 @@ func GetAnnotatedVariables(s interface{}) []ConfigField {
 				continue
 			}
 			v := fmt.Sprintf("%v", value.Interface())
-			fields = append(fields, ConfigField{Name: strings.ReplaceAll(env, ";", "<br/>"), DefaultValue: v, Description: desc, Type: value.Type().Name()})
+			fields = append(fields, ConfigField{Name: strings.ReplaceAll(env, ";", "<br/>"), DefaultValue: html.EscapeString(strings.Replace(v, "|", "\\|", -1)), Description: desc, Type: value.Type().Name()})
 		case reflect.Ptr:
 			// PolicySelectors in the Proxy are being skipped atm
 			// they are not configurable via env vars, if that changes

--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -8,7 +8,10 @@
 | Description
 
 {{- range .Fields}}
-| `{{.Name}}`
+{{ $numVars := len .EnvVars }}
+| {{- range $i, $value := .EnvVars }}{{- if $i }} +{{ end }}
+`{{- $value }}` 
+{{- end }}
 | {{.Type}}
 | {{.DefaultValue}}
 | {{.Description}}


### PR DESCRIPTION
This PR fixes to minor nuisances. When generating docs:

1) Fix broken line wraps for adoc generation
2) Fix broken markdown tables because of special chars

Refs #3686 