### PR TITLE
Allow initial self-assignemnt of UserRole

### DIFF
--- a/changelog/unreleased/initial-role-assignment.md
+++ b/changelog/unreleased/initial-role-assignment.md
@@ -1,0 +1,5 @@
+Bugfix: Initial role assingment with external IDM
+
+We've the initial user role assignment when using an external LDAP server.
+
+https://github.com/owncloud/ocis/issues/5045

--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -87,9 +87,7 @@ func (c *cs3backend) GetUserByClaims(ctx context.Context, claim, value string, w
 				// https://github.com/owncloud/ocis/v2/issues/1825 for more context.
 				if user.Id.Type == cs3.UserType_USER_TYPE_PRIMARY {
 					c.logger.Info().Str("userid", user.Id.OpaqueId).Msg("user has no role assigned, assigning default user role")
-					// Updating context to have the Account-ID field and suffixing with _init
-					// so that the safety check for setting users' own role doesn't fail
-					ctx = metadata.Set(ctx, middleware.AccountID, user.Id.OpaqueId+"_init")
+					ctx = metadata.Set(ctx, middleware.AccountID, user.Id.OpaqueId)
 					_, err := c.settingsRoleService.AssignRoleToUser(ctx, &settingssvc.AssignRoleToUserRequest{
 						AccountUuid: user.Id.OpaqueId,
 						RoleId:      settingsService.BundleUUIDRoleUser,


### PR DESCRIPTION
When using an external user management we need to allow users to self-assign the default role. This adds an explicit check for that to the settings service. This also means we no longer need to fiddle with the account id in the proxy upon first login.
    
Fixes: #5045