### PR TITLE
fix: add index.html to unprotected paths in auth middleware

### DIFF
--- a/changelog/unreleased/missing-unprotected-paths.md
+++ b/changelog/unreleased/missing-unprotected-paths.md
@@ -1,5 +1,6 @@
 Enhancement: Add missing unprotected paths
 
-Added missing unprotected paths for the text-editor, preview, pdf-viewer and draw-io to the authentication middleware.
+Added missing unprotected paths for the text-editor, preview, pdf-viewer, draw-io and index.html to the authentication middleware.
 
 https://github.com/owncloud/ocis/pull/4454
+https://github.com/owncloud/ocis/pull/4458

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -66,6 +66,7 @@ var (
 		"/preview/",
 		"/pdf-viewer/",
 		"/draw-io/",
+		"/index.html#/",
 	}
 )
 

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -50,7 +50,7 @@ var (
 		"/data/",
 		"/account/",
 		"/s/",
-		"/external/spaces",
+		"/external",
 		"/apps/openidconnect/redirect",
 		"/settings/",
 		"/user-management/",


### PR DESCRIPTION
## Description
When ownCloud Web uses the vue router hash mode we need `/index.html#/whatever-ruotes` to be unprotected as well.

`open with web` internally resolves into `/external`, so I needed to shorten the unprotected path prefix `/external/spaces` to `/external`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
