### PR TITLE
add expand query for personal drive

### DIFF
--- a/changelog/unreleased/user-expand-drive.md
+++ b/changelog/unreleased/user-expand-drive.md
@@ -1,0 +1,5 @@
+Enhancement: Expand personal drive on the graph user
+
+We can now list the personal drive on the users endpoint via the graph API. A user can add an `$expand=drive` query to list the personal drive of the requested user.
+
+https://github.com/owncloud/ocis/pull/4357

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.0
 	github.com/orcaman/concurrent-map v1.0.0
-	github.com/owncloud/libre-graph-api-go v0.14.3
+	github.com/owncloud/libre-graph-api-go v0.16.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/rs/zerolog v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -973,6 +973,8 @@ github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CF
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
 github.com/owncloud/libre-graph-api-go v0.14.3 h1:+lkIkLHjrLfazANYfg2MYEhaJsMXzfOjtIY1hF3PbU4=
 github.com/owncloud/libre-graph-api-go v0.14.3/go.mod h1:579sFrPP7aP24LZXGPopLfvE+hAka/2DYHk0+Ij+w+U=
+github.com/owncloud/libre-graph-api-go v0.16.0 h1:CyW69/lREyx+nkUrXYJnMyshBygwkfPVCjm0ngqjcYs=
+github.com/owncloud/libre-graph-api-go v0.16.0/go.mod h1:579sFrPP7aP24LZXGPopLfvE+hAka/2DYHk0+Ij+w+U=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -213,13 +213,13 @@ func (g Graph) GetUser(w http.ResponseWriter, r *http.Request) {
 			d.Quota = quota
 			if slices.Contains(sel, "drive") || slices.Contains(exp, "drive") {
 				if *d.DriveType == "personal" {
-					drives = append(drives, *d)
+					user.Drive = d
 				}
 			} else {
 				drives = append(drives, *d)
+				user.Drives = drives
 			}
 		}
-		user.Drives = drives
 	}
 
 	render.Status(r, http.StatusOK)


### PR DESCRIPTION
## Description

Enhancement: Expand personal drive on the graph user

We can now list the personal drive on the users endpoint via the graph API. A user can add an `$expand=drive` query to list the personal drive of the requested user.


## Related Issue

- Fixes #4327 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

### Request Example

```sh
curl -L -X GET "https://localhost:9200/graph/v1.0/users/f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/?$expand=drive" \
-H "Authorization: Basic YWRtaW46YWRtaW4="
```

#### Response

```json
{
    "displayName": "Marie Skłodowska Curie",
    "drive": {
        "driveAlias": "personal/marie",
        "driveType": "personal",
        "id": "1284d238-aa92-42ce-bdc4-0b0000009157$f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
        "lastModifiedDateTime": "2022-08-03T17:38:40.549113+02:00",
        "name": "Marie Skłodowska Curie",
        "owner": {
            "user": {
                "id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
            }
        },
        "quota": {
            "remaining": 13343125504,
            "state": "normal",
            "used": 1
        },
        "root": {
            "eTag": "\"28e59e5290b57eaf2fb9b3469a21970a\"",
            "id": "1284d238-aa92-42ce-bdc4-0b0000009157$f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
            "webDavUrl": "https://localhost:9200/dav/spaces/1284d238-aa92-42ce-bdc4-0b0000009157$f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
        }
    },
    "id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
    "mail": "marie@example.org",
    "onPremisesSamAccountName": "marie"
}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
