### PR TITLE
fix the oidc provider cache

### DIFF
--- a/changelog/unreleased/fix-oidc-provider-cache.md
+++ b/changelog/unreleased/fix-oidc-provider-cache.md
@@ -1,0 +1,6 @@
+Bugfix: Fix the OIDC provider cache
+
+We've fixed the OIDC provider cache. It never had a cache hit before this fix.
+Under some circumstances it could cause a painfully slow OCIS if the IDP wellknown endpoint takes some time to respond.
+
+https://github.com/owncloud/ocis/pull/4600


### PR DESCRIPTION
## Description
fixes the oidc provider cache. It never had a cache hit before this fix.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- introduced in https://github.com/owncloud/ocis/pull/4374

## Motivation and Context
Caused a painfully slow oCIS if the IDP wellknown endpoint was not too fast.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- debug and see if we have cache hits

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
