### PR TITLE
Allow self for iframes in web service

### DIFF
--- a/changelog/unreleased/fix-csp-silent-refresh.md
+++ b/changelog/unreleased/fix-csp-silent-refresh.md
@@ -1,0 +1,6 @@
+Bugfix: CSP rules for silent token refresh in iframe
+
+When renewing the access token silently web needs to be opened in an iframe. This was previously blocked by a restrictive iframe CSP rule in the `Secure` middleware and has now been fixed by allow `self` for iframes.
+
+https://github.com/owncloud/ocis/pull/4031
+https://github.com/owncloud/web/issues/7030

--- a/services/web/pkg/middleware/silentrefresh.go
+++ b/services/web/pkg/middleware/silentrefresh.go
@@ -8,6 +8,7 @@ import (
 func SilentRefresh(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'self'")
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
## Description
For a silent token renewal via iframe we need to allow `self` as frame ancestor.
If a refresh token exists (i.e. when `offline_access` is present in the requested scopes) this is not needed.

## Related Issue
- Works towards https://github.com/owncloud/web/issues/7030

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
