### PR TITLE
fix search reva addr config parsing

### DIFF
--- a/services/search/pkg/config/config.go
+++ b/services/search/pkg/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	GRPC GRPC `yaml:"grpc"`
 
 	Datapath string `yaml:"data_path" env:"SEARCH_DATA_PATH" desc:"Path for the search persistence directory."`
-	Reva     Reva   `yaml:"reva"`
+	Reva     *Reva  `yaml:"reva"`
 	Events   Events `yaml:"events"`
 
 	MachineAuthAPIKey string `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY;SEARCH_MACHINE_AUTH_API_KEY" desc:"Machine auth API key used to validate internal requests necessary for the access to resources from other services."`

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -29,7 +29,7 @@ func DefaultConfig() *config.Config {
 			Name: "search",
 		},
 		Datapath: path.Join(defaults.BaseDataPath(), "search"),
-		Reva: config.Reva{
+		Reva: &config.Reva{
 			Address: "127.0.0.1:9142",
 		},
 		Events: config.Events{
@@ -67,6 +67,14 @@ func EnsureDefaults(cfg *config.Config) {
 
 	if cfg.MachineAuthAPIKey == "" && cfg.Commons != nil && cfg.Commons.MachineAuthAPIKey != "" {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
+	}
+
+	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
+		cfg.Reva = &config.Reva{
+			Address: cfg.Commons.Reva.Address,
+		}
+	} else if cfg.Reva == nil {
+		cfg.Reva = &config.Reva{}
 	}
 }
 


### PR DESCRIPTION
drone configures `GATEWAY_GRPC_ADDR=0.0.0.0:9142` while the default is `127.0.0.1:9142`. during testing the reva config might not be copied correctly.

this error
```
{"level":"error","service":"search","error":"error: not found: unknown client id","authRes":{"status":{"code":6,"message":"unknown client id","trace":"00000000000000000000000000000000"}},"time":"2022-07-12T11:52:06.978647891Z","message":"error using machine auth"}
{"level":"error","service":"search","error":"error: not found: unknown client id","time":"2022-07-12T11:52:06.978668069Z","message":"failed to stat the changed resource"}
```

is logged when the testsuite cleaned the user before the event could be consumed and acted upon. unrelated to this PR