### PR TITLE
Make idp only wait for certs when using ldap

### DIFF
--- a/changelog/unreleased/make-idp-only-wait-for-certs-when-using-ldap.md
+++ b/changelog/unreleased/make-idp-only-wait-for-certs-when-using-ldap.md
@@ -1,0 +1,5 @@
+Bugfix: Make IDP only wait for certs when using LDAP
+
+When configuring cs3 as the backend the IDP no longer waits for an LDAP certificate to appear.
+
+https://github.com/owncloud/ocis/pull/3965

--- a/extensions/idp/pkg/service/v0/service.go
+++ b/extensions/idp/pkg/service/v0/service.go
@@ -44,14 +44,6 @@ func NewService(opts ...Option) Service {
 		assets.Config(options.Config),
 	)
 
-	if err := ldap.WaitForCA(options.Logger, options.Config.IDP.Insecure, options.Config.Ldap.TLSCACert); err != nil {
-		logger.Fatal().Err(err).Msg("The configured LDAP CA cert does not exist")
-	}
-	if options.Config.IDP.Insecure {
-		// force CACert to be empty to avoid lico try to load it
-		options.Config.Ldap.TLSCACert = ""
-	}
-
 	if err := createTemporaryClientsConfig(
 		options.Config.IDP.IdentifierRegistrationConf,
 		options.Config.IDP.Iss,
@@ -67,6 +59,15 @@ func NewService(opts ...Option) Service {
 			logger.Fatal().Err(err).Msg("could not initialize cs3 backend env vars")
 		}
 	case "ldap":
+
+		if err := ldap.WaitForCA(options.Logger, options.Config.IDP.Insecure, options.Config.Ldap.TLSCACert); err != nil {
+			logger.Fatal().Err(err).Msg("The configured LDAP CA cert does not exist")
+		}
+		if options.Config.IDP.Insecure {
+			// force CACert to be empty to avoid lico try to load it
+			options.Config.Ldap.TLSCACert = ""
+		}
+
 		ldapBackendSupport.MustRegister()
 		if err := initLicoInternalLDAPEnvVars(&options.Config.Ldap); err != nil {
 			logger.Fatal().Err(err).Msg("could not initialize ldap env vars")


### PR DESCRIPTION
When configuring cs3 as the backend the IDP no longer waits for an LDAP certificate to appear.
