### PR TITLE
harden drives api and improve logging

### DIFF
--- a/changelog/unreleased/logging-improvements.md
+++ b/changelog/unreleased/logging-improvements.md
@@ -1,0 +1,5 @@
+Enhancement: Logging improvements
+
+We improved the logging of several http services. If possible and present, we now log the `X-Request-Id`.
+
+https://github.com/owncloud/ocis/pull/4815

--- a/ocis-pkg/log/log.go
+++ b/ocis-pkg/log/log.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	RequestIDString = "request"
+	RequestIDString = "request-id"
 )
 
 func init() {

--- a/ocis-pkg/log/log.go
+++ b/ocis-pkg/log/log.go
@@ -1,16 +1,22 @@
 package log
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	mzlog "github.com/go-micro/plugins/v4/logger/zerolog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go-micro.dev/v4/logger"
+)
+
+var (
+	RequestIDString = "request"
 )
 
 func init() {
@@ -115,5 +121,12 @@ func NewLogger(opts ...Option) Logger {
 
 	return Logger{
 		logger,
+	}
+}
+
+// SubloggerWithRequestID returns a sublogger with the x-request-id added to all events
+func (l Logger) SubloggerWithRequestID(c context.Context) Logger {
+	return Logger{
+		l.With().Str(RequestIDString, chimiddleware.GetReqID(c)).Logger(),
 	}
 }

--- a/ocis-pkg/middleware/logger.go
+++ b/ocis-pkg/middleware/logger.go
@@ -17,7 +17,7 @@ func Logger(logger log.Logger) func(http.Handler) http.Handler {
 			next.ServeHTTP(wrap, r)
 
 			logger.Debug().
-				Str("request", r.Header.Get("X-Request-ID")).
+				Str(log.RequestIDString, r.Header.Get("X-Request-ID")).
 				Str("proto", r.Proto).
 				Str("method", r.Method).
 				Int("status", wrap.Status()).

--- a/services/graph/pkg/identity/cs3.go
+++ b/services/graph/pkg/identity/cs3.go
@@ -40,9 +40,11 @@ func (i *CS3) UpdateUser(ctx context.Context, nameOrID string, user libregraph.U
 }
 
 func (i *CS3) GetUser(ctx context.Context, userID string, queryParam url.Values) (*libregraph.User, error) {
+	logger := i.Logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "cs3").Msg("GetUser")
 	client, err := pool.GetGatewayServiceClient(i.Config.Address)
 	if err != nil {
-		i.Logger.Error().Err(err).Msg("could not get client")
+		logger.Error().Str("backend", "cs3").Err(err).Msg("could not get client")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	}
 
@@ -53,22 +55,24 @@ func (i *CS3) GetUser(ctx context.Context, userID string, queryParam url.Values)
 
 	switch {
 	case err != nil:
-		i.Logger.Error().Err(err).Str("userid", userID).Msg("error sending get user by claim id grpc request")
+		logger.Error().Str("backend", "cs3").Err(err).Str("userid", userID).Msg("error sending get user by claim id grpc request: transport error")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	case res.Status.Code != cs3rpc.Code_CODE_OK:
 		if res.Status.Code == cs3rpc.Code_CODE_NOT_FOUND {
 			return nil, errorcode.New(errorcode.ItemNotFound, res.Status.Message)
 		}
-		i.Logger.Error().Err(err).Str("userid", userID).Msg("error sending get user by claim id grpc request")
+		logger.Debug().Str("backend", "cs3").Err(err).Str("userid", userID).Msg("error sending get user by claim id grpc request")
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 	return CreateUserModelFromCS3(res.User), nil
 }
 
 func (i *CS3) GetUsers(ctx context.Context, queryParam url.Values) ([]*libregraph.User, error) {
+	logger := i.Logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "cs3").Msg("GetUsers")
 	client, err := pool.GetGatewayServiceClient(i.Config.Address)
 	if err != nil {
-		i.Logger.Error().Err(err).Msg("could not get client")
+		logger.Error().Str("backend", "cs3").Err(err).Msg("could not get client")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	}
 
@@ -84,13 +88,13 @@ func (i *CS3) GetUsers(ctx context.Context, queryParam url.Values) ([]*libregrap
 	})
 	switch {
 	case err != nil:
-		i.Logger.Error().Err(err).Str("search", search).Msg("error sending find users grpc request")
+		logger.Error().Str("backend", "cs3").Err(err).Str("search", search).Msg("error sending find users grpc request: transport error")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	case res.Status.Code != cs3rpc.Code_CODE_OK:
 		if res.Status.Code == cs3rpc.Code_CODE_NOT_FOUND {
 			return nil, errorcode.New(errorcode.ItemNotFound, res.Status.Message)
 		}
-		i.Logger.Error().Err(err).Str("search", search).Msg("error sending find users grpc request")
+		logger.Debug().Str("backend", "cs3").Err(err).Str("search", search).Msg("error sending find users grpc request")
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 
@@ -104,9 +108,11 @@ func (i *CS3) GetUsers(ctx context.Context, queryParam url.Values) ([]*libregrap
 }
 
 func (i *CS3) GetGroups(ctx context.Context, queryParam url.Values) ([]*libregraph.Group, error) {
+	logger := i.Logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "cs3").Msg("GetGroups")
 	client, err := pool.GetGatewayServiceClient(i.Config.Address)
 	if err != nil {
-		i.Logger.Error().Err(err).Msg("could not get client")
+		logger.Error().Str("backend", "cs3").Err(err).Msg("could not get client")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	}
 
@@ -123,13 +129,13 @@ func (i *CS3) GetGroups(ctx context.Context, queryParam url.Values) ([]*libregra
 
 	switch {
 	case err != nil:
-		i.Logger.Error().Err(err).Str("search", search).Msg("error sending find groups grpc request")
+		logger.Error().Str("backend", "cs3").Err(err).Str("search", search).Msg("error sending find groups grpc request: transport error")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	case res.Status.Code != cs3rpc.Code_CODE_OK:
 		if res.Status.Code == cs3rpc.Code_CODE_NOT_FOUND {
 			return nil, errorcode.New(errorcode.ItemNotFound, res.Status.Message)
 		}
-		i.Logger.Error().Err(err).Str("search", search).Msg("error sending find groups grpc request")
+		logger.Debug().Str("backend", "cs3").Err(err).Str("search", search).Msg("error sending find groups grpc request")
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 
@@ -148,9 +154,11 @@ func (i *CS3) CreateGroup(ctx context.Context, group libregraph.Group) (*libregr
 }
 
 func (i *CS3) GetGroup(ctx context.Context, groupID string, queryParam url.Values) (*libregraph.Group, error) {
+	logger := i.Logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "cs3").Msg("GetGroup")
 	client, err := pool.GetGatewayServiceClient(i.Config.Address)
 	if err != nil {
-		i.Logger.Error().Err(err).Msg("could not get client")
+		logger.Error().Str("backend", "cs3").Err(err).Msg("could not get client")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	}
 
@@ -161,13 +169,13 @@ func (i *CS3) GetGroup(ctx context.Context, groupID string, queryParam url.Value
 
 	switch {
 	case err != nil:
-		i.Logger.Error().Err(err).Str("groupid", groupID).Msg("error sending get group by claim id grpc request")
+		logger.Error().Str("backend", "cs3").Err(err).Str("groupid", groupID).Msg("error sending get group by claim id grpc request: transport error")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
 	case res.Status.Code != cs3rpc.Code_CODE_OK:
 		if res.Status.Code == cs3rpc.Code_CODE_NOT_FOUND {
 			return nil, errorcode.New(errorcode.ItemNotFound, res.Status.Message)
 		}
-		i.Logger.Error().Err(err).Str("groupid", groupID).Msg("error sending get group by claim id grpc request")
+		logger.Debug().Str("backend", "cs3").Err(err).Str("groupid", groupID).Msg("error sending get group by claim id grpc request")
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 

--- a/services/graph/pkg/middleware/auth.go
+++ b/services/graph/pkg/middleware/auth.go
@@ -7,6 +7,7 @@ import (
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/token/manager/jwt"
 	"github.com/owncloud/ocis/v2/ocis-pkg/account"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	opkgm "github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 	gmmetadata "go-micro.dev/v4/metadata"
@@ -66,7 +67,7 @@ func Auth(opts ...account.Option) func(http.Handler) http.Handler {
 				return
 			}
 			if ok, err := scope.VerifyScope(ctx, tokenScope, r); err != nil || !ok {
-				opt.Logger.Error().Err(err).Msg("verifying scope failed")
+				opt.Logger.Error().Str(log.RequestIDString, r.Header.Get("X-Request-ID")).Err(err).Msg("verifying scope failed")
 				errorcode.InvalidAuthenticationToken.Render(w, r, http.StatusUnauthorized, "verifying scope failed")
 				return
 			}

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -399,7 +399,7 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logger.Debug().Interface("request", updateSpaceRequest).Msg("calling update space on backend")
+	logger.Debug().Interface("payload", updateSpaceRequest).Msg("calling update space on backend")
 	resp, err := client.UpdateStorageSpace(r.Context(), updateSpaceRequest)
 	if err != nil {
 		logger.Error().Err(err).Msg("could not update drive: transport error")

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -29,6 +29,7 @@ import (
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 	settingsServiceExt "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
+	"github.com/pkg/errors"
 	merrors "go-micro.dev/v4/errors"
 )
 
@@ -45,30 +46,36 @@ func (g Graph) GetAllDrives(w http.ResponseWriter, r *http.Request) {
 
 // getDrives implements the Service interface.
 func (g Graph) getDrives(w http.ResponseWriter, r *http.Request, unrestricted bool) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().
+		Interface("query", r.URL.Query()).
+		Bool("unrestricted", unrestricted).
+		Msg("calling get drives")
 	sanitizedPath := strings.TrimPrefix(r.URL.Path, "/graph/v1.0/")
 	// Parse the request with odata parser
 	odataReq, err := godata.ParseRequest(r.Context(), sanitizedPath, r.URL.Query())
 	if err != nil {
-		g.logger.Err(err).Interface("query", r.URL.Query()).Msg("query error")
+		logger.Debug().Err(err).Interface("query", r.URL.Query()).Msg("could not get drives: query error")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
-	g.logger.Debug().
-		Interface("query", r.URL.Query()).
-		Bool("unrestricted", unrestricted).
-		Msg("Calling getDrives")
 	ctx := r.Context()
 
 	filters, err := generateCs3Filters(odataReq)
 	if err != nil {
-		g.logger.Err(err).Interface("query", r.URL.Query()).Msg("query error")
+		logger.Debug().Err(err).Interface("query", r.URL.Query()).Msg("could not get drives: error parsing filters")
 		errorcode.NotSupported.Render(w, r, http.StatusNotImplemented, err.Error())
 		return
 	}
+
+	logger.Debug().
+		Interface("filters", filters).
+		Bool("unrestricted", unrestricted).
+		Msg("calling list storage spaces on backend")
 	res, err := g.ListStorageSpacesWithFilters(ctx, filters, unrestricted)
 	switch {
 	case err != nil:
-		g.logger.Error().Err(err).Msg(ListStorageSpacesTransportErr)
+		logger.Error().Err(err).Msg("could not get drives: transport error")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	case res.Status.Code != cs3rpc.Code_CODE_OK:
@@ -78,27 +85,28 @@ func (g Graph) getDrives(w http.ResponseWriter, r *http.Request, unrestricted bo
 			render.JSON(w, r, &listResponse{})
 			return
 		}
-		g.logger.Error().Err(err).Msg(ListStorageSpacesReturnsErr)
+		logger.Debug().Str("message", res.GetStatus().GetMessage()).Msg("could not get drives: grpc error")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, res.Status.Message)
 		return
 	}
 
-	wdu, err := url.Parse(g.config.Spaces.WebDavBase + g.config.Spaces.WebDavPath)
+	webDavBaseURL, err := g.getWebDavBaseURL()
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error parsing url")
+		logger.Error().Err(err).Str("url", webDavBaseURL.String()).Msg("could not get drives: error parsing url")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
-	spaces, err := g.formatDrives(ctx, wdu, res.StorageSpaces)
+
+	spaces, err := g.formatDrives(ctx, webDavBaseURL, res.StorageSpaces)
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error encoding response as json")
+		logger.Debug().Err(err).Msg("could not get drives: error parsing grpc response")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	spaces, err = sortSpaces(odataReq, spaces)
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error sorting the spaces list")
+		logger.Debug().Err(err).Msg("could not get drives: error sorting the spaces list according to query")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -109,60 +117,71 @@ func (g Graph) getDrives(w http.ResponseWriter, r *http.Request, unrestricted bo
 
 // GetSingleDrive does a lookup of a single space by spaceId
 func (g Graph) GetSingleDrive(w http.ResponseWriter, r *http.Request) {
-	driveID, _ := url.PathUnescape(chi.URLParam(r, "driveID"))
-	if driveID == "" {
-		err := fmt.Errorf("no valid space id retrieved")
-		g.logger.Err(err)
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Interface("query", r.URL.Query()).Msg("calling get drive")
+	driveID, err := url.PathUnescape(chi.URLParam(r, "driveID"))
+
+	if err != nil {
+		logger.Debug().Err(err).Str("driveID", chi.URLParam(r, "driveID")).Msg("could not get drive: unescaping drive id failed")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping drive id failed")
 		return
 	}
 
-	g.logger.Info().Str("driveID", driveID).Msg("Calling GetSingleDrive")
+	if driveID == "" {
+		logger.Debug().Msg("could not get drive: missing drive id")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing drive id")
+		return
+	}
+
+	logger.Debug().Str("driveID", driveID).Msg("calling list storage spaces with id filter")
 	ctx := r.Context()
 
 	filters := []*storageprovider.ListStorageSpacesRequest_Filter{listStorageSpacesIDFilter(driveID)}
 	res, err := g.ListStorageSpacesWithFilters(ctx, filters, true)
 	switch {
 	case err != nil:
-		g.logger.Error().Err(err).Msg(ListStorageSpacesTransportErr)
-		errorcode.ServiceNotAvailable.Render(w, r, http.StatusInternalServerError, err.Error())
+		logger.Error().Err(err).Msg("could not get drive: transport error")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	case res.Status.Code != cs3rpc.Code_CODE_OK:
 		if res.Status.Code == cs3rpc.Code_CODE_NOT_FOUND {
 			// the client is doing a lookup for a specific space, therefore we need to return
 			// not found to the caller
-			g.logger.Error().Str("driveID", driveID).Msg(fmt.Sprintf(NoSpaceFoundMessage, driveID))
-			errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, fmt.Sprintf(NoSpaceFoundMessage, driveID))
+			logger.Debug().Str("driveID", driveID).Msg("could not get drive: not found")
+			errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, "drive not found")
 			return
 		}
-		g.logger.Error().Err(err).Msg(ListStorageSpacesReturnsErr)
+		logger.Debug().
+			Str("id", driveID).
+			Str("grpcmessage", res.GetStatus().GetMessage()).
+			Msg("could not get drive: grpc error")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, res.Status.Message)
 		return
 	}
 
-	wdu, err := url.Parse(g.config.Spaces.WebDavBase + g.config.Spaces.WebDavPath)
+	webDavBaseURL, err := g.getWebDavBaseURL()
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error parsing url")
+		logger.Error().Err(err).Str("url", webDavBaseURL.String()).Msg("could not get drive: error parsing webdav base url")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
-	spaces, err := g.formatDrives(ctx, wdu, res.StorageSpaces)
+	spaces, err := g.formatDrives(ctx, webDavBaseURL, res.StorageSpaces)
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error encoding response")
+		logger.Debug().Err(err).Msg("could not get drive: error parsing grpc response")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 	switch num := len(spaces); {
 	case num == 0:
-		g.logger.Error().Str("driveID", driveID).Msg("no space found")
-		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, fmt.Sprintf(NoSpaceFoundMessage, driveID))
+		logger.Debug().Str("id", driveID).Msg("could not get drive: no drive returned from storage")
+		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, "no drive returned from storage")
 		return
 	case num == 1:
 		render.Status(r, http.StatusOK)
 		render.JSON(w, r, spaces[0])
 	default:
-		g.logger.Error().Int("number", num).Msg("expected to find a single space but found more")
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "expected to find a single space but found more")
+		logger.Debug().Int("number", num).Msg("could not get drive: expected to find a single drive but fetched more")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "could not get drive: expected to find a single drive but fetched more")
 		return
 	}
 }
@@ -185,28 +204,35 @@ func canCreateSpace(ctx context.Context, ownPersonalHome bool) bool {
 
 // CreateDrive creates a storage drive (space).
 func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling create drive")
 	us, ok := ctxpkg.ContextGetUser(r.Context())
 	if !ok {
-		errorcode.GeneralException.Render(w, r, http.StatusUnauthorized, "invalid user")
+		logger.Debug().Msg("could not create drive: invalid user")
+		errorcode.NotAllowed.Render(w, r, http.StatusUnauthorized, "invalid user")
 		return
 	}
 
 	// TODO determine if the user tries to create his own personal space and pass that as a boolean
-	if !canCreateSpace(r.Context(), false) {
+	canCreateSpace := canCreateSpace(r.Context(), false)
+	if !canCreateSpace {
+		logger.Debug().Bool("cancreatespace", canCreateSpace).Msg("could not create drive: insufficient permissions")
 		// if the permission is not existing for the user in context we can assume we don't have it. Return 401.
-		errorcode.GeneralException.Render(w, r, http.StatusUnauthorized, "insufficient permissions to create a space.")
+		errorcode.NotAllowed.Render(w, r, http.StatusUnauthorized, "insufficient permissions to create a space.")
 		return
 	}
 
 	client := g.GetGatewayClient()
 	drive := libregraph.Drive{}
 	if err := json.NewDecoder(r.Body).Decode(&drive); err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, "invalid schema definition")
+		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create drive: invalid body schema definition")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
 	}
 	spaceName := *drive.Name
 	if spaceName == "" {
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "invalid name")
+		logger.Debug().Str("name", spaceName).Msg("could not create drive: invalid name")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid name")
 		return
 	}
 
@@ -218,7 +244,8 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 	case "", "project":
 		driveType = "project"
 	default:
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Sprintf("drives of type %s cannot be created via this api", driveType))
+		logger.Debug().Str("type", driveType).Msg("could not create drive: drives of this type cannot be created via this api")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "drives of this type cannot be created via this api")
 		return
 	}
 
@@ -242,25 +269,32 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := client.CreateStorageSpace(r.Context(), &csr)
 	if err != nil {
+		logger.Error().Err(err).Msg("could not create drive: transport error")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	if resp.GetStatus().GetCode() != cs3rpc.Code_CODE_OK {
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "")
+		if resp.GetStatus().GetCode() == cs3rpc.Code_CODE_PERMISSION_DENIED {
+			logger.Debug().Str("grpcmessage", resp.GetStatus().GetMessage()).Msg("could not create drive: permission denied")
+			errorcode.NotAllowed.Render(w, r, http.StatusForbidden, "permission denied")
+			return
+		}
+		logger.Debug().Interface("grpcmessage", csr).Str("grpc", resp.GetStatus().GetMessage()).Msg("could not create drive: grpc error")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, resp.GetStatus().GetMessage())
 		return
 	}
 
-	wdu, err := url.Parse(g.config.Spaces.WebDavBase + g.config.Spaces.WebDavPath)
+	webDavBaseURL, err := g.getWebDavBaseURL()
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error parsing url")
+		logger.Error().Str("url", webDavBaseURL.String()).Err(err).Msg("could not create drive: error parsing webdav base url")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	newDrive, err := g.cs3StorageSpaceToDrive(r.Context(), wdu, resp.StorageSpace)
+	newDrive, err := g.cs3StorageSpaceToDrive(r.Context(), webDavBaseURL, resp.StorageSpace)
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error parsing space")
+		logger.Debug().Err(err).Msg("could not create drive: error parsing drive")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -269,20 +303,25 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling update drive")
 	driveID, err := url.PathUnescape(chi.URLParam(r, "driveID"))
 	if err != nil {
+		logger.Debug().Err(err).Str("id", chi.URLParam(r, "driveID")).Msg("could not update drive, unescaping drive id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping drive id failed")
 		return
 	}
 
 	if driveID == "" {
+		logger.Debug().Msg("Could not update drive, missing drive id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing drive id")
 		return
 	}
 
 	drive := libregraph.Drive{}
 	if err = json.NewDecoder(r.Body).Decode(&drive); err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", r.Body))
+		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update drive, invalid request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: error: %v", err.Error()))
 		return
 	}
 
@@ -290,7 +329,8 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 
 	rid, err := storagespace.ParseID(driveID)
 	if err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid resource id: %v", rid))
+		logger.Debug().Err(err).Interface("id", rid).Msg("could not update drive, invalid resource id")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid resource id")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -343,11 +383,15 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 		user := ctxpkg.ContextMustGetUser(r.Context())
 		canSetSpaceQuota, err := canSetSpaceQuota(r.Context(), user)
 		if err != nil {
+			logger.Error().Err(err).Msg("could not update drive: failed to check if the user can set space quota")
 			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 			return
 		}
 		if !canSetSpaceQuota {
-			errorcode.GeneralException.Render(w, r, http.StatusUnauthorized, "user is not allowed to set the space quota")
+			logger.Debug().
+				Bool("cansetspacequota", canSetSpaceQuota).
+				Msg("could not update drive: user is not allowed to set the space quota")
+			errorcode.NotAllowed.Render(w, r, http.StatusUnauthorized, "user is not allowed to set the space quota")
 			return
 		}
 		updateSpaceRequest.StorageSpace.Quota = &storageprovider.Quota{
@@ -355,36 +399,41 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	logger.Debug().Interface("request", updateSpaceRequest).Msg("calling update space on backend")
 	resp, err := client.UpdateStorageSpace(r.Context(), updateSpaceRequest)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		logger.Error().Err(err).Msg("could not update drive: transport error")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "transport error")
 		return
 	}
 
 	if resp.GetStatus().GetCode() != cs3rpc.Code_CODE_OK {
 		switch resp.Status.GetCode() {
 		case cs3rpc.Code_CODE_NOT_FOUND:
+			logger.Debug().Interface("id", rid).Msg("could not update drive: drive not found")
 			errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, resp.GetStatus().GetMessage())
 			return
 		case cs3rpc.Code_CODE_PERMISSION_DENIED:
+			logger.Debug().Interface("id", rid).Msg("could not update drive, permission denied")
 			errorcode.NotAllowed.Render(w, r, http.StatusForbidden, resp.GetStatus().GetMessage())
 			return
 		default:
+			logger.Debug().Interface("id", rid).Str("grpc", resp.GetStatus().GetMessage()).Msg("could not update drive: grpc error")
 			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, resp.GetStatus().GetMessage())
 			return
 		}
 	}
 
-	wdu, err := url.Parse(g.config.Spaces.WebDavBase + g.config.Spaces.WebDavPath)
+	webDavBaseURL, err := g.getWebDavBaseURL()
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error parsing url")
+		logger.Error().Err(err).Interface("url", webDavBaseURL.String()).Msg("could not update drive: error parsing url")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	spaces, err := g.formatDrives(r.Context(), wdu, []*storageprovider.StorageSpace{resp.StorageSpace})
+	spaces, err := g.formatDrives(r.Context(), webDavBaseURL, []*storageprovider.StorageSpace{resp.StorageSpace})
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error parsing space")
+		logger.Debug().Err(err).Msg("could not update drive: error parsing grpc response")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -452,8 +501,10 @@ func (g Graph) ListStorageSpacesWithFilters(ctx context.Context, filters []*stor
 }
 
 func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, space *storageprovider.StorageSpace) (*libregraph.Drive, error) {
+	logger := g.logger.SubloggerWithRequestID(ctx)
 	if space.Root == nil {
-		return nil, fmt.Errorf("space has no root")
+		logger.Error().Msg("unable to parse space: space has no root")
+		return nil, errors.New("space has no root")
 	}
 	spaceRid := *space.Root
 	if space.Root.GetSpaceId() == space.Root.GetOpaqueId() {
@@ -468,10 +519,11 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 		if ok {
 			err := json.Unmarshal(entry.Value, &m)
 			if err != nil {
-				g.logger.Error().
+				logger.Debug().
 					Err(err).
-					Str("space", space.Root.OpaqueId).
-					Msg("failed to read spaces grants")
+					Interface("space", space.Root).
+					Bytes("grants", entry.Value).
+					Msg("unable to parse space: failed to read spaces grants")
 			}
 		}
 		if len(m) != 0 {
@@ -542,7 +594,7 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 			var err error
 			remoteItem, err = g.getRemoteItem(ctx, &grantID, baseURL)
 			if err != nil {
-				g.logger.Debug().Err(err).Msg(err.Error())
+				logger.Debug().Err(err).Interface("id", grantID).Msg("could not fetch remote item for space, continue")
 			}
 		}
 		if remoteItem != nil {
@@ -578,10 +630,10 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 
 	webURL, err := url.Parse(g.config.Spaces.WebDavBase)
 	if err != nil {
-		g.logger.Error().
+		logger.Error().
 			Err(err).
 			Str("url", g.config.Spaces.WebDavBase).
-			Msg("failed to parse base url")
+			Msg("failed to parse webURL base url")
 		return nil, err
 	}
 
@@ -616,6 +668,7 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 }
 
 func (g Graph) getDriveQuota(ctx context.Context, space *storageprovider.StorageSpace) (*libregraph.Quota, error) {
+	logger := g.logger.SubloggerWithRequestID(ctx)
 	client := g.GetGatewayClient()
 
 	req := &gateway.GetQuotaRequest{
@@ -627,13 +680,13 @@ func (g Graph) getDriveQuota(ctx context.Context, space *storageprovider.Storage
 	res, err := client.GetQuota(ctx, req)
 	switch {
 	case err != nil:
-		g.logger.Error().Err(err).Msg("could not call GetQuota")
+		logger.Error().Err(err).Interface("ref", req.Ref).Msg("could not call GetQuota: transport error")
 		return nil, nil
-	case res.Status.Code == cs3rpc.Code_CODE_UNIMPLEMENTED:
-		// TODO well duh
+	case res.GetStatus().GetCode() == cs3rpc.Code_CODE_UNIMPLEMENTED:
+		logger.Debug().Msg("get quota is not implemented on the storage driver")
 		return nil, nil
-	case res.Status.Code != cs3rpc.Code_CODE_OK:
-		g.logger.Error().Err(err).Msg("error sending get quota grpc request")
+	case res.GetStatus().GetCode() != cs3rpc.Code_CODE_OK:
+		logger.Debug().Str("grpc", res.GetStatus().GetMessage()).Msg("error sending get quota grpc request")
 		return nil, err
 	}
 
@@ -723,7 +776,7 @@ func generateCs3Filters(request *godata.GoDataRequest) ([]*storageprovider.ListS
 				filters = append(filters, listStorageSpacesIDFilter(strings.Trim(request.Query.Filter.Tree.Children[1].Token.Value, "'")))
 			}
 		} else {
-			err := fmt.Errorf("unsupported filter operand: %s", request.Query.Filter.Tree.Token.Value)
+			err := errors.Errorf("unsupported filter operand: %s", request.Query.Filter.Tree.Token.Value)
 			return nil, err
 		}
 	}
@@ -762,21 +815,25 @@ func listStorageSpacesTypeFilter(spaceType string) *storageprovider.ListStorageS
 }
 
 func (g Graph) DeleteDrive(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling delete drive")
 	driveID, err := url.PathUnescape(chi.URLParam(r, "driveID"))
 	if err != nil {
+		logger.Debug().Err(err).Str("id", chi.URLParam(r, "driveID")).Msg("could not delete drive: unescaping drive id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping drive id failed")
 		return
 	}
 
 	if driveID == "" {
+		logger.Debug().Msg("could not delete drive: missing drive id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing drive id")
 		return
 	}
 
 	rid, err := storagespace.ParseID(driveID)
 	if err != nil {
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid resource id: %v", rid))
-		w.WriteHeader(http.StatusInternalServerError)
+		logger.Debug().Interface("id", rid).Err(err).Msg("could not delete drive: invalid resource id")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid resource id")
 		return
 	}
 
@@ -798,8 +855,8 @@ func (g Graph) DeleteDrive(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 	if err != nil {
-		g.logger.Error().Err(err).Msg("error deleting storage space")
-		w.WriteHeader(http.StatusInternalServerError)
+		logger.Error().Err(err).Interface("id", rid).Msg("could not delete drive: transport error")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "transport error")
 		return
 	}
 
@@ -808,16 +865,17 @@ func (g Graph) DeleteDrive(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	case cs3rpc.Code_CODE_INVALID_ARGUMENT:
-		errorcode.GeneralException.Render(w, r, http.StatusBadRequest, dRes.Status.Message)
-		w.WriteHeader(http.StatusBadRequest)
+		logger.Debug().Interface("id", rid).Str("grpc", dRes.GetStatus().GetMessage()).Msg("could not delete drive: invalid argument")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, dRes.Status.Message)
 		return
 	case cs3rpc.Code_CODE_PERMISSION_DENIED:
-		w.WriteHeader(http.StatusForbidden)
+		logger.Debug().Interface("id", rid).Msg("could not delete drive: permission denied")
+		errorcode.NotAllowed.Render(w, r, http.StatusForbidden, "permission denied to delete drive")
 		return
 	// don't expose internal error codes to the outside world
 	default:
-		g.logger.Error().Err(err).Msg("error deleting storage space")
-		w.WriteHeader(http.StatusInternalServerError)
+		logger.Debug().Str("grpc", dRes.GetStatus().GetMessage()).Interface("id", rid).Msg("could not delete drive: grpc error")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "grpc error")
 		return
 	}
 
@@ -834,7 +892,7 @@ func sortSpaces(req *godata.GoDataRequest, spaces []*libregraph.Drive) ([]*libre
 	case "lastModifiedDateTime":
 		sorter = spacesByLastModifiedDateTime{spaces}
 	default:
-		return nil, fmt.Errorf("we do not support <%s> as a order parameter", req.Query.OrderBy.OrderByItems[0].Field.Value)
+		return nil, errors.Errorf("we do not support <%s> as a order parameter", req.Query.OrderBy.OrderByItems[0].Field.Value)
 	}
 
 	if req.Query.OrderBy.OrderByItems[0].Order == "desc" {

--- a/services/graph/pkg/service/v0/errorcode/errorcode.go
+++ b/services/graph/pkg/service/v0/errorcode/errorcode.go
@@ -50,6 +50,8 @@ const (
 	QuotaLimitReached
 	// Unauthenticated the caller is not authenticated.
 	Unauthenticated
+	// PreconditionFailed the request cannot be made and this error response is sent back
+	PreconditionFailed
 )
 
 var errorCodes = [...]string{
@@ -69,6 +71,7 @@ var errorCodes = [...]string{
 	"serviceNotAvailable",
 	"quotaLimitReached",
 	"unauthenticated",
+	"preconditionFailed",
 }
 
 func New(e ErrorCode, msg string) Error {
@@ -82,7 +85,6 @@ func New(e ErrorCode, msg string) Error {
 func (e ErrorCode) Render(w http.ResponseWriter, r *http.Request, status int, msg string) {
 	innererror := map[string]interface{}{
 		"date": time.Now().UTC().Format(time.RFC3339),
-		// TODO return client-request-id?
 	}
 
 	innererror["request-id"] = middleware.GetReqID(r.Context())

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -3,6 +3,8 @@ package svc
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"path"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -100,14 +102,20 @@ func (g Graph) publishEvent(ev interface{}) {
 	}
 }
 
+func (g Graph) getWebDavBaseURL() (*url.URL, error) {
+	webDavBaseURL, err := url.Parse(g.config.Spaces.WebDavBase)
+	if err != nil {
+		return nil, err
+	}
+	webDavBaseURL.Path = path.Join(webDavBaseURL.Path, g.config.Spaces.WebDavPath)
+	return webDavBaseURL, nil
+}
+
 type listResponse struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
 const (
-	NoSpaceFoundMessage           = "space with id `%s` not found"
-	ListStorageSpacesTransportErr = "transport error sending list storage spaces grpc request"
-	ListStorageSpacesReturnsErr   = "list storage spaces grpc request returns an errorcode in the response"
-	ReadmeSpecialFolderName       = "readme"
-	SpaceImageSpecialFolderName   = "image"
+	ReadmeSpecialFolderName     = "readme"
+	SpaceImageSpecialFolderName = "image"
 )

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -23,17 +23,19 @@ const memberRefsLimit = 20
 
 // GetGroups implements the Service interface.
 func (g Graph) GetGroups(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Interface("query", r.URL.Query()).Msg("calling get groups")
 	sanitizedPath := strings.TrimPrefix(r.URL.Path, "/graph/v1.0/")
 	odataReq, err := godata.ParseRequest(r.Context(), sanitizedPath, r.URL.Query())
 	if err != nil {
-		g.logger.Err(err).Interface("query", r.URL.Query()).Msg("query error")
+		logger.Debug().Err(err).Interface("query", r.URL.Query()).Msg("could not get groups: query error")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	groups, err := g.identityBackend.GetGroups(r.Context(), r.URL.Query())
-
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not get groups: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -44,12 +46,8 @@ func (g Graph) GetGroups(w http.ResponseWriter, r *http.Request) {
 
 	groups, err = sortGroups(odataReq, groups)
 	if err != nil {
-		var errcode errorcode.Error
-		if errors.As(err, &errcode) {
-			errcode.Render(w, r)
-		} else {
-			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
-		}
+		logger.Debug().Err(err).Interface("query", r.URL.Query()).Msg("cannot get groups: could not sort groups according to query")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
 	render.Status(r, http.StatusOK)
@@ -58,14 +56,18 @@ func (g Graph) GetGroups(w http.ResponseWriter, r *http.Request) {
 
 // PostGroup implements the Service interface.
 func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling post group")
 	grp := libregraph.NewGroup()
 	err := json.NewDecoder(r.Body).Decode(grp)
 	if err != nil {
-		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create group: invalid request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
 
 	if _, ok := grp.GetDisplayNameOk(); !ok {
+		logger.Debug().Err(err).Interface("group", grp).Msg("could not create group: missing required attribute")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Missing Required Attribute")
 		return
 	}
@@ -74,11 +76,13 @@ func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
 	// generating them in the backend ourselves or rely on the Backend's
 	// storage (e.g. LDAP) to provide a unique ID.
 	if _, ok := grp.GetIdOk(); ok {
+		logger.Debug().Msg("could not create group: id is a read-only attribute")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "group id is a read-only attribute")
 		return
 	}
 
 	if grp, err = g.identityBackend.CreateGroup(r.Context(), *grp); err != nil {
+		logger.Debug().Interface("group", grp).Msg("could not create group: backend error")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -93,29 +97,37 @@ func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
 
 // PatchGroup implements the Service interface.
 func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
-	g.logger.Debug().Msg("Calling PatchGroup")
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling patch group")
 	groupID := chi.URLParam(r, "groupID")
 	groupID, err := url.PathUnescape(groupID)
 	if err != nil {
+		logger.Debug().Str("id", groupID).Msg("could not change group: unescaping group id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping group id failed")
 		return
 	}
 
 	if groupID == "" {
+		logger.Debug().Msg("could not change group: missing group id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing group id")
 		return
 	}
 	changes := libregraph.NewGroup()
 	err = json.NewDecoder(r.Body).Decode(changes)
 	if err != nil {
-		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not change group: invalid request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
 
 	if memberRefs, ok := changes.GetMembersodataBindOk(); ok {
 		// The spec defines a limit of 20 members maxium per Request
 		if len(memberRefs) > memberRefsLimit {
-			errorcode.NotAllowed.Render(w, r, http.StatusInternalServerError,
+			logger.Debug().
+				Int("number", len(memberRefs)).
+				Int("limit", memberRefsLimit).
+				Msg("could not create group, exceeded members limit")
+			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
 				fmt.Sprintf("Request is limited to %d members", memberRefsLimit))
 			return
 		}
@@ -123,14 +135,20 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 		for _, memberRef := range memberRefs {
 			memberType, id, err := g.parseMemberRef(memberRef)
 			if err != nil {
-				errorcode.InvalidRequest.Render(w, r, http.StatusInternalServerError, "Error parsing member@odata.bind values")
+				logger.Debug().
+					Str("memberref", memberRef).
+					Msg("could not change group: Error parsing member@odata.bind values")
+				errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Error parsing member@odata.bind values")
 				return
 			}
-			g.logger.Debug().Str("memberType", memberType).Str("memberid", id).Msg("Add Member")
+			logger.Debug().Str("membertype", memberType).Str("memberid", id).Msg("add group member")
 			// The MS Graph spec allows "directoryObject", "user", "group" and "organizational Contact"
 			// we restrict this to users for now. Might add Groups as members later
 			if memberType != "users" {
-				errorcode.InvalidRequest.Render(w, r, http.StatusInternalServerError, "Only user are allowed as group members")
+				logger.Debug().
+					Str("type", memberType).
+					Msg("could not change group: could not add member, only user type is allowed")
+				errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Only user are allowed as group members")
 				return
 			}
 			memberIDs = append(memberIDs, id)
@@ -139,6 +157,7 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not change group: backend could not add members")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -153,19 +172,28 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 // GetGroup implements the Service interface.
 func (g Graph) GetGroup(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling get group")
 	groupID := chi.URLParam(r, "groupID")
 	groupID, err := url.PathUnescape(groupID)
 	if err != nil {
+		logger.Debug().Str("id", groupID).Msg("could not get group: unescaping group id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping group id failed")
 	}
 
 	if groupID == "" {
+		logger.Debug().Msg("could not get group: missing group id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing group id")
 		return
 	}
 
+	logger.Debug().
+		Str("id", groupID).
+		Interface("query", r.URL.Query()).
+		Msg("calling get group on backend")
 	group, err := g.identityBackend.GetGroup(r.Context(), groupID, r.URL.Query())
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not get group: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -180,21 +208,27 @@ func (g Graph) GetGroup(w http.ResponseWriter, r *http.Request) {
 
 // DeleteGroup implements the Service interface.
 func (g Graph) DeleteGroup(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling delete group")
 	groupID := chi.URLParam(r, "groupID")
 	groupID, err := url.PathUnescape(groupID)
 	if err != nil {
+		logger.Debug().Err(err).Str("id", groupID).Msg("could not delete group: unescaping group id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping group id failed")
 		return
 	}
 
 	if groupID == "" {
+		logger.Debug().Msg("could not delete group: missing group id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing group id")
 		return
 	}
 
+	logger.Debug().Str("id", groupID).Msg("calling delete group on backend")
 	err = g.identityBackend.DeleteGroup(r.Context(), groupID)
 
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not delete group: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -211,20 +245,26 @@ func (g Graph) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g Graph) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling get group members")
 	groupID := chi.URLParam(r, "groupID")
 	groupID, err := url.PathUnescape(groupID)
 	if err != nil {
+		logger.Debug().Str("id", groupID).Msg("could not get group members: unescaping group id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping group id failed")
 		return
 	}
 
 	if groupID == "" {
+		logger.Debug().Msg("could not get group members: missing group id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing group id")
 		return
 	}
 
+	logger.Debug().Str("id", groupID).Msg("calling get group members on backend")
 	members, err := g.identityBackend.GetGroupMembers(r.Context(), groupID)
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not get group members: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -240,46 +280,60 @@ func (g Graph) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
 
 // PostGroupMember implements the Service interface.
 func (g Graph) PostGroupMember(w http.ResponseWriter, r *http.Request) {
-	g.logger.Info().Msg("Calling PostGroupMember")
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("Calling post group member")
 
 	groupID := chi.URLParam(r, "groupID")
 	groupID, err := url.PathUnescape(groupID)
 	if err != nil {
+		logger.Debug().
+			Err(err).
+			Str("id", groupID).
+			Msg("could not add member to group: unescaping group id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping group id failed")
 		return
 	}
 
 	if groupID == "" {
+		logger.Debug().Msg("could not add group member: missing group id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing group id")
 		return
 	}
 	memberRef := libregraph.NewMemberReference()
 	err = json.NewDecoder(r.Body).Decode(memberRef)
 	if err != nil {
-		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		logger.Debug().
+			Err(err).
+			Interface("body", r.Body).
+			Msg("could not add group member: invalid request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
 	memberRefURL, ok := memberRef.GetOdataIdOk()
 	if !ok {
-		errorcode.InvalidRequest.Render(w, r, http.StatusInternalServerError, "@odata.id refernce is missing")
+		logger.Debug().Msg("could not add group member: @odata.id reference is missing")
+		errorcode.InvalidRequest.Render(w, r, http.StatusInternalServerError, "@odata.id reference is missing")
 		return
 	}
 	memberType, id, err := g.parseMemberRef(*memberRefURL)
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not add group member: error parsing @odata.id url")
 		errorcode.InvalidRequest.Render(w, r, http.StatusInternalServerError, "Error parsing @odata.id url")
 		return
 	}
 	// The MS Graph spec allows "directoryObject", "user", "group" and "organizational Contact"
 	// we restrict this to users for now. Might add Groups as members later
 	if memberType != "users" {
-		errorcode.InvalidRequest.Render(w, r, http.StatusInternalServerError, "Only user are allowed as group members")
+		logger.Debug().Str("type", memberType).Msg("could not add group member: Only users are allowed as group members")
+		errorcode.InvalidRequest.Render(w, r, http.StatusInternalServerError, "Only users are allowed as group members")
 		return
 	}
 
-	g.logger.Debug().Str("memberType", memberType).Str("id", id).Msg("Add Member")
+	logger.Debug().Str("memberType", memberType).Str("id", id).Msg("calling add member on backend")
 	err = g.identityBackend.AddMembersToGroup(r.Context(), groupID, []string{id})
 
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not add group member: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -297,16 +351,19 @@ func (g Graph) PostGroupMember(w http.ResponseWriter, r *http.Request) {
 
 // DeleteGroupMember implements the Service interface.
 func (g Graph) DeleteGroupMember(w http.ResponseWriter, r *http.Request) {
-	g.logger.Info().Msg("Calling DeleteGroupMember")
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Msg("calling delete group member")
 
 	groupID := chi.URLParam(r, "groupID")
 	groupID, err := url.PathUnescape(groupID)
 	if err != nil {
+		logger.Debug().Err(err).Str("id", groupID).Msg("could not delete group member: unescaping group id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping group id failed")
 		return
 	}
 
 	if groupID == "" {
+		logger.Debug().Msg("could not delete group member: missing group id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing group id")
 		return
 	}
@@ -314,18 +371,21 @@ func (g Graph) DeleteGroupMember(w http.ResponseWriter, r *http.Request) {
 	memberID := chi.URLParam(r, "memberID")
 	memberID, err = url.PathUnescape(memberID)
 	if err != nil {
+		logger.Debug().Err(err).Str("id", memberID).Msg("could not delete group member: unescaping group id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping group id failed")
 		return
 	}
 
 	if memberID == "" {
+		logger.Debug().Msg("could not delete group member: missing group id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing group id")
 		return
 	}
-	g.logger.Debug().Str("groupID", groupID).Str("memberID", memberID).Msg("DeleteGroupMember")
+	logger.Debug().Str("groupID", groupID).Str("memberID", memberID).Msg("calling delete member on backend")
 	err = g.identityBackend.RemoveMemberFromGroup(r.Context(), groupID, memberID)
 
 	if err != nil {
+		logger.Debug().Err(err).Msg("could not delete group member: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)

--- a/services/proxy/pkg/middleware/accesslog.go
+++ b/services/proxy/pkg/middleware/accesslog.go
@@ -19,7 +19,7 @@ func AccessLog(logger log.Logger) func(http.Handler) http.Handler {
 
 			logger.Info().
 				Str("proto", r.Proto).
-				Str("request", chimiddleware.GetReqID(r.Context())).
+				Str(log.RequestIDString, chimiddleware.GetReqID(r.Context())).
 				Str("remote-addr", r.RemoteAddr).
 				Str("method", r.Method).
 				Int("status", wrap.Status()).

--- a/services/thumbnails/pkg/service/http/v0/service.go
+++ b/services/thumbnails/pkg/service/http/v0/service.go
@@ -78,7 +78,7 @@ func (s Thumbnails) GetThumbnail(w http.ResponseWriter, r *http.Request) {
 
 	thumbnail, err := s.manager.GetThumbnail(key)
 	if err != nil {
-		logger.Error().
+		logger.Debug().
 			Err(err).
 			Str("key", key).
 			Msg("could not get the thumbnail")

--- a/services/thumbnails/pkg/service/http/v0/service.go
+++ b/services/thumbnails/pkg/service/http/v0/service.go
@@ -73,11 +73,12 @@ func (s Thumbnails) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // GetThumbnail implements the Service interface.
 func (s Thumbnails) GetThumbnail(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.SubloggerWithRequestID(r.Context())
 	key := r.Context().Value(keyContextKey).(string)
 
 	thumbnail, err := s.manager.GetThumbnail(key)
 	if err != nil {
-		s.logger.Error().
+		logger.Error().
 			Err(err).
 			Str("key", key).
 			Msg("could not get the thumbnail")
@@ -88,7 +89,7 @@ func (s Thumbnails) GetThumbnail(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Length", strconv.Itoa(len(thumbnail)))
 	if _, err = w.Write(thumbnail); err != nil {
-		s.logger.Error().
+		logger.Error().
 			Err(err).
 			Str("key", key).
 			Msg("could not write the thumbnail response")
@@ -97,6 +98,7 @@ func (s Thumbnails) GetThumbnail(w http.ResponseWriter, r *http.Request) {
 
 func (s Thumbnails) TransferTokenValidator(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := s.logger.SubloggerWithRequestID(r.Context())
 		tokenString := r.Header.Get("Transfer-Token")
 		token, err := jwt.ParseWithClaims(tokenString, &tjwt.ThumbnailClaims{}, func(token *jwt.Token) (interface{}, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -105,7 +107,7 @@ func (s Thumbnails) TransferTokenValidator(next http.Handler) http.Handler {
 			return []byte(s.config.Thumbnail.TransferSecret), nil
 		})
 		if err != nil {
-			s.logger.Error().
+			logger.Debug().
 				Err(err).
 				Str("transfer-token", tokenString).
 				Msg("failed to parse transfer token")
@@ -118,6 +120,7 @@ func (s Thumbnails) TransferTokenValidator(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
+		logger.Debug().Msg("invalid transfer token")
 		w.WriteHeader(http.StatusUnauthorized)
 	})
 }

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -243,7 +243,7 @@ func (g Webdav) SpacesThumbnail(w http.ResponseWriter, r *http.Request) {
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
-		logger.Error().Err(err).Msg("could not get thumbnail")
+		logger.Debug().Err(err).Msg("could not get thumbnail")
 		return
 	}
 
@@ -407,7 +407,7 @@ func (g Webdav) PublicThumbnailHead(w http.ResponseWriter, r *http.Request) {
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
-		logger.Error().Err(err).Msg("could not get thumbnail")
+		logger.Debug().Err(err).Msg("could not get thumbnail")
 		return
 	}
 
@@ -423,7 +423,7 @@ func (g Webdav) sendThumbnailResponse(rsp *thumbnailssvc.GetThumbnailResponse, w
 	dlReq, err := http.NewRequest(http.MethodGet, rsp.DataEndpoint, http.NoBody)
 	if err != nil {
 		renderError(w, r, errInternalError(err.Error()))
-		logger.Error().Err(err).Msg("could not download thumbnail")
+		logger.Error().Err(err).Msg("could not create download thumbnail request")
 		return
 	}
 	dlReq.Header.Set("Transfer-Token", rsp.TransferToken)
@@ -431,13 +431,13 @@ func (g Webdav) sendThumbnailResponse(rsp *thumbnailssvc.GetThumbnailResponse, w
 	dlRsp, err := client.Do(dlReq)
 	if err != nil {
 		renderError(w, r, errInternalError(err.Error()))
-		logger.Error().Err(err).Msg("could not download thumbnail")
+		logger.Error().Err(err).Msg("could not download thumbnail: transport error")
 		return
 	}
 	defer dlRsp.Body.Close()
 
 	if dlRsp.StatusCode != http.StatusOK {
-		logger.Error().
+		logger.Debug().
 			Str("transfer_token", rsp.TransferToken).
 			Str("data_endpoint", rsp.DataEndpoint).
 			Str("response_status", dlRsp.Status).


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

We improved the logging of several http services. If possible and present, we now log the `X-Request-Id`.

## Logging Documentation

In ocis, we have the following log levels

### FATAL

FATAL means that the application is about to stop a serious problem or corruption from happening. This level of logging shows that the application’s situation is catastrophic, such that an important function is not working. For example the application is unable to connect to the data store due to config errors or not able to parse the config

### ERROR (default setting, OCIS_LOG_LEVEL=error)
This is the default log level, all errors on this level are important for admins because they need to fix them.  This log level is used when a severe issue is stopping functions within the application from operating correctly. Ocis logs all kind of inter service communication errors on this level because these needs to be addressed.

### WARN
The WARN log level is used when ocis detects an unexpected failure during an operation. It is also used if some operations might be incomplete. It  does not mean that the application has been harmed, the code should continue to work as usual. Admins should eventually check these warnings just in case the problem reoccurs.

### INFO
Messages  on this level are documenting the normal behavior of applications. They state what happened. These entries are purely informative to confirm that the application is working as desired. The info log level also enables the ocis Proxy to write a full access log.

### DEBUG
This log level provides diagnostic information in a detailed manner. It is verbose and has more information than you would need when using the application. This log level is used to understand problems in the application and during reproduction of problems. This log level could put a very high load on the output device and is not recommended in production environments. You should consider enabling this level only on a single service or very few services to pinpoint issues or bugs.


## To do

- [x] Drives API
- [x] User API
- [x] Groups API
- [x] Thumbnails API
- [x] Search API

## Motivation and Context

Increase the debuggability of the stack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: [<link> ](https://github.com/owncloud/docs-ocis/issues/266)
