### PR TITLE
[full-ci] update reva to v2.5.2-0.20220616180355-84264e82e451

### DIFF
--- a/changelog/unreleased/update-reva-beta.4.md
+++ b/changelog/unreleased/update-reva-beta.4.md
@@ -3,3 +3,4 @@ Enhancement: Update reva
 TBD
 
 https://github.com/owncloud/ocis/pull/3944
+https://github.com/owncloud/ocis/pull/3975

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.0.2
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/cs3org/go-cs3apis v0.0.0-20220512100524-551800f020d8
-	github.com/cs3org/reva/v2 v2.5.2-0.20220614082505-03c87b6fe46b
+	github.com/cs3org/reva/v2 v2.5.2-0.20220616180355-84264e82e451
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3p
 github.com/crewjam/saml v0.4.6 h1:XCUFPkQSJLvzyl4cW9OvpWUbRf0gE7VUpU8ZnilbeM4=
 github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD96t1A=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/reva/v2 v2.5.2-0.20220614082505-03c87b6fe46b h1:8MZDpKch9klQJZYjGaabCKWJgYZ0LqHS6pGlm/jpLcM=
-github.com/cs3org/reva/v2 v2.5.2-0.20220614082505-03c87b6fe46b/go.mod h1:TwD1FmU0tcnZbIzwMt01BxcEP42o220tBvGOeFPmSEg=
+github.com/cs3org/reva/v2 v2.5.2-0.20220616180355-84264e82e451 h1:0AW5wwavrqL7rBvvwyvy8B49aYLGiNUkiSSpaAAZ/y8=
+github.com/cs3org/reva/v2 v2.5.2-0.20220616180355-84264e82e451/go.mod h1:TwD1FmU0tcnZbIzwMt01BxcEP42o220tBvGOeFPmSEg=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/ocis-pkg/tracing/tracing.go
+++ b/ocis-pkg/tracing/tracing.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/propagation"
@@ -54,6 +55,7 @@ func GetTraceProvider(agentEndpoint, collectorEndpoint, serviceName, traceType s
 			return nil, err
 		}
 
+		rtrace.InitDefaultTracerProvider(collectorEndpoint, agentEndpoint)
 		return sdktrace.NewTracerProvider(
 			sdktrace.WithBatcher(exp),
 			sdktrace.WithResource(resource.NewWithAttributes(


### PR DESCRIPTION
update reva to include
https://github.com/cs3org/reva/pull/2975 
https://github.com/cs3org/reva/pull/2974 
https://github.com/cs3org/reva/pull/2962