### PR TITLE
[tests-only][full-ci]Reuse code from core for `shareOperation`

### DIFF
--- a/tests/acceptance/features/apiSpaces/shareOperations.feature
+++ b/tests/acceptance/features/apiSpaces/shareOperations.feature
@@ -17,7 +17,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "19"
 
 
@@ -34,7 +34,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "19"
 
 
@@ -61,7 +61,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "3"
 
 
@@ -88,7 +88,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "17"
 
 
@@ -99,7 +99,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "31"
 
 
@@ -115,7 +115,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "31"
 
 
@@ -142,7 +142,7 @@ Feature: sharing
      When user "Brian" gets the following properties of folder "/tmp" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "29"
 
 
@@ -169,7 +169,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "27"
 
 
@@ -196,7 +196,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "23"
 
 
@@ -223,7 +223,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares Jail" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "15"
 
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3122,30 +3122,8 @@ class SpacesContext implements Context {
 		string $spaceName,
 		TableNode $propertiesTable
 	):void {
-		$space = $this->getSpaceByName($user, $spaceName);
-		$properties = null;
-		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($resourceName, "/");
-		$this->featureContext->verifyTableNodeColumns($propertiesTable, ["propertyName"]);
-		$this->featureContext->verifyTableNodeColumnsCount($propertiesTable, 1);
-		if ($propertiesTable instanceof TableNode) {
-			foreach ($propertiesTable->getColumnsHash() as $row) {
-				$properties[] = $row["propertyName"];
-			}
-		}
-		$body = WebDavHelper::getBodyForPropfind($properties);
-		$headers['Depth'] = '1';
-		$this->featureContext->setResponse(
-			$this->sendPropfindRequestToUrl(
-				$fullUrl,
-				$user,
-				$this->featureContext->getPasswordForUser($user),
-				'',
-				$headers,
-				$body
-			)
-		);
-		$responseXml = $this->featureContext->getResponseXml(null, __METHOD__);
-		$this->featureContext->setResponseXmlObject($responseXml);
+		$this->setSpaceIDByName($user, $spaceName);
+		$this->webDavPropertiesContext->userGetsPropertiesOfFolder($user, $resourceName, $propertiesTable);
 	}
 
 	/**


### PR DESCRIPTION
### Description
This PR reuses code from core for the `shareOperation.feature` in `ocis` and avoid duplication.

### Related Issue
https://github.com/owncloud/ocis/issues/4509