### PR TITLE
[tests-only][full-ci]Reuse code from code for `favorites.feature` in ocis

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=d8ed82769fc422c38d6f6bc21253a052eef5e239
+CORE_COMMITID=b51fb4c01f08763e023aece4f90308e07a7ac73f
 CORE_BRANCH=master
 
 # The test runner source for UI tests

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -61,6 +61,7 @@ default:
         - FilesVersionsContext:
         - OCSContext:
         - PublicWebDavContext:
+        - FavoritesContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -270,6 +270,21 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * This method sets space id by Space Name
+	 * This is currently used to set space id from ocis in core so that we can reuse available resource (code) and avoid duplication
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function setSpaceIDByName(string $user, string $spaceName): void {
+		$space = $this->getSpaceByName($user, $spaceName);
+		WebDavHelper::$SPACE_ID_FROM_OCIS = $space['id'];
+	}
+
+	/**
 	 * The method finds available spaces to the manager user and returns the space by spaceName
 	 *
 	 * @param string $user
@@ -3259,7 +3274,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userFavoritesElementInSpaceUsingTheWebdavApi(string $user, string $path, string $spaceName): void {
-		$space = $this->getSpaceByName($user, $spaceName);
-		$this->favoritesContext->userFavoritesElement($user, $path, $space['id']);
+		$this->setSpaceIDByName($user, $spaceName);
+		$this->favoritesContext->userFavoritesElement($user, $path);
 	}
 }

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -61,6 +61,11 @@ class SpacesContext implements Context {
 	private WebDavPropertiesContext $webDavPropertiesContext;
 
 	/**
+	 * @var FavoritesContext
+	 */
+	private FavoritesContext $favoritesContext;
+
+	/**
 	 * @var string
 	 */
 	private string $baseUrl;
@@ -430,6 +435,7 @@ class SpacesContext implements Context {
 		$this->ocsContext = $environment->getContext('OCSContext');
 		$this->trashbinContext = $environment->getContext('TrashbinContext');
 		$this->webDavPropertiesContext = $environment->getContext('WebDavPropertiesContext');
+		$this->favoritesContext = $environment->getContext('FavoritesContext');
 		// Run the BeforeScenario function in OCSContext to set it up correctly
 		$this->ocsContext->before($scope);
 		$this->baseUrl = \trim($this->featureContext->getBaseUrl(), "/");
@@ -616,28 +622,6 @@ class SpacesContext implements Context {
 		array $headers = []
 	): ResponseInterface {
 		return HttpRequestHelper::sendRequest($fullUrl, $xRequestId, $method, $user, $password, $headers);
-	}
-
-	/**
-	 * send proppatch request to url
-	 *
-	 * @param string $fullUrl
-	 * @param string $user
-	 * @param string $password
-	 * @param string $xRequestId
-	 * @param array $headers
-	 * @param mixed|null $body
-	 * @return ResponseInterface
-	 */
-	public function sendPropPatchRequest(
-		string $fullUrl,
-		string $user,
-		string $password,
-		string $xRequestId = '',
-		array  $headers = [],
-		$body
-	): ResponseInterface {
-		return HttpRequestHelper::sendRequest($fullUrl, $xRequestId, 'PROPPATCH', $user, $password, $headers, $body);
 	}
 
 	/**
@@ -3276,25 +3260,6 @@ class SpacesContext implements Context {
 	 */
 	public function userFavoritesElementInSpaceUsingTheWebdavApi(string $user, string $path, string $spaceName): void {
 		$space = $this->getSpaceByName($user, $spaceName);
-		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($path, "/");
-		$body = '<?xml version="1.0"?>
-				<d:propertyupdate xmlns:d="DAV:"
-				   xmlns:oc="http://owncloud.org/ns">
-				 <d:set>
-				  <d:prop>
-				    <oc:favorite xmlns:oc="http://owncloud.org/ns">1</oc:favorite>
-				  </d:prop>
-				 </d:set>
-				</d:propertyupdate>';
-		$this->featureContext->setResponse(
-			$this->sendProppatchRequest(
-				$fullUrl,
-				$user,
-				$this->featureContext->getPasswordForUser($user),
-				$this->featureContext->getStepLineRef(),
-				[],
-				$body
-			)
-		);
+		$this->favoritesContext->userFavoritesElement($user, $path, $space['id']);
 	}
 }


### PR DESCRIPTION
This PR of using the resource (code) from core as much as possible since there has been a duplication of code that already exists in core. A method to set the space id sets the space id of (Space) not implemented on core is added to make it work. This is an example with `favorite.feature` of ocis. A few adjustment has been done in core for this to works. Can be seen in this Core PR https://github.com/owncloud/core/pull/40328.

### And This PR depends on:
https://github.com/owncloud/core/pull/40328