### PR TITLE
[full-ci] Introduce TLS Settings for go-micro based http services

### DIFF
--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	CacheStore     *shared.CacheStore     `yaml:"cache_store"`
 	GRPCClientTLS  *shared.GRPCClientTLS  `yaml:"grpc_client_tls"`
 	GRPCServiceTLS *shared.GRPCServiceTLS `yaml:"grpc_service_tls"`
+	HTTPServiceTLS shared.HTTPServiceTLS  `yaml:"http_service_tls"`
 
 	Mode    Mode // DEPRECATED
 	File    string

--- a/ocis-pkg/config/parser/parse.go
+++ b/ocis-pkg/config/parser/parse.go
@@ -109,6 +109,8 @@ func EnsureCommons(cfg *config.Config) {
 		cfg.Commons.GRPCServiceTLS = cfg.GRPCServiceTLS
 	}
 
+	cfg.Commons.HTTPServiceTLS = cfg.HTTPServiceTLS
+
 	// copy token manager to the commons part if set
 	if cfg.TokenManager != nil {
 		cfg.Commons.TokenManager = cfg.TokenManager

--- a/ocis-pkg/crypto/gencert.go
+++ b/ocis-pkg/crypto/gencert.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	mtls "go-micro.dev/v4/util/tls"
 )
 
 var (
@@ -48,6 +50,16 @@ func GenCert(certName string, keyName string, l log.Logger) error {
 	}
 
 	return nil
+}
+
+// GenTempCertForAddr generates temporary TLS-Certificates in memory.
+func GenTempCertForAddr(addr string) (tls.Certificate, error) {
+	subjects := defaultHosts
+
+	if host, _, err := net.SplitHostPort(addr); err == nil && host != "" {
+		subjects = []string{host}
+	}
+	return mtls.Certificate(subjects...)
 }
 
 // persistCertificate generates a certificate using pk as private key and proceeds to store it into a file named certName.

--- a/ocis-pkg/service/http/option.go
+++ b/ocis-pkg/service/http/option.go
@@ -2,10 +2,10 @@ package http
 
 import (
 	"context"
-	"crypto/tls"
 	"net/http"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/urfave/cli/v2"
 )
 
@@ -15,7 +15,7 @@ type Option func(o *Options)
 // Options defines the available options for this package.
 type Options struct {
 	Logger    log.Logger
-	TLSConfig *tls.Config
+	TLSConfig shared.HTTPServiceTLS
 	Namespace string
 	Name      string
 	Version   string
@@ -88,7 +88,7 @@ func Flags(flags ...cli.Flag) Option {
 }
 
 // TLSConfig provides a function to set the TLSConfig option.
-func TLSConfig(config *tls.Config) Option {
+func TLSConfig(config shared.HTTPServiceTLS) Option {
 	return func(o *Options) {
 		o.TLSConfig = config
 	}

--- a/ocis-pkg/service/http/service.go
+++ b/ocis-pkg/service/http/service.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"crypto/tls"
+	"fmt"
 	"strings"
 	"time"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 
 	mhttps "github.com/go-micro/plugins/v4/server/http"
+	ociscrypto "github.com/owncloud/ocis/v2/ocis-pkg/crypto"
 	"go-micro.dev/v4"
 	"go-micro.dev/v4/server"
 )
@@ -18,11 +21,42 @@ type Service struct {
 }
 
 // NewService initializes a new http service.
-func NewService(opts ...Option) Service {
+func NewService(opts ...Option) (Service, error) {
 	noopBroker := broker.NoOp{}
 	sopts := newOptions(opts...)
+	var mServer server.Server
+	if sopts.TLSConfig.Enabled {
+		var cert tls.Certificate
+		var err error
+		if sopts.TLSConfig.Cert != "" {
+			cert, err = tls.LoadX509KeyPair(sopts.TLSConfig.Cert, sopts.TLSConfig.Key)
+			if err != nil {
+				sopts.Logger.Error().Err(err).
+					Str("cert", sopts.TLSConfig.Cert).
+					Str("key", sopts.TLSConfig.Key).
+					Msg("error loading server certifcate and key")
+				return Service{}, fmt.Errorf("error loading server certificate and key: %w", err)
+			}
+		} else {
+			// Generate a self-signed server certificate on the fly. This requires the clients
+			// to connect with InsecureSkipVerify.
+			sopts.Logger.Warn().Str("address", sopts.Address).
+				Msg("No server certificate configured. Generating a temporary self-signed certificate")
+			cert, err = ociscrypto.GenTempCertForAddr(sopts.Address)
+			if err != nil {
+				return Service{}, fmt.Errorf("error creating temporary self-signed certificate: %w", err)
+			}
+		}
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		}
+		mServer = mhttps.NewServer(server.TLSConfig(tlsConfig))
+	} else {
+		mServer = mhttps.NewServer()
+	}
+
 	wopts := []micro.Option{
-		micro.Server(mhttps.NewServer(server.TLSConfig(sopts.TLSConfig))),
+		micro.Server(mServer),
 		micro.Broker(noopBroker),
 		micro.Address(sopts.Address),
 		micro.Name(strings.Join([]string{sopts.Namespace, sopts.Name}, ".")),
@@ -33,6 +67,9 @@ func NewService(opts ...Option) Service {
 		micro.RegisterTTL(time.Second * 30),
 		micro.RegisterInterval(time.Second * 10),
 	}
+	if sopts.TLSConfig.Enabled {
+		wopts = append(wopts, micro.Metadata(map[string]string{"use_tls": "true"}))
+	}
 
-	return Service{micro.NewService(wopts...)}
+	return Service{micro.NewService(wopts...)}, nil
 }

--- a/ocis-pkg/shared/shared_types.go
+++ b/ocis-pkg/shared/shared_types.go
@@ -46,6 +46,12 @@ type GRPCServiceTLS struct {
 	Key     string `yaml:"key" env:"OCIS_GRPC_TLS_KEY" desc:"Path/File name for the TLS certificate key (in PEM format) for the server certificate to use for the grpc services."`
 }
 
+type HTTPServiceTLS struct {
+	Enabled bool   `yaml:"enabled" env:"OCIS_HTTP_TLS_ENABLED"`
+	Cert    string `yaml:"cert" env:"OCIS_HTTP_TLS_CERTIFICATE" desc:"Path/File name of the TLS server certificate (in PEM format) for the http services."`
+	Key     string `yaml:"key" env:"OCIS_HTTP_TLS_KEY" desc:"Path/File name for the TLS certificate key (in PEM format) for the server certificate to use for the http services."`
+}
+
 type CacheStore struct {
 	Type    string `yaml:"type" env:"OCIS_CACHE_STORE_TYPE" desc:"The type of the cache store. Valid options are \"noop\", \"ocmem\", \"etcd\" and \"memory\""`
 	Address string `yaml:"address" env:"OCIS_CACHE_STORE_ADDRESS" desc:"A comma-separated list of addresses to connect to. Only valid if the above setting is set to \"etcd\""`
@@ -60,6 +66,7 @@ type Commons struct {
 	CacheStore        *CacheStore     `yaml:"cache_store"`
 	GRPCClientTLS     *GRPCClientTLS  `yaml:"grpc_client_tls"`
 	GRPCServiceTLS    *GRPCServiceTLS `yaml:"grpc_service_tls"`
+	HTTPServiceTLS    HTTPServiceTLS  `yaml:"http_service_tls"`
 	OcisURL           string          `yaml:"ocis_url" env:"OCIS_URL" desc:"URL, where oCIS is reachable for users."`
 	TokenManager      *TokenManager   `mask:"struct" yaml:"token_manager"`
 	Reva              *Reva           `yaml:"reva"`

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -121,6 +121,10 @@ func EnsureDefaults(cfg *config.Config) {
 			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
 		}
 	}
+
+	if cfg.Commons != nil {
+		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
 }
 
 func Sanitize(cfg *config.Config) {

--- a/services/graph/pkg/config/http.go
+++ b/services/graph/pkg/config/http.go
@@ -1,8 +1,11 @@
 package config
 
+import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
+
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"GRAPH_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Namespace string `yaml:"-"`
-	Root      string `yaml:"root" env:"GRAPH_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
+	Addr      string                `yaml:"addr" env:"GRAPH_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	Namespace string                `yaml:"-"`
+	Root      string                `yaml:"root" env:"GRAPH_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
 }

--- a/services/graph/pkg/server/http/server.go
+++ b/services/graph/pkg/server/http/server.go
@@ -3,6 +3,7 @@ package http
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 
 	"github.com/cs3org/reva/v2/pkg/events/server"
@@ -24,7 +25,8 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
-	service := http.NewService(
+	service, err := http.NewService(
+		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
 		http.Namespace(options.Config.HTTP.Namespace),
 		http.Name("graph"),
@@ -33,6 +35,12 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Context(options.Context),
 		http.Flags(options.Flags...),
 	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("Error initializing http service")
+		return http.Service{}, fmt.Errorf("could not initialize http service: %w", err)
+	}
 
 	var publisher events.Stream
 

--- a/services/ocs/pkg/config/defaults/defaultconfig.go
+++ b/services/ocs/pkg/config/defaults/defaultconfig.go
@@ -106,6 +106,9 @@ func EnsureDefaults(cfg *config.Config) {
 			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
 		}
 	}
+	if cfg.Commons != nil {
+		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
 }
 
 func Sanitize(cfg *config.Config) {

--- a/services/ocs/pkg/config/http.go
+++ b/services/ocs/pkg/config/http.go
@@ -1,11 +1,14 @@
 package config
 
+import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
+
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"OCS_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Root      string `yaml:"root" env:"OCS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
-	Namespace string `yaml:"-"`
-	CORS      CORS   `yaml:"cors"`
+	Addr      string                `yaml:"addr" env:"OCS_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	Root      string                `yaml:"root" env:"OCS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
+	Namespace string                `yaml:"-"`
+	CORS      CORS                  `yaml:"cors"`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
 }
 
 // CORS defines the available cors configuration.

--- a/services/ocs/pkg/server/http/server.go
+++ b/services/ocs/pkg/server/http/server.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"fmt"
+
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/cors"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
@@ -15,7 +17,8 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
-	service := http.NewService(
+	service, err := http.NewService(
+		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
 		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),
@@ -24,6 +27,12 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Context(options.Context),
 		http.Flags(options.Flags...),
 	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("Error initializing http service")
+		return http.Service{}, fmt.Errorf("could not initialize http service: %w", err)
+	}
 
 	handle := svc.NewService(
 		svc.Logger(options.Logger),

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -72,10 +72,13 @@ func Server(cfg *config.Config) *cli.Command {
 
 			m.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
-			rp := proxy.NewMultiHostReverseProxy(
+			rp, err := proxy.NewMultiHostReverseProxy(
 				proxy.Logger(logger),
 				proxy.Config(cfg),
 			)
+			if err != nil {
+				return fmt.Errorf("Failed to initialize reverse proxy: %w", err)
+			}
 
 			{
 				server, err := proxyHTTP.Server(

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	AutoprovisionAccounts bool            `yaml:"auto_provision_accounts" env:"PROXY_AUTOPROVISION_ACCOUNTS" desc:"Set this to 'true' to automatically provision users that do not yet exist in the users service on-demand upon first sign-in. To use this a write-enabled libregraph user backend needs to be setup an running."`
 	EnableBasicAuth       bool            `yaml:"enable_basic_auth" env:"PROXY_ENABLE_BASIC_AUTH" desc:"Set this to true to enable 'basic authentication' (username/password)."`
 	InsecureBackends      bool            `yaml:"insecure_backends" env:"PROXY_INSECURE_BACKENDS" desc:"Disable TLS certificate validation for all HTTP backend connections."`
+	BackendHTTPSCACert    string          `yaml:"backend_https_cacert" env:"PROXY_HTTPS_CACERT" desc:"The root CA certificate used to validate TLS server certificates of https enabled backend services."`
 	AuthMiddleware        AuthMiddleware  `yaml:"auth_middleware"`
 
 	Context context.Context `yaml:"-" json:"-"`

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -70,47 +70,47 @@ func DefaultPolicies() []config.Policy {
 			Routes: []config.Route{
 				{
 					Endpoint:    "/",
-					Backend:     "http://localhost:9100",
+					Service:     "com.owncloud.web.web",
 					Unprotected: true,
 				},
 				{
 					Endpoint:    "/.well-known/",
-					Backend:     "http://localhost:9130",
+					Service:     "com.owncloud.web.idp",
 					Unprotected: true,
 				},
 				{
 					Endpoint:    "/konnect/",
-					Backend:     "http://localhost:9130",
+					Service:     "com.owncloud.web.idp",
 					Unprotected: true,
 				},
 				{
 					Endpoint:    "/signin/",
-					Backend:     "http://localhost:9130",
+					Service:     "com.owncloud.web.idp",
 					Unprotected: true,
 				},
 				{
 					Endpoint: "/archiver",
-					Backend:  "http://localhost:9140",
+					Service:  "com.owncloud.web.frontend",
 				},
 				{
 					Type:     config.RegexRoute,
 					Endpoint: "/ocs/v[12].php/cloud/user/signing-key", // only `user/signing-key` is left in ocis-ocs
-					Backend:  "http://localhost:9110",
+					Service:  "com.owncloud.web.ocs",
 				},
 				{
 					Type:        config.RegexRoute,
 					Endpoint:    "/ocs/v[12].php/config",
-					Backend:     "http://localhost:9140",
+					Service:     "com.owncloud.web.frontend",
 					Unprotected: true,
 				},
 				{
 					Endpoint: "/ocs/",
-					Backend:  "http://localhost:9140",
+					Service:  "com.owncloud.web.frontend",
 				},
 				{
 					Type:     config.QueryRoute,
 					Endpoint: "/remote.php/?preview=1",
-					Backend:  "http://localhost:9115",
+					Service:  "com.owncloud.web.webdav",
 				},
 				// TODO the actual REPORT goes to /dav/files/{username}, which is user specific ... how would this work in a spaces world?
 				// TODO what paths are returned? the href contains the full path so it should be possible to return urls from other spaces?
@@ -119,27 +119,27 @@ func DefaultPolicies() []config.Policy {
 				{
 					Method:   "REPORT",
 					Endpoint: "/remote.php/dav/",
-					Backend:  "http://localhost:9115", // TODO use registry?
+					Service:  "com.owncloud.web.webdav",
 				},
 				{
 					Method:   "REPORT",
 					Endpoint: "/remote.php/webdav",
-					Backend:  "http://localhost:9115", // TODO use registry?
+					Service:  "com.owncloud.web.webdav",
 				},
 				{
 					Method:   "REPORT",
 					Endpoint: "/dav/spaces",
-					Backend:  "http://localhost:9115",
+					Service:  "com.owncloud.web.webdav",
 				},
 				{
 					Type:     config.QueryRoute,
 					Endpoint: "/dav/?preview=1",
-					Backend:  "http://localhost:9115",
+					Service:  "com.owncloud.web.webdav",
 				},
 				{
 					Type:     config.QueryRoute,
 					Endpoint: "/webdav/?preview=1",
-					Backend:  "http://localhost:9115",
+					Service:  "com.owncloud.web.webdav",
 				},
 				{
 					Endpoint: "/remote.php/",
@@ -173,29 +173,29 @@ func DefaultPolicies() []config.Policy {
 				},
 				{
 					Endpoint:    "/data",
-					Backend:     "http://localhost:9140",
+					Service:     "com.owncloud.web.frontend",
 					Unprotected: true,
 				},
 				{
 					Endpoint:    "/app/list",
-					Backend:     "http://localhost:9140",
+					Service:     "com.owncloud.web.frontend",
 					Unprotected: true,
 				},
 				{
 					Endpoint: "/app/", // /app or /apps? ocdav only handles /apps
-					Backend:  "http://localhost:9140",
+					Service:  "com.owncloud.web.frontend",
 				},
 				{
 					Endpoint: "/graph/",
-					Backend:  "http://localhost:9120",
+					Service:  "com.owncloud.graph.graph",
 				},
 				{
 					Endpoint: "/api/v0/settings",
-					Backend:  "http://localhost:9190",
+					Service:  "com.owncloud.web.settings",
 				},
 				{
 					Endpoint:    "/settings.js",
-					Backend:     "http://localhost:9190",
+					Service:     "com.owncloud.web.settings",
 					Unprotected: true,
 				},
 			},

--- a/services/proxy/pkg/proxy/proxy_integration_test.go
+++ b/services/proxy/pkg/proxy/proxy_integration_test.go
@@ -164,7 +164,7 @@ func TestProxyIntegration(t *testing.T) {
 }
 
 func newTestProxy(cfg *config.Config, fn RoundTripFunc) *MultiHostReverseProxy {
-	rp := NewMultiHostReverseProxy(Config(cfg))
+	rp, _ := NewMultiHostReverseProxy(Config(cfg))
 	rp.Transport = fn
 	return rp
 }

--- a/services/proxy/pkg/router/router.go
+++ b/services/proxy/pkg/router/router.go
@@ -148,7 +148,9 @@ func (rt Router) addHost(policy string, target *url.URL, route config.Route) {
 				}
 				req.URL.Host = node.Address
 				req.URL.Scheme = node.Metadata["protocol"] // TODO check property exists?
-
+				if node.Metadata["use_tls"] == "true" {
+					req.URL.Scheme = "https"
+				}
 			} else {
 				req.URL.Host = target.Host
 				req.URL.Scheme = target.Scheme

--- a/services/proxy/pkg/server/http/server.go
+++ b/services/proxy/pkg/server/http/server.go
@@ -1,11 +1,13 @@
 package http
 
 import (
-	"crypto/tls"
+	"fmt"
 	"os"
 
 	pkgcrypto "github.com/owncloud/ocis/v2/ocis-pkg/crypto"
+	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
 	svc "github.com/owncloud/ocis/v2/ocis-pkg/service/http"
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"go-micro.dev/v4"
 )
@@ -16,9 +18,6 @@ func Server(opts ...Option) (svc.Service, error) {
 	l := options.Logger
 	httpCfg := options.Config.HTTP
 
-	var cer tls.Certificate
-
-	var tlsConfig *tls.Config
 	if options.Config.HTTP.TLS {
 		l.Warn().Msgf("No tls certificate provided, using a generated one")
 		_, certErr := os.Stat(httpCfg.TLSCert)
@@ -31,27 +30,29 @@ func Server(opts ...Option) (svc.Service, error) {
 				os.Exit(1)
 			}
 		}
-
-		cer, certErr = tls.LoadX509KeyPair(httpCfg.TLSCert, httpCfg.TLSKey)
-		if certErr != nil {
-			options.Logger.Fatal().Err(certErr).Msg("Could not setup TLS")
-			os.Exit(1)
-		}
-
-		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cer}}
 	}
 	chain := options.Middlewares.Then(options.Handler)
 
-	service := svc.NewService(
+	service, err := svc.NewService(
 		svc.Name(options.Config.Service.Name),
 		svc.Version(version.GetString()),
-		svc.TLSConfig(tlsConfig),
+		http.TLSConfig(shared.HTTPServiceTLS{
+			Enabled: options.Config.HTTP.TLS,
+			Cert:    options.Config.HTTP.TLSCert,
+			Key:     options.Config.HTTP.TLSKey,
+		}),
 		svc.Logger(options.Logger),
 		svc.Address(options.Config.HTTP.Addr),
 		svc.Namespace(options.Config.HTTP.Namespace),
 		svc.Context(options.Context),
 		svc.Flags(options.Flags...),
 	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("Error initializing http service")
+		return http.Service{}, fmt.Errorf("could not initialize http service: %w", err)
+	}
 
 	if err := micro.RegisterHandler(service.Server(), chain); err != nil {
 		return svc.Service{}, err

--- a/services/settings/pkg/command/server.go
+++ b/services/settings/pkg/command/server.go
@@ -52,13 +52,19 @@ func Server(cfg *config.Config) *cli.Command {
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
 			// prepare an HTTP server and add it to the group run.
-			httpServer := http.Server(
+			httpServer, err := http.Server(
 				http.Name(cfg.Service.Name),
 				http.Logger(logger),
 				http.Context(ctx),
 				http.Config(cfg),
 				http.Metrics(mtrcs),
 			)
+			if err != nil {
+				logger.Error().
+					Err(err).
+					Msg("Error initializing http service")
+				return fmt.Errorf("could not initialize http service: %w", err)
+			}
 			servers.Add(httpServer.Run, func(_ error) {
 				logger.Info().Str("server", "http").Msg("Shutting down server")
 				cancel()

--- a/services/settings/pkg/config/defaults/defaultconfig.go
+++ b/services/settings/pkg/config/defaults/defaultconfig.go
@@ -117,6 +117,10 @@ func EnsureDefaults(cfg *config.Config) {
 			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
 		}
 	}
+
+	if cfg.Commons != nil {
+		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
 }
 
 func Sanitize(cfg *config.Config) {

--- a/services/settings/pkg/config/http.go
+++ b/services/settings/pkg/config/http.go
@@ -1,12 +1,15 @@
 package config
 
+import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
+
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"SETTINGS_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Namespace string `yaml:"-"`
-	Root      string `yaml:"root" env:"SETTINGS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
-	CacheTTL  int    `yaml:"cache_ttl" env:"SETTINGS_CACHE_TTL" desc:"Browser cache control max-age value in seconds for settings Web UI assets."`
-	CORS      CORS   `yaml:"cors"`
+	Addr      string                `yaml:"addr" env:"SETTINGS_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
+	Namespace string                `yaml:"-"`
+	Root      string                `yaml:"root" env:"SETTINGS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
+	CacheTTL  int                   `yaml:"cache_ttl" env:"SETTINGS_CACHE_TTL" desc:"Browser cache control max-age value in seconds for settings Web UI assets."`
+	CORS      CORS                  `yaml:"cors"`
 }
 
 // CORS defines the available cors configuration.

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -88,6 +88,10 @@ func EnsureDefaults(cfg *config.Config) {
 			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
 		}
 	}
+
+	if cfg.Commons != nil {
+		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
 }
 
 func Sanitize(cfg *config.Config) {

--- a/services/thumbnails/pkg/config/http.go
+++ b/services/thumbnails/pkg/config/http.go
@@ -1,8 +1,11 @@
 package config
 
+import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
+
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"THUMBNAILS_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Root      string `yaml:"root" env:"THUMBNAILS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
-	Namespace string `yaml:"-"`
+	Addr      string                `yaml:"addr" env:"THUMBNAILS_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
+	Root      string                `yaml:"root" env:"THUMBNAILS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
+	Namespace string                `yaml:"-"`
 }

--- a/services/thumbnails/pkg/server/http/server.go
+++ b/services/thumbnails/pkg/server/http/server.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"fmt"
+
 	"github.com/go-chi/chi/v5/middleware"
 	ocismiddleware "github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
@@ -14,7 +16,8 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
-	service := http.NewService(
+	service, err := http.NewService(
+		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
 		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),
@@ -22,6 +25,12 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Address(options.Config.HTTP.Addr),
 		http.Context(options.Context),
 	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("Error initializing http service")
+		return http.Service{}, fmt.Errorf("could not initialize http service: %w", err)
+	}
 
 	handle := svc.NewService(
 		svc.Logger(options.Logger),

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -96,6 +96,10 @@ func EnsureDefaults(cfg *config.Config) {
 	} else if cfg.Tracing == nil {
 		cfg.Tracing = &config.Tracing{}
 	}
+
+	if cfg.Commons != nil {
+		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
 }
 
 func Sanitize(cfg *config.Config) {

--- a/services/web/pkg/config/http.go
+++ b/services/web/pkg/config/http.go
@@ -1,9 +1,12 @@
 package config
 
+import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
+
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"WEB_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Namespace string `yaml:"-"`
-	Root      string `yaml:"root" env:"WEB_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
-	CacheTTL  int    `yaml:"cache_ttl" env:"WEB_CACHE_TTL" desc:"Cache policy in seconds for ownCloud Web assets."`
+	Addr      string                `yaml:"addr" env:"WEB_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
+	Namespace string                `yaml:"-"`
+	Root      string                `yaml:"root" env:"WEB_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
+	CacheTTL  int                   `yaml:"cache_ttl" env:"WEB_CACHE_TTL" desc:"Cache policy in seconds for ownCloud Web assets."`
 }

--- a/services/web/pkg/server/http/server.go
+++ b/services/web/pkg/server/http/server.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"fmt"
+
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
@@ -14,7 +16,8 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
-	service := http.NewService(
+	service, err := http.NewService(
+		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
 		http.Namespace(options.Namespace),
 		http.Name("web"),
@@ -23,6 +26,12 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Context(options.Context),
 		http.Flags(options.Flags...),
 	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("Error initializing http service")
+		return http.Service{}, fmt.Errorf("could not initialize http service: %w", err)
+	}
 
 	handle := svc.NewService(
 		svc.Logger(options.Logger),

--- a/services/webdav/pkg/config/defaults/defaultconfig.go
+++ b/services/webdav/pkg/config/defaults/defaultconfig.go
@@ -73,6 +73,10 @@ func EnsureDefaults(cfg *config.Config) {
 			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
 		}
 	}
+
+	if cfg.Commons != nil {
+		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
 }
 
 func Sanitize(cfg *config.Config) {

--- a/services/webdav/pkg/config/http.go
+++ b/services/webdav/pkg/config/http.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
+
 // CORS defines the available cors configuration.
 type CORS struct {
 	AllowedOrigins   []string `yaml:"allow_origins" env:"OCIS_CORS_ALLOW_ORIGINS;WEBDAV_CORS_ALLOW_ORIGINS" desc:"A comma-separated list of allowed CORS origins. See following chapter for more details: *Access-Control-Allow-Origin* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin"`
@@ -10,8 +12,9 @@ type CORS struct {
 
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string `yaml:"addr" env:"WEBDAV_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Namespace string `yaml:"-"`
-	Root      string `yaml:"root" env:"WEBDAV_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
-	CORS      CORS   `yaml:"cors"`
+	Addr      string                `yaml:"addr" env:"WEBDAV_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	Namespace string                `yaml:"-"`
+	Root      string                `yaml:"root" env:"WEBDAV_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service."`
+	CORS      CORS                  `yaml:"cors"`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
 }

--- a/services/webdav/pkg/server/http/server.go
+++ b/services/webdav/pkg/server/http/server.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"fmt"
+
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/cors"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
@@ -14,7 +16,8 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
-	service := http.NewService(
+	service, err := http.NewService(
+		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
 		http.Namespace(options.Config.HTTP.Namespace),
 		http.Name(options.Config.Service.Name),
@@ -23,6 +26,12 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Context(options.Context),
 		http.Flags(options.Flags...),
 	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("Error initializing http service")
+		return http.Service{}, fmt.Errorf("could not initialize http service: %w", err)
+	}
 
 	handle, err := svc.NewService(
 		svc.Logger(options.Logger),


### PR DESCRIPTION
TLS for the services can be configure by setting the "OCIS_HTTP_TLS_ENABLED",
"OCIS_HTTP_TLS_CERTIFICATE" and "OCIS_HTTP_TLS_KEY" environment variables.
Currently the ocis proxy is this only service that directly accesses backend
services. It determines whether to use TLS or not by looking a the new registry
metadata "use_tls". As specific CA Cert for certificate verification
can be set with the "PROXY_HTTPS_CACERT" environment variable.
