### PR TITLE
[test-only] Apitest. Add checking parentId

### DIFF
--- a/tests/acceptance/features/apiSpaces/search.feature
+++ b/tests/acceptance/features/apiSpaces/search.feature
@@ -13,8 +13,8 @@ Feature: Search
     And using spaces DAV path
     And the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "find data" with the default quota using the GraphApi
-    And user "Alice" has created a folder "folder/SubFolder1/subFOLDER2" in space "find data"
-    And user "Alice" has uploaded a file inside space "find data" with content "some content" to "folder/SubFolder1/subFOLDER2/insideTheFolder.txt"
+    And user "Alice" has created a folder "folderMain/SubFolder1/subFOLDER2" in space "find data"
+    And user "Alice" has uploaded a file inside space "find data" with content "some content" to "folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt"
     And using new DAV path
 
   Scenario: Alice can find data from the project space
@@ -22,10 +22,10 @@ Feature: Search
     Then the HTTP status code should be "207"
     And the search result should contain "4" entries
     And the search result of user "Alice" should contain these entries:
-      | /folder                                           |
-      | /folder/SubFolder1                                |
-      | /folder/SubFolder1/subFOLDER2                     |
-      | /folder/SubFolder1/subFOLDER2/insideTheFolder.txt |
+      | /folderMain                                           |
+      | /folderMain/SubFolder1                                |
+      | /folderMain/SubFolder1/subFOLDER2                     |
+      | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
 
 
   Scenario: Alice can find data from the project space
@@ -33,16 +33,16 @@ Feature: Search
     Then the HTTP status code should be "207"
     And the search result should contain "2" entries
     And the search result of user "Alice" should contain these entries:
-      | /folder/SubFolder1            |
-      | /folder/SubFolder1/subFOLDER2 |
+      | /folderMain/SubFolder1            |
+      | /folderMain/SubFolder1/subFOLDER2 |
     But the search result of user "Alice" should not contain these entries:
-      | /folder                                           |
-      | /folder/SubFolder1/subFOLDER2/insideTheFolder.txt |
+      | /folderMain                                           |
+      | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
 
 
   Scenario: Brian can find data from the shares jail
-    Given user "Alice" shares the following entity "folder" inside of space "find data" with user "Brian" with role "viewer"
-    And user "Brian" has accepted share "/folder" offered by user "Alice"
+    Given user "Alice" shares the following entity "folderMain" inside of space "find data" with user "Brian" with role "viewer"
+    And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "folder" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "4" entries
@@ -50,7 +50,7 @@ Feature: Search
       | /SubFolder1                                |
       | /SubFolder1/subFOLDER2                     |
       | /SubFolder1/subFOLDER2/insideTheFolder.txt |
-    And for user "Brian" the search result should contain space "mountpoint/folder"
+    And for user "Brian" the search result should contain space "mountpoint/folderMain"
 
 
   Scenario: User can find hidden file
@@ -63,7 +63,7 @@ Feature: Search
 
 
   Scenario: User cannot find pending folder
-    Given user "Alice" shares the following entity "folder" inside of space "find data" with user "Brian" with role "viewer"
+    Given user "Alice" shares the following entity "folderMain" inside of space "find data" with user "Brian" with role "viewer"
     When user "Brian" searches for "folder" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
@@ -74,8 +74,8 @@ Feature: Search
 
 
   Scenario: User cannot find declined folder
-    Given user "Alice" shares the following entity "folder" inside of space "find data" with user "Brian" with role "viewer"
-    And user "Brian" has declined share "/folder" offered by user "Alice"
+    Given user "Alice" shares the following entity "folderMain" inside of space "find data" with user "Brian" with role "viewer"
+    And user "Brian" has declined share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "folder" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
@@ -86,8 +86,8 @@ Feature: Search
 
 
   Scenario: User cannot find deleted folder
-    Given user "Alice" has removed the folder "folder" from space "find data"
-    When user "Alice" searches for "folder" using the WebDAV API
+    Given user "Alice" has removed the folder "folderMain" from space "find data"
+    When user "Alice" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
 
@@ -98,6 +98,7 @@ Feature: Search
     And the search result should contain "1" entries
     And for user "Alice" the search result should contain space "find data"
 
+
   Scenario Outline: search result for project space contains resource parentID
     When user "Alice" searches for "<searchObject>" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -106,18 +107,22 @@ Feature: Search
       | /<searchObject> |
     And for user "Alice" the response should contains the parent "<parentFolder>" from space "find data"
     Examples:
-      | searchObject        | parentFolder                 |
-      | SubFolder1          | folder                       |
-      | insideTheFolder.txt | folder/SubFolder1/subFOLDER2 |
+      | searchObject        | parentFolder                     |
+      | SubFolder1          | folderMain                       |
+      | insideTheFolder.txt | folderMain/SubFolder1/subFOLDER2 |
+      | folderMain          | find data                        |
 
 
-  Scenario: search result for shares jail contains resource parentID
-    Given user "Alice" shares the following entity "folder" inside of space "find data" with user "Brian" with role "viewer"
-    And user "Brian" has accepted share "/folder" offered by user "Alice"
-    When user "Brian" searches for "insideTheFolder.txt" using the WebDAV API
+  Scenario Outline: search result for shares jail contains resource parentID
+    Given user "Alice" shares the following entity "folderMain" inside of space "find data" with user "Brian" with role "viewer"
+    And user "Brian" has accepted share "/folderMain" offered by user "Alice"
+    When user "Brian" searches for "<searchObject>" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "1" entries
     And the search result of user "Brian" should contain these entries:
-      | /insideTheFolder.txt |
-    And for user "Brian" the response should contains the parent "SubFolder1/subFOLDER2" from mountpoint "folder"
-   
+      | /<searchObject> |
+    And for user "Brian" the response should contains the parent "<parentFolder>" from mountpoint "folderMain"
+    Examples:
+      | searchObject        | parentFolder          |
+      | insideTheFolder.txt | SubFolder1/subFOLDER2 |
+      | SubFolder1          | folderMain            |

--- a/tests/acceptance/features/apiSpaces/search.feature
+++ b/tests/acceptance/features/apiSpaces/search.feature
@@ -33,8 +33,8 @@ Feature: Search
     Then the HTTP status code should be "207"
     And the search result should contain "2" entries
     And the search result of user "Alice" should contain these entries:
-      | /folder/SubFolder1             |
-      | /folder/SubFolder1/subFOLDER2  |
+      | /folder/SubFolder1            |
+      | /folder/SubFolder1/subFOLDER2 |
     But the search result of user "Alice" should not contain these entries:
       | /folder                                           |
       | /folder/SubFolder1/subFOLDER2/insideTheFolder.txt |
@@ -98,3 +98,26 @@ Feature: Search
     And the search result should contain "1" entries
     And for user "Alice" the search result should contain space "find data"
 
+  Scenario Outline: search result for project space contains resource parentID
+    When user "Alice" searches for "<searchObject>" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "1" entries
+    And the search result of user "Alice" should contain these entries:
+      | /<searchObject> |
+    And for user "Alice" the response should contains the parent "<parentFolder>" from space "find data"
+    Examples:
+      | searchObject        | parentFolder                 |
+      | SubFolder1          | folder                       |
+      | insideTheFolder.txt | folder/SubFolder1/subFOLDER2 |
+
+
+  Scenario: search result for shares jail contains resource parentID
+    Given user "Alice" shares the following entity "folder" inside of space "find data" with user "Brian" with role "viewer"
+    And user "Brian" has accepted share "/folder" offered by user "Alice"
+    When user "Brian" searches for "insideTheFolder.txt" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "1" entries
+    And the search result of user "Brian" should contain these entries:
+      | /insideTheFolder.txt |
+    And for user "Brian" the response should contains the parent "SubFolder1/subFOLDER2" from mountpoint "folder"
+   

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -344,10 +344,10 @@ class SpacesContext implements Context {
 	 */
 	public function getFolderId(string $user, string $spaceName, string $folderName): string {
 		$space = $this->getSpaceByName($user, $spaceName);
-    // For a level 1 folder, the parent is space so $folderName = ''
-    if ($folderName === $space["name"]) {
-      $folderName = '';
-    }
+		// For a level 1 folder, the parent is space so $folderName = ''
+		if ($folderName === $space["name"]) {
+			$folderName = '';
+		}
 		$fullUrl = $this->baseUrl . $this->davSpacesUrl . $space["id"] . "/" . $folderName;
 		$this->featureContext->setResponse(
 			HttpRequestHelper::sendRequest(

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -333,6 +333,34 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * The method returns folderId
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 * @param string $folderName
+	 *
+	 * @return string
+	 * @throws GuzzleException
+	 */
+	public function getFolderId(string $user, string $spaceName, string $folderName): string {
+		$space = $this->getSpaceByName($user, $spaceName);
+		$fullUrl = $this->baseUrl . $this->davSpacesUrl . $space["id"] . "/" . $folderName;
+		$this->featureContext->setResponse(
+			HttpRequestHelper::sendRequest(
+				$fullUrl,
+				$this->featureContext->getStepLineRef(),
+				'PROPFIND',
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				['Depth' => '0'],
+			)
+		);
+		$responseArray = json_decode(json_encode($this->featureContext->getResponseXml()->xpath("//d:response/d:propstat/d:prop/oc:fileid")), true, 512, JSON_THROW_ON_ERROR);
+		Assert::assertNotEmpty($responseArray, "the PROPFIND response for $folderName is empty");
+		return $responseArray[0][0];
+	}
+
+	/**
 	 * The method returns eTag
 	 *
 	 * @param string $user
@@ -2928,5 +2956,22 @@ class SpacesContext implements Context {
 			}
 		}
 		Assert::assertTrue($spaceFound, "response does not contain the space '$spaceName'");
+	}
+
+	/**
+	 * @Then /^for user "([^"]*)" the response should contains the parent "([^"]*)" from (?:space|mountpoint) "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $parent
+	 * @param string $space
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function responseShouldContainParent(string $user, string $parent, string $space): void {
+		// get a response after a Report request (called in the core)
+		$responseArray = json_decode(json_encode($this->featureContext->getResponseXml()->xpath("//d:response/d:propstat/d:prop/oc:file-parent")), true, 512, JSON_THROW_ON_ERROR);
+		Assert::assertNotEmpty($responseArray, "search result is empty");
+		Assert::assertEquals($this->getFolderId($user, $space, $parent), $responseArray[0][0], 'wrong file-parentId');
 	}
 }

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -344,6 +344,10 @@ class SpacesContext implements Context {
 	 */
 	public function getFolderId(string $user, string $spaceName, string $folderName): string {
 		$space = $this->getSpaceByName($user, $spaceName);
+    // For a level 1 folder, the parent is space so $folderName = ''
+    if ($folderName === $space["name"]) {
+      $folderName = '';
+    }
 		$fullUrl = $this->baseUrl . $this->davSpacesUrl . $space["id"] . "/" . $folderName;
 		$this->featureContext->setResponse(
 			HttpRequestHelper::sendRequest(


### PR DESCRIPTION
- added test for checking parentID for project space and shares jail.

Need clarify: 

- for folder 1 level in project space parentId should be spaceId?
<oc:file-parentId>: `1284d238-aa92-42ce-bdc4-0b0000009157$105adae8-b126-43d1-93d8-6744e01d8d8c!105adae8-b126-43d1-93d8-6744e01d8d8c` 
spaceId: `1284d238-aa92-42ce-bdc4-0b0000009157$105adae8-b126-43d1-93d8-6744e01d8d8c`


- for folder 1 level in shares jail should be mountpoint?  
<oc:file-parentId> : `1284d238-aa92-42ce-bdc4-0b0000009157$4c510ada-c86b-4815-8820-42cdf82c3d51!4c510ada-c86b-4815-8820-42cdf82c3d51` 
mountpointId: `a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!1284d238-aa92-42ce-bdc4-0b0000009157:4c510ada-c86b-4815-8820-42cdf82c3d51:eb54855b-94a3-43ee-bd97-0f6963ea460b`
