### PR TITLE
[full-ci] [tests-only] Refactored inter scenarios space

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -16,22 +16,22 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiArchiver/downloadById.feature:135](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadById.feature#L135)
 
 ### [create request for already existing user exits with status code 500 ](https://github.com/owncloud/ocis/issues/3516)
-- [apiGraph/createGroupCaseSensitive.feature:16](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L16)
 - [apiGraph/createGroupCaseSensitive.feature:17](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L17)
 - [apiGraph/createGroupCaseSensitive.feature:18](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L18)
 - [apiGraph/createGroupCaseSensitive.feature:19](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L19)
 - [apiGraph/createGroupCaseSensitive.feature:20](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L20)
 - [apiGraph/createGroupCaseSensitive.feature:21](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L21)
+- [apiGraph/createGroupCaseSensitive.feature:22](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L22)
 
 ### [PROPFIND on accepted shares with identical names containing brackets exit with 404](https://github.com/owncloud/ocis/issues/4421)
 - [apiSpacesShares/changingFilesShare.feature:12](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature#L12)
 
 ### [copy to overwrite (file and folder) from Personal to Shares Jail behaves differently](https://github.com/owncloud/ocis/issues/4393)
-- [apiSpacesShares/copySpaces.feature:488](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L488)
-- [apiSpacesShares/copySpaces.feature:502](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L502)
+- [apiSpacesShares/copySpaces.feature:487](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L487)
+- [apiSpacesShares/copySpaces.feature:501](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L501)
 
 ### [search doesn't find the project space by name](https://github.com/owncloud/ocis/issues/4506)
-- [apiSpaces/search.feature:95](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/search.feature#L95)
+- [apiSpaces/search.feature:96](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/search.feature#L96)
 
 #### [PATCH request for TUS upload with wrong checksum gives incorrect response](https://github.com/owncloud/ocis/issues/1755)
 - [apiSpacesShares/shareUploadTUS.feature:204](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature#L204)
@@ -39,6 +39,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpacesShares/shareUploadTUS.feature:284](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature#L284)
 
 ### [Copy or move on an existing resource doesn't create a new version but deletes instead](https://github.com/owncloud/ocis/issues/4797)
-- [apiSpacesShares/moveSpaces.feature:304](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/moveSpaces.feature#L304)
-- [apiSpacesShares/copySpaces.feature:711](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L711)
-- [apiSpacesShares/copySpaces.feature:749](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L749)
+- [apiSpacesShares/moveSpaces.feature:306](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/moveSpaces.feature#L306)
+- [apiSpacesShares/copySpaces.feature:710](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L710)
+- [apiSpacesShares/copySpaces.feature:748](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L748)

--- a/tests/acceptance/features/apiAccountsHashDifficulty/addUser.feature
+++ b/tests/acceptance/features/apiAccountsHashDifficulty/addUser.feature
@@ -7,6 +7,7 @@ Feature: add user
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
 
+
   Scenario Outline: admin creates a user
     Given using OCS API version "<ocs_api_version>"
     And user "brand-new-user" has been deleted

--- a/tests/acceptance/features/apiAccountsHashDifficulty/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiAccountsHashDifficulty/createShareToSharesFolder.feature
@@ -7,6 +7,7 @@ Feature: sharing
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
 
+
   Scenario Outline: Creating a share of a file with a user
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiAccountsHashDifficulty/uploadFile.feature
+++ b/tests/acceptance/features/apiAccountsHashDifficulty/uploadFile.feature
@@ -7,6 +7,7 @@ Feature: upload file
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
 
+
   Scenario Outline: upload a file and check download content
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiAccountsHashDifficulty/webDavPUTAuthInvalid.feature
+++ b/tests/acceptance/features/apiAccountsHashDifficulty/webDavPUTAuthInvalid.feature
@@ -11,6 +11,7 @@ Feature: attempt to PUT files with invalid password
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
 
+
   Scenario: send PUT requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -20,6 +21,7 @@ Feature: attempt to PUT files with invalid password
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
+
 
   Scenario: send PUT requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "" about user "Alice"

--- a/tests/acceptance/features/apiGraph/changeOwnPassword.feature
+++ b/tests/acceptance/features/apiGraph/changeOwnPassword.feature
@@ -1,6 +1,7 @@
 @api
 Feature: an user changes its own password
 
+
     Scenario Outline: change own password
         Given user "Alice" has been created with default attributes and without skeleton files
         When the user "Alice" changes its own password "<currentPassword>" to "<newPassword>" using the Graph API

--- a/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature
@@ -1,6 +1,7 @@
 @api
 Feature: create groups, group names are case insensitive
 
+
   Scenario Outline: group names are case insensitive, creating groups with different upper and lower case names
     Given using OCS API version "<ocs_api_version>"
     And group "<group_id1>" has been created

--- a/tests/acceptance/features/apiSpaces/search.feature
+++ b/tests/acceptance/features/apiSpaces/search.feature
@@ -17,6 +17,7 @@ Feature: Search
     And user "Alice" has uploaded a file inside space "find data" with content "some content" to "folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt"
     And using new DAV path
 
+
   Scenario: Alice can find data from the project space
     When user "Alice" searches for "fol" using the WebDAV API
     Then the HTTP status code should be "207"

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -300,7 +300,6 @@ Feature: copy file
       | viewer  | should not  | 403         |
 
 
-
   Scenario Outline: User copies a folder from a space project with different role to a space project with different role
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi

--- a/tests/acceptance/features/apiSpacesShares/createFileFolderWhenSharesSpaceExist.feature
+++ b/tests/acceptance/features/apiSpacesShares/createFileFolderWhenSharesSpaceExist.feature
@@ -13,6 +13,7 @@ Feature: create file or folder named similar to Shares folder
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,update"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
 
+
   Scenario Outline: create a folder with a name similar to Shares
     Given using spaces DAV path
     When user "Brian" creates folder "<folder_name>" using the WebDAV API
@@ -24,6 +25,7 @@ Feature: create file or folder named similar to Shares folder
       | Share       |
       | shares      |
       | Share1      |
+
 
   Scenario Outline: create a file with a name similar to Shares
     Given using spaces DAV path
@@ -40,12 +42,14 @@ Feature: create file or folder named similar to Shares folder
       | shares   |
       | Share1   |
 
+
   Scenario: try to create a folder named Shares
     Given using spaces DAV path
     When user "Brian" creates folder "/Shares" using the WebDAV API
     Then the HTTP status code should be "201"
     And for user "Brian" the space "Shares" should contain these entries:
       | FOLDER/ |
+
 
   Scenario: try to create a file named Shares
     Given using spaces DAV path

--- a/tests/acceptance/features/apiSpacesShares/etagPropagation.feature
+++ b/tests/acceptance/features/apiSpacesShares/etagPropagation.feature
@@ -9,6 +9,7 @@ Feature: check etag propagation after different file alterations
     And using spaces DAV path
     And user "Alice" has created folder "/upload"
 
+
   Scenario: copying a file inside a folder as a share receiver changes its etag for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -35,6 +36,7 @@ Feature: check etag propagation after different file alterations
       | user  | path             | space       |
       | Alice | /upload/file.txt | Personal    |
       | Brian | /upload/file.txt | Shares |
+
 
   Scenario: copying a file inside a folder as a sharer changes its etag for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -11,6 +11,7 @@ Feature: move (rename) file
       | Brian    |
     And using spaces DAV path
 
+
   Scenario Outline: Moving a file within same space project with role manager and editor
     Given the administrator has given "Brian" the role "Space Admin" using the settings api
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
@@ -301,7 +302,8 @@ Feature: move (rename) file
     And for user "Brian" the space "Personal" should not contain these entries:
       | /testshare/testsubfolder |
 
-   Scenario: Overwriting a file while moving
+
+  Scenario: Overwriting a file while moving
     Given user "Brian" has created folder "/folder"
     And user "Brian" has uploaded file with content "old content version 1" to "/folder/testfile.txt"
     And user "Brian" has uploaded file with content "old content version 2" to "/folder/testfile.txt"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Interspacing between two scenarios is made consistent as documented https://github.com/owncloud/docs-server/pull/697/files#diff-12a0f404a5bbbda65e50018a487cd725797106d670f4308b921d2081dc4b3516R1129-R1154:~:text=more%20relevant%20discussion.-,%3D%3D%3D%3D%20Inter%2Dscenario%20spacings,%2D%2D%2D%2D,-Commenting%20on%20lines

Suites covered:
- apiAccountsHashDifficulty
- apiArchiver
- apiContract
- apiGraph
- apiSpaces
- apiSpacesShares

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/769

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
