### PR TITLE
[tests-only][full-ci]Added test to get user information with GraphAPI

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -184,6 +184,31 @@ class GraphHelper {
 	/**
 	 * @param string $baseUrl
 	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $userPassword
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function getUserInformation(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $userPassword
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, 'me/?%24expand=memberOf');
+		return HttpRequestHelper::get(
+			$url,
+			$xRequestId,
+			$user,
+			$userPassword,
+			self::getRequestHeaders()
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
 	 * @param string $adminUser
 	 * @param string $adminPassword
 	 * @param string $userName

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -27,6 +27,16 @@ class GraphHelper {
 	}
 
 	/**
+	 * @param string $id
+	 *
+	 * @return int (1 = true | 0 = false)
+	 */
+	public static function isUUIDv4(string $id): int {
+		$regex = '/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
+		return preg_match($regex, $id);
+	}
+
+	/**
 	 * @param string $baseUrl
 	 * @param string $path
 	 *
@@ -190,7 +200,7 @@ class GraphHelper {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public static function getUserInformation(
+	public static function getOwnInformationAndGroupMemberships(
 		string $baseUrl,
 		string $xRequestId,
 		string $user,

--- a/tests/acceptance/features/apiGraph/getUser.feature
+++ b/tests/acceptance/features/apiGraph/getUser.feature
@@ -1,0 +1,11 @@
+@api
+Feature: get user information
+  As an admin, subadmin or as myself
+  I want to be able to retrieve user information
+  So that I can see the information
+
+
+  Scenario: admin gets an existing user
+    Given these users have been created with default attributes and without skeleton files:
+      | username       | displayname    |
+      | brand-new-user | Brand New User |

--- a/tests/acceptance/features/apiGraph/getUser.feature
+++ b/tests/acceptance/features/apiGraph/getUser.feature
@@ -1,11 +1,36 @@
 @api
 Feature: get user information
-  As an admin, subadmin or as myself
-  I want to be able to retrieve user information
-  So that I can see the information
+  As user
+  I want to be able to retrieve my own information
+  So that I can see my information
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
 
 
-  Scenario: admin gets an existing user
-    Given these users have been created with default attributes and without skeleton files:
-      | username       | displayname    |
-      | brand-new-user | Brand New User |
+  Scenario: user gets his/her own information with no group involvement
+    When the user "Alice" retrives her information using the Graph API
+    Then the HTTP status code should be "200"
+    And the api response for user "Alice" should contains the following information:
+      | displayName              | Alice Hansen      |
+      | id                       | %user_id%         |
+      | mail                     | alice@example.org |
+      | onPremisesSamAccountName | Alice             |
+      | memberOf                 |                   |
+
+
+  Scenario: user gets his/her own information with group involvement
+    Given group "tea-lover" has been created
+    And group "coffee-lover" has been created
+    And user "Alice" has been added to group "tea-lover"
+    And user "Alice" has been added to group "coffee-lover"
+    When the user "Alice" retrives her information using the Graph API
+    And the api response for user "Alice" should contains the following information:
+      | displayName              | Alice Hansen            |
+      | id                       | %user_id%               |
+      | onPremisesSamAccountName | Alice                   |
+      | mail                     | alice@example.org       |
+      | memberOf                 | tea-lover, coffee-lover |
+
+
+

--- a/tests/acceptance/features/apiGraph/getUserOwnInformation.feature
+++ b/tests/acceptance/features/apiGraph/getUserOwnInformation.feature
@@ -1,5 +1,5 @@
-@api
-Feature: get user own information
+@api @skipOnOcV10
+Feature: get user's own information
   As user
   I want to be able to retrieve my own information
   So that I can see my information
@@ -9,14 +9,11 @@ Feature: get user own information
 
 
   Scenario: user gets his/her own information with no group involvement
-    When the user "Alice" retrives her information using the Graph API
+    When the user "Alice" retrieves her information using the Graph API
     Then the HTTP status code should be "200"
-    And the api response should contains the following information:
-      | displayName              | Alice Hansen      |
-      | id                       | %UUIDv4%          |
-      | mail                     | alice@example.org |
-      | onPremisesSamAccountName | Alice             |
-      | memberOf                 |                   |
+    And the user retrieve API response should contain the following information:
+      | displayName  | id        | mail              | onPremisesSamAccountName |
+      | Alice Hansen | %uuid_v4% | alice@example.org | Alice                    |
 
 
   Scenario: user gets his/her own information with group involvement
@@ -24,13 +21,8 @@ Feature: get user own information
     And group "coffee-lover" has been created
     And user "Alice" has been added to group "tea-lover"
     And user "Alice" has been added to group "coffee-lover"
-    When the user "Alice" retrives her information using the Graph API
-    And the api response should contains the following information:
-      | displayName              | Alice Hansen            |
-      | id                       | %UUIDv4%                |
-      | onPremisesSamAccountName | Alice                   |
-      | mail                     | alice@example.org       |
-      | memberOf                 | tea-lover, coffee-lover |
-
-
-
+    When the user "Alice" retrieves her information using the Graph API
+    Then the HTTP status code should be "200"
+    And the user retrieve API response should contain the following information:
+      | displayName  | id        | mail              | onPremisesSamAccountName | memberOf                |
+      | Alice Hansen | %uuid_v4% | alice@example.org | Alice                    | tea-lover, coffee-lover |

--- a/tests/acceptance/features/apiGraph/getUserOwnInformation.feature
+++ b/tests/acceptance/features/apiGraph/getUserOwnInformation.feature
@@ -1,5 +1,5 @@
 @api
-Feature: get user information
+Feature: get user own information
   As user
   I want to be able to retrieve my own information
   So that I can see my information
@@ -11,9 +11,9 @@ Feature: get user information
   Scenario: user gets his/her own information with no group involvement
     When the user "Alice" retrives her information using the Graph API
     Then the HTTP status code should be "200"
-    And the api response for user "Alice" should contains the following information:
+    And the api response should contains the following information:
       | displayName              | Alice Hansen      |
-      | id                       | %user_id%         |
+      | id                       | %UUIDv4%          |
       | mail                     | alice@example.org |
       | onPremisesSamAccountName | Alice             |
       | memberOf                 |                   |
@@ -25,9 +25,9 @@ Feature: get user information
     And user "Alice" has been added to group "tea-lover"
     And user "Alice" has been added to group "coffee-lover"
     When the user "Alice" retrives her information using the Graph API
-    And the api response for user "Alice" should contains the following information:
+    And the api response should contains the following information:
       | displayName              | Alice Hansen            |
-      | id                       | %user_id%               |
+      | id                       | %UUIDv4%                |
       | onPremisesSamAccountName | Alice                   |
       | mail                     | alice@example.org       |
       | memberOf                 | tea-lover, coffee-lover |

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -649,7 +649,7 @@ class GraphContext implements Context {
 	public function theAdministratorTriesToAddUserToGroupUsingTheGraphAPI(string $user, string $group): void {
 		$this->featureContext->setResponse($this->addUserToGroup($group, $user));
 	}
- 
+
 	/**
 	 * @When user :user tries to add himself/herself to group :group using the Graph API
 	 *
@@ -874,7 +874,7 @@ class GraphContext implements Context {
 		$response = $this->userDeletesGroupWithGroupId($groupId, $user);
 		$this->featureContext->setResponse($response);
 	}
-  
+
 	/**
 	 * @Then the following users should be listed in the following groups
 	 *
@@ -997,5 +997,83 @@ class GraphContext implements Context {
 			$userId = WebDavHelper::generateUUIDv4();
 		}
 		$this->featureContext->setResponse($this->removeUserFromGroup($groupId, $userId, $byUser));
+	}
+
+	/**
+	 * @param string $user
+	 *
+	 * @return ResponseInterface
+	 * @throws JsonException
+	 * @throws GuzzleException
+	 */
+	public function retrieveUserInformationUsingGraphApi(
+		string $user
+	):ResponseInterface {
+		$credentials = $this->getAdminOrUserCredentials($user);
+		return GraphHelper::getUserInformation(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$credentials["username"],
+			$credentials["password"],
+		);
+	}
+
+	/**
+	 * @When /^the user "([^"]*)" retrives (:?her|his) information using the Graph API$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws JsonException
+	 */
+	public function userRetrievesHisorHerInformationOfUserUsingGraphApi(
+		string $user
+	):void {
+		$response = $this->retrieveUserInformationUsingGraphApi($user);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @Then /^the api response for user "([^"]*)" should contains the following information:$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theApiResponseForUserShouldContainsTheFollowingInformation(string $user, TableNode $table): void {
+		$rows = $table->getRowsHash();
+		$apiResponse = \json_decode((string)$this->featureContext->getResponse()->getBody(), true, 512, JSON_THROW_ON_ERROR);
+		// assertion of the user is member of groups
+		if ($rows['memberOf']) {
+			// collect memberOf from response
+			$memberOfFromApiReponse = [];
+			$memberOf = preg_split('/\s*,\s*/', trim($rows['memberOf']));
+			foreach ($apiResponse['memberOf'] as $member) {
+				$memberOfFromApiReponse[] = $member['displayName'];
+			}
+			Assert::assertEqualsCanonicalizing($memberOf, $memberOfFromApiReponse);
+		}
+		// get user_id for the given user
+		$rows['id'] = $this->featureContext->substituteInLineCodes(
+			$rows['id'],
+			$this->featureContext->getCurrentUser(),
+			[],
+			[
+				[
+					"code" => "%user_id%",
+					"function" =>
+						[$this->spacesContext, "getUserIdByUserName"],
+					"parameter" => [$user]
+				],
+			]
+		);
+
+		// assertion for remaining key other than 'memberOf'
+		foreach (array_keys($rows) as $keyName) {
+			if ($keyName !== 'memberOf') {
+				Assert::assertEquals($rows[$keyName], $apiResponse[$keyName]);
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Description
This PR adds API test scenarios to get user own information with `Graph API` 
Added scenarios:
1. `Scenario: user gets his/her own information with no group involvement`
2. `Scenario: user gets his/her own information with group involvement`

### Related Issue
https://github.com/owncloud/ocis/issues/4937