### PR TITLE
[tests-only][full-ci]Add /Shares related move tests on ocis which are removed from core

### DIFF
--- a/tests/acceptance/features/apiSpaces/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/moveSpaces.feature
@@ -262,7 +262,7 @@ Feature: move (rename) file
     And user "Brian" folder "/folderB/ONE" of the space "Shares Jail" should have the previously stored id
 
 
-  Scenario: Moving a file out of a shared folder as the sharer
+  Scenario: Moving a file out of a shared folder as a sharer
     Given user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
     And user "Brian" has created a share with settings
@@ -280,7 +280,7 @@ Feature: move (rename) file
       | /testshare/testfile.txt |
 
 
-  Scenario: Moving a folder out of a shared folder as the sharer
+  Scenario: Moving a folder out of a shared folder as a sharer
     Given user "Brian" has created the following folders
       | path                     |
       | /testshare               |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -90,6 +90,11 @@ class SpacesContext implements Context {
 	 */
 	private string $davSpacesUrl = '/remote.php/dav/spaces/';
 
+    /**
+     * @var string
+     */
+    private string $storedFileID;
+
 	/**
 	 * @var array map with user as key, spaces and file etags as value
 	 * @example

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -90,11 +90,6 @@ class SpacesContext implements Context {
 	 */
 	private string $davSpacesUrl = '/remote.php/dav/spaces/';
 
-    /**
-     * @var string
-     */
-    private string $storedFileID;
-
 	/**
 	 * @var array map with user as key, spaces and file etags as value
 	 * @example
@@ -3229,5 +3224,39 @@ class SpacesContext implements Context {
 	public function userFavoritesElementInSpaceUsingTheWebdavApi(string $user, string $path, string $spaceName): void {
 		$this->setSpaceIDByName($user, $spaceName);
 		$this->favoritesContext->userFavoritesElement($user, $path);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has stored id of (file|folder) "([^"]*)" of the space "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $fileOrFolder
+	 * @param string $path
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 *
+	 * @throws GuzzleException
+	 */
+	public function userHasStoredIdOfPathOfTheSpace(string $user, string $fileOrFolder, string $path, string $spaceName): void {
+		$this->setSpaceIDByName($user, $spaceName);
+		$this->featureContext->userStoresFileIdForPath($user, $fileOrFolder, $path);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" (folder|file) "([^"]*)" of the space "([^"]*)" should have the previously stored id$/
+	 *
+	 * @param string|null $user
+	 * @param string $fileOrFolder
+	 * @param string $path
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 *
+	 * @throws GuzzleException
+	 */
+	public function userFolderOfTheSpaceShouldHaveThePreviouslyStoredId(string $user, string $fileOrFolder, string $path, string $spaceName): void {
+		$this->setSpaceIDByName($user, $spaceName);
+		$this->featureContext->userFileShouldHaveStoredId($user, $fileOrFolder, $path);
 	}
 }


### PR DESCRIPTION
### Description

This PR adds the tests for move properties related to `/Shares` which is removed from this PR https://github.com/owncloud/core/pull/40294 as `/Shares` related implementation is not in core and is shifted to ocis.

### Related issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045
