### PR TITLE
don't cache the web index.html

### DIFF
--- a/changelog/unreleased/fix-static-asset-caching.md
+++ b/changelog/unreleased/fix-static-asset-caching.md
@@ -1,0 +1,6 @@
+Bugfix: Disable cache for selected static web assets.
+
+We've disabled caching for some static web assets.
+Files like the web index.html, oidc-callback.html or similar contain paths to timestamped resources and should not be cached.
+
+https://github.com/owncloud/ocis/pull/4809

--- a/changelog/unreleased/fix-static-asset-caching.md
+++ b/changelog/unreleased/fix-static-asset-caching.md
@@ -1,4 +1,4 @@
-Bugfix: Disable cache for selected static web assets.
+Bugfix: Disable cache for selected static web assets
 
 We've disabled caching for some static web assets.
 Files like the web index.html, oidc-callback.html or similar contain paths to timestamped resources and should not be cached.

--- a/services/web/pkg/service/v0/service.go
+++ b/services/web/pkg/service/v0/service.go
@@ -152,6 +152,13 @@ func (p Web) Static(ttl int) http.HandlerFunc {
 		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s, must-revalidate", strconv.Itoa(ttl)))
 		w.Header().Set("Expires", expires)
 		w.Header().Set("Last-Modified", lastModified)
+
+		if r.URL.Path == rootWithSlash || r.URL.Path == rootWithSlash+"index.html" {
+			w.Header().Set("Cache-Control", "no-cache")
+
+		} else {
+			w.Header().Set("Cache-Control", "must-revalidate")
+		}
 		w.Header().Set("SameSite", "Strict")
 
 		static.ServeHTTP(w, r)

--- a/services/web/pkg/service/v0/service.go
+++ b/services/web/pkg/service/v0/service.go
@@ -3,7 +3,6 @@ package svc
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -90,7 +89,7 @@ func (p Web) getPayload() (payload []byte, err error) {
 			Msg("web config doesn't exist")
 	}
 
-	payload, err = ioutil.ReadFile(p.config.Web.Path)
+	payload, err = os.ReadFile(p.config.Web.Path)
 
 	if err != nil {
 		p.logger.Fatal().
@@ -102,7 +101,7 @@ func (p Web) getPayload() (payload []byte, err error) {
 }
 
 // Config implements the Service interface.
-func (p Web) Config(w http.ResponseWriter, r *http.Request) {
+func (p Web) Config(w http.ResponseWriter, _ *http.Request) {
 
 	payload, err := p.getPayload()
 	if err != nil {
@@ -152,13 +151,6 @@ func (p Web) Static(ttl int) http.HandlerFunc {
 		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%s, must-revalidate", strconv.Itoa(ttl)))
 		w.Header().Set("Expires", expires)
 		w.Header().Set("Last-Modified", lastModified)
-
-		if r.URL.Path == rootWithSlash || r.URL.Path == rootWithSlash+"index.html" {
-			w.Header().Set("Cache-Control", "no-cache")
-
-		} else {
-			w.Header().Set("Cache-Control", "must-revalidate")
-		}
 		w.Header().Set("SameSite", "Strict")
 
 		static.ServeHTTP(w, r)


### PR DESCRIPTION
## Description
we should not cache the index.html for oC web. If we cache the index.html it may require bundles that are no longer available after an update.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes with caching

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
