### PR TITLE
[docs] Add a blank to type and default value pass thru

### DIFF
--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -13,9 +13,9 @@
 `{{- $value }}`
 {{- end }}
 a| [subs=-attributes]
-++{{.Type}}++
+++{{.Type}} ++
 a| [subs=-attributes]
-++{{.DefaultValue}}++
+++{{.DefaultValue}} ++
 a| [subs=-attributes]
 {{.Description}}
 


### PR DESCRIPTION
This is a small fix which just adds a blank to the type and default value field in the pass thru definition.

**Reason**: while it renders totally fine, when building the site with Antora 2.3 (our outdated version), we get many warnings about an `unterminated pass block` when using `++++`. This happens when there is no type or no default value set. When adding a blank, the warning goes away. 

`++++` -->  `++ ++`
renders to
`<p></p>` --> `<p> </p>`

This warning will possibly change respectively go away totally with Antora 3.1.1 (lets see) and we can remove the blank.
