### PR TITLE
update reva to v2.5.1-0.20220608092821-954c578109df

### DIFF
--- a/changelog/unreleased/update-reva.md
+++ b/changelog/unreleased/update-reva.md
@@ -1,4 +1,6 @@
-Enhancement: update reva to version 2.5.0
+Enhancement: update reva to version 2.5.1-0.20220608092821-954c578109df
+
+TODO
 
 Changelog for reva 2.5.0 (2022-06-07)
 =======================================

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.0.2
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/cs3org/go-cs3apis v0.0.0-20220512100524-551800f020d8
-	github.com/cs3org/reva/v2 v2.5.0
+	github.com/cs3org/reva/v2 v2.5.1-0.20220608092821-954c578109df
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -298,10 +298,8 @@ github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD9
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20220512100524-551800f020d8 h1:31jPSD5BOjc4+h4xK1e+NFf34gtwHEexor3V7JbdcPM=
 github.com/cs3org/go-cs3apis v0.0.0-20220512100524-551800f020d8/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva/v2 v2.4.2-0.20220607110316-1e461b750389 h1:4UylXWCA1/KrxAP4xyQYDAXULMawx3EwgEPZoL5UbI0=
-github.com/cs3org/reva/v2 v2.4.2-0.20220607110316-1e461b750389/go.mod h1:XflInIn7f9DbWrdFgQjfzQEN5ctdBBc1+OEn15zNDeo=
-github.com/cs3org/reva/v2 v2.5.0 h1:JobrUAZgs+GTJQD4o2sxNhuu03d/kSs6HNpuAVAQSLE=
-github.com/cs3org/reva/v2 v2.5.0/go.mod h1:XflInIn7f9DbWrdFgQjfzQEN5ctdBBc1+OEn15zNDeo=
+github.com/cs3org/reva/v2 v2.5.1-0.20220608092821-954c578109df h1:k27FjUKtUtmRws1LRV+By/AjNKDfSelao19cmW0URSs=
+github.com/cs3org/reva/v2 v2.5.1-0.20220608092821-954c578109df/go.mod h1:XflInIn7f9DbWrdFgQjfzQEN5ctdBBc1+OEn15zNDeo=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=


### PR DESCRIPTION
update to include https://github.com/cs3org/reva/pull/2918 and https://github.com/cs3org/reva/pull/2931