### PR TITLE
[full-ci] [tests-only] Added api test for sharing disabled space

### DIFF
--- a/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
@@ -87,3 +87,17 @@ Feature: Share spaces
     Then the user "Bob" should have a space called "share space" granted to "Bob" with role "viewer"
     And for user "Bob" the space "share space" should contain these entries:
       | test.txt |
+
+
+  Scenario Outline: A user cannot share a disabled space to another user
+    Given user "Alice" has disabled a space "share space"
+    When user "Alice" shares a space "share space" to user "Brian" with role "<role>"
+    Then the HTTP status code should be "404"
+    And the OCS status code should be "404"
+    And the OCS status message should be "Wrong path, file/folder doesn't exist"
+    And the user "Brian" should not have a space called "share space"
+    Examples:
+      | role    |
+      | manager |
+      | editor  |
+      | viewer  |

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -91,3 +91,13 @@ Feature: Share spaces via link
         Then the HTTP status code should be "200"
         And the OCS status code should be "200"
         And for user "Alice" the space "share space" should contain the last created public link
+
+
+    Scenario: A user cannot share a disabled space to public via link
+        Given user "Alice" has disabled a space "share space"
+        When user "Alice" creates a public link share of the space "share space" with settings:
+            | permissions | 1 |
+        Then the HTTP status code should be "404"
+        And the OCS status code should be "404"
+        And the OCS status message should be "Wrong path, file/folder doesn't exist"
+        And for user "Alice" the space "share space" should not contain the last created public link


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added API tests for sharing disabled space to another user and via public link.

Added scenarios:

1. `Scenario Outline: A user cannot share a disabled space to another user`
2. `Scenario: A user cannot share a disabled space to public via link`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/4937 (share disabled space is not possible (ink public link))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
