### PR TITLE
[tests-only] Fix clean-files target in tests/acceptance/docker/Makefile

### DIFF
--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -219,6 +219,7 @@ clean-docker-volumes: ## clean docker volumes created during acceptance tests
 	docker-compose down --remove-orphans -v
 
 .PHONY: clean-files
+clean-files:
 	@$(MAKE) --no-print-directory -C ../. clean-tests
 
 .PHONY: clean


### PR DESCRIPTION
## Description
My IDE noticed this. The `clean` target in `tests/acceptance/docker/Makefile` mentions `clean-files` but `clean-files` is not correctly defined.

What was broken because of this? Or what is going to break by fixing it?

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
