### PR TITLE
[tests-only][full-ci] Bump core commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=032f166f0595f293d6690d097d9019d13ba1a427
+CORE_COMMITID=eb49183e7853e304421e4ab7e40af1a28cf5073a
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
Bump core commit id to the latest for the tests

Part of https://github.com/owncloud/QA/issues/768