### PR TITLE
set idm ldap to readonly for keycloak deployment example

### DIFF
--- a/deployments/examples/ocis_keycloak/.env
+++ b/deployments/examples/ocis_keycloak/.env
@@ -2,10 +2,6 @@
 # It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
 INSECURE=true
 
-# The demo users should not be created on a production instance
-# because their passwords are public
-DEMO_USERS=false
-
 ### Traefik settings ###
 # Serve Traefik dashboard. Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     environment:
       # Keycloak IDP specific configuration
       PROXY_AUTOPROVISION_ACCOUNTS: "true"
+      GRAPH_LDAP_SERVER_WRITE_ENABLED: "false" # disable adding users via the oCIS user management
       OCIS_OIDC_ISSUER: https://${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}/auth/realms/${KEYCLOAK_REALM:-oCIS}
       WEB_OIDC_CLIENT_ID: ${OCIS_OIDC_CLIENT_ID:-web}
       # general config


### PR DESCRIPTION
## Description
set idm to readonly for the keycloak deployment example

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- login as admin and try to add user

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
