### PR TITLE
remove dependencies from nightly example deploys

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -229,12 +229,17 @@ def main(ctx):
 
     pipelines = test_pipelines + build_release_pipelines + build_release_helpers
 
-    pipelines = \
-        pipelines + \
-        pipelinesDependsOn(
-            example_deploys(ctx),
-            pipelines,
-        )
+    if ctx.build.event == "cron":
+        pipelines = \
+            pipelines + \
+            example_deploys(ctx)
+    else:
+        pipelines = \
+            pipelines + \
+            pipelinesDependsOn(
+                example_deploys(ctx),
+                pipelines,
+            )
 
     # always append notification step
     pipelines.append(


### PR DESCRIPTION
## Description
remove dependencies from nightly example deploys to ensure they run even if tests fail, like eg. https://drone.owncloud.com/owncloud/ocis/11690

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
