### PR TITLE
[deployments] Add specific LDAP_GROUP_BASE_DN and LDAP_USER_BASE_DN needed for tests

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/testing/docker-compose-additions.yml
+++ b/deployments/examples/oc10_ocis_parallel/testing/docker-compose-additions.yml
@@ -4,6 +4,8 @@ version: "3.7"
 services:
   ocis:
     environment:
+      LDAP_GROUP_BASE_DN: "ou=TestGroups,dc=owncloud,dc=com"
+      LDAP_USER_BASE_DN: "ou=TestUsers,dc=owncloud,dc=com"
       PROXY_ENABLE_BASIC_AUTH: "true"
 
   oc10:


### PR DESCRIPTION
## Description
In the tests,  `LDAP_GROUP_BASE_DN` and `LDAP_USER_BASE_DN` are different than `ou=groups,dc=owncloud,dc=com` and `ou=users,dc=owncloud,dc=com` respectively. Due to this, running parallel deployment tests locally was not possible.

In this PR, I have added LDAP_GROUP_BASE_DN and LDAP_USER_BASE_DN with necessary values to the `testing/docker-compose-additions.yml`.


## Related Issue
Running parallel deployment tests locally was not successful

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
