### PR TITLE
expose IDP secret configuration via environment variables

### DIFF
--- a/changelog/unreleased/fix-configure-idp-secrets-env.md
+++ b/changelog/unreleased/fix-configure-idp-secrets-env.md
@@ -1,0 +1,6 @@
+Bugfix: Make IDP secrets configurable via environment variables
+
+We've fixed the configuration options of the IDP to make the IDP secrets again
+configurable via environment variables.
+
+https://github.com/owncloud/ocis/pull/3744

--- a/extensions/idp/pkg/config/config.go
+++ b/extensions/idp/pkg/config/config.go
@@ -86,7 +86,7 @@ type Settings struct {
 	AllowClientGuests              bool     `yaml:"allow_client_guests" env:"IDP_ALLOW_CLIENT_GUESTS"`
 	AllowDynamicClientRegistration bool     `yaml:"allow_dynamic_client_registration" env:"IDP_ALLOW_DYNAMIC_CLIENT_REGISTRATION"`
 
-	EncryptionSecretFile string `yaml:"encrypt_secret_file" env:"IDP_ENCRYPTION_SECRET"`
+	EncryptionSecretFile string `yaml:"encrypt_secret_file" env:"IDP_ENCRYPTION_SECRET_FILE"`
 
 	Listen string
 
@@ -101,7 +101,7 @@ type Settings struct {
 
 	SigningKid             string   `yaml:"signing_kid" env:"IDP_SIGNING_KID"`
 	SigningMethod          string   `yaml:"signing_method" env:"IDP_SIGNING_METHOD"`
-	SigningPrivateKeyFiles []string `yaml:"signing_private_key_files"` // TODO: is this even needed?
+	SigningPrivateKeyFiles []string `yaml:"signing_private_key_files" env:"IDP_SIGNING_PRIVATE_KEY_FILES"`
 	ValidationKeysPath     string   `yaml:"validation_keys_path" env:"IDP_VALIDATION_KEYS_PATH"`
 
 	CookieBackendURI string


### PR DESCRIPTION
## Description
Bugfix: Make IDP secrets configurable via environment variables

We've fixed the configuration options of the IDP to make the IDP secrets again
configurable via environment variables.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
