### PR TITLE
[DOC] Improve Auth Basic service descriptions in README

### DIFF
--- a/services/auth-basic/README.md
+++ b/services/auth-basic/README.md
@@ -1,6 +1,10 @@
 # Auth-Basic Service
 
+The oCIS Auth Basic service provides basic authentication for those clients who cannot handle OIDC. This is a rare case, is usually not necessary and mainly used for tests or development.
+
 The `auth-basic` service is responsible for validating authentication of incoming requests. To do so, it will use the configured `auth manager`, see the `Auth Managers` section. Only HTTP basic auth requests to ocis will involve the `auth-basic` service.
+
+To enable `auth-basic`, you first must set `PROXY_ENABLE_BASIC_AUTH` to `true`.
 
 ## Auth Managers
 


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/4919 (Readme for Auth-Basic)

Make the case using auth-basic more clear.

