### PR TITLE
improve error log for "could not get user by claim" error

### DIFF
--- a/changelog/unreleased/enhancement-error-by-claim.md
+++ b/changelog/unreleased/enhancement-error-by-claim.md
@@ -1,0 +1,7 @@
+Enhancement: Improve error log for "could not get user by claim" error
+
+We've improved the error log for "could not get user by claim" error where
+previously only the "nil" error has been logged. Now we're logging the
+message from the transport.
+
+https://github.com/owncloud/ocis/pull/4227

--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -65,7 +65,7 @@ func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, w
 		if res.Status.Code == rpcv1beta1.Code_CODE_NOT_FOUND {
 			return nil, "", ErrAccountNotFound
 		}
-		return nil, "", fmt.Errorf("could not get user by claim %v with value %v : %w ", claim, value, err)
+		return nil, "", fmt.Errorf("could not get user by claim %v with value %v : %s ", claim, value, res.Status.Message)
 	}
 
 	user := res.User


### PR DESCRIPTION

## Description
Enhancement: Improve error log for "could not get user by claim" error

We've improved the error log for "could not get user by claim" error where
previously only the "nil" error has been logged. Now we're logging the
message from the transport.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-

## Motivation and Context
Helps debugging

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
