### PR TITLE
graph: Fix role-id extraction from token

### DIFF
--- a/changelog/unreleased/fix-user-autoprovision.md
+++ b/changelog/unreleased/fix-user-autoprovision.md
@@ -1,0 +1,7 @@
+Bugfix: Fix user autoprovisioning
+
+We've fixed the autoprovsioning feature that was introduced in beta2. Due to a bug
+the role assignment of the privileged user that is used to create accounts wasn't
+propagated correctly to the `graph` service.
+
+https://github.com/owncloud/ocis/issues/3893

--- a/extensions/graph/pkg/middleware/auth.go
+++ b/extensions/graph/pkg/middleware/auth.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/auth/scope"
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/token/manager/jwt"
-	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/owncloud/ocis/v2/extensions/graph/pkg/service/v0/errorcode"
 	"github.com/owncloud/ocis/v2/ocis-pkg/account"
 	opkgm "github.com/owncloud/ocis/v2/ocis-pkg/middleware"
@@ -75,8 +74,10 @@ func Auth(opts ...account.Option) func(http.Handler) http.Handler {
 			ctx = revactx.ContextSetToken(ctx, t)
 			ctx = revactx.ContextSetUser(ctx, u)
 			ctx = gmmetadata.Set(ctx, opkgm.AccountID, u.Id.OpaqueId)
-			if role := utils.ReadPlainFromOpaque(u.Opaque, "roles"); role != "" {
-				ctx = gmmetadata.Set(ctx, opkgm.RoleIDs, role)
+			if u.Opaque != nil && u.Opaque.Map != nil {
+				if roles, ok := u.Opaque.Map["roles"]; ok {
+					ctx = gmmetadata.Set(ctx, opkgm.RoleIDs, string(roles.Value))
+				}
 			}
 			ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, t)
 


### PR DESCRIPTION
We can't use ReadPlainFromOpaque here since the OpaqueEntry entry is
"json" encoded (not "plain").

Fixes: #3893

