### PR TITLE
Bugfix: Autocreate IDP private key also if file exists but is empty

### DIFF
--- a/changelog/unreleased/bugfix-idp-init-certificate-empty-file
+++ b/changelog/unreleased/bugfix-idp-init-certificate-empty-file
@@ -1,0 +1,6 @@
+Bugfix: Autocreate IDP private key also if file exists but is empty
+
+We've fixed the behavior for the IDP private key generation so that
+a private key is also generated when the file already exists but is empty.
+
+https://github.com/owncloud/ocis/pull/4394

--- a/services/idp/pkg/command/server.go
+++ b/services/idp/pkg/command/server.go
@@ -161,12 +161,12 @@ func ensureEncryptionSecretExists(path string) error {
 
 func ensureSigningPrivateKeyExists(paths []string) error {
 	for _, path := range paths {
-		_, err := os.Stat(path)
-		if err == nil {
-			// If the file exists we can just return
+		file, err := os.Stat(path)
+		if err == nil && file.Size() > 0 {
+			// If the file exists and is not empty we can just return
 			return nil
 		}
-		if !errors.Is(err, fs.ErrNotExist) {
+		if !errors.Is(err, fs.ErrNotExist) && file.Size() > 0 {
 			return err
 		}
 


### PR DESCRIPTION
## Description
Bugfix: Autocreate IDP private key also if file exists but is empty

We've fixed the behavior for the IDP private key generation so that
a private key is also generated when the file already exists but is empty.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Boostrap issues on continously deployed oCIS demo instances

## Motivation and Context
Somehow the IDP`s private-key.pem ends up as empty file after initalization. Therefore oCIS is stuck in a reboot loop sometimes.
If the private-key.pem is empty we can safely just overwrite it to prevent the reboot loop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- rm private-key.pem from the IDP data directory and create a empty file instead. oCIS from master does not start. oCIS from this PR will start just fine.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
