### PR TITLE
[test-only]Api test. add tests for changing quota of the personal space

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -38,3 +38,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpaces/moveSpaces.feature:185](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/moveSpaces.feature#L185)
 - [apiSpaces/moveSpaces.feature:186](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/moveSpaces.feature#L186)
 - [apiSpaces/moveSpaces.feature:189](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/moveSpaces.feature#L189)
+
+### [Changing personal drive quota on another user as admin is not possible](https://github.com/owncloud/ocis/issues/4325)
+- [apiSpaces/changeSpaces.feature:221](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L221)
+- [apiSpaces/changeSpaces.feature:222](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L222)
+- [apiSpaces/changeSpaces.feature:223](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L223)
+- [apiSpaces/changeSpaces.feature:224](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L224)

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -183,7 +183,7 @@ Feature: Change data of space
     When user "<user>" has uploaded a file inside space "Project Jupiter" with content "" to ".space/newSpaceImage.png"
     And user "<user>" sets the file ".space/newSpaceImage.png" as a space image in a special section of the "Project Jupiter" space
     Then the HTTP status code should be "200"
-     And the user "<user>" should have a space called "Project Jupiter" owned by "Alice" with space image ".space/newSpaceImage.png" with these key and value pairs:
+    And the user "<user>" should have a space called "Project Jupiter" owned by "Alice" with space image ".space/newSpaceImage.png" with these key and value pairs:
       | key                                | value             |
       | name                               | Project Jupiter   |
       | special@@@0@@@size                 | 0                 |
@@ -196,3 +196,29 @@ Feature: Change data of space
       | user  |
       | Alice |
       | Brian |
+
+
+  Scenario Outline: An admin user set own quota of a personal space via the Graph API
+    When user "Admin" changes the quota of the "Admin" space to "<quotaValue>"
+    Then the HTTP status code should be "200"
+    When user "Admin" uploads a file inside space "Admin" with content "file is more than 15 bytes" to "file.txt" using the WebDAV API
+    Then the HTTP status code should be <code>
+    Examples:
+      | quotaValue | code                    |
+      | 15         | "507"                   |
+      | 10000      | between "201" and "204" |
+      | 0          | between "201" and "204" |
+      | -1         | between "201" and "204" |
+
+
+  Scenario Outline: An admin user set an user personal space quota of via the Graph API
+    When user "Admin" changes the quota of the "Brian Murphy" space to "<quotaValue>"
+    Then the HTTP status code should be "200"
+    When user "Brian" uploads a file inside space "Brian Murphy" with content "file is more than 15 bytes" to "file.txt" using the WebDAV API
+    Then the HTTP status code should be <code>
+    Examples:
+      | quotaValue | code                    |
+      | 15         | "507"                   |
+      | 10000      | between "201" and "204" |
+      | 0          | between "201" and "204" |
+      | -1         | between "201" and "204" |


### PR DESCRIPTION
- added api test. for now user admin can change only own quota 
- if admin tries to change quota another user, he get 403: https://github.com/owncloud/ocis/issues/4325
- failed tests added to expected failures
- changed method `getSpaceByName`. If user admin call this method, he get **ALL** spaces `/graph/v1.0/drives`. in other cases users still see own personal space and project spaces(if user is member) `/graph/v1.0/me/drives`. 
- brought back "cleaning after tests". But we can enable it, if admin get ability to disable and delete others spaces. 