### PR TITLE
remove duplicated web preview app

### DIFF
--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -47,7 +47,7 @@ func DefaultConfig() *config.Config {
 					ResponseType: "code",
 					Scope:        "openid profile email",
 				},
-				Apps: []string{"files", "search", "preview", "text-editor", "pdf-viewer", "external", "user-management", "activities"},
+				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "user-management", "activities"},
 				ExternalApps: []config.ExternalApp{
 					{
 						ID:   "settings",


### PR DESCRIPTION
preview app was listed twice in web config.json which leads to acceptance test errors in web.