### PR TITLE
Make permission and role ids unique

### DIFF
--- a/services/settings/pkg/service/v0/service.go
+++ b/services/settings/pkg/service/v0/service.go
@@ -563,9 +563,14 @@ func (g Service) hasStaticPermission(ctx context.Context, permissionID string) b
 			return false
 		}
 
-		roleIDs = make([]string, 0, len(assignments))
+		// deduplicate roleids
+		uniqueRoleIds := make(map[string]struct{})
 		for _, a := range assignments {
-			roleIDs = append(roleIDs, a.GetRoleId())
+			uniqueRoleIds[a.GetRoleId()] = struct{}{}
+		}
+		roleIDs = make([]string, 0, len(uniqueRoleIds))
+		for a := range uniqueRoleIds {
+			roleIDs = append(roleIDs, a)
 		}
 	}
 	p, err := g.manager.ReadPermissionByID(permissionID, roleIDs)

--- a/services/settings/pkg/service/v0/settings.go
+++ b/services/settings/pkg/service/v0/settings.go
@@ -24,7 +24,7 @@ const (
 	RoleManagementPermissionName string = "role-management"
 
 	// SettingsManagementPermissionID is the hardcoded setting UUID for the settings management permission
-	SettingsManagementPermissionID string = "79e13b30-3e22-11eb-bc51-0b9f0bad9a58"
+	SettingsManagementPermissionID string = "3d58f441-4a05-42f8-9411-ef5874528ae1"
 	// SettingsManagementPermissionName is the hardcoded setting name for the settings management permission
 	SettingsManagementPermissionName string = "settings-management"
 

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -24,7 +24,7 @@ const (
 	RoleManagementPermissionName string = "role-management"
 
 	// SettingsManagementPermissionID is the hardcoded setting UUID for the settings management permission
-	SettingsManagementPermissionID string = "79e13b30-3e22-11eb-bc51-0b9f0bad9a58"
+	SettingsManagementPermissionID string = "3d58f441-4a05-42f8-9411-ef5874528ae1"
 	// SettingsManagementPermissionName is the hardcoded setting name for the settings management permission
 	SettingsManagementPermissionName string = "settings-management"
 


### PR DESCRIPTION
We've fixed the duplicate assignment of `79e13b30-3e22-11eb-bc51-0b9f0bad9a58` for both: `create-space` and `settings-management` permissions. We also deduplicate role ids after listing them internally to make permission retrieval more efficient.

fixes https://github.com/owncloud/ocis/issues/5033