### PR TITLE
auto orientate pictures for thumbnails

### DIFF
--- a/changelog/unreleased/orientate-thumbnails.md
+++ b/changelog/unreleased/orientate-thumbnails.md
@@ -1,0 +1,6 @@
+Enhancement: Automatically orientate photos when generating thumbnails
+
+The thumbnailer now makes use of the exif orientation information to automatically orientate pictures before generating thumbnails.
+
+https://github.com/owncloud/ocis/issues/4477
+https://github.com/owncloud/ocis/pull/4513

--- a/services/thumbnails/pkg/preprocessor/preprocessor.go
+++ b/services/thumbnails/pkg/preprocessor/preprocessor.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"strings"
 
+	"github.com/disintegration/imaging"
 	"github.com/pkg/errors"
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/opentype"
@@ -23,7 +24,7 @@ type FileConverter interface {
 type ImageDecoder struct{}
 
 func (i ImageDecoder) Convert(r io.Reader) (interface{}, error) {
-	img, _, err := image.Decode(r)
+	img, err := imaging.Decode(r, imaging.AutoOrientation(true))
 	if err != nil {
 		return nil, errors.Wrap(err, `could not decode the image`)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The thumbnailer now makes use of the exif orientation information to automatically orientate pictures before generating thumbnails.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/4477



## Screenshots (if appropriate):
|Before|After|
|---------|------|
|![image](https://user-images.githubusercontent.com/5579653/188472842-56e933db-1d7e-49e8-b743-c2f73ce0482c.png)|![image](https://user-images.githubusercontent.com/5579653/188473165-b0f4476d-3f27-4cab-abd8-c172b6f81fb0.png)|


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
