### PR TITLE
remove the Open Sans font

### DIFF
--- a/services/idp/public/index.html
+++ b/services/idp/public/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#1b223d">
     <link rel="shortcut icon" href="%PUBLIC_URL%/static/favicon.ico" type="image/x-icon">
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
     <meta property="csp-nonce" content="__CSP_NONCE__">
     <title>Sign in - ownCloud</title>
   </head>

--- a/services/idp/src/app.css
+++ b/services/idp/src/app.css
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-  font-family: Inter, 'Open Sans', sans-serif;
+  font-family: Inter, sans-serif;
 }
 
 strong {


### PR DESCRIPTION
Closes: https://github.com/owncloud/ocis/issues/4212
We were using the Open Sans font only as a fallback to the "Inter" font which we served ourselves so removing the google font does no harm.