### PR TITLE
Exit when encountering config parsing errors

### DIFF
--- a/changelog/unreleased/change-ocis-init.md
+++ b/changelog/unreleased/change-ocis-init.md
@@ -10,3 +10,4 @@ bootstrap you a configuration file for a secure oCIS instance.
 
 https://github.com/owncloud/ocis/pull/3551
 https://github.com/owncloud/ocis/issues/3524
+https://github.com/owncloud/ocis/pull/3743

--- a/extensions/accounts/pkg/command/server.go
+++ b/extensions/accounts/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/accounts/pkg/config"
@@ -28,6 +29,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/app-provider/pkg/command/server.go
+++ b/extensions/app-provider/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/app-registry/pkg/command/server.go
+++ b/extensions/app-registry/pkg/command/server.go
@@ -30,6 +30,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/audit/pkg/command/server.go
+++ b/extensions/audit/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/server"
@@ -25,6 +26,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/auth-basic/pkg/command/server.go
+++ b/extensions/auth-basic/pkg/command/server.go
@@ -32,6 +32,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/auth-bearer/pkg/command/server.go
+++ b/extensions/auth-bearer/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/auth-machine/pkg/command/server.go
+++ b/extensions/auth-machine/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/frontend/pkg/command/server.go
+++ b/extensions/frontend/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/gateway/pkg/command/server.go
+++ b/extensions/gateway/pkg/command/server.go
@@ -30,6 +30,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/glauth/pkg/command/server.go
+++ b/extensions/glauth/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	accountssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/accounts/v0"
 
@@ -31,6 +32,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/graph-explorer/pkg/command/server.go
+++ b/extensions/graph-explorer/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/graph-explorer/pkg/config"
@@ -26,6 +27,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/graph/pkg/command/server.go
+++ b/extensions/graph/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/graph/pkg/config"
@@ -26,6 +27,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/groups/pkg/command/server.go
+++ b/extensions/groups/pkg/command/server.go
@@ -32,6 +32,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/idm/pkg/command/server.go
+++ b/extensions/idm/pkg/command/server.go
@@ -32,6 +32,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/idp/pkg/command/server.go
+++ b/extensions/idp/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/idp/pkg/config"
@@ -26,6 +27,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/nats/pkg/command/server.go
+++ b/extensions/nats/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 
@@ -23,6 +24,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/notifications/pkg/command/server.go
+++ b/extensions/notifications/pkg/command/server.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/server"
@@ -24,6 +25,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/ocdav/pkg/command/server.go
+++ b/extensions/ocdav/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/cs3org/reva/v2/pkg/micro/ocdav"
 	"github.com/oklog/run"
@@ -25,6 +26,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/ocs/pkg/command/server.go
+++ b/extensions/ocs/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/owncloud/ocis/v2/extensions/ocs/pkg/config/parser"
 	"github.com/owncloud/ocis/v2/extensions/ocs/pkg/logging"
@@ -27,6 +28,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/proxy/pkg/command/server.go
+++ b/extensions/proxy/pkg/command/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	accountssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/accounts/v0"
@@ -46,6 +47,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/search/pkg/command/server.go
+++ b/extensions/search/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/search/pkg/config"
@@ -26,6 +27,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/settings/pkg/command/server.go
+++ b/extensions/settings/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/settings/pkg/config"
@@ -27,6 +28,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/sharing/pkg/command/server.go
+++ b/extensions/sharing/pkg/command/server.go
@@ -32,6 +32,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/storage-publiclink/pkg/command/server.go
+++ b/extensions/storage-publiclink/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/storage-shares/pkg/command/server.go
+++ b/extensions/storage-shares/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/storage-system/pkg/command/server.go
+++ b/extensions/storage-system/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/storage-users/pkg/command/server.go
+++ b/extensions/storage-users/pkg/command/server.go
@@ -31,6 +31,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/store/pkg/command/server.go
+++ b/extensions/store/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 
@@ -27,6 +28,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/thumbnails/pkg/command/server.go
+++ b/extensions/thumbnails/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/thumbnails/pkg/config"
@@ -27,6 +28,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/users/pkg/command/server.go
+++ b/extensions/users/pkg/command/server.go
@@ -32,6 +32,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/web/pkg/command/server.go
+++ b/extensions/web/pkg/command/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/web/pkg/config"
@@ -27,6 +28,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/extensions/webdav/pkg/command/server.go
+++ b/extensions/webdav/pkg/command/server.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/config"
@@ -26,6 +27,7 @@ func Server(cfg *config.Config) *cli.Command {
 			err := parser.ParseConfig(cfg)
 			if err != nil {
 				fmt.Printf("%v", err)
+				os.Exit(1)
 			}
 			return err
 		},

--- a/ocis-pkg/shared/errors.go
+++ b/ocis-pkg/shared/errors.go
@@ -23,7 +23,7 @@ func MissingSystemUserApiKeyError(service string) error {
 }
 
 func MissingJWTTokenError(service string) error {
-	return fmt.Errorf("jwt_secret has not been set properly in your config for %s. "+
+	return fmt.Errorf("The jwt_secret has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
 		"(e.g. by running ocis init or setting it manually in "+
 		"the config/corresponding environment variable).",
@@ -31,7 +31,7 @@ func MissingJWTTokenError(service string) error {
 }
 
 func MissingRevaTransferSecretError(service string) error {
-	return fmt.Errorf("transfer_secret has not been set properly in your config for %s. "+
+	return fmt.Errorf("The transfer_secret has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
 		"(e.g. by running ocis init or setting it manually in "+
 		"the config/corresponding environment variable).",
@@ -39,7 +39,7 @@ func MissingRevaTransferSecretError(service string) error {
 }
 
 func MissingLDAPBindPassword(service string) error {
-	return fmt.Errorf("bind_password has not been set properly in your config for %s. "+
+	return fmt.Errorf("The ldap bind_password has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
 		"(e.g. by running ocis init or setting it manually in "+
 		"the config/corresponding environment variable).",
@@ -47,7 +47,7 @@ func MissingLDAPBindPassword(service string) error {
 }
 
 func MissingServiceUserPassword(service, serviceUser string) error {
-	return fmt.Errorf("password of service user %s has not been set properly in your config for %s. "+
+	return fmt.Errorf("The password of service user %s has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
 		"(e.g. by running ocis init or setting it manually in "+
 		"the config/corresponding environment variable).",


### PR DESCRIPTION
## Description

When one of the required secrets is not set or the config parsing has returned an error, stop the runtime by calling `os.Exit(1)`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
