### PR TITLE
add config option to provide TLS certificate

### DIFF
--- a/changelog/unreleased/graph-cacert.md
+++ b/changelog/unreleased/graph-cacert.md
@@ -1,0 +1,6 @@
+Enhancement: Add config option to provide TLS certificate
+
+Added a config option to the graph service to provide a TLS certificate to be used to verify the LDAP server certificate.
+
+https://github.com/owncloud/ocis/issues/3818
+https://github.com/owncloud/ocis/pull/3888

--- a/extensions/graph/pkg/config/config.go
+++ b/extensions/graph/pkg/config/config.go
@@ -38,6 +38,7 @@ type Spaces struct {
 
 type LDAP struct {
 	URI           string `yaml:"uri" env:"LDAP_URI;GRAPH_LDAP_URI"`
+	CACert        string `yaml:"cacert" env:"LDAP_CACERT;GRAPH_LDAP_CACERT" desc:"The certificate to verify TLS connections"`
 	Insecure      bool   `yaml:"insecure" env:"OCIS_INSECURE;GRAPH_LDAP_INSECURE"`
 	BindDN        string `yaml:"bind_dn" env:"LDAP_BIND_DN;GRAPH_LDAP_BIND_DN"`
 	BindPassword  string `yaml:"bind_password" env:"LDAP_BIND_PASSWORD;GRAPH_LDAP_BIND_PASSWORD"`

--- a/extensions/graph/pkg/config/defaults/defaultconfig.go
+++ b/extensions/graph/pkg/config/defaults/defaultconfig.go
@@ -1,9 +1,11 @@
 package defaults
 
 import (
+	"path"
 	"strings"
 
 	"github.com/owncloud/ocis/v2/extensions/graph/pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 )
 
 func FullDefaultConfig() *config.Config {
@@ -41,6 +43,7 @@ func DefaultConfig() *config.Config {
 			LDAP: config.LDAP{
 				URI:                      "ldaps://localhost:9235",
 				Insecure:                 true,
+				CACert:                   path.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
 				BindDN:                   "uid=libregraph,ou=sysusers,o=libregraph-idm",
 				UseServerUUID:            false,
 				WriteEnabled:             true,


### PR DESCRIPTION
Added a config option to the graph service to provide a TLS certificate to be used to verify the LDAP server certificate.

Closes: https://github.com/owncloud/ocis/issues/3818