### PR TITLE
Bugfix: Make storage users mount ids unique by default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,6 +54,9 @@
                 // idp ldap
                 "IDM_IDPSVC_PASSWORD": "some-ldap-idp-password",
                 "IDP_LDAP_BIND_PASSWORD": "some-ldap-idp-password",
+                // storage users mount ID
+                "GATEWAY_STORAGE_USERS_MOUNT_ID": "storage-users-1",
+                "STORAGE_USERS_MOUNT_ID": "storage-users-1"
             }
         }
     ]

--- a/changelog/unreleased/mount-ids.md
+++ b/changelog/unreleased/mount-ids.md
@@ -1,0 +1,5 @@
+Bugfix: Make storage users mount ids unique by default
+
+The mount ID of the storage users provider needs to be unique by default. We made this value configurable and added it to ocis init to be sure that we have a random uuid v4. This is important for federated instances.
+
+https://github.com/owncloud/ocis/pull/5091

--- a/ocis/pkg/init/init.go
+++ b/ocis/pkg/init/init.go
@@ -110,7 +110,16 @@ type Sharing struct {
 }
 
 type StorageUsers struct {
-	Events Events
+	Events  Events
+	MountID string `yaml:"mount_id"`
+}
+
+type Gateway struct {
+	StorageRegistry StorageRegistry `yaml:"storage_registry"`
+}
+
+type StorageRegistry struct {
+	StorageUsersMountID string `yaml:"storage_users_mount_id"`
 }
 
 type Notifications struct {
@@ -160,6 +169,7 @@ type OcisConfig struct {
 	StorageUsers      StorageUsers `yaml:"storage_users"`
 	Notifications     Notifications
 	Nats              Nats
+	Gateway           Gateway
 }
 
 func checkConfigPath(configPath string) error {
@@ -210,6 +220,7 @@ func CreateConfig(insecure, forceOverwrite bool, configPath, adminPassword strin
 
 	systemUserID := uuid.Must(uuid.NewV4()).String()
 	adminUserID := uuid.Must(uuid.NewV4()).String()
+	storageUsersMountID := uuid.Must(uuid.NewV4()).String()
 
 	idmServicePassword, err := generators.GenerateRandomPassword(passwordLength)
 	if err != nil {
@@ -306,6 +317,14 @@ func CreateConfig(insecure, forceOverwrite bool, configPath, adminPassword strin
 			Thumbnail: ThumbnailSettings{
 				TransferSecret: thumbnailsTransferSecret,
 			},
+		},
+		Gateway: Gateway{
+			StorageRegistry: StorageRegistry{
+				StorageUsersMountID: storageUsersMountID,
+			},
+		},
+		StorageUsers: StorageUsers{
+			MountID: storageUsersMountID,
 		},
 	}
 

--- a/services/gateway/pkg/config/config.go
+++ b/services/gateway/pkg/config/config.go
@@ -80,9 +80,10 @@ type GRPCConfig struct {
 }
 
 type StorageRegistry struct {
-	Driver string   `yaml:"driver"` //TODO: configure via env?
-	Rules  []string `yaml:"rules"`  //TODO: configure via env?
-	JSON   string   `yaml:"json"`   //TODO: configure via env?
+	Driver              string   `yaml:"driver"` //TODO: configure via env?
+	Rules               []string `yaml:"rules"`  //TODO: configure via env?
+	JSON                string   `yaml:"json"`   //TODO: configure via env?
+	StorageUsersMountID string   `yaml:"storage_users_mount_id" env:"GATEWAY_STORAGE_USERS_MOUNT_ID" desc:"Mount ID of this storage. This ID needs to be unique."`
 }
 
 // Cache holds cache config

--- a/services/gateway/pkg/config/parser/parse.go
+++ b/services/gateway/pkg/config/parser/parse.go
@@ -2,13 +2,14 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
+	defaults2 "github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/envdecode"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/gateway/pkg/config"
 	"github.com/owncloud/ocis/v2/services/gateway/pkg/config/defaults"
-
-	"github.com/owncloud/ocis/v2/ocis-pkg/config/envdecode"
 )
 
 // ParseConfig loads configuration from known paths.
@@ -40,6 +41,14 @@ func Validate(cfg *config.Config) error {
 
 	if cfg.TransferSecret == "" {
 		return shared.MissingRevaTransferSecretError(cfg.Service.Name)
+	}
+
+	if cfg.StorageRegistry.StorageUsersMountID == "" {
+		return fmt.Errorf("The storage users mount ID has not been configured for %s. "+
+			"Make sure your %s config contains the proper values "+
+			"(e.g. by running ocis init or setting it manually in "+
+			"the config/corresponding environment variable).",
+			"gateway", defaults2.BaseConfigPath())
 	}
 
 	return nil

--- a/services/gateway/pkg/revaconfig/config.go
+++ b/services/gateway/pkg/revaconfig/config.go
@@ -123,11 +123,10 @@ func spacesProviders(cfg *config.Config, logger log.Logger) map[string]map[strin
 		}
 		return rules
 	}
-
 	// generate rules based on default config
 	return map[string]map[string]interface{}{
 		cfg.StorageUsersEndpoint: {
-			"providerid": "1284d238-aa92-42ce-bdc4-0b0000009157",
+			"providerid": cfg.StorageRegistry.StorageUsersMountID,
 			"spaces": map[string]interface{}{
 				"personal": map[string]interface{}{
 					"mount_point":   "/users",

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -39,7 +39,6 @@ func DefaultConfig() *config.Config {
 		},
 		Reva:             shared.DefaultRevaConfig(),
 		DataServerURL:    "http://localhost:9158/data",
-		MountID:          "1284d238-aa92-42ce-bdc4-0b0000009157",
 		UploadExpiration: 24 * 60 * 60,
 		Driver:           "ocis",
 		Drivers: config.Drivers{

--- a/services/storage-users/pkg/config/parser/parse.go
+++ b/services/storage-users/pkg/config/parser/parse.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
+	defaults2 "github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config"
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config/defaults"
@@ -38,5 +40,12 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingJWTTokenError(cfg.Service.Name)
 	}
 
+	if cfg.MountID == "" {
+		return fmt.Errorf("The storage users mount ID has not been configured for %s. "+
+			"Make sure your %s config contains the proper values "+
+			"(e.g. by running ocis init or setting it manually in "+
+			"the config/corresponding environment variable).",
+			"storage-users", defaults2.BaseConfigPath())
+	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

The mount ID of the storage users provider needs to be unique by default. We made this value configurable and added it to ocis init to be sure that we have a random uuid v4. This is important for federated instances.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #5064 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
