### PR TITLE
proxy: Avoid sorting endpoints for every request

### DIFF
--- a/changelog/unreleased/refactor-proxy.md
+++ b/changelog/unreleased/refactor-proxy.md
@@ -3,4 +3,7 @@ Enhancement: Refactor the proxy service
 The routes of the proxy service now have a "unprotected" flag. This is used by the authentication middleware to determine if the request needs to be blocked when missing authentication or not. 
 
 https://github.com/owncloud/ocis/issues/4401
+https://github.com/owncloud/ocis/issues/4497
 https://github.com/owncloud/ocis/pull/4461
+https://github.com/owncloud/ocis/pull/4498
+https://github.com/owncloud/ocis/pull/4514

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -51,7 +51,8 @@ func Authentication(auths []Authenticator, opts ...Option) func(next http.Handle
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ri := router.ContextRoutingInfo(r.Context())
 			if isOIDCTokenAuth(r) || ri.IsRouteUnprotected() {
-				// The authentication for this request is handled by the IdP.
+				// Either this is a request that does not need any authentication or
+				// the authentication for this request is handled by the IdP.
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/services/proxy/pkg/middleware/public_share_auth.go
+++ b/services/proxy/pkg/middleware/public_share_auth.go
@@ -25,9 +25,22 @@ type PublicShareAuthenticator struct {
 	RevaGatewayClient gateway.GatewayAPIClient
 }
 
+// The archiver is able to create archives from public shares in which case it needs to use the
+// PublicShareAuthenticator. It might however also be called using "normal" authentication or
+// using signed url, which are handled by other middleware. For this reason we can't just
+// handle `/archiver` with the `isPublicPath()` check.
+func isPublicShareArchive(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, "/archiver") {
+		if r.URL.Query().Get(headerShareToken) != "" || r.Header.Get(headerShareToken) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // Authenticate implements the authenticator interface to authenticate requests via public share auth.
 func (a PublicShareAuthenticator) Authenticate(r *http.Request) (*http.Request, bool) {
-	if !isPublicPath(r.URL.Path) {
+	if !isPublicPath(r.URL.Path) && !isPublicShareArchive(r) {
 		return nil, false
 	}
 

--- a/services/proxy/pkg/middleware/public_share_auth_test.go
+++ b/services/proxy/pkg/middleware/public_share_auth_test.go
@@ -28,6 +28,10 @@ var _ = Describe("Authenticating requests", Label("PublicShareAuthenticator"), f
 						return "exampletoken", rpcv1beta1.Code_CODE_OK
 					}
 
+					if clientID == "sharetoken" && clientSecret == "password|" {
+						return "otherexampletoken", rpcv1beta1.Code_CODE_OK
+					}
+
 					return "", rpcv1beta1.Code_CODE_NOT_FOUND
 				},
 			},
@@ -59,6 +63,29 @@ var _ = Describe("Authenticating requests", Label("PublicShareAuthenticator"), f
 
 				h := req2.Header
 				Expect(h.Get(_headerRevaAccessToken)).To(Equal("exampletoken"))
+			})
+		})
+	})
+	When("the reguest is for the archiver", func() {
+		Context("using a public-token", func() {
+			It("should successfully authenticate", func() {
+				req := httptest.NewRequest(http.MethodGet, "http://example.com/archiver?public-token=sharetoken", http.NoBody)
+				req2, valid := authenticator.Authenticate(req)
+
+				Expect(valid).To(Equal(true))
+				Expect(req2).ToNot(BeNil())
+
+				h := req2.Header
+				Expect(h.Get(_headerRevaAccessToken)).To(Equal("otherexampletoken"))
+			})
+		})
+		Context("not using a public-token", func() {
+			It("should fail to authenticate", func() {
+				req := httptest.NewRequest(http.MethodGet, "http://example.com/archiver", http.NoBody)
+				req2, valid := authenticator.Authenticate(req)
+
+				Expect(valid).To(Equal(false))
+				Expect(req2).To(BeNil())
 			})
 		})
 	})

--- a/services/proxy/pkg/router/router.go
+++ b/services/proxy/pkg/router/router.go
@@ -57,6 +57,7 @@ func New(policySelector *config.PolicySelector, policies []config.Policy, logger
 	}
 
 	r := Router{
+		logger:         logger,
 		directors:      make(map[string]map[config.RouteType]map[string]map[string]RoutingInfo),
 		policySelector: selector,
 	}


### PR DESCRIPTION
## Description
The endpoints are no longer hashed by path name in the directors map since that made iterating over the endpoints unstable. They are now stored in a slice in the order in which the are defined in the configuration.

This also includes a fix to make the archiver work for public-links (https://github.com/owncloud/ocis/pull/4461#pullrequestreview-1093104888)

## Related Issue
- Fixes  #4497
