### PR TITLE
workaround ldaps insecure bind for graph https://github.com/owncloud/ocis/issues/3812

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -126,6 +126,7 @@ services:
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:

--- a/deployments/examples/ocis_hello/docker-compose.yml
+++ b/deployments/examples/ocis_hello/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       SETTINGS_GRPC_ADDR: 0.0.0.0:9191
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password

--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password

--- a/deployments/examples/ocis_s3/docker-compose.yml
+++ b/deployments/examples/ocis_s3/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       STORAGE_USERS_S3NG_BUCKET: ${MINIO_BUCKET:-ocis-bucket}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       GATEWAY_GRPC_ADDR: 0.0.0.0:9142 # make the REVA gateway accessible to the app drivers
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
+      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password


### PR DESCRIPTION
setting the environment variable OCIS_INSECURE=true breaks the graph api ldaps connection because GRAPH_LDAP_INSECURE needs always be true, since we have a ldaps connection to the idm and don't use the ca cert in the graph extension

As a workaround for our deployment examples we set:
```
      OCIS_INSECURE: "${INSECURE:-false}"
      GRAPH_LDAP_INSECURE: true
```
