### PR TITLE
fix webdav URL of drive roots in graph API

### DIFF
--- a/changelog/unreleased/graph-webdav-url.md
+++ b/changelog/unreleased/graph-webdav-url.md
@@ -1,0 +1,6 @@
+Bugfix: Fix the webdav URL of drive roots
+
+Fixed the webdav URL of drive roots in the graph API.
+
+https://github.com/owncloud/ocis/issues/3706
+https://github.com/owncloud/ocis/pull/3916

--- a/extensions/graph/pkg/service/v0/drives.go
+++ b/extensions/graph/pkg/service/v0/drives.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -581,8 +582,9 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 		// TODO read from StorageSpace ... needs Opaque for now
 		// TODO how do we build the url?
 		// for now: read from request
-		webDavURL := baseURL.String() + spaceID
-		drive.Root.WebDavUrl = &webDavURL
+		webDavURL := *baseURL
+		webDavURL.Path = path.Join(webDavURL.Path, spaceID)
+		drive.Root.WebDavUrl = libregraph.PtrString(webDavURL.String())
 	}
 
 	// TODO The public space has no owner ... should we even show it?

--- a/extensions/graph/pkg/service/v0/graph_test.go
+++ b/extensions/graph/pkg/service/v0/graph_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -245,11 +246,12 @@ var _ = Describe("Graph", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(response["value"])).To(Equal(1))
 			value := response["value"][0]
+			webdavURL, _ := url.PathUnescape(*value.Root.WebDavUrl)
 			Expect(*value.DriveAlias).To(Equal("mountpoint/new-folder"))
 			Expect(*value.DriveType).To(Equal("mountpoint"))
 			Expect(*value.Id).To(Equal("prID$aID!differentID"))
 			Expect(*value.Name).To(Equal("New Folder"))
-			Expect(*value.Root.WebDavUrl).To(Equal("https://localhost:9200/dav/spaces/prID$aID!differentID"))
+			Expect(webdavURL).To(Equal("https://localhost:9200/dav/spaces/prID$aID!differentID"))
 			Expect(*value.Root.ETag).To(Equal("101112131415"))
 			Expect(*value.Root.Id).To(Equal("prID$aID!differentID"))
 			Expect(*value.Root.RemoteItem.ETag).To(Equal("123456789"))


### PR DESCRIPTION
Fixed the webdav URL of drive roots in the graph API.

Fixes: https://github.com/owncloud/ocis/issues/3706