### PR TITLE
[tests-only][full-ci]Add etag propagation for delete files folder for spaces

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=76048f490ac50af03594d181c5baf49f87c18b6e
+CORE_COMMITID=f79fbff0a0d129df7b6ec20bc202665c4fda5fad
 CORE_BRANCH=master
 
 # The test runner source for UI tests

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -954,10 +954,6 @@ And other missing implementation of favorites
 - [apiWebdavUploadTUS/uploadToShare.feature:254](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L254)
 - [apiWebdavUploadTUS/uploadToShare.feature:301](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L301)
 - [apiWebdavUploadTUS/uploadToShare.feature:326](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L326)
-- [apiWebdavEtagPropagation1/deleteFileFolder.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature#L120)
-- [apiWebdavEtagPropagation1/deleteFileFolder.feature:156](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature#L156)
-- [apiWebdavEtagPropagation1/deleteFileFolder.feature:194](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature#L194)
-- [apiWebdavEtagPropagation1/deleteFileFolder.feature:232](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature#L232)
 - [apiWebdavLocks2/resharedSharesToShares.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature#L117)
 - [apiWebdavLocks2/resharedSharesToShares.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature#L118)
 - [apiWebdavLocks2/resharedSharesToShares.feature:144](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature#L144)
@@ -1396,6 +1392,10 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [apiTrashbin/trashbinFilesFolders.feature:384](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L384)
 - [apiTrashbin/trashbinFilesFolders.feature:438](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L438)
 - [apiTrashbin/trashbinFilesFolders.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L475)
+
+#### [valid WebDAV (DELETE, COPY or MOVE) requests with body must exit with 415](https://github.com/owncloud/ocis/issues/4332)
+- [apiAuthWebDav/webDavDELETEAuth.feature:188](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L188)
+- [apiAuthWebDav/webDavDELETEAuth.feature:199](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L199)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSpaces/etagPropagation.feature
+++ b/tests/acceptance/features/apiSpaces/etagPropagation.feature
@@ -81,7 +81,7 @@ Feature: check etag propagation after different file alterations
       | Alice | /                   | Personal    |
       | Alice | /upload             | Personal    |
       | Brian | /                   | Shares Jail |
-      | Brian | /upload             | Shares Jail | 
+      | Brian | /upload             | Shares Jail |
     And these etags should not have changed
       | user  | path                | space       |
       | Alice | /upload/renamed.txt | Personal    |
@@ -105,7 +105,7 @@ Feature: check etag propagation after different file alterations
       | Alice | /                   | Personal    |
       | Alice | /upload             | Personal    |
       | Brian | /                   | Shares Jail |
-      | Brian | /upload             | Shares Jail | 
+      | Brian | /upload             | Shares Jail |
     And these etags should not have changed
       | user  | path                | space       |
       | Alice | /upload/renamed.txt | Personal    |
@@ -186,7 +186,7 @@ Feature: check etag propagation after different file alterations
       | Brian | /           | Shares Jail |
       | Brian | /upload     | Shares Jail |
       | Brian | /dst        | Shares Jail |
-  
+
 
   Scenario: as share reciever moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Alice" has created folder "/dst"
@@ -229,7 +229,7 @@ Feature: check etag propagation after different file alterations
       | Brian | /              | Shares Jail |
       | Brian | /upload        | Shares Jail |
 
-  
+
   Scenario: as sharer creating a folder inside a shared folder changes etag for all collaborators
     Given user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
@@ -261,10 +261,10 @@ Feature: check etag propagation after different file alterations
       | Alice | /              | Personal    |
       | Alice | /upload        | Personal    |
       | Brian | /              | Shares Jail |
-      | Brian | /upload        | Shares Jail |    
+      | Brian | /upload        | Shares Jail |
 
 
-  Scenario: as sharer uploading a file inside a shared folder should update etags for all collaborators    
+  Scenario: as sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/" inside space "Personal"
@@ -298,8 +298,8 @@ Feature: check etag propagation after different file alterations
       | Brian | /              | Shares Jail |
       | Brian | /upload        | Shares Jail |
 
-  
-  Scenario: as sharer overwriting a file inside a shared folder should update etags for all collaborators    
+
+  Scenario: as sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
@@ -315,3 +315,110 @@ Feature: check etag propagation after different file alterations
       | Alice | /upload        | Personal    |
       | Brian | /              | Shares Jail |
       | Brian | /upload        | Shares Jail |
+
+
+  Scenario: As share receiver deleting (removing) a file changes the etags of all parents for all collaborators
+    Given user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload/sub" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload/sub" inside space "Shares Jail"
+    When user "Brian" removes the file "upload/sub/file.txt" from space "Shares Jail"
+    Then the HTTP status code should be "204"
+    And these etags should have changed
+      | user  | path        | space       |
+      | Alice | /           | Personal    |
+      | Alice | /upload     | Personal    |
+      | Alice | /upload/sub | Personal    |
+      | Brian | /           | Shares Jail |
+      | Brian | /upload     | Shares Jail |
+      | Brian | /upload/sub | Shares Jail |
+    And these etags should not have changed
+      | user  | path | space    |
+      | Brian | /    | Personal |
+
+
+  Scenario: As sharer deleting (removing) a file changes the etags of all parents for all collaborators
+    Given user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload/sub" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload/sub" inside space "Shares Jail"
+    When user "Alice" removes the file "upload/sub/file.txt" from space "Personal"
+    Then the HTTP status code should be "204"
+    And these etags should have changed
+      | user  | path        | space       |
+      | Alice | /           | Personal    |
+      | Alice | /upload     | Personal    |
+      | Alice | /upload/sub | Personal    |
+      | Brian | /           | Shares Jail |
+      | Brian | /upload     | Shares Jail |
+      | Brian | /upload/sub | Shares Jail |
+    And these etags should not have changed
+      | user  | path | space    |
+      | Brian | /    | Personal |
+
+
+  Scenario: As share receiver deleting (removing) a folder changes the etags of all parents for all collaborators
+    Given user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created folder "/upload/sub/toDelete"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload/sub" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload/sub" inside space "Shares Jail"
+    When user "Brian" removes the file "upload/sub/toDelete" from space "Shares Jail"
+    Then the HTTP status code should be "204"
+    And these etags should have changed
+      | user  | path        | space       |
+      | Alice | /           | Personal    |
+      | Alice | /upload     | Personal    |
+      | Alice | /upload/sub | Personal    |
+      | Brian | /           | Shares Jail |
+      | Brian | /upload     | Shares Jail |
+      | Brian | /upload/sub | Shares Jail |
+    And these etags should not have changed
+      | user  | path | space    |
+      | Brian | /    | Personal |
+
+  Scenario: As sharer deleting (removing) a folder changes the etags of all parents for all collaborators
+    Given user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created folder "/upload/sub/toDelete"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload" inside space "Personal"
+    And user "Alice" has stored etag of element "/upload/sub" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Personal"
+    And user "Brian" has stored etag of element "/" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload" inside space "Shares Jail"
+    And user "Brian" has stored etag of element "/upload/sub" inside space "Shares Jail"
+    When user "Alice" removes the file "upload/sub/toDelete" from space "Personal"
+    Then the HTTP status code should be "204"
+    And these etags should have changed
+      | user  | path        | space       |
+      | Alice | /           | Personal    |
+      | Alice | /upload     | Personal    |
+      | Alice | /upload/sub | Personal    |
+      | Brian | /           | Shares Jail |
+      | Brian | /upload     | Shares Jail |
+      | Brian | /upload/sub | Shares Jail |
+    And these etags should not have changed
+      | user  | path | space    |
+      | Brian | /    | Personal |

--- a/tests/acceptance/features/apiSpaces/etagPropagation.feature
+++ b/tests/acceptance/features/apiSpaces/etagPropagation.feature
@@ -397,6 +397,7 @@ Feature: check etag propagation after different file alterations
       | user  | path | space    |
       | Brian | /    | Personal |
 
+
   Scenario: As sharer deleting (removing) a folder changes the etags of all parents for all collaborators
     Given user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2215,7 +2215,7 @@ class SpacesContext implements Context {
 		string $spaceName
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
-		$spaceWebDavUrl = $space["root"]["webDavUrl"] . '/' . $object;
+		$spaceWebDavUrl = $space["root"]["webDavUrl"] . '/' . ltrim($object, "/");
 		$this->featureContext->setResponse(
 			HttpRequestHelper::delete(
 				$spaceWebDavUrl,
@@ -3035,7 +3035,7 @@ class SpacesContext implements Context {
 			Assert::assertEmpty($responseArray, __METHOD__ . ' Response should be empty');
 		}
 	}
-	   
+
 	/**
 	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry|resource) "([^"]*)" inside space "([^"]*)" using the WebDAV API$/
 	 *


### PR DESCRIPTION
### Description

This PR adds the tests for etag propagation when deleting files and folders related to `/Shares` which is removed from this PR https://github.com/owncloud/core/pull/40288 as `/Shares` related implementation is not in core and is shifted to ocis.

### Related issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045

### Bump Core latest core commit
https://github.com/owncloud/QA/issues/761

Note: Most of the tests for the `etag` check when deleting files and folder is run from core API suites on ocis. This test added on ocis is only related to `/Shares` (Shares Jail)