### PR TITLE
[tests-only] [full-ci] Adjust text in ParallelContext

### DIFF
--- a/tests/parallelDeployAcceptance/features/bootstrap/ParallelContext.php
+++ b/tests/parallelDeployAcceptance/features/bootstrap/ParallelContext.php
@@ -28,7 +28,7 @@ use TestHelpers\HttpRequestHelper;
 require_once 'bootstrap.php';
 
 /**
- * Steps related to parallel deploy setup
+ * Steps related to parallel deployment setup
  */
 class ParallelContext implements Context {
 


### PR DESCRIPTION
We are seeing the `apiWebdavOperations` parallel deployment test pipeline failing this morning. Example:
https://drone.owncloud.com/owncloud/ocis/13820/78/15
```
BEHAT_BIN=vendor-bin/behat/vendor/bin/behat BEHAT_YML=tests/parallelDeployAcceptance/config/behat.yml /drone/src/oc10/testrunner/tests/acceptance/run.sh --type api
bash: /drone/src/oc10/testrunner/tests/acceptance/run.sh: No such file or directory
```
Possibly there is just some startup timing issue with the pipeline steps, and that there needs to be better waiting for other steps to finish that fetch the test code?

This PR is really just to try and get an example of that independent of the code in the other PRs.