### PR TITLE
Add the missing auth providers to AUTH_BASIC_AUTH_PROVIDER description

### DIFF
--- a/services/auth-basic/pkg/config/config.go
+++ b/services/auth-basic/pkg/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Reva         *shared.Reva  `yaml:"reva"`
 
 	SkipUserGroupsInToken bool          `yaml:"skip_user_groups_in_token" env:"AUTH_BASIC_SKIP_USER_GROUPS_IN_TOKEN" desc:"Disables the encoding of the user's group memberships in the reva access token. This reduces the token size, especially when users are members of a large number of groups."`
-	AuthProvider          string        `yaml:"auth_provider" env:"AUTH_BASIC_AUTH_PROVIDER" desc:"The auth provider which should be used by the service like 'ldap'."`
+	AuthProvider          string        `yaml:"auth_provider" env:"AUTH_BASIC_AUTH_PROVIDER" desc:"The authentication provider that should be used by the service. Possible values are 'ldap', 'json' and 'owncloudsql'. Note that 'ldap' is the preferred setting."`
 	AuthProviders         AuthProviders `yaml:"auth_providers"`
 
 	Supervised bool            `yaml:"-"`


### PR DESCRIPTION
Catched while writing the `auth basic` readme, see https://github.com/owncloud/ocis/pull/4919