### PR TITLE
idp automatically generates signing key and encryption secret

### DIFF
--- a/changelog/unreleased/idp-default-files.md
+++ b/changelog/unreleased/idp-default-files.md
@@ -1,0 +1,7 @@
+Enhancement: Generate signing key and encryption secret
+
+The idp service now automatically generates a signing key and encryption secret when they don't exist.
+This will enable service restarts without invalidating existing sessions.
+
+https://github.com/owncloud/ocis/issues/3909
+https://github.com/owncloud/ocis/pull/4022

--- a/extensions/idp/pkg/config/defaults/defaultconfig.go
+++ b/extensions/idp/pkg/config/defaults/defaultconfig.go
@@ -1,7 +1,7 @@
 package defaults
 
 import (
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/owncloud/ocis/v2/extensions/idp/pkg/config"
@@ -24,8 +24,8 @@ func DefaultConfig() *config.Config {
 			Addr:      "127.0.0.1:9130",
 			Root:      "/",
 			Namespace: "com.owncloud.web",
-			TLSCert:   path.Join(defaults.BaseDataPath(), "idp", "server.crt"),
-			TLSKey:    path.Join(defaults.BaseDataPath(), "idp", "server.key"),
+			TLSCert:   filepath.Join(defaults.BaseDataPath(), "idp", "server.crt"),
+			TLSKey:    filepath.Join(defaults.BaseDataPath(), "idp", "server.key"),
 			TLS:       false,
 		},
 		Reva: &config.Reva{
@@ -47,18 +47,18 @@ func DefaultConfig() *config.Config {
 			AllowScope:                        nil,
 			AllowClientGuests:                 false,
 			AllowDynamicClientRegistration:    false,
-			EncryptionSecretFile:              "",
+			EncryptionSecretFile:              filepath.Join(defaults.BaseDataPath(), "idp", "encryption.key"),
 			Listen:                            "",
 			IdentifierClientDisabled:          true,
-			IdentifierClientPath:              path.Join(defaults.BaseDataPath(), "idp"),
-			IdentifierRegistrationConf:        path.Join(defaults.BaseDataPath(), "idp", "tmp", "identifier-registration.yaml"),
+			IdentifierClientPath:              filepath.Join(defaults.BaseDataPath(), "idp"),
+			IdentifierRegistrationConf:        filepath.Join(defaults.BaseDataPath(), "idp", "tmp", "identifier-registration.yaml"),
 			IdentifierScopesConf:              "",
 			IdentifierDefaultBannerLogo:       "",
 			IdentifierDefaultSignInPageText:   "",
 			IdentifierDefaultUsernameHintText: "",
-			SigningKid:                        "",
+			SigningKid:                        "private-key",
 			SigningMethod:                     "PS256",
-			SigningPrivateKeyFiles:            nil,
+			SigningPrivateKeyFiles:            []string{filepath.Join(defaults.BaseDataPath(), "idp", "private-key.pem")},
 			ValidationKeysPath:                "",
 			CookieBackendURI:                  "",
 			CookieNames:                       nil,
@@ -124,7 +124,7 @@ func DefaultConfig() *config.Config {
 		},
 		Ldap: config.Ldap{
 			URI:               "ldaps://localhost:9235",
-			TLSCACert:         path.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
+			TLSCACert:         filepath.Join(defaults.BaseDataPath(), "idm", "ldap.crt"),
 			BindDN:            "uid=idp,ou=sysusers,o=libregraph-idm",
 			BaseDN:            "ou=users,o=libregraph-idm",
 			Scope:             "sub",


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Automatically generate the signing key and encryption secret when the idp service starts

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/3909

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
oCIS can now be restarted without invalidating all existing user sessions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: locally
- Start ocis and check the config directory of the idp service
- Log in with a user
- Restart ocis
- Refresh the browser window and verify that user is still logged in

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
