### PR TITLE
[tests-only] Git ignore vendor-php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ composer.lock
 vendor
 vendor-bin/**/vendor
 vendor-bin/**/composer.lock
+vendor-php
 
 # API acceptance tests - auto-generated files
 .php-cs-fixer.cache


### PR DESCRIPTION
## Description
The PHP dependencies of acceptance tests were moved into `vendor-php` some time ago. I  sometimes have them locally, and have to remember not to accidentally commit them with `git add -A`

Add them to `.gitgnore` so that they do not get accidentally committed.

## How Has This Been Tested?
Checked that my local vendor-php folder is now ignored.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
