### PR TITLE
[full-ci] update reva to 6a346676da20

### DIFF
--- a/changelog/unreleased/update-reva-beta.4.md
+++ b/changelog/unreleased/update-reva-beta.4.md
@@ -5,3 +5,4 @@ TBD
 https://github.com/owncloud/ocis/pull/3944
 https://github.com/owncloud/ocis/pull/3975
 https://github.com/owncloud/ocis/pull/3982
+https://github.com/owncloud/ocis/pull/3995

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.0.2
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/cs3org/go-cs3apis v0.0.0-20220512100524-551800f020d8
-	github.com/cs3org/reva/v2 v2.5.2-0.20220617144643-4758360f5d55
+	github.com/cs3org/reva/v2 v2.5.2-0.20220620175644-6a346676da20
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD9
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/reva/v2 v2.5.2-0.20220617144643-4758360f5d55 h1:N1E8H+pgrDW//X315BniqmvDYYPoMBkbJZhQEQ3Y+98=
 github.com/cs3org/reva/v2 v2.5.2-0.20220617144643-4758360f5d55/go.mod h1:zAHqzr36X4lIalonDQeNbwrIXjn66C38lp5A+MTRS1c=
+github.com/cs3org/reva/v2 v2.5.2-0.20220620175644-6a346676da20 h1:VThDePQJ55dm2JgzDR9CxVKGRNa07SeGnhogO5+nN7o=
+github.com/cs3org/reva/v2 v2.5.2-0.20220620175644-6a346676da20/go.mod h1:zAHqzr36X4lIalonDQeNbwrIXjn66C38lp5A+MTRS1c=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=


### PR DESCRIPTION
fix slowness introduced by [switching to cs3 shares driver](https://github.com/owncloud/ocis/pull/3697) by bringing in https://github.com/cs3org/reva/pull/2991