### PR TITLE
[deployments] Enclose boolean with string in docker-compose env

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
-      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
+      GRAPH_LDAP_INSECURE: "true" # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
     volumes:

--- a/deployments/examples/ocis_hello/docker-compose.yml
+++ b/deployments/examples/ocis_hello/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       SETTINGS_GRPC_ADDR: 0.0.0.0:9191
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
-      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
+      GRAPH_LDAP_INSECURE: "true" # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password

--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -55,7 +55,6 @@ services:
     # therefore we ignore the error and then start the ocis server
     command: ["-c", "ocis init || true; ocis server"]
     environment:
-
       # users/gropups from ldap
       LDAP_URI: ldaps://ldap-server
       LDAP_INSECURE: "true"
@@ -81,7 +80,7 @@ services:
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
-      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
+      GRAPH_LDAP_INSECURE: "true" # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password

--- a/deployments/examples/ocis_s3/docker-compose.yml
+++ b/deployments/examples/ocis_s3/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       STORAGE_USERS_S3NG_BUCKET: ${MINIO_BUCKET:-ocis-bucket}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
-      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
+      GRAPH_LDAP_INSECURE: "true" # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password
@@ -94,7 +94,11 @@ services:
       ocis-net:
     entrypoint:
       - /bin/sh
-    command:  ["-c", "mkdir -p /data/${MINIO_BUCKET:-ocis-bucket} && minio server --console-address ':9001' /data"]
+    command:
+      [
+        "-c",
+        "mkdir -p /data/${MINIO_BUCKET:-ocis-bucket} && minio server --console-address ':9001' /data",
+      ]
     volumes:
       - minio-data:/data
     environment:

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
-      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
+      GRAPH_LDAP_INSECURE: "true" # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password
@@ -83,7 +83,6 @@ volumes:
   certs:
   ocis-config:
   ocis-data:
-
 
 networks:
   ocis-net:

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       GATEWAY_GRPC_ADDR: 0.0.0.0:9142 # make the REVA gateway accessible to the app drivers
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
-      GRAPH_LDAP_INSECURE: true # https://github.com/owncloud/ocis/issues/3812
+      GRAPH_LDAP_INSECURE: "true" # https://github.com/owncloud/ocis/issues/3812
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
       # admin user password


### PR DESCRIPTION
## Description
`docker-compose up` inside deployments/examples give this error:
```bash
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.ocis.environment.GRAPH_LDAP_INSECURE contains true, which is an invalid type, it should be a string, number, or a null
```

This PR fixes the error by enclosing boolean value into string.

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
