### PR TITLE
[tests-only] fix CI on tag

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -891,6 +891,8 @@ def e2eTests(ctx):
             "volumes": e2e_volumes,
         }]
 
+    return []
+
 def uploadTracingResult(ctx):
     return [{
         "name": "upload-tracing-result",


### PR DESCRIPTION
## Description
PR #4318 adjusted CI so that it runs e2e tests on every PR, and not on tag.

But it accidentally delete a `return []` that returned an empty list for the case when e2e tests are not needed. That caused:
https://drone.owncloud.com/owncloud/ocis/14396
unknown binary op: list + NoneType

This puts back the `return []`

## How Has This Been Tested?
Needs a tag to happen to really know if it works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
