### PR TITLE
update reva to v2.3.2-0.20220519173447-80f88dfbc02d

### DIFF
--- a/changelog/unreleased/update-reva.md
+++ b/changelog/unreleased/update-reva.md
@@ -5,3 +5,4 @@ bumps reva version
 https://github.com/owncloud/ocis/pull/3746
 https://github.com/owncloud/ocis/pull/3771
 https://github.com/owncloud/ocis/pull/3778
+https://github.com/owncloud/ocis/pull/3842

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.0.1
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde
-	github.com/cs3org/reva/v2 v2.3.2-0.20220518201235-fc42c1a84d5a
+	github.com/cs3org/reva/v2 v2.3.2-0.20220519173447-80f88dfbc02d
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD9
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde h1:WrD9O8ZaWvsm0eBzpzVBIuczDhqVq50Nmjc7PGHHA9Y=
 github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva/v2 v2.3.2-0.20220518201235-fc42c1a84d5a h1:GkOtCxtt/k4ZoDyFnnKuONDFp7o3yYhKHFydnZvhnpI=
-github.com/cs3org/reva/v2 v2.3.2-0.20220518201235-fc42c1a84d5a/go.mod h1:uGeTncJa3FISh8AERkbZYVNXFV40PjYyRht5L09i+LQ=
+github.com/cs3org/reva/v2 v2.3.2-0.20220519173447-80f88dfbc02d h1:MLHllEQ80uyRp4eeEXILTZ6Yk1Nglv2C7LI9dGjkXmo=
+github.com/cs3org/reva/v2 v2.3.2-0.20220519173447-80f88dfbc02d/go.mod h1:uGeTncJa3FISh8AERkbZYVNXFV40PjYyRht5L09i+LQ=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -587,8 +587,6 @@ cannot share a folder with create permission
 #### [share permissions are not enforced](https://github.com/owncloud/product/issues/270)
 
 - [apiShareManagementToShares/mergeShare.feature:124](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L124)
-- [apiShareReshareToShares3/reShareUpdate.feature:61](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L61)
-- [apiShareReshareToShares3/reShareUpdate.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L62)
 
 #### [500 status code on update share](https://github.com/owncloud/ocis/issues/2011)
 
@@ -801,18 +799,6 @@ _ocs: api compatibility, return correct status code_
 
 #### [Share permissions can be updated to any value](https://github.com/owncloud/ocis/issues/2173)
 
-- [apiShareUpdateToShares/updateShare.feature:131](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L131)
-- [apiShareUpdateToShares/updateShare.feature:132](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L132)
-- [apiShareUpdateToShares/updateShare.feature:133](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L133)
-- [apiShareUpdateToShares/updateShare.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L134)
-- [apiShareUpdateToShares/updateShare.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L135)
-- [apiShareUpdateToShares/updateShare.feature:136](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L136)
-- [apiShareUpdateToShares/updateShare.feature:155](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L155)
-- [apiShareUpdateToShares/updateShare.feature:156](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L156)
-- [apiShareUpdateToShares/updateShare.feature:157](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L157)
-- [apiShareUpdateToShares/updateShare.feature:158](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L158)
-- [apiShareUpdateToShares/updateShare.feature:159](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L159)
-- [apiShareUpdateToShares/updateShare.feature:160](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L160)
 
 #### [Cannot move folder/file from one received share to another](https://github.com/owncloud/ocis/issues/2442)
 
@@ -840,11 +826,6 @@ _ocs: api compatibility, return correct status code_
 - [apiShareManagementBasicToShares/createShareToSharesFolder.feature:747](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L747)
 - [apiShareManagementBasicToShares/createShareToSharesFolder.feature:762](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L762)
 - [apiShareManagementBasicToShares/createShareToSharesFolder.feature:763](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L763)
-
-#### [reshared resource is not listed for sharee after accepting share](https://github.com/owncloud/ocis/issues/2214)
-
-- [apiShareReshareToShares2/reShareSubfolder.feature:178](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature#L178)
-- [apiShareReshareToShares2/reShareSubfolder.feature:179](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature#L179)
 
 #### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 


### PR DESCRIPTION
bump reva to 80f88dfbc02d to include https://github.com/cs3org/reva/pull/2884 and https://github.com/cs3org/reva/pull/2883

```
runsh: Total unexpected passed scenarios throughout the test run:
apiShareReshareToShares2/reShareSubfolder.feature:178
apiShareReshareToShares2/reShareSubfolder.feature:179
apiShareReshareToShares3/reShareUpdate.feature:61
apiShareReshareToShares3/reShareUpdate.feature:62
apiShareUpdateToShares/updateShare.feature:131
apiShareUpdateToShares/updateShare.feature:132
apiShareUpdateToShares/updateShare.feature:133
apiShareUpdateToShares/updateShare.feature:134
apiShareUpdateToShares/updateShare.feature:135
apiShareUpdateToShares/updateShare.feature:136
apiShareUpdateToShares/updateShare.feature:155
apiShareUpdateToShares/updateShare.feature:156
apiShareUpdateToShares/updateShare.feature:157
apiShareUpdateToShares/updateShare.feature:158
apiShareUpdateToShares/updateShare.feature:159
apiShareUpdateToShares/updateShare.feature:160
```

fixes https://github.com/owncloud/ocis/issues/2173
fixes https://github.com/owncloud/ocis/issues/2214

related https://github.com/owncloud/product/issues/270
