### PR TITLE
Make ocdav service behave

### DIFF
--- a/changelog/unreleased/make-ocdav-service-behave.md
+++ b/changelog/unreleased/make-ocdav-service-behave.md
@@ -1,0 +1,5 @@
+Bugfix: make ocdav service behave properly
+
+The ocdav service now properly passes the tracing config and shuts down when receiving a kill signal.
+
+https://github.com/owncloud/ocis/pull/3957

--- a/extensions/ocdav/pkg/command/server.go
+++ b/extensions/ocdav/pkg/command/server.go
@@ -64,7 +64,7 @@ func Server(cfg *config.Config) *cli.Command {
 					ocdav.Version(cfg.Status.Version),
 					ocdav.VersionString(cfg.Status.VersionString),
 					ocdav.Edition(cfg.Status.Edition),
-					// ocdav.FavoriteManager() // FIXME needs a proper persistence implementation
+					// ocdav.FavoriteManager() // FIXME needs a proper persistence implementation https://github.com/owncloud/ocis/issues/1228
 					// ocdav.LockSystem(), // will default to the CS3 lock system
 					// ocdav.TLSConfig() // tls config for the http server
 				)

--- a/extensions/ocdav/pkg/command/server.go
+++ b/extensions/ocdav/pkg/command/server.go
@@ -47,6 +47,7 @@ func Server(cfg *config.Config) *cli.Command {
 					ocdav.Version(version.GetString()),
 					ocdav.Context(ctx),
 					ocdav.Logger(logger.Logger),
+					ocdav.Tracing(cfg.Tracing.Endpoint, cfg.Tracing.Collector),
 					ocdav.Address(cfg.HTTP.Addr),
 					ocdav.FilesNamespace(cfg.FilesNamespace),
 					ocdav.WebdavNamespace(cfg.WebdavNamespace),

--- a/extensions/ocdav/pkg/command/server.go
+++ b/extensions/ocdav/pkg/command/server.go
@@ -90,6 +90,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			gr.Add(debugServer.ListenAndServe, func(_ error) {
+				_ = debugServer.Shutdown(ctx)
 				cancel()
 			})
 

--- a/extensions/ocdav/pkg/command/server.go
+++ b/extensions/ocdav/pkg/command/server.go
@@ -42,12 +42,12 @@ func Server(cfg *config.Config) *cli.Command {
 			defer cancel()
 
 			gr.Add(func() error {
-				s, err := ocdav.Service(
-					ocdav.Name(cfg.HTTP.Namespace+"."+cfg.Service.Name),
+
+				opts := []ocdav.Option{
+					ocdav.Name(cfg.HTTP.Namespace + "." + cfg.Service.Name),
 					ocdav.Version(version.GetString()),
 					ocdav.Context(ctx),
 					ocdav.Logger(logger.Logger),
-					ocdav.Tracing(cfg.Tracing.Endpoint, cfg.Tracing.Collector),
 					ocdav.Address(cfg.HTTP.Addr),
 					ocdav.FilesNamespace(cfg.FilesNamespace),
 					ocdav.WebdavNamespace(cfg.WebdavNamespace),
@@ -67,7 +67,13 @@ func Server(cfg *config.Config) *cli.Command {
 					// ocdav.FavoriteManager() // FIXME needs a proper persistence implementation https://github.com/owncloud/ocis/issues/1228
 					// ocdav.LockSystem(), // will default to the CS3 lock system
 					// ocdav.TLSConfig() // tls config for the http server
-				)
+				}
+
+				if cfg.Tracing.Enabled {
+					opts = append(opts, ocdav.Tracing(cfg.Tracing.Endpoint, cfg.Tracing.Collector))
+				}
+
+				s, err := ocdav.Service(opts...)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
The ocdav service now properly passes the tracing config and shuts down when receiving a kill signal.
