### PR TITLE
remove references to identifier-registration.yml

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1584,7 +1584,6 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
             "SHARING_USER_JSON_FILE": "/srv/app/tmp/ocis/shares.json",
             "PROXY_ENABLE_BASIC_AUTH": True,
             "WEB_UI_CONFIG": "/drone/src/tests/config/drone/ocis-config.json",
-            "IDP_IDENTIFIER_REGISTRATION_CONF": "/drone/src/tests/config/drone/identifier-registration.yml",
             "OCIS_LOG_LEVEL": "error",
             "SETTINGS_DATA_PATH": "/srv/app/tmp/ocis/settings",
             "IDM_CREATE_DEMO_USERS": True,

--- a/docs/extensions/settings/tests.md
+++ b/docs/extensions/settings/tests.md
@@ -16,15 +16,6 @@ You need a working installation of [the Go programming language](https://golang.
 
 Make sure you've cloned the [web frontend repo](https://github.com/owncloud/web/) and the [infinite scale repo](https://github.com/owncloud/ocis/) next to each other. If your file/folder structure is different, you'll have to change the paths below accordingly.
 
-{{< hint info >}}
-For now, an IDP configuration file gets generated once and will fail upon changing the oCIS url as done below. To avoid any clashes, remove this file before starting the tests:
-
-```bash
-rm ~/.ocis/idp/identifier-registration.yaml
-```
-
-{{< /hint >}}
-
 ### In the web repo
 
 #### **Optional:** Build web to test local changes

--- a/docs/ocis/deployment/basic-remote-setup.md
+++ b/docs/ocis/deployment/basic-remote-setup.md
@@ -19,12 +19,6 @@ Initialize the oCIS configuration by running `./bin/ocis init`.
 
 Upon first start of the oCIS fullstack server with `./bin/ocis server` it will generate a directory tree skeleton in `$HOME/.ocis`. If that is already existing it will not be overwritten as it contains all relevant data for oCIS.
 
-In `$HOME/.ocis/idp` is a file `identifier-registration.yaml`. It is used to configure the built-in identity provider and therefore contains the OpenID Connect issuer and also information about relying parties, for example ownCloud Web and our desktop and mobile applications.
-
-{{< hint warning >}}
-The `identifier-registration.yaml` file will only be generated if it does not exist yet. If you want to change certain environment variables like `OCIS_URL`, please delete this file first before doing so. Otherwise your changes will not be applied correctly and you will run into errors.
-{{< /hint >}}
-
 For the following examples you need to have the oCIS binary in your current working directory, we assume it is named `ocis` and it needs to be marked as executable. See [Getting Started]({{< ref "../getting-started/#binaries" >}}) for where to get the binary from.
 
 ### Using automatically generated certificates

--- a/docs/ocis/deployment/bridge.md
+++ b/docs/ocis/deployment/bridge.md
@@ -204,15 +204,6 @@ export IDP_LDAP_NAME_ATTRIBUTE=givenName
 ```
 Don't forget to use an existing user with admin permissions (only admins are allowed to list all users via the graph api) and the correct password.
 
-{{< hint warning >}}
-* TODO: change the default values in glauth & ocis to use an `ownclouduuid` attribute.
-* TODO: split `OCIS_URL` and `IDP_ISS` env vars and use `OCIS_URL` to generate the clients in the `identifier-registration.yaml`.
-{{< /hint >}}
-
-### Configure clients
-
-When the `identifier-registration.yaml` does not exist it will be generated based on the `OCIS_URL` environment variable.
-
 #### Run it!
 
 You can now bring up `ocis/bin/ocis idp` with:
@@ -276,7 +267,7 @@ $ bin/web server --web-config-server https://cloud.example.com --oidc-authority 
 - `--web-config-server https://cloud.example.com` is ownCloud url with webdav and ocs endpoints (oc10 or ocis)
 - `--oidc-authority https://192.168.1.100:9130` the openid connect issuing authority, in our case `oidc-idp`, running on port 9130
 - `--oidc-metadata-url https://192.168.1.100:9130/.well-known/openid-configuration` the openid connect configuration endpoint, typically the issuer host with `.well-known/openid-configuration`, but there are cases when another endpoint is used, e.g. ping identity provides multiple endpoints to separate domains
-- `--oidc-client-id ocis` the client id we will register later with `ocis-idp` in the `identifier-registration.yaml`
+- `--oidc-client-id ocis` the client id we will register later with `ocis-idp` in idp OIDC client settings
 
 ### Patch owncloud
 
@@ -324,4 +315,4 @@ In the above configuration replace
 
 Aside from the above todos these are the next steps
 - tie it all together behind `ocis-proxy`
-- create an `ocis bridge` command that runs all the ocis services in one step with a properly preconfigured `ocis-idp` `identifier-registration.yaml` file for `ownCloud Web` and the owncloud 10 `openidconnect` app, as well as a randomized `--signing-kid`.
+- create an `ocis bridge` command that runs all the ocis services in one step with a properly preconfigured idp OIDC client `ocis-idp` for `ownCloud Web` and the owncloud 10 `openidconnect` app, as well as a randomized `--signing-kid`.

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -12,7 +12,6 @@ services:
       SETTINGS_DATA_PATH: "/srv/app/tmp/ocis/settings"
       PROXY_ENABLE_BASIC_AUTH: "true"
       WEB_UI_CONFIG: /drone/src/tests/config/drone/ocis-config.json
-      IDP_IDENTIFIER_REGISTRATION_CONF: /drone/src/tests/config/drone/identifier-registration.yml
       ACCOUNTS_HASH_DIFFICULTY: 4
       OCIS_INSECURE: "true"
       # s3ng specific settings


### PR DESCRIPTION
## Description
removes references to the `identifier-registration.yml` from docs and configuration.

This file is no longer used to actively configure the idp (before 2.0.0-beta it was created once and could be modified, now you have all options in the IDP config file).
The file still exist in <ocis-data-root>/idp/tmp/identifier-registration.yml but is not expected to be edited and will be overwritten on every idp startup. Therefore 
the warnings, we had in documentation do no longer apply.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes confusion

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
