### PR TITLE
proxy config revamp

### DIFF
--- a/changelog/unreleased/fix-remove-legacy-accounts-routes.md
+++ b/changelog/unreleased/fix-remove-legacy-accounts-routes.md
@@ -1,0 +1,8 @@
+Bugfix: remove legacy accounts proxy routes
+
+We've removed the legacy accounts routes from the proxy default config.
+There were no longer used since the switch to IDM as the default user
+backend. Also accounts is no longer part of the oCIS binary and therefore
+should not be part of the proxy default route config.
+
+https://github.com/owncloud/ocis/pull/3831

--- a/deployments/examples/oc10_ocis_parallel/config/ocis/proxy.yaml
+++ b/deployments/examples/oc10_ocis_parallel/config/ocis/proxy.yaml
@@ -17,7 +17,7 @@ policies:
       - endpoint: /archiver
         backend: http://localhost:9140
       - type: regex
-        endpoint: /ocs/v[12].php/cloud/(users?|groups)
+        endpoint: /ocs/v[12].php/cloud/user/signing-key
         backend: http://localhost:9110
       - endpoint: /ocs/
         backend: http://localhost:9140
@@ -53,10 +53,6 @@ policies:
         backend: http://localhost:9120
       - endpoint: /graph-explorer
         backend: http://localhost:9135
-      - endpoint: /api/v0/accounts
-        backend: http://localhost:9181
-      - endpoint: /accounts.js
-        backend: http://localhost:9181
       - endpoint: /api/v0/settings
         backend: http://localhost:9190
       - endpoint: /settings.js

--- a/deployments/examples/ocis_hello/config/ocis/proxy.yaml
+++ b/deployments/examples/ocis_hello/config/ocis/proxy.yaml
@@ -3,149 +3,62 @@ policy_selector:
     policy: ocis
 
 policies:
-- name: ocis
-  routes:
-  # defaults, taken from https://owncloud.dev/extensions/proxy/configuration/
-  - type: ""
-    method: ""
-    endpoint: /
-    backend: http://localhost:9100
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /.well-known/
-    backend: http://localhost:9130
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /konnect/
-    backend: http://localhost:9130
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /signin/
-    backend: http://localhost:9130
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /archiver
-    backend: http://localhost:9140
-    service: ""
-    apache_vhost: false
-  - type: regex
-    method: ""
-    endpoint: /ocs/v[12].php/cloud/(users?|groups)
-    backend: http://localhost:9110
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /ocs/
-    backend: http://localhost:9140
-    service: ""
-    apache_vhost: false
-  - type: query
-    method: ""
-    endpoint: /remote.php/?preview=1
-    backend: http://localhost:9115
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: REPORT
-    endpoint: /remote.php/dav/
-    backend: http://localhost:9115
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /remote.php/
-    backend: ""
-    service: ocdav
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /dav/
-    backend: ""
-    service: ocdav
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /webdav/
-    backend: ""
-    service: ocdav
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /status.php
-    backend: ""
-    service: ocdav
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /index.php/
-    backend: ""
-    service: ocdav
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /apps/
-    backend: ""
-    service: ocdav
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /data
-    backend: http://localhost:9140
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /app/
-    backend: http://localhost:9140
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /graph/
-    backend: http://localhost:9120
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /graph-explorer
-    backend: http://localhost:9135
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /api/v0/accounts
-    backend: http://localhost:9181
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /accounts.js
-    backend: http://localhost:9181
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /api/v0/settings
-    backend: http://localhost:9190
-    service: ""
-    apache_vhost: false
-  - type: ""
-    method: ""
-    endpoint: /settings.js
-    backend: http://localhost:9190
-    service: ""
-    apache_vhost: false
-  # oCIS Hello specific routes
-  - endpoint: "/api/v0/greet"
-    backend: http://ocis-hello:9105
-  - endpoint: "/hello.js"
-    backend: http://ocis-hello:9105
+  - name: ocis
+    routes:
+      # defaults, taken from https://owncloud.dev/extensions/proxy/configuration/
+      - endpoint: /
+        backend: http://localhost:9100
+      - endpoint: /.well-known/
+        backend: http://localhost:9130
+      - endpoint: /konnect/
+        backend: http://localhost:9130
+      - endpoint: /signin/
+        backend: http://localhost:9130
+      - endpoint: /archiver
+        backend: http://localhost:9140
+      - type: regex
+        endpoint: /ocs/v[12].php/cloud/user/signing-key
+        backend: http://localhost:9110
+      - endpoint: /ocs/
+        backend: http://localhost:9140
+      - type: query
+        endpoint: /remote.php/?preview=1
+        backend: http://localhost:9115
+      - method: REPORT
+        endpoint: /remote.php/dav/
+        backend: http://localhost:9115
+      - type: query
+        endpoint: /dav/?preview=1
+        backend: http://localhost:9115
+      - type: query
+        endpoint: /webdav/?preview=1
+        backend: http://localhost:9115
+      - endpoint: /remote.php/
+        service: com.owncloud.web.ocdav
+      - endpoint: /dav/
+        service: com.owncloud.web.ocdav
+      - endpoint: /webdav/
+        service: com.owncloud.web.ocdav
+      - endpoint: /status.php
+        service: com.owncloud.web.ocdav
+      - endpoint: /index.php/
+        service: com.owncloud.web.ocdav
+      - endpoint: /apps/
+        service: com.owncloud.web.ocdav
+      - endpoint: /data
+        backend: http://localhost:9140
+      - endpoint: /app/
+        backend: http://localhost:9140
+      - endpoint: /graph/
+        backend: http://localhost:9120
+      - endpoint: /graph-explorer
+        backend: http://localhost:9135
+      - endpoint: /api/v0/settings
+        backend: http://localhost:9190
+      - endpoint: /settings.js
+        backend: http://localhost:9190
+      # oCIS Hello specific routes
+      - endpoint: "/api/v0/greet"
+        backend: http://ocis-hello:9105
+      - endpoint: "/hello.js"
+        backend: http://ocis-hello:9105

--- a/extensions/proxy/pkg/config/defaults/defaultconfig.go
+++ b/extensions/proxy/pkg/config/defaults/defaultconfig.go
@@ -156,16 +156,6 @@ func DefaultPolicies() []config.Policy {
 					Endpoint: "/graph-explorer",
 					Backend:  "http://localhost:9135",
 				},
-				// if we were using the go micro api gateway we could look up the endpoint in the registry dynamically
-				{
-					Endpoint: "/api/v0/accounts",
-					Backend:  "http://localhost:9181",
-				},
-				// TODO the lookup needs a better mechanism
-				{
-					Endpoint: "/accounts.js",
-					Backend:  "http://localhost:9181",
-				},
 				{
 					Endpoint: "/api/v0/settings",
 					Backend:  "http://localhost:9190",

--- a/tests/parallelDeployAcceptance/drone/ocis/proxy.yaml
+++ b/tests/parallelDeployAcceptance/drone/ocis/proxy.yaml
@@ -17,7 +17,7 @@ policies:
       - endpoint: /archiver
         backend: http://localhost:9140
       - type: regex
-        endpoint: /ocs/v[12].php/cloud/(users?|groups)
+        endpoint: /ocs/v[12].php/cloud/user/signing-key
         backend: http://localhost:9110
       - endpoint: /ocs/
         backend: http://localhost:9140
@@ -53,10 +53,6 @@ policies:
         backend: http://localhost:9120
       - endpoint: /graph-explorer
         backend: http://localhost:9135
-      - endpoint: /api/v0/accounts
-        backend: http://localhost:9181
-      - endpoint: /accounts.js
-        backend: http://localhost:9181
       - endpoint: /api/v0/settings
         backend: http://localhost:9190
       - endpoint: /settings.js


### PR DESCRIPTION
## Description

Bugfix: remove legacy accounts proxy routes

We've removed the legacy accounts routes from the proxy default config.
There were no longer used since the switch to IDM as the default user
backend. Also accounts is no longer part of the oCIS binary and therefore
should not be part of the proxy default route config.


+ update routes on the deployments (fixes login error into oCIS in the parallel deployment)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
