### PR TITLE
[test-only]Api test. check that link or share exist for space members

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,11 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch"
+        },
+        {
             "name": "oCIS server",
             "type": "go",
             "request": "launch",

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -25,3 +25,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 ### [Changing personal drive quota on another user as admin is not possible](https://github.com/owncloud/ocis/issues/4325)
 - [apiSpaces/changeSpaces.feature:221](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L221)
 
+### [Member of project space cannot see "share a resource with people](https://github.com/owncloud/ocis/issues/4347)
+- [apiSpaces/shareSubItemOfSpace.feature:74](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature#L74)
+- [apiSpaces/shareSubItemOfSpace.feature:75](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature#L75)
+- [apiSpaces/shareSubItemOfSpace.feature:76](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature#L76)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -25,7 +25,3 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 ### [Changing personal drive quota on another user as admin is not possible](https://github.com/owncloud/ocis/issues/4325)
 - [apiSpaces/changeSpaces.feature:221](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L221)
 
-### [Member of project space cannot see "share a resource with people](https://github.com/owncloud/ocis/issues/4347)
-- [apiSpaces/shareSubItemOfSpace.feature:74](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature#L74)
-- [apiSpaces/shareSubItemOfSpace.feature:75](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature#L75)
-- [apiSpaces/shareSubItemOfSpace.feature:76](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature#L76)

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -52,18 +52,18 @@ Feature: A manager of the space can edit public link
       | 15          | read,update,create,delete |          | newName  | 2042-03-25T23:59:59+0100 |
 
 
-  Scenario Outline: Only users with manager role can see a created public link
+  Scenario Outline: All members can see a created public link
     Given using OCS API version "2"
     When user "Alice" shares a space "edit space" to user "Brian" with role "<role>"
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And for user "Alice" the space "edit space" should contain the last created public link
-    And for user "Brian" the space "edit space" <shouldOrNot> contain the last created public link
+    And for user "Brian" the space "edit space" should contain the last created public link
     Examples:
-      | role    | shouldOrNot |
-      | manager | should      |
-      | editor  | should      |
-      | viewer  | should      |
+      | role    |
+      | manager |
+      | editor  |
+      | viewer  |
 
 
   Scenario Outline: Members of the space try to edit a public link

--- a/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/shareSubItemOfSpace.feature
@@ -62,3 +62,15 @@ Feature: Share a file or folder that is inside a space
       | file.txt | editor    | 404        | No share permission |
       | file.txt | viewer    | 404        | No share permission |
       | folder   | viewer    | 404        | No share permission |
+
+
+  Scenario Outline: An user participant of the project space can see the created resources share
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
+    When user "Alice" shares the following entity "file.txt" inside of space "share sub-item" with user "Bob" with role "editor"
+    Then for user "Alice" the space "share sub-item" should contain the last created share of the file "file.txt"
+    And for user "Brian" the space "share sub-item" should contain the last created share of the file "file.txt"
+    Examples:
+      | spaceRole |
+      | editor    |
+      | viewer    |
+      | manager   |

--- a/tests/acceptance/features/apiSpaces/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpaces/shareSubItemOfSpaceViaPublicLink.feature
@@ -121,11 +121,11 @@ Feature: Share a file or folder that is inside a space via public link
 
   Scenario Outline: An user participant of the project space can see the created public resources link
     Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
-    And user "Alice" has created a public link share inside of space "share sub-item" with settings:
+    When user "Alice" creates a public link share inside of space "share sub-item" with settings:
       | path        | folder/file.txt |
       | shareType   | 3               |
       | permissions | 1               |
-    And for user "Brian" the space "share sub-item" should contain the last created public link of the file "folder/file.txt"
+    Then for user "Brian" the space "share sub-item" should contain the last created public link of the file "folder/file.txt"
     Examples:
       | spaceRole |
       | editor    |

--- a/tests/acceptance/features/apiSpaces/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpaces/shareSubItemOfSpaceViaPublicLink.feature
@@ -117,3 +117,17 @@ Feature: Share a file or folder that is inside a space via public link
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+
+  Scenario Outline: An user participant of the project space can see the created public resources link
+    Given user "Alice" has shared a space "share sub-item" to user "Brian" with role "<spaceRole>"
+    And user "Alice" has created a public link share inside of space "share sub-item" with settings:
+      | path        | folder/file.txt |
+      | shareType   | 3               |
+      | permissions | 1               |
+    And for user "Brian" the space "share sub-item" should contain the last created public link of the file "folder/file.txt"
+    Examples:
+      | spaceRole |
+      | editor    |
+      | viewer    |
+      | manager   |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -381,8 +381,7 @@ class SpacesContext implements Context {
 	 * 
 	 * @return void
 	 */
-	public function setLastShareData(): void
-	{
+	public function setLastShareData(): void {
 		// set last response as PublicShareData
 		$this->featureContext->setLastPublicShareData($this->featureContext->getResponseXml(null, __METHOD__));
 		// set last shareId if ShareData exists
@@ -2078,7 +2077,7 @@ class SpacesContext implements Context {
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
-	 * @param TableNode|null $table
+	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws GuzzleException
@@ -2086,7 +2085,7 @@ class SpacesContext implements Context {
 	public function createPublicLinkToEntityInsideOfSpaceRequest(
 		string $user,
 		string $spaceName,
-		?TableNode $table
+		TableNode $table
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$rows = $table->getRowsHash();
@@ -2122,19 +2121,19 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" has created a public link share inside of space "([^"]*)" with settings:$/
+	 * @Given /^user "([^"]*)" has created a public link share inside of space "([^"]*)" with settings:$/
 	 *
 	 * @param  string $user
 	 * @param  string $spaceName
-	 * @param TableNode|null $table
+	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function userHAsCreatedPublicLinkToEntityInsideOfSpaceRequest(
+	public function userHasCreatedPublicLinkToEntityInsideOfSpaceRequest(
 		string $user,
 		string $spaceName,
-		?TableNode $table
+		TableNode $table
 	): void {
 		$this->createPublicLinkToEntityInsideOfSpaceRequest($user, $spaceName, $table);
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -377,6 +377,21 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * using method from core to set share data
+	 * 
+	 * @return void
+	 */
+	public function setLastShareData(): void
+	{
+		// set last response as PublicShareData
+		$this->featureContext->setLastPublicShareData($this->featureContext->getResponseXml(null, __METHOD__));
+		// set last shareId if ShareData exists
+		if (isset($this->featureContext->getLastPublicShareData()->data)) {
+			$this->featureContext->setLastPublicLinkShareId((string) $this->featureContext->getLastPublicShareData()->data[0]->id);
+		}
+	}
+
+	/**
 	 * @BeforeScenario
 	 *
 	 * @param BeforeScenarioScope $scope
@@ -2055,8 +2070,7 @@ class SpacesContext implements Context {
 				$body
 			)
 		);
-		$this->featureContext->setLastPublicShareData($this->featureContext->getResponseXml(null, __METHOD__));
-		$this->featureContext->setLastPublicLinkShareId((string) $this->featureContext->getLastPublicShareData()->data[0]->id);
+		$this->setLastShareData();
 	}
 
 	/**
@@ -2104,8 +2118,7 @@ class SpacesContext implements Context {
 			)
 		);
 
-		$this->featureContext->setLastPublicShareData($this->featureContext->getResponseXml(null, __METHOD__));
-		$this->featureContext->setLastPublicLinkShareId((string) $this->featureContext->getLastPublicShareData()->data[0]->id);
+		$this->setLastShareData();
 	}
 
 	/**
@@ -2946,12 +2959,7 @@ class SpacesContext implements Context {
 			)
 		);
 
-		// set last response as PublicShareData. using method from core
-		$this->featureContext->setLastPublicShareData($this->featureContext->getResponseXml(null, __METHOD__));
-		// set last shareId if ShareData exists. using method from core
-		if (isset($this->featureContext->getLastPublicShareData()->data)) {
-			$this->featureContext->setLastPublicLinkShareId((string) $this->featureContext->getLastPublicShareData()->data[0]->id);
-		}
+		$this->setLastShareData();
 	}
 
 	/**


### PR DESCRIPTION
- Members of the project space should be able to see public link or share resourses
- added api tests
- created bug #4347 and failed tests moved to expected failures 

note: I could not add tests for: check that **folder** contains link because there were difficulties in getting folderID (should hard parsing xml). I've marked it as a technical debt