### PR TITLE
Fix translations on login page

### DIFF
--- a/changelog/unreleased/bugfix-i18n-login-page.md
+++ b/changelog/unreleased/bugfix-i18n-login-page.md
@@ -1,0 +1,6 @@
+Bugfix: Translations on login page
+
+We've fixed several translations on the login page. Also, the browser language is now being used properly to determine the language.
+
+https://github.com/owncloud/web/issues/7550
+https://github.com/owncloud/ocis/pull/4504

--- a/services/idp/src/containers/Login/Login.jsx
+++ b/services/idp/src/containers/Login/Login.jsx
@@ -147,8 +147,8 @@ function Login(props) {
               margin="normal"
               onChange={handleChange('password')}
               autoComplete="kopano-account current-password"
-              placeholder={t("konnect.login.usernameField.label", "Password")}
-              label={t("konnect.login.usernameField.label", "Password")}
+              placeholder={t("konnect.login.passwordField.label", "Password")}
+              label={t("konnect.login.passwordField.label", "Password")}
               id="oc-login-password"
               {...extraPropsPassword}
           />

--- a/services/idp/src/i18n.ts
+++ b/services/idp/src/i18n.ts
@@ -14,9 +14,9 @@ const config = {
   uiLocaleLocalStorageName: 'lico.identifier_ui_locale', // Sufficiently unique, set here.
 }
 
-const supportedLanguages = locales.map((locale) => {
+const supportedLanguages = ['en-GB', 'en', ...locales.map((locale) => {
   return locale.locale;
-});
+})];
 
 const queryUiLocalesDetector: CustomDetector = {
   name: 'queryUiLocales',

--- a/services/idp/src/locales/de/translation.json
+++ b/services/idp/src/locales/de/translation.json
@@ -32,6 +32,7 @@
         },
         "login": {
             "usernameField": {
+                "label": "Benutzername",
                 "placeholder": {
                     "email": "E-Mail",
                     "identity": "Identität",


### PR DESCRIPTION
## Description
We've fixed several translations on the login page. Also, the browser language is now being used properly to determine the language.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7550

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
