### PR TITLE
Bump nodejs in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -38,7 +38,7 @@ SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:latest"
 THEGEEKLAB_DRONE_GITHUB_COMMENT = "thegeeklab/drone-github-comment:1"
 
 DEFAULT_PHP_VERSION = "7.4"
-DEFAULT_NODEJS_VERSION = "14"
+DEFAULT_NODEJS_VERSION = "16"
 
 dirs = {
     "base": "/drone/src",


### PR DESCRIPTION
## Description
Ran into trouble when trying to bump nodejs to it's current stable version (v16) on https://github.com/owncloud/ocis/pull/4057 as the `arm` docker build step had memory issues on installing dependencies. 

Update: Node v15 doesn't work since the updated `eslint` in the settings service requires either v14 or v16. Best guess is that the `owncloudci/nodejs` image for node16 doesn't work with `arm`