### PR TITLE
fix: clear loading state if consent or logon received

### DIFF
--- a/services/idp/src/reducers/login.js
+++ b/services/idp/src/reducers/login.js
@@ -32,13 +32,10 @@ function loginReducer(state = {
 
     case RECEIVE_CONSENT:
     case RECEIVE_LOGON:
-      if (!action.success) {
-        return Object.assign({}, state, {
-          errors: action.errors ? action.errors : {},
-          loading: ''
-        });
-      }
-      return state;
+      return Object.assign({}, state, {
+        errors: !action.success && action.errors ? action.errors : {},
+        loading: ''
+      });
 
     case RECEIVE_LOGOFF:
       return Object.assign({}, state, {


### PR DESCRIPTION
## Description
Not having good insights into the idp web ui, @JammingBen and I debugged the Chooseaccount page, which is shown in case of a client login. Seemed only logical to us that the `loading` application state needs to be cleared when a `RECEIVE_CONSENT` or `RECEIVE_LOGON` event is catched. But since we're not familiar with the code base and there is no test coverage whatsoever, we're not sure if we break something else with this change... needs manual testing with various clients.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/4704
- hopefully doesn't create new issues 😕 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
