### PR TITLE
[tests-only][full-ci]Add Tests for creating Files and Folder When Space Shares Jail exists for core PR 40239

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=cb5fdb6c031dcd4fa118eaa1d44ca206e9feeeae
-CORE_BRANCH=removeSharesSpaceRelatedFromCore
+CORE_COMMITID=751c7d92b189cdc30b2a39bc08f31336a0ec2c41
+CORE_BRANCH=master
 
 # The test runner source for UI tests
 WEB_COMMITID=0bb33e791f10f1afebfde4ea4da356e46ecdc201

--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=11d71074d4e9f44e4367af22421c857629f24c59
-CORE_BRANCH=master
+CORE_COMMITID=cb5fdb6c031dcd4fa118eaa1d44ca206e9feeeae
+CORE_BRANCH=removeSharesSpaceRelatedFromCore
 
 # The test runner source for UI tests
 WEB_COMMITID=0bb33e791f10f1afebfde4ea4da356e46ecdc201

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -987,12 +987,6 @@ And other missing implementation of favorites
 - [apiWebdavProperties1/copyFile.feature:548](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L548)
 - [apiWebdavProperties1/copyFile.feature:580](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L580)
 - [apiWebdavProperties1/copyFile.feature:612](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L612)
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L37)
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L38)
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L39)
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L60)
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:61](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L61)
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L62)
 - [apiWebdavUploadTUS/uploadToShare.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L31)
 - [apiWebdavUploadTUS/uploadToShare.feature:50](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L50)
 - [apiWebdavUploadTUS/uploadToShare.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L72)
@@ -1323,11 +1317,6 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [apiWebdavOperations/downloadFile.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L229)
 - [apiWebdavOperations/downloadFile.feature:230](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L230)
 - [apiWebdavOperations/downloadFile.feature:235](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L235)
-
-#### [Creating a new folder which is a substring of Shares leads to Unknown Error](https://github.com/owncloud/ocis/issues/3033)
-
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L79)
-- [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:96](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L96)
 
 #### [moveShareInsideAnotherShare behaves differently on oCIS than oC10](https://github.com/owncloud/ocis/issues/3047)
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -45,7 +45,3 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 ### [A space manager cannot see the public links of another manager](https://github.com/owncloud/ocis/issues/4260)
 - [apiSpaces/editPublicLinkOfSpace.feature:67](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature#L67)
-
-### [Shares named (file | folder) can be created in Personal space with spaces webdav](https://github.com/owncloud/ocis/issues/4286)
-- [apiSpaces/createFileFolderWhenSharesSpaceExist.feature:43](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature#L43)
-- [apiSpaces/createFileFolderWhenSharesSpaceExist.feature:50](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature#L50)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -45,3 +45,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 ### [A space manager cannot see the public links of another manager](https://github.com/owncloud/ocis/issues/4260)
 - [apiSpaces/editPublicLinkOfSpace.feature:67](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature#L67)
+
+### [Shares named (file | folder) can be created in Personal space with spaces webdav](https://github.com/owncloud/ocis/issues/4286)
+- [apiSpaces/createFileFolderWhenSharesSpaceExist.feature:43](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature#L43)
+- [apiSpaces/createFileFolderWhenSharesSpaceExist.feature:50](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature#L50)

--- a/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature
+++ b/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature
@@ -1,0 +1,55 @@
+@api @skipOnOcV10
+Feature: create file or folder named similar to Shares folder
+  As a user
+  I want to be able to create files and folders when the Shares folder exists
+  So that I can organise the files in my file system
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,update"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+
+  Scenario Outline: create a folder with a name similar to Shares
+    Given using spaces DAV path
+    When user "Brian" creates folder "<folder_name>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And for user "Brian" the space "Personal" should contain these entries:
+      | /<folder_name> |
+    Examples:
+      | folder_name |
+      | /Share      |
+      | /shares     |
+      | /Share1     |
+
+  Scenario Outline: create a file with a name similar to Shares
+    Given using spaces DAV path
+    When user "Brian" uploads file with content "some text" to "<file_name>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "<file_name>" for user "Brian" should be "some text"
+    And for user "Brian" the space "Personal" should contain these entries:
+      | /<file_name> |
+    And for user "Brian" the space "Shares Jail" should contain these entries:
+      | /FOLDER |
+    Examples:
+      | file_name |
+      | /Share    |
+      | /shares   |
+      | /Share1   |
+
+  Scenario: try to create a folder named Shares
+    Given using spaces DAV path
+    When user "Brian" creates folder "/Shares" using the WebDAV API
+    Then the HTTP status code should be "405"
+    And for user "Brian" the space "Shares Jail" should contain these entries:
+      | /FOLDER |
+
+  Scenario: try to create a file named Shares
+    Given using spaces DAV path
+    When user "Brian" uploads file with content "some text" to "/Shares" using the WebDAV API
+    Then the HTTP status code should be "409"
+    And for user "Brian" the space "Shares Jail" should contain these entries:
+      | /FOLDER |

--- a/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature
+++ b/tests/acceptance/features/apiSpaces/createFileFolderWhenSharesSpaceExist.feature
@@ -43,13 +43,13 @@ Feature: create file or folder named similar to Shares folder
   Scenario: try to create a folder named Shares
     Given using spaces DAV path
     When user "Brian" creates folder "/Shares" using the WebDAV API
-    Then the HTTP status code should be "405"
+    Then the HTTP status code should be "201"
     And for user "Brian" the space "Shares Jail" should contain these entries:
       | /FOLDER |
 
   Scenario: try to create a file named Shares
     Given using spaces DAV path
     When user "Brian" uploads file with content "some text" to "/Shares" using the WebDAV API
-    Then the HTTP status code should be "409"
+    Then the HTTP status code should be "201"
     And for user "Brian" the space "Shares Jail" should contain these entries:
       | /FOLDER |


### PR DESCRIPTION
### Description
All the tests related to the `Shares` folder from core is to be implemented in ocis. This PR adds tests to create files and folders when space `Shares Jail` exists. Since `Shares` folder is not created on `OCIS` like as in `core`. Those Tests are shifted here. 

### Related issue
https://github.com/owncloud/ocis/issues/4154
https://github.com/owncloud/ocis/issues/3033

### Dependent Issue
https://github.com/owncloud/core/pull/40239

I have not updated the expected to failure command. see this comment https://github.com/owncloud/ocis/issues/3033#issuecomment-1195214016

