### PR TITLE
remove composition of Commons

### DIFF
--- a/extensions/app-provider/pkg/config/config.go
+++ b/extensions/app-provider/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/app-registry/pkg/config/config.go
+++ b/extensions/app-registry/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service  `yaml:"-"`
 	Tracing *Tracing `yaml:"tracing"`

--- a/extensions/audit/pkg/config/config.go
+++ b/extensions/audit/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/auth-basic/pkg/config/config.go
+++ b/extensions/auth-basic/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/auth-bearer/pkg/config/config.go
+++ b/extensions/auth-bearer/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/auth-machine/pkg/config/config.go
+++ b/extensions/auth-machine/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/frontend/pkg/config/config.go
+++ b/extensions/frontend/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	HTTP HTTPConfig `yaml:"http"`
 

--- a/extensions/gateway/pkg/config/config.go
+++ b/extensions/gateway/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service  `yaml:"-"`
 	Tracing *Tracing `yaml:"tracing"`

--- a/extensions/graph-explorer/pkg/config/config.go
+++ b/extensions/graph-explorer/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/graph/pkg/config/config.go
+++ b/extensions/graph/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/groups/pkg/config/config.go
+++ b/extensions/groups/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/idm/pkg/config/config.go
+++ b/extensions/idm/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/idp/pkg/config/config.go
+++ b/extensions/idp/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/nats/pkg/config/config.go
+++ b/extensions/nats/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/notifications/pkg/config/config.go
+++ b/extensions/notifications/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 
@@ -22,7 +22,6 @@ type Config struct {
 
 // Notifications definces the config options for the notifications service.
 type Notifications struct {
-	*shared.Commons   `yaml:"-"`
 	SMTP              SMTP   `yaml:"SMTP"`
 	Events            Events `yaml:"events"`
 	RevaGateway       string `yaml:"reva_gateway" env:"REVA_GATEWAY;NOTIFICATIONS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`

--- a/extensions/ocdav/pkg/config/config.go
+++ b/extensions/ocdav/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	HTTP HTTPConfig `yaml:"http"`
 

--- a/extensions/ocs/pkg/config/config.go
+++ b/extensions/ocs/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/proxy/pkg/config/config.go
+++ b/extensions/proxy/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/search/pkg/config/config.go
+++ b/extensions/search/pkg/config/config.go
@@ -8,23 +8,23 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `ocisConfig:"-" yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
-	Service Service `ocisConfig:"-" yaml:"-"`
+	Service Service `yaml:"-"`
 
-	Tracing *Tracing `ocisConfig:"tracing"`
-	Log     *Log     `ocisConfig:"log"`
-	Debug   Debug    `ocisConfig:"debug"`
+	Tracing *Tracing `yaml:"tracing"`
+	Log     *Log     `yaml:"log"`
+	Debug   Debug    `yaml:"debug"`
 
-	GRPC GRPC `ocisConfig:"grpc"`
+	GRPC GRPC `yaml:"grpc"`
 
 	Datapath string `yaml:"data_path" env:"SEARCH_DATA_PATH"`
-	Reva     Reva   `ocisConfig:"reva"`
+	Reva     Reva   `yaml:"reva"`
 	Events   Events `yaml:"events"`
 
 	MachineAuthAPIKey string `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY;SEARCH_MACHINE_AUTH_API_KEY"`
 
-	Context context.Context `ocisConfig:"-" yaml:"-"`
+	Context context.Context `yaml:"-"`
 }
 
 // Events combines the configuration options for the event bus.

--- a/extensions/settings/pkg/config/config.go
+++ b/extensions/settings/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/sharing/pkg/config/config.go
+++ b/extensions/sharing/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/storage-publiclink/pkg/config/config.go
+++ b/extensions/storage-publiclink/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/storage-shares/pkg/config/config.go
+++ b/extensions/storage-shares/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/storage-system/pkg/config/config.go
+++ b/extensions/storage-system/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 	HTTP HTTPConfig `yaml:"http"`

--- a/extensions/storage-users/pkg/config/config.go
+++ b/extensions/storage-users/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 	HTTP HTTPConfig `yaml:"http"`

--- a/extensions/store/pkg/config/config.go
+++ b/extensions/store/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/thumbnails/pkg/config/config.go
+++ b/extensions/thumbnails/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/users/pkg/config/config.go
+++ b/extensions/users/pkg/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Config struct {
-	*shared.Commons `yaml:"-"`
-	Service         Service  `yaml:"-"`
-	Tracing         *Tracing `yaml:"tracing"`
-	Log             *Log     `yaml:"log"`
-	Debug           Debug    `yaml:"debug"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
+	Service Service         `yaml:"-"`
+	Tracing *Tracing        `yaml:"tracing"`
+	Log     *Log            `yaml:"log"`
+	Debug   Debug           `yaml:"debug"`
 
 	GRPC GRPCConfig `yaml:"grpc"`
 

--- a/extensions/web/pkg/config/config.go
+++ b/extensions/web/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 

--- a/extensions/webdav/pkg/config/config.go
+++ b/extensions/webdav/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config combines all available configuration parts.
 type Config struct {
-	*shared.Commons `yaml:"-"`
+	Commons *shared.Commons `yaml:"-"` // don't use this directly as configuration for a service
 
 	Service Service `yaml:"-"`
 


### PR DESCRIPTION
## Description
Removes the composition of the `Commons` config, since it is not used and confusing to devs and produces undesirable IDE autocompletion.

`Commons` should only be used:
- in ./ocis or ./ocis-pkg to copy common configuration into the Commons struct
- in ./extensions/xxx to copy configuration out of the Commons struct


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needs https://github.com/owncloud/ocis/pull/3799 first
- Needs https://github.com/owncloud/ocis/pull/3798 first

## Motivation and Context
Removes undesired IDE autocompletion

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
