### PR TITLE
enable a 300sec in memory cache for resource infos when listing shares on the ocs API

### DIFF
--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -117,10 +117,12 @@ type OCS struct {
 	CacheWarmupDrivers      CacheWarmupDrivers `yaml:"cache_warmup_drivers,omitempty"` // not supported by the oCIS product, therefore not part of docs
 }
 
+// ResourceInfoCaches holds resource info cache configurations
 type ResourceInfoCaches struct {
 	Redis RedisDriver `yaml:"redis,omitempty"`
 }
 
+// RedisDriver holds redis configuration
 type RedisDriver struct {
 	Address  string `yaml:"address" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_REDIS_ADDR" desc:"Redis service address"`
 	Username string `yaml:"username" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_REDIS_USERNAME" desc:"Redis username"`

--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -110,9 +110,21 @@ type OCS struct {
 	SharePrefix             string             `yaml:"share_prefix" env:"FRONTEND_OCS_SHARE_PREFIX" desc:"Path prefix for shares."`
 	HomeNamespace           string             `yaml:"home_namespace" env:"FRONTEND_OCS_HOME_NAMESPACE" desc:"Homespace namespace identifier."`
 	AdditionalInfoAttribute string             `yaml:"additional_info_attribute" env:"FRONTEND_OCS_ADDITIONAL_INFO_ATTRIBUTE" desc:"Additional information attribute for the user like {{.Mail}}."`
-	ResourceInfoCacheTTL    int                `yaml:"resource_info_cache_ttl" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_TTL" desc:"Max TTL for the resource info cache."`
+	ResourceInfoCacheTTL    int                `yaml:"resource_info_cache_ttl" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_TTL" desc:"Max TTL for the resource info cache. 0 disables the cache."`
+	ResourceInfoCacheType   string             `yaml:"resource_info_cache_type" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_TYPE" desc:"Resource info cache type ('memory' or 'redis')."`
+	ResourceInfoCaches      ResourceInfoCaches `yaml:"resource_info_caches,omitempty"` // only used for redis
 	CacheWarmupDriver       string             `yaml:"cache_warmup_driver,omitempty"`  // not supported by the oCIS product, therefore not part of docs
 	CacheWarmupDrivers      CacheWarmupDrivers `yaml:"cache_warmup_drivers,omitempty"` // not supported by the oCIS product, therefore not part of docs
+}
+
+type ResourceInfoCaches struct {
+	Redis RedisDriver `yaml:"redis,omitempty"`
+}
+
+type RedisDriver struct {
+	Address  string `yaml:"address" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_REDIS_ADDR" desc:"Redis service address"`
+	Username string `yaml:"username" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_REDIS_USERNAME" desc:"Redis username"`
+	Password string `yaml:"password" env:"FRONTEND_OCS_RESOURCE_INFO_CACHE_REDIS_PASSWORD" desc:"Redis password"`
 }
 
 type CacheWarmupDrivers struct {

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -62,7 +62,7 @@ func DefaultConfig() *config.Config {
 			HomeNamespace:           "/users/{{.Id.OpaqueId}}",
 			AdditionalInfoAttribute: "{{.Mail}}",
 			ResourceInfoCacheType:   "memory",
-			ResourceInfoCacheTTL:    60,
+			ResourceInfoCacheTTL:    0,
 		},
 		Middleware: config.Middleware{
 			Auth: config.Auth{

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -61,7 +61,8 @@ func DefaultConfig() *config.Config {
 			SharePrefix:             "/Shares",
 			HomeNamespace:           "/users/{{.Id.OpaqueId}}",
 			AdditionalInfoAttribute: "{{.Mail}}",
-			ResourceInfoCacheTTL:    0,
+			ResourceInfoCacheType:   "memory",
+			ResourceInfoCacheTTL:    60,
 		},
 		Middleware: config.Middleware{
 			Auth: config.Auth{

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -125,10 +125,19 @@ func FrontendConfigFromStruct(cfg *config.Config) (map[string]interface{}, error
 					"insecure":               true,
 				},
 				"ocs": map[string]interface{}{
-					"storage_registry_svc":      cfg.Reva.Address,
-					"share_prefix":              cfg.OCS.SharePrefix,
-					"home_namespace":            cfg.OCS.HomeNamespace,
-					"resource_info_cache_ttl":   cfg.OCS.ResourceInfoCacheTTL,
+					"storage_registry_svc":     cfg.Reva.Address,
+					"share_prefix":             cfg.OCS.SharePrefix,
+					"home_namespace":           cfg.OCS.HomeNamespace,
+					"resource_info_cache_ttl":  cfg.OCS.ResourceInfoCacheTTL,
+					"resource_info_cache_type": cfg.OCS.ResourceInfoCacheType,
+					"resource_info_caches": map[string]interface{}{
+						// memory has no additional config
+						"redis": map[string]interface{}{
+							"redis_address":  cfg.OCS.ResourceInfoCaches.Redis.Address,
+							"redis_username": cfg.OCS.ResourceInfoCaches.Redis.Username,
+							"redis_password": cfg.OCS.ResourceInfoCaches.Redis.Password,
+						},
+					},
 					"prefix":                    cfg.OCS.Prefix,
 					"additional_info_attribute": cfg.OCS.AdditionalInfoAttribute,
 					"machine_auth_apikey":       cfg.MachineAuthAPIKey,


### PR DESCRIPTION
Listing the received shares for a user that has 150 incoming shares currently takes 6-10sec. (that is with the gateway cache enabled by locally reverting https://github.com/cs3org/reva/pull/3167)

While the internal listing of shares is in the 140ms ballpark with https://github.com/cs3org/reva/pull/3148 the ocs api also returns file and path information, requiring a stat and a getpath for every share, adding up to hundreds of internal stat requests.

reva can cache the stat requests with an in memory cache or in redis, dropping the response time for the same user from 8sec to 700ms on my machine. The difference between 140ms and 700ms is spent on GetPath calls that we could get rid of completely by requesting the path in the stat request in the fieldmask. something for another PR.

This PR sets the timeout to 300sec / 5min. I don't know if that is a good initial duration. cbox even has a cache warmup that prefetches the list of shared resources, stats them and caches them for the TTL ... which only really makes sense when the TTL is quite large ... anyway, lets start with this.

I absolutely assume the tests will cry over this ... It did, so I disabled the cache by setting TTL to 0 ... The cache can be enabled by setting `FRONTEND_OCS_RESOURCE_INFO_CACHE_TTL=60` or more ... but this breaks our tests. In any case as is the PR at least allows enabling and configuring the cache.

Related: https://github.com/cs3org/reva/issues/2976
