### PR TITLE
allow overwriting a default value by setting an empty envirionment variable

### DIFF
--- a/changelog/unreleased/fix-allow-empty-environment-variables
+++ b/changelog/unreleased/fix-allow-empty-environment-variables
@@ -1,0 +1,8 @@
+Bugfix: Allow empty environment variables
+
+We've fixed the behavior for empty environment variables, that previously would
+not have overwritten default values. Therefore it had the same effect like not
+setting the environment variable. We now check if the environment variable is
+set at all and if so, we also allow to override a default value with an empty value.
+
+https://github.com/owncloud/ocis/pull/3892

--- a/ocis-pkg/config/envdecode/envdecode.go
+++ b/ocis-pkg/config/envdecode/envdecode.go
@@ -149,10 +149,11 @@ func decode(target interface{}, strict bool) (int, error) {
 		overrides := strings.Split(parts[0], `;`)
 
 		var env string
+		var envSet bool
 		for _, override := range overrides {
-			v := os.Getenv(override)
-			if v != "" {
+			if v, set := os.LookupEnv(override); set {
 				env = v
+				envSet = true
 			}
 		}
 
@@ -176,13 +177,13 @@ func decode(target interface{}, strict bool) (int, error) {
 		if required && hasDefault {
 			panic(`envdecode: "default" and "required" may not be specified in the same annotation`)
 		}
-		if env == "" && required {
+		if !envSet && required {
 			return 0, fmt.Errorf("the environment variable \"%s\" is missing", parts[0])
 		}
-		if env == "" {
+		if !envSet {
 			env = defaultValue
 		}
-		if env == "" {
+		if !envSet && env == "" {
 			continue
 		}
 


### PR DESCRIPTION
## Description
allow overwriting a default value by setting an empty enviornment variable

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
assuming, that you don't want to have a ldap ca cert, you may want to set `LDAP_CACERT=""`. This didn't work prior to this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
