### PR TITLE
graph: implement search and expand for listing drives

### DIFF
--- a/changelog/unreleased/graph-select-expand-drives.md
+++ b/changelog/unreleased/graph-select-expand-drives.md
@@ -1,0 +1,5 @@
+Enhancement: listing drives now supports $select and $filter
+
+The default response no longer expands the `root` relation. To do that use a query parameter `graph/v1.0/me/drives?$expand=root`
+
+https://github.com/owncloud/ocis/pull/4586

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -224,6 +224,7 @@ func (g Graph) GetExtendedSpaceProperties(ctx context.Context, baseURL *url.URL,
 	metadata := space.Opaque.Map
 	names := [2]string{SpaceImageSpecialFolderName, ReadmeSpecialFolderName}
 
+	// TODO skip fetching if not selected
 	for _, itemName := range names {
 		if itemID, ok := metadata[itemName]; ok {
 			rid, _ := storagespace.ParseID(string(itemID.Value))

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -543,6 +543,9 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 				}
 			}
 		case "etag":
+			// actually a space only has lastModifiedDateTime
+			// we could implement `$expand=root&$select=id,root/etag` or whatever clients need to quickly determine changes
+			// maybe even an if-match header for the list of drives itself
 			// FIXME add eTag to CS3 space property
 			// FIXME mountpoints have no etag here ...
 			if space.Opaque != nil {

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -227,7 +227,7 @@ func (g Graph) GetUser(w http.ResponseWriter, r *http.Request) {
 		}
 		drives := []libregraph.Drive{}
 		for _, sp := range lspr.GetStorageSpaces() {
-			d, err := g.cs3StorageSpaceToDrive(r.Context(), wdu, sp)
+			d, err := g.cs3StorageSpaceToDrive(r.Context(), wdu, sp, nil)
 			if err != nil {
 				g.logger.Err(err).Interface("query", r.URL.Query()).Msg("error converting space to drive")
 			}


### PR DESCRIPTION
The default response no longer expands the `root` relation. To do that use a query parameter `graph/v1.0/me/drives?$expand=root`

This prevents stating all root resources, and reduces overall stat load on the storage when not needed.

- [ ] mount point spaces currently do not have an etag in the opaque