### PR TITLE
Multiple fixes for notification service

### DIFF
--- a/changelog/unreleased/fix-share-notifications.md
+++ b/changelog/unreleased/fix-share-notifications.md
@@ -1,0 +1,8 @@
+Bugfix: Mail notifications for group shares
+
+We fixed multiple issues in the notifications service, which broke notifcation
+mails new shares with groups.
+
+https://github.com/owncloud/ocis/pull/4714
+https://github.com/owncloud/ocis/issues/4703
+https://github.com/owncloud/ocis/issues/4688

--- a/ocis-pkg/config/defaultconfig.go
+++ b/ocis-pkg/config/defaultconfig.go
@@ -35,6 +35,7 @@ import (
 
 func DefaultConfig() *Config {
 	return &Config{
+		OcisURL: "https://localhost:9200",
 		Runtime: Runtime{
 			Port: "9250",
 			Host: "localhost",

--- a/ocis-pkg/config/parser/parse.go
+++ b/ocis-pkg/config/parser/parse.go
@@ -124,6 +124,10 @@ func EnsureCommons(cfg *config.Config) {
 	if cfg.AdminUserID != "" {
 		cfg.Commons.AdminUserID = cfg.AdminUserID
 	}
+
+	if cfg.OcisURL != "" {
+		cfg.Commons.OcisURL = cfg.OcisURL
+	}
 }
 
 func Validate(cfg *config.Config) error {

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -55,7 +55,7 @@ func Server(cfg *config.Config) *cli.Command {
 				logger.Fatal().Err(err).Str("addr", cfg.Notifications.RevaGateway).Msg("could not get reva client")
 			}
 
-			svc := service.NewEventsNotifier(evts, channel, logger, gwclient, cfg.Notifications.MachineAuthAPIKey, cfg.Notifications.EmailTemplatePath)
+			svc := service.NewEventsNotifier(evts, channel, logger, gwclient, cfg.Notifications.MachineAuthAPIKey, cfg.Notifications.EmailTemplatePath, cfg.Commons.OcisURL)
 			return svc.Run()
 		},
 	}

--- a/services/notifications/pkg/email/templates/shareCreated.email.tmpl
+++ b/services/notifications/pkg/email/templates/shareCreated.email.tmpl
@@ -1,6 +1,6 @@
 Hello {{ .ShareGrantee }},
 
-{{ .ShareSharer }} has shared {{ .ShareFolder }} with you.
+{{ .ShareSharer }} has shared "{{ .ShareFolder }}" with you.
 
 Click here to view it: {{ .ShareLink }}
 
@@ -8,7 +8,7 @@ Click here to view it: {{ .ShareLink }}
 
 Hallo {{ .Grantee }},
 
-{{ .ShareSharer }} hat dich zu {{ .ShareFolder }} eingeladen.
+{{ .ShareSharer }} hat dich zu "{{ .ShareFolder }}" eingeladen.
 
 Klicke hier zum Anzeigen: {{ .ShareLink }}
 

--- a/services/notifications/pkg/email/templates/sharedSpace.email.tmpl
+++ b/services/notifications/pkg/email/templates/sharedSpace.email.tmpl
@@ -1,6 +1,6 @@
 Hello {{ .SpaceGrantee }},
 
-{{ .SpaceSharer }} has invited you to join {{ .SpaceName }}.
+{{ .SpaceSharer }} has invited you to join "{{ .SpaceName }}".
 
 Click here to view it: {{ .ShareLink }}
 
@@ -8,7 +8,7 @@ Click here to view it: {{ .ShareLink }}
 
 Hallo {{ .SpaceGrantee }},
 
-{{ .SpaceSharer }} hat dich in den Space {{ .SpaceName }} eingeladen.
+{{ .SpaceSharer }} hat dich in den Space "{{ .SpaceName }}" eingeladen.
 
 Klicke hier zum Anzeigen: {{ .ShareLink }}
 

--- a/services/notifications/pkg/service/service.go
+++ b/services/notifications/pkg/service/service.go
@@ -209,9 +209,9 @@ func (s eventsNotifier) handleSpaceShared(e events.SpaceShared) {
 
 	emailSubject := fmt.Sprintf("%s invited you to join %s", sharerUserResponse.GetUser().DisplayName, md.GetInfo().GetSpace().Name)
 	if e.GranteeUserID != nil {
-		err = s.channel.SendMessage([]string{e.GranteeUserID.OpaqueId}, msg, emailSubject, sharerDisplayName)
+		err = s.channel.SendMessage(ownerCtx, []string{e.GranteeUserID.OpaqueId}, msg, emailSubject, sharerDisplayName)
 	} else if e.GranteeGroupID != nil {
-		err = s.channel.SendMessageToGroup(e.GranteeGroupID, msg, emailSubject, sharerDisplayName)
+		err = s.channel.SendMessageToGroup(ownerCtx, e.GranteeGroupID, msg, emailSubject, sharerDisplayName)
 	}
 	if err != nil {
 		s.logger.Error().
@@ -347,9 +347,9 @@ func (s eventsNotifier) handleShareCreated(e events.ShareCreated) {
 
 	emailSubject := fmt.Sprintf("%s shared %s with you", sharerUserResponse.GetUser().DisplayName, md.GetInfo().Name)
 	if e.GranteeUserID != nil {
-		err = s.channel.SendMessage([]string{e.GranteeUserID.OpaqueId}, msg, emailSubject, sharerDisplayName)
+		err = s.channel.SendMessage(ownerCtx, []string{e.GranteeUserID.OpaqueId}, msg, emailSubject, sharerDisplayName)
 	} else if e.GranteeGroupID != nil {
-		err = s.channel.SendMessageToGroup(e.GranteeGroupID, msg, emailSubject, sharerDisplayName)
+		err = s.channel.SendMessageToGroup(ownerCtx, e.GranteeGroupID, msg, emailSubject, sharerDisplayName)
 	}
 	if err != nil {
 		s.logger.Error().


### PR DESCRIPTION
## Description
- Notications for group shares caused nil pointer derefs
- Notifications for group shares did not send mails (failed to lookup group members)
- Notifications mails might contain the wrong link

Fixes: #4703 , #4688 