### PR TITLE
[Docs] Fixing the adoc template

### DIFF
--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -13,9 +13,9 @@
 `{{- $value }}`
 {{- end }}
 a| [subs=-attributes]
-+{{.Type}}+
+++{{.Type}}++
 a| [subs=-attributes]
-pass:[{{.DefaultValue}}]
+++{{.DefaultValue}}++
 a| [subs=-attributes]
 {{.Description}}
 


### PR DESCRIPTION
## Description
This fixes the adoc template because eMails in the form `<me@example.com>` were not rendered (note the less than/ greater than symbols)

The change uses a better way for passthrough, see [pass-macro in asciidoc](https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/#single-double-plus)

## Related Issue
- References #4589 (Notification service env variable update needed)

## Motivation and Context
Render eMail addresses in the form as written above

## How Has This Been Tested?
Local build with `make -C docs docs-generate`
Then check all services adoc files if the output is correct ✔️ 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
