### PR TITLE
add description tags to graph-explorer config

### DIFF
--- a/changelog/unreleased/graph-explorer-env-doc.md
+++ b/changelog/unreleased/graph-explorer-env-doc.md
@@ -1,0 +1,5 @@
+Enhancement: Add descriptions for graph-explorer config
+
+Added descriptions tags to the graph-explorer config tags so that they will be included in the documentation.
+
+https://github.com/owncloud/ocis/pull/3759

--- a/extensions/graph-explorer/pkg/config/http.go
+++ b/extensions/graph-explorer/pkg/config/http.go
@@ -2,8 +2,8 @@ package config
 
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"GRAPH_EXPLORER_HTTP_ADDR"`
-	Root      string `yaml:"root" env:"GRAPH_EXPLORER_HTTP_ROOT"`
+	Addr      string `yaml:"addr" env:"GRAPH_EXPLORER_HTTP_ADDR" desc:"The HTTP service address."`
+	Root      string `yaml:"root" env:"GRAPH_EXPLORER_HTTP_ROOT" desc:"The HTTP service root path."`
 	Namespace string `yaml:"-"`
 }
 

--- a/extensions/graph-explorer/pkg/config/log.go
+++ b/extensions/graph-explorer/pkg/config/log.go
@@ -2,8 +2,8 @@ package config
 
 // Log defines the available log configuration.
 type Log struct {
-	Level  string `mapstructure:"level" env:"OCIS_LOG_LEVEL;GRAPH_EXPLORER_LOG_LEVEL"`
-	Pretty bool   `mapstructure:"pretty" env:"OCIS_LOG_PRETTY;GRAPH_EXPLORER_LOG_PRETTY"`
-	Color  bool   `mapstructure:"color" env:"OCIS_LOG_COLOR;GRAPH_EXPLORER_LOG_COLOR"`
-	File   string `mapstructure:"file" env:"OCIS_LOG_FILE;GRAPH_EXPLORER_LOG_FILE"`
+	Level  string `mapstructure:"level" env:"OCIS_LOG_LEVEL;GRAPH_EXPLORER_LOG_LEVEL" desc:"The log level."`
+	Pretty bool   `mapstructure:"pretty" env:"OCIS_LOG_PRETTY;GRAPH_EXPLORER_LOG_PRETTY" desc:"Enable pretty logs."`
+	Color  bool   `mapstructure:"color" env:"OCIS_LOG_COLOR;GRAPH_EXPLORER_LOG_COLOR" desc:"Enable colored logs."`
+	File   string `mapstructure:"file" env:"OCIS_LOG_FILE;GRAPH_EXPLORER_LOG_FILE" desc:"The path to the log file when logging to file."`
 }

--- a/extensions/graph-explorer/pkg/config/tracing.go
+++ b/extensions/graph-explorer/pkg/config/tracing.go
@@ -2,8 +2,8 @@ package config
 
 // Tracing defines the available tracing configuration.
 type Tracing struct {
-	Enabled   bool   `yaml:"enabled" env:"OCIS_TRACING_ENABLED;GRAPH_EXPLORER_TRACING_ENABLED"`
-	Type      string `yaml:"type" env:"OCIS_TRACING_TYPE;GRAPH_EXPLORER_TRACING_TYPE"`
-	Endpoint  string `yaml:"endpoint" env:"OCIS_TRACING_ENDPOINT;GRAPH_EXPLORER_TRACING_ENDPOINT"`
-	Collector string `yaml:"collector" env:"OCIS_TRACING_COLLECTOR;GRAPH_EXPLORER_TRACING_COLLECTOR"`
+	Enabled   bool   `yaml:"enabled" env:"OCIS_TRACING_ENABLED;GRAPH_EXPLORER_TRACING_ENABLED" desc:"Enable tracing."`
+	Type      string `yaml:"type" env:"OCIS_TRACING_TYPE;GRAPH_EXPLORER_TRACING_TYPE" desc:"The sampler type: remote, const, probabilistic, ratelimiting (default remote). See also https://www.jaegertracing.io/docs/latest/sampling/."`
+	Endpoint  string `yaml:"endpoint" env:"OCIS_TRACING_ENDPOINT;GRAPH_EXPLORER_TRACING_ENDPOINT" desc:"The endpoint of the tracing service."`
+	Collector string `yaml:"collector" env:"OCIS_TRACING_COLLECTOR;GRAPH_EXPLORER_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. If specified, the tracing endpoint is ignored."`
 }


### PR DESCRIPTION
 Added descriptions tags to the graph-explorer config tags so that they will be included in the documentation.
 
 /cc @mmattel 