### PR TITLE
Request revatoken via machine auth after autoprovsioning user

### DIFF
--- a/changelog/unreleased/fix-autoprovison-token.md
+++ b/changelog/unreleased/fix-autoprovison-token.md
@@ -1,0 +1,6 @@
+Bugfix: Fix authentication for autoprovisioned users
+
+We've fixed an issue in the proxy, which made the first http request of an
+autoprovisioned user fail.
+
+https://github.com/owncloud/ocis/issues/4616

--- a/services/proxy/pkg/middleware/account_resolver.go
+++ b/services/proxy/pkg/middleware/account_resolver.go
@@ -76,6 +76,10 @@ func (m accountResolver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			if err != nil {
 				m.logger.Error().Err(err).Msg("Autoprovisioning user failed")
 			}
+			user, token, err = m.userProvider.GetUserByClaims(req.Context(), "userid", user.Id.OpaqueId, true)
+			if err != nil {
+				m.logger.Error().Err(err).Str("userid", user.Id.OpaqueId).Msg("Error getting token for autoprovisioned user")
+			}
 		}
 
 		if errors.Is(err, backend.ErrAccountDisabled) {


### PR DESCRIPTION
To successfully authenticate a user after it was autoprovisioned, we need to get a valid reva token.

Fixes: #4616

