### PR TITLE
[tests-only] [full-ci] cache core repos for testing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -41,8 +41,8 @@ DEFAULT_PHP_VERSION = "7.4"
 DEFAULT_NODEJS_VERSION = "14"
 
 dirs = {
-    "core": "/drone/src/oc10/testrunner",
-    "testing": "/drone/src/oc10/testing",
+    "core": "oc10/testrunner",
+    "testing": "oc10/testing",
 }
 
 # configuration
@@ -458,8 +458,8 @@ def cacheCoreReposForTesting(ctx):
         },
         "steps": skipIfUnchanged(ctx, "acceptance-tests") +  # skip for those pipelines where core repos are not needed
                  cloneCoreRepos() +
-                 rebuildBuildArtifactCache(ctx, "testrunner", "oc10/testrunner") +
-                 rebuildBuildArtifactCache(ctx, "testing_app", "oc10/testing"),
+                 rebuildBuildArtifactCache(ctx, "testrunner", dirs["core"]) +
+                 rebuildBuildArtifactCache(ctx, "testing_app", dirs["testing"]),
         "trigger": {
             "ref": [
                 "refs/heads/master",
@@ -577,8 +577,8 @@ def localApiTests(ctx, storage, suite, accounts_hash_difficulty = 4):
         "steps": skipIfUnchanged(ctx, "acceptance-tests") +
                  restoreBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin/ocis") +
                  ocisServer(storage, accounts_hash_difficulty) +
-                 restoreBuildArtifactCache(ctx, "testrunner", "oc10/testrunner") +
-                 restoreBuildArtifactCache(ctx, "testing_app", "oc10/testing") +
+                 restoreBuildArtifactCache(ctx, "testrunner", dirs["core"]) +
+                 restoreBuildArtifactCache(ctx, "testing_app", dirs["testing"]) +
                  [
                      {
                          "name": "localApiTests-%s-%s" % (suite, storage),
@@ -666,8 +666,8 @@ def coreApiTests(ctx, part_number = 1, number_of_parts = 1, storage = "ocis", ac
         "steps": skipIfUnchanged(ctx, "acceptance-tests") +
                  restoreBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin/ocis") +
                  ocisServer(storage, accounts_hash_difficulty) +
-                 restoreBuildArtifactCache(ctx, "testrunner", "oc10/testrunner") +
-                 restoreBuildArtifactCache(ctx, "testing_app", "oc10/testing") +
+                 restoreBuildArtifactCache(ctx, "testrunner", dirs["core"]) +
+                 restoreBuildArtifactCache(ctx, "testing_app", dirs["testing"]) +
                  [
                      {
                          "name": "oC10ApiTests-%s-storage-%s" % (storage, part_number),
@@ -2271,8 +2271,8 @@ def parallelDeployAcceptancePipeline(ctx):
                 },
                 "steps": skipIfUnchanged(ctx, "acceptance-tests") +
                          restoreBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin/ocis") +
-                         restoreBuildArtifactCache(ctx, "testrunner", "oc10/testrunner") +
-                         restoreBuildArtifactCache(ctx, "testing_app", "oc10/testing") +
+                         restoreBuildArtifactCache(ctx, "testrunner", dirs["core"]) +
+                         restoreBuildArtifactCache(ctx, "testing_app", dirs["testing"]) +
                          copyConfigs() +
                          parallelDeploymentOC10Server() +
                          owncloudLog() +


### PR DESCRIPTION
## Description
To run:
- localApiTests
- coreApiTests
- parallelDeployment tests

we need `owncloud/core` & `owncloud/testing`

these are now cached at first and used as the cached artifact on the test pipeline.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes: https://github.com/owncloud/ocis/issues/4059

## Motivation and Context
- have less unrelated errors on the CI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
