### PR TITLE
[docs-only] Fix path name in ocis_s3 docs

### DIFF
--- a/docs/ocis/deployment/ocis_s3.md
+++ b/docs/ocis/deployment/ocis_s3.md
@@ -45,7 +45,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
 
 * Go to the deployment example
 
-  `cd ocis/deployment/examples/ocis_s3`
+  `cd ocis/deployments/examples/ocis_s3`
 
 * Open the `.env` file in a text editor
   The file by default looks like this:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This path `cd ocis/deployment/examples/ocis_s3` that's mentioned in the docs is not valid, so this PR fixes that

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/4595
