### PR TITLE
Set public link defaultname capability

### DIFF
--- a/changelog/unreleased/fix-public-link-defaultname-capability
+++ b/changelog/unreleased/fix-public-link-defaultname-capability
@@ -1,0 +1,6 @@
+Bugfix: Set default name for public link via capabilities
+
+We have now added a default name for public link shares which is communicated via the capabilities.
+
+https://github.com/owncloud/ocis/pull/3834
+https://github.com/owncloud/ocis/issues/1237

--- a/extensions/frontend/pkg/revaconfig/config.go
+++ b/extensions/frontend/pkg/revaconfig/config.go
@@ -166,12 +166,13 @@ func FrontendConfigFromStruct(cfg *config.Config) map[string]interface{} {
 								"default_permissions":               22,
 								"search_min_length":                 3,
 								"public": map[string]interface{}{
-									"enabled":              true,
-									"send_mail":            true,
-									"social_share":         true,
-									"upload":               true,
-									"multiple":             true,
-									"supports_upload_only": true,
+									"enabled":                    true,
+									"send_mail":                  true,
+									"defaultPublicLinkShareName": "Public link",
+									"social_share":               true,
+									"upload":                     true,
+									"multiple":                   true,
+									"supports_upload_only":       true,
 									"password": map[string]interface{}{
 										"enforced": false,
 										"enforced_for": map[string]interface{}{

--- a/extensions/ocs/pkg/service/v0/data/user.go
+++ b/extensions/ocs/pkg/service/v0/data/user.go
@@ -8,7 +8,7 @@ type Users struct {
 // User holds the payload for a GetUser response
 type User struct {
 	Enabled           string `json:"enabled" xml:"enabled"`
-	UserID            string `json:"id" xml:"id"`// UserID is mapped to the preferred_name attribute in accounts
+	UserID            string `json:"id" xml:"id"` // UserID is mapped to the preferred_name attribute in accounts
 	DisplayName       string `json:"display-name" xml:"display-name"`
 	LegacyDisplayName string `json:"displayname" xml:"displayname"`
 	Email             string `json:"email" xml:"email"`

--- a/extensions/webdav/pkg/metrics/metrics.go
+++ b/extensions/webdav/pkg/metrics/metrics.go
@@ -28,8 +28,8 @@ func New() *Metrics {
 		BuildInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: Subsystem,
-			Name: "build_info",
-			Help: "Build Information",
+			Name:      "build_info",
+			Help:      "Build Information",
 		}, []string{"version"}),
 	}
 

--- a/ocis-pkg/sync/cache.go
+++ b/ocis-pkg/sync/cache.go
@@ -11,8 +11,8 @@ type Cache struct {
 	// capacity and length have to be the first words
 	// in order to be 64-aligned on 32-bit architectures.
 	capacity, length uint64 // access atomically
-	entries  sync.Map
-	pool     sync.Pool
+	entries          sync.Map
+	pool             sync.Pool
 }
 
 // CacheEntry represents an entry on the cache. You can type assert on V.


### PR DESCRIPTION
## Description
It's not really worth fixing this since we will switch to setting a different, translatable default name for freshly created links in https://github.com/owncloud/web/pull/6961 but anyways :)

## Related Issue
- Fixes #1237
