### PR TITLE
fix search report webdav permissions

### DIFF
--- a/changelog/unreleased/fix-search-webdav-permissions.md
+++ b/changelog/unreleased/fix-search-webdav-permissions.md
@@ -1,0 +1,6 @@
+Bugfix: render webdav permissions as string in search report
+
+We now correctly render the `oc:permissions` of resources as a string.
+
+https://github.com/owncloud/ocis/issues/4575
+https://github.com/owncloud/ocis/pull/4579


### PR DESCRIPTION
We now correctly render the `oc:permissions` of resources as a string.

fixes https://github.com/owncloud/ocis/issues/4575
