### PR TITLE
Remove redundant setting of cli.HelpFlag

### DIFF
--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -25,10 +25,5 @@ func Execute() error {
 		)
 	}
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }

--- a/services/app-provider/pkg/command/root.go
+++ b/services/app-provider/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/app-registry/pkg/command/root.go
+++ b/services/app-registry/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/audit/pkg/command/root.go
+++ b/services/audit/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/auth-basic/pkg/command/root.go
+++ b/services/auth-basic/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/auth-bearer/pkg/command/root.go
+++ b/services/auth-bearer/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/auth-machine/pkg/command/root.go
+++ b/services/auth-machine/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/frontend/pkg/command/root.go
+++ b/services/frontend/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/gateway/pkg/command/root.go
+++ b/services/gateway/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/graph-explorer/pkg/command/root.go
+++ b/services/graph-explorer/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/graph/pkg/command/root.go
+++ b/services/graph/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Usage:    "Serve Graph API for oCIS",
 		Commands: GetCommands(cfg),
 	})
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/groups/pkg/command/root.go
+++ b/services/groups/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/idm/pkg/command/root.go
+++ b/services/idm/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/idp/pkg/command/root.go
+++ b/services/idp/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/nats/pkg/command/root.go
+++ b/services/nats/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/notifications/pkg/command/root.go
+++ b/services/notifications/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/ocdav/pkg/command/root.go
+++ b/services/ocdav/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/ocs/pkg/command/root.go
+++ b/services/ocs/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/proxy/pkg/command/root.go
+++ b/services/proxy/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/search/pkg/command/root.go
+++ b/services/search/pkg/command/root.go
@@ -34,11 +34,6 @@ func Execute(cfg *config.Config) error {
 		Usage:    "Serve search API for oCIS",
 		Commands: GetCommands(cfg),
 	})
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/settings/pkg/command/root.go
+++ b/services/settings/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/sharing/pkg/command/root.go
+++ b/services/sharing/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/storage-publiclink/pkg/command/root.go
+++ b/services/storage-publiclink/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/storage-shares/pkg/command/root.go
+++ b/services/storage-shares/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/storage-system/pkg/command/root.go
+++ b/services/storage-system/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/storage-users/pkg/command/root.go
+++ b/services/storage-users/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/store/pkg/command/root.go
+++ b/services/store/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/thumbnails/pkg/command/root.go
+++ b/services/thumbnails/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/users/pkg/command/root.go
+++ b/services/users/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/web/pkg/command/root.go
+++ b/services/web/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 

--- a/services/webdav/pkg/command/root.go
+++ b/services/webdav/pkg/command/root.go
@@ -33,11 +33,6 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	cli.HelpFlag = &cli.BoolFlag{
-		Name:  "help,h",
-		Usage: "Show the help",
-	}
-
 	return app.Run(os.Args)
 }
 


### PR DESCRIPTION
The help flag is configured automatically by default already. We don't
need to redo that for every single service.

This also addresses one of the finding of "go race" (#4088)

