### PR TITLE
add config options for mail encryption and authentication

### DIFF
--- a/changelog/unreleased/enhancement-mail-authentication-encryption-settings.md
+++ b/changelog/unreleased/enhancement-mail-authentication-encryption-settings.md
@@ -1,0 +1,10 @@
+Enhancement: Add configuration options for mail authentication and encryption
+
+We've added configuration options to configure the authentication and encryption
+for sending mails in the notifications service.
+
+Furthermore there is now a distinguished configuration option for the username to use
+for authentication against the mail server. This allows you to customize the sender address
+to your liking. For example sender addresses like `my oCIS instance <ocis@owncloud.test>` are now possible, too.
+
+https://github.com/owncloud/ocis/pull/4443

--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -68,7 +68,8 @@ services:
       # email server (in this case inbucket acts as mail catcher)
       NOTIFICATIONS_SMTP_HOST: inbucket
       NOTIFICATIONS_SMTP_PORT: 2500
-      NOTIFICATIONS_SMTP_SENDER: notifications@${OCIS_DOMAIN:-ocis.owncloud.test}
+      NOTIFICATIONS_SMTP_SENDER: oCIS notifications <notifications@${OCIS_DOMAIN:-ocis.owncloud.test}>
+      NOTIFICATIONS_SMTP_USERNAME: notifications@${OCIS_DOMAIN:-ocis.owncloud.test}
       NOTIFICATIONS_SMTP_INSECURE: true # the mail catcher uses self signed certificates
     volumes:
       - ocis-config:/etc/ocis

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -30,11 +30,14 @@ type Notifications struct {
 
 // SMTP combines the smtp configuration options.
 type SMTP struct {
-	Host     string `yaml:"smtp_host" env:"NOTIFICATIONS_SMTP_HOST" desc:"SMTP host to connect to."`
-	Port     int    `yaml:"smtp_port" env:"NOTIFICATIONS_SMTP_PORT" desc:"Port of the SMTP host to connect to."`
-	Sender   string `yaml:"smtp_sender" env:"NOTIFICATIONS_SMTP_SENDER" desc:"Sender of emails that will be sent."`
-	Password string `yaml:"smtp_password" env:"NOTIFICATIONS_SMTP_PASSWORD" desc:"Password of the SMTP host to connect to."`
-	Insecure bool   `yaml:"insecure" env:"NOTIFICATIONS_SMTP_INSECURE" desc:"Allow insecure connections to the SMTP server."`
+	Host           string `yaml:"smtp_host" env:"NOTIFICATIONS_SMTP_HOST" desc:"SMTP host to connect to."`
+	Port           int    `yaml:"smtp_port" env:"NOTIFICATIONS_SMTP_PORT" desc:"Port of the SMTP host to connect to."`
+	Sender         string `yaml:"smtp_sender" env:"NOTIFICATIONS_SMTP_SENDER" desc:"Sender address of emails that will be sent."`
+	Username       string `yaml:"smtp_username" env:"NOTIFICATIONS_SMTP_USERNAME" desc:"Username for the SMTP host to connect to."`
+	Password       string `yaml:"smtp_password" env:"NOTIFICATIONS_SMTP_PASSWORD" desc:"Password for the SMTP host to connect to."`
+	Insecure       bool   `yaml:"insecure" env:"NOTIFICATIONS_SMTP_INSECURE" desc:"Allow insecure connections to the SMTP server."`
+	Authentication string `yaml:"smtp_authentication" env:"NOTIFICATIONS_SMTP_AUTHENTICATION" desc:"Authentication method for the SMTP communication. Possible values are 'login', 'plain', 'crammd5', 'none'"`
+	Encryption     string `yaml:"smtp_encryption" env:"NOTIFICATIONS_SMTP_ENCRYPTION" desc:"Encryption method for the SMTP communication. Possible values  are 'starttls', 'ssl', 'ssltls', 'tls'  and 'none'."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/notifications/pkg/config/defaults/defaultconfig.go
+++ b/services/notifications/pkg/config/defaults/defaultconfig.go
@@ -24,9 +24,11 @@ func DefaultConfig() *config.Config {
 		},
 		Notifications: config.Notifications{
 			SMTP: config.SMTP{
-				Host:   "",
-				Port:   1025,
-				Sender: "noreply@example.com",
+				Host:           "",
+				Port:           1025,
+				Sender:         "ownCloud <noreply@example.com>",
+				Authentication: "none",
+				Encryption:     "none",
 			},
 			Events: config.Events{
 				Endpoint:      "127.0.0.1:9233",


### PR DESCRIPTION
## Description
Enhancement: Add configuration options for mail authentication and encryption

We've added configuration options to configure the authentication and encryption
for sending mails in the notifications service.

Furthermore there is now a distinguished configuration option for the username to use
for authentication against the mail server. This allows you to customize the sender address
to your liking. For example sender addresses like `my oCIS instance <ocis@owncloud.test>` are now possible, too.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Could not send agains servers using STARTTLS / TLS with authentication

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested agains a production mail server

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
