### PR TITLE
[tests-only] Hardcode header in GraphHelper::deleteSpace

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -523,7 +523,7 @@ class GraphHelper {
 		}
 		return \json_encode($payload);
 	}
-	
+
 	/**
 	 * Send Graph Create Space Request
 	 *
@@ -668,13 +668,13 @@ class GraphHelper {
 
 	/**
 	 * send disable space request
-	 * 
+	 *
 	 * @param string $baseUrl
 	 * @param string $user
 	 * @param string $password
 	 * @param string $spaceId
 	 * @param string $xRequestId
-	 * 
+	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
@@ -686,7 +686,7 @@ class GraphHelper {
 		string $xRequestId = ''
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'drives/' . $spaceId);
-		
+
 		return HttpRequestHelper::delete(
 			$url,
 			$xRequestId,
@@ -697,14 +697,13 @@ class GraphHelper {
 
 	/**
 	 * send delete space request
-	 * 
+	 *
 	 * @param string $baseUrl
 	 * @param string $user
 	 * @param string $password
 	 * @param string $spaceId
-	 * @param array  $header
 	 * @param string $xRequestId
-	 * 
+	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
@@ -713,11 +712,11 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $spaceId,
-		array $header,
 		string $xRequestId = ''
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'drives/' . $spaceId);
-		
+		$header = ["Purge" => "T"];
+
 		return HttpRequestHelper::delete(
 			$url,
 			$xRequestId,
@@ -750,7 +749,7 @@ class GraphHelper {
 
 		return HttpRequestHelper::sendRequest($url, '', 'PATCH', $user, $password, $header, $body);
 	}
-  
+
 	/**
 	 * @param string $baseUrl
 	 * @param string $xRequestId
@@ -773,7 +772,7 @@ class GraphHelper {
 		$url = self::getFullUrl($baseUrl, 'me/changePassword');
 		$payload['currentPassword'] = $currentPassword;
 		$payload['newPassword'] = $newPassword;
-		
+
 		return HttpRequestHelper::sendRequest(
 			$url,
 			$xRequestId,

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2334,16 +2334,14 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName
 	): void {
-		$header = ["Purge" => "T"];
 		$space = $this->getSpaceByName($user, $spaceName);
-		
+
 		$this->featureContext->setResponse(
 			GraphHelper::deleteSpace(
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$space["id"],
-				$header
+				$space["id"]
 			)
 		);
 	}


### PR DESCRIPTION
## Description
See comment https://github.com/owncloud/ocis/pull/4488#discussion_r961492404

`restoreSpace` has the needed header coded inside it. Do the same for `deleteSpace`

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
