### PR TITLE
Allow providing list of services not to start

### DIFF
--- a/changelog/unreleased/exclude-services-option.md
+++ b/changelog/unreleased/exclude-services-option.md
@@ -1,0 +1,7 @@
+Enhancement: Allow providing list of services NOT to start
+
+Until now if one wanted to use a custom version of a service, one
+needed to provide `OCIS_RUN_SERVICES` which is a list of all services to start.
+Now one can provide `OCIS_EXCLUDE_RUN_SERVICES` which is a list of only services not to start
+
+https://github.com/owncloud/ocis/pull/4254

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -49,8 +49,8 @@ type Mode int
 type Runtime struct {
 	Port       string `yaml:"port" env:"OCIS_RUNTIME_PORT"`
 	Host       string `yaml:"host" env:"OCIS_RUNTIME_HOST"`
-	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES" desc:"Expects a space separated list of service names. Will start only the listed services."`
-	Disabled   string `yaml:"disabled_services" env:"OCIS_EXCLUDE_RUN_SERVICES" desc:"Expects a space separated list of service names. Will start all services except for the ones listed. Has no effect when OCIS_RUN_SERVICES is set."`
+	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES" desc:"Expects a comma separated list of service names. Will start only the listed services."`
+	Disabled   string `yaml:"disabled_services" env:"OCIS_EXCLUDE_RUN_SERVICES" desc:"Expects a comma separated list of service names. Will start all services except of the ones listed. Has no effect when OCIS_RUN_SERVICES is set."`
 }
 
 // Config combines all available configuration parts.

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -49,8 +49,8 @@ type Mode int
 type Runtime struct {
 	Port       string `yaml:"port" env:"OCIS_RUNTIME_PORT"`
 	Host       string `yaml:"host" env:"OCIS_RUNTIME_HOST"`
-	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES" desc:"Expects a space seperated list of service names. Will start only the listed services."`
-	Disabled   string `yaml:"disabled_services" env:"OCIS_EXCLUDE_RUN_SERVICES" desc:"Expects a space seperated list of service names. Will start all services except of the ones listed. Has no effect when OCIS_RUN_SERVICES is set."`
+	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES" desc:"Expects a space separated list of service names. Will start only the listed services."`
+	Disabled   string `yaml:"disabled_services" env:"OCIS_EXCLUDE_RUN_SERVICES" desc:"Expects a space separated list of service names. Will start all services except for the ones listed. Has no effect when OCIS_RUN_SERVICES is set."`
 }
 
 // Config combines all available configuration parts.

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -49,7 +49,8 @@ type Mode int
 type Runtime struct {
 	Port       string `yaml:"port" env:"OCIS_RUNTIME_PORT"`
 	Host       string `yaml:"host" env:"OCIS_RUNTIME_HOST"`
-	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES"`
+	Extensions string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES" desc:"Expects a space seperated list of service names. Will start only the listed services."`
+	Disabled   string `yaml:"disabled_services" env:"OCIS_EXCLUDE_RUN_SERVICES" desc:"Expects a space seperated list of service names. Will start all services except of the ones listed. Has no effect when OCIS_RUN_SERVICES is set."`
 }
 
 // Config combines all available configuration parts.

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -248,12 +248,24 @@ func (s *Service) generateRunSet(cfg *ociscfg.Config) {
 		return
 	}
 
+	disabled := make(map[string]bool)
+	if cfg.Runtime.Disabled != "" {
+		e := strings.Split(strings.ReplaceAll(cfg.Runtime.Disabled, " ", ""), ",")
+		for _, s := range e {
+			disabled[s] = true
+		}
+	}
+
 	for name := range s.ServicesRegistry {
-		runset = append(runset, name)
+		if !disabled[name] {
+			runset = append(runset, name)
+		}
 	}
 
 	for name := range s.Delayed {
-		runset = append(runset, name)
+		if !disabled[name] {
+			runset = append(runset, name)
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: jkoberg <jkoberg@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
#### Allow providing list of services NOT to start

Until now if one wanted to use a custom version of a service, one
needed to provide `OCIS_RUN_SERVICES` which is a list of all services to start.
Now one can provide `OCIS_EXCLUDE_RUN_SERVICES` which is a list of only services not to start


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
