### PR TITLE
forward trace context in graph service

### DIFF
--- a/changelog/unreleased/graph-forward-trace-ctx.md
+++ b/changelog/unreleased/graph-forward-trace-ctx.md
@@ -1,0 +1,3 @@
+Bugfix: graph service now forwards trace context
+
+https://github.com/owncloud/ocis/pull/4582

--- a/services/graph/pkg/server/http/server.go
+++ b/services/graph/pkg/server/http/server.go
@@ -49,6 +49,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.Logger(options.Logger),
 		svc.Config(options.Config),
 		svc.Middleware(
+			middleware.TraceContext,
 			chimiddleware.RequestID,
 			middleware.Version(
 				"graph",


### PR DESCRIPTION
allows tracing graph requests