### PR TITLE
[tests-only][full-ci]Add `/Shares` related copy tests on ocis which are removed from core

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -43,3 +43,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpaces/lockSpaces.feature:72](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/lockSpaces.feature#L72)
 - [apiSpaces/lockSpaces.feature:89](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/lockSpaces.feature#L89)
 - [apiSpaces/lockSpaces.feature:90](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/lockSpaces.feature#L90)
+
+### [copy to overwrite (file and folder) from Personal to Shares Jail behaves differently](https://github.com/owncloud/ocis/issues/4393)
+- [apiSpaces/copySpaces.feature:487](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/copySpaces.feature#L487)
+- [apiSpaces/copySpaces.feature:501](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/copySpaces.feature#L501)

--- a/tests/acceptance/features/apiSpaces/copySpaces.feature
+++ b/tests/acceptance/features/apiSpaces/copySpaces.feature
@@ -14,14 +14,14 @@ Feature: copy file
   Scenario Outline: Copying a file within a same space project with role manager and editor
     Given the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
-    And user "Alice" has created a folder "newfolder" in space "Project"
-    And user "Alice" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
+    And user "Alice" has created a folder "/newfolder" in space "Project"
+    And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/insideSpace.txt"
     And user "Alice" has shared a space "Project" to user "Brian" with role "<role>"
-    When user "Brian" copies file "insideSpace.txt" to "/newfolder/insideSpace.txt" inside space "Project" using the WebDAV API
+    When user "Brian" copies file "/insideSpace.txt" to "/newfolder/insideSpace.txt" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Brian" the space "Project" should contain these entries:
-      | newfolder/insideSpace.txt |
-    And for user "Alice" the content of the file "newfolder/insideSpace.txt" of the space "Project" should be "some content"
+      | /newfolder/insideSpace.txt |
+    And for user "Alice" the content of the file "/newfolder/insideSpace.txt" of the space "Project" should be "some content"
     Examples:
       | role    |
       | manager |
@@ -31,27 +31,27 @@ Feature: copy file
   Scenario: Copying a file within a same space project with role viewer
     Given the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
-    And user "Alice" has created a folder "newfolder" in space "Project"
+    And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
     And user "Alice" has shared a space "Project" to user "Brian" with role "viewer"
-    When user "Brian" copies file "insideSpace.txt" to "newfolder/insideSpace.txt" inside space "Project" using the WebDAV API
+    When user "Brian" copies file "/insideSpace.txt" to "/newfolder/insideSpace.txt" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Brian" the space "Project" should not contain these entries:
-      | newfolder/insideSpace.txt |
+      | /newfolder/insideSpace.txt |
 
 
   Scenario Outline: User copies a file from a space project with a different role to a space project with the manager role
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi
     And user "Brian" has created a space "Project2" with the default quota using the GraphApi
-    And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "project1.txt"
+    And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "/project1.txt"
     And user "Brian" has shared a space "Project2" to user "Alice" with role "<to_role>"
     And user "Brian" has shared a space "Project1" to user "Alice" with role "<from_role>"
-    When user "Alice" copies file "project1.txt" from space "Project1" to "project1.txt" inside space "Project2" using the WebDAV API
+    When user "Alice" copies file "/project1.txt" from space "Project1" to "/project1.txt" inside space "Project2" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Project2" should contain these entries:
-      | project1.txt |
-    And for user "Alice" the content of the file "project1.txt" of the space "Project2" should be "Project1 content"
+      | /project1.txt |
+    And for user "Alice" the content of the file "/project1.txt" of the space "Project2" should be "Project1 content"
     Examples:
       | from_role | to_role |
       | manager   | manager |
@@ -64,10 +64,10 @@ Feature: copy file
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi
     And user "Brian" has created a space "Project2" with the default quota using the GraphApi
-    And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "project1.txt"
+    And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "/project1.txt"
     And user "Brian" has shared a space "Project2" to user "Alice" with role "viewer"
     And user "Brian" has shared a space "Project1" to user "Alice" with role "<role>"
-    When user "Alice" copies file "project1.txt" from space "Project1" to "project1.txt" inside space "Project2" using the WebDAV API
+    When user "Alice" copies file "/project1.txt" from space "Project1" to "/project1.txt" inside space "Project2" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" the space "Project2" should not contain these entries:
       | project1.txt |
@@ -80,13 +80,13 @@ Feature: copy file
   Scenario Outline: User copies a file from space project with different role to space personal
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
-    And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "project.txt"
+    And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
     And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
-    When user "Alice" copies file "project.txt" from space "Project" to "project.txt" inside space "Personal" using the WebDAV API
+    When user "Alice" copies file "/project.txt" from space "Project" to "/project.txt" inside space "Personal" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | project.txt |
-    And for user "Alice" the content of the file "project.txt" of the space "Personal" should be "Project content"
+    And for user "Alice" the content of the file "/project.txt" of the space "Personal" should be "Project content"
     Examples:
       | role    |
       | manager |
@@ -98,14 +98,14 @@ Feature: copy file
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created folder "/testshare"
-    And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "project.txt"
+    And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
     And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "31"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    When user "Alice" copies file "project.txt" from space "Project" to "/testshare/project.txt" inside space "Shares Jail" using the WebDAV API
+    When user "Alice" copies file "/project.txt" from space "Project" to "/testshare/project.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" folder "testshare" of the space "Shares Jail" should contain these files:
-      | project.txt |
+      | /project.txt |
     And for user "Alice" the content of the file "/testshare/project.txt" of the space "Shares Jail" should be "Project content"
     Examples:
       | role    |
@@ -118,11 +118,11 @@ Feature: copy file
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created folder "/testshare"
-    And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "project.txt"
+    And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
     And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "17"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    When user "Alice" copies file "project.txt" from space "Project" to "/testshare/project.txt" inside space "Shares Jail" using the WebDAV API
+    When user "Alice" copies file "/project.txt" from space "Project" to "/testshare/project.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" the space "Shares Jail" should not contain these entries:
       | /testshare/project.txt |
@@ -138,11 +138,11 @@ Feature: copy file
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
     And user "Alice" has uploaded file with content "personal space content" to "/personal.txt"
-    When user "Alice" copies file "personal.txt" from space "Personal" to "personal.txt" inside space "Project" using the WebDAV API
+    When user "Alice" copies file "/personal.txt" from space "Personal" to "/personal.txt" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Project" should contain these entries:
-      | personal.txt |
-    And for user "Alice" the content of the file "personal.txt" of the space "Project" should be "personal space content"
+      | /personal.txt |
+    And for user "Alice" the content of the file "/personal.txt" of the space "Project" should be "personal space content"
     Examples:
       | role    |
       | manager |
@@ -154,10 +154,10 @@ Feature: copy file
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" to user "Alice" with role "viewer"
     And user "Alice" has uploaded file with content "personal space content" to "/personal.txt"
-    When user "Alice" copies file "personal.txt" from space "Personal" to "personal.txt" inside space "Project" using the WebDAV API
+    When user "Alice" copies file "/personal.txt" from space "Personal" to "/personal.txt" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" the space "Project" should not contain these entries:
-      | personal.txt |
+      | /personal.txt |
 
 
   Scenario: User copies a file from space personal to space shares jail with role editor
@@ -165,7 +165,7 @@ Feature: copy file
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "31"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
     And user "Alice" has uploaded file with content "personal content" to "personal.txt"
-    When user "Alice" copies file "personal.txt" from space "Personal" to "/testshare/personal.txt" inside space "Shares Jail" using the WebDAV API
+    When user "Alice" copies file "/personal.txt" from space "Personal" to "/testshare/personal.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" folder "testshare" of the space "Shares Jail" should contain these files:
       | personal.txt |
@@ -176,8 +176,8 @@ Feature: copy file
     Given user "Brian" has created folder "/testshare"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "17"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    And user "Alice" has uploaded file with content "personal content" to "personal.txt"
-    When user "Alice" copies file "personal.txt" from space "Personal" to "/testshare/personal.txt" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has uploaded file with content "personal content" to "/personal.txt"
+    When user "Alice" copies file "/personal.txt" from space "Personal" to "/testshare/personal.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" the space "Shares Jail" should not contain these entries:
       | /testshare/personal.txt |
@@ -189,7 +189,7 @@ Feature: copy file
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "testshare.txt" inside space "Personal" using the WebDAV API
+    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "/testshare.txt" inside space "Personal" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | /testshare.txt |
@@ -208,11 +208,11 @@ Feature: copy file
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "testshare.txt" inside space "Project" using the WebDAV API
+    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "/testshare.txt" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Project" should contain these entries:
       | /testshare.txt |
-    And for user "Alice" the content of the file "testshare.txt" of the space "Project" should be "testshare content"
+    And for user "Alice" the content of the file "/testshare.txt" of the space "Project" should be "testshare content"
     Examples:
       | role    | permissions |
       | manager | 31          |
@@ -229,7 +229,7 @@ Feature: copy file
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "testshare.txt" inside space "Project" using the WebDAV API
+    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "/testshare.txt" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" the space "Project" should not contain these entries:
       | /testshare.txt |
@@ -250,7 +250,7 @@ Feature: copy file
     When user "Alice" copies file "/testshare1/testshare1.txt" from space "Shares Jail" to "/testshare2/testshare1.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" folder "testshare2" of the space "Shares Jail" should contain these files:
-      | testshare1.txt |
+      | /testshare1.txt |
     And for user "Brian" the space "Personal" should contain these entries:
       | /testshare2/testshare1.txt |
     And for user "Alice" the content of the file "/testshare2/testshare1.txt" of the space "Shares Jail" should be "testshare1 content"
@@ -284,11 +284,11 @@ Feature: copy file
   Scenario Outline: Copying a folder within the same space project with different role
     Given the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
-    And user "Alice" has created a folder "folder1" in space "Project"
-    And user "Alice" has created a folder "folder2" in space "Project"
-    And user "Alice" has uploaded a file inside space "Project" with content "some content" to "folder2/demo.txt"
+    And user "Alice" has created a folder "/folder1" in space "Project"
+    And user "Alice" has created a folder "/folder2" in space "Project"
+    And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/folder2/demo.txt"
     And user "Alice" has shared a space "Project" to user "Brian" with role "<role>"
-    When user "Brian" copies folder "folder2" to "folder1/folder2" inside space "Project" using the WebDAV API
+    When user "Brian" copies folder "/folder2" to "/folder1/folder2" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "<status-code>"
     And for user "Brian" the space "Project" <shouldOrNot> contain these entries:
       | folder1/folder2/demo.txt |
@@ -304,14 +304,14 @@ Feature: copy file
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi
     And user "Brian" has created a space "Project2" with the default quota using the GraphApi
-    And user "Brian" has created a folder "folder1" in space "Project1"
+    And user "Brian" has created a folder "/folder1" in space "Project1"
     And user "Brian" has uploaded a file inside space "Project1" with content "some content" to "/folder1/demo.txt"
     And user "Brian" has shared a space "Project2" to user "Alice" with role "<to_role>"
     And user "Brian" has shared a space "Project1" to user "Alice" with role "<from_role>"
-    When user "Alice" copies folder "folder1" from space "Project1" to "folder1" inside space "Project2" using the WebDAV API
+    When user "Alice" copies folder "/folder1" from space "Project1" to "/folder1" inside space "Project2" using the WebDAV API
     Then the HTTP status code should be "<status-code>"
     And for user "Alice" the space "Project2" <shouldOrNot> contain these entries:
-      | folder1/demo.txt |
+      | /folder1/demo.txt |
     Examples:
       | from_role | to_role | status-code | shouldOrNot |
       | manager   | manager | 201         | should      |
@@ -326,13 +326,13 @@ Feature: copy file
   Scenario Outline: User copies a folder from space project with different role to space personal
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
-    And user "Brian" has created a folder "folder1" in space "Project"
+    And user "Brian" has created a folder "/folder1" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "/folder1/demo.txt"
     And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
-    When user "Alice" copies file "folder1" from space "Project" to "folder1" inside space "Personal" using the WebDAV API
+    When user "Alice" copies file "/folder1" from space "Project" to "/folder1" inside space "Personal" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
-      | folder1/demo.txt |
+      | /folder1/demo.txt |
     Examples:
       | role    |
       | manager |
@@ -344,15 +344,15 @@ Feature: copy file
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created folder "/testshare"
-    And user "Brian" has created a folder "folder1" in space "Project"
+    And user "Brian" has created a folder "/folder1" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "/folder1/demo.txt"
     And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    When user "Alice" copies folder "folder1" from space "Project" to "/testshare/folder1" inside space "Shares Jail" using the WebDAV API
+    When user "Alice" copies folder "/folder1" from space "Project" to "/testshare/folder1" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "<status-code>"
     And for user "Alice" folder "testshare" of the space "Shares Jail" <shouldOrNot> contain these files:
-      | folder1/demo.txt |
+      | /folder1/demo.txt |
     Examples:
       | role    | shouldOrNot | permissions | status-code |
       | manager | should      | 31          | 201         |
@@ -367,12 +367,12 @@ Feature: copy file
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
-    And user "Alice" has created folder "folder1"
+    And user "Alice" has created folder "/folder1"
     And user "Alice" has uploaded file with content "some content" to "folder1/demo.txt"
-    When user "Alice" copies folder "folder1" from space "Personal" to "folder1" inside space "Project" using the WebDAV API
+    When user "Alice" copies folder "/folder1" from space "Personal" to "/folder1" inside space "Project" using the WebDAV API
     Then the HTTP status code should be "<status-code>"
     And for user "Alice" the space "Project" <shouldOrNot> contain these entries:
-      | folder1/demo.txt |
+      | /folder1/demo.txt |
     Examples:
       | role    | shouldOrNot | status-code |
       | manager | should      | 201         |
@@ -386,7 +386,7 @@ Feature: copy file
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
     And user "Alice" has created folder "folder1"
     And user "Alice" has uploaded file with content "some content" to "folder1/demo.txt"
-    When user "Alice" copies folder "folder1" from space "Personal" to "/testshare/folder1" inside space "Shares Jail" using the WebDAV API
+    When user "Alice" copies folder "/folder1" from space "Personal" to "/testshare/folder1" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "<status-code>"
     And for user "Alice" folder "testshare" of the space "Shares Jail" <shouldOrNot> contain these files:
       | folder1/demo.txt |
@@ -402,7 +402,7 @@ Feature: copy file
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "testshare.txt" inside space "Personal" using the WebDAV API
+    When user "Alice" copies file "/testshare/testshare.txt" from space "Shares Jail" to "/testshare.txt" inside space "Personal" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | /testshare.txt |
@@ -465,13 +465,13 @@ Feature: copy file
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" copies file "/textfile0.txt" from space "Personal" to "/testshare/textfile0.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "403"
-    And user "Alice" should not be able to download file "/testshare/textfile0.txt" inside space "Shares Jail"
+    And user "Alice" should not be able to download file "/testshare/textfile0.txt" from space "Shares Jail"
 
 
   Scenario: Copying a file to overwrite a file into a folder with no permissions
     Given using spaces DAV path
     And user "Brian" has created folder "/testshare"
-    And user "Brian" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
+    And user "Brian" has uploaded file with content "ownCloud test text file 1" to "/testshare/overwritethis.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -479,7 +479,6 @@ Feature: copy file
       | permissions | read      |
       | shareWith   | Alice     |
     And user "Alice" has accepted share "/testshare" offered by user "Brian"
-    And user "Brian" has copied file "textfile1.txt" to "/testshare/overwritethis.txt"
     When user "Alice" copies file "/textfile0.txt" from space "Personal" to "/testshare/overwritethis.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" the content of the file "/testshare/overwritethis.txt" of the space "Shares Jail" should be "ownCloud test text file 1"
@@ -487,7 +486,7 @@ Feature: copy file
 
   Scenario: copy a file over the top of an existing folder received as a user share
     Given using spaces DAV path
-    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
     And user "Brian" has created folder "/BRIAN-Folder"
     And user "Brian" has created folder "BRIAN-Folder/sample-folder"
     And user "Brian" has shared folder "BRIAN-Folder" with user "Alice"
@@ -495,8 +494,6 @@ Feature: copy file
     When user "Alice" copies file "/textfile1.txt" from space "Personal" to "/BRIAN-Folder" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And for user "Alice" the content of the file "/BRIAN-Folder" of the space "Shares Jail" should be "ownCloud test text file 1"
-    And for user "Alice" folder "BRIAN-Folder" of the space "Shares Jail" should not contain these files:
-      | /sample-folder |
     And as "Alice" file "/textfile1.txt" should exist
     And user "Alice" should not have any received shares
 
@@ -511,25 +508,27 @@ Feature: copy file
     When user "Alice" copies folder "/FOLDER" from space "Personal" to "/sharedfile1.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/FOLDER/sample-folder" should exist
-    And for user "Alice" folder "sharedfile1.txt" of the space "Shares Jail" should contain these files:
+    And for user "Alice" folder "/sharedfile1.txt" of the space "Shares Jail" should contain these files:
       | /sample-folder |
     And user "Alice" should not have any received shares
 
 
   Scenario: copy a folder into another folder at different level which is received as a user share
     Given using spaces DAV path
-    And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with user "Alice"
+    And user "Brian" has created folder "/BRIAN-FOLDER"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with user "Alice"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    And user "Alice" has created folder "Sample-Folder-A"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b/sample-folder-c"
-    When user "Alice" copies folder "Sample-Folder-A/sample-folder-b" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-folder" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has created folder "/Sample-Folder-A"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b/sample-folder-c"
+    When user "Alice" copies folder "/Sample-Folder-A/sample-folder-b" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-folder" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/Sample-Folder-A/sample-folder-b/sample-folder-c" should exist
-    And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these files:
+    And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these entries:
+      | /second-level-folder/third-level-folder/sample-folder-c |
+    And for user "Brian" folder "BRIAN-FOLDER" of the space "Personal" should contain these files:
       | /second-level-folder/third-level-folder/sample-folder-c |
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
@@ -537,15 +536,15 @@ Feature: copy file
 
   Scenario: copy a file into a folder at different level received as a user share
     Given using spaces DAV path
-    And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with user "Alice"
+    And user "Brian" has created folder "/BRIAN-FOLDER"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with user "Alice"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    And user "Alice" has created folder "Sample-Folder-A"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
-    And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
-    When user "Alice" copies folder "Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-folder" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has created folder "/Sample-Folder-A"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b"
+    And user "Alice" has uploaded file with content "sample file-c" to "/Sample-Folder-A/sample-folder-b/textfile-c.txt"
+    When user "Alice" copies file "/Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-folder" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should not contain these files:
       | /second-level-folder/third-level-folder |
@@ -553,20 +552,21 @@ Feature: copy file
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these files:
       | /second-level-folder |
     And for user "Alice" the content of the file "/BRIAN-FOLDER/second-level-folder" of the space "Shares Jail" should be "sample file-c"
+    And for user "Brian" the content of the file "/BRIAN-FOLDER/second-level-folder" of the space "Personal" should be "sample file-c"
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
 
 
   Scenario: copy a file into a file at different level received as a user share
     Given using spaces DAV path
-    And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has uploaded file with content "file at second level" to "BRIAN-FOLDER/second-level-file.txt"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with user "Alice"
+    And user "Brian" has created folder "/BRIAN-FOLDER"
+    And user "Brian" has uploaded file with content "file at second level" to "/BRIAN-FOLDER/second-level-file.txt"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with user "Alice"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    And user "Alice" has created folder "Sample-Folder-A"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
-    And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
-    When user "Alice" copies folder "Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-file.txt" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has created folder "/Sample-Folder-A"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b"
+    And user "Alice" has uploaded file with content "sample file-c" to "/Sample-Folder-A/sample-folder-b/textfile-c.txt"
+    When user "Alice" copies file "/Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-file.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "Sample-Folder-A/sample-folder-b/textfile-c.txt" should exist
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these files:
@@ -574,23 +574,23 @@ Feature: copy file
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should not contain these files:
       | /textfile-c.txt |
     And for user "Alice" the content of the file "/BRIAN-FOLDER/second-level-file.txt" of the space "Shares Jail" should be "sample file-c"
+    And for user "Brian" the content of the file "/BRIAN-FOLDER/second-level-file.txt" of the space "Personal" should be "sample file-c"
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
 
 
   Scenario: copy a folder into a file at different level received as a user share
     Given using spaces DAV path
-    And user "Alice" has created folder "FOLDER"
-    And user "Alice" has created folder "FOLDER/second-level-folder"
-    And user "Alice" has created folder "FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has created folder "/FOLDER/second-level-folder"
+    And user "Alice" has created folder "/FOLDER/second-level-folder/third-level-folder"
+    And user "Brian" has created folder "/BRIAN-FOLDER"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
     And user "Brian" has uploaded file with content "file at third level" to "BRIAN-FOLDER/second-level-folder/third-level-file.txt"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with user "Alice"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with user "Alice"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    When user "Alice" copies folder "FOLDER/second-level-folder" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-file.txt" inside space "Shares Jail" using the WebDAV API
+    When user "Alice" copies folder "/FOLDER/second-level-folder" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-file.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" folder "FOLDER/second-level-folder/third-level-folder" should exist
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these entries:
       | /second-level-folder/third-level-file.txt/third-level-folder |
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should not contain these entries:
@@ -604,15 +604,15 @@ Feature: copy file
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
-    And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with group "grp1"
+    And user "Brian" has created folder "/BRIAN-FOLDER"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with group "grp1"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    And user "Alice" has created folder "Sample-Folder-A"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b/sample-folder-c"
-    When user "Alice" copies folder "Sample-Folder-A/sample-folder-b" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-folder" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has created folder "/Sample-Folder-A"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b/sample-folder-c"
+    When user "Alice" copies folder "/Sample-Folder-A/sample-folder-b" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-folder" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/Sample-Folder-A/sample-folder-b/sample-folder-c" should exist
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these files:
@@ -626,22 +626,20 @@ Feature: copy file
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
-    And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with group "grp1"
+    And user "Brian" has created folder "/BRIAN-FOLDER"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with group "grp1"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    And user "Alice" has created folder "Sample-Folder-A"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
-    And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
-    When user "Alice" copies file "Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-folder" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has created folder "/Sample-Folder-A"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b"
+    And user "Alice" has uploaded file with content "sample file-c" to "/Sample-Folder-A/sample-folder-b/textfile-c.txt"
+    When user "Alice" copies file "/Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-folder" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should not contain these entries:
       | /second-level-folder/third-level-folder |
-    And as "Alice" file "Sample-Folder-A/sample-folder-b/textfile-c.txt" should exist
-    And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these files:
-      | /second-level-folder |
     And for user "Alice" the content of the file "/BRIAN-FOLDER/second-level-folder" of the space "Shares Jail" should be "sample file-c"
+    And for user "Brian" the content of the file "/BRIAN-FOLDER/second-level-folder" of the space "Personal" should be "sample file-c"
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
 
@@ -652,19 +650,20 @@ Feature: copy file
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
     And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has uploaded file with content "file at second level" to "BRIAN-FOLDER/second-level-file.txt"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with group "grp1"
+    And user "Brian" has uploaded file with content "file at second level" to "/BRIAN-FOLDER/second-level-file.txt"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with group "grp1"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    And user "Alice" has created folder "Sample-Folder-A"
-    And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
-    And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
-    When user "Alice" copies file "Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-file.txt" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has created folder "/Sample-Folder-A"
+    And user "Alice" has created folder "/Sample-Folder-A/sample-folder-b"
+    And user "Alice" has uploaded file with content "sample file-c" to "/Sample-Folder-A/sample-folder-b/textfile-c.txt"
+    When user "Alice" copies file "/Sample-Folder-A/sample-folder-b/textfile-c.txt" from space "Personal" to "/BRIAN-FOLDER/second-level-file.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" file "Sample-Folder-A/sample-folder-b/textfile-c.txt" should exist
-    And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should not contain these files:
+    And as "Alice" file "/Sample-Folder-A/sample-folder-b/textfile-c.txt" should exist
+    And for user "Alice" folder "/BRIAN-FOLDER" of the space "Shares Jail" should not contain these files:
       | /textfile-c.txt |
-    And as "Alice" file "Sample-Folder-A/sample-folder-b/textfile-c.txt" should exist
+    And as "Alice" file "/Sample-Folder-A/sample-folder-b/textfile-c.txt" should exist
     And for user "Alice" the content of the file "/BRIAN-FOLDER/second-level-file.txt" of the space "Shares Jail" should be "sample file-c"
+    And for user "Brian" the content of the file "/BRIAN-FOLDER/second-level-file.txt" of the space "Personal" should be "sample file-c"
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
 
@@ -674,15 +673,15 @@ Feature: copy file
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
-    And user "Brian" has created folder "BRIAN-FOLDER"
-    And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
-    And user "Brian" has uploaded file with content "file at third level" to "BRIAN-FOLDER/second-level-folder/third-level-file.txt"
-    And user "Brian" has shared folder "BRIAN-FOLDER" with group "grp1"
+    And user "Brian" has created folder "/BRIAN-FOLDER"
+    And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
+    And user "Brian" has uploaded file with content "file at third level" to "/BRIAN-FOLDER/second-level-folder/third-level-file.txt"
+    And user "Brian" has shared folder "/BRIAN-FOLDER" with group "grp1"
     And user "Alice" has accepted share "/BRIAN-FOLDER" offered by user "Brian"
-    And user "Alice" has created folder "FOLDER"
-    And user "Alice" has created folder "FOLDER/second-level-folder"
-    And user "Alice" has created folder "FOLDER/second-level-folder/third-level-folder"
-    When user "Alice" copies folder "FOLDER/second-level-folder" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-file.txt" inside space "Shares Jail" using the WebDAV API
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has created folder "/FOLDER/second-level-folder"
+    And user "Alice" has created folder "/FOLDER/second-level-folder/third-level-folder"
+    When user "Alice" copies folder "/FOLDER/second-level-folder" from space "Personal" to "/BRIAN-FOLDER/second-level-folder/third-level-file.txt" inside space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "204"
     And for user "Alice" folder "BRIAN-FOLDER" of the space "Shares Jail" should contain these files:
       | /second-level-folder/third-level-file.txt                    |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2021,7 +2021,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to download file "([^"]*)" inside space "([^"]*)"$/
+	 * @Then /^user "([^"]*)" should not be able to download file "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $fileName

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -317,6 +317,29 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * Download a file using user password
+	 *
+	 * @param string $fullUrl
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function downloadFileAsUserUsingPassword(
+		string $fullUrl,
+		string $user
+	):void {
+		$this->featureContext->setResponse(
+			HttpRequestHelper::sendRequest(
+				$fullUrl,
+				$this->featureContext->getStepLineRef(),
+				'GET',
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+			)
+		);
+	}
+
+	/**
 	 * The method returns fileId
 	 *
 	 * @param string $user
@@ -1995,6 +2018,39 @@ class SpacesContext implements Context {
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName);
 		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($fileSource, "/");
 		$this->copyFilesAndFoldersRequest($user, $fullUrl, $headers);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" should not be able to download file "([^"]*)" inside space "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $fileName
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userShouldNotBeAbleToDownloadFileInsideSpace(
+		string $user,
+		string $fileName,
+		string $spaceName
+	):void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($fileName, "/");
+		$this->downloadFileAsUserUsingPassword($fullUrl, $user);
+		Assert::assertGreaterThanOrEqual(
+			400,
+			$this->featureContext->getResponse()->getStatusCode(),
+			__METHOD__
+			. ' download must fail'
+		);
+		Assert::assertLessThanOrEqual(
+			499,
+			$this->featureContext->getResponse()->getStatusCode(),
+			__METHOD__
+			. ' 4xx error expected but got status code "'
+			. $this->featureContext->getResponse()->getStatusCode() . '"'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Description

This PR adds the tests for copy properties related to `/Shares` which is removed from this PR https://github.com/owncloud/core/pull/40278 as `/Shares` related implementation is not in core and is shifted to ocis.

### Related issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045

Note: Most of the tests for the `copy` is run from core API suites on ocis. This test added on ocis is only related to `/Shares` (Shares Jail)