### PR TITLE
[ci] fix restore for web cache

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -276,15 +276,15 @@ def main(ctx):
     pipelineSanityChecks(ctx, pipelines)
     return pipelines
 
-def buildWebCache(ctx):
-    return [{
+def cachePipeline(name, steps):
+    return {
         "kind": "pipeline",
         "type": "docker",
-        "name": "build-web-cache",
+        "name": "build-%s-cache" % name,
         "clone": {
             "disable": True,
         },
-        "steps": generateWebCache(ctx),
+        "steps": steps,
         "trigger": {
             "ref": [
                 "refs/heads/master",
@@ -292,7 +292,14 @@ def buildWebCache(ctx):
                 "refs/pull/**",
             ],
         },
-    }]
+    }
+
+def buildWebCache(ctx):
+    return [
+        cachePipeline("web", generateWebCache(ctx)),
+        cachePipeline("web-acceptance", generateWebAcceptanceCache(ctx)),
+        cachePipeline("web-e2e", generateWebE2ECache(ctx)),
+    ]
 
 def testOcisModules(ctx):
     pipelines = []
@@ -2870,45 +2877,127 @@ def setupForLitmus():
         ],
     }]
 
-def generateWebCache(ctx):
+def getDroneEnvAndCheckScript(ctx):
     ocis_git_base_url = "https://raw.githubusercontent.com/owncloud/ocis"
     path_to_drone_env = "%s/%s/.drone.env" % (ocis_git_base_url, ctx.build.commit)
     path_to_check_script = "%s/%s/tests/config/drone/check_web_cache.sh" % (ocis_git_base_url, ctx.build.commit)
+    return {
+        "name": "get-drone-env-and-check-script",
+        "image": OC_UBUNTU,
+        "commands": [
+            "curl -s -o .drone.env %s" % path_to_drone_env,
+            "curl -s -o check_web_cache.sh %s" % path_to_check_script,
+        ],
+    }
 
-    return [
-        {
-            "name": "get-drone-env-and-check-script",
-            "image": OC_UBUNTU,
-            "commands": [
-                "curl -s -o .drone.env %s" % path_to_drone_env,
-                "curl -s -o check_web_cache.sh %s" % path_to_check_script,
-            ],
-        },
-        {
-            "name": "check-for-web-cache",
-            "image": OC_UBUNTU,
-            "environment": {
-                "CACHE_ENDPOINT": {
-                    "from_secret": "cache_public_s3_server",
-                },
-                "CACHE_BUCKET": {
-                    "from_secret": "cache_public_s3_bucket",
-                },
+def checkForWebCache(name):
+    return {
+        "name": "check-for-%s-cache" % name,
+        "image": OC_UBUNTU,
+        "environment": {
+            "CACHE_ENDPOINT": {
+                "from_secret": "cache_public_s3_server",
             },
-            "commands": [
-                "bash check_web_cache.sh",
-            ],
+            "CACHE_BUCKET": {
+                "from_secret": "cache_public_s3_bucket",
+            },
         },
+        "commands": [
+            "bash -x check_web_cache.sh %s" % name,
+        ],
+    }
+
+def cloneWeb():
+    return {
+        "name": "clone-web",
+        "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
+        "commands": [
+            ". ./.drone.env",
+            "rm -rf %s" % dirs["web"],
+            "git clone -b $WEB_BRANCH --single-branch --no-tags https://github.com/owncloud/web.git %s" % dirs["web"],
+            "cd %s && git checkout $WEB_COMMITID" % dirs["web"],
+        ],
+    }
+
+def generateWebAcceptanceCache(ctx):
+    return [
+        getDroneEnvAndCheckScript(ctx),
+        checkForWebCache("acceptance"),
+        cloneWeb(),
         {
-            "name": "clone-web",
+            "name": "install-yarn",
             "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
             "commands": [
-                ". ./.drone.env",
-                "rm -rf %s" % dirs["web"],
-                "git clone -b $WEB_BRANCH --single-branch --no-tags https://github.com/owncloud/web.git %s" % dirs["web"],
-                "cd %s && git checkout $WEB_COMMITID" % dirs["web"],
+                "cd %s" % dirs["web"],
+                "cd tests/acceptance",
+                "retry -t 3 'yarn install --immutable --frozen-lockfile'",
             ],
         },
+        {
+            "name": "zip-yarn",
+            "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
+            "commands": [
+                # zip the yarn deps before caching
+                "if [ ! -d '%s' ]; then mkdir -p %s; fi" % (dirs["zip"], dirs["zip"]),
+                "cd %s" % dirs["web"],
+                "cd tests/acceptance",
+                "tar -czvf %s .yarn" % dirs["acceptanceYarnZip"],
+            ],
+        },
+        {
+            "name": "cache-yarn",
+            "image": MINIO_MC,
+            "environment": MINIO_MC_ENV,
+            "commands": [
+                "source ./.drone.env",
+                # cache using the minio/mc client to the public bucket (long term bucket)
+                "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
+                "mc cp -r -a %s s3/$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID" % dirs["acceptanceYarnZip"],
+            ],
+        },
+    ]
+
+def generateWebE2ECache(ctx):
+    return [
+        getDroneEnvAndCheckScript(ctx),
+        checkForWebCache("e2e"),
+        cloneWeb(),
+        {
+            "name": "install-yarn",
+            "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
+            "commands": [
+                "cd %s" % dirs["web"],
+                "retry -t 3 'yarn install --immutable --frozen-lockfile'",
+            ],
+        },
+        {
+            "name": "zip-yarn",
+            "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
+            "commands": [
+                # zip the yarn deps before caching
+                "if [ ! -d '%s' ]; then mkdir -p %s; fi" % (dirs["zip"], dirs["zip"]),
+                "cd %s" % dirs["web"],
+                "tar -czvf %s .yarn" % dirs["e2eYarnZip"],
+            ],
+        },
+        {
+            "name": "cache-yarn",
+            "image": MINIO_MC,
+            "environment": MINIO_MC_ENV,
+            "commands": [
+                "source ./.drone.env",
+                # cache using the minio/mc client to the public bucket (long term bucket)
+                "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
+                "mc cp -r -a %s s3/$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID" % dirs["e2eYarnZip"],
+            ],
+        },
+    ]
+
+def generateWebCache(ctx):
+    return [
+        getDroneEnvAndCheckScript(ctx),
+        checkForWebCache("web"),
+        cloneWeb(),
         {
             "name": "zip-web",
             "image": OC_UBUNTU,
@@ -2926,48 +3015,6 @@ def generateWebCache(ctx):
                 # cache using the minio/mc client to the 'owncloud' bucket (long term bucket)
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
                 "mc cp -r -a %s s3/$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID" % dirs["webZip"],
-            ],
-        },
-        {
-            "name": "install-yarn",
-            "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
-            "commands": [
-                "cd %s" % dirs["web"],
-                "retry -t 3 'yarn install --immutable --frozen-lockfile'",
-                "cd tests/acceptance",
-                "retry -t 3 'yarn install --immutable --frozen-lockfile'",
-            ],
-        },
-        {
-            "name": "zip-yarn",
-            "image": OC_CI_NODEJS % DEFAULT_NODEJS_VERSION,
-            "commands": [
-                # zip the yarn deps before caching
-                "cd %s" % dirs["web"],
-                "tar -czvf %s .yarn" % dirs["e2eYarnZip"],
-                "cd tests/acceptance",
-                "tar -czvf %s .yarn" % dirs["acceptanceYarnZip"],
-            ],
-        },
-        {
-            "name": "cache-yarn",
-            "image": MINIO_MC,
-            "environment": MINIO_MC_ENV,
-            "commands": [
-                "source ./.drone.env",
-                # cache using the minio/mc client to the public bucket (long term bucket)
-                "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                "mc cp -r -a %s s3/$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID" % dirs["e2eYarnZip"],
-                "mc cp -r -a %s s3/$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID" % dirs["acceptanceYarnZip"],
-            ],
-        },
-        {
-            "name": "list-web-cache",
-            "image": MINIO_MC,
-            "environment": MINIO_MC_ENV,
-            "commands": [
-                "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                "mc ls --recursive s3/$CACHE_BUCKET/ocis/web-test-runner",
             ],
         },
     ]

--- a/tests/config/drone/check_web_cache.sh
+++ b/tests/config/drone/check_web_cache.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
 source .drone.env
 
+# if no $1 is supplied end the script
+# Can be web, acceptance or e2e
+if [ -z "$1" ]; then
+  echo "No cache item is supplied."
+  exit 1
+fi
+
 echo "Checking web version - $WEB_COMMITID in cache"
 
-URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID/web.tar.gz"
+URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID/$1.tar.gz"
 
 echo "Checking for the web cache at '$URL'."
 
 if curl --output /dev/null --silent --head --fail "$URL"
 then
-	echo "Web with commit id $WEB_COMMITID already available in cache"
+	echo "$1 cache with commit id $WEB_COMMITID already available."
 	# https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
 	# exit a Pipeline early without failing
 	exit 78
 else
-	echo "Web with $WEB_COMMITID not available in cache"
+	echo "$1 cache with commit id $WEB_COMMITID was not available."
 fi


### PR DESCRIPTION
## Description
The `web` is cached for the CI with these three:
- the web itself (install & build)
- web-acceptance (yarn install)
- web-e2e (yarn install)

While performing the caching, the web.tar.gz is checked inside the `$CACHE_BUCKET/ocis/web-test-runner/$WEB_COMMITID` location.
But somehow, there was only web.tar.gz and no acceptance.tar.gz and e2e.tar.gz for the current pinned web commit id. This was very uncommon because every time we build a new web for the new commit id, at the same time the acceptance of an e2e cache should also be built and saved inside the bucket. But sometimes strange things happen.

To cope with this case, I've divided the web caching pipeline into 3, all separately caching their stuff. Each pipeline will check for its target in the cache-store. If available, they exit as usual and if not found, a new cache is built and uploaded to the cache-store.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/4653

## Motivation and Context
Green CI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>