### PR TITLE
don't setup demo role assignments on default

### DIFF
--- a/changelog/unreleased/default-role-assignments.md
+++ b/changelog/unreleased/default-role-assignments.md
@@ -1,0 +1,6 @@
+Enhancement: Don't setup demo role assignments on default 
+
+Added a configuration option to explicitly tell the settings service to generate the default role assignments.
+
+https://github.com/owncloud/ocis/issues/3661
+https://github.com/owncloud/ocis/pull/3956

--- a/extensions/settings/pkg/config/config.go
+++ b/extensions/settings/pkg/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	Asset        Asset         `yaml:"asset"`
 	TokenManager *TokenManager `yaml:"token_manager"`
 
+	SetupDefaultAssignments bool `yaml:"set_default_assignments" env:"SETTINGS_SETUP_DEFAULT_ASSIGNMENTS;ACCOUNTS_DEMO_USERS_AND_GROUPS" desc:"If the default role assignments for the demo users should be setup."`
+
 	Context context.Context `yaml:"-"`
 }
 

--- a/extensions/settings/pkg/config/defaults/defaultconfig.go
+++ b/extensions/settings/pkg/config/defaults/defaultconfig.go
@@ -48,7 +48,7 @@ func DefaultConfig() *config.Config {
 		Asset: config.Asset{
 			Path: "",
 		},
-
+		SetupDefaultAssignments: false,
 		Metadata: config.Metadata{
 			GatewayAddress: "127.0.0.1:9215", // system storage
 			StorageAddress: "127.0.0.1:9215",

--- a/extensions/settings/pkg/service/v0/service.go
+++ b/extensions/settings/pkg/service/v0/service.go
@@ -126,9 +126,11 @@ func (g Service) RegisterDefaultRoles() {
 		}
 	}
 
-	for _, req := range g.defaultRoleAssignments() {
-		if _, err := g.manager.WriteRoleAssignment(req.AccountUuid, req.RoleId); err != nil {
-			g.logger.Error().Err(err).Msg("failed to register role assignment")
+	if g.config.SetupDefaultAssignments {
+		for _, req := range g.defaultRoleAssignments() {
+			if _, err := g.manager.WriteRoleAssignment(req.AccountUuid, req.RoleId); err != nil {
+				g.logger.Error().Err(err).Msg("failed to register role assignment")
+			}
 		}
 	}
 }

--- a/extensions/settings/pkg/service/v0/settings.go
+++ b/extensions/settings/pkg/service/v0/settings.go
@@ -544,15 +544,15 @@ func (g Service) defaultRoleAssignments() []*settingsmsg.UserRoleAssignment {
 		},
 		// default users with role "user"
 		{
-			AccountUuid: "4c510ada-c86b-4815-8820-42cdf82c3d51",
+			AccountUuid: "4c510ada-c86b-4815-8820-42cdf82c3d51", // demo user "einstein"
 			RoleId:      BundleUUIDRoleUser,
 		}, {
-			AccountUuid: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+			AccountUuid: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c", // demo user "marie"
 			RoleId:      BundleUUIDRoleUser,
 		},
 		// default users with role "spaceadmin"
 		{
-			AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7",
+			AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7", // demo user "katherine"
 			RoleId:      BundleUUIDRoleSpaceAdmin,
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added a configuration option to explicitly tell the settings service to generate the default role assignments.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/3661

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We don't want to have the demo user information in production systems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
