### PR TITLE
add missing unprotected paths

### DIFF
--- a/changelog/unreleased/missing-unprotected-paths.md
+++ b/changelog/unreleased/missing-unprotected-paths.md
@@ -1,0 +1,5 @@
+Enhancement: Add missing unprotected paths
+
+Added missing unprotected paths for the text-editor, preview, pdf-viewer and draw-io to the authentication middleware.
+
+https://github.com/owncloud/ocis/pull/4454

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -62,6 +62,10 @@ var (
 		"/themes/",
 		"/signin/",
 		"/konnect/",
+		"/text-editor/",
+		"/preview/",
+		"/pdf-viewer/",
+		"/draw-io/",
 	}
 )
 


### PR DESCRIPTION
Added missing unprotected paths for the text-editor, preview, pdf-viewer and draw-io to the authentication middleware.

