### PR TITLE
fix event publisher in graph options

### DIFF
--- a/services/graph/pkg/service/v0/option.go
+++ b/services/graph/pkg/service/v0/option.go
@@ -23,7 +23,7 @@ type Options struct {
 	IdentityBackend identity.Backend
 	RoleService     settingssvc.RoleService
 	RoleManager     *roles.Manager
-	EventsPublisher events.Publisher
+	EventsPublisher events.Stream
 }
 
 // newOptions initializes the available default options.
@@ -87,7 +87,7 @@ func RoleManager(val *roles.Manager) Option {
 }
 
 // EventsPublisher provides a function to set the EventsPublisher option.
-func EventsPublisher(val events.Publisher) Option {
+func EventsPublisher(val events.Stream) Option {
 	return func(o *Options) {
 		o.EventsPublisher = val
 	}


### PR DESCRIPTION
## Description

Fix wrong event Publisher type in the graph service

## Motivation and Context

Make the linter happy

## How Has This Been Tested?
- manually,
- tested create user and create space events via audit log ✅ 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
