### PR TITLE
lower default access / id / refresh token lifespans

### DIFF
--- a/changelog/unreleased/change-lower-idp-token-lifespans.md
+++ b/changelog/unreleased/change-lower-idp-token-lifespans.md
@@ -1,0 +1,5 @@
+Fix: Lower IDP token lifespans
+
+We've lowered the IDP token lifespans to more reasonable durations.
+
+https://github.com/owncloud/ocis/pull/5077

--- a/changelog/unreleased/change-lower-idp-token-lifespans.md
+++ b/changelog/unreleased/change-lower-idp-token-lifespans.md
@@ -1,4 +1,4 @@
-Fix: Lower IDP token lifespans
+Bugfix: Lower IDP token lifespans
 
 We've lowered the IDP token lifespans to more reasonable durations.
 

--- a/services/idp/pkg/config/config.go
+++ b/services/idp/pkg/config/config.go
@@ -111,8 +111,8 @@ type Settings struct {
 	CookieBackendURI string
 	CookieNames      []string
 
-	AccessTokenDurationSeconds        uint64 `yaml:"access_token_duration_seconds" env:"IDP_ACCESS_TOKEN_EXPIRATION" desc:"Expiration time in seconds for IDP access token."`
-	IDTokenDurationSeconds            uint64 `yaml:"id_token_duration_seconds" env:"IDP_ID_TOKEN_EXPIRATION" desc:"Expiration time in seconds for IDP ID tokens."`
-	RefreshTokenDurationSeconds       uint64 `yaml:"refresh_token_duration_seconds" env:"IDP_REFRESH_TOKEN_EXPIRATION" desc:"Expiration time in seconds for refresh tokens."`
-	DyamicClientSecretDurationSeconds uint64 `yaml:"dynamic_client_secret_duration_seconds" env:"IDP_DYNAMIC_CLIENT_SECRET_DURATION" desc:"Expiration time in seconds for dynamic clients."`
+	AccessTokenDurationSeconds        uint64 `yaml:"access_token_duration_seconds" env:"IDP_ACCESS_TOKEN_EXPIRATION" desc:"'Access token lifespan in seconds (time before an access token is expired).'"`
+	IDTokenDurationSeconds            uint64 `yaml:"id_token_duration_seconds" env:"IDP_ID_TOKEN_EXPIRATION" desc:"ID token lifespan in seconds (time before an ID token is expired)."`
+	RefreshTokenDurationSeconds       uint64 `yaml:"refresh_token_duration_seconds" env:"IDP_REFRESH_TOKEN_EXPIRATION" desc:"Refresh token lifespan in seconds (time before an refresh token is expired). This also limits the duration of an idle offline session."`
+	DyamicClientSecretDurationSeconds uint64 `yaml:"dynamic_client_secret_duration_seconds" env:"IDP_DYNAMIC_CLIENT_SECRET_DURATION" desc:"Lifespan in seconds of a dynamically registered OIDC client."`
 }

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -61,9 +61,9 @@ func DefaultConfig() *config.Config {
 			ValidationKeysPath:                "",
 			CookieBackendURI:                  "",
 			CookieNames:                       nil,
-			AccessTokenDurationSeconds:        60 * 60 * 24,           // 1 day
-			IDTokenDurationSeconds:            60 * 60,                // 1 hour
-			RefreshTokenDurationSeconds:       60 * 60 * 24 * 365 * 3, // 1 year
+			AccessTokenDurationSeconds:        60 * 5,            // 5 minutes
+			IDTokenDurationSeconds:            60 * 5,            // 5 minutes
+			RefreshTokenDurationSeconds:       60 * 60 * 24 * 30, // 30 days
 			DyamicClientSecretDurationSeconds: 0,
 		},
 		Clients: []config.Client{


### PR DESCRIPTION
## Description
We've lowered the IDP token lifespans to more reasonable durations.

## Related Issue
- -

## Motivation and Context
-

## How Has This Been Tested?
- -

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
