### PR TITLE
ApiTest. owner does not see the space after deleting the access

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -23,5 +23,5 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpaces/search.feature:43](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/search.feature#L43)
 
 ### [Space Admin still has access to the project despite being removed from it](https://github.com/owncloud/ocis/issues/4127)
-- [apiSpaces/shareSpace.feature:77](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSpace.feature#L77)
-- [apiSpaces/shareSpace.feature:78](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSpace.feature#L78)
+- [apiSpaces/shareSpaces.feature:77](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSpaces.feature#L77)
+- [apiSpaces/shareSpaces.feature:78](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSpaces.feature#L78)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -21,3 +21,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 ### [Search by shares jail works incorrect](https://github.com/owncloud/ocis/issues/4014)
 - [apiSpaces/search.feature:43](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/search.feature#L43)
+
+### [Space Admin still has access to the project despite being removed from it](https://github.com/owncloud/ocis/issues/4127)
+- [apiSpaces/shareSpace.feature:77](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSpace.feature#L77)
+- [apiSpaces/shareSpace.feature:78](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSpace.feature#L78)

--- a/tests/acceptance/features/apiSpaces/shareSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/shareSpaces.feature
@@ -62,6 +62,22 @@ Feature: Share spaces
     Then the user "Brian" should not have a space called "share space"
 
 
+  Scenario Outline: Owner of a space cannot see the space after removing his access to the space
+    Given user "Alice" has shared a space "share space" to user "Brian" with role "manager"
+    When user "<user>" unshares a space "share space" to user "Alice"
+    Then the HTTP status code should be "200"
+    And the user "Brian" should have a space called "share space" owned by "Alice" with these key and value pairs:
+      | key       | value       |
+      | driveType | project     |
+      | id        | %space_id%  |
+      | name      | share space |
+    But the user "Alice" should not have a space called "share space"
+    Examples:
+      | user  |
+      | Alice |
+      | Brian |
+
+
   Scenario: A user can add another user to the space managers to enable him
     Given user "Alice" has uploaded a file inside space "share space" with content "Test" to "test.txt"
     When user "Alice" shares a space "share space" to user "Brian" with role "manager"


### PR DESCRIPTION
- added api test for an issue https://github.com/owncloud/ocis/issues/4127
- test added to expected failures