### PR TITLE
[tests-only][full-ci] Add API tests for creating groups (graph API)

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=1eed08f1229136ac5cd7ef3ae2ccd2821a113129
-CORE_BRANCH=master
+CORE_COMMITID=ac8532546217ee719391ce68a25e541ba44544c5
+CORE_BRANCH=test/get-with-groupname
 
 # The test runner source for UI tests
 WEB_COMMITID=37e83b008f5baa762c6544e126e3836d44c11c10

--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=ac8532546217ee719391ce68a25e541ba44544c5
-CORE_BRANCH=test/get-with-groupname
+CORE_COMMITID=93344602834833fa01d90975e3c955c3b90266fe
+CORE_BRANCH=master
 
 # The test runner source for UI tests
 WEB_COMMITID=37e83b008f5baa762c6544e126e3836d44c11c10

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -22,6 +22,8 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/createGroupCaseSensitive.feature:20](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L20)
 - [apiGraph/createGroupCaseSensitive.feature:21](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L21)
 - [apiGraph/createGroupCaseSensitive.feature:22](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L22)
+- [apiGraph/createGroup.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroup.feature#L26)
+- [apiGraph/createUser.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createUser.feature#L28)
 
 ### [PROPFIND on accepted shares with identical names containing brackets exit with 404](https://github.com/owncloud/ocis/issues/4421)
 - [apiSpacesShares/changingFilesShare.feature:12](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature#L12)

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -26,7 +26,7 @@ Feature: create group
   Scenario: admin user tries to create a group that already exists
     Given group "mygroup" has been created
     When user "Alice" tries to create a group "mygroup" using the Graph API
-    And the HTTP status code should be "500"
+    And the HTTP status code should be "400"
     And group "mygroup" should exist
 
 

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -1,0 +1,38 @@
+@api @skipOnOcV10
+Feature: create group
+  Only user with admin permissions can create new groups
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has given "Alice" the role "Admin" using the settings api
+
+
+  Scenario Outline: admin user creates a group
+    When user "Alice" creates a group "<groupname>" using the Graph API
+    And the administrator creates a group "grp1" using the Graph API
+    Then the HTTP status code should be "200"
+    And group "<groupname>" should exist
+    Examples:
+    | groupname       |
+    | simplegroup     |
+    | España§àôœ€     |
+    | नेपाली            |
+    | $x<=>[y*z^2+1]! |
+    | 😅 😆           |
+    | comma,grp1      |
+    | Finance (NP)    |
+    | slash\Middle    |
+
+
+  Scenario: admin user tries to create a group that already exists
+    Given group "mygroup" has been created
+    When user "Alice" tries to create a group "mygroup" using the Graph API
+    And the HTTP status code should be "500"
+    And group "mygroup" should exist
+
+
+  Scenario: normal user tries to create a group
+    Given user "Brian" has been created with default attributes and without skeleton files
+    When user "Brian" tries to create a group "mygroup" using the Graph API
+    And the HTTP status code should be "401"
+    And group "mygroup" should not exist

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -9,7 +9,6 @@ Feature: create group
 
   Scenario Outline: admin user creates a group
     When user "Alice" creates a group "<groupname>" using the Graph API
-    And the administrator creates a group "grp1" using the Graph API
     Then the HTTP status code should be "200"
     And group "<groupname>" should exist
     Examples:

--- a/tests/acceptance/features/apiGraph/createUser.feature
+++ b/tests/acceptance/features/apiGraph/createUser.feature
@@ -25,7 +25,7 @@ Feature: create user
       | name                         | pass with space  | example@example.org | my pass                      | 200  | should     |
       | nameWithCharacters(*:!;_+-&) | user             | new@example.org     | 123                          | 400  | should not |
       | withoutEmail                 | without email    |                     | 123                          | 400  | should not |
-      | Alice                        | same userName    | new@example.org     | 123                          | 500  | should     |
+      | Alice                        | same userName    | new@example.org     | 123                          | 400  | should     |
       | name with space              | name with space  | example@example.org | 123                          | 400  | should not |
 
 

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -504,7 +504,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
-	public function adminCreatesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
+	public function userCreatesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
 		$response = $this->createGroup($group, $user);
 		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastHttpStatusCodesArray((string) $response->getStatusCode());

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -14,6 +14,7 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\GraphHelper;
+use TestHelpers\WebDavHelper;
 use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
@@ -467,22 +468,44 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator creates a group "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $group
+	 * @param ?string $user
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public function createGroup(string $group, ?string $user = null): ResponseInterface {
+		if ($user) {
+			$username = $user;
+			$password = $this->featureContext->getPasswordForUser($user);
+		} else {
+			$username = $this->featureContext->getAdminUsername();
+			$password = $this->featureContext->getAdminPassword();
+		}
+		return GraphHelper::createGroup(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$username,
+			$password,
+			$group,
+		);
+	}
+
+	/**
+	 * @When /^the administrator creates a group "([^"]*)" using the Graph API$/
+	 * @When user :user creates a group :group using the Graph API
+	 * @When user :user tries to create a group :group using the Graph API
+	 *
+	 * @param string $group
+	 * @param ?string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
-	public function adminCreatesGroupUsingTheGraphApi(string $group): void {
-		$response = GraphHelper::createGroup(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getStepLineRef(),
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$group,
-		);
+	public function adminCreatesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
+		$response = $this->createGroup($group, $user);
 		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastHttpStatusCodesArray((string) $response->getStatusCode());
 
@@ -502,13 +525,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function adminHasCreatedGroupUsingTheGraphApi(string $group): array {
-		$result = GraphHelper::createGroup(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getStepLineRef(),
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$group,
-		);
+		$result = $this->createGroup($group);
 		if ($result->getStatusCode() === 200) {
 			return $this->featureContext->getJsonDecodedResponse($result);
 		} else {


### PR DESCRIPTION
## Description
Added API tests for group creation

Added scenarios:
1. `Scenario Outline: admin user creates a group`
```feature
    | simplegroup     |
    | España§àôœ€     |
    | नेपाली            |
    | $x<=>[y*z^2+1]! |
    | 😅 😆           |
    | comma,grp1      |
    | Finance (NP)    |
    | slash\Middle    |
```
2. `Scenario: admin user tries to create a group that already exists`
3. `Scenario: normal user tries to create a group`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/4937

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
