### PR TITLE
[test-only] Api-test. Overwriting a file while coping and moving

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -37,3 +37,8 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpacesShares/shareUploadTUS.feature:204](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature#L204)
 - [apiSpacesShares/shareUploadTUS.feature:219](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature#L219)
 - [apiSpacesShares/shareUploadTUS.feature:284](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature#L284)
+
+### [Copy or move on an existing resource doesn't create a new version but deletes instead](https://github.com/owncloud/ocis/issues/4797)
+- [apiSpacesShares/moveSpaces.feature:304](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/moveSpaces.feature#L304)
+- [apiSpacesShares/copySpaces.feature:711](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L711)
+- [apiSpacesShares/copySpaces.feature:748](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L748)

--- a/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature
+++ b/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature
@@ -28,7 +28,8 @@ Feature:
 
 
   Scenario: overwrite a received file share
-    Given user "Alice" has uploaded file with content "this is the old content" to "/textfile1.txt"
+    Given user "Alice" has uploaded file with content "old content version 1" to "/textfile1.txt"
+    And user "Alice" has uploaded file with content "old content version 2" to "/textfile1.txt"
     And user "Alice" has shared file "/textfile1.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile1.txt" offered by user "Alice"
     When user "Brian" uploads a file inside space "Shares Jail" with content "this is a new content" to "textfile1.txt" using the WebDAV API
@@ -37,3 +38,9 @@ Feature:
       | textfile1.txt |
     And for user "Brian" the content of the file "/textfile1.txt" of the space "Shares Jail" should be "this is a new content"
     And for user "Alice" the content of the file "/textfile1.txt" of the space "Personal" should be "this is a new content"
+    When user "Alice" downloads version of the file "/textfile1.txt" with the index "2" of the space "Personal" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "old content version 1"
+    When user "Brian" downloads version of the file "/textfile1.txt" with the index "1" of the space "Shares Jail" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "old content version 2"

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -300,3 +300,21 @@ Feature: move (rename) file
       | testsubfolder |
     And for user "Brian" the space "Personal" should not contain these entries:
       | /testshare/testsubfolder |
+
+   Scenario: Overwriting a file while moving
+    Given user "Brian" has created folder "/folder"
+    And user "Brian" has uploaded file with content "old content version 1" to "/folder/testfile.txt"
+    And user "Brian" has uploaded file with content "old content version 2" to "/folder/testfile.txt"
+    And user "Brian" has uploaded file with content "new data" to "/testfile.txt"
+    When user "Brian" overwrites file "/testfile.txt" from space "Personal" to "folder/testfile.txt" inside space "Personal" while moving using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/folder/testfile.txt" for user "Brian" should be "new data"
+    And for user "Brian" the space "Personal" should not contain these entries:
+      | /testfile.txt |
+    When user "Brian" downloads version of the file "/folder/testfile.txt" with the index "1" of the space "Personal" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "old content version 2"
+    When user "Brian" downloads version of the file "/folder/testfile.txt" with the index "2" of the space "Personal" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "old content version 1"
+

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1674,6 +1674,38 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" overwrites file "([^"]*)" from space "([^"]*)" to "([^"]*)" inside space "([^"]*)" while (copying|moving)\s? using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $fileSource
+	 * @param string $fromSpaceName
+	 * @param string $fileDestination
+	 * @param string $toSpaceName
+	 * @param string $action
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userOverwritesFileFromAndToSpaceBetweenSpaces(
+		string $user,
+		string $fileSource,
+		string $fromSpaceName,
+		string $fileDestination,
+		string $toSpaceName,
+		string $action
+	):void {
+		$space = $this->getSpaceByName($user, $fromSpaceName);
+		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName);
+		$headers['Overwrite'] = 'T';
+		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($fileSource, "/");
+		if ($action === 'copying') {
+			$this->copyFilesAndFoldersRequest($user, $fullUrl, $headers);
+		} else {
+			$this->moveFilesAndFoldersRequest($user, $fullUrl, $headers);
+		}
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" should not be able to download file "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $user


### PR DESCRIPTION
When we copy or move file with same name we have 2 option:
- keep both- the new file changes its name as `new (1).txt`
- replace- we change the contents of the file and the file has the old version

I added:
- [x] overwrite a file when moving inside a personal space (moving between spaces is not allowed) 
- [x] overwriting the file when working inside the project space
- [x] overwriting a file when moving between personal space and general prison space
- [x] added failed tests to expected failures
- [x] added checking for the existence of a version
- [x] overwritten file keeps old versions

related: https://github.com/owncloud/ocis/issues/4797