### PR TITLE
[full-ci] Add support for the jsoncs3 public share manager

### DIFF
--- a/changelog/unreleased/update-reva-beta8.md
+++ b/changelog/unreleased/update-reva-beta8.md
@@ -4,3 +4,4 @@ Update reva to latest edge.
 
 https://github.com/owncloud/ocis/pull/4522
 https://github.com/owncloud/ocis/pull/4534
+https://github.com/owncloud/ocis/pull/4548

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.0.3
 	github.com/coreos/go-oidc/v3 v3.3.0
 	github.com/cs3org/go-cs3apis v0.0.0-20220818202316-e92afdddac6d
-	github.com/cs3org/reva/v2 v2.8.1-0.20220908102548-7bea458e3873
+	github.com/cs3org/reva/v2 v2.9.1-0.20220909134913-22e6b3280127
 	github.com/disintegration/imaging v1.6.2
 	github.com/ggwhite/go-masker v1.0.9
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20220818202316-e92afdddac6d h1:toyZ7IsXlUdEP
 github.com/cs3org/go-cs3apis v0.0.0-20220818202316-e92afdddac6d/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva/v2 v2.8.1-0.20220908102548-7bea458e3873 h1:XY44uSQQFuRb7xBG47Y9zMKhGuG/++KKxL8GXmol0pI=
 github.com/cs3org/reva/v2 v2.8.1-0.20220908102548-7bea458e3873/go.mod h1:+BYVpRV8g1hL8wF3+3BunL9BKPsXVyJYmH8COxq/V7Y=
+github.com/cs3org/reva/v2 v2.9.1-0.20220909134913-22e6b3280127 h1:pUgPEA2a7bdFM3xREBadRaROSw71SxORtRLBZtqrEdQ=
+github.com/cs3org/reva/v2 v2.9.1-0.20220909134913-22e6b3280127/go.mod h1:+BYVpRV8g1hL8wF3+3BunL9BKPsXVyJYmH8COxq/V7Y=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -275,6 +275,13 @@ func revaPublicShareConfig(cfg *sharing.Config) map[string]interface{} {
 			"file":         cfg.PublicSharingDrivers.JSON.File,
 			"gateway_addr": cfg.Reva.Address,
 		},
+		"jsoncs3": map[string]interface{}{
+			"gateway_addr":        cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
+			"provider_addr":       cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
+			"service_user_id":     cfg.PublicSharingDrivers.JSONCS3.SystemUserID,
+			"service_user_idp":    cfg.PublicSharingDrivers.JSONCS3.SystemUserIDP,
+			"machine_auth_apikey": cfg.PublicSharingDrivers.JSONCS3.SystemUserAPIKey,
+		},
 		"sql": map[string]interface{}{
 			"db_username":                   cfg.PublicSharingDrivers.SQL.DBUsername,
 			"db_password":                   cfg.PublicSharingDrivers.SQL.DBPassword,

--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -276,7 +276,7 @@ func revaPublicShareConfig(cfg *sharing.Config) map[string]interface{} {
 			"gateway_addr": cfg.Reva.Address,
 		},
 		"jsoncs3": map[string]interface{}{
-			"gateway_addr":        cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
+			"gateway_addr":        cfg.Reva.Address,
 			"provider_addr":       cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
 			"service_user_id":     cfg.PublicSharingDrivers.JSONCS3.SystemUserID,
 			"service_user_idp":    cfg.PublicSharingDrivers.JSONCS3.SystemUserIDP,

--- a/services/sharing/pkg/config/config.go
+++ b/services/sharing/pkg/config/config.go
@@ -110,8 +110,9 @@ type UserSharingJSONCS3Driver struct {
 }
 
 type PublicSharingDrivers struct {
-	JSON PublicSharingJSONDriver `yaml:"json"`
-	CS3  PublicSharingCS3Driver  `yaml:"cs3"`
+	JSON    PublicSharingJSONDriver    `yaml:"json"`
+	CS3     PublicSharingCS3Driver     `yaml:"cs3"`
+	JSONCS3 PublicSharingJSONCS3Driver `yaml:"jsoncs3"`
 
 	SQL PublicSharingSQLDriver `yaml:"sql,omitempty"` // not supported by the oCIS product, therefore not part of docs
 }
@@ -136,7 +137,15 @@ type PublicSharingCS3Driver struct {
 	ProviderAddr     string `yaml:"provider_addr" env:"SHARING_PUBLIC_CS3_PROVIDER_ADDR" desc:"GRPC address of the STORAGE-SYSTEM service."`
 	SystemUserID     string `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID;SHARING_PUBLIC_CS3_SYSTEM_USER_ID" desc:"ID of the oCIS STORAGE-SYSTEM system user. Admins need to set the ID for the STORAGE-SYSTEM system user in this config option which is then used to reference the user. Any reasonable long string is possible, preferably this would be an UUIDv4 format."`
 	SystemUserIDP    string `yaml:"system_user_idp" env:"OCIS_SYSTEM_USER_IDP;SHARING_PUBLIC_CS3_SYSTEM_USER_IDP" desc:"IDP of the oCIS STORAGE-SYSTEM system user."`
-	SystemUserAPIKey string `yaml:"system_user_api_key" env:"OCIS_SYSTEM_USER_API_KEY;SHARING_USER_CS3_SYSTEM_USER_API_KEY" desc:"API key for the STORAGE-SYSTEM system user."`
+	SystemUserAPIKey string `yaml:"system_user_api_key" env:"OCIS_SYSTEM_USER_API_KEY;SHARING_PUBLIC_CS3_SYSTEM_USER_API_KEY" desc:"API key for the STORAGE-SYSTEM system user."`
+}
+
+// PublicSharingJSONCS3Driver holds the jsoncs3 driver config
+type PublicSharingJSONCS3Driver struct {
+	ProviderAddr     string `yaml:"provider_addr" env:"SHARING_PUBLIC_CS3_PROVIDER_ADDR" desc:"GRPC address of the STORAGE-SYSTEM service."`
+	SystemUserID     string `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID;SHARING_PUBLIC_CS3_SYSTEM_USER_ID" desc:"ID of the oCIS STORAGE-SYSTEM system user. Admins need to set the ID for the STORAGE-SYSTEM system user in this config option which is then used to reference the user. Any reasonable long string is possible, preferably this would be an UUIDv4 format."`
+	SystemUserIDP    string `yaml:"system_user_idp" env:"OCIS_SYSTEM_USER_IDP;SHARING_PUBLIC_CS3_SYSTEM_USER_ID" desc:"IDP of the oCIS STORAGE-SYSTEM system user."`
+	SystemUserAPIKey string `yaml:"system_user_api_key" env:"OCIS_SYSTEM_USER_API_KEY;SHARING_PUBLIC_CS3_SYSTEM_USER_API_KEY" desc:"API key for the STORAGE-SYSTEM system user."`
 }
 
 type Events struct {

--- a/services/sharing/pkg/config/config.go
+++ b/services/sharing/pkg/config/config.go
@@ -111,8 +111,8 @@ type UserSharingJSONCS3Driver struct {
 
 type PublicSharingDrivers struct {
 	JSON    PublicSharingJSONDriver    `yaml:"json"`
-	CS3     PublicSharingCS3Driver     `yaml:"cs3"`
 	JSONCS3 PublicSharingJSONCS3Driver `yaml:"jsoncs3"`
+	CS3     PublicSharingCS3Driver     `yaml:"cs3"`
 
 	SQL PublicSharingSQLDriver `yaml:"sql,omitempty"` // not supported by the oCIS product, therefore not part of docs
 }

--- a/services/sharing/pkg/config/defaults/defaultconfig.go
+++ b/services/sharing/pkg/config/defaults/defaultconfig.go
@@ -62,6 +62,10 @@ func DefaultConfig() *config.Config {
 				ProviderAddr:  "127.0.0.1:9215", // system storage
 				SystemUserIDP: "internal",
 			},
+			JSONCS3: config.PublicSharingJSONCS3Driver{
+				ProviderAddr:  "127.0.0.1:9215", // system storage
+				SystemUserIDP: "internal",
+			},
 			// TODO implement and add owncloudsql publicshare driver
 		},
 		Events: config.Events{

--- a/services/sharing/pkg/config/defaults/defaultconfig.go
+++ b/services/sharing/pkg/config/defaults/defaultconfig.go
@@ -53,7 +53,7 @@ func DefaultConfig() *config.Config {
 				DBName:     "owncloud",
 			},
 		},
-		PublicSharingDriver: "cs3",
+		PublicSharingDriver: "jsoncs3",
 		PublicSharingDrivers: config.PublicSharingDrivers{
 			JSON: config.PublicSharingJSONDriver{
 				File: filepath.Join(defaults.BaseDataPath(), "storage", "publicshares.json"),
@@ -137,6 +137,14 @@ func EnsureDefaults(cfg *config.Config) {
 
 	if cfg.PublicSharingDrivers.CS3.SystemUserID == "" && cfg.Commons != nil && cfg.Commons.SystemUserID != "" {
 		cfg.PublicSharingDrivers.CS3.SystemUserID = cfg.Commons.SystemUserID
+	}
+
+	if cfg.PublicSharingDrivers.JSONCS3.SystemUserAPIKey == "" && cfg.Commons != nil && cfg.Commons.SystemUserAPIKey != "" {
+		cfg.PublicSharingDrivers.JSONCS3.SystemUserAPIKey = cfg.Commons.SystemUserAPIKey
+	}
+
+	if cfg.PublicSharingDrivers.JSONCS3.SystemUserID == "" && cfg.Commons != nil && cfg.Commons.SystemUserID != "" {
+		cfg.PublicSharingDrivers.JSONCS3.SystemUserID = cfg.Commons.SystemUserID
 	}
 }
 

--- a/services/sharing/pkg/revaconfig/config.go
+++ b/services/sharing/pkg/revaconfig/config.go
@@ -89,6 +89,13 @@ func SharingConfigFromStruct(cfg *config.Config) map[string]interface{} {
 							"service_user_idp":    cfg.PublicSharingDrivers.CS3.SystemUserIDP,
 							"machine_auth_apikey": cfg.PublicSharingDrivers.CS3.SystemUserAPIKey,
 						},
+						"jsoncs3": map[string]interface{}{
+							"gateway_addr":        cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
+							"provider_addr":       cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
+							"service_user_id":     cfg.PublicSharingDrivers.JSONCS3.SystemUserID,
+							"service_user_idp":    cfg.PublicSharingDrivers.JSONCS3.SystemUserIDP,
+							"machine_auth_apikey": cfg.PublicSharingDrivers.JSONCS3.SystemUserAPIKey,
+						},
 					},
 				},
 			},

--- a/services/sharing/pkg/revaconfig/config.go
+++ b/services/sharing/pkg/revaconfig/config.go
@@ -90,7 +90,7 @@ func SharingConfigFromStruct(cfg *config.Config) map[string]interface{} {
 							"machine_auth_apikey": cfg.PublicSharingDrivers.CS3.SystemUserAPIKey,
 						},
 						"jsoncs3": map[string]interface{}{
-							"gateway_addr":        cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
+							"gateway_addr":        cfg.Reva.Address,
 							"provider_addr":       cfg.PublicSharingDrivers.JSONCS3.ProviderAddr,
 							"service_user_id":     cfg.PublicSharingDrivers.JSONCS3.SystemUserID,
 							"service_user_idp":    cfg.PublicSharingDrivers.JSONCS3.SystemUserIDP,

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -517,20 +517,6 @@ cannot share a folder with create permission
 - [apiSharePublicLink3/updatePublicLinkShare.feature:45](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature#L45)
 - [apiSharePublicLink3/updatePublicLinkShare.feature:46](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature#L46)
 
-#### [Increasing permission of a public link of a folder that was initially shared with share+read permissions is allowed](https://github.com/owncloud/ocis/issues/3881)
-
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:159](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L159)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:160](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L160)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L181)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:182](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L182)
-
-#### [Adding public upload to a read only shared folder as a recipient is allowed ](https://github.com/owncloud/ocis/issues/2164)
-
-- [apiSharePublicLink3/updatePublicLinkShare.feature:364](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature#L364)
-- [apiSharePublicLink3/updatePublicLinkShare.feature:365](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature#L365)
-- [apiSharePublicLink3/updatePublicLinkShare.feature:424](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature#L424)
-- [apiSharePublicLink3/updatePublicLinkShare.feature:425](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature#L425)
-
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis-reva/issues/286)
 
 - [apiSharePublicLink3/uploadToPublicLinkShare.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature#L24)


### PR DESCRIPTION
This PR allows for configuring the jsoncs3 public share manager from https://github.com/cs3org/reva/pull/3199

FIxes https://github.com/owncloud/ocis/issues/3881
Fixes https://github.com/owncloud/ocis/issues/2164