### PR TITLE
remove unused iopsecret from wopi example

### DIFF
--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -30,8 +30,6 @@ WOPISERVER_DOCKER_TAG=
 WOPISERVER_DOMAIN=
 # JWT secret which is used for the documents to be request by the Wopi client from the cs3org Wopi server. Must be change in order to have a secure Wopi server. Defaults to "LoremIpsum567"
 WOPI_JWT_SECRET=
-# JWT secret which is used for the documents to be request by the Wopi client from the cs3org Wopi server. Must be change in order to have a secure Wopi server. Defaults to "LoremIpsum123"
-WOPI_IOP_SECRET=
 
 ### Collabora settings ###
 # Domain of Collabora, where you can find the frontend. Defaults to "collabora.owncloud.test"

--- a/deployments/examples/ocis_wopi/config/wopiserver/entrypoint-override.sh
+++ b/deployments/examples/ocis_wopi/config/wopiserver/entrypoint-override.sh
@@ -2,7 +2,6 @@
 set -e
 
 echo "${WOPISECRET}" > /etc/wopi/wopisecret
-echo "${IOPSECRET}" > /etc/wopi/iopsecret
 
 cp /etc/wopi/wopiserver.conf.dist /etc/wopi/wopiserver.conf
 sed -i 's/wopiserver.owncloud.test/'${WOPISERVER_DOMAIN}'/g' /etc/wopi/wopiserver.conf

--- a/deployments/examples/ocis_wopi/config/wopiserver/wopiserver.conf.dist
+++ b/deployments/examples/ocis_wopi/config/wopiserver/wopiserver.conf.dist
@@ -81,7 +81,8 @@ detectexternallocks = False
 # Location of the secret files. Requires a restart of the
 # WOPI server when either the files or their content change.
 wopisecretfile = /etc/wopi/wopisecret
-iopsecretfile = /etc/wopi/iopsecret
+# iop secret is not used for cs3 storage type
+#iopsecretfile = /etc/wopi/iopsecret
 
 # Use https as opposed to http (requires certificate)
 usehttps = no

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -158,7 +158,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:21.11.5.3.1
+    image: collabora/code:22.05.0.1
     networks:
       ocis-net:
     environment:
@@ -181,7 +181,7 @@ services:
     restart: always
 
   onlyoffice:
-    image: onlyoffice/documentserver:7.1
+    image: onlyoffice/documentserver:7.1.1
     networks:
       ocis-net:
     environment:

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -98,7 +98,6 @@ services:
       APP_PROVIDER_WOPI_APP_ICON_URI: https://${COLLABORA_DOMAIN:-collabora.owncloud.test}/favicon.ico
       APP_PROVIDER_WOPI_APP_URL: https://${COLLABORA_DOMAIN:-collabora.owncloud.test}
       APP_PROVIDER_WOPI_INSECURE: "${INSECURE:-false}"
-      APP_PROVIDER_WOPI_WOPI_SERVER_IOP_SECRET: ${WOPI_IOP_SECRET:-LoremIpsum123}
       APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL: https://${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
     volumes:
       - ocis-config:/etc/ocis
@@ -124,7 +123,6 @@ services:
       APP_PROVIDER_WOPI_APP_ICON_URI: https://${ONLYOFFICE_DOMAIN:-onlyoffice.owncloud.test}/web-apps/apps/documenteditor/main/resources/img/favicon.ico
       APP_PROVIDER_WOPI_APP_URL: https://${ONLYOFFICE_DOMAIN:-onlyoffice.owncloud.test}
       APP_PROVIDER_WOPI_INSECURE: "${INSECURE:-false}"
-      APP_PROVIDER_WOPI_WOPI_SERVER_IOP_SECRET: ${WOPI_IOP_SECRET:-LoremIpsum123}
       APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL: https://${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
     volumes:
       - ./config/ocis-appdriver-onlyoffice/entrypoint-override.sh:/entrypoint-override.sh
@@ -142,7 +140,6 @@ services:
     environment:
       WOPISERVER_INSECURE: "${INSECURE:-false}"
       WOPISECRET: ${WOPI_JWT_SECRET:-LoremIpsum567}
-      IOPSECRET: ${WOPI_IOP_SECRET:-LoremIpsum123}
       WOPISERVER_DOMAIN: ${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
     volumes:
       - ./config/wopiserver/entrypoint-override.sh:/entrypoint-override.sh

--- a/docs/ocis/deployment/ocis_wopi.md
+++ b/docs/ocis/deployment/ocis_wopi.md
@@ -86,8 +86,6 @@ See also [example server setup]({{< ref "preparing_server" >}})
   WOPISERVER_DOMAIN=
   # JWT secret which is used for the documents to be request by the Wopi client from the cs3org Wopi server. Must be change in order to have a secure Wopi server. Defaults to "LoremIpsum567"
   WOPI_JWT_SECRET=
-  # JWT secret which is used for the documents to be request by the Wopi client from the cs3org Wopi server. Must be change in order to have a secure Wopi server. Defaults to "LoremIpsum123"
-  WOPI_IOP_SECRET=
 
   ### Collabora settings ###
   # Domain of Collabora, where you can find the frontend. Defaults to "collabora.owncloud.test"
@@ -120,7 +118,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
 
   Set your domain for the CS3Org WOPI server in `WOPISERVER_DOMAIN=`, where all office suites can download the files via the WOPI protocol.
 
-  You also must override the default WOPI JWT secret and the WOPI IOP secret, in order to have a secure setup. Do this by setting `WOPI_JWT_SECRET` and `WOPI_IOP_SECRET` to a long and random string.
+  You also must override the default WOPI JWT secret in order to have a secure setup. Do this by setting `WOPI_JWT_SECRET` to a long and random string.
 
   Now it's time to set up Collabora and you need to configure the domain of Collabora in `COLLABORA_DOMAIN=`.
 


### PR DESCRIPTION
## Description
after https://github.com/cs3org/wopiserver/commit/d9b241da81305dee037ed376e8d358ab88f79845, we can remove the IOP secret from our wopi example deployment. It is still configurable and could also be removed from the Code at some point in time

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
