### PR TITLE
[tests-only][full-ci]Add `/Shares` realated tests from core

### DIFF
--- a/tests/acceptance/features/apiSpaces/checksum.feature
+++ b/tests/acceptance/features/apiSpaces/checksum.feature
@@ -1,0 +1,31 @@
+@api @skipOnOcV10
+Feature: checksums
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  @files_sharing-app-required @issue-ocis-reva-196
+  Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    And user "Alice" has shared file "/myChecksumFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/myChecksumFile.txt" offered by user "Alice"
+    When user "Brian" requests the checksum of "/myChecksumFile.txt" in space "Shares Jail" via propfind
+    Then the HTTP status code should be "207"
+    And the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
+
+  @files_sharing-app-required @issue-ocis-reva-196
+  Scenario: Modifying a shared file should return correct checksum in the propfind using new DAV path
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    And user "Alice" has shared file "/myChecksumFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/myChecksumFile.txt" offered by user "Alice"
+    When user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/myChecksumFile.txt" in space "Shares Jail" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as user "Alice" the webdav checksum of "/myChecksumFile.txt" via propfind should match "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a"

--- a/tests/acceptance/features/apiSpaces/checksum.feature
+++ b/tests/acceptance/features/apiSpaces/checksum.feature
@@ -3,27 +3,23 @@ Feature: checksums
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-
-  @files_sharing-app-required @issue-ocis-reva-196
-  Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
-    Given the administrator has set the default folder for received shares to "Shares"
+    And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+
+  @files_sharing-app-required @issue-ocis-reva-196
+  Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     And user "Alice" has shared file "/myChecksumFile.txt" with user "Brian"
     And user "Brian" has accepted share "/myChecksumFile.txt" offered by user "Alice"
-    When user "Brian" requests the checksum of "/myChecksumFile.txt" in space "Shares Jail" via propfind
+    When user "Brian" requests the checksum of file "/myChecksumFile.txt" in space "Shares Jail" via propfind using the WebDAV API
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
   @files_sharing-app-required @issue-ocis-reva-196
   Scenario: Modifying a shared file should return correct checksum in the propfind using new DAV path
-    Given the administrator has set the default folder for received shares to "Shares"
-    And auto-accept shares has been disabled
-    And using spaces DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     And user "Alice" has shared file "/myChecksumFile.txt" with user "Brian"
     And user "Brian" has accepted share "/myChecksumFile.txt" offered by user "Alice"
     When user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/myChecksumFile.txt" in space "Shares Jail" using the WebDAV API

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2560,6 +2560,74 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" requests the checksum of "([^"]*)" in space "([^"]*)" via propfind$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $spaceName
+	 *
+	 * @throws GuzzleException
+	 */
+	public function userRequestsTheChecksumViaPropfindInSpace(
+		string $user,
+		string $path,
+		string $spaceName
+	): void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($path, "/");
+		$body = '<?xml version="1.0"?>
+			<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+			  <d:prop>
+				<oc:checksums />
+			  </d:prop>
+			</d:propfind>';
+
+		$this->featureContext->setResponse(
+			$this->sendPropfindRequestToUrl(
+				$fullUrl,
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				$this->featureContext->getStepLineRef(),
+				[],
+				$body
+			)
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" uploads file with checksum "([^"]*)" and content "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $checksum
+	 * @param string $content
+	 * @param string $path
+	 * @param string $spaceName
+	 *
+	 * @throws GuzzleException
+	 */
+	public function userUploadsFileWithChecksumWithContentInSpace(
+		string $user,
+		string $checksum,
+		string $content,
+		string $path,
+		string $spaceName
+	): void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($path, "/");
+
+		$this->featureContext->setResponse(
+			$this->sendPutRequestToUrl(
+				$fullUrl,
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				"",
+				['OC-Checksum' => $checksum],
+				$content
+			)
+		);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" downloads version of the file "([^"]*)" with the index "([^"]*)" of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param  string $user

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2560,7 +2560,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" requests the checksum of "([^"]*)" in space "([^"]*)" via propfind$/
+	 * @When /^user "([^"]*)" requests the checksum of (?:file|folder|entry) "([^"]*)" in space "([^"]*)" via propfind using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path


### PR DESCRIPTION
### Description

This PR adds the tests for checksum related to `/Shares` which is removed from this PR https://github.com/owncloud/core/pull/40271 as `/Shares` related implementation is not in core and is shifted to ocis.

### Related issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045

Note: Most of the tests for the checksum is run from core on ocis. This test added on ocis is only related to `/Shares` (Shares Jail)

Note: Expected to failure for this PR is removed in this PR https://github.com/owncloud/ocis/pull/4364