### PR TITLE
[full-ci] Default to in-memory registry in single-binary mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/go-micro/plugins/v4/registry/etcd v1.1.0
 	github.com/go-micro/plugins/v4/registry/kubernetes v1.1.0
 	github.com/go-micro/plugins/v4/registry/mdns v1.1.0
+	github.com/go-micro/plugins/v4/registry/memory v1.1.0
 	github.com/go-micro/plugins/v4/registry/nats v1.1.0
 	github.com/go-micro/plugins/v4/server/grpc v1.1.1
 	github.com/go-micro/plugins/v4/server/http v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ github.com/go-micro/plugins/v4/registry/kubernetes v1.1.0 h1:JfkrimhACDviPtKT7Fh
 github.com/go-micro/plugins/v4/registry/kubernetes v1.1.0/go.mod h1:6SNUr4g/JTzmR8OWU1KaIOS+lCFaqDnCRvbH3L5uUro=
 github.com/go-micro/plugins/v4/registry/mdns v1.1.0 h1:qRB93cviMeY4n3/r9T/5zJF3PF+Ol5tw/VW5e6TSG4s=
 github.com/go-micro/plugins/v4/registry/mdns v1.1.0/go.mod h1:k71V05hytGwaO3jqKKf8NmBPo07NFlCLmeIwPNr6n50=
+github.com/go-micro/plugins/v4/registry/memory v1.1.0 h1:omyL8l12mzNCjNSDxMkAReEWOiv58j62X7sIa6aRCj8=
+github.com/go-micro/plugins/v4/registry/memory v1.1.0/go.mod h1:7gsV2dwpFr+1rFhncmnxA9Tjv/NjQr9Zy8KpVKS7/jQ=
 github.com/go-micro/plugins/v4/registry/nats v1.1.0 h1:oqQzP5P2FkfoYZiBRuCWsKqh4BCJG6MQkxYmLw2lNrU=
 github.com/go-micro/plugins/v4/registry/nats v1.1.0/go.mod h1:4tTfa958PiYUOZNBBNoY1awmgfxFcqQOmix8cR3UM+E=
 github.com/go-micro/plugins/v4/server/grpc v1.1.1 h1:7V5K8RTQhzzFsJCPkKXTJr4YrWyIw5xebUTtDY27l3k=

--- a/ocis-pkg/registry/registry.go
+++ b/ocis-pkg/registry/registry.go
@@ -3,52 +3,77 @@ package registry
 import (
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	consulr "github.com/go-micro/plugins/v4/registry/consul"
 	etcdr "github.com/go-micro/plugins/v4/registry/etcd"
 	kubernetesr "github.com/go-micro/plugins/v4/registry/kubernetes"
 	mdnsr "github.com/go-micro/plugins/v4/registry/mdns"
+	memr "github.com/go-micro/plugins/v4/registry/memory"
 	natsr "github.com/go-micro/plugins/v4/registry/nats"
 
 	"go-micro.dev/v4/registry"
 	"go-micro.dev/v4/registry/cache"
 )
 
-var (
+const (
 	registryEnv        = "MICRO_REGISTRY"
 	registryAddressEnv = "MICRO_REGISTRY_ADDRESS"
 )
+
+var (
+	once      sync.Once
+	regPlugin string
+	reg       registry.Registry
+)
+
+func Configure(plugin string) {
+	if reg == nil {
+		regPlugin = plugin
+	}
+}
 
 // GetRegistry returns a configured micro registry based on Micro env vars.
 // It defaults to mDNS, so mind that systems with mDNS disabled by default (i.e SUSE) will have a hard time
 // and it needs to explicitly use etcd. Os awareness for providing a working registry out of the box should be done.
 func GetRegistry() registry.Registry {
-	addresses := strings.Split(os.Getenv(registryAddressEnv), ",")
+	once.Do(func() {
+		addresses := strings.Split(os.Getenv(registryAddressEnv), ",")
+		// prefer env of setting from Configure()
+		plugin := os.Getenv(registryEnv)
+		if plugin == "" {
+			plugin = regPlugin
+		}
 
-	var r registry.Registry
-	switch os.Getenv(registryEnv) {
-	case "nats":
-		r = natsr.NewRegistry(
-			registry.Addrs(addresses...),
-		)
-	case "kubernetes":
-		r = kubernetesr.NewRegistry(
-			registry.Addrs(addresses...),
-		)
-	case "etcd":
-		r = etcdr.NewRegistry(
-			registry.Addrs(addresses...),
-		)
-	case "consul":
-		r = consulr.NewRegistry(
-			registry.Addrs(addresses...),
-		)
-	default:
-		r = mdnsr.NewRegistry()
-	}
-
+		switch plugin {
+		case "nats":
+			reg = natsr.NewRegistry(
+				registry.Addrs(addresses...),
+			)
+		case "kubernetes":
+			reg = kubernetesr.NewRegistry(
+				registry.Addrs(addresses...),
+			)
+		case "etcd":
+			reg = etcdr.NewRegistry(
+				registry.Addrs(addresses...),
+			)
+		case "consul":
+			reg = consulr.NewRegistry(
+				registry.Addrs(addresses...),
+			)
+		case "memory":
+			reg = memr.NewRegistry()
+		default:
+			reg = mdnsr.NewRegistry()
+		}
+		// No cache needed for in-memory registry
+		if plugin == "memory" {
+			reg = cache.New(reg, cache.WithTTL(20*time.Second))
+		}
+	})
 	// always use cached registry to prevent registry
 	// lookup for every request
-	return cache.New(r, cache.WithTTL(20*time.Second))
+	return reg
 }

--- a/ocis/pkg/command/server.go
+++ b/ocis/pkg/command/server.go
@@ -4,6 +4,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/owncloud/ocis/v2/ocis/pkg/runtime"
 	"github.com/urfave/cli/v2"
@@ -19,6 +20,8 @@ func Server(cfg *config.Config) *cli.Command {
 			return configlog.ReturnError(parser.ParseConfig(cfg, false))
 		},
 		Action: func(c *cli.Context) error {
+			// Prefer the in-memory registry as the default when running in single-binary mode
+			registry.Configure("memory")
 			r := runtime.New(cfg)
 			return r.Start()
 		},

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -168,7 +168,7 @@ func (g Graph) GetSingleDrive(w http.ResponseWriter, r *http.Request) {
 }
 
 func canCreateSpace(ctx context.Context, ownPersonalHome bool) bool {
-	s := settingssvc.NewPermissionService("com.owncloud.api.settings", grpc.DefaultClient)
+	s := settingssvc.NewPermissionService("com.owncloud.api.settings", grpc.DefaultClient())
 
 	pr, err := s.GetPermissionByID(ctx, &settingssvc.GetPermissionByIDRequest{
 		PermissionId: settingsServiceExt.CreateSpacePermissionID,
@@ -420,7 +420,7 @@ func (g Graph) ListStorageSpacesWithFilters(ctx context.Context, filters []*stor
 	client := g.GetGatewayClient()
 
 	permissions := make(map[string]struct{}, 1)
-	s := settingssvc.NewPermissionService("com.owncloud.api.settings", grpc.DefaultClient)
+	s := settingssvc.NewPermissionService("com.owncloud.api.settings", grpc.DefaultClient())
 
 	_, err := s.GetPermissionByID(ctx, &settingssvc.GetPermissionByIDRequest{
 		PermissionId: settingsServiceExt.ListAllSpacesPermissionID,
@@ -700,7 +700,7 @@ func getQuota(quota *libregraph.Quota, defaultQuota string) *storageprovider.Quo
 }
 
 func canSetSpaceQuota(ctx context.Context, user *userv1beta1.User) (bool, error) {
-	settingsService := settingssvc.NewPermissionService("com.owncloud.api.settings", grpc.DefaultClient)
+	settingsService := settingssvc.NewPermissionService("com.owncloud.api.settings", grpc.DefaultClient())
 	_, err := settingsService.GetPermissionByID(ctx, &settingssvc.GetPermissionByIDRequest{PermissionId: settingsServiceExt.SetSpaceQuotaPermissionID})
 	if err != nil {
 		merror := merrors.FromError(err)

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -137,7 +137,7 @@ func NewService(opts ...Option) Service {
 	}
 
 	if options.RoleService == nil {
-		svc.roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient)
+		svc.roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
 	} else {
 		svc.roleService = options.RoleService
 	}

--- a/services/ocs/pkg/service/v0/service.go
+++ b/services/ocs/pkg/service/v0/service.go
@@ -38,7 +38,7 @@ func NewService(opts ...Option) Service {
 
 	roleService := options.RoleService
 	if roleService == nil {
-		roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient)
+		roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
 	}
 	roleManager := options.RoleManager
 	if roleManager == nil {

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -127,7 +127,7 @@ func Server(cfg *config.Config) *cli.Command {
 }
 
 func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config) alice.Chain {
-	rolesClient := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient)
+	rolesClient := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
 	revaClient, err := cs3.GetGatewayServiceClient(cfg.Reva.Address)
 	var userProvider backend.UserBackend
 	switch cfg.AccountBackend {
@@ -145,7 +145,7 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config)
 		logger.Fatal().Msgf("Invalid accounts backend type '%s'", cfg.AccountBackend)
 	}
 
-	storeClient := storesvc.NewStoreService("com.owncloud.api.store", grpc.DefaultClient)
+	storeClient := storesvc.NewStoreService("com.owncloud.api.store", grpc.DefaultClient())
 	if err != nil {
 		logger.Error().Err(err).
 			Str("gateway", cfg.Reva.Address).

--- a/services/search/pkg/command/index.go
+++ b/services/search/pkg/command/index.go
@@ -37,7 +37,7 @@ func Index(cfg *config.Config) *cli.Command {
 			return parser.ParseConfig(cfg)
 		},
 		Action: func(c *cli.Context) error {
-			client := searchsvc.NewSearchProviderService("com.owncloud.api.search", grpc.DefaultClient)
+			client := searchsvc.NewSearchProviderService("com.owncloud.api.search", grpc.DefaultClient())
 			_, err := client.IndexSpace(context.Background(), &searchsvc.IndexSpaceRequest{
 				SpaceId: c.String("space"),
 				UserId:  c.String("user"),

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -69,8 +69,8 @@ func NewService(opts ...Option) (Service, error) {
 		config:           conf,
 		log:              options.Logger,
 		mux:              m,
-		searchClient:     searchsvc.NewSearchProviderService("com.owncloud.api.search", grpc.DefaultClient),
-		thumbnailsClient: thumbnailssvc.NewThumbnailService("com.owncloud.api.thumbnails", grpc.DefaultClient),
+		searchClient:     searchsvc.NewSearchProviderService("com.owncloud.api.search", grpc.DefaultClient()),
+		thumbnailsClient: thumbnailssvc.NewThumbnailService("com.owncloud.api.thumbnails", grpc.DefaultClient()),
 		revaClient:       gwc,
 	}
 


### PR DESCRIPTION
Default to in-memory registry in single-binary mode
    
This avoids various issues of the old "mdns" default. At least for the simple single process setup (#3134, #4597). When starting the services individually we still default to "mdns".

This needs: https://github.com/cs3org/reva/pull/3258