### PR TITLE
[full-ci] update reva to v2.4.2-0.20220601110755-6b47effc3759

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.0.1
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde
-	github.com/cs3org/reva/v2 v2.4.1
+	github.com/cs3org/reva/v2 v2.4.2-0.20220601110755-6b47effc3759
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD9
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde h1:WrD9O8ZaWvsm0eBzpzVBIuczDhqVq50Nmjc7PGHHA9Y=
 github.com/cs3org/go-cs3apis v0.0.0-20220412090512-93c5918b4bde/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva/v2 v2.4.1 h1:+IjaDbMv2rH0VKXcJ26oI6Zc6R7nV5NHB1eIYnuoPaQ=
-github.com/cs3org/reva/v2 v2.4.1/go.mod h1:uGeTncJa3FISh8AERkbZYVNXFV40PjYyRht5L09i+LQ=
+github.com/cs3org/reva/v2 v2.4.2-0.20220601110755-6b47effc3759 h1:caNJk02Z1S/49qJVYsxBXYxyrMVRpJgNbxux/5P09Jc=
+github.com/cs3org/reva/v2 v2.4.2-0.20220601110755-6b47effc3759/go.mod h1:uGeTncJa3FISh8AERkbZYVNXFV40PjYyRht5L09i+LQ=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -18,6 +18,3 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 ### Tries to download /Shares/ folder but it cannot be downloaded any more directly
 - [apiArchiver/downloadById.feature:134](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadById.feature#L134)
 - [apiArchiver/downloadById.feature:135](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadById.feature#L135)
-
-### [User can not upload file after setting the quota without restriction](https://github.com/owncloud/ocis/issues/3810)
-- [apiSpaces/changeSpaces.feature:138](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L138)


### PR DESCRIPTION
update ocis to include https://github.com/cs3org/reva/pull/2888, https://github.com/cs3org/reva/pull/2909, https://github.com/cs3org/reva/pull/2905, https://github.com/cs3org/reva/pull/2903 and https://github.com/cs3org/reva/pull/2907