### PR TITLE
[full-ci] run the wopivalidator in CI

### DIFF
--- a/tests/config/drone/hosting-discovery.xml
+++ b/tests/config/drone/hosting-discovery.xml
@@ -1,0 +1,8 @@
+<wopi-discovery>
+<net-zone name="external-http">
+<app favIconUrl="https://fakeoffice.owncloud.test/favicon.ico" name="wopitest">
+<action default="true" ext="wopitest" name="view" urlsrc="https://fakeoffice.owncloud.test/not/relevant?"/>
+<action default="true" ext="wopitest" name="edit" urlsrc="https://fakeoffice.owncloud.test/not/relevant?"/>
+</app>
+</net-zone>
+</wopi-discovery>

--- a/tests/config/drone/serve-hosting-discovery.sh
+++ b/tests/config/drone/serve-hosting-discovery.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+while true; do
+  echo -e "HTTP/1.1 200 OK\n\n$(cat /drone/src/tests/config/drone/hosting-discovery.xml)" | nc -l -k -p 8080
+done

--- a/tests/config/drone/wopiserver.conf
+++ b/tests/config/drone/wopiserver.conf
@@ -1,0 +1,131 @@
+#
+# This config is based on https://github.com/cs3org/wopiserver/blob/master/wopiserver.conf
+#
+# wopiserver.conf
+#
+# Default configuration file for the WOPI server for oCIS
+#
+##############################################################
+
+[general]
+# Storage access layer to be loaded in order to operate this WOPI server
+# only "cs3" is supported with oCIS
+storagetype = cs3
+
+# Port where to listen for WOPI requests
+port = 8880
+
+# Logging level. Debug enables the Flask debug mode as well.
+# Valid values are: Debug, Info, Warning, Error.
+loglevel = Debug
+loghandler = stream
+logdest = stdout
+
+# URL of your WOPI server or your HA proxy in front of it
+wopiurl = http://wopiserver
+
+# URL for direct download of files. The complete URL that is sent
+# to clients will include the access_token argument
+downloadurl = http://wopiserver/wopi/cbox/download
+
+# The internal server engine to use (defaults to flask).
+# Set to waitress for production installations.
+internalserver = waitress
+
+# List of file extensions deemed incompatible with LibreOffice:
+# interoperable locking will be disabled for such files
+nonofficetypes = .md .zmd .txt .epd
+
+# List of file extensions to be supported by Collabora (deprecated)
+codeofficetypes = .odt .ott .ods .ots .odp .otp .odg .otg .doc .dot .xls .xlt .xlm .ppt .pot .pps .vsd .dxf .wmf .cdr .pages .number .key
+
+brandingname=CS3org WOPI server
+brandingurl=https://github.com/cs3org/wopiserver
+
+# WOPI access token expiration time [seconds]
+tokenvalidity = 86400
+
+# WOPI lock expiration time [seconds]
+wopilockexpiration = 3600
+
+# WOPI lock strict check: if True, WOPI locks will be compared according to specs,
+# that is their representation must match. False (default) allows for a more relaxed
+# comparison, which compensates incorrect lock requests from Microsoft Office Online
+# on-premise setups.
+wopilockstrictcheck = False
+
+# Enable support of rename operations from WOPI apps. This is currently
+# disabled by default as it has been observed that both MS Office and Collabora
+# Online do not play well with this feature.
+# Not supported with oCIS, must always be set to "False"
+enablerename = False
+
+# Detection of external Microsoft Office or LibreOffice locks. By default, lock files
+# compatible with Office for Desktop applications are detected, assuming that the
+# underlying storage can be mounted as a remote filesystem: in this case, WOPI GetLock
+# and SetLock operations return such locks and prevent online apps from entering edit mode.
+# This feature can be disabled in order to operate a pure WOPI server for online apps.
+# Not supported with oCIS, must always be set to "False"
+detectexternallocks = False
+
+# Location of the webconflict files. By default, such files are stored in the same path
+# as the original file. If that fails (e.g. because of missing permissions),
+# an attempt is made to store such files in this path if specified, otherwise
+# the system falls back to the recovery space (cf. io|recoverypath).
+# The keywords <user_initial> and <username> are replaced with the actual username's
+# initial letter and the actual username, respectively, so you can use e.g.
+# /your_storage/home/user_initial/username
+#conflictpath = /
+
+# ownCloud's WOPI proxy configuration. Disabled by default.
+#wopiproxy = https://external-wopi-proxy.com
+#wopiproxysecretfile = /path/to/your/shared-key-file
+#proxiedappname = Name of your proxied app
+
+[security]
+# Location of the secret files. Requires a restart of the
+# WOPI server when either the files or their content change.
+wopisecretfile = /etc/wopi/wopisecret
+# iop secret is not used for cs3 storage type
+#iopsecretfile = /etc/wopi/iopsecret
+
+# Use https as opposed to http (requires certificate)
+usehttps = no
+
+# Certificate and key for https. Requires a restart
+# to apply a change.
+wopicert = /etc/grid-security/host.crt
+wopikey = /etc/grid-security/host.key
+
+[bridge]
+# SSL certificate check for the connected apps
+sslverify = True
+
+# Minimal time interval between two consecutive save operations [seconds]
+#saveinterval = 200
+
+# Minimal time interval before a closed file is WOPI-unlocked [seconds]
+#unlockinterval = 90
+
+# CodiMD: disable creating zipped bundles when files contain pictures
+#disablezip = False
+
+[io]
+# Size used for buffered reads [bytes]
+chunksize = 4194304
+
+# Path to a recovery space in case of I/O errors when reaching to the remote storage.
+# This is expected to be a local path, and it is provided in order to ease user support.
+# Defaults to the indicated spool folder.
+recoverypath = /var/spool/wopirecovery
+
+[cs3]
+# Host and port of the Reva(-like) CS3-compliant GRPC gateway endpoint
+revagateway = ocis-server:9142
+
+# Reva/gRPC authentication token expiration time [seconds]
+# The default value matches Reva's default
+authtokenvalidity = 3600
+
+# SSL certificate check for Reva
+sslverify = False


### PR DESCRIPTION
## Description
brings the wopi-validator for the personal space to CI

similar to the oC10 WOPI ci: https://github.com/owncloud/wopi/blob/272da26580b9e936d0dc7419cd2140d396f69d02/.drone.star#L2333-L2341

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Follow up ticket: https://github.com/owncloud/ocis/issues/5111

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
