### PR TITLE
Add access_token verification

### DIFF
--- a/changelog/unreleased/enhancement-access-token-validation.md
+++ b/changelog/unreleased/enhancement-access-token-validation.md
@@ -1,0 +1,14 @@
+Enhancement: Improve validation of OIDC access tokens
+
+Previously OIDC access tokes were only validated by requesting the userinfo from
+the IDP. It is now possible to enable additional verification if the IDP issues
+access tokens in JWT format. In that case the oCIS proxy service will now verify
+the signature of the token using the public keys provided by jwks_uri endpoint
+of the IDP. It will also verify if the issuer claim (iss) matches the expected
+values.
+
+The new validation is enabled by setting `PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD`
+to "jwt". Which is also the default. Setting it to "none" will disable the feature.
+
+https://github.com/owncloud/ocis/issues/3841
+https://github.com/owncloud/ocis/pull/4227

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/CiscoM31/godata v1.0.5
 	github.com/Masterminds/semver v1.5.0
+	github.com/MicahParks/keyfunc v1.1.0
 	github.com/ReneKroon/ttlcache/v2 v2.11.0
 	github.com/blevesearch/bleve/v2 v2.3.3
 	github.com/blevesearch/bleve_index_api v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/MicahParks/keyfunc v1.1.0 h1:9NcnRwS0ciuVeVNi+vTdYVMTmk62OID7VlG6y9BgLK0=
+github.com/MicahParks/keyfunc v1.1.0/go.mod h1:a4yfunv77gZ0RgTNw7tOYS+bjtHk5565e+1dPz+YJI8=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
@@ -518,6 +520,7 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 h1:gtexQ/VGyN+VVFRXSFiguSNcXmS6rkKT+X7FdIrTtfo=

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -189,6 +189,7 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config)
 			middleware.HTTPClient(oidcHTTPClient),
 			middleware.TokenCacheSize(cfg.OIDC.UserinfoCache.Size),
 			middleware.TokenCacheTTL(time.Second*time.Duration(cfg.OIDC.UserinfoCache.TTL)),
+			middleware.AccessTokenVerifyMethod(cfg.OIDC.AccessTokenVerifyMethod),
 
 			// basic Options
 			middleware.Logger(logger),

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -190,6 +190,7 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config)
 			middleware.TokenCacheSize(cfg.OIDC.UserinfoCache.Size),
 			middleware.TokenCacheTTL(time.Second*time.Duration(cfg.OIDC.UserinfoCache.TTL)),
 			middleware.AccessTokenVerifyMethod(cfg.OIDC.AccessTokenVerifyMethod),
+			middleware.JWKSOptions(cfg.OIDC.JWKS),
 
 			// basic Options
 			middleware.Logger(logger),

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -92,16 +92,16 @@ const (
 type OIDC struct {
 	Issuer                  string        `yaml:"issuer" env:"OCIS_URL;OCIS_OIDC_ISSUER;PROXY_OIDC_ISSUER" desc:"URL of the OIDC issuer. It defaults to URL of the builtin IDP."`
 	Insecure                bool          `yaml:"insecure" env:"OCIS_INSECURE;PROXY_OIDC_INSECURE" desc:"Disable TLS certificate validation for connections to the IDP. Note that this is not recommended for production environments."`
-	AccessTokenVerifyMethod string        `yaml:"access_token_verify_method" env:"PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD" desc:"Sets how OIDC access tokens should be verified. Possible values: 'none', which means that no special validation apart from using it for accessing the IPD's userinfo endpoint will be done. Or 'jwt', which tries to parse the access token as a jwt token and verifies the signature using the keys published on the IDP's 'jwks_uri'."`
+	AccessTokenVerifyMethod string        `yaml:"access_token_verify_method" env:"PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD" desc:"Sets how OIDC access tokens should be verified. Possible values are 'none' and 'jwt'. When using 'none', no special validation apart from using it for accessing the IPD's userinfo endpoint will be done. When using 'jwt', it tries to parse the access token as a jwt token and verifies the signature using the keys published on the IDP's 'jwks_uri'."`
 	UserinfoCache           UserinfoCache `yaml:"user_info_cache"`
 	JWKS                    JWKS          `yaml:"jwks"`
 }
 
 type JWKS struct {
-	RefreshInterval   uint64 `yaml:"refresh_interval" env:"PROXY_OIDC_JWKS_REFRESH_INTERVAL" desc:"The interval for refreshing the JWKS in the background via a new HTTP request to the IDP in minutes."`
-	RefreshTimeout    uint64 `yaml:"refresh_timeout" env:"PROXY_OIDC_JWKS_REFRESH_TIMEOUT" desc:"The timeout, in seconds, for and outgoing JWKS request."`
-	RefreshRateLimit  uint64 `yaml:"refresh_limit" env:"PROXY_OIDC_JWKS_REFRESH_RATE_LIMIT" desc:"Limits the rate at which refresh requests are performed for unknown keys in seconds. (To prevent malicious client from imposing high network load on the IDP via ocis)"`
-	RefreshUnknownKID bool   `yaml:"refresh_unknown_kid" env:"PROXY_OIDC_JWKS_REFRESH_UNKNOWN_KID" desc:"If true the JWKS refresh request will occur every time an unknown key id (kid) is seen. Always set a 'refresh_limit' when enabling this"`
+	RefreshInterval   uint64 `yaml:"refresh_interval" env:"PROXY_OIDC_JWKS_REFRESH_INTERVAL" desc:"The interval for refreshing the JWKS (JSON Web Key Set) in minutes in the background via a new HTTP request to the IDP."`
+	RefreshTimeout    uint64 `yaml:"refresh_timeout" env:"PROXY_OIDC_JWKS_REFRESH_TIMEOUT" desc:"The timeout in seconds for an outgoing JWKS request."`
+	RefreshRateLimit  uint64 `yaml:"refresh_limit" env:"PROXY_OIDC_JWKS_REFRESH_RATE_LIMIT" desc:"Limits the rate in seconds at which refresh requests are performed for unknown keys. This is used to prevent malicious clients from imposing high network load on the IDP via ocis."`
+	RefreshUnknownKID bool   `yaml:"refresh_unknown_kid" env:"PROXY_OIDC_JWKS_REFRESH_UNKNOWN_KID" desc:"If set to 'true', the JWKS refresh request will occur every time an unknown KEY ID (KID) is seen. Always set a 'refresh_limit' when enabling this."`
 }
 
 // UserinfoCache is a TTL cache configuration.

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -94,6 +94,14 @@ type OIDC struct {
 	Insecure                bool          `yaml:"insecure" env:"OCIS_INSECURE;PROXY_OIDC_INSECURE" desc:"Disable TLS certificate validation for connections to the IDP. Note that this is not recommended for production environments."`
 	AccessTokenVerifyMethod string        `yaml:"access_token_verify_method" env:"PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD" desc:"Sets how OIDC access tokens should be verified. Possible values: 'none', which means that no special validation apart from using it for accessing the IPD's userinfo endpoint will be done. Or 'jwt', which tries to parse the access token as a jwt token and verifies the signature using the keys published on the IDP's 'jwks_uri'."`
 	UserinfoCache           UserinfoCache `yaml:"user_info_cache"`
+	JWKS                    JWKS          `yaml:"jwks"`
+}
+
+type JWKS struct {
+	RefreshInterval   uint64 `yaml:"refresh_interval" env:"PROXY_OIDC_JWKS_REFRESH_INTERVAL" desc:"The interval for refreshing the JWKS in the background via a new HTTP request to the IDP in minutes."`
+	RefreshTimeout    uint64 `yaml:"refresh_timeout" env:"PROXY_OIDC_JWKS_REFRESH_TIMEOUT" desc:"The timeout, in seconds, for and outgoing JWKS request."`
+	RefreshRateLimit  uint64 `yaml:"refresh_limit" env:"PROXY_OIDC_JWKS_REFRESH_RATE_LIMIT" desc:"Limits the rate at which refresh requests are performed for unknown keys in seconds. (To prevent malicious client from imposing high network load on the IDP via ocis)"`
+	RefreshUnknownKID bool   `yaml:"refresh_unknown_kid" env:"PROXY_OIDC_JWKS_REFRESH_UNKNOWN_KID" desc:"If true the JWKS refresh request will occur every time an unknown key id (kid) is seen. Always set a 'refresh_limit' when enabling this"`
 }
 
 // UserinfoCache is a TTL cache configuration.

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -80,12 +80,20 @@ type AuthMiddleware struct {
 	CredentialsByUserAgent map[string]string `yaml:"credentials_by_user_agent"`
 }
 
+const (
+	AccessTokenVerificationNone = "none"
+	AccessTokenVerificationJWT  = "jwt"
+	// tdb:
+	// AccessTokenVerificationIntrospect = "introspect"
+)
+
 // OIDC is the config for the OpenID-Connect middleware. If set the proxy will try to authenticate every request
 // with the configured oidc-provider
 type OIDC struct {
-	Issuer        string        `yaml:"issuer" env:"OCIS_URL;OCIS_OIDC_ISSUER;PROXY_OIDC_ISSUER" desc:"URL of the OIDC issuer. It defaults to URL of the builtin IDP."`
-	Insecure      bool          `yaml:"insecure" env:"OCIS_INSECURE;PROXY_OIDC_INSECURE" desc:"Disable TLS certificate validation for connections to the IDP. Note that this is not recommended for production environments."`
-	UserinfoCache UserinfoCache `yaml:"user_info_cache"`
+	Issuer                  string        `yaml:"issuer" env:"OCIS_URL;OCIS_OIDC_ISSUER;PROXY_OIDC_ISSUER" desc:"URL of the OIDC issuer. It defaults to URL of the builtin IDP."`
+	Insecure                bool          `yaml:"insecure" env:"OCIS_INSECURE;PROXY_OIDC_INSECURE" desc:"Disable TLS certificate validation for connections to the IDP. Note that this is not recommended for production environments."`
+	AccessTokenVerifyMethod string        `yaml:"access_token_verify_method" env:"PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD" desc:"Sets how OIDC access tokens should be verified. Possible values: 'none', which means that no special validation apart from using it for accessing the IPD's userinfo endpoint will be done. Or 'jwt', which tries to parse the access token as a jwt token and verifies the signature using the keys published on the IDP's 'jwks_uri'."`
+	UserinfoCache           UserinfoCache `yaml:"user_info_cache"`
 }
 
 // UserinfoCache is a TTL cache configuration.

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -36,6 +36,7 @@ func DefaultConfig() *config.Config {
 			Issuer:   "https://localhost:9200",
 			Insecure: true,
 			//Insecure: true,
+			AccessTokenVerifyMethod: config.AccessTokenVerificationJWT,
 			UserinfoCache: config.UserinfoCache{
 				Size: 1024,
 				TTL:  10,

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -41,6 +41,12 @@ func DefaultConfig() *config.Config {
 				Size: 1024,
 				TTL:  10,
 			},
+			JWKS: config.JWKS{
+				RefreshInterval:   60, // minutes
+				RefreshRateLimit:  60, // seconds
+				RefreshTimeout:    10, // seconds
+				RefreshUnknownKID: true,
+			},
 		},
 		PolicySelector: nil,
 		Reva: &config.Reva{

--- a/services/proxy/pkg/config/parser/parse.go
+++ b/services/proxy/pkg/config/parser/parse.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
@@ -39,6 +40,15 @@ func Validate(cfg *config.Config) error {
 
 	if cfg.MachineAuthAPIKey == "" {
 		return shared.MissingMachineAuthApiKeyError(cfg.Service.Name)
+	}
+
+	if cfg.OIDC.AccessTokenVerifyMethod != config.AccessTokenVerificationNone &&
+		cfg.OIDC.AccessTokenVerifyMethod != config.AccessTokenVerificationJWT {
+		return fmt.Errorf(
+			"Invalid value '%s' for 'access_token_verify_method' in service %s. Possible values are: '%s' or '%s'.",
+			cfg.OIDC.AccessTokenVerifyMethod, cfg.Service.Name,
+			config.AccessTokenVerificationJWT, config.AccessTokenVerificationNone,
+		)
 	}
 
 	return nil

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -116,6 +116,7 @@ func newOIDCAuth(options Options) func(http.Handler) http.Handler {
 		TokenCacheTTL(options.UserinfoCacheTTL),
 		CredentialsByUserAgent(options.CredentialsByUserAgent),
 		AccessTokenVerifyMethod(options.AccessTokenVerifyMethod),
+		JWKSOptions(options.JWKS),
 	)
 }
 

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -115,6 +115,7 @@ func newOIDCAuth(options Options) func(http.Handler) http.Handler {
 		TokenCacheSize(options.UserinfoCacheSize),
 		TokenCacheTTL(options.UserinfoCacheTTL),
 		CredentialsByUserAgent(options.CredentialsByUserAgent),
+		AccessTokenVerifyMethod(options.AccessTokenVerifyMethod),
 	)
 }
 

--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -74,7 +74,6 @@ type oidcAuth struct {
 func (m oidcAuth) getClaims(token string, req *http.Request) (claims map[string]interface{}, status int) {
 	hit := m.tokenCache.Load(token)
 	if hit == nil {
-		// TODO cache userinfo for access token if we can determine the expiry (which works in case it is a jwt based access token)
 		oauth2Token := &oauth2.Token{
 			AccessToken: token,
 		}

--- a/services/proxy/pkg/middleware/oidc_auth_test.go
+++ b/services/proxy/pkg/middleware/oidc_auth_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
 	"golang.org/x/oauth2"
 )
 
@@ -21,6 +22,7 @@ func TestOIDCAuthMiddleware(t *testing.T) {
 			return mockOP(false), nil
 		}),
 		OIDCIss("https://localhost:9200"),
+		AccessTokenVerifyMethod(config.AccessTokenVerificationNone),
 	)(next)
 
 	r := httptest.NewRequest(http.MethodGet, "https://idp.example.com", nil)

--- a/services/proxy/pkg/middleware/options.go
+++ b/services/proxy/pkg/middleware/options.go
@@ -58,6 +58,8 @@ type Options struct {
 	// AccessTokenVerifyMethod configures how access_tokens should be verified but the oidc_auth middleware.
 	// Possible values currently: "jwt" and "none"
 	AccessTokenVerifyMethod string
+	// JWKS sets the options for fetching the JWKS from the IDP
+	JWKS config.JWKS
 }
 
 // newOptions initializes the available default options.
@@ -201,5 +203,12 @@ func UserProvider(up backend.UserBackend) Option {
 func AccessTokenVerifyMethod(method string) Option {
 	return func(o *Options) {
 		o.AccessTokenVerifyMethod = method
+	}
+}
+
+// JWKS sets the options for fetching the JWKS from the IDP
+func JWKSOptions(jo config.JWKS) Option {
+	return func(o *Options) {
+		o.JWKS = jo
 	}
 }

--- a/services/proxy/pkg/middleware/options.go
+++ b/services/proxy/pkg/middleware/options.go
@@ -55,6 +55,9 @@ type Options struct {
 	UserinfoCacheTTL time.Duration
 	// CredentialsByUserAgent sets the auth challenges on a per user-agent basis
 	CredentialsByUserAgent map[string]string
+	// AccessTokenVerifyMethod configures how access_tokens should be verified but the oidc_auth middleware.
+	// Possible values currently: "jwt" and "none"
+	AccessTokenVerifyMethod string
 }
 
 // newOptions initializes the available default options.
@@ -191,5 +194,12 @@ func TokenCacheTTL(ttl time.Duration) Option {
 func UserProvider(up backend.UserBackend) Option {
 	return func(o *Options) {
 		o.UserProvider = up
+	}
+}
+
+// AccessTokenVerifyMethod set the mechanism for access token verification
+func AccessTokenVerifyMethod(method string) Option {
+	return func(o *Options) {
+		o.AccessTokenVerifyMethod = method
 	}
 }


### PR DESCRIPTION
Try to verify access_token as JWT and extract expiry

We try to parse the access token as a JWT now. Verifying the signature using the keys downloaded from the jwks_uri of the IDP. Currently we only use it to extract the expiry information from the JWT. This could be reworked to extract other claims from the token for authorization purposes.

