### PR TITLE
fix thumbnails for empty trailing paths

### DIFF
--- a/changelog/unreleased/share-jail-fixes.md
+++ b/changelog/unreleased/share-jail-fixes.md
@@ -1,0 +1,5 @@
+Bugfix: Fix Thumbnails for IDs without a trailing path
+
+The routes in the chi router were not matching thumbnail requests without a trailing path.
+
+https://github.com/owncloud/ocis/pull/3791

--- a/extensions/webdav/pkg/dav/requests/thumbnail.go
+++ b/extensions/webdav/pkg/dav/requests/thumbnail.go
@@ -1,7 +1,6 @@
 package requests
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -43,9 +42,6 @@ func ParseThumbnailRequest(r *http.Request) (*ThumbnailRequest, error) {
 	ctx := r.Context()
 
 	fp := ctx.Value(constants.ContextKeyPath).(string)
-	if fp == "" {
-		return nil, errors.New("invalid file path")
-	}
 
 	id := ""
 	v := ctx.Value(constants.ContextKeyID)

--- a/extensions/webdav/pkg/service/v0/service.go
+++ b/extensions/webdav/pkg/service/v0/service.go
@@ -79,10 +79,14 @@ func NewService(opts ...Option) (Service, error) {
 		r.Group(func(r chi.Router) {
 			r.Use(svc.DavUserContext())
 
+			r.Get("/remote.php/dav/spaces/{id}", svc.SpacesThumbnail)
 			r.Get("/remote.php/dav/spaces/{id}/*", svc.SpacesThumbnail)
+			r.Get("/dav/spaces/{id}", svc.SpacesThumbnail)
 			r.Get("/dav/spaces/{id}/*", svc.SpacesThumbnail)
 
+			r.Get("/remote.php/dav/files/{id}", svc.Thumbnail)
 			r.Get("/remote.php/dav/files/{id}/*", svc.Thumbnail)
+			r.Get("/dav/files/{id}", svc.Thumbnail)
 			r.Get("/dav/files/{id}/*", svc.Thumbnail)
 		})
 
@@ -151,11 +155,12 @@ func (g Webdav) DavUserContext() func(next http.Handler) http.Handler {
 			}
 
 			if id != "" {
-				filePath = strings.TrimPrefix(filePath, path.Join("/remote.php/dav/spaces", id)+"/")
-				filePath = strings.TrimPrefix(filePath, path.Join("/dav/spaces", id)+"/")
+				filePath = strings.TrimPrefix(filePath, path.Join("/remote.php/dav/spaces", id))
+				filePath = strings.TrimPrefix(filePath, path.Join("/dav/spaces", id))
 
-				filePath = strings.TrimPrefix(filePath, path.Join("/remote.php/dav/files", id)+"/")
-				filePath = strings.TrimPrefix(filePath, path.Join("/dav/files", id)+"/")
+				filePath = strings.TrimPrefix(filePath, path.Join("/remote.php/dav/files", id))
+				filePath = strings.TrimPrefix(filePath, path.Join("/dav/files", id))
+				filePath = strings.TrimPrefix(filePath, "/")
 			}
 
 			ctx = context.WithValue(ctx, constants.ContextKeyPath, filePath)


### PR DESCRIPTION
## Description

Bugfix: Fix Thumbnails for IDs without a trailing path

The routes in the chi router were not matching thumbnail requests without a trailing path.

## Related Issue
- Fixes #3760 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
