### PR TITLE
Use golang 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ COPY ./ /ocis/
 WORKDIR /ocis/ocis
 RUN make ci-node-generate
 
-FROM owncloudci/golang:1.17 as build
+FROM owncloudci/golang:1.18 as build
 
 COPY --from=generate /ocis /ocis
 
 WORKDIR /ocis/ocis
 RUN make ci-go-generate build
 
-FROM alpine:3.13
+FROM alpine:3.15
 
 RUN apk update && \
 	apk upgrade && \


### PR DESCRIPTION
## Description

Update golang to v1.18 in the root Dockerfile

## Related Issue

- Fixes #4370 


## How Has This Been Tested?

- manually


## Screenshots (if appropriate):

```sh
docker build -t ocis .
 COPY ./ /ocis/
 WORKDIR /ocis/ocis
 RUN make ci-node-generate

-FROM owncloudci/golang:1.17 as build
+FROM owncloudci/golang:1.18 as build

 COPY --from=generate /ocis /ocis

 WORKDIR /ocis/ocis
 RUN make ci-go-generate build

-FROM alpine:3.13
+FROM alpine:3.15

 RUN apk update && \
        apk upgrade && \
...skipping...
[+] Building 431.1s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                     0.0s
 => => transferring dockerfile: 1.24kB                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                        0.0s
 => => transferring context: 34B                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/alpine:3.15                                                                                                                                                           1.2s
 => [internal] load metadata for docker.io/owncloudci/nodejs:14                                                                                                                                                          0.6s
 => [internal] load metadata for docker.io/owncloudci/golang:1.18                                                                                                                                                        2.1s
 => [internal] load build context                                                                                                                                                                                        0.1s
 => => transferring context: 152.35kB                                                                                                                                                                                    0.1s
 => [stage-2 1/3] FROM docker.io/library/alpine:3.15@sha256:69463fdff1f025c908939e86d4714b4d5518776954ca627cbeff4c74bcea5b22                                                                                             3.2s
 => => resolve docker.io/library/alpine:3.15@sha256:69463fdff1f025c908939e86d4714b4d5518776954ca627cbeff4c74bcea5b22                                                                                                     0.0s
 => => sha256:69463fdff1f025c908939e86d4714b4d5518776954ca627cbeff4c74bcea5b22 1.64kB / 1.64kB                                                                                                                           0.0s
 => => sha256:7a38a4540724813e4190d086e955a8e757a7302551cc7555012fa63b57f1cf87 528B / 528B                                                                                                                               0.0s
 => => sha256:c4fc938168588a0ba6178945c3d9047f27101eb3a420d9b758295e9ef8df3dc0 1.47kB / 1.47kB                                                                                                                           0.0s
 => => sha256:9621f1afde84053b2f9b6ff34fc7f7460712247c01cbab483c5fa7132cf782ca 2.82MB / 2.82MB                                                                                                                           3.0s
 => => extracting sha256:9621f1afde84053b2f9b6ff34fc7f7460712247c01cbab483c5fa7132cf782ca                                                                                                                                0.2s
 => CACHED [generate 1/4] FROM docker.io/owncloudci/nodejs:14@sha256:471ade88fc5a73189e56997661c772bb1c6abf348555c7f36e441a9711cb386d                                                                                    0.0s
 => [build 1/4] FROM docker.io/owncloudci/golang:1.18@sha256:9cd11b3146a101a46d27ac7c4cf1028ca25300ee003b5c7469e79fdb9d30573b                                                                                           55.5s
 => => resolve docker.io/owncloudci/golang:1.18@sha256:9cd11b3146a101a46d27ac7c4cf1028ca25300ee003b5c7469e79fdb9d30573b                                                                                                  0.0s
 => => sha256:9cd11b3146a101a46d27ac7c4cf1028ca25300ee003b5c7469e79fdb9d30573b 1.11kB / 1.11kB                                                                                                                           0.0s
 => => sha256:5ed2db52ff3ef243e33ad641b6a7d844b43e25f0756322028f41cc34d2d17585 1.58kB / 1.58kB                                                                                                                           0.0s
 => => sha256:6c9156526933ec20627065a67a5c9aa60b80fc8099d8f0cfea852dcf5a1f5bdb 8.52kB / 8.52kB                                                                                                                           0.0s
 => => sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49 2.81MB / 2.81MB                                                                                                                           1.8s
 => => sha256:5299e6f7860564fd4df7e9a224f3d05dc26d0e855fb26ac7e9d9e156cf1422b2 284.73kB / 284.73kB                                                                                                                       0.2s
 => => sha256:1cab0e43db0af1d30e55de347bd78df438344691f8fb379f631a07e2c8a80f0a 155B / 155B                                                                                                                               0.3s
 => => sha256:af72e8bb74dba7b7a51456e414ac4999ff55a6a68e532a7cd1b6f32707be625f 115.31MB / 115.31MB                                                                                                                      43.5s
 => => sha256:3a421caacf35538ce671745cb9396eea38bf42cd3093eaf78dbcbe8bf5f83f82 156B / 156B                                                                                                                               0.8s
 => => sha256:1e9520d370f2b6b5948aca2dad6fc570b7feaf223970002047abda22b948cf91 55.62MB / 55.62MB                                                                                                                        35.5s
 => => extracting sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49                                                                                                                                0.2s
 => => extracting sha256:5299e6f7860564fd4df7e9a224f3d05dc26d0e855fb26ac7e9d9e156cf1422b2                                                                                                                                0.1s
 => => extracting sha256:1cab0e43db0af1d30e55de347bd78df438344691f8fb379f631a07e2c8a80f0a                                                                                                                                0.0s
 => => extracting sha256:af72e8bb74dba7b7a51456e414ac4999ff55a6a68e532a7cd1b6f32707be625f                                                                                                                                8.3s
 => => extracting sha256:3a421caacf35538ce671745cb9396eea38bf42cd3093eaf78dbcbe8bf5f83f82                                                                                                                                0.1s
 => => extracting sha256:1e9520d370f2b6b5948aca2dad6fc570b7feaf223970002047abda22b948cf91                                                                                                                                2.7s
 => [generate 2/4] COPY ./ /ocis/                                                                                                                                                                                        1.7s
 => [generate 3/4] WORKDIR /ocis/ocis                                                                                                                                                                                    0.0s
 => [generate 4/4] RUN make ci-node-generate                                                                                                                                                                           184.2s
 => [stage-2 2/3] RUN apk update &&  apk upgrade &&  apk add ca-certificates mailcap &&  rm -rf /var/cache/apk/* &&  echo 'hosts: files dns' >| /etc/nsswitch.conf                                                       3.0s
 => [build 2/4] COPY --from=generate /ocis /ocis                                                                                                                                                                        36.4s
 => [build 3/4] WORKDIR /ocis/ocis                                                                                                                                                                                       0.0s
 => [build 4/4] RUN make ci-go-generate build                                                                                                                                                                          172.1s
 => [stage-2 3/3] COPY --from=build /ocis/ocis/bin/ocis /usr/bin/ocis                                                                                                                                                    0.3s
 => exporting to image                                                                                                                                                                                                   0.4s
 => => exporting layers                                                                                                                                                                                                  0.4s
 => => writing image sha256:a481b843d9319880b7571fc54d9580278419dc719aaabf1414a95176db336d17                                                                                                                             0.0s
 => => naming to docker.io/library/ocis                                                                                                                                                                                  0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
