### PR TITLE
Set the alias link capability to `false`

### DIFF
--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -167,7 +167,7 @@ func FrontendConfigFromStruct(cfg *config.Config) map[string]interface{} {
 								"default_permissions":               22,
 								"search_min_length":                 cfg.SearchMinLength,
 								"public": map[string]interface{}{
-									"alias":                      true,
+									"alias":                      false,
 									"enabled":                    true,
 									"send_mail":                  true,
 									"defaultPublicLinkShareName": "Public link",


### PR DESCRIPTION
## Description
We can't resolve alias links in Web yet, but creating those will be possible within the next few days. Hence we figured it would be best to temporarily set the alias link capability to `false` (see https://github.com/owncloud/web/pull/7133#issuecomment-1191287739).
