### PR TITLE
remove unused transfer secret from app provider

### DIFF
--- a/changelog/unreleased/fix-app-provider-unused-transfer-secret.md
+++ b/changelog/unreleased/fix-app-provider-unused-transfer-secret.md
@@ -1,0 +1,8 @@
+Bugfix: Remove unused transfer secret from app provider
+
+We've fixed the startup of the app provider by removing the startup dependency
+on a configured transfer secret, which was not used. This only happend if you
+start the app provider without runtime (eg. `ocis app-provider server`) and didn't
+have configured all oCIS secrets.
+
+https://github.com/owncloud/ocis/pull/3798

--- a/extensions/app-registry/pkg/config/parser/parse.go
+++ b/extensions/app-registry/pkg/config/parser/parse.go
@@ -38,9 +38,5 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingJWTTokenError(cfg.Service.Name)
 	}
 
-	if cfg.TransferSecret == "" {
-		return shared.MissingRevaTransferSecretError(cfg.Service.Name)
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Description
We've fixed the startup of the app provider by removing the startup dependency
on a configured transfer secret, which was not used. This only happend if you
start the app provider without runtime (eg. `ocis app-provider server`) and didn't
have configured all oCIS secrets.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes startup of the app provider in https://github.com/owncloud/ocis-charts/pull/43

## Motivation and Context
only have dependencies on secrets that are needed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- none

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
