### PR TITLE
add thumbnail support for tiff and bmp files

### DIFF
--- a/changelog/unreleased/thumbnails-tiff-bmp.md
+++ b/changelog/unreleased/thumbnails-tiff-bmp.md
@@ -1,0 +1,5 @@
+Enhancement: Add thumbnails support for tiff and bmp files
+
+Support generating thumbnails for tiff and bmp files in the thumbnails service.
+
+https://github.com/owncloud/ocis/pull/4634

--- a/services/thumbnails/pkg/thumbnail/thumbnail.go
+++ b/services/thumbnails/pkg/thumbnail/thumbnail.go
@@ -13,11 +13,14 @@ import (
 var (
 	// SupportedMimeTypes contains a all mimetypes which are supported by the thumbnailer.
 	SupportedMimeTypes = map[string]struct{}{
-		"image/png":  {},
-		"image/jpg":  {},
-		"image/jpeg": {},
-		"image/gif":  {},
-		"text/plain": {},
+		"image/png":      {},
+		"image/jpg":      {},
+		"image/jpeg":     {},
+		"image/gif":      {},
+		"image/bmp":      {},
+		"image/x-ms-bmp": {},
+		"image/tiff":     {},
+		"text/plain":     {},
 	}
 )
 

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -49,7 +49,7 @@ func DefaultConfig() *config.Config {
 				},
 				Apps: []string{"files", "search", "preview", "text-editor", "pdf-viewer", "external", "user-management"},
 				Options: map[string]interface{}{
-					"previewFileMimeTypes": []string{"image/gif", "image/png", "image/jpeg", "text/plain"},
+					"previewFileMimeTypes": []string{"image/gif", "image/png", "image/jpeg", "text/plain", "image/tiff", "image/bmp", "image/x-ms-bmp"},
 				},
 			},
 		},


### PR DESCRIPTION
Support generating thumbnails for tiff and bmp files in the thumbnails service.

@kulmann, I guess the mime-types still need to be added to the preview app in the web repository. 