### PR TITLE
Update the adoc table generation

### DIFF
--- a/docs/helpers/adoc-generator.go.tmpl
+++ b/docs/helpers/adoc-generator.go.tmpl
@@ -89,9 +89,9 @@ func GetAnnotatedVariables(s interface{}) []ConfigField {
 			}
 			v := fmt.Sprintf("%v", value.Interface())			
 			td := strings.Split(env, ";")
-			re := regexp.MustCompile(`^(https?:\/\/)`)
-			v = re.ReplaceAllString(v,"\\$1")
-			re = regexp.MustCompile(`(https?:\/\/)`)
+			// re := regexp.MustCompile(`^(https?:\/\/)`)
+			// v = re.ReplaceAllString(v,"\\$1")
+			re := regexp.MustCompile(`(https?:\/\/)`)
 			desc = re.ReplaceAllString(desc, "\\$1")
 			re = regexp.MustCompile(`(\|)`)
 			v = re.ReplaceAllString(v, "\\$1")

--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -15,9 +15,9 @@
 {{- end }}
 | {{.Type}}
 a| [subs=-attributes]
-{{.DefaultValue}} 
+pass:[{{.DefaultValue}}]
 a| [subs=-attributes]
-{{.Description}}
+pass:[{{.Description}}]
 
 {{- end }}
 |===


### PR DESCRIPTION
Fixes: https://github.com/owncloud/ocis/issues/4097 (Some env content provided does not make it into the documentation)

Adding the `pass` macro for those two cells is neccessary because the content are go slices (arrays) which would be interpreted differently in Antora.
