### PR TITLE
use command -v instead of which

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -3,7 +3,7 @@
 BINGO_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 GOPATH ?= $(shell go env GOPATH)
 GOBIN  ?= $(firstword $(subst :, ,${GOPATH}))/bin
-GO     ?= $(shell which go)
+GO     ?= $(shell command -v go)
 
 # Below generated variables ensure that every time a tool under each variable is invoked, the correct version
 # will be used; reinstalling only if needed.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ PHP_CODEBEAUTIFIER=vendor-bin/php_codesniffer/vendor/bin/phpcbf
 PHAN=php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan
 PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
 
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include .bingo/Variables.mk
 endif
 

--- a/extensions/app-provider/Makefile
+++ b/extensions/app-provider/Makefile
@@ -4,7 +4,7 @@ NAME := app-provider
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/app-registry/Makefile
+++ b/extensions/app-registry/Makefile
@@ -4,7 +4,7 @@ NAME := app-registry
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/audit/Makefile
+++ b/extensions/audit/Makefile
@@ -4,7 +4,7 @@ NAME := audit
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/auth-basic/Makefile
+++ b/extensions/auth-basic/Makefile
@@ -4,7 +4,7 @@ NAME := auth-basic
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/auth-bearer/Makefile
+++ b/extensions/auth-bearer/Makefile
@@ -4,7 +4,7 @@ NAME := auth-bearer
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/auth-machine/Makefile
+++ b/extensions/auth-machine/Makefile
@@ -4,7 +4,7 @@ NAME := auth-machine
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/frontend/Makefile
+++ b/extensions/frontend/Makefile
@@ -4,7 +4,7 @@ NAME := frontend
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/gateway/Makefile
+++ b/extensions/gateway/Makefile
@@ -4,7 +4,7 @@ NAME := gateway
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/graph-explorer/Makefile
+++ b/extensions/graph-explorer/Makefile
@@ -4,7 +4,7 @@ NAME := graph-explorer
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/graph/Makefile
+++ b/extensions/graph/Makefile
@@ -4,7 +4,7 @@ NAME := graph
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/groups/Makefile
+++ b/extensions/groups/Makefile
@@ -4,7 +4,7 @@ NAME := groups
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/idm/Makefile
+++ b/extensions/idm/Makefile
@@ -6,7 +6,7 @@ TAGS := disable_crypt
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/idp/Makefile
+++ b/extensions/idp/Makefile
@@ -4,7 +4,7 @@ NAME := idp
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/nats/Makefile
+++ b/extensions/nats/Makefile
@@ -4,7 +4,7 @@ NAME := nats
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/notifications/Makefile
+++ b/extensions/notifications/Makefile
@@ -4,7 +4,7 @@ NAME := notifications
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/ocdav/Makefile
+++ b/extensions/ocdav/Makefile
@@ -4,7 +4,7 @@ NAME := ocdav
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/ocs/Makefile
+++ b/extensions/ocs/Makefile
@@ -4,7 +4,7 @@ NAME := ocs
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/proxy/Makefile
+++ b/extensions/proxy/Makefile
@@ -4,7 +4,7 @@ NAME := proxy
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/settings/Makefile
+++ b/extensions/settings/Makefile
@@ -9,7 +9,7 @@ test-acceptance-webui:
 
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/sharing/Makefile
+++ b/extensions/sharing/Makefile
@@ -4,7 +4,7 @@ NAME := sharing
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/storage-publiclink/Makefile
+++ b/extensions/storage-publiclink/Makefile
@@ -4,7 +4,7 @@ NAME := storage-publiclink
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/storage-shares/Makefile
+++ b/extensions/storage-shares/Makefile
@@ -4,7 +4,7 @@ NAME := storage-shares
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/storage-system/Makefile
+++ b/extensions/storage-system/Makefile
@@ -4,7 +4,7 @@ NAME := storage-system
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/storage-users/Makefile
+++ b/extensions/storage-users/Makefile
@@ -4,7 +4,7 @@ NAME := storage-users
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/store/Makefile
+++ b/extensions/store/Makefile
@@ -4,7 +4,7 @@ NAME := store
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/thumbnails/Makefile
+++ b/extensions/thumbnails/Makefile
@@ -4,7 +4,7 @@ NAME := thumbnails
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/users/Makefile
+++ b/extensions/users/Makefile
@@ -4,7 +4,7 @@ NAME := users
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/web/Makefile
+++ b/extensions/web/Makefile
@@ -5,7 +5,7 @@ WEB_ASSETS_VERSION = v5.5.0-rc.5
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/extensions/webdav/Makefile
+++ b/extensions/webdav/Makefile
@@ -4,7 +4,7 @@ NAME := webdav
 include ../../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../../.bingo/Variables.mk
 endif
 

--- a/ocis-pkg/Makefile
+++ b/ocis-pkg/Makefile
@@ -4,7 +4,7 @@ NAME := ocis-pkg
 include ../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../.bingo/Variables.mk
 endif
 

--- a/ocis/Makefile
+++ b/ocis/Makefile
@@ -6,7 +6,7 @@ TAGS := disable_crypt
 include ../.make/recursion.mk
 
 ############ tooling ############
-ifneq (, $(shell which go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
+ifneq (, $(shell command -v go 2> /dev/null)) # suppress `command not found warnings` for non go targets in CI
 include ../.bingo/Variables.mk
 GOARCH := $(shell go env GOARCH)
 endif


### PR DESCRIPTION
I ran into a deprecation warning of `which` when building ocis in termux. It seems `command -v` is preferred?

see https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1814961.html