### PR TITLE
Improve search

### DIFF
--- a/extensions/search/pkg/search/index/index.go
+++ b/extensions/search/pkg/search/index/index.go
@@ -212,7 +212,7 @@ func (i *Index) Search(ctx context.Context, req *searchsvc.SearchIndexRequest) (
 	deletedQuery := bleve.NewBoolFieldQuery(false)
 	deletedQuery.SetField("Deleted")
 	query := bleve.NewConjunctionQuery(
-		bleve.NewQueryStringQuery("Name:"+strings.ToLower(req.Query)),
+		bleve.NewQueryStringQuery(req.Query),
 		deletedQuery, // Skip documents that have been marked as deleted
 		bleve.NewQueryStringQuery("RootID:"+req.Ref.ResourceId.StorageId+"!"+req.Ref.ResourceId.OpaqueId), // Limit search to the space
 		bleve.NewQueryStringQuery("Path:"+utils.MakeRelativePath(path.Join(req.Ref.Path, "/"))+"*"),       // Limit search to this directory in the space

--- a/extensions/search/pkg/search/index/index.go
+++ b/extensions/search/pkg/search/index/index.go
@@ -165,15 +165,16 @@ func (i *Index) Purge(id *sprovider.ResourceId) error {
 }
 
 // Move update the path of an entry and all its children
-func (i *Index) Move(ri *sprovider.ResourceInfo, fullPath string) error {
-	doc, err := i.getEntity(idToBleveId(ri.Id))
+func (i *Index) Move(id *sprovider.ResourceId, fullPath string) error {
+	bleveId := idToBleveId(id)
+	doc, err := i.getEntity(bleveId)
 	if err != nil {
 		return err
 	}
 	oldName := doc.Path
 	newName := utils.MakeRelativePath(fullPath)
 
-	doc, err = i.updateEntity(idToBleveId(ri.Id), func(doc *indexDocument) {
+	doc, err = i.updateEntity(bleveId, func(doc *indexDocument) {
 		doc.Path = newName
 		doc.Name = path.Base(newName)
 	})

--- a/extensions/search/pkg/search/index/index_test.go
+++ b/extensions/search/pkg/search/index/index_test.go
@@ -366,7 +366,7 @@ var _ = Describe("Index", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			parentRi.Path = "newname"
-			err = i.Move(parentRi, "./somewhere/else/newname")
+			err = i.Move(parentRi.Id, "./somewhere/else/newname")
 			Expect(err).ToNot(HaveOccurred())
 
 			assertDocCount(rootId, "subdir", 0)

--- a/extensions/search/pkg/search/index/index_test.go
+++ b/extensions/search/pkg/search/index/index_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Index", func() {
 		}
 		ref = &sprovider.Reference{
 			ResourceId: rootId,
-			Path:       "./foo.pdf",
+			Path:       "./Foo.pdf",
 		}
 		ri = &sprovider.ResourceInfo{
 			Id: &sprovider.ResourceId{
@@ -133,14 +133,14 @@ var _ = Describe("Index", func() {
 							OpaqueId:  "differentopaqueid",
 						},
 					},
-					Query: "foo.pdf",
+					Query: "Name:foo.pdf",
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
 				Expect(len(res.Matches)).To(Equal(0))
 			})
 
-			It("limits the search to the relevant fields", func() {
+			It("limits the search to the specified fields", func() {
 				res, err := i.Search(ctx, &searchsvc.SearchIndexRequest{
 					Ref: &searchmsg.Reference{
 						ResourceId: &searchmsg.ResourceID{
@@ -148,7 +148,7 @@ var _ = Describe("Index", func() {
 							OpaqueId:  ref.ResourceId.OpaqueId,
 						},
 					},
-					Query: "*" + ref.ResourceId.OpaqueId + "*",
+					Query: "Name:*" + ref.ResourceId.OpaqueId + "*",
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
@@ -163,7 +163,7 @@ var _ = Describe("Index", func() {
 							OpaqueId:  ref.ResourceId.OpaqueId,
 						},
 					},
-					Query: "foo.pdf",
+					Query: "Name:foo.pdf",
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
@@ -203,7 +203,7 @@ var _ = Describe("Index", func() {
 				}
 			})
 
-			It("is case-insensitive", func() {
+			It("uses a lower-case index", func() {
 				res, err := i.Search(ctx, &searchsvc.SearchIndexRequest{
 					Ref: &searchmsg.Reference{
 						ResourceId: &searchmsg.ResourceID{
@@ -211,11 +211,24 @@ var _ = Describe("Index", func() {
 							OpaqueId:  ref.ResourceId.OpaqueId,
 						},
 					},
-					Query: "Foo*",
+					Query: "Name:foo*",
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
 				Expect(len(res.Matches)).To(Equal(1))
+
+				res, err = i.Search(ctx, &searchsvc.SearchIndexRequest{
+					Ref: &searchmsg.Reference{
+						ResourceId: &searchmsg.ResourceID{
+							StorageId: ref.ResourceId.StorageId,
+							OpaqueId:  ref.ResourceId.OpaqueId,
+						},
+					},
+					Query: "Name:Foo*",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).ToNot(BeNil())
+				Expect(len(res.Matches)).To(Equal(0))
 			})
 
 			Context("and an additional file in a subdirectory", func() {
@@ -271,7 +284,7 @@ var _ = Describe("Index", func() {
 							},
 							Path: "./nested/",
 						},
-						Query: "foo.pdf",
+						Query: "Name:foo.pdf",
 					})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(res).ToNot(BeNil())
@@ -372,7 +385,7 @@ var _ = Describe("Index", func() {
 			assertDocCount(rootId, "subdir", 0)
 
 			res, err := i.Search(ctx, &searchsvc.SearchIndexRequest{
-				Query: "child.pdf",
+				Query: "Name:child.pdf",
 				Ref: &searchmsg.Reference{
 					ResourceId: &searchmsg.ResourceID{
 						StorageId: rootId.StorageId,

--- a/extensions/search/pkg/search/mocks/IndexClient.go
+++ b/extensions/search/pkg/search/mocks/IndexClient.go
@@ -30,13 +30,13 @@ func (_m *IndexClient) Add(ref *providerv1beta1.Reference, ri *providerv1beta1.R
 	return r0
 }
 
-// Delete provides a mock function with given fields: ri
-func (_m *IndexClient) Delete(ri *providerv1beta1.ResourceId) error {
-	ret := _m.Called(ri)
+// Delete provides a mock function with given fields: id
+func (_m *IndexClient) Delete(id *providerv1beta1.ResourceId) error {
+	ret := _m.Called(id)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*providerv1beta1.ResourceId) error); ok {
-		r0 = rf(ri)
+		r0 = rf(id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -65,13 +65,13 @@ func (_m *IndexClient) DocCount() (uint64, error) {
 	return r0, r1
 }
 
-// Move provides a mock function with given fields: ri, path
-func (_m *IndexClient) Move(ri *providerv1beta1.ResourceInfo, path string) error {
-	ret := _m.Called(ri, path)
+// Move provides a mock function with given fields: id, fullPath
+func (_m *IndexClient) Move(id *providerv1beta1.ResourceId, fullPath string) error {
+	ret := _m.Called(id, fullPath)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*providerv1beta1.ResourceInfo, string) error); ok {
-		r0 = rf(ri, path)
+	if rf, ok := ret.Get(0).(func(*providerv1beta1.ResourceId, string) error); ok {
+		r0 = rf(id, fullPath)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -79,13 +79,13 @@ func (_m *IndexClient) Move(ri *providerv1beta1.ResourceInfo, path string) error
 	return r0
 }
 
-// Purge provides a mock function with given fields: ri
-func (_m *IndexClient) Purge(ri *providerv1beta1.ResourceId) error {
-	ret := _m.Called(ri)
+// Purge provides a mock function with given fields: id
+func (_m *IndexClient) Purge(id *providerv1beta1.ResourceId) error {
+	ret := _m.Called(id)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*providerv1beta1.ResourceId) error); ok {
-		r0 = rf(ri)
+		r0 = rf(id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -93,13 +93,13 @@ func (_m *IndexClient) Purge(ri *providerv1beta1.ResourceId) error {
 	return r0
 }
 
-// Restore provides a mock function with given fields: ri
-func (_m *IndexClient) Restore(ri *providerv1beta1.ResourceId) error {
-	ret := _m.Called(ri)
+// Restore provides a mock function with given fields: id
+func (_m *IndexClient) Restore(id *providerv1beta1.ResourceId) error {
+	ret := _m.Called(id)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*providerv1beta1.ResourceId) error); ok {
-		r0 = rf(ri)
+		r0 = rf(id)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/extensions/search/pkg/search/provider/events.go
+++ b/extensions/search/pkg/search/provider/events.go
@@ -58,11 +58,11 @@ func (p *Provider) handleEvent(ev interface{}) {
 
 		statRes, err := p.statResource(ref, owner)
 		if err != nil {
-			p.logger.Error().Err(err).Msg("failed to stat the changed resource")
+			p.logger.Error().Err(err).Msg("failed to stat the moved resource")
 			return
 		}
 		if statRes.Status.Code != rpc.Code_CODE_OK {
-			p.logger.Error().Interface("statRes", statRes).Msg("failed to stat the changed resource")
+			p.logger.Error().Interface("statRes", statRes).Msg("failed to stat the moved resource")
 			return
 		}
 
@@ -78,7 +78,7 @@ func (p *Provider) handleEvent(ev interface{}) {
 
 		err = p.indexClient.Move(statRes.Info.Id, gpRes.Path)
 		if err != nil {
-			p.logger.Error().Err(err).Msg("failed to restore the changed resource in the index")
+			p.logger.Error().Err(err).Msg("failed to move the changed resource in the index")
 		}
 		return
 	case events.ContainerCreated:

--- a/extensions/search/pkg/search/provider/events.go
+++ b/extensions/search/pkg/search/provider/events.go
@@ -76,7 +76,7 @@ func (p *Provider) handleEvent(ev interface{}) {
 			return
 		}
 
-		err = p.indexClient.Move(statRes.Info, gpRes.Path)
+		err = p.indexClient.Move(statRes.Info.Id, gpRes.Path)
 		if err != nil {
 			p.logger.Error().Err(err).Msg("failed to restore the changed resource in the index")
 		}

--- a/extensions/search/pkg/search/provider/events.go
+++ b/extensions/search/pkg/search/provider/events.go
@@ -126,7 +126,6 @@ func (p *Provider) statResource(ref *provider.Reference, owner *user.User) (*pro
 		return nil, err
 	}
 
-	// Stat changed resource resource
 	return p.gwClient.Stat(ownerCtx, &provider.StatRequest{Ref: ref})
 }
 
@@ -136,7 +135,6 @@ func (p *Provider) getPath(id *provider.ResourceId, owner *user.User) (*provider
 		return nil, err
 	}
 
-	// Stat changed resource resource
 	return p.gwClient.GetPath(ownerCtx, &provider.GetPathRequest{ResourceId: id})
 }
 

--- a/extensions/search/pkg/search/provider/events_test.go
+++ b/extensions/search/pkg/search/provider/events_test.go
@@ -156,8 +156,8 @@ var _ = Describe("Searchprovider", func() {
 				Status: status.NewOK(ctx),
 				Path:   "./new/path.pdf",
 			}, nil)
-			indexClient.On("Move", mock.MatchedBy(func(riToIndex *sprovider.ResourceInfo) bool {
-				return riToIndex.Id.OpaqueId == ri.Id.OpaqueId
+			indexClient.On("Move", mock.MatchedBy(func(id *sprovider.ResourceId) bool {
+				return id.OpaqueId == ri.Id.OpaqueId
 			}), "./new/path.pdf").Return(nil).Run(func(args mock.Arguments) {
 				called = true
 			})

--- a/extensions/search/pkg/search/provider/searchprovider.go
+++ b/extensions/search/pkg/search/provider/searchprovider.go
@@ -220,8 +220,13 @@ func (p *Provider) logDocCount() {
 
 func formatQuery(q string) string {
 	query := q
-	if strings.Contains(q, ":") {
-		return q // Sophisticated field based search
+	fields := []string{"RootID", "Path", "ID", "Name", "Size", "Mtime", "MimeType", "Type"}
+	for _, field := range fields {
+		query = strings.ReplaceAll(query, strings.ToLower(field)+":", field+":")
+	}
+
+	if strings.Contains(query, ":") {
+		return query // Sophisticated field based search
 	}
 
 	// this is a basic filename search

--- a/extensions/search/pkg/search/provider/searchprovider.go
+++ b/extensions/search/pkg/search/provider/searchprovider.go
@@ -125,7 +125,7 @@ func (p *Provider) Search(ctx context.Context, req *searchsvc.SearchRequest) (*s
 
 		_, rootStorageID := storagespace.SplitStorageID(space.Root.StorageId)
 		res, err := p.indexClient.Search(ctx, &searchsvc.SearchIndexRequest{
-			Query: "Name:" + strings.ReplaceAll(strings.ToLower(req.Query), " ", `\ `),
+			Query: formatQuery(req.Query),
 			Ref: &searchmsg.Reference{
 				ResourceId: &searchmsg.ResourceID{
 					StorageId: space.Root.StorageId,
@@ -216,4 +216,14 @@ func (p *Provider) logDocCount() {
 		p.logger.Error().Err(err).Msg("error getting document count from the index")
 	}
 	p.logger.Debug().Interface("count", c).Msg("new document count")
+}
+
+func formatQuery(q string) string {
+	query := q
+	if strings.Contains(q, ":") {
+		return q // Sophisticated field based search
+	}
+
+	// this is a basic filename search
+	return "Name:*" + strings.ReplaceAll(strings.ToLower(query), " ", `\ `) + "*"
 }

--- a/extensions/search/pkg/search/provider/searchprovider.go
+++ b/extensions/search/pkg/search/provider/searchprovider.go
@@ -125,7 +125,7 @@ func (p *Provider) Search(ctx context.Context, req *searchsvc.SearchRequest) (*s
 
 		_, rootStorageID := storagespace.SplitStorageID(space.Root.StorageId)
 		res, err := p.indexClient.Search(ctx, &searchsvc.SearchIndexRequest{
-			Query: "Name:" + strings.ToLower(req.Query),
+			Query: "Name:" + strings.ReplaceAll(strings.ToLower(req.Query), " ", `\ `),
 			Ref: &searchmsg.Reference{
 				ResourceId: &searchmsg.ResourceID{
 					StorageId: space.Root.StorageId,

--- a/extensions/search/pkg/search/provider/searchprovider.go
+++ b/extensions/search/pkg/search/provider/searchprovider.go
@@ -125,7 +125,7 @@ func (p *Provider) Search(ctx context.Context, req *searchsvc.SearchRequest) (*s
 
 		_, rootStorageID := storagespace.SplitStorageID(space.Root.StorageId)
 		res, err := p.indexClient.Search(ctx, &searchsvc.SearchIndexRequest{
-			Query: req.Query,
+			Query: "Name:" + strings.ToLower(req.Query),
 			Ref: &searchmsg.Reference{
 				ResourceId: &searchmsg.ResourceID{
 					StorageId: space.Root.StorageId,

--- a/extensions/search/pkg/search/provider/searchprovider_test.go
+++ b/extensions/search/pkg/search/provider/searchprovider_test.go
@@ -146,6 +146,24 @@ var _ = Describe("Searchprovider", func() {
 				}, nil)
 			})
 
+			It("lowercases the filename", func() {
+				p.Search(ctx, &searchsvc.SearchRequest{
+					Query: "Foo.pdf",
+				})
+				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
+					return req.Query == "Name:foo.pdf"
+				}))
+			})
+
+			It("escapes special characters", func() {
+				p.Search(ctx, &searchsvc.SearchRequest{
+					Query: "Foo oo.pdf",
+				})
+				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
+					return req.Query == `Name:foo\ oo.pdf`
+				}))
+			})
+
 			It("searches the personal user space", func() {
 				res, err := p.Search(ctx, &searchsvc.SearchRequest{
 					Query: "foo",

--- a/extensions/search/pkg/search/provider/searchprovider_test.go
+++ b/extensions/search/pkg/search/provider/searchprovider_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Searchprovider", func() {
 				Expect(match.Entity.Ref.Path).To(Equal("./path/to/Foo.pdf"))
 
 				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
-					return req.Query == "foo" && req.Ref.ResourceId.OpaqueId == personalSpace.Root.OpaqueId && req.Ref.Path == ""
+					return req.Query == "Name:foo" && req.Ref.ResourceId.OpaqueId == personalSpace.Root.OpaqueId && req.Ref.Path == ""
 				}))
 			})
 		})
@@ -225,7 +225,7 @@ var _ = Describe("Searchprovider", func() {
 				}, nil)
 
 				res, err := p.Search(ctx, &searchsvc.SearchRequest{
-					Query: "foo",
+					Query: "Foo",
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
@@ -237,7 +237,7 @@ var _ = Describe("Searchprovider", func() {
 				Expect(match.Entity.Ref.Path).To(Equal("./to/Shared.pdf"))
 
 				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
-					return req.Query == "foo" && req.Ref.ResourceId.StorageId == grantSpace.Root.StorageId && req.Ref.Path == "./grant/path"
+					return req.Query == "Name:foo" && req.Ref.ResourceId.StorageId == grantSpace.Root.StorageId && req.Ref.Path == "./grant/path"
 				}))
 			})
 

--- a/extensions/search/pkg/search/provider/searchprovider_test.go
+++ b/extensions/search/pkg/search/provider/searchprovider_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Searchprovider", func() {
 					Query: "Foo.pdf",
 				})
 				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
-					return req.Query == "Name:foo.pdf"
+					return req.Query == "Name:*foo.pdf*"
 				}))
 			})
 
@@ -164,12 +164,29 @@ var _ = Describe("Searchprovider", func() {
 				}))
 			})
 
+			It("uppercases field names", func() {
+				tests := []struct {
+					Original string
+					Expected string
+				}{
+					{Original: "size:<100", Expected: "Size:<100"},
+				}
+				for _, test := range tests {
+					p.Search(ctx, &searchsvc.SearchRequest{
+						Query: test.Original,
+					})
+					indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
+						return req.Query == test.Expected
+					}))
+				}
+			})
+
 			It("escapes special characters", func() {
 				p.Search(ctx, &searchsvc.SearchRequest{
 					Query: "Foo oo.pdf",
 				})
 				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
-					return req.Query == `Name:foo\ oo.pdf`
+					return req.Query == `Name:*foo\ oo.pdf*`
 				}))
 			})
 
@@ -187,7 +204,7 @@ var _ = Describe("Searchprovider", func() {
 				Expect(match.Entity.Ref.Path).To(Equal("./path/to/Foo.pdf"))
 
 				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
-					return req.Query == "Name:foo" && req.Ref.ResourceId.OpaqueId == personalSpace.Root.OpaqueId && req.Ref.Path == ""
+					return req.Query == "Name:*foo*" && req.Ref.ResourceId.OpaqueId == personalSpace.Root.OpaqueId && req.Ref.Path == ""
 				}))
 			})
 		})
@@ -264,7 +281,7 @@ var _ = Describe("Searchprovider", func() {
 				Expect(match.Entity.Ref.Path).To(Equal("./to/Shared.pdf"))
 
 				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
-					return req.Query == "Name:foo" && req.Ref.ResourceId.StorageId == grantSpace.Root.StorageId && req.Ref.Path == "./grant/path"
+					return req.Query == "Name:*foo*" && req.Ref.ResourceId.StorageId == grantSpace.Root.StorageId && req.Ref.Path == "./grant/path"
 				}))
 			})
 

--- a/extensions/search/pkg/search/provider/searchprovider_test.go
+++ b/extensions/search/pkg/search/provider/searchprovider_test.go
@@ -155,6 +155,15 @@ var _ = Describe("Searchprovider", func() {
 				}))
 			})
 
+			It("does not mess with field-based searches", func() {
+				p.Search(ctx, &searchsvc.SearchRequest{
+					Query: "Size:<10",
+				})
+				indexClient.AssertCalled(GinkgoT(), "Search", mock.Anything, mock.MatchedBy(func(req *searchsvc.SearchIndexRequest) bool {
+					return req.Query == "Size:<10"
+				}))
+			})
+
 			It("escapes special characters", func() {
 				p.Search(ctx, &searchsvc.SearchRequest{
 					Query: "Foo oo.pdf",

--- a/extensions/search/pkg/search/search.go
+++ b/extensions/search/pkg/search/search.go
@@ -38,9 +38,9 @@ type ProviderClient interface {
 type IndexClient interface {
 	Search(ctx context.Context, req *searchsvc.SearchIndexRequest) (*searchsvc.SearchIndexResponse, error)
 	Add(ref *providerv1beta1.Reference, ri *providerv1beta1.ResourceInfo) error
-	Move(ri *providerv1beta1.ResourceInfo, path string) error
-	Delete(ri *providerv1beta1.ResourceId) error
-	Restore(ri *providerv1beta1.ResourceId) error
-	Purge(ri *providerv1beta1.ResourceId) error
+	Move(id *providerv1beta1.ResourceId, fullPath string) error
+	Delete(id *providerv1beta1.ResourceId) error
+	Restore(id *providerv1beta1.ResourceId) error
+	Purge(id *providerv1beta1.ResourceId) error
 	DocCount() (uint64, error)
 }

--- a/extensions/webdav/pkg/service/v0/search.go
+++ b/extensions/webdav/pkg/service/v0/search.go
@@ -43,7 +43,7 @@ func (g Webdav) Search(w http.ResponseWriter, r *http.Request) {
 	ctx := revactx.ContextSetToken(r.Context(), t)
 	ctx = metadata.Set(ctx, revactx.TokenHeader, t)
 	rsp, err := g.searchClient.Search(ctx, &searchsvc.SearchRequest{
-		Query: "*" + rep.SearchFiles.Search.Pattern + "*",
+		Query: rep.SearchFiles.Search.Pattern,
 	})
 	if err != nil {
 		e := merrors.Parse(err.Error())

--- a/extensions/webdav/pkg/service/v0/search.go
+++ b/extensions/webdav/pkg/service/v0/search.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/net"
 	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/prop"
@@ -128,9 +129,15 @@ func matchToPropResponse(ctx context.Context, match *searchmsg.Match) (*propfind
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("d:getcontenttype", match.Entity.MimeType))
 
 	size := strconv.FormatUint(match.Entity.Size, 10)
-	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:size", size))
-	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("d:getcontentlength", size))
-
+	if match.Entity.Type == uint64(provider.ResourceType_RESOURCE_TYPE_CONTAINER) {
+		propstatOK.Prop = append(propstatOK.Prop, prop.Raw("d:resourcetype", "<d:collection/>"))
+		propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:size", size))
+	} else {
+		propstatOK.Prop = append(propstatOK.Prop,
+			prop.Escaped("d:resourcetype", ""),
+			prop.Escaped("d:getcontentlength", size),
+		)
+	}
 	// TODO find name for score property
 	score := strconv.FormatFloat(float64(match.Score), 'f', -1, 64)
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:score", score))


### PR DESCRIPTION
This PR fixes a few smaller issues with the file search like searching for files or directories with spaces or digits and enables advanced search features. In addition to the plain filename search it is now possible to specify search criteria on metadata as well, e.g.

1. Search for files small than 100 bytes

    `size:<100`

1. Search for pdfs that were modified after May 11th

      `+name:*pdf +mtime:>"2022-05-11"`
