### PR TITLE
enable request tracking prometheus middleware in reva

### DIFF
--- a/services/app-provider/pkg/revaconfig/config.go
+++ b/services/app-provider/pkg/revaconfig/config.go
@@ -43,6 +43,12 @@ func AppProviderConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "app_provider",
+				},
+			},
 		},
 	}
 	return rcfg

--- a/services/app-registry/pkg/revaconfig/config.go
+++ b/services/app-registry/pkg/revaconfig/config.go
@@ -33,6 +33,12 @@ func AppRegistryConfigFromStruct(cfg *config.Config, logger log.Logger) map[stri
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "app_registry",
+				},
+			},
 		},
 	}
 	return rcfg

--- a/services/auth-basic/pkg/revaconfig/config.go
+++ b/services/auth-basic/pkg/revaconfig/config.go
@@ -42,6 +42,12 @@ func AuthBasicConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "auth_basic",
+				},
+			},
 		},
 	}
 	return rcfg

--- a/services/auth-bearer/pkg/revaconfig/config.go
+++ b/services/auth-bearer/pkg/revaconfig/config.go
@@ -33,6 +33,12 @@ func AuthBearerConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "auth_bearer",
+				},
+			},
 		},
 	}
 }

--- a/services/auth-machine/pkg/revaconfig/config.go
+++ b/services/auth-machine/pkg/revaconfig/config.go
@@ -32,6 +32,12 @@ func AuthMachineConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "auth_machine",
+				},
+			},
 		},
 	}
 }

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -85,6 +85,10 @@ func FrontendConfigFromStruct(cfg *config.Config) (map[string]interface{}, error
 					"credentials_by_user_agent": cfg.Middleware.Auth.CredentialsByUserAgent,
 					"credential_chain":          []string{"bearer"},
 				},
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "frontend",
+				},
 			},
 			// TODO build services dynamically
 			"services": map[string]interface{}{

--- a/services/gateway/pkg/revaconfig/config.go
+++ b/services/gateway/pkg/revaconfig/config.go
@@ -80,6 +80,12 @@ func GatewayConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]i
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "gateway",
+				},
+			},
 		},
 	}
 	return rcfg

--- a/services/groups/pkg/revaconfig/config.go
+++ b/services/groups/pkg/revaconfig/config.go
@@ -44,6 +44,12 @@ func GroupsConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "groups",
+				},
+			},
 		},
 	}
 }

--- a/services/ocdav/pkg/command/server.go
+++ b/services/ocdav/pkg/command/server.go
@@ -65,6 +65,8 @@ func Server(cfg *config.Config) *cli.Command {
 					// ocdav.FavoriteManager() // FIXME needs a proper persistence implementation https://github.com/owncloud/ocis/issues/1228
 					// ocdav.LockSystem(), // will default to the CS3 lock system
 					// ocdav.TLSConfig() // tls config for the http server
+					ocdav.MetricsEnabled(true),
+					ocdav.MetricsNamespace("ocis"),
 				}
 
 				if cfg.Tracing.Enabled {

--- a/services/sharing/pkg/revaconfig/config.go
+++ b/services/sharing/pkg/revaconfig/config.go
@@ -107,6 +107,10 @@ func SharingConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					"address":   cfg.Events.Addr,
 					"clusterID": cfg.Events.ClusterID,
 				},
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "sharing",
+				},
 			},
 		},
 	}

--- a/services/storage-publiclink/pkg/revaconfig/config.go
+++ b/services/storage-publiclink/pkg/revaconfig/config.go
@@ -23,6 +23,10 @@ func StoragePublicLinkConfigFromStruct(cfg *config.Config) map[string]interface{
 			"address": cfg.GRPC.Addr,
 			"interceptors": map[string]interface{}{
 				"log": map[string]interface{}{},
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "storage_publiclink",
+				},
 			},
 			"services": map[string]interface{}{
 				"publicstorageprovider": map[string]interface{}{

--- a/services/storage-shares/pkg/revaconfig/config.go
+++ b/services/storage-shares/pkg/revaconfig/config.go
@@ -27,6 +27,12 @@ func StorageSharesConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					"mount_id":             cfg.MountID,
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "storage_shares",
+				},
+			},
 		},
 	}
 	if cfg.ReadOnly {

--- a/services/storage-system/pkg/revaconfig/config.go
+++ b/services/storage-system/pkg/revaconfig/config.go
@@ -98,6 +98,12 @@ func StorageSystemFromStruct(cfg *config.Config) map[string]interface{} {
 					"data_server_url": cfg.DataServerURL,
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "storage_system",
+				},
+			},
 		},
 		"http": map[string]interface{}{
 			"network": cfg.HTTP.Protocol,
@@ -125,6 +131,12 @@ func StorageSystemFromStruct(cfg *config.Config) map[string]interface{} {
 							"cache_table":    "stat",
 						},
 					},
+				},
+			},
+			"middlewares": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "storage_system",
 				},
 			},
 		},

--- a/services/storage-users/pkg/revaconfig/config.go
+++ b/services/storage-users/pkg/revaconfig/config.go
@@ -39,6 +39,10 @@ func StorageUsersConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					"address":   cfg.Events.Addr,
 					"clusterID": cfg.Events.ClusterID,
 				},
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "storage_users",
+				},
 			},
 		},
 		"http": map[string]interface{}{

--- a/services/users/pkg/revaconfig/config.go
+++ b/services/users/pkg/revaconfig/config.go
@@ -45,6 +45,12 @@ func UsersConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					},
 				},
 			},
+			"interceptors": map[string]interface{}{
+				"prometheus": map[string]interface{}{
+					"namespace": "ocis",
+					"subsystem": "users",
+				},
+			},
 		},
 	}
 	return rcfg


### PR DESCRIPTION
Part of https://github.com/cs3org/reva/issues/2976 to make reva master and edge comparable at the request level.

Requires https://github.com/cs3org/reva/pull/3229 to get metrics like this:
```
$ curl 127.0.0.1:9165/metrics -s | grep _requests | grep -v '#' | grep -v 'promhttp_metric_'
ocis_app_provider_grpc_requests_total 0
ocis_app_registry_grpc_requests_total 1
ocis_auth_basic_grpc_requests_total 1
ocis_auth_bearer_grpc_requests_total 0
ocis_auth_machine_grpc_requests_total 1
ocis_frontend_http_requests_total 1
ocis_gateway_grpc_requests_total 1013
ocis_groups_grpc_requests_total 0
ocis_sharing_grpc_requests_total 1
ocis_storage_publiclink_grpc_requests_total 0
ocis_storage_shares_grpc_requests_total 0
ocis_storage_system_grpc_requests_total 858
ocis_storage_system_http_requests_total 118
ocis_storage_users_grpc_requests_total 501
ocis_users_grpc_requests_total 5
```

- [ ] also add counters to ocis services for eg ocdav?

there are minio metrics:
```
$ curl 127.0.0.1:9165/metrics -s | grep micro | grep -v '#' | grep -v 'promhttp_metric_'
micro_latency_microseconds_sum{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version=""} 922593.6510000001
micro_latency_microseconds_count{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version=""} 1
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="0.005"} 0
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="0.01"} 0
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="0.025"} 0
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="0.05"} 0
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="0.1"} 0
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="0.25"} 0
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="0.5"} 0
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="1"} 1
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="2.5"} 1
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="5"} 1
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="10"} 1
micro_request_duration_seconds_bucket{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version="",le="+Inf"} 1
micro_request_duration_seconds_sum{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version=""} 0.922593651
micro_request_duration_seconds_count{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_version=""} 1
micro_request_total{micro_endpoint="RoleService.ListRoleAssignments",micro_id="",micro_name="",micro_status="success",micro_version=""} 1
```

