### PR TITLE
update buf lock

### DIFF
--- a/protogen/proto/buf.lock
+++ b/protogen/proto/buf.lock
@@ -4,14 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 5860854adf6a48c39b19d54342b68385
-    digest: b1-WayFxGJKhSLbpMCQ-VZ5-3R5Gj9iRFYsMG7o57lgqog=
-    create_time: 2021-12-14T15:10:38.563007Z
+    commit: 62f35d8aed1149c291d606d958a7ce32
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    branch: main
-    commit: ff83506eb9cc4cf8972f49ce87e6ed3e
-    digest: b1-iLPHgLaoeWWinMiXXqPnxqE4BThtY3eSbswVGh9GOGI=
-    create_time: 2021-10-23T16:26:52.283938Z
+    commit: bc28b723cd774c32b6fbc77621518765


### PR DESCRIPTION
Update the buf lock file in the hope that this will fix the CI builds:
E.g.: https://drone.owncloud.com/owncloud/ocis/15253/3/4