### PR TITLE
[tests-only] [full-ci] Do not fetch the retry script in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -289,7 +289,6 @@ def yarnInstallUITests():
         "name": "yarn-install",
         "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
         "commands": [
-            "curl -SsfL -o /usr/local/bin/retry https://raw.githubusercontent.com/owncloud-ci/retry/master/retry && chmod +x /usr/local/bin/retry",
             ". /drone/src/.drone.env",
             "cd webTestRunner",
             "git checkout $WEB_COMMITID",
@@ -846,7 +845,6 @@ def settingsUITests(ctx, storage = "ocis", accounts_hash_difficulty = 4):
                     "MIDDLEWARE_HOST": "http://middleware:3000",
                 },
                 "commands": [
-                    "curl -SsfL -o /usr/local/bin/retry https://raw.githubusercontent.com/owncloud-ci/retry/master/retry && chmod +x /usr/local/bin/retry",
                     ". /drone/src/.drone.env",
                     # we need to have Web around for some general step definitions (eg. how to log in)
                     "git clone -b $WEB_BRANCH --single-branch --no-tags https://github.com/owncloud/web.git /srv/app/web",


### PR DESCRIPTION
## Description
The `retry` script is already in the `nodejs` docker image. We do not need to fetch it from the `retry` repo.

See issue https://github.com/owncloud-ci/retry/issues/7

This is a follow-up of PR #4223 

## Related Issue

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
