### PR TITLE
[full-ci]fallback to stored roles

### DIFF
--- a/changelog/unreleased/settings-permissions-check.md
+++ b/changelog/unreleased/settings-permissions-check.md
@@ -1,0 +1,5 @@
+Bugfix: Fix permission check in settings service
+
+Added a check of the stored roles as a fallback if no roles are contained in the context.
+
+https://github.com/owncloud/ocis/pull/4890

--- a/services/settings/pkg/service/v0/service.go
+++ b/services/settings/pkg/service/v0/service.go
@@ -556,7 +556,20 @@ func (g Service) hasStaticPermission(ctx context.Context, permissionID string) b
 		// - at least the proxy needs to look up account info
 		// - glauth needs to make bind requests
 		// tracked as OCIS-454
-		return true
+
+		accountID, ok := metadata.Get(ctx, middleware.AccountID)
+		if !ok {
+			return false
+		}
+		assignments, err := g.manager.ListRoleAssignments(accountID)
+		if err != nil {
+			return false
+		}
+
+		roleIDs = make([]string, 0, len(assignments))
+		for _, a := range assignments {
+			roleIDs = append(roleIDs, a.GetRoleId())
+		}
 	}
 	p, err := g.manager.ReadPermissionByID(permissionID, roleIDs)
 	return err == nil && p != nil

--- a/services/settings/pkg/service/v0/service_test.go
+++ b/services/settings/pkg/service/v0/service_test.go
@@ -66,6 +66,19 @@ func TestGetValidatedAccountUUID(t *testing.T) {
 
 func TestEditOwnRoleAssignment(t *testing.T) {
 	manager := &mocks.Manager{}
+	a := []*settingsmsg.UserRoleAssignment{
+		{
+			Id:          "00000000-0000-0000-0000-000000000001",
+			AccountUuid: "61445573-4dbe-4d56-88dc-88ab47aceba7",
+			RoleId:      "aceb15b8-7486-479f-ae32-c91118e07a39",
+		},
+	}
+	editRolePermission := &settingsmsg.Permission{
+		Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+		Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+	}
+	manager.On("ListRoleAssignments", mock.Anything).Return(a, nil)
+	manager.On("ReadPermissionByID", mock.Anything, mock.Anything).Return(editRolePermission, nil)
 	svc := Service{
 		manager: manager,
 	}
@@ -99,6 +112,11 @@ func TestRemoveOwnRoleAssignment(t *testing.T) {
 			RoleId:      "aceb15b8-7486-479f-ae32-c91118e07a39",
 		},
 	}
+	editRolePermission := &settingsmsg.Permission{
+		Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+		Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+	}
+	manager.On("ReadPermissionByID", mock.Anything, mock.Anything).Return(editRolePermission, nil)
 	manager.On("ListRoleAssignments", mock.Anything).Return(a, nil)
 	svc := Service{
 		manager: manager,
@@ -114,6 +132,7 @@ func TestRemoveOwnRoleAssignment(t *testing.T) {
 	manager = &mocks.Manager{}
 	manager.On("ListRoleAssignments", mock.Anything).Return(nil, nil)
 	manager.On("RemoveRoleAssignment", mock.Anything).Return(nil)
+	manager.On("ReadPermissionByID", mock.Anything, mock.Anything).Return(editRolePermission, nil)
 	svc = Service{
 		manager: manager,
 	}


### PR DESCRIPTION
The settings service allowed anyone to assign roles to any user. This change is an improvement but generally the settings service code needs some more work and some other methods need checks as well but I will tackle those in other PRs.
