### PR TITLE
add nats tls insecure flags to ocis init

### DIFF
--- a/changelog/unreleased/nats-tls.md
+++ b/changelog/unreleased/nats-tls.md
@@ -3,3 +3,4 @@ Enhancement: Secure the nats connectin with TLS
 Encyrpted the connection to the event broker using TLS.
 
 https://github.com/owncloud/ocis/pull/4781
+https://github.com/owncloud/ocis/pull/4800


### PR DESCRIPTION
The original PR was missing this crucial part.
When running `ocis init --insecure true` then all the nats related insecure flags must be set.