### PR TITLE
escape adoc pipe & remove linewrap in output

### DIFF
--- a/docs/helpers/adoc-generator.go.tmpl
+++ b/docs/helpers/adoc-generator.go.tmpl
@@ -91,6 +91,8 @@ func GetAnnotatedVariables(s interface{}) []ConfigField {
 			td := strings.Split(env, ";")
 			re := regexp.MustCompile(`^(https?:\/\/)`)
 			v = re.ReplaceAllString(v,"\\$1")
+			re = regexp.MustCompile(`(\|)`)
+			v = re.ReplaceAllString(v, "\\$1")
 			fields = append(fields, ConfigField{EnvVars: td, DefaultValue: v, Description: desc, Type: value.Type().Name()})
 		case reflect.Ptr:
 			// PolicySelectors in the Proxy are being skipped atm

--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -9,7 +9,8 @@
 
 {{- range .Fields}}
 {{ $numVars := len .EnvVars }}
-| {{- range $i, $value := .EnvVars }}{{- if $i }} +{{ end }}
+| {{- range $i, $value := .EnvVars }}{{- if $i }} +
+{{ end -}}
 `{{- $value }}` 
 {{- end }}
 | {{.Type}}


### PR DESCRIPTION
This PR fixes a small bug resulting in a broken output of the adoc rendering because of unescaped `|`.
Also an unneeded line wrap is removed.

Fixes #3711