### PR TITLE
bring back the settings ui

### DIFF
--- a/changelog/unreleased/fix-bring-back-settings-ui.md
+++ b/changelog/unreleased/fix-bring-back-settings-ui.md
@@ -1,0 +1,5 @@
+Bugfix: Bring back the settings UI in Web
+
+We've fixed the oC Web configuration in oCIS so that the settings UI will be shown again in Web.
+
+https://github.com/owncloud/ocis/pull/4691

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -50,6 +50,10 @@ func DefaultConfig() *config.Config {
 				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "user-management"},
 				ExternalApps: []config.ExternalApp{
 					{
+						ID:   "settings",
+						Path: "/settings.js",
+					},
+					{
 						ID:   "preview",
 						Path: "web-app-preview",
 						Config: map[string]interface{}{

--- a/services/web/pkg/service/v0/service.go
+++ b/services/web/pkg/service/v0/service.go
@@ -73,15 +73,6 @@ func (p Web) getPayload() (payload []byte, err error) {
 			p.config.Web.Config.Theme = p.config.Web.ThemePath
 		}
 
-		if p.config.Web.Config.ExternalApps == nil {
-			p.config.Web.Config.ExternalApps = []config.ExternalApp{
-				{
-					ID:   "settings",
-					Path: "/settings.js",
-				},
-			}
-		}
-
 		// make apps render as empty array if it is empty
 		// TODO remove once https://github.com/golang/go/issues/27589 is fixed
 		if len(p.config.Web.Config.Apps) == 0 {


### PR DESCRIPTION
## Description
Bugfix: Bring back the settings UI in Web

We've fixed the oC Web configuration in oCIS so that the settings UI will be shown again in Web.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
