### PR TITLE
make adoc-generator escape links for antorra

### DIFF
--- a/docs/helpers/adoc-generator.go.tmpl
+++ b/docs/helpers/adoc-generator.go.tmpl
@@ -91,6 +91,8 @@ func GetAnnotatedVariables(s interface{}) []ConfigField {
 			td := strings.Split(env, ";")
 			re := regexp.MustCompile(`^(https?:\/\/)`)
 			v = re.ReplaceAllString(v,"\\$1")
+			re = regexp.MustCompile(`(https?:\/\/)`)
+			desc = re.ReplaceAllString(desc, "\\$1")
 			re = regexp.MustCompile(`(\|)`)
 			v = re.ReplaceAllString(v, "\\$1")
 			fields = append(fields, ConfigField{EnvVars: td, DefaultValue: v, Description: desc, Type: value.Type().Name()})


### PR DESCRIPTION
Minor fix to the doc generator, makes adoc-generator escape links for antorra.