### PR TITLE
[full-ci] disable misconfigured default expiration date public links

### DIFF
--- a/changelog/unreleased/bugfix-disable-public-link-default-expiration.md
+++ b/changelog/unreleased/bugfix-disable-public-link-default-expiration.md
@@ -1,0 +1,6 @@
+Bugfix: Disable default expiration for public links
+
+The default expiration for public links was enabled in the capabilities without providing a (then required) default amount of days for clients to pick a reasonable expiration date upon link creation. This has been fixed by disabling the default expiration for public links in the capabilities. With this configuration clients will no longer set a default expiration date upon link creation.
+
+https://github.com/owncloud/ocis/issues/4445
+https://github.com/owncloud/ocis/pull/4475

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -206,7 +206,7 @@ func FrontendConfigFromStruct(cfg *config.Config) (map[string]interface{}, error
 										},
 									},
 									"expire_date": map[string]interface{}{
-										"enabled": true,
+										"enabled": false,
 									},
 									"can_edit": true,
 								},


### PR DESCRIPTION
## Description
The `public.expire_date` capability has misleading naming, as it represents the default expiration date configuration. `enabled: true` requires that a default number of days is provided as well. Since that's not done we should disable the default expiration (or decide to add a default amount of days). This PR disables the default expiration date for public links so that clients behave correctly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/4445

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
