### PR TITLE
Fix inconsistent env var naming for LDAP filter configuration

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1617,7 +1617,7 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "LDAP_GROUP_SCHEMA_ID": "cn",
             "LDAP_GROUP_SCHEMA_MAIL": "mail",
             "LDAP_GROUP_SCHEMA_MEMBER": "cn",
-            "LDAP_GROUPFILTER": "(objectclass=owncloud)",
+            "LDAP_GROUP_FILTER": "(objectclass=owncloud)",
             "LDAP_LOGIN_ATTRIBUTES": "uid",
             "LDAP_USER_BASE_DN": "ou=TestUsers,dc=owncloud,dc=com",
             "LDAP_USER_OBJECTCLASS": "posixAccount",
@@ -1625,7 +1625,7 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "LDAP_USER_SCHEMA_ID": "ownclouduuid",
             "LDAP_USER_SCHEMA_MAIL": "mail",
             "LDAP_USER_SCHEMA_USERNAME": "cn",
-            "LDAP_USERFILTER": "(objectclass=owncloud)",
+            "LDAP_USER_FILTER": "(objectclass=owncloud)",
             # ownCloudSQL storage driver
             "STORAGE_USERS_DRIVER": "owncloudsql",
             "STORAGE_USERS_OWNCLOUDSQL_DATADIR": "/mnt/data/files",
@@ -2307,11 +2307,11 @@ def parallelDeploymentOC10Server():
                 "LDAP_LOGINFILTER": "(&(objectclass=owncloud)(|(uid=%uid)(mail=%uid)))",
                 "LDAP_GROUP_SCHEMA_DISPLAYNAME": "cn",
                 "LDAP_USER_SCHEMA_NAME_ATTR": "uid",
-                "LDAP_GROUPFILTER": "(&(objectclass=groupOfUniqueNames)(objectclass=owncloud))",
+                "LDAP_GROUP_FILTER": "(&(objectclass=groupOfUniqueNames)(objectclass=owncloud))",
                 "LDAP_USER_SCHEMA_UID": "ownclouduuid",
                 "LDAP_USERATTRIBUTEFILTERS": "uid",  # ownCloudUUID;cn;uid;mail
                 "LDAP_USER_SCHEMA_MAIL": "mail",
-                "LDAP_USERFILTER": "(&(objectclass=owncloud))",
+                "LDAP_USER_FILTER": "(&(objectclass=owncloud))",
                 "LDAP_GROUP_MEMBER_ASSOC_ATTR": "uniqueMember",
                 # database
                 "OWNCLOUD_DB_TYPE": "mysql",

--- a/changelog/unreleased/fix-ldap-filter-envvar.md
+++ b/changelog/unreleased/fix-ldap-filter-envvar.md
@@ -1,0 +1,13 @@
+Bugfix: Inconsistency env var naming for LDAP filter configuration
+
+There was a naming inconsitency for the enviroment variables used to define
+LDAP filters for user and groups queries. Some services used `LDAP_USER_FILTER`
+while others used `LDAP_USERFILTER`. This is now changed to use `LDAP_USER_FILTER`
+and `LDAP_GROUP_FILTER`.
+
+Note: If your oCIS setup is using an LDAP configuration that has any of the
+`*_LDAP_USERFILTER` or `*_LDAP_GROUPFILTER` environment variables set, please
+update the configuration to use the new unified names `*_LDAP_USER_FILTER`
+respectively `*_LDAP_GROUP_FILTER` instead.
+
+https://github.com/owncloud/ocis/issues/3890

--- a/deployments/examples/oc10_ocis_parallel/config/oc10/ldap-config.tmpl.json
+++ b/deployments/examples/oc10_ocis_parallel/config/oc10/ldap-config.tmpl.json
@@ -24,7 +24,7 @@
       "s01ldap_expert_uuid_user_attr": "{{ .Env.LDAP_USER_SCHEMA_UID }}",
       "s01ldap_group_display_name": "{{ .Env.LDAP_GROUP_SCHEMA_DISPLAYNAME }}",
       "s01ldap_group_filter_mode": "0",
-      "s01ldap_group_filter": "{{ .Env.LDAP_GROUPFILTER }}",
+      "s01ldap_group_filter": "{{ .Env.LDAP_GROUP_FILTER }}",
       "s01ldap_group_member_assoc_attribute": "{{ .Env.LDAP_GROUP_MEMBER_ASSOC_ATTR }}",
       "s01ldap_groupfilter_groups": "",
       "s01ldap_groupfilter_objectclass": "",
@@ -46,7 +46,7 @@
       "s01ldap_user_filter_mode": "0",
       "s01ldap_userfilter_groups": "",
       "s01ldap_userfilter_objectclass": "",
-      "s01ldap_userlist_filter": "{{ .Env.LDAP_USERFILTER }}",
+      "s01ldap_userlist_filter": "{{ .Env.LDAP_USER_FILTER }}",
       "s01use_memberof_to_detect_membership": "1"
     }
   }

--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       LDAP_GROUP_SCHEMA_ID: "cn"
       LDAP_GROUP_SCHEMA_MAIL: "mail"
       LDAP_GROUP_SCHEMA_MEMBER: "cn"
-      LDAP_GROUPFILTER: "(objectclass=owncloud)"
+      LDAP_GROUP_FILTER: "(objectclass=owncloud)"
       LDAP_LOGIN_ATTRIBUTES: "uid"
       LDAP_USER_BASE_DN: "ou=users,dc=owncloud,dc=com"
       LDAP_USER_OBJECTCLASS: "posixAccount"
@@ -98,7 +98,7 @@ services:
       LDAP_USER_SCHEMA_ID: "ownclouduuid"
       LDAP_USER_SCHEMA_MAIL: "mail"
       LDAP_USER_SCHEMA_USERNAME: "cn"
-      LDAP_USERFILTER: "(objectclass=owncloud)"
+      LDAP_USER_FILTER: "(objectclass=owncloud)"
       # ownCloudSQL storage driver
       STORAGE_USERS_DRIVER: "owncloudsql"
       STORAGE_USERS_OWNCLOUDSQL_DATADIR: "/mnt/data/files"
@@ -168,11 +168,11 @@ services:
       LDAP_LOGINFILTER: "(&(objectclass=owncloud)(|(uid=%uid)(mail=%uid)))"
       LDAP_GROUP_SCHEMA_DISPLAYNAME: "cn"
       LDAP_USER_SCHEMA_NAME_ATTR: "uid"
-      LDAP_GROUPFILTER: "(&(objectclass=groupOfUniqueNames)(objectclass=owncloud))"
+      LDAP_GROUP_FILTER: "(&(objectclass=groupOfUniqueNames)(objectclass=owncloud))"
       LDAP_USER_SCHEMA_UID: "ownclouduuid"
       LDAP_USERATTRIBUTEFILTERS: "" #"ownclouduuid;cn;uid;mail"
       LDAP_USER_SCHEMA_MAIL: "mail"
-      LDAP_USERFILTER: "(&(objectclass=owncloud))"
+      LDAP_USER_FILTER: "(&(objectclass=owncloud))"
       LDAP_GROUP_MEMBER_ASSOC_ATTR: "uniqueMember"
       # ownCloud config
       OWNCLOUD_DB_TYPE: mysql

--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -61,10 +61,10 @@ services:
       LDAP_BIND_DN: "cn=admin,dc=owncloud,dc=com"
       LDAP_BIND_PASSWORD: ${LDAP_ADMIN_PASSWORD:-admin}
       LDAP_GROUP_BASE_DN: "dc=owncloud,dc=com"
-      LDAP_GROUPFILTER: "(objectclass=owncloud)"
+      LDAP_GROUP_FILTER: "(objectclass=owncloud)"
       LDAP_GROUP_OBJECTCLASS: "groupOfUniqueNames"
       LDAP_USER_BASE_DN: "dc=owncloud,dc=com"
-      LDAP_USERFILTER: "(objectclass=owncloud)"
+      LDAP_USER_FILTER: "(objectclass=owncloud)"
       LDAP_USER_OBEJECTCLASS: "inetOrgPerson"
       LDAP_LOGIN_ATTRIBUTES: "uid,mail"
       IDP_LDAP_URI: ldap://ldap-server

--- a/docs/extensions/storage/users.md
+++ b/docs/extensions/storage/users.md
@@ -51,8 +51,8 @@ If the below defaults don't match your environment change them accordingly:
 export STORAGE_LDAP_HOSTNAME=localhost
 export STORAGE_LDAP_PORT=9126
 export STORAGE_LDAP_BASE_DN='dc=ocis,dc=test'
-export STORAGE_LDAP_USERFILTER='(&(objectclass=posixAccount)(cn=%s))'
-export STORAGE_LDAP_GROUPFILTER='(&(objectclass=posixGroup)(cn=%s))'
+export STORAGE_LDAP_USER_FILTER='(&(objectclass=posixAccount)(cn=%s))'
+export STORAGE_LDAP_GROUP_FILTER='(&(objectclass=posixGroup)(cn=%s))'
 export STORAGE_LDAP_BIND_DN='cn=reva,ou=sysusers,dc=ocis,dc=test'
 export STORAGE_LDAP_BIND_PASSWORD=reva
 export STORAGE_LDAP_USER_SCHEMA_UID=uid

--- a/extensions/auth-basic/pkg/config/config.go
+++ b/extensions/auth-basic/pkg/config/config.go
@@ -76,8 +76,8 @@ type LDAPProvider struct {
 	GroupBaseDN      string          `yaml:"group_base_dn" env:"LDAP_GROUP_BASE_DN;AUTH_BASIC_LDAP_GROUP_BASE_DN" desc:"Search base DN for looking up LDAP groups."`
 	UserScope        string          `yaml:"user_scope" env:"LDAP_USER_SCOPE;AUTH_BASIC_LDAP_USER_SCOPE" desc:"LDAP search scope to use when looking up users ('base', 'one', 'sub')."`
 	GroupScope       string          `yaml:"group_scope" env:"LDAP_GROUP_SCOPE;AUTH_BASIC_LDAP_GROUP_SCOPE" desc:"LDAP search scope to use when looking up gruops ('base', 'one', 'sub')."`
-	UserFilter       string          `yaml:"user_filter" env:"LDAP_USERFILTER;AUTH_BASIC_LDAP_USERFILTER" desc:"LDAP filter to add to the default filters for user search (e.g. '(objectclass=ownCloud)')."`
-	GroupFilter      string          `yaml:"group_filter" env:"LDAP_GROUPFILTER;AUTH_BASIC_LDAP_GROUPFILTER" desc:"LDAP filter to add to the default filters for group searches."`
+	UserFilter       string          `yaml:"user_filter" env:"LDAP_USER_FILTER;AUTH_BASIC_LDAP_USER_FILTER" desc:"LDAP filter to add to the default filters for user search (e.g. '(objectclass=ownCloud)')."`
+	GroupFilter      string          `yaml:"group_filter" env:"LDAP_GROUP_FILTER;AUTH_BASIC_LDAP_GROUP_FILTER" desc:"LDAP filter to add to the default filters for group searches."`
 	UserObjectClass  string          `yaml:"user_object_class" env:"LDAP_USER_OBJECTCLASS;AUTH_BASIC_LDAP_USER_OBJECTCLASS" desc:"The object class to use for users in the default user search filter ('inetOrgPerson')."`
 	GroupObjectClass string          `yaml:"group_object_class" env:"LDAP_GROUP_OBJECTCLASS;AUTH_BASIC_LDAP_GROUP_OBJECTCLASS" desc:"The object class to use for groups in the default group search filter ('groupOfNames'). "`
 	LoginAttributes  []string        `yaml:"login_attributes" env:"LDAP_LOGIN_ATTRIBUTES;AUTH_BASIC_LDAP_LOGIN_ATTRIBUTES"`

--- a/extensions/groups/pkg/config/config.go
+++ b/extensions/groups/pkg/config/config.go
@@ -74,8 +74,8 @@ type LDAPDriver struct {
 	GroupBaseDN      string          `yaml:"group_base_dn" env:"LDAP_GROUP_BASE_DN;GROUPS_LDAP_GROUP_BASE_DN" desc:"Search base DN for looking up LDAP groups."`
 	UserScope        string          `yaml:"user_scope" env:"LDAP_USER_SCOPE;GROUPS_LDAP_USER_SCOPE" desc:"LDAP search scope to use when looking up users ('base', 'one', 'sub')."`
 	GroupScope       string          `yaml:"group_scope" env:"LDAP_GROUP_SCOPE;GROUPS_LDAP_GROUP_SCOPE" desc:"LDAP search scope to use when looking up gruops ('base', 'one', 'sub')."`
-	UserFilter       string          `yaml:"user_filter" env:"LDAP_USERFILTER;GROUPS_LDAP_USERFILTER" desc:"LDAP filter to add to the default filters for user search (e.g. '(objectclass=ownCloud)')."`
-	GroupFilter      string          `yaml:"group_filter" env:"LDAP_GROUPFILTER;GROUPS_LDAP_GROUPFILTER" desc:"LDAP filter to add to the default filters for group searches."`
+	UserFilter       string          `yaml:"user_filter" env:"LDAP_USER_FILTER;GROUPS_LDAP_USER_FILTER" desc:"LDAP filter to add to the default filters for user search (e.g. '(objectclass=ownCloud)')."`
+	GroupFilter      string          `yaml:"group_filter" env:"LDAP_GROUP_FILTER;GROUPS_LDAP_GROUP_FILTER" desc:"LDAP filter to add to the default filters for group searches."`
 	UserObjectClass  string          `yaml:"user_object_class" env:"LDAP_USER_OBJECTCLASS;GROUPS_LDAP_USER_OBJECTCLASS" desc:"The object class to use for users in the default user search filter ('inetOrgPerson')."`
 	GroupObjectClass string          `yaml:"group_object_class" env:"LDAP_GROUP_OBJECTCLASS;GROUPS_LDAP_GROUP_OBJECTCLASS" desc:"The object class to use for groups in the default group search filter ('groupOfNames')."`
 	IDP              string          `yaml:"idp" env:"OCIS_URL;OCIS_OIDC_ISSUER;GROUPS_IDP_URL" desc:"The identity provider value to set in the groupids of the CS3 group objects for groups returned by this group provider."`

--- a/extensions/users/pkg/config/config.go
+++ b/extensions/users/pkg/config/config.go
@@ -78,8 +78,8 @@ type LDAPDriver struct {
 	GroupBaseDN      string          `yaml:"group_base_dn" env:"LDAP_GROUP_BASE_DN;USERS_LDAP_GROUP_BASE_DN" desc:"Search base DN for looking up LDAP groups."`
 	UserScope        string          `yaml:"user_scope" env:"LDAP_USER_SCOPE;USERS_LDAP_USER_SCOPE" desc:"LDAP search scope to use when looking up users ('base', 'one', 'sub')."`
 	GroupScope       string          `yaml:"group_scope" env:"LDAP_GROUP_SCOPE;USERS_LDAP_GROUP_SCOPE" desc:"LDAP search scope to use when looking up gruops ('base', 'one', 'sub')."`
-	UserFilter       string          `yaml:"user_filter" env:"LDAP_USERFILTER;USERS_LDAP_USERFILTER" desc:"LDAP filter to add to the default filters for user search (e.g. '(objectclass=ownCloud)')."`
-	GroupFilter      string          `yaml:"group_filter" env:"LDAP_GROUPFILTER;USERS_LDAP_GROUPFILTER" desc:"LDAP filter to add to the default filters for group searches."`
+	UserFilter       string          `yaml:"user_filter" env:"LDAP_USER_FILTER;USERS_LDAP_USER_FILTER" desc:"LDAP filter to add to the default filters for user search (e.g. '(objectclass=ownCloud)')."`
+	GroupFilter      string          `yaml:"group_filter" env:"LDAP_GROUP_FILTER;USERS_LDAP_GROUP_FILTER" desc:"LDAP filter to add to the default filters for group searches."`
 	UserObjectClass  string          `yaml:"user_object_class" env:"LDAP_USER_OBJECTCLASS;USERS_LDAP_USER_OBJECTCLASS" desc:"The object class to use for users in the default user search filter ('inetOrgPerson')."`
 	GroupObjectClass string          `yaml:"group_object_class" env:"LDAP_GROUP_OBJECTCLASS;USERS_LDAP_GROUP_OBJECTCLASS" desc:"The object class to use for groups in the default group search filter ('groupOfNames'). "`
 	IDP              string          `yaml:"idp" env:"OCIS_URL;OCIS_OIDC_ISSUER;USERS_IDP_URL" desc:"The identity provider value to set in the userids of the CS3 user objects for users returned by this user provider."`

--- a/tests/parallelDeployAcceptance/drone/oc10/ldap-config.tmpl.json
+++ b/tests/parallelDeployAcceptance/drone/oc10/ldap-config.tmpl.json
@@ -24,7 +24,7 @@
       "s01ldap_expert_uuid_user_attr": "{{ .Env.LDAP_USER_SCHEMA_UID }}",
       "s01ldap_group_display_name": "{{ .Env.LDAP_GROUP_SCHEMA_DISPLAYNAME }}",
       "s01ldap_group_filter_mode": "0",
-      "s01ldap_group_filter": "{{ .Env.LDAP_GROUPFILTER }}",
+      "s01ldap_group_filter": "{{ .Env.LDAP_GROUP_FILTER }}",
       "s01ldap_group_member_assoc_attribute": "{{ .Env.LDAP_GROUP_MEMBER_ASSOC_ATTR }}",
       "s01ldap_groupfilter_groups": "",
       "s01ldap_groupfilter_objectclass": "",
@@ -46,7 +46,7 @@
       "s01ldap_user_filter_mode": "0",
       "s01ldap_userfilter_groups": "",
       "s01ldap_userfilter_objectclass": "",
-      "s01ldap_userlist_filter": "{{ .Env.LDAP_USERFILTER }}",
+      "s01ldap_userlist_filter": "{{ .Env.LDAP_USER_FILTER }}",
       "s01use_memberof_to_detect_membership": "1"
     }
   }


### PR DESCRIPTION
There was a naming inconsitency for the enviroment variables used to define
LDAP filters for user and groups queries. Some services used `LDAP_USER_FILTER`
while others used `LDAP_USERFILTER`. This is now changed to use `LDAP_USER_FILTER`
and `LDAP_GROUP_FILTER`

Closes: #3890