### PR TITLE
[tests-only][full-ci] Add API tests for adding user to group (graph API)

### DIFF
--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -1,0 +1,182 @@
+@api
+Feature: add users to group
+  As a admin
+  I want to be able to add users to a group
+  So that I can give a user access to the resources of the group
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario: adding a user to a group
+    Given these groups have been created:
+      | groupname   | comment                               |
+      | simplegroup | nothing special here                  |
+      | España§àôœ€ | special European and other characters |
+      | नेपाली        | Unicode group name                    |
+    When the administrator adds the following users to the following groups using the Graph API
+      | username | groupname   |
+      | Alice    | simplegroup |
+      | Alice    | España§àôœ€ |
+      | Alice    | नेपाली        |
+    And the HTTP status code of responses on all endpoints should be "204"
+
+
+  Scenario: adding a user to a group with special character in its name
+    Given these groups have been created:
+      | groupname           | comment            |
+      | brand-new-group     | dash               |
+      | the.group           | dot                |
+      | left,right          | comma              |
+      | 0                   | The "false" group  |
+      | Finance (NP)        | Space and brackets |
+      | Admin&Finance       | Ampersand          |
+      | maint+eng           | Plus sign          |
+      | $x<=>[y*z^2]!       | Maths symbols      |
+      | 😁 😂               | emoji              |
+      | admin:Pokhara@Nepal | Colon and @        |
+    When the administrator adds the following users to the following groups using the Graph API
+      | username | groupname           |
+      | Alice    | brand-new-group     |
+      | Alice    | the.group           |
+      | Alice    | left,right          |
+      | Alice    | 0                   |
+      | Alice    | Finance (NP)        |
+      | Alice    | Admin&Finance       |
+      | Alice    | maint+eng           |
+      | Alice    | $x<=>[y*z^2]!       |
+      | Alice    | 😁 😂               |
+      | Alice    | admin:Pokhara@Nepal |
+    And the HTTP status code of responses on all endpoints should be "204"
+
+
+  Scenario: adding a user to a group with % and # in its name
+    Given these groups have been created:
+      | groupname           | comment                                 |
+      | maintenance#123     | Hash sign                               |
+      | 50%pass             | Percent sign (special escaping happens) |
+      | 50%25=0             | %25 literal looks like an escaped "%"   |
+      | 50%2Eagle           | %2E literal looks like an escaped "."   |
+      | 50%2Fix             | %2F literal looks like an escaped slash |
+      | Mgmt\Middle         | Backslash                               |
+      | staff?group         | Question mark                           |
+    When the administrator adds the following users to the following groups using the Graph API
+      | username | groupname       |
+      | Alice    | maintenance#123 |
+      | Alice    | 50%pass         |
+      | Alice    | 50%25=0         |
+      | Alice    | 50%2Eagle       |
+      | Alice    | 50%2Fix         |
+      | Alice    | Mgmt\Middle     |
+      | Alice    | staff?group     |
+    And the HTTP status code of responses on all endpoints should be "204"
+
+
+  Scenario: adding a user to a group that has a forward-slash in the group name
+    Given these groups have been created:
+      | groupname        | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
+    When the administrator adds the following users to the following groups using the Graph API
+      | username | groupname        |
+      | Alice    | Mgmt/Sydney      |
+      | Alice    | Mgmt//NSW/Sydney |
+      | Alice    | priv/subadmins/1 |
+    And the HTTP status code of responses on all endpoints should be "204"
+
+
+  Scenario: normal user tries to add himself to a group
+    Given group "groupA" has been created
+    When user "Alice" tries to add himself to group "groupA" using the Graph API
+    Then the HTTP status code should be "401"
+    And the last response should be an unauthorized response
+
+
+  Scenario: normal user tries to other user to a group
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And group "groupA" has been created
+    When user "Alice" tries to add user "Brian" to group "groupA" using the Graph API
+    Then the HTTP status code should be "401"
+    And the last response should be an unauthorized response
+
+  @skipOnLDAP
+  Scenario: admin tries to add user to a group which does not exist
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And group "nonexistentgroup" has been deleted
+    When the administrator tries to add user "Alice" to group "nonexistentgroup" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
+
+  @skipOnLDAP
+  Scenario: admin tries to add user to a group without sending the group
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator tries to add user "Alice" to group "" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
+
+  @skipOnLDAP
+  Scenario: admin tries to add a user which does not exist to a group
+    Given user "nonexistentuser" has been deleted
+    And group "brand-new-group" has been created
+    When the administrator tries to add user "nonexistentuser" to group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And the API should not return any data
+
+  @skipOnLDAP @notToImplementOnOCIS
+  Scenario: subadmin adds users to groups the subadmin is responsible for
+    Given these users have been created with default attributes and without skeleton files:
+      | username       |
+      | Alice |
+      | subadmin       |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" tries to add user "Alice" to group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "403"
+    And user "Alice" should not belong to group "brand-new-group"
+
+  @skipOnLDAP @notToImplementOnOCIS
+  Scenario: subadmin tries to add user to groups the subadmin is not responsible for
+    Given these users have been created with default attributes and without skeleton files:
+      | username         |
+      | Alice   |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And group "another-new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "another-new-group"
+    When user "another-subadmin" tries to add user "Alice" to group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "403"
+    And user "Alice" should not belong to group "brand-new-group"
+
+  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+  Scenario: a subadmin can add users to other groups the subadmin is responsible for
+    Given these users have been created with default attributes and without skeleton files:
+      | username         |
+      | Alice   |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And group "another-new-group" has been created
+    And user "Alice" has been added to group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "another-new-group"
+    When user "another-subadmin" tries to add user "Alice" to group "another-new-group" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "Alice" should belong to group "brand-new-group"
+
+  # merge this with scenario on line 62 once the issue is fixed
+  @issue-31015 @skipOnLDAP @toImplementOnOCIS @issue-product-284
+  Scenario Outline: adding a user to a group that has a forward-slash and dot in the group name
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    When the administrator adds user "Alice" to group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id         | comment                            |
+      | var/../etc       | using slash-dot-dot                |

--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -19,7 +19,12 @@ Feature: add users to group
       | Alice    | simplegroup |
       | Alice    | España§àôœ€ |
       | Alice    | नेपाली        |
-    And the HTTP status code of responses on all endpoints should be "204"
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And the following users should be listed in the following groups
+      | username | groupname   |
+      | Alice    | simplegroup |
+      | Alice    | España§àôœ€ |
+      | Alice    | नेपाली        |
 
 
   Scenario: adding a user to a group with special character in its name
@@ -47,7 +52,19 @@ Feature: add users to group
       | Alice    | $x<=>[y*z^2]!       |
       | Alice    | 😁 😂               |
       | Alice    | admin:Pokhara@Nepal |
-    And the HTTP status code of responses on all endpoints should be "204"
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And the following users should be listed in the following groups
+      | username | groupname           |
+      | Alice    | brand-new-group     |
+      | Alice    | the.group           |
+      | Alice    | left,right          |
+      | Alice    | 0                   |
+      | Alice    | Finance (NP)        |
+      | Alice    | Admin&Finance       |
+      | Alice    | maint+eng           |
+      | Alice    | $x<=>[y*z^2]!       |
+      | Alice    | 😁 😂               |
+      | Alice    | admin:Pokhara@Nepal |
 
 
   Scenario: adding a user to a group with % and # in its name
@@ -69,7 +86,16 @@ Feature: add users to group
       | Alice    | 50%2Fix         |
       | Alice    | Mgmt\Middle     |
       | Alice    | staff?group     |
-    And the HTTP status code of responses on all endpoints should be "204"
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And the following users should be listed in the following groups
+      | username | groupname       |
+      | Alice    | maintenance#123 |
+      | Alice    | 50%pass         |
+      | Alice    | 50%25=0         |
+      | Alice    | 50%2Eagle       |
+      | Alice    | 50%2Fix         |
+      | Alice    | Mgmt\Middle     |
+      | Alice    | staff?group     |
 
 
   Scenario: adding a user to a group that has a forward-slash in the group name
@@ -85,7 +111,13 @@ Feature: add users to group
       | Alice    | Mgmt//NSW/Sydney |
       | Alice    | priv/subadmins/1 |
       | Alice    | var/../etc       |
-    And the HTTP status code of responses on all endpoints should be "204"
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And the following users should be listed in the following groups
+      | username | groupname        |
+      | Alice    | Mgmt/Sydney      |
+      | Alice    | Mgmt//NSW/Sydney |
+      | Alice    | priv/subadmins/1 |
+      | Alice    | var/../etc       |
 
 
   Scenario: normal user tries to add himself to a group

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -536,7 +536,7 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * admin adds a user to a group
+	 * adds a user to a group
 	 *
 	 * @param string $group
 	 * @param string $user
@@ -569,8 +569,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * adds a user to a group
-	 *
 	 * @Given /^the administrator has added a user "([^"]*)" to the group "([^"]*)" using GraphApi$/
 	 *
 	 * @param string $user
@@ -610,8 +608,6 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * adds a user to a group
-	 *
 	 * @When the administrator tries to add user :user to group :group using the Graph API
 	 *
 	 * @param string $user
@@ -624,7 +620,7 @@ class GraphContext implements Context {
 	}
  
 	/**
-	 * @When user :user tries to add himself to group :group using the Graph API
+	 * @When user :user tries to add himself/herself to group :group using the Graph API
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -854,14 +850,11 @@ class GraphContext implements Context {
 					break;
 				}
 			}
-			if (!$exists) {
-				Assert::assertEquals(
-					true,
-					$exists,
-					__METHOD__
-					. "\nExpected user '" . $userGroup['username'] . "' to be in group '" . $userGroup['groupname'] . "'. But not found."
-				);
-			}
+			Assert::assertTrue(
+				$exists,
+				__METHOD__
+				. "\nExpected user '" . $userGroup['username'] . "' to be in group '" . $userGroup['groupname'] . "'. But not found."
+			);
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -548,8 +548,16 @@ class GraphContext implements Context {
 	 */
 	public function addUserToGroup(string $group, string $user, ?string $byUser = null): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($byUser);
-		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
-		$userId = $this->featureContext->getAttributeOfCreatedUser($user, "id");
+		try {
+			$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
+		} catch (Exception $e) {
+			$groupId = WebDavHelper::generateUUIDv4();
+		}
+		try {
+			$userId = $this->featureContext->getAttributeOfCreatedUser($user, "id");
+		} catch (Exception $e) {
+			$userId = WebDavHelper::generateUUIDv4();
+		}
 
 		return GraphHelper::addUserToGroup(
 			$this->featureContext->getBaseUrl(),
@@ -560,6 +568,7 @@ class GraphContext implements Context {
 			$groupId
 		);
 	}
+
 	/**
 	 * adds a user to a group
 	 *
@@ -601,6 +610,20 @@ class GraphContext implements Context {
 		}
 	}
 
+	/**
+	* adds a user to a group
+	*
+	* @When the administrator tries to add user :user to group :group using the Graph API
+	*
+	* @param string $user
+	* @param string $group
+	*
+	* @return void
+	*/
+	public function theAdministratorTriesToAddUserToGroupUsingTheGraphAPI(string $user, string $group): void {
+		$this->featureContext->setResponse($this->addUserToGroup($group, $user));
+	}
+ 
 	/**
 	 * @When user :user tries to add himself to group :group using the Graph API
 	 * 

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -535,14 +535,13 @@ class GraphContext implements Context {
 		$this->featureContext->setResponse($response);
 	}
 
-
 	/**
 	 * admin adds a user to a group
-	 * 
+	 *
 	 * @param string $group
 	 * @param string $user
 	 * @param string|null $byUser
-	 * 
+	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
@@ -595,41 +594,41 @@ class GraphContext implements Context {
 
 	/**
 	 * @When the administrator adds the following users to the following groups using the Graph API
-	 * 
+	 *
 	 * @param TableNode $table
-	 * 
+	 *
 	 * @return void
 	 */
 	public function theAdministratorAddsTheFollowingUsersToTheFollowingGroupsUsingTheGraphAPI(TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['username', 'groupname']);
 		$userGroupList = $table->getColumnsHash();
 
-		foreach($userGroupList as $userGroup) {
+		foreach ($userGroupList as $userGroup) {
 			$this->featureContext->setResponse($this->addUserToGroup($userGroup['groupname'], $userGroup['username']));
 			$this->featureContext->pushToLastHttpStatusCodesArray();
 		}
 	}
 
 	/**
-	* adds a user to a group
-	*
-	* @When the administrator tries to add user :user to group :group using the Graph API
-	*
-	* @param string $user
-	* @param string $group
-	*
-	* @return void
-	*/
+	 * adds a user to a group
+	 *
+	 * @When the administrator tries to add user :user to group :group using the Graph API
+	 *
+	 * @param string $user
+	 * @param string $group
+	 *
+	 * @return void
+	 */
 	public function theAdministratorTriesToAddUserToGroupUsingTheGraphAPI(string $user, string $group): void {
 		$this->featureContext->setResponse($this->addUserToGroup($group, $user));
 	}
  
 	/**
 	 * @When user :user tries to add himself to group :group using the Graph API
-	 * 
+	 *
 	 * @param string $user
 	 * @param string $group
-	 * 
+	 *
 	 * @return void
 	 */
 	public function theUserTriesToAddHimselfToGroupUsingTheGraphAPI(string $user, string $group): void {
@@ -638,11 +637,11 @@ class GraphContext implements Context {
 
 	/**
 	 * @When user :byUser tries to add user :user to group :group using the Graph API
-	 * 
+	 *
 	 * @param string $byUser
-	 * @param string $group
 	 * @param string $user
-	 * 
+	 * @param string $group
+	 *
 	 * @return void
 	 */
 	public function theUserTriesToAddAnotherUserToGroupUsingTheGraphAPI(string $byUser, string $user, string $group): void {

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -836,7 +836,7 @@ class GraphContext implements Context {
 	 * @Then the following users should be listed in the following groups
 	 *
 	 * @param TableNode $table
-	 * 
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -854,7 +854,7 @@ class GraphContext implements Context {
 					break;
 				}
 			}
-			if (!$exists){
+			if (!$exists) {
 				Assert::assertEquals(
 					true,
 					$exists,

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -831,4 +831,37 @@ class GraphContext implements Context {
 			. "\nExpected unauthorized message but got '" . $errorText . "'"
 		);
 	}
+
+	/**
+	 * @Then the following users should be listed in the following groups
+	 *
+	 * @param TableNode $table
+	 * 
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theFollowingUsersShouldBeListedInFollowingGroups(TableNode $table): void {
+		$this->featureContext->verifyTableNodeColumns($table, ['username', 'groupname']);
+		$usersGroups = $table->getColumnsHash();
+		foreach ($usersGroups as $userGroup) {
+			$members = $this->listGroupMembers($userGroup['groupname']);
+			$members = $this->featureContext->getJsonDecodedResponse($members);
+
+			$exists = false;
+			foreach ($members as $member) {
+				if ($member['onPremisesSamAccountName'] === $userGroup['username']) {
+					$exists = true;
+					break;
+				}
+			}
+			if (!$exists){
+				Assert::assertEquals(
+					true,
+					$exists,
+					__METHOD__
+					. "\nExpected user '" . $userGroup['username'] . "' to be in group '" . $userGroup['groupname'] . "'. But not found."
+				);
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Description
Added API tests for adding user to groups

Added scenarios:
1. `Scenario: adding a user to a group`
2. `Scenario: adding a user to a group with special character in its name`
3. `Scenario: adding a user to a group with % and # in its name`
4. `Scenario: adding a user to a group that has a forward-slash in the group name`
5. `Scenario: normal user tries to add himself to a group`
6. `Scenario: normal user tries to other user to a group`
7. `Scenario: admin tries to add user to a non-existing group`
8. `Scenario: admin tries to add a non-existing user to a group`
9. `Scenario: admin tries to add user to a group without sending the group`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/4937

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
