### PR TITLE
[test-only] Api test checking trash after overwriting

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -41,4 +41,4 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 ### [Copy or move on an existing resource doesn't create a new version but deletes instead](https://github.com/owncloud/ocis/issues/4797)
 - [apiSpacesShares/moveSpaces.feature:304](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/moveSpaces.feature#L304)
 - [apiSpacesShares/copySpaces.feature:711](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L711)
-- [apiSpacesShares/copySpaces.feature:748](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L748)
+- [apiSpacesShares/copySpaces.feature:749](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L749)

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -724,6 +724,7 @@ Feature: copy file
     When user "Alice" downloads version of the file "/newfolder/insideSpace.txt" with the index "1" of the space "Project" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "old content version 2"
+    And as "Alice" file "insideSpace.txt" should not exist in the trashbin of the space "Project"
 
 
   Scenario: Copying a file from Personal to Shares Jail with an option "keep both"
@@ -766,3 +767,4 @@ Feature: copy file
     When user "Brian" downloads version of the file "/newfolder/personal.txt" with the index "2" of the space "Shares Jail" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "old content version 1"
+    And as "Brian" file "insideSpace.txt" should not exist in the trashbin of the space "Personal"

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -317,4 +317,5 @@ Feature: move (rename) file
     When user "Brian" downloads version of the file "/folder/testfile.txt" with the index "2" of the space "Personal" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "old content version 1"
+    And as "Brian" file "testfile.txt" should exist in the trashbin of the space "Personal"
 


### PR DESCRIPTION
I noticed that after overwriting through copying, the file goes to the trash. for this reason the file loses its old versions when we overwrite it. we simply delete the file and replace it with a new one

I added checking that:
- after overwriting through copying trash should not have file
- after overwriting through moving trash should have file. @phil-davis Here we can check that the versions are saved. I should restore file from trash. but I have wrong Destination. the file tries to restore to the place where we moved it to, not where it came from