### PR TITLE
go 1.18 is required

### DIFF
--- a/docs/ocis/development/getting-started.md
+++ b/docs/ocis/development/getting-started.md
@@ -16,7 +16,7 @@ So we are trying to reflect this in the tooling. It should be kept simple and qu
 
 Besides standard development tools like git and a text editor, you need the following software for development:
 
-- Go >= v1.17 ([install instructions](https://golang.org/doc/install))
+- Go >= v1.18 ([install instructions](https://golang.org/doc/install))
 - Yarn ([install instructions](https://classic.yarnpkg.com/en/docs/install))
 - docker ([install instructions](https://docs.docker.com/get-docker/))
 - docker-compose ([install instructions](https://docs.docker.com/compose/install/))


### PR DESCRIPTION
we need go 1.18 to build ocis