### PR TITLE
[tests-only][full-ci]Bump core latest commit-id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=ff3c509f6956ed6d1b51dab63176b122c2027cb0
+CORE_COMMITID=77907465a69d0e71566df580cc605e62f390b132
 CORE_BRANCH=master
 
 # The test runner source for UI tests


### PR DESCRIPTION
### Description
Bump latest core commit id on `oCis`

### Related Issue
https://github.com/owncloud/QA/issues/772