### PR TITLE
Switch default for user and group substring search

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1808,8 +1808,6 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
         environment = {
             "OCIS_URL": OCIS_URL,
             "OCIS_CONFIG_DIR": "/root/.ocis/config",
-            "LDAP_GROUP_SUBSTRING_FILTER_TYPE": "any",
-            "LDAP_USER_SUBSTRING_FILTER_TYPE": "any",
             "GATEWAY_GRPC_ADDR": "0.0.0.0:9142",  # cs3api-validator needs the cs3api gatway exposed
             "STORAGE_USERS_DRIVER": "%s" % (storage),
             "STORAGE_USERS_DRIVER_LOCAL_ROOT": "/srv/app/tmp/ocis/local/root",

--- a/services/groups/pkg/config/defaults/defaultconfig.go
+++ b/services/groups/pkg/config/defaults/defaultconfig.go
@@ -43,7 +43,7 @@ func DefaultConfig() *config.Config {
 				GroupBaseDN:              "ou=groups,o=libregraph-idm",
 				UserScope:                "sub",
 				GroupScope:               "sub",
-				GroupSubstringFilterType: "initial",
+				GroupSubstringFilterType: "any",
 				UserFilter:               "",
 				GroupFilter:              "",
 				UserObjectClass:          "inetOrgPerson",

--- a/services/users/pkg/config/defaults/defaultconfig.go
+++ b/services/users/pkg/config/defaults/defaultconfig.go
@@ -43,7 +43,7 @@ func DefaultConfig() *config.Config {
 				GroupBaseDN:             "ou=groups,o=libregraph-idm",
 				UserScope:               "sub",
 				GroupScope:              "sub",
-				UserSubstringFilterType: "initial",
+				UserSubstringFilterType: "any",
 				UserFilter:              "",
 				GroupFilter:             "",
 				UserObjectClass:         "inetOrgPerson",


### PR DESCRIPTION
## Description
We now default LDAP_GROUP_SUBSTRING_FILTER_TYPE and LDAP_USER_SUBSTRING_FILTER_TYPE
to "any", which means full substring search. The previous default was just using prefix
matching.

## Related Issue
Closes #4282

## Motivation and Context
See discussing in #4282
