### PR TITLE
Skip content extraction for 0 byte files

### DIFF
--- a/services/search/pkg/content/tika.go
+++ b/services/search/pkg/content/tika.go
@@ -48,6 +48,11 @@ func (t Tika) Extract(ctx context.Context, ri *provider.ResourceInfo) (Document,
 	if err != nil {
 		return doc, err
 	}
+
+	if ri.Size == 0 {
+		return doc, nil
+	}
+
 	if ri.Type != provider.ResourceType_RESOURCE_TYPE_FILE {
 		return doc, nil
 	}

--- a/services/search/pkg/content/tika_test.go
+++ b/services/search/pkg/content/tika_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Tika", func() {
 
 			doc, err := tika.Extract(context.TODO(), &provider.ResourceInfo{
 				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
+				Size: 1,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(doc.Content).To(Equal(body))
@@ -85,6 +86,7 @@ var _ = Describe("Tika", func() {
 
 			doc, err := tika.Extract(context.TODO(), &provider.ResourceInfo{
 				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
+				Size: 1,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(doc.Content).To(Equal("body test stop words i stay "))


### PR DESCRIPTION
## Description
Content extractor also scanned empty files which is unnecessary, this pr takes care of it and skips the tika request in those cases. 