### PR TITLE
filter out search path manually

### DIFF
--- a/services/search/pkg/engine/bleve.go
+++ b/services/search/pkg/engine/bleve.go
@@ -161,7 +161,7 @@ func (b *Bleve) Search(_ context.Context, sir *searchService.SearchIndexRequest)
 		// Limit search to this directory in the space
 		if !strings.HasPrefix(
 			getValue[string](hit.Fields, "Path"),
-			escapeQuery(utils.MakeRelativePath(path.Join(sir.Ref.Path, "/"))),
+			utils.MakeRelativePath(path.Join(sir.Ref.Path, "/")),
 		) {
 			continue
 		}


### PR DESCRIPTION
## Description
searching for wildcards in bleve is expensive, not sure if we use it wrong, but for now this pr contains a workaround where we're filtering out non matches manually after the search is done. 

once more time is there we should investigate if a different field analyzer or something else could fix this.