### PR TITLE
Bugfix: Rename the search extensions environment variable for the grpc server address

### DIFF
--- a/changelog/unreleased/fix-search-grpc-addr-env.md
+++ b/changelog/unreleased/fix-search-grpc-addr-env.md
@@ -1,0 +1,6 @@
+Bugfix: Rename the search extensions environment variable for the grpc server address
+
+We've fixed the gprc server address configuration environment variable by renaming it from
+`ACCOUNTS_GRPC_ADDR` to `SEARCH_GRPC_ADDR`
+
+https://github.com/owncloud/ocis/pull/55555

--- a/changelog/unreleased/fix-search-grpc-addr-env.md
+++ b/changelog/unreleased/fix-search-grpc-addr-env.md
@@ -1,6 +1,6 @@
-Bugfix: Rename the search extensions environment variable for the grpc server address
+Bugfix: Rename search env variable for the grpc server address
 
 We've fixed the gprc server address configuration environment variable by renaming it from
 `ACCOUNTS_GRPC_ADDR` to `SEARCH_GRPC_ADDR`
 
-https://github.com/owncloud/ocis/pull/55555
+https://github.com/owncloud/ocis/pull/3800

--- a/extensions/search/pkg/config/grpc.go
+++ b/extensions/search/pkg/config/grpc.go
@@ -2,6 +2,6 @@ package config
 
 // GRPC defines the available grpc configuration.
 type GRPC struct {
-	Addr      string `ocisConfig:"addr" env:"ACCOUNTS_GRPC_ADDR" desc:"The address of the grpc service."`
+	Addr      string `ocisConfig:"addr" env:"SEARCH_GRPC_ADDR" desc:"The address of the grpc service."`
 	Namespace string `ocisConfig:"-" yaml:"-"`
 }


### PR DESCRIPTION
## Description
We've fixed the gprc server address configuration environment variable by renaming it from
`ACCOUNTS_GRPC_ADDR` to `SEARCH_GRPC_ADDR`

WARNING: this could be considered as a breaking change!?

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needed for https://github.com/owncloud/ocis-charts/pull/43

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- none

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
