### PR TITLE
pin wopiserver to v8.3.3 for continous deployment examples

### DIFF
--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -24,7 +24,7 @@ ADMIN_PASSWORD=
 DEMO_USERS=
 
 ### Wopi server settings ###
-# cs3org wopi server version. Defaults to "latest"
+# cs3org wopi server version. Defaults to "v8.3.3"
 WOPISERVER_DOCKER_TAG=
 # cs3org wopi server domain. Defaults to "wopiserver.owncloud.test"
 WOPISERVER_DOMAIN=

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       driver: "local"
     restart: always
   wopiserver:
-    image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-latest}
+    image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-v8.3.3}
     networks:
       ocis-net:
     entrypoint:

--- a/docs/ocis/deployment/ocis_wopi.md
+++ b/docs/ocis/deployment/ocis_wopi.md
@@ -80,7 +80,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
   DEMO_USERS=
 
   ### Wopi server settings ###
-  # cs3org wopi server version. Defaults to "latest"
+  # cs3org wopi server version. Defaults to "v8.3.3"
   WOPISERVER_DOCKER_TAG=
   # cs3org wopi server domain. Defaults to "wopiserver.owncloud.test"
   WOPISERVER_DOMAIN=


### PR DESCRIPTION
## Description
pins the wopiserver in the deployment examples to v8.3.3

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
