### PR TITLE
Actually use the sharing configuration from the config file

### DIFF
--- a/changelog/unreleased/migrate-command.md
+++ b/changelog/unreleased/migrate-command.md
@@ -1,0 +1,6 @@
+Enhancement: New migrate command for migrating shares and public shares
+
+We added a new `migrate` subcommand which can be used to migrate shares and public shares between different share and publicshare managers.
+
+https://github.com/owncloud/ocis/pull/3987
+https://github.com/owncloud/ocis/pull/4019

--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -12,8 +12,10 @@ import (
 	"github.com/cs3org/reva/v2/pkg/share"
 	"github.com/cs3org/reva/v2/pkg/share/manager/registry"
 	sharing "github.com/owncloud/ocis/v2/extensions/sharing/pkg/config"
+	sharingparser "github.com/owncloud/ocis/v2/extensions/sharing/pkg/config/parser"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v2"
@@ -26,7 +28,15 @@ func Migrate(cfg *config.Config) *cli.Command {
 		Usage:    "migrate data from an existing to another instance",
 		Category: "migration",
 		Before: func(c *cli.Context) error {
+			// Parse base config
 			if err := parser.ParseConfig(cfg, true); err != nil {
+				fmt.Printf("%v", err)
+				return err
+			}
+
+			// Parse sharing config
+			cfg.Sharing.Commons = cfg.Commons
+			if err := sharingparser.ParseConfig(cfg.Sharing); err != nil {
 				fmt.Printf("%v", err)
 				return err
 			}
@@ -58,14 +68,6 @@ func MigrateShares(cfg *config.Config) *cli.Command {
 				Value: "cs3",
 				Usage: "Share manager to import the data into",
 			},
-		},
-		Before: func(c *cli.Context) error {
-			err := parser.ParseConfig(cfg, true)
-			if err != nil {
-				fmt.Printf("%v", err)
-				os.Exit(1)
-			}
-			return nil
 		},
 		Action: func(c *cli.Context) error {
 			log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
@@ -151,14 +153,6 @@ func MigratePublicShares(cfg *config.Config) *cli.Command {
 				Value: "cs3",
 				Usage: "Public share manager to import the data into",
 			},
-		},
-		Before: func(c *cli.Context) error {
-			err := parser.ParseConfig(cfg, true)
-			if err != nil {
-				fmt.Printf("%v", err)
-				os.Exit(1)
-			}
-			return err
 		},
 		Action: func(c *cli.Context) error {
 			log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()


### PR DESCRIPTION
This PR fixes a problem with the `migrate` command where the settings from the ocis configuration file were not being used.