### PR TITLE
[tests-only] [full-ci] Bump CORE_COMMITID to include core PR 40174 test code

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=ca4294642f8391dd3f294e0bfd8277fa0ca478f5
+CORE_COMMITID=7e9caa446346426de197b475e03be19dfe367a54
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
## Description
core PR https://github.com/owncloud/core/pull/40174 adjusted some test code for finding a resource in a project space.

Bump the core commit id so that we use the changed test code in CI.

## Related Issue
part of https://github.com/owncloud/QA/issues/747

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
