### PR TITLE
relax folder permissions in the dockerfile

### DIFF
--- a/ocis/docker/Dockerfile.linux.amd64
+++ b/ocis/docker/Dockerfile.linux.amd64
@@ -26,10 +26,10 @@ RUN addgroup -g 1000 -S ocis-group && \
 
 RUN mkdir -p /var/lib/ocis && \
  chown -R ocis-user:ocis-group /var/lib/ocis && \
- chmod -R 750 /var/lib/ocis && \
+ chmod -R 751 /var/lib/ocis && \
  mkdir -p /etc/ocis && \
  chown -R ocis-user:ocis-group /etc/ocis && \
- chmod -R 750 /etc/ocis
+ chmod -R 751 /etc/ocis
 
 VOLUME [ "/var/lib/ocis", "/etc/ocis" ]
 WORKDIR /var/lib/ocis

--- a/ocis/docker/Dockerfile.linux.arm
+++ b/ocis/docker/Dockerfile.linux.arm
@@ -26,10 +26,10 @@ RUN addgroup -g 1000 -S ocis-group && \
 
 RUN mkdir -p /var/lib/ocis && \
  chown -R ocis-user:ocis-group /var/lib/ocis && \
- chmod -R 750 /var/lib/ocis && \
+ chmod -R 751 /var/lib/ocis && \
  mkdir -p /etc/ocis && \
  chown -R ocis-user:ocis-group /etc/ocis && \
- chmod -R 750 /etc/ocis
+ chmod -R 751 /etc/ocis
 
 VOLUME [ "/var/lib/ocis", "/etc/ocis" ]
 WORKDIR /var/lib/ocis

--- a/ocis/docker/Dockerfile.linux.arm64
+++ b/ocis/docker/Dockerfile.linux.arm64
@@ -26,10 +26,10 @@ RUN addgroup -g 1000 -S ocis-group && \
 
 RUN mkdir -p /var/lib/ocis && \
  chown -R ocis-user:ocis-group /var/lib/ocis && \
- chmod -R 750 /var/lib/ocis && \
+ chmod -R 751 /var/lib/ocis && \
  mkdir -p /etc/ocis && \
  chown -R ocis-user:ocis-group /etc/ocis && \
- chmod -R 750 /etc/ocis
+ chmod -R 751 /etc/ocis
 
 VOLUME [ "/var/lib/ocis", "/etc/ocis" ]
 WORKDIR /var/lib/ocis


### PR DESCRIPTION
## Description
relax folder permissions in the dockerfile for
- /var/lib/ocis
- /etc/ocis from 750 to 751
to allow oCIS running with uid/pid != 1000 to traverse these directories for eg. the case that a volume is mounted in these directories.

https://github.com/owncloud/ocis-charts/pull/46 uses a workaround to achieve this. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- 

## Motivation and Context
Simplify volume mounting to /etc/ocis and /var/lib/ocis subdirectories when using a non default uid / pid for the oCIS process

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
