### PR TITLE
[full-ci] let search service exit 

### DIFF
--- a/services/search/pkg/command/server.go
+++ b/services/search/pkg/command/server.go
@@ -50,14 +50,14 @@ func Server(cfg *config.Config) *cli.Command {
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
-			grpcServer, err := grpc.Server(
+			grpcServer, teardown, err := grpc.Server(
 				grpc.Config(cfg),
 				grpc.Logger(logger),
 				grpc.Name(cfg.Service.Name),
 				grpc.Context(ctx),
 				grpc.Metrics(mtrcs),
 			)
-
+			defer teardown()
 			if err != nil {
 				logger.Info().Err(err).Str("transport", "grpc").Msg("Failed to initialize server")
 				return err

--- a/services/search/pkg/command/server.go
+++ b/services/search/pkg/command/server.go
@@ -50,13 +50,18 @@ func Server(cfg *config.Config) *cli.Command {
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
-			grpcServer := grpc.Server(
+			grpcServer, err := grpc.Server(
 				grpc.Config(cfg),
 				grpc.Logger(logger),
 				grpc.Name(cfg.Service.Name),
 				grpc.Context(ctx),
 				grpc.Metrics(mtrcs),
 			)
+
+			if err != nil {
+				logger.Info().Err(err).Str("transport", "grpc").Msg("Failed to initialize server")
+				return err
+			}
 
 			gr.Add(grpcServer.Run, func(_ error) {
 				logger.Error().
@@ -71,7 +76,6 @@ func Server(cfg *config.Config) *cli.Command {
 				debug.Context(ctx),
 				debug.Config(cfg),
 			)
-
 			if err != nil {
 				logger.Info().Err(err).Str("transport", "debug").Msg("Failed to initialize server")
 				return err

--- a/services/search/pkg/engine/bleve.go
+++ b/services/search/pkg/engine/bleve.go
@@ -35,7 +35,7 @@ type Bleve struct {
 func NewBleveIndex(root string) (bleve.Index, error) {
 	destination := filepath.Join(root, "bleve")
 	index, err := bleve.Open(destination)
-	if err != nil {
+	if errors.Is(bleve.ErrorIndexPathDoesNotExist, err) {
 		m, err := BuildBleveMapping()
 		if err != nil {
 			return nil, err
@@ -44,9 +44,11 @@ func NewBleveIndex(root string) (bleve.Index, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		return index, nil
 	}
 
-	return index, nil
+	return index, err
 }
 
 // NewBleveEngine creates a new Bleve instance

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -22,7 +22,7 @@ import (
 
 // NewHandler returns a service implementation for Service.
 func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error) {
-	closer := func() {}
+	teardown := func() {}
 	options := newOptions(opts...)
 	logger := options.Logger
 	cfg := options.Config
@@ -33,37 +33,37 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error)
 	case "bleve":
 		idx, err := engine.NewBleveIndex(cfg.Engine.Bleve.Datapath)
 		if err != nil {
-			return nil, closer, err
+			return nil, teardown, err
 		}
 
-		closer = func() {
-			idx.Close()
+		teardown = func() {
+			_ = idx.Close()
 		}
 
 		eng = engine.NewBleveEngine(idx)
 	default:
-		return nil, closer, fmt.Errorf("unknown search engine: %s", cfg.Engine.Type)
+		return nil, teardown, fmt.Errorf("unknown search engine: %s", cfg.Engine.Type)
 	}
 
 	// initialize gateway
 	gw, err := pool.GetGatewayServiceClient(cfg.Reva.Address)
 	if err != nil {
 		logger.Fatal().Err(err).Str("addr", cfg.Reva.Address).Msg("could not get reva client")
-		return nil, closer, err
+		return nil, teardown, err
 	}
 	// initialize search content extractor
 	var extractor content.Extractor
 	switch cfg.Extractor.Type {
 	case "basic":
 		if extractor, err = content.NewBasicExtractor(logger); err != nil {
-			return nil, closer, err
+			return nil, teardown, err
 		}
 	case "tika":
 		if extractor, err = content.NewTikaExtractor(gw, logger, cfg); err != nil {
-			return nil, closer, err
+			return nil, teardown, err
 		}
 	default:
-		return nil, closer, fmt.Errorf("unknown search extractor: %s", cfg.Extractor.Type)
+		return nil, teardown, fmt.Errorf("unknown search extractor: %s", cfg.Extractor.Type)
 	}
 
 	// initialize nats
@@ -72,19 +72,19 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error)
 		natsjs.ClusterID(cfg.Events.Cluster),
 	)
 	if err != nil {
-		return nil, closer, err
+		return nil, teardown, err
 	}
 
 	// setup event handling
 	if err := search.HandleEvents(eng, extractor, gw, bus, logger, cfg); err != nil {
-		return nil, closer, err
+		return nil, teardown, err
 	}
 
 	return &Service{
 		id:       cfg.GRPC.Namespace + "." + cfg.Service.Name,
 		log:      logger,
 		provider: search.NewProvider(gw, eng, extractor, logger, cfg.MachineAuthAPIKey),
-	}, closer, nil
+	}, teardown, nil
 }
 
 // Service implements the searchServiceHandler interface

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -21,7 +21,8 @@ import (
 )
 
 // NewHandler returns a service implementation for Service.
-func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, error) {
+func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error) {
+	closer := func() {}
 	options := newOptions(opts...)
 	logger := options.Logger
 	cfg := options.Config
@@ -32,33 +33,37 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, error) {
 	case "bleve":
 		idx, err := engine.NewBleveIndex(cfg.Engine.Bleve.Datapath)
 		if err != nil {
-			return nil, err
+			return nil, closer, err
+		}
+
+		closer = func() {
+			idx.Close()
 		}
 
 		eng = engine.NewBleveEngine(idx)
 	default:
-		return nil, fmt.Errorf("unknown search engine: %s", cfg.Engine.Type)
+		return nil, closer, fmt.Errorf("unknown search engine: %s", cfg.Engine.Type)
 	}
 
 	// initialize gateway
 	gw, err := pool.GetGatewayServiceClient(cfg.Reva.Address)
 	if err != nil {
 		logger.Fatal().Err(err).Str("addr", cfg.Reva.Address).Msg("could not get reva client")
+		return nil, closer, err
 	}
-
 	// initialize search content extractor
 	var extractor content.Extractor
 	switch cfg.Extractor.Type {
 	case "basic":
 		if extractor, err = content.NewBasicExtractor(logger); err != nil {
-			return nil, err
+			return nil, closer, err
 		}
 	case "tika":
 		if extractor, err = content.NewTikaExtractor(gw, logger, cfg); err != nil {
-			return nil, err
+			return nil, closer, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown search extractor: %s", cfg.Extractor.Type)
+		return nil, closer, fmt.Errorf("unknown search extractor: %s", cfg.Extractor.Type)
 	}
 
 	// initialize nats
@@ -67,19 +72,19 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, error) {
 		natsjs.ClusterID(cfg.Events.Cluster),
 	)
 	if err != nil {
-		return nil, err
+		return nil, closer, err
 	}
 
 	// setup event handling
 	if err := search.HandleEvents(eng, extractor, gw, bus, logger, cfg); err != nil {
-		return nil, err
+		return nil, closer, err
 	}
 
 	return &Service{
 		id:       cfg.GRPC.Namespace + "." + cfg.Service.Name,
 		log:      logger,
 		provider: search.NewProvider(gw, eng, extractor, logger, cfg.MachineAuthAPIKey),
-	}, nil
+	}, closer, nil
 }
 
 // Service implements the searchServiceHandler interface


### PR DESCRIPTION
## Description
Search service kept alive even if an error happens due initialization... this is changed to let the service die and the runtime can handle the re-initialization.

## Motivation and Context
be able to use `restart: always` docker option.