### PR TITLE
Increase access token duration to 1 day

### DIFF
--- a/extensions/idp/pkg/config/defaults/defaultconfig.go
+++ b/extensions/idp/pkg/config/defaults/defaultconfig.go
@@ -62,7 +62,7 @@ func DefaultConfig() *config.Config {
 			ValidationKeysPath:                "",
 			CookieBackendURI:                  "",
 			CookieNames:                       nil,
-			AccessTokenDurationSeconds:        60 * 10,                // 10 minutes
+			AccessTokenDurationSeconds:        60 * 60 * 24,           // 1 day
 			IDTokenDurationSeconds:            60 * 60,                // 1 hour
 			RefreshTokenDurationSeconds:       60 * 60 * 24 * 365 * 3, // 1 year
 			DyamicClientSecretDurationSeconds: 0,


### PR DESCRIPTION
## Description
We currently have an [issue in web](https://github.com/owncloud/web/issues/7030) which causes a hard page load / redirect to the personal space view after token expiry / during token refresh. Fixing the issue in web is quite some work as it involves a lot of loose ends (see linked ticket). In order to mitigate this annoying behaviour I'd like to increase the access token duration to 1 day.

Do we need a changelog item for this?

Is 10 minutes a conscious decision / reasonable value? Or do we want to have e.g. 30 or 60 minutes when we fixed the issue in web and can revert to a smaller value again here?

## Related Issue
- Related to https://github.com/owncloud/web/issues/7030

## Motivation and Context
Mitigate an annoying redirect during token refresh.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
