### PR TITLE
[test-only] add API acceptance tests to create user using the admin privilege

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -115,7 +115,20 @@ default:
       context: *common_ldap_suite_context
       contexts:
         - GraphContext:
+        - SpacesContext:
+        - OccContext:
         - FeatureContext: *common_feature_context_params
+        - CapabilitiesContext:
+        - ChecksumContext:
+        - FavoritesContext:
+        - FilesVersionsContext:
+        - OCSContext:
+        - PublicWebDavContext:
+        - SearchContext:
+        - TrashbinContext:
+        - WebDavPropertiesContext:
+        - TUSContext:
+        - SpacesTUSContext:
 
   extensions:
     Cjm\Behat\StepThroughExtension: ~

--- a/tests/acceptance/features/apiGraph/createUser.feature
+++ b/tests/acceptance/features/apiGraph/createUser.feature
@@ -1,0 +1,54 @@
+@api @skipOnOcV10
+Feature: create user
+  Only user with admin permissions can create new user
+
+  Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
+  See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario Outline: the admin creates a user
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    When the user "Alice" creates a new user using GraphAPI with the following settings:
+      | userName    | <userName>    |
+      | displayName | <displayName> |
+      | email       | <email>       |
+      | password    | <password>    |
+    Then the HTTP status code should be "<code>"
+    And user "<userName>" <shouldOrNot> exist
+    Examples:
+      | userName                     | displayName      | email               | password                     | code | shouldOrNot |
+      | SameDisplayName              | Alice Hansen     | new@example.org     | containsCharacters(*:!;_+-&) | 200  | should     |
+      | withoutPassSameEmail         | without pass     | alice@example.org   |                              | 200  | should     |
+      | name                         | pass with space  | example@example.org | my pass                      | 200  | should     |
+      | nameWithCharacters(*:!;_+-&) | user             | new@example.org     | 123                          | 400  | should not |
+      | withoutEmail                 | without email    |                     | 123                          | 400  | should not |
+      | Alice                        | same userName    | new@example.org     | 123                          | 500  | should     |
+      | name with space              | name with space  | example@example.org | 123                          | 400  | should not |
+
+
+  Scenario: a user cannot be created with empty name
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    When the user "Alice" creates a new user using GraphAPI with the following settings:
+      | userName    |              |
+      | displayName | emptyName    |
+      | email       | @example.org |
+      | password    | 123          |
+    Then the HTTP status code should be "400"
+
+
+  Scenario Outline: a user without admin right cannot create a user
+    Given the administrator has given "Alice" the role "<role>" using the settings api
+    When the user "Alice" creates a new user using GraphAPI with the following settings:
+      | userName    | user         |
+      | displayName | user         |
+      | email       | @example.org |
+      | password    | 123          |
+    Then the HTTP status code should be "401"
+    And user "user" should not exist
+    Examples:
+      | role        |
+      | Space Admin |
+      | User        |

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -420,7 +420,8 @@ class GraphContext implements Context {
 		);
 
 		// add created user to list except for the user with an empty name
-		// because reguest /graph/v1.0/users/emptyUserName get 200 and all users
+		// because request /graph/v1.0/users/emptyUserName exits with 200 
+    // and we cannot check that the user with empty name doesn't exist
 		if (!empty($rows["userName"])) {
 			$this->featureContext->addUserToCreatedUsersList(
 				$rows["userName"],

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * ownCloud
  *
@@ -396,6 +398,41 @@ class GraphContext implements Context {
 	}
 
 	/**
+	 * @When /^the user "([^"]*)" creates a new user using GraphAPI with the following settings:$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception|GuzzleException
+	 */
+	public function theUserCreatesNewUser(string $user, TableNode $table): void {
+		$rows = $table->getRowsHash();
+		$response = GraphHelper::createUser(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$rows["userName"],
+			$rows["password"],
+			$rows["email"],
+			$rows["displayName"]
+		);
+
+		// add created user to list except for the user with an empty name
+		// because reguest /graph/v1.0/users/emptyUserName get 200 and all users
+		if (!empty($rows["userName"])) {
+			$this->featureContext->addUserToCreatedUsersList(
+				$rows["userName"],
+				$rows["password"],
+				$rows["displayName"],
+				$rows["email"]
+			);
+		}
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * adds a user to a group
 	 *
 	 * @Given /^the administrator has added a user "([^"]*)" to the group "([^"]*)" using GraphApi$/
@@ -549,7 +586,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
-	public function userChangesOwnPassword(string $user, string $currentPassword, $newPassword): void {
+	public function userChangesOwnPassword(string $user, string $currentPassword, string $newPassword): void {
 		$response = GraphHelper::changeOwnPassword(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -420,8 +420,8 @@ class GraphContext implements Context {
 		);
 
 		// add created user to list except for the user with an empty name
-		// because request /graph/v1.0/users/emptyUserName exits with 200 
-    // and we cannot check that the user with empty name doesn't exist
+		// because request /graph/v1.0/users/emptyUserName exits with 200
+		// and we cannot check that the user with empty name doesn't exist
 		if (!empty($rows["userName"])) {
 			$this->featureContext->addUserToCreatedUsersList(
 				$rows["userName"],


### PR DESCRIPTION
added: 

- [x] api tests for creating user (Positive and negative scenarios)
- [x] cleaning created users after test