### PR TITLE
[tests-only][full-ci] Add API tests for getting groups and group members (graph API)

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=7ae6fbf467d4d85f09595ff6ad6c9d98bf4c0536
-CORE_BRANCH=test/check-users-groups-graph
+CORE_COMMITID=63c96dc3211ca1ec06c1ff16f171be82c7ce935f
+CORE_BRANCH=master
 
 # The test runner source for UI tests
 WEB_COMMITID=37e83b008f5baa762c6544e126e3836d44c11c10

--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=63c96dc3211ca1ec06c1ff16f171be82c7ce935f
+CORE_COMMITID=ff3c509f6956ed6d1b51dab63176b122c2027cb0
 CORE_BRANCH=master
 
 # The test runner source for UI tests

--- a/.drone.env
+++ b/.drone.env
@@ -1,6 +1,6 @@
 # The test runner source for API tests
-CORE_COMMITID=7296d4f3544a0de278d8d2eee7388b6c44160724
-CORE_BRANCH=master
+CORE_COMMITID=7ae6fbf467d4d85f09595ff6ad6c9d98bf4c0536
+CORE_BRANCH=test/check-users-groups-graph
 
 # The test runner source for UI tests
 WEB_COMMITID=37e83b008f5baa762c6544e126e3836d44c11c10

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -44,3 +44,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpacesShares/moveSpaces.feature:306](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/moveSpaces.feature#L306)
 - [apiSpacesShares/copySpaces.feature:710](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L710)
 - [apiSpacesShares/copySpaces.feature:748](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L748)
+
+### [Creating group with empty name returns status code 200](https://github.com/owncloud/ocis/issues/5050)
+- [apiGraph/createGroup.feature:40](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroup.feature#L40)

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -39,4 +39,4 @@ Feature: create group
 
   Scenario: admin user tries to create a group that is the empty string
     When user "Alice" tries to create a group "" using the Graph API
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "400"

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -35,3 +35,8 @@ Feature: create group
     When user "Brian" tries to create a group "mygroup" using the Graph API
     And the HTTP status code should be "401"
     And group "mygroup" should not exist
+
+
+  Scenario: admin user tries to create a group that is the empty string
+    When user "Alice" tries to create a group "" using the Graph API
+    Then the HTTP status code should be "500"

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -39,4 +39,4 @@ Feature: create group
 
   Scenario: admin user tries to create a group that is the empty string
     When user "Alice" tries to create a group "" using the Graph API
-    Then the HTTP status code should be "500"
+    Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiGraph/getGroup.feature
+++ b/tests/acceptance/features/apiGraph/getGroup.feature
@@ -44,7 +44,7 @@ Feature: get groups and their members
       | Carol |
 
 
-  Scenario: normal user tries to get users in their group
+  Scenario: normal user tries to get users of a group
     Given user "Brian" has been created with default attributes and without skeleton files
     And group "tea-lover" has been created
     When user "Brian" gets all the members of group "tea-lover" using the Graph API

--- a/tests/acceptance/features/apiGraph/getGroup.feature
+++ b/tests/acceptance/features/apiGraph/getGroup.feature
@@ -1,0 +1,51 @@
+@api @skipOnOcV10
+Feature: get groups and their members
+  As an admin
+  I want to be able to get groups
+  So that I can see all the groups and their members
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has given "Alice" the role "Admin" using the settings api
+
+
+  Scenario: admin user lists all the groups
+    Given group "tea-lover" has been created
+    And group "coffee-lover" has been created
+    And group "h2o-lover" has been created
+    When user "Alice" gets all the groups using the Graph API
+    Then the extra groups returned by the API should be
+      | tea-lover    |
+      | coffee-lover |
+      | h2o-lover    |
+
+
+  Scenario: normal user cannot get the groups list
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And group "tea-lover" has been created
+    And group "coffee-lover" has been created
+    And group "h2o-lover" has been created
+    When user "Brian" gets all the groups using the Graph API
+    Then the HTTP status code should be "401"
+
+
+  Scenario: admin user gets users of a group
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+      | Carol    |
+    And group "tea-lover" has been created
+    And user "Brian" has been added to group "tea-lover"
+    And user "Carol" has been added to group "tea-lover"
+    When user "Alice" gets all the members of group "tea-lover" using the Graph API
+    Then the HTTP status code should be "200"
+    And the users returned by the API should be
+      | Brian |
+      | Carol |
+
+
+  Scenario: normal user tries to get users in their group
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And group "tea-lover" has been created
+    When user "Brian" gets all the members of group "tea-lover" using the Graph API
+    Then the HTTP status code should be "401"

--- a/tests/acceptance/features/apiGraph/getGroup.feature
+++ b/tests/acceptance/features/apiGraph/getGroup.feature
@@ -14,7 +14,8 @@ Feature: get groups and their members
     And group "coffee-lover" has been created
     And group "h2o-lover" has been created
     When user "Alice" gets all the groups using the Graph API
-    Then the extra groups returned by the API should be
+    Then the HTTP status code should be "200"
+    And the extra groups returned by the API should be
       | tea-lover    |
       | coffee-lover |
       | h2o-lover    |
@@ -27,6 +28,7 @@ Feature: get groups and their members
     And group "h2o-lover" has been created
     When user "Brian" gets all the groups using the Graph API
     Then the HTTP status code should be "401"
+    And the last response should be an unauthorized response
 
 
   Scenario: admin user gets users of a group
@@ -49,3 +51,4 @@ Feature: get groups and their members
     And group "tea-lover" has been created
     When user "Brian" gets all the members of group "tea-lover" using the Graph API
     Then the HTTP status code should be "401"
+    And the last response should be an unauthorized response

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -318,24 +318,135 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * returns list of all groups
+	 * 
+	 * @param array $groups
+	 * 
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theseExtraGroupsShouldBeInTheResponse(array $groups): void {
+		$respondedGroups = $this->getArrayOfGroupsResponded($this->featureContext->getResponse());
+		foreach ($groups as $group) {
+			$found = false;
+			foreach ($respondedGroups as $respondedGroup) {
+				if ($respondedGroup["displayName"] === $group) {
+					$found = true;
+					break;
+				}
+			}
+			Assert::assertTrue($found, "Group '$group' not found in the list");
+		}
+	}
+
+	/**
+	 * 
+	 * @param array $users
+	 * 
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theseUsersShouldBeInTheResponse(array $users): void {
+		$respondedUsers = $this->getArrayOfUsersResponded($this->featureContext->getResponse());
+		foreach ($users as $user) {
+			$found = false;
+			foreach ($respondedUsers as $respondedUser) {
+				if ($respondedUser["onPremisesSamAccountName"] === $user) {
+					$found = true;
+					break;
+				}
+			}
+			Assert::assertTrue($found, "User '$user' not found in the list");
+		}
+	}
+
+	/**
+	 *
+	 * @param string|null $user
+	 * 
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public function listGroups(?string $user = null): ResponseInterface {
+		if ($user) {
+			$username = $user;
+			$password = $this->featureContext->getPasswordForUser($user);
+		} else {
+			$username = $this->featureContext->getAdminUsername();
+			$password = $this->featureContext->getAdminPassword();
+		}
+		return GraphHelper::getGroups(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$username,
+			$password
+		);
+	}
+
+	/**
+	 * returns list of groups
+	 *
+	 * @param ResponseInterface $response
+	 * 
+	 * @return array
+	 * @throws Exception
+	 */
+	public function getArrayOfGroupsResponded(ResponseInterface $response): array {
+		if ($response->getStatusCode() === 200) {
+			$jsonResponseBody = $this->featureContext->getJsonDecodedResponse($response);
+			return $jsonResponseBody["value"];
+		} else {
+			$this->throwHttpException($response, "Could not retrieve groups list.");
+		}
+	}
+
+	/**
 	 *
 	 * @return array
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
 	public function adminHasRetrievedGroupListUsingTheGraphApi(): array {
-		$response =  GraphHelper::getGroups(
+		return  $this->getArrayOfGroupsResponded($this->listGroups());
+	}
+
+	/**
+	 *
+	 * @param string $group
+	 * @param string|null $user
+	 * 
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public function listGroupMembers(string $group, ?string $user = null): ResponseInterface {
+		if ($user) {
+			$username = $user;
+			$password = $this->featureContext->getPasswordForUser($user);
+		} else {
+			$username = $this->featureContext->getAdminUsername();
+			$password = $this->featureContext->getAdminPassword();
+		}
+		return GraphHelper::getMembersList(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword()
+			$username,
+			$password,
+			$this->featureContext->getAttributeOfCreatedGroup($group, 'id')
 		);
+	}
+
+	/**
+	 * returns list of users of a group
+	 *
+	 * @param ResponseInterface $response
+	 * 
+	 * @return array
+	 * @throws Exception
+	 */
+	public function getArrayOfUsersResponded(ResponseInterface $response): array {
 		if ($response->getStatusCode() === 200) {
-			$jsonResponseBody = $this->featureContext->getJsonDecodedResponse($response);
-			return $jsonResponseBody["value"];
+			return $this->featureContext->getJsonDecodedResponse($response);
 		} else {
-			$this->throwHttpException($response, "Could not retrieve groups list.");
+			$this->throwHttpException($response, "Could not retrieve group members list.");
 		}
 	}
 
@@ -349,18 +460,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function theAdminHasRetrievedMembersListOfGroupUsingTheGraphApi(string $group): array {
-		$response = GraphHelper::getMembersList(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getStepLineRef(),
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$this->featureContext->getAttributeOfCreatedGroup($group, 'id')
-		);
-		if ($response->getStatusCode() === 200) {
-			return $this->featureContext->getJsonDecodedResponse($response);
-		} else {
-			$this->throwHttpException($response, "Could not retrieve members list for group $group.");
-		}
+		return $this->getArrayOfUsersResponded($this->listGroupMembers($group));
 	}
 
 	/**
@@ -615,4 +715,27 @@ class GraphContext implements Context {
 		);
 		$this->featureContext->setResponse($response);
 	}
+
+	/**
+	 * @When user :user gets all the groups using the Graph API
+	 * 
+	 * @param string $user
+	 * 
+	 * @return void
+	 */
+	public function userGetsAllTheGroupsUsingTheGraphApi(string $user): void {
+		$this->featureContext->setResponse($this->listGroups($user));
+	}
+
+	/**
+     * @When user :user gets all the members of group :group using the Graph API
+	 * 
+	 * @param string $user
+	 * @param string $group
+	 * 
+	 * @return void
+     */
+    public function userGetsAllTheMembersOfGroupUsingTheGraphApi($user, $group): void {
+        $this->featureContext->setResponse($this->listGroupMembers($group, $user));
+    }
 }

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -752,7 +752,7 @@ class GraphContext implements Context {
 			'Unauthorized',
 			$errorText,
 			__METHOD__
-			. " Expected text 'Unauthorized' but got '". $errorText . "'"
+			. " Expected text 'Unauthorized' but got '" . $errorText . "'"
 		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -738,4 +738,21 @@ class GraphContext implements Context {
 	public function userGetsAllTheMembersOfGroupUsingTheGraphApi($user, $group): void {
 		$this->featureContext->setResponse($this->listGroupMembers($group, $user));
 	}
+
+	/**
+	 * @Then the last response should be an unauthorized response
+	 *
+	 * @return void
+	 */
+	public function theLastResponseShouldBeUnauthorizedReponse(): void {
+		$response = $this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse());
+		$errorText = $response['error']['message'];
+
+		Assert::assertEquals(
+			'Unauthorized',
+			$errorText,
+			__METHOD__
+			. " Expected text 'Unauthorized' but got '". $errorText . "'"
+		);
+	}
 }

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -318,9 +318,9 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param array $groups
-	 * 
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -339,9 +339,9 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param array $users
-	 * 
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -362,7 +362,7 @@ class GraphContext implements Context {
 	/**
 	 *
 	 * @param string|null $user
-	 * 
+	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
@@ -386,7 +386,7 @@ class GraphContext implements Context {
 	 * returns list of groups
 	 *
 	 * @param ResponseInterface $response
-	 * 
+	 *
 	 * @return array
 	 * @throws Exception
 	 */
@@ -413,7 +413,7 @@ class GraphContext implements Context {
 	 *
 	 * @param string $group
 	 * @param string|null $user
-	 * 
+	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
@@ -438,7 +438,7 @@ class GraphContext implements Context {
 	 * returns list of users of a group
 	 *
 	 * @param ResponseInterface $response
-	 * 
+	 *
 	 * @return array
 	 * @throws Exception
 	 */
@@ -718,9 +718,9 @@ class GraphContext implements Context {
 
 	/**
 	 * @When user :user gets all the groups using the Graph API
-	 * 
+	 *
 	 * @param string $user
-	 * 
+	 *
 	 * @return void
 	 */
 	public function userGetsAllTheGroupsUsingTheGraphApi(string $user): void {
@@ -728,14 +728,14 @@ class GraphContext implements Context {
 	}
 
 	/**
-     * @When user :user gets all the members of group :group using the Graph API
-	 * 
+	 * @When user :user gets all the members of group :group using the Graph API
+	 *
 	 * @param string $user
 	 * @param string $group
-	 * 
+	 *
 	 * @return void
-     */
-    public function userGetsAllTheMembersOfGroupUsingTheGraphApi($user, $group): void {
-        $this->featureContext->setResponse($this->listGroupMembers($group, $user));
-    }
+	 */
+	public function userGetsAllTheMembersOfGroupUsingTheGraphApi($user, $group): void {
+		$this->featureContext->setResponse($this->listGroupMembers($group, $user));
+	}
 }

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -363,22 +363,28 @@ class GraphContext implements Context {
 	 *
 	 * @param string|null $user
 	 *
+	 * @return array
+	 */
+	public function getAdminOrUserCredentials(?string $user): array {
+		$credentials["username"] = $user ? $this->featureContext->getActualUsername($user) : $this->featureContext->getAdminUsername();
+		$credentials["password"] = $user ? $this->featureContext->getPasswordForUser($user) : $this->featureContext->getAdminPassword();
+		return $credentials;
+	}
+	/**
+	 *
+	 * @param string|null $user
+	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
 	public function listGroups(?string $user = null): ResponseInterface {
-		if ($user) {
-			$username = $user;
-			$password = $this->featureContext->getPasswordForUser($user);
-		} else {
-			$username = $this->featureContext->getAdminUsername();
-			$password = $this->featureContext->getAdminPassword();
-		}
+		$credentials = $this->getAdminOrUserCredentials($user);
+
 		return GraphHelper::getGroups(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
-			$username,
-			$password
+			$credentials["username"],
+			$credentials["password"]
 		);
 	}
 
@@ -418,18 +424,13 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function listGroupMembers(string $group, ?string $user = null): ResponseInterface {
-		if ($user) {
-			$username = $user;
-			$password = $this->featureContext->getPasswordForUser($user);
-		} else {
-			$username = $this->featureContext->getAdminUsername();
-			$password = $this->featureContext->getAdminPassword();
-		}
+		$credentials = $this->getAdminOrUserCredentials($user);
+
 		return GraphHelper::getMembersList(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
-			$username,
-			$password,
+			$credentials["username"],
+			$credentials["password"],
 			$this->featureContext->getAttributeOfCreatedGroup($group, 'id')
 		);
 	}
@@ -576,18 +577,13 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function createGroup(string $group, ?string $user = null): ResponseInterface {
-		if ($user) {
-			$username = $user;
-			$password = $this->featureContext->getPasswordForUser($user);
-		} else {
-			$username = $this->featureContext->getAdminUsername();
-			$password = $this->featureContext->getAdminPassword();
-		}
+		$credentials = $this->getAdminOrUserCredentials($user);
+
 		return GraphHelper::createGroup(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
-			$username,
-			$password,
+			$credentials["username"],
+			$credentials["password"],
 			$group,
 		);
 	}
@@ -752,7 +748,7 @@ class GraphContext implements Context {
 			'Unauthorized',
 			$errorText,
 			__METHOD__
-			. " Expected text 'Unauthorized' but got '" . $errorText . "'"
+			. "\nExpected unauthorized message but got '" . $errorText . "'"
 		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -324,7 +324,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theseExtraGroupsShouldBeInTheResponse(array $groups): void {
+	public function theseGroupsShouldBeInTheResponse(array $groups): void {
 		$respondedGroups = $this->getArrayOfGroupsResponded($this->featureContext->getResponse());
 		foreach ($groups as $group) {
 			$found = false;


### PR DESCRIPTION
## Description
Added API tests for listing groups and group members

Added scenarios:
1. `Scenario: admin user lists all the groups`
2. `Scenario: normal user cannot get the groups list`
3. `Scenario: admin user gets users of a group`
4. `Scenario: normal user tries to get users of a group`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/4937

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
