### PR TITLE
Add UserID to context during initial login

### DIFF
--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -24,6 +24,8 @@ import (
 	settingsService "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 	merrors "go-micro.dev/v4/errors"
 	"go-micro.dev/v4/selector"
+	"go-micro.dev/v4/metadata"
+	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 )
 
 type cs3backend struct {
@@ -85,6 +87,9 @@ func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, w
 				// https://github.com/owncloud/ocis/v2/issues/1825 for more context.
 				if user.Id.Type == cs3.UserType_USER_TYPE_PRIMARY {
 					c.logger.Info().Str("userid", user.Id.OpaqueId).Msg("user has no role assigned, assigning default user role")
+					// Updating context to have the Account-ID field and suffixing with _init
+					// so that the safety check for setting users' own role doesn't fail
+					ctx = metadata.Set(ctx, middleware.AccountID, user.Id.OpaqueId + "_init")
 					_, err := c.settingsRoleService.AssignRoleToUser(ctx, &settingssvc.AssignRoleToUserRequest{
 						AccountUuid: user.Id.OpaqueId,
 						RoleId:      settingsService.BundleUUIDRoleUser,

--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -17,15 +17,15 @@ import (
 	"github.com/cs3org/reva/v2/pkg/token"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 	settingsService "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 	merrors "go-micro.dev/v4/errors"
-	"go-micro.dev/v4/selector"
 	"go-micro.dev/v4/metadata"
-	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
+	"go-micro.dev/v4/selector"
 )
 
 type cs3backend struct {
@@ -89,7 +89,7 @@ func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, w
 					c.logger.Info().Str("userid", user.Id.OpaqueId).Msg("user has no role assigned, assigning default user role")
 					// Updating context to have the Account-ID field and suffixing with _init
 					// so that the safety check for setting users' own role doesn't fail
-					ctx = metadata.Set(ctx, middleware.AccountID, user.Id.OpaqueId + "_init")
+					ctx = metadata.Set(ctx, middleware.AccountID, user.Id.OpaqueId+"_init")
 					_, err := c.settingsRoleService.AssignRoleToUser(ctx, &settingssvc.AssignRoleToUserRequest{
 						AccountUuid: user.Id.OpaqueId,
 						RoleId:      settingsService.BundleUUIDRoleUser,


### PR DESCRIPTION
## Description
Fixed a bug introduced in https://github.com/owncloud/ocis/commit/87eaf72020a71f9714ec2c1b396023f32a5d8523 due to improper preparation _(missing Account-Id)_ of context before the invocation of `AssignRoleToUser`. 

## Related Issue
- Fixes [#4787 ](https://github.com/owncloud/ocis/issues/4787)

## Motivation and Context
External user backend (e.g. external LDAP) deployments couldn't log in due to the infinite loop / error caused at login.

## How Has This Been Tested?
Tested in the aforementioned external LDAP auth. environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
