### PR TITLE
[tests-only][full-ci]Add /Shares related favorite tests on ocis which are removed from core

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=db3913cd9ba67b2d603f8917017734903dfd432a
+CORE_COMMITID=f16ee06034a041433e53fb3d86145d29155ea3d9
 CORE_BRANCH=master
 
 # The test runner source for UI tests

--- a/tests/acceptance/features/apiSpaces/favorite.feature
+++ b/tests/acceptance/features/apiSpaces/favorite.feature
@@ -1,0 +1,46 @@
+@api @skipOnOcV10
+Feature: favorite
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And using spaces DAV path
+    And user "Alice" has created folder "/PARENT"
+
+
+  Scenario: favorite a received share itself
+    Given user "Alice" has shared folder "/PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" favorites element "/PARENT" in space "Shares Jail" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" folder "/PARENT" inside space "Shares Jail" should contain a property "oc:favorite" with value "1"
+
+
+  Scenario: favorite a file inside of a received share
+    Given user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" favorites element "/PARENT/parent.txt" in space "Shares Jail" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" file "/PARENT/parent.txt" inside space "Shares Jail" should contain a property "oc:favorite" with value "1"
+
+
+  Scenario: favorite a folder inside of a received share
+    Given user "Alice" has created folder "/PARENT/sub-folder"
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" favorites element "/PARENT/sub-folder" in space "Shares Jail" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" folder "/PARENT/sub-folder" inside space "Shares Jail" should contain a property "oc:favorite" with value "1"
+
+
+  Scenario: sharee file favorite state should not change the favorite state of sharer
+    Given user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+    And user "Alice" has shared file "/PARENT/parent.txt" with user "Brian"
+    And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
+    When user "Brian" favorites element "/parent.txt" in space "Shares Jail" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" file "/parent.txt" inside space "Shares Jail" should contain a property "oc:favorite" with value "1"
+    And as user "Alice" file "/PARENT/parent.txt" inside space "Personal" should contain a property "oc:favorite" with value "0"

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -696,6 +696,28 @@ class SpacesContext implements Context {
 		return HttpRequestHelper::sendRequest($fullUrl, $xRequestId, $method, $user, $password, $headers);
 	}
 
+    /**
+     * send proppatch request to url
+     * @param string $fullUrl
+     * @param string $user
+     * @param string $password
+     * @param string $xRequestId
+     * @param array $headers
+     * @param mixed|null $body
+     * @return ResponseInterface
+     */
+    public function sendPropPatchRequest(
+        string $fullUrl,
+        string $user,
+        string $password,
+        string $xRequestId = '',
+        array  $headers = [],
+        $body
+    ): ResponseInterface
+    {
+        return HttpRequestHelper::sendRequest($fullUrl, $xRequestId, 'PROPPATCH', $user, $password, $headers, $body);
+    }
+
 	/**
 	 * @When /^user "([^"]*)" lists all available spaces via the GraphApi$/
 	 * @When /^user "([^"]*)" lists all available spaces via the GraphApi with query "([^"]*)"$/
@@ -3146,4 +3168,39 @@ class SpacesContext implements Context {
 			$expectedValue
 		);
 	}
+
+    /**
+     * @When /^user "([^"]*)" favorites element "([^"]*)" in space "([^"]*)" using the WebDAV API$/
+     *
+     * @param string $user
+     * @param string $path
+     * @param string $spaceName
+     *
+     * @return void
+     * @throws GuzzleException
+     */
+    public function userFavoritesElementInSpaceUsingTheWebdavApi(string $user, string $path, string $spaceName): void
+    {
+        $space = $this->getSpaceByName($user, $spaceName);
+        $fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($path, "/");
+        $body = '<?xml version="1.0"?>
+				<d:propertyupdate xmlns:d="DAV:"
+				   xmlns:oc="http://owncloud.org/ns">
+				 <d:set>
+				  <d:prop>
+				    <oc:favorite xmlns:oc="http://owncloud.org/ns">1</oc:favorite>
+				  </d:prop>
+				 </d:set>
+				</d:propertyupdate>';
+        $this->featureContext->setResponse(
+            $this->sendProppatchRequest(
+                $fullUrl,
+                $user,
+                $this->featureContext->getPasswordForUser($user),
+                $this->featureContext->getStepLineRef(),
+                [],
+                $body
+            )
+        );
+    }
 }


### PR DESCRIPTION
### Description

This PR adds the tests for favorite properties related to `/Shares` which is removed from this PR https://github.com/owncloud/core/pull/40274 as `/Shares` related implementation is not in core and is shifted to ocis.

### Related issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045
