### PR TITLE
Dont reindex twice

### DIFF
--- a/changelog/unreleased/dont-reindex-twice.md
+++ b/changelog/unreleased/dont-reindex-twice.md
@@ -1,0 +1,6 @@
+Bugfix: Do not reindex a space twice at the same time
+
+We fixed a problem where the search service reindexed a space while another
+reindex process was still in progress.
+
+https://github.com/owncloud/ocis/pull/5001


### PR DESCRIPTION
This PR changes the search service so that it doesn't reindex a space while another reindex process is still in progress.