### PR TITLE
[test-only] apiTest. change own password

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -523,4 +523,38 @@ class GraphHelper {
 		}
 		return \json_encode($payload);
 	}
+	
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $currentPassword
+	 * @param string $newPassword
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function changeOwnPassword(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $currentPassword,
+		string $newPassword
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, 'me/changePassword');
+		$payload['currentPassword'] = $currentPassword;
+		$payload['newPassword'] = $newPassword;
+		
+		return HttpRequestHelper::sendRequest(
+			$url,
+			$xRequestId,
+			"POST",
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			\json_encode($payload)
+		);
+	}
 }

--- a/tests/acceptance/features/apiGraph/changeOwnPassword.feature
+++ b/tests/acceptance/features/apiGraph/changeOwnPassword.feature
@@ -5,7 +5,6 @@ Feature: an user changes its own password
         Given user "Alice" has been created with default attributes and without skeleton files
         When the user "Alice" changes its own password "<currentPassword>" to "<newPassword>" using the Graph API
         Then the HTTP status code should be "<code>"
-        And the HTTP response message should be "<message>"
         Examples:
             | currentPassword | newPassword | code |
             | 123456          | validPass   | 204  |

--- a/tests/acceptance/features/apiGraph/changeOwnPassword.feature
+++ b/tests/acceptance/features/apiGraph/changeOwnPassword.feature
@@ -1,0 +1,18 @@
+@api
+Feature: an user changes its own password
+
+    Scenario Outline: change own password
+        Given user "Alice" has been created with default attributes and without skeleton files
+        When the user "Alice" changes its own password "<currentPassword>" to "<newPassword>" using the Graph API
+        Then the HTTP status code should be "<code>"
+        And the HTTP response message should be "<message>"
+        Examples:
+            | currentPassword | newPassword | code |
+            | 123456          | validPass   | 204  |
+            | 123456          | кириллица   | 204  |
+            | 123456          | 密码        | 204  |
+            | 123456          | ?&^%0       | 204  |
+            | 123456          |             | 400  |
+            | 123456          | 123456      | 400  |
+            | wrongPass       | 123456      | 500  |
+            |                 | validPass   | 400  |

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -539,7 +539,7 @@ class GraphContext implements Context {
 
 	/**
 	 * @When /^the user "([^"]*)" changes its own password "([^"]*)" to "([^"]*)" using the Graph API$/
-	 * @param string $user 
+	 * @param string $user
 	 * @param string $currentPassword
 	 * @param string $newPassword
 	 *

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -536,4 +536,25 @@ class GraphContext implements Context {
 			}
 		}
 	}
+
+	/**
+	 * @When /^the user "([^"]*)" changes its own password "([^"]*)" to "([^"]*)" using the Graph API$/
+	 * @param string $user 
+	 * @param string $currentPassword
+	 * @param string $newPassword
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function userChangesOwnPassword(string $user, string $currentPassword, $newPassword): void {
+		$response = GraphHelper::changeOwnPassword(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$currentPassword,
+			$newPassword
+		);
+		$this->featureContext->setResponse($response);
+	}
 }

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -457,7 +457,7 @@ class SpacesContext implements Context {
 							}
 							$this->sendDeleteSpaceRequest($userName, $value["name"]);
 						}
-					}						
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- added api tests for changing own password

in case the user sends an incorrect current password, we get a 500 Server error.  @rhafer Is it correct? 

maybe we should return 400 with "incorrect current password"? 

in the comparison oc10 returns 200 and message: 
<img width="1304" alt="Screenshot 2022-08-31 at 09 31 41" src="https://user-images.githubusercontent.com/84779829/187620299-99a1407b-8ef7-4eef-bb48-a427a598f5cd.png">
