### PR TITLE
[tests-only][full-ci]Select Available role only while sharing space

### DIFF
--- a/tests/acceptance/features/apiSpaces/copySpaces.feature
+++ b/tests/acceptance/features/apiSpaces/copySpaces.feature
@@ -437,7 +437,7 @@ Feature: copy file
   Scenario Outline: User copies a folder from space shares jail with different role to space project with role viewer
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
-    And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
+    And user "Brian" has shared a space "Project" to user "Alice" with role "viewer"
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created folder "/testshare/folder1"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/folder1/testshare.txt"

--- a/tests/acceptance/features/apiSpaces/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/moveSpaces.feature
@@ -33,7 +33,7 @@ Feature: move (rename) file
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created a folder "newfolder" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
-    And user "Brian" has shared a space "Project" to user "Alice" with role "<role>"
+    And user "Brian" has shared a space "Project" to user "Alice" with role "viewer"
     When user "Alice" moves file "insideSpace.txt" to "newfolder/insideSpace.txt" in space "Project" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" the space "Project" should not contain these entries:

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1989,6 +1989,10 @@ class SpacesContext implements Context {
 		string $role
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
+		$availableRoleToAssignToShareSpace = ['manager', 'editor', 'viewer'];
+		if (!\in_array(\strtolower($role), $availableRoleToAssignToShareSpace)) {
+			throw new Error("The Selected " . $role . " Cannot be Found");
+		}
 		$body = [
 			"space_ref" => $space['id'],
 			"shareType" => 7,
@@ -1997,7 +2001,6 @@ class SpacesContext implements Context {
 		];
 
 		$fullUrl = $this->baseUrl . $this->ocsApiUrl;
-
 		$this->featureContext->setResponse(
 			$this->sendPostRequestToUrl(
 				$fullUrl,
@@ -2111,7 +2114,6 @@ class SpacesContext implements Context {
 		string $role
 	): void {
 		$this->sendShareSpaceRequest($user, $spaceName, $userRecipient, $role);
-
 		$expectedHTTPStatus = "200";
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHTTPStatus,


### PR DESCRIPTION
### Description
While Sharing space, the available roles are only `manager`, `editor` and `viewer`. So in case if we pass other value the default value `viewer` is set through API. So a validation code has been added to prevent it.