### PR TITLE
Branch to debug the preview fail on ocis

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=3eebf7b731759e71c76481fa2de1d5cdb308f21d
-CORE_BRANCH=master
+CORE_COMMITID=7a5595c55f849cc3f57ca9940a8278530f397244
+CORE_BRANCH=debugPreviewsNightylFailure
 
 # The test runner source for UI tests
 WEB_COMMITID=9882f20cdce1b5e699b6ff31057bce29189ab4c7

--- a/.drone.star
+++ b/.drone.star
@@ -84,31 +84,31 @@ config = {
         "ocis",
     ],
     "cs3ApiTests": {
-        "skip": False,
+        "skip": True,
         "earlyFail": True,
     },
     "localApiTests": {
-        "skip": False,
+        "skip": True,
         "earlyFail": True,
     },
     "apiTests": {
         "numberOfParts": 10,
         "skip": False,
-        "skipExceptParts": [],
+        "skipExceptParts": [10],
         "earlyFail": True,
     },
     "uiTests": {
         "filterTags": "@ocisSmokeTest",
-        "skip": False,
+        "skip": True,
         "skipExceptParts": [],
         "earlyFail": True,
     },
     "e2eTests": {
-        "skip": False,
+        "skip": True,
         "earlyFail": True,
     },
     "settingsUITests": {
-        "skip": False,
+        "skip": True,
         "earlyFail": True,
     },
     "parallelApiTests": {


### PR DESCRIPTION
Cannot reproduce nightly fail locally for preview failure (core api tests on ocis). So Debugging in CI for nightly failure https://drone.owncloud.com/owncloud/ocis/14181/52/3

Related issue: https://github.com/owncloud/ocis/issues/4339 