### PR TITLE
remove unused `GRAPH_SPACES_INSECURE`

### DIFF
--- a/changelog/unreleased/fix-remove-unused-GRAPH_SPACES_INSECURE.md
+++ b/changelog/unreleased/fix-remove-unused-GRAPH_SPACES_INSECURE.md
@@ -1,0 +1,5 @@
+Bugfix: Fix unused config option `GRAPH_SPACES_INSECURE`
+
+We've removed the unused config option `GRAPH_SPACES_INSECURE` from the GRAPH service.
+
+https://github.com/owncloud/ocis/pull/55555

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -32,7 +32,6 @@ type Spaces struct {
 	WebDavBase                      string `yaml:"webdav_base" env:"OCIS_URL;GRAPH_SPACES_WEBDAV_BASE" desc:"The public facing URL of WebDAV."`
 	WebDavPath                      string `yaml:"webdav_path" env:"GRAPH_SPACES_WEBDAV_PATH" desc:"The WebDAV subpath for spaces."`
 	DefaultQuota                    string `yaml:"default_quota" env:"GRAPH_SPACES_DEFAULT_QUOTA" desc:"The default quota in bytes."`
-	Insecure                        bool   `yaml:"insecure" env:"OCIS_INSECURE;GRAPH_SPACES_INSECURE" desc:"Allow insecure connetctions to the spaces."`
 	ExtendedSpacePropertiesCacheTTL int    `yaml:"extended_space_properties_cache_ttl" env:"GRAPH_SPACES_EXTENDED_SPACE_PROPERTIES_CACHE_TTL" desc:"Max TTL for the spaces property cache."`
 }
 

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -36,7 +36,6 @@ func DefaultConfig() *config.Config {
 			WebDavBase:   "https://localhost:9200",
 			WebDavPath:   "/dav/spaces/",
 			DefaultQuota: "1000000000",
-			Insecure:     false,
 		},
 		Identity: config.Identity{
 			Backend: "ldap",

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -75,7 +75,6 @@ type Graph struct {
 	logger               *log.Logger
 	identityBackend      identity.Backend
 	gatewayClient        GatewayClient
-	httpClient           HTTPClient
 	roleService          settingssvc.RoleService
 	spacePropertiesCache *ttlcache.Cache
 	eventsPublisher      events.Publisher
@@ -89,11 +88,6 @@ func (g Graph) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // GetClient returns a gateway client to talk to reva
 func (g Graph) GetGatewayClient() GatewayClient {
 	return g.gatewayClient
-}
-
-// GetClient returns a gateway client to talk to reva
-func (g Graph) GetHTTPClient() HTTPClient {
-	return g.httpClient
 }
 
 func (g Graph) publishEvent(ev interface{}) {

--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -29,7 +29,6 @@ var _ = Describe("Graph", func() {
 	var (
 		svc             service.Service
 		gatewayClient   *mocks.GatewayClient
-		httpClient      *mocks.HTTPClient
 		eventsPublisher mocks.Publisher
 		ctx             context.Context
 		cfg             *config.Config
@@ -42,12 +41,10 @@ var _ = Describe("Graph", func() {
 		cfg.TokenManager.JWTSecret = "loremipsum"
 
 		gatewayClient = &mocks.GatewayClient{}
-		httpClient = &mocks.HTTPClient{}
 		eventsPublisher = mocks.Publisher{}
 		svc = service.NewService(
 			service.Config(cfg),
 			service.WithGatewayClient(gatewayClient),
-			service.WithHTTPClient(httpClient),
 			service.EventsPublisher(&eventsPublisher),
 		)
 	})

--- a/services/graph/pkg/service/v0/option.go
+++ b/services/graph/pkg/service/v0/option.go
@@ -21,7 +21,6 @@ type Options struct {
 	Middleware      []func(http.Handler) http.Handler
 	GatewayClient   GatewayClient
 	IdentityBackend identity.Backend
-	HTTPClient      HTTPClient
 	RoleService     settingssvc.RoleService
 	RoleManager     *roles.Manager
 	EventsPublisher events.Publisher
@@ -70,13 +69,6 @@ func WithGatewayClient(val GatewayClient) Option {
 func WithIdentityBackend(val identity.Backend) Option {
 	return func(o *Options) {
 		o.IdentityBackend = val
-	}
-}
-
-// WithHTTPClient provides a function to set the http client option.
-func WithHTTPClient(val HTTPClient) Option {
-	return func(o *Options) {
-		o.HTTPClient = val
 	}
 }
 

--- a/services/graph/pkg/service/v0/password_test.go
+++ b/services/graph/pkg/service/v0/password_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Users changing their own password", func() {
 	var (
 		svc             service.Service
 		gatewayClient   *mocks.GatewayClient
-		httpClient      *mocks.HTTPClient
 		ldapClient      *mocks.Client
 		ldapConfig      config.LDAP
 		identityBackend identity.Backend
@@ -70,13 +69,11 @@ var _ = Describe("Users changing their own password", func() {
 		identityBackend, err = identity.NewLDAPBackend(ldapClient, ldapConfig, &loggger)
 		Expect(err).To(BeNil())
 
-		httpClient = &mocks.HTTPClient{}
 		eventsPublisher = mocks.Publisher{}
 		svc = service.NewService(
 			service.Config(cfg),
 			service.WithGatewayClient(gatewayClient),
 			service.WithIdentityBackend(identityBackend),
-			service.WithHTTPClient(httpClient),
 			service.EventsPublisher(&eventsPublisher),
 		)
 		user = &userv1beta1.User{

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -136,15 +136,6 @@ func NewService(opts ...Option) Service {
 		svc.identityBackend = options.IdentityBackend
 	}
 
-	if options.HTTPClient == nil {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: options.Config.Spaces.Insecure, //nolint:gosec
-		}
-		svc.httpClient = &http.Client{}
-	} else {
-		svc.httpClient = options.HTTPClient
-	}
-
 	if options.RoleService == nil {
 		svc.roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient)
 	} else {


### PR DESCRIPTION
## Description
Bugfix: Fix unused config option `GRAPH_SPACES_INSECURE`

We've removed the unused config option `GRAPH_SPACES_INSECURE` from the GRAPH service.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `go build`does not complain

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
