### PR TITLE
advise antorra to ignore entries in curly brackets

### DIFF
--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -14,8 +14,10 @@
 `{{- $value }}` 
 {{- end }}
 | {{.Type}}
-| {{.DefaultValue}}
-| {{.Description}}
+a| [subs=-attributes]
+{{.DefaultValue}} 
+a| [subs=-attributes]
+{{.Description}}
 
 {{- end }}
 |===


### PR DESCRIPTION
This PR adapts the antorra template for the env vars in extensions to ignore entries in curly brackets `{}`. Enforcing antorra not to try to render them as variables.

fixes #3969 