### PR TITLE
unify ocis subcommands

### DIFF
--- a/changelog/unreleased/fix-search-command-server-command.md
+++ b/changelog/unreleased/fix-search-command-server-command.md
@@ -1,0 +1,8 @@
+Bugfix: Fix the `ocis search` command
+
+We've fixed the behavior for `ocis search`, which didn't show further help when not all secrets have been configured.
+It also was not possible to start the search service standalone from the oCIS binary without configuring all oCIS secrets,
+even they were not needed by the search service.
+
+https://github.com/owncloud/ocis/pull/3796
+

--- a/ocis/pkg/command/app-provider.go
+++ b/ocis/pkg/command/app-provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/app-provider/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func AppProviderCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.AppProvider.Service.Name,
-		Usage:    subcommandDescription(cfg.AppProvider.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.AppProvider.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/app-registry.go
+++ b/ocis/pkg/command/app-registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/app-registry/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func AppRegistryCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.AppRegistry.Service.Name,
-		Usage:    subcommandDescription(cfg.AppRegistry.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.AppRegistry.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/audit.go
+++ b/ocis/pkg/command/audit.go
@@ -6,15 +6,16 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/audit/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
 
-// AuditCommand is the entrypoint for the audit command.
+// AuditCommand is the entrypoint for the Audit command.
 func AuditCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:     "audit",
-		Usage:    "start audit service",
+		Name:     cfg.Audit.Service.Name,
+		Usage:    helper.SubcommandDescription(cfg.Audit.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/auth-basic.go
+++ b/ocis/pkg/command/auth-basic.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/auth-basic/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func AuthBasicCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.AuthBasic.Service.Name,
-		Usage:    subcommandDescription(cfg.AuthBasic.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.AuthBasic.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/auth-bearer.go
+++ b/ocis/pkg/command/auth-bearer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/auth-bearer/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func AuthBearerCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.AuthBearer.Service.Name,
-		Usage:    subcommandDescription(cfg.AuthBearer.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.AuthBearer.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/auth-machine.go
+++ b/ocis/pkg/command/auth-machine.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/auth-machine/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func AuthMachineCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.AuthMachine.Service.Name,
-		Usage:    subcommandDescription(cfg.AuthMachine.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.AuthMachine.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/frontend.go
+++ b/ocis/pkg/command/frontend.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/frontend/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func FrontendCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Frontend.Service.Name,
-		Usage:    subcommandDescription(cfg.Frontend.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Frontend.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/gateway.go
+++ b/ocis/pkg/command/gateway.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/gateway/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func GatewayCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Gateway.Service.Name,
-		Usage:    subcommandDescription(cfg.Gateway.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Gateway.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/graph-explorer.go
+++ b/ocis/pkg/command/graph-explorer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/graph-explorer/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func GraphExplorerCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.GraphExplorer.Service.Name,
-		Usage:    subcommandDescription(cfg.GraphExplorer.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.GraphExplorer.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/graph.go
+++ b/ocis/pkg/command/graph.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/graph/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func GraphCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Graph.Service.Name,
-		Usage:    subcommandDescription(cfg.Graph.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Graph.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/groups.go
+++ b/ocis/pkg/command/groups.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/groups/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func GroupsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Groups.Service.Name,
-		Usage:    subcommandDescription(cfg.Groups.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Groups.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/helper/common.go
+++ b/ocis/pkg/command/helper/common.go
@@ -1,9 +1,9 @@
-package command
+package helper
 
 import (
 	"fmt"
 )
 
-func subcommandDescription(serviceName string) string {
+func SubcommandDescription(serviceName string) string {
 	return fmt.Sprintf("%s extension commands", serviceName)
 }

--- a/ocis/pkg/command/idm.go
+++ b/ocis/pkg/command/idm.go
@@ -6,15 +6,16 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/idm/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
 
-// IDMCommand is the entrypoint for the idm server command.
+// IDMCommand is the entrypoint for the idm command.
 func IDMCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:     "idm",
-		Usage:    "idm extension commands",
+		Name:     cfg.IDM.Service.Name,
+		Usage:    helper.SubcommandDescription(cfg.IDM.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/idp.go
+++ b/ocis/pkg/command/idp.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/idp/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func IDPCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.IDP.Service.Name,
-		Usage:    subcommandDescription(cfg.IDP.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.IDP.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/nats.go
+++ b/ocis/pkg/command/nats.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/nats/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func NatsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Nats.Service.Name,
-		Usage:    subcommandDescription(cfg.Nats.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Nats.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/notifications.go
+++ b/ocis/pkg/command/notifications.go
@@ -6,15 +6,16 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/notifications/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
 
-// NatsServerCommand is the entrypoint for the nats server command.
+// NotificationsCommand is the entrypoint for the notifications command.
 func NotificationsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:     "notifications",
-		Usage:    "start notifications service",
+		Name:     cfg.Notifications.Service.Name,
+		Usage:    helper.SubcommandDescription(cfg.Notifications.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/ocdav.go
+++ b/ocis/pkg/command/ocdav.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/ocdav/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func OCDavCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.OCDav.Service.Name,
-		Usage:    subcommandDescription(cfg.OCDav.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.OCDav.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/ocs.go
+++ b/ocis/pkg/command/ocs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/ocs/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func OCSCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.OCS.Service.Name,
-		Usage:    subcommandDescription(cfg.OCS.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.OCS.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/proxy.go
+++ b/ocis/pkg/command/proxy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/proxy/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func ProxyCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Proxy.Service.Name,
-		Usage:    subcommandDescription(cfg.Proxy.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Proxy.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -15,7 +15,7 @@ func Execute() error {
 
 	app := clihelper.DefaultApp(&cli.App{
 		Name:  "ocis",
-		Usage: "ownCloud Infinite Scale Stack",
+		Usage: "ownCloud Infinite Scale",
 	})
 
 	for _, fn := range register.Commands {

--- a/ocis/pkg/command/search.go
+++ b/ocis/pkg/command/search.go
@@ -1,9 +1,12 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/owncloud/ocis/v2/extensions/search/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -12,10 +15,14 @@ import (
 func SearchCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Search.Service.Name,
-		Usage:    subcommandDescription(cfg.Search.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Search.Service.Name),
 		Category: "extensions",
-		Before: func(ctx *cli.Context) error {
-			return parser.ParseConfig(cfg)
+		Before: func(c *cli.Context) error {
+			if err := parser.ParseConfig(cfg); err != nil {
+				fmt.Printf("%v", err)
+			}
+			cfg.Search.Commons = cfg.Commons
+			return nil
 		},
 		Subcommands: command.GetCommands(cfg.Search),
 	}

--- a/ocis/pkg/command/server.go
+++ b/ocis/pkg/command/server.go
@@ -17,11 +17,11 @@ func Server(cfg *config.Config) *cli.Command {
 		Usage:    "start a fullstack server (runtime and all extensions in supervised mode)",
 		Category: "fullstack",
 		Before: func(c *cli.Context) error {
-			err := parser.ParseConfig(cfg)
-			if err != nil {
+			if err := parser.ParseConfig(cfg); err != nil {
 				fmt.Printf("%v", err)
+				return err
 			}
-			return err
+			return nil
 		},
 		Action: func(c *cli.Context) error {
 			r := runtime.New(cfg)

--- a/ocis/pkg/command/settings.go
+++ b/ocis/pkg/command/settings.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/settings/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func SettingsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Settings.Service.Name,
-		Usage:    subcommandDescription(cfg.Settings.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Settings.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/sharing.go
+++ b/ocis/pkg/command/sharing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/sharing/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func SharingCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Sharing.Service.Name,
-		Usage:    subcommandDescription(cfg.Sharing.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Sharing.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/storage-publiclink.go
+++ b/ocis/pkg/command/storage-publiclink.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/storage-publiclink/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func StoragePublicLinkCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.StoragePublicLink.Service.Name,
-		Usage:    subcommandDescription(cfg.StoragePublicLink.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.StoragePublicLink.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/storage-shares.go
+++ b/ocis/pkg/command/storage-shares.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/storage-shares/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func StorageSharesCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.StorageShares.Service.Name,
-		Usage:    subcommandDescription(cfg.StorageShares.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.StorageShares.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/storage-system.go
+++ b/ocis/pkg/command/storage-system.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/storage-system/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func StorageSystemCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.StorageSystem.Service.Name,
-		Usage:    subcommandDescription(cfg.StorageSystem.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.StorageSystem.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/storage-users.go
+++ b/ocis/pkg/command/storage-users.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/storage-users/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func StorageUsersCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.StorageUsers.Service.Name,
-		Usage:    subcommandDescription(cfg.StorageUsers.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.StorageUsers.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/store.go
+++ b/ocis/pkg/command/store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/store/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -15,7 +16,7 @@ func StoreCommand(cfg *config.Config) *cli.Command {
 
 	return &cli.Command{
 		Name:     cfg.Store.Service.Name,
-		Usage:    subcommandDescription(cfg.Store.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Store.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/thumbnails.go
+++ b/ocis/pkg/command/thumbnails.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/thumbnails/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func ThumbnailsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Thumbnails.Service.Name,
-		Usage:    subcommandDescription(cfg.Thumbnails.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Thumbnails.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/users.go
+++ b/ocis/pkg/command/users.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/users/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func UsersCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Users.Service.Name,
-		Usage:    subcommandDescription(cfg.Users.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Users.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/web.go
+++ b/ocis/pkg/command/web.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/web/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -14,7 +15,7 @@ import (
 func WebCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:     cfg.Web.Service.Name,
-		Usage:    subcommandDescription(cfg.Web.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.Web.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {

--- a/ocis/pkg/command/webdav.go
+++ b/ocis/pkg/command/webdav.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/extensions/webdav/pkg/command"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
 )
@@ -15,7 +16,7 @@ func WebDAVCommand(cfg *config.Config) *cli.Command {
 
 	return &cli.Command{
 		Name:     cfg.WebDAV.Service.Name,
-		Usage:    subcommandDescription(cfg.WebDAV.Service.Name),
+		Usage:    helper.SubcommandDescription(cfg.WebDAV.Service.Name),
 		Category: "extensions",
 		Before: func(c *cli.Context) error {
 			if err := parser.ParseConfig(cfg); err != nil {


### PR DESCRIPTION
## Description

We've fixed the behavior for `ocis search`, which didn't show further help when not all secrets have been configured.
It also was not possible to start the search service standalone from the oCIS binary without configuring all oCIS secrets,
even they were not needed by the search service.

Additionally:
- moved the `SubcommandDescription` function into a helper package, ensure that it is used by all extensions
- ensure that all services use ther service name for the subcommands name

## Related Issue
- Needed for owncloud/ocis-charts#43, #3764 to start the search service as a standalone service without configuring all oCIS secrets

## Motivation and Context
The search service should be startable without configuring all oCIS secrets

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `ocis search` should always yield a help, also if no secrets are configured

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
