### PR TITLE
remove secrets configuration and demo users from keycloak deployment example

### DIFF
--- a/deployments/examples/ocis_keycloak/.env
+++ b/deployments/examples/ocis_keycloak/.env
@@ -23,16 +23,6 @@ OCIS_DOCKER_TAG=
 OCIS_DOMAIN=
 # owncloud Web openid connect client id. Defaults to "web"
 OCIS_OIDC_CLIENT_ID=
-# IDP LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "idp".
-IDP_LDAP_BIND_PASSWORD=
-# Storage LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "reva".
-STORAGE_LDAP_BIND_PASSWORD=
-# JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
-OCIS_JWT_SECRET=
-# JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-STORAGE_TRANSFER_SECRET=
-# Machine auth api key secret. Must be changed in order to have a secure oCIS. Defaults to "change-me-please"
-OCIS_MACHINE_AUTH_API_KEY=
 
 ### Keycloak ###
 # Domain of Keycloak, where you can find the management and authentication frontend. Defaults to "keycloak.owncloud.test"

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -63,14 +63,6 @@ services:
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
       OCIS_LOG_COLOR: "${OCIS_LOG_COLOR:-false}"
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
-      # demo users
-      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
-      # change default secrets
-      IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
-      STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
-      OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
-      STORAGE_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
-      OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
     volumes:

--- a/docs/ocis/deployment/ocis_keycloak.md
+++ b/docs/ocis/deployment/ocis_keycloak.md
@@ -72,16 +72,6 @@ See also [example server setup]({{< ref "preparing_server" >}})
   OCIS_DOMAIN=
   # ownCloud Web openid connect client id. Defaults to "ocis-web"
   OCIS_OIDC_CLIENT_ID=
-  # IDP LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "idp".
-  IDP_LDAP_BIND_PASSWORD=
-  # Storage LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "reva".
-  STORAGE_LDAP_BIND_PASSWORD=
-  # JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
-  OCIS_JWT_SECRET=
-  # JWT secret which is used for uploads to create transfer tokens. Must be changed in order to have a secure oCIS. Defaults to "replace-me-with-a-transfer-secret"
-  STORAGE_TRANSFER_SECRET=
-  # Machine auth api key secret. Must be changed in order to have a secure oCIS. Defaults to "change-me-please"
-  OCIS_MACHINE_AUTH_API_KEY=
 
   ### Keycloak ###
   # Domain of Keycloak, where you can find the management and authentication frontend. Defaults to "keycloak.owncloud.test"


### PR DESCRIPTION
## Description
- removes secrets from keycloak deployment example because we already call ocis init
- removes demo users settings from keyclok deployment example because the demo users come from keycloak

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- 

## Motivation and Context
have a clean example

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
