### PR TITLE
fix: add index.html to unprotected paths

### DIFF
--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -34,6 +34,7 @@ var (
 		"/app/list":            {},
 		"/config.json":         {},
 		"/manifest.json":       {},
+		"/index.html":          {},
 		"/oidc-callback.html":  {},
 		"/oidc-callback":       {},
 		"/settings.js":         {},


### PR DESCRIPTION
## Description
index.html itself needs to be unprotected as well... in https://github.com/owncloud/ocis/pull/4458 I only added the `/index.html#/` path prefix, which is not enough...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
