### PR TITLE
Fix `$expand=members` query for groups with just a single member

### DIFF
--- a/extensions/graph/pkg/identity/ldap.go
+++ b/extensions/graph/pkg/identity/ldap.go
@@ -467,7 +467,7 @@ func (i *LDAP) GetGroup(ctx context.Context, nameOrID string, queryParam url.Val
 		if err != nil {
 			return nil, err
 		}
-		if len(members) > 1 {
+		if len(members) > 0 {
 			m := make([]libregraph.User, 0, len(members))
 			for _, u := range members {
 				m = append(m, *u)
@@ -623,7 +623,7 @@ func (i *LDAP) GetGroups(ctx context.Context, queryParam url.Values) ([]*libregr
 			if err != nil {
 				return nil, err
 			}
-			if len(members) > 1 {
+			if len(members) > 0 {
 				m := make([]libregraph.User, 0, len(members))
 				for _, u := range members {
 					m = append(m, *u)


### PR DESCRIPTION
`curl -ki  'https://localhost:9200/graph/v1.0/groups/?$expand=members' -u admin:admin`

did not properly expand group members for groups that just had a single member.