### PR TITLE
make thumbnails service log less noisy

### DIFF
--- a/changelog/unreleased/thumbnails-log.md
+++ b/changelog/unreleased/thumbnails-log.md
@@ -1,0 +1,6 @@
+Enhancement: Make thumbnails service log less noisy
+
+Reduced the log severity when no thumbnail was found from warn to debug.
+This reduces the spam in the logs.
+
+https://github.com/owncloud/ocis/pull/3959

--- a/extensions/thumbnails/pkg/service/grpc/v0/decorators/logging.go
+++ b/extensions/thumbnails/pkg/service/grpc/v0/decorators/logging.go
@@ -2,10 +2,12 @@ package decorators
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	thumbnailssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/thumbnails/v0"
+	merrors "go-micro.dev/v4/errors"
 )
 
 // NewLogging returns a service that logs messages.
@@ -32,9 +34,17 @@ func (l logging) GetThumbnail(ctx context.Context, req *thumbnailssvc.GetThumbna
 		Logger()
 
 	if err != nil {
-		logger.Warn().
-			Err(err).
-			Msg("Failed to execute")
+		merror := merrors.FromError(err)
+		switch merror.Code {
+		case http.StatusNotFound:
+			logger.Debug().
+				Str("error_detail", merror.Detail).
+				Msg("no thumbnail found")
+		default:
+			logger.Warn().
+				Err(err).
+				Msg("Failed to execute")
+		}
 	} else {
 		logger.Debug().
 			Msg("")


### PR DESCRIPTION
Reduced the log severity when no thumbnail was found from warn to debug.
This reduces the spam in the logs.