### PR TITLE
[tests-only] Remove passed tests from expected failures

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -43,8 +43,5 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpaces/moveSpaces.feature:186](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/moveSpaces.feature#L186)
 - [apiSpaces/moveSpaces.feature:189](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/moveSpaces.feature#L189)
 
-### [Removing the public link password is broken](https://github.com/owncloud/ocis/issues/4262)
-- [apiSpaces/editPublicLinkOfSpace.feature:55](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature#L55)
-
 ### [A space manager cannot see the public links of another manager](https://github.com/owncloud/ocis/issues/4260)
 - [apiSpaces/editPublicLinkOfSpace.feature:67](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature#L67)


### PR DESCRIPTION
after fixing https://github.com/owncloud/ocis/issues/4262 I deleted passed tests from expected failures