### PR TITLE
make graph service events optional

### DIFF
--- a/changelog/unreleased/feature-optional-events-in-graph-service.md
+++ b/changelog/unreleased/feature-optional-events-in-graph-service.md
@@ -1,0 +1,8 @@
+Enhancement: Optional events in graph service
+
+We've changed the graph service so that you also can start it without any
+event bus.
+Therefore you need to set `GRAPH_EVENTS_ENDPOINT` to an empty string.
+The graph API will not emit any events in this case.
+
+https://github.com/owncloud/ocis/pull/55555

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -69,6 +69,6 @@ type Identity struct {
 
 // Events combines the configuration options for the event bus.
 type Events struct {
-	Endpoint string `yaml:"endpoint" env:"GRAPH_EVENTS_ENDPOINT" desc:"The address of the streaming service."`
+	Endpoint string `yaml:"endpoint" env:"GRAPH_EVENTS_ENDPOINT" desc:"The address of the streaming service. Set to a empty string to disable emitting events."`
 	Cluster  string `yaml:"cluster" env:"GRAPH_EVENTS_CLUSTER" desc:"The clusterID of the streaming service. Mandatory when using the NATS service."`
 }

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -91,10 +91,12 @@ func (g Graph) GetGatewayClient() GatewayClient {
 }
 
 func (g Graph) publishEvent(ev interface{}) {
-	if err := events.Publish(g.eventsPublisher, ev); err != nil {
-		g.logger.Error().
-			Err(err).
-			Msg("could not publish user created event")
+	if g.eventsPublisher != nil {
+		if err := events.Publish(g.eventsPublisher, ev); err != nil {
+			g.logger.Error().
+				Err(err).
+				Msg("could not publish user created event")
+		}
 	}
 }
 


### PR DESCRIPTION

## Description
We've changed the graph service so that you also can start it without any
event bus.
Therefore you need to set `GRAPH_EVENTS_ENDPOINT` to an empty string.
The graph API will not emit any events in this case.

Test case:
Assumption: No events / nats service is running. Then:
- Running `ocis graph server` will not expose any api before this PR.
- When running `GRAPH_EVENTS_ENDPOINT="" ocis graph server` with this PR, the graph api will be exposed.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Be able to start the graph service without any event bus.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
