### PR TITLE
add NOTIFICATIONS_WEB_UI_URL

### DIFF
--- a/changelog/unreleased/fix-notifications-web-ui-url.md
+++ b/changelog/unreleased/fix-notifications-web-ui-url.md
@@ -1,0 +1,7 @@
+Bugfix: Fix notifications Web UI url
+
+We've fixed the configuration of the notification service's Web UI url that appears in emails.
+
+Previously it was only configurable via the global "OCIS_URL" and is now also configurable via "NOTIFICATIONS_WEB_UI_URL".
+
+https://github.com/owncloud/ocis/pull/4998

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -91,7 +91,7 @@ func Server(cfg *config.Config) *cli.Command {
 				logger.Fatal().Err(err).Str("addr", cfg.Notifications.RevaGateway).Msg("could not get reva client")
 			}
 
-			svc := service.NewEventsNotifier(evts, channel, logger, gwclient, cfg.Notifications.MachineAuthAPIKey, cfg.Notifications.EmailTemplatePath, cfg.Commons.OcisURL)
+			svc := service.NewEventsNotifier(evts, channel, logger, gwclient, cfg.Notifications.MachineAuthAPIKey, cfg.Notifications.EmailTemplatePath, cfg.WebUiURL)
 			return svc.Run()
 		},
 	}

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -91,7 +91,7 @@ func Server(cfg *config.Config) *cli.Command {
 				logger.Fatal().Err(err).Str("addr", cfg.Notifications.RevaGateway).Msg("could not get reva client")
 			}
 
-			svc := service.NewEventsNotifier(evts, channel, logger, gwclient, cfg.Notifications.MachineAuthAPIKey, cfg.Notifications.EmailTemplatePath, cfg.WebUiURL)
+			svc := service.NewEventsNotifier(evts, channel, logger, gwclient, cfg.Notifications.MachineAuthAPIKey, cfg.Notifications.EmailTemplatePath, cfg.WebUIURL)
 			return svc.Run()
 		},
 	}

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	Log   *Log  `yaml:"log"`
 	Debug Debug `yaml:"debug"`
 
-	WebUiURL string `yaml:"ocis_url" env:"OCIS_URL;NOTIFICATIONS_WEB_UI_URL" desc:"The public facing URL of the oCIS Web UI."`
+	WebUIURL string `yaml:"ocis_url" env:"OCIS_URL;NOTIFICATIONS_WEB_UI_URL" desc:"The public facing URL of the oCIS Web UI, used e.g. when sending notification eMails"`
 
 	Notifications Notifications `yaml:"notifications"`
 

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	Log   *Log  `yaml:"log"`
 	Debug Debug `yaml:"debug"`
 
+	WebUiURL string `yaml:"ocis_url" env:"OCIS_URL;NOTIFICATIONS_WEB_UI_URL" desc:"The public facing URL of the oCIS Web UI."`
+
 	Notifications Notifications `yaml:"notifications"`
 
 	Context context.Context `yaml:"-"`

--- a/services/notifications/pkg/config/defaults/defaultconfig.go
+++ b/services/notifications/pkg/config/defaults/defaultconfig.go
@@ -23,7 +23,7 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "notifications",
 		},
-		WebUiURL: "https://localhost:9200",
+		WebUIURL: "https://localhost:9200",
 		Notifications: config.Notifications{
 			SMTP: config.SMTP{
 				Host:           "",

--- a/services/notifications/pkg/config/defaults/defaultconfig.go
+++ b/services/notifications/pkg/config/defaults/defaultconfig.go
@@ -23,6 +23,7 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "notifications",
 		},
+		WebUiURL: "https://localhost:9200",
 		Notifications: config.Notifications{
 			SMTP: config.SMTP{
 				Host:           "",


### PR DESCRIPTION
## Description
We've fixed the configuration of the notification service's Web UI url that appears in emails.
Previously it was only configurable via the global "OCIS_URL" and is now also configurable via "NOTIFICATIONS_WEB_UI_URL".

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- found in https://github.com/owncloud/ocis-charts/pull/105

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- -

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
