### PR TITLE
fix `OCIS_RUN_SERVICES`

### DIFF
--- a/changelog/unreleased/fix-ocis-run-services.md
+++ b/changelog/unreleased/fix-ocis-run-services.md
@@ -1,0 +1,12 @@
+Bugfix: Fix `OCIS_RUN_SERVICES`
+
+`OCIS_RUN_SERVICES` was introduced as successor to `OCIS_RUN_EXTENSIONS` because
+we wanted to call oCIS "core" extensions services. We kept `OCIS_RUN_EXTENSIONS` for
+backwards compatibility reasons.
+
+It turned out, that setting `OCIS_RUN_SERVICES` has no effect since introduced. `OCIS_RUN_EXTENSIONS`.
+`OCIS_RUN_EXTENSIONS` was working fine all the time.
+
+We now fixed `OCIS_RUN_SERVICES`, so that you can use it as a equivalent replacement for `OCIS_RUN_EXTENSIONS`
+
+https://github.com/owncloud/ocis/pull/4133

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -49,7 +49,7 @@ type Mode int
 type Runtime struct {
 	Port       string `yaml:"port" env:"OCIS_RUNTIME_PORT"`
 	Host       string `yaml:"host" env:"OCIS_RUNTIME_HOST"`
-	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS,OCIS_RUN_SERVICES"`
+	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES"`
 }
 
 // Config combines all available configuration parts.


### PR DESCRIPTION
## Description
`OCIS_RUN_SERVICES` was introduced as successor to `OCIS_RUN_EXTENSIONS` because
we wanted to call oCIS "core" extensions services. We kept `OCIS_RUN_EXTENSIONS` for
backwards compatibility reasons.

It turned out, that setting `OCIS_RUN_SERVICES` has no effect since introduced. `OCIS_RUN_EXTENSIONS`.
`OCIS_RUN_EXTENSIONS` was working fine all the time.

We now fixed `OCIS_RUN_SERVICES`, so that you can use it as a equivalent replacement for `OCIS_RUN_EXTENSIONS`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
