### PR TITLE
Bugfix: Fix multiple configuration environment variables for the storage-users extension

### DIFF
--- a/changelog/unreleased/fix-storage-users-config.md
+++ b/changelog/unreleased/fix-storage-users-config.md
@@ -1,0 +1,11 @@
+Bugfix: Fix multiple configuration environment variables for the storage-users extension
+
+We've fixed multiple environment variable configuration options for the storage-users extension:
+
+* `STORAGE_USERS_GRPC_ADDR` was used to configure both the address of the http and grpc server.
+  This resulted in a failing startup of the storage-users extension if this config option is set,
+  because the service tries to double-bind the configured port (one time for each of the http and grpc server). You can now configure the grpc server's address with the environment variable `STORAGE_USERS_GRPC_ADDR` and the http server's address with the environment variable `STORAGE_USERS_HTTP_ADDR`
+* `STORAGE_USERS_S3NG_USERS_PROVIDER_ENDPOINT` was used to configure the permissions service endpoint for the S3NG driver and was therefore renamed to `STORAGE_USERS_S3NG_PERMISSIONS_ENDPOINT`
+* It's now possible to configure the permissions service endpoint for all  storage drivers with the environment variable `STORAGE_USERS_PERMISSION_ENDPOINT`, which was previously only used by the S3NG driver.
+
+https://github.com/owncloud/ocis/pull/3802

--- a/changelog/unreleased/fix-storage-users-config.md
+++ b/changelog/unreleased/fix-storage-users-config.md
@@ -1,4 +1,4 @@
-Bugfix: Fix multiple configuration environment variables for the storage-users extension
+Bugfix: Fix multiple storage-users env variables
 
 We've fixed multiple environment variable configuration options for the storage-users extension:
 

--- a/extensions/storage-users/pkg/config/config.go
+++ b/extensions/storage-users/pkg/config/config.go
@@ -66,9 +66,9 @@ type GRPCConfig struct {
 }
 
 type HTTPConfig struct {
-	Addr      string `yaml:"addr" env:"STORAGE_USERS_GRPC_ADDR" desc:"The address of the grpc service."`
+	Addr      string `yaml:"addr" env:"STORAGE_USERS_HTTP_ADDR" desc:"The address of the http service."`
 	Namespace string `yaml:"-"`
-	Protocol  string `yaml:"protocol" env:"STORAGE_USERS_GRPC_PROTOCOL" desc:"The transport protocol of the grpc service."`
+	Protocol  string `yaml:"protocol" env:"STORAGE_USERS_HTTP_PROTOCOL" desc:"The transport protocol of the http service."`
 	Prefix    string
 }
 
@@ -86,7 +86,7 @@ type OCISDriver struct {
 	// Root is the absolute path to the location of the data
 	Root                string `yaml:"root" env:"STORAGE_USERS_OCIS_ROOT"`
 	UserLayout          string `yaml:"user_layout" env:"STORAGE_USERS_OCIS_USER_LAYOUT"`
-	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_OCIS_PERMISSIONS_ENDPOINT"`
+	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT,STORAGE_USERS_OCIS_PERMISSIONS_ENDPOINT"`
 	// PersonalSpaceAliasTemplate  contains the template used to construct
 	// the personal space alias, eg: `"{{.SpaceType}}/{{.User.Username | lower}}"`
 	PersonalSpaceAliasTemplate string `yaml:"personalspacealias_template" env:"STORAGE_USERS_OCIS_PERSONAL_SPACE_ALIAS_TEMPLATE"`
@@ -101,7 +101,7 @@ type S3NGDriver struct {
 	// Root is the absolute path to the location of the data
 	Root                string `yaml:"root" env:"STORAGE_USERS_S3NG_ROOT"`
 	UserLayout          string `yaml:"user_layout" env:"STORAGE_USERS_S3NG_USER_LAYOUT"`
-	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_S3NG_USERS_PROVIDER_ENDPOINT"`
+	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_S3NG_PERMISSIONS_ENDPOINT"`
 	Region              string `yaml:"region" env:"STORAGE_USERS_S3NG_REGION"`
 	AccessKey           string `yaml:"access_key" env:"STORAGE_USERS_S3NG_ACCESS_KEY"`
 	SecretKey           string `yaml:"secret_key" env:"STORAGE_USERS_S3NG_SECRET_KEY"`


### PR DESCRIPTION
## Description
We've fixed multiple environment variable configuration options for the storage-users extension:

* `STORAGE_USERS_GRPC_ADDR` was used to configure both the address of the http and grpc server.
  This resulted in a failing startup of the storage-users extension if this config option is set,
  because the service tries to double-bind the configured port (one time for each of the http and grpc server). You can now configure the grpc server's address with the environment variable `STORAGE_USERS_GRPC_ADDR` and the http server's address with the environment variable `STORAGE_USERS_HTTP_ADDR`
* `STORAGE_USERS_S3NG_USERS_PROVIDER_ENDPOINT` was used to configure the permissions service endpoint for the S3NG driver and was therefore renamed to `STORAGE_USERS_S3NG_PERMISSIONS_ENDPOINT`
* It's now possible to configure the permissions service endpoint for all  storage drivers with the environment variable `STORAGE_USERS_PERMISSION_ENDPOINT`, which was previously only used by the S3NG driver.

WARNING: this could be considered a breaking change

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needed for https://github.com/owncloud/ocis-charts/pull/43 to start the storage-users http and grpc servers listening on all interfaces

## Motivation and Context
fix the config

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
