### PR TITLE
[tests-only][full-ci]Bump core commit 2022-11-14

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=93344602834833fa01d90975e3c955c3b90266fe
+CORE_COMMITID=7296d4f3544a0de278d8d2eee7388b6c44160724
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
## Description

Updated the oC/core commit iD for the tests to the latest upto november 14, 2022

### Related Issue
https://github.com/owncloud/QA/issues/772