### PR TITLE
[tests-only] Api test. fix search test

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -19,9 +19,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiArchiver/downloadById.feature:134](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadById.feature#L134)
 - [apiArchiver/downloadById.feature:135](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadById.feature#L135)
 
-### [Search by shares jail works incorrect](https://github.com/owncloud/ocis/issues/4014)
-- [apiSpaces/search.feature:43](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/search.feature#L43)
-
 ### [create request for already existing user exits with status code 500 ](https://github.com/owncloud/ocis/issues/3516)
 - [apiGraph/createGroupCaseSensitive.feature:16](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L16)
 - [apiGraph/createGroupCaseSensitive.feature:17](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L17)

--- a/tests/acceptance/features/apiSpaces/search.feature
+++ b/tests/acceptance/features/apiSpaces/search.feature
@@ -47,8 +47,6 @@ Feature: Search
     Then the HTTP status code should be "207"
     And the search result should contain "4" entries
     And the search result of user "Brian" should contain these entries:
-      | /folder                                           |
-      | /folder/SubFolder1                                |
-      | /folder/SubFolder1/subFOLDER2                     |
-      | /folder/SubFolder1/subFOLDER2/insideTheFolder.txt |
-
+      | /SubFolder1                                |
+      | /SubFolder1/subFOLDER2                     |
+      | /SubFolder1/subFOLDER2/insideTheFolder.txt |


### PR DESCRIPTION
issue was closed #4014, but the failed tests still existed

- with the existing implementation we cannot find the folder "folder" in the search response. but we still check that search result contains subfolders
- in test we have checking that response should contain 4 entries

folder "folder" is mountpoint and looks like id
<img width="788" alt="Screenshot 2022-08-26 at 08 48 31" src="https://user-images.githubusercontent.com/84779829/186840945-18423f42-13a8-483b-9a67-491ef7fdb586.png">

but the other folders we can find with the existing implementation:
<img width="1437" alt="Screenshot 2022-08-26 at 08 49 50" src="https://user-images.githubusercontent.com/84779829/186841015-4590e396-312a-42d9-a7ef-9dc5c2c09b02.png">

