### PR TITLE
introduce service registry cache

### DIFF
--- a/changelog/unreleased/enhancement-registry-cache.md
+++ b/changelog/unreleased/enhancement-registry-cache.md
@@ -1,0 +1,7 @@
+Enhancement: Introduce service registry cache
+
+We've improved the service registry / service discovery by
+setting up registry caching (TTL 20s), so that not every requests
+has to do a lookup on the registry.
+
+https://github.com/owncloud/ocis/pull/3833

--- a/ocis-pkg/registry/registry.go
+++ b/ocis-pkg/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"os"
 	"strings"
+	"time"
 
 	consulr "github.com/go-micro/plugins/v4/registry/consul"
 	etcdr "github.com/go-micro/plugins/v4/registry/etcd"
@@ -11,6 +12,7 @@ import (
 	natsr "github.com/go-micro/plugins/v4/registry/nats"
 
 	"go-micro.dev/v4/registry"
+	"go-micro.dev/v4/registry/cache"
 )
 
 var (
@@ -46,5 +48,7 @@ func GetRegistry() registry.Registry {
 		r = mdnsr.NewRegistry()
 	}
 
-	return r
+	// always use cached registry to prevent registry
+	// lookup for every request
+	return cache.New(r, cache.WithTTL(20*time.Second))
 }


### PR DESCRIPTION
## Description

Enhancement: Introduce service registry cache

We've improved the service registry / service discovery by
setting up registry caching (TTL 20s), so that not every requests
has to do a lookup on the registry.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- none

## Motivation and Context
- don't put too much pressure on the service registry
- speed up requests (since a registry lookup takes time)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
