### PR TITLE
[tests-only] Enhance getSpaceByNameManager test code

### DIFF
--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -267,8 +267,9 @@ class SpacesContext implements Context {
 		$this->theUserListsAllAvailableSpacesUsingTheGraphApi($user);
 
 		$spaces = $this->getAvailableSpaces();
-		Assert::assertIsArray($spaces[$spaceName], "Space with name $spaceName for user $user not found");
-		Assert::assertNotEmpty($spaces[$spaceName]["root"]["webDavUrl"], "WebDavUrl for space with name $spaceName for user $user not found");
+		Assert::assertArrayHasKey($spaceName, $spaces, "Space with name '$spaceName' for user '$user' not found");
+		Assert::assertIsArray($spaces[$spaceName], "Data for space with name '$spaceName' for user '$user' not found");
+		Assert::assertNotEmpty($spaces[$spaceName]["root"]["webDavUrl"], "WebDavUrl for space with name '$spaceName' for user '$user' not found");
 
 		return $spaces[$spaceName];
 	}


### PR DESCRIPTION
## Description
This failed in drone CI:

https://drone.owncloud.com/owncloud/ocis/13901/42/8
```
runsh: Total unexpected failed scenarios throughout the test run:
apiSpaces/restoreSpaces.feature:63
apiSpaces/restoreSpaces.feature:64
```

```
        Failed step: When user "Brian" restores a disabled space "restore a space" without manager rights
        Notice: Undefined index: restore a space in /drone/src/tests/acceptance/features/bootstrap/SpacesContext.php line 270
```

Enhance the test code so that it checks for the existence of the array key, rather than just crashing like this.

Put the space name and username in single quotes in error messages. That will make messsages easier to understand. For example, "Undefined index: restore a space in..." - 'restore a space' is actually the name of the space, and that confused me for a minute when reading this sort of error output.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
