### PR TITLE
[tests-only] remove dedicated spaces cleanup for the localAPI tests

### DIFF
--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -24,9 +24,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Behat\Hook\Call\AfterScenario;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Testwork\Environment\Environment;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
@@ -362,17 +360,6 @@ class SpacesContext implements Context {
 			$this->baseUrl,
 			$this->featureContext->getOcPath()
 		);
-	}
-
-	/**
-	 * @AfterScenario
-	 *
-	 * @return void
-	 *
-	 * @throws Exception|GuzzleException
-	 */
-	public function cleanDataAfterTests(): void {
-		$this->deleteAllSpacesOfTheType('project');
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -363,43 +363,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * The method first disables and then deletes spaces
-	 *
-	 * @param  string $driveType
-	 *
-	 * @return void
-	 *
-	 * @throws Exception|GuzzleException
-	 */
-	public function deleteAllSpacesOfTheType(string $driveType): void {
-		$query = "\$filter=driveType eq $driveType";
-		$userAdmin = $this->featureContext->getAdminUsername();
-
-		for ($i = 0; $i < 2; ++$i) {
-			$this->theUserListsAllAvailableSpacesUsingTheGraphApi(
-				$userAdmin,
-				$query
-			);
-
-			$rawBody =  $this->featureContext->getResponse()->getBody()->getContents();
-			$drives = json_decode($rawBody, true, 512);
-			if (isset($drives["value"])) {
-				$drives = $drives["value"];
-			}
-
-			if (!empty($drives)) {
-				foreach ($drives as $value) {
-					if (!\array_key_exists("deleted", $value["root"])) {
-						$this->sendDisableSpaceRequest($userAdmin, $value["name"]);
-					} else {
-						$this->sendDeleteSpaceRequest($userAdmin, $value["name"]);
-					}
-				}
-			}
-		}
-	}
-
-	/**
 	 * Send Graph List My Spaces Request
 	 *
 	 * @param  string $user


### PR DESCRIPTION
### Description
In the after scenario of the local Api tests, a cleanup job is initialized to delete all spaces of the type `project`.
For this we do not need to remember the spaces (only needed in between of the tests not on the after Scenario).
If we have no `project` type spaces the Query API will return `{value: []}` which is not acceptable for the remember function `rememberTheAvailableSpaces`, due to which we see an unnecessary error as:
```console
 ╳  No drives were found on that endpoint
      ╳  Failed asserting that an array has the key 0.
      │
      └─ @AfterScenario # SpacesContext::cleanDataAfterTests()
```

With this PR:
- no more spaces cleanup. Why? cause the spaces for any users will be cleared when it is deleted. see https://github.com/owncloud/ocis/commit/f01d56fe5fef946eb523db8d31d8d49ff1c4e7ff. we clear the test users, the spaces created by them will be removed with that same req.

### Related:
fixes https://github.com/owncloud/ocis/issues/4173

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>