### PR TITLE
[tests-only] [full-ci] Bump core commit id for tests as at 2022-06-01

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=ebd2ffc734c0c627e1b6e45e9380d8aa73041095
+CORE_COMMITID=3e90678303c023a064a80809ed207af662b07ba0
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
## Description
This gets the test code from https://github.com/owncloud/core/pull/40114 running in CI.

## Related Issue
https://github.com/owncloud/QA/issues/742

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
