### PR TITLE
remove non existing env variables from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,15 +27,15 @@ A clear and concise description of what happened.
 
 ## Setup
 
-Please describe how you started the server and provide a list of relevant environment variables.
+Please describe how you started the server and provide a list of relevant environment variables or configuration files.
 
 <details>
 <p>
 
 ```console
-OCIS_VERSION=vX.X.X
-BRANCH=vX.X.X
-STORAGE_FRONTEND_UPLOAD_DISABLE_TUS=false
+OCIS_XXX=somevalue
+OCIS_YYY=somevalue
+PROXY_XXX=somevalue
 ```
 
 </p>


### PR DESCRIPTION
## Description
removes non existing environment variables from the bug template.

## Related Issue

## Motivation and Context
I see a lot of issues which say that oCIS is started with `STORAGE_FRONTEND_UPLOAD_DISABLE_TUS`, but that option doesn't even exist (and may not be obvious to all people)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- none

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

