### PR TITLE
[docs-only] update sharing docs

### DIFF
--- a/docs/services/frontend/_index.md
+++ b/docs/services/frontend/_index.md
@@ -10,7 +10,28 @@ geekdocCollapseSection: true
 
 ## Abstract
 
+The frontend service provides multiple HTTP endpoints to translate OCS, archiver and approvider requests into CS3 requests.
 
 ## Table of Contents
 
 {{< toc-tree >}}
+
+## OCS
+
+The OCS endpoint implements the open collaboration services API in a backwards compatible manner.
+
+### Sharing
+
+Aggregating share information as one of the most time consuming operations in OCIS. The service fetches a list of either received or created shares and has to stat every resource individually. While stats are fast, the default behavior scales linear with the number of shares.
+
+To save network trips the sharing implementation can cache the stat requests with an in memory cache or in redis. It will shorten the response time by the network rountrip overhead at the cost of the API only eventually being updated. 
+
+Setting `FRONTEND_OCS_RESOURCE_INFO_CACHE_TTL=60` would cache the stat info for 60 seconds. Increasing this value makes sense for large deployments with thousands of active users that keep the cache up to date. Low frequency usage scenarios should not expect a noticeable improvement.
+
+## Archiver
+
+The archiver endpoint provides bundled downloads of multiple files and folders.
+
+## Appprovider
+
+The appprovider endpoint is used to manage available apps that can be used to open different file types.

--- a/docs/services/frontend/_index.md
+++ b/docs/services/frontend/_index.md
@@ -22,7 +22,7 @@ The OCS endpoint implements the open collaboration services API in a backwards c
 
 ### Sharing
 
-Aggregating share information as one of the most time consuming operations in OCIS. The service fetches a list of either received or created shares and has to stat every resource individually. While stats are fast, the default behavior scales linear with the number of shares.
+Aggregating share information is one of the most time consuming operations in OCIS. The service fetches a list of either received or created shares and has to stat every resource individually. While stats are fast, the default behavior scales linearly with the number of shares.
 
 To save network trips the sharing implementation can cache the stat requests with an in memory cache or in redis. It will shorten the response time by the network rountrip overhead at the cost of the API only eventually being updated. 
 

--- a/docs/services/sharing/_index.md
+++ b/docs/services/sharing/_index.md
@@ -9,7 +9,7 @@ geekdocCollapseSection: true
 
 ## Abstract
 
-This service provides sharing functionality.
+This service implements the CS3 [LinkAPI](https://cs3org.github.io/cs3apis/#cs3.sharing.link.v1beta1.LinkAPI) to manage public links as well as the [CollaborationAPI](https://cs3org.github.io/cs3apis/#cs3.sharing.collaboration.v1beta1.CollaborationAPI) to manage user and group shares.
 
 ## Table of Contents
 


### PR DESCRIPTION
I added a few basic infos about sharing related services.

@dragotin the info from https://github.com/owncloud/ocis/pull/4438#issuecomment-1241825616 is pretty outdated, as @aduffeck and I managed to reduce listing of 500 shares as a recipient from 46 down to 4 seconds. A combination of different public share manager implementations share manager bugs and ocs performance tuning.

I still added an explanation for the only worthwile option to enable the resource stat info cache in the ocs service. I put that on the frontend index page. That seems to currently be the best place.