### PR TITLE
allow to configure applications for web

### DIFF
--- a/changelog/unreleased/enhancement-web-applications.md
+++ b/changelog/unreleased/enhancement-web-applications.md
@@ -1,0 +1,5 @@
+Enhancement: Allow to configure applications in Web
+
+We've added the possibility to configure applications in the Web configuration.
+
+https://github.com/owncloud/ocis/pull/4578

--- a/services/web/pkg/config/config.go
+++ b/services/web/pkg/config/config.go
@@ -36,6 +36,7 @@ type WebConfig struct {
 	Theme         string                 `json:"theme,omitempty" yaml:"-"`
 	OpenIDConnect OIDC                   `json:"openIdConnect,omitempty" yaml:"oidc"`
 	Apps          []string               `json:"apps" yaml:"apps"`
+	Applications  []Application          `json:"applications,omitempty" yaml:"applications"`
 	ExternalApps  []ExternalApp          `json:"external_apps,omitempty" yaml:"external_apps"`
 	Options       map[string]interface{} `json:"options,omitempty" yaml:"options"`
 }
@@ -47,6 +48,15 @@ type OIDC struct {
 	ClientID     string `json:"client_id,omitempty" yaml:"client_id" env:"WEB_OIDC_CLIENT_ID" desc:"OIDC client ID, which ownCloud Web uses. This client needs to be set up in your IDP."`
 	ResponseType string `json:"response_type,omitempty" yaml:"response_type" env:"WEB_OIDC_RESPONSE_TYPE" desc:"OIDC response type to use for authentication."`
 	Scope        string `json:"scope,omitempty" yaml:"scope" env:"WEB_OIDC_SCOPE" desc:"OIDC scopes to request during authentication."`
+}
+
+// Application defines an application for the Web app switcher.
+type Application struct {
+	Icon   string            `json:"icon,omitempty" yaml:"icon"`
+	Target string            `json:"target,omitempty" yaml:"target"`
+	Title  map[string]string `json:"title,omitempty" yaml:"title"`
+	Menu   string            `json:"menu,omitempty" yaml:"menu"`
+	URL    string            `json:"url,omitempty" yaml:"url"`
 }
 
 // ExternalApp defines an external web app.


### PR DESCRIPTION
## Description
allows to configure applications for web.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- 

## Motivation and Context
Modify the app switcher in web

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `web.yaml`:
  ```
  web:
    config:
      applications:
        -  icon: swap-box
           url: https://owncloud.com
           target: _self
           title:
             de: ownCloud Webseite
             en: ownCloud Webpage
  ```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
