### PR TITLE
[full-ci] change default sharing driver to cs3

### DIFF
--- a/extensions/sharing/pkg/config/defaults/defaultconfig.go
+++ b/extensions/sharing/pkg/config/defaults/defaultconfig.go
@@ -33,13 +33,13 @@ func DefaultConfig() *config.Config {
 		Reva: &config.Reva{
 			Address: "127.0.0.1:9142",
 		},
-		UserSharingDriver: "json", // TODO use "cs3", see https://github.com/owncloud/ocis/pull/3697
+		UserSharingDriver: "cs3",
 		UserSharingDrivers: config.UserSharingDrivers{
 			JSON: config.UserSharingJSONDriver{
 				File: filepath.Join(defaults.BaseDataPath(), "storage", "shares.json"),
 			},
 			CS3: config.UserSharingCS3Driver{
-				ProviderAddr:  "127.0.0.1:9215", // metadata storage
+				ProviderAddr:  "127.0.0.1:9215", // system storage
 				SystemUserIDP: "internal",
 			},
 			OwnCloudSQL: config.UserSharingOwnCloudSQLDriver{
@@ -49,15 +49,16 @@ func DefaultConfig() *config.Config {
 				DBName:     "owncloud",
 			},
 		},
-		PublicSharingDriver: "json", // TODO use "cs3", see https://github.com/owncloud/ocis/pull/3697
+		PublicSharingDriver: "cs3",
 		PublicSharingDrivers: config.PublicSharingDrivers{
 			JSON: config.PublicSharingJSONDriver{
 				File: filepath.Join(defaults.BaseDataPath(), "storage", "publicshares.json"),
 			},
 			CS3: config.PublicSharingCS3Driver{
-				ProviderAddr:  "127.0.0.1:9215", // metadata storage
+				ProviderAddr:  "127.0.0.1:9215", // system storage
 				SystemUserIDP: "internal",
 			},
+			// TODO implement and add owncloudsql publicshare driver
 		},
 		Events: config.Events{
 			Addr:      "127.0.0.1:9233",

--- a/extensions/sharing/pkg/revaconfig/config.go
+++ b/extensions/sharing/pkg/revaconfig/config.go
@@ -50,6 +50,7 @@ func SharingConfigFromStruct(cfg *config.Config) map[string]interface{} {
 							"db_name":          cfg.UserSharingDrivers.OwnCloudSQL.DBName,
 						},
 						"cs3": map[string]interface{}{
+							"gateway_addr":        cfg.UserSharingDrivers.CS3.ProviderAddr,
 							"provider_addr":       cfg.UserSharingDrivers.CS3.ProviderAddr,
 							"service_user_id":     cfg.UserSharingDrivers.CS3.SystemUserID,
 							"service_user_idp":    cfg.UserSharingDrivers.CS3.SystemUserIDP,
@@ -75,6 +76,7 @@ func SharingConfigFromStruct(cfg *config.Config) map[string]interface{} {
 							"janitor_run_interval":          cfg.PublicSharingDrivers.SQL.JanitorRunInterval,
 						},
 						"cs3": map[string]interface{}{
+							"gateway_addr":        cfg.PublicSharingDrivers.CS3.ProviderAddr,
 							"provider_addr":       cfg.PublicSharingDrivers.CS3.ProviderAddr,
 							"service_user_id":     cfg.PublicSharingDrivers.CS3.SystemUserID,
 							"service_user_idp":    cfg.PublicSharingDrivers.CS3.SystemUserIDP,


### PR DESCRIPTION
we now use the `cs3` drivers to persist user shares and public links