### PR TITLE
fix adoc for slices

### DIFF
--- a/docs/helpers/adoc-generator.go.tmpl
+++ b/docs/helpers/adoc-generator.go.tmpl
@@ -95,7 +95,11 @@ func GetAnnotatedVariables(s interface{}) []ConfigField {
 			desc = re.ReplaceAllString(desc, "\\$1")
 			re = regexp.MustCompile(`(\|)`)
 			v = re.ReplaceAllString(v, "\\$1")
-			fields = append(fields, ConfigField{EnvVars: td, DefaultValue: v, Description: desc, Type: value.Type().Name()})
+			typeName := value.Type().Name()
+			if typeName == "" {
+				typeName = value.Type().String()
+			}
+			fields = append(fields, ConfigField{EnvVars: td, DefaultValue: v, Description: desc, Type: typeName})
 		case reflect.Ptr:
 			// PolicySelectors in the Proxy are being skipped atm
 			// they are not configurable via env vars, if that changes


### PR DESCRIPTION
This PR fixes the doc templates to include slices properly in the adoc output.

fixes #4128 
closes #4128