### PR TITLE
[tests-only][full-ci] Add API tests for editing group displayName (graph API)

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -60,3 +60,11 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 - [apiGraph/deleteGroup.feature:62](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L62)
+
+#### [Updating group displayName request seems OK but group is not being renamed](https://github.com/owncloud/ocis/issues/5099)
+- [apiGraph/editGroup.feature:20](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L20)
+- [apiGraph/editGroup.feature:21](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L21)
+- [apiGraph/editGroup.feature:22](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L22)
+- [apiGraph/editGroup.feature:23](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L23)
+- [apiGraph/editGroup.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L24)
+- [apiGraph/editGroup.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L25)

--- a/tests/acceptance/features/apiGraph/editGroup.feature
+++ b/tests/acceptance/features/apiGraph/editGroup.feature
@@ -1,0 +1,25 @@
+@api @skipOnOcV10
+Feature: edit group name
+  As an admin
+  I want to be able to edit group name
+  So that I can manage group name
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has given "Alice" the role "Admin" using the settings api
+
+  @issue-5099
+  Scenario Outline: admin user renames a group
+    Given group "<old_group>" has been created
+    When user "Alice" renames group "<old_group>" to "<new_group>" using the Graph API
+    Then the HTTP status code should be "204"
+    And group "<old_group>" should not exist
+    And group "<new_group>" should exist
+    Examples:
+      | old_group | new_group     |
+      | grp1      | grp101        |
+      | grp1      | España§àôœ€   |
+      | grp1      | नेपाली          |
+      | grp1      | $x<=>[y*z^2]! |
+      | grp1      | staff?group   |
+      | grp1      | 50%pass       |

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -889,4 +889,41 @@ class GraphContext implements Context {
 			);
 		}
 	}
+
+	/**
+	 * rename group name
+	 *
+	 * @param string $oldGroup
+	 * @param string $newGroup
+	 * @param string $user
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public function renameGroup(string $oldGroup, string $newGroup, ?string $user = null): ResponseInterface {
+		$credentials = $this->getAdminOrUserCredentials($user);
+		$groupId = $this->featureContext->getAttributeOfCreatedGroup($oldGroup, "id");
+
+		return GraphHelper::updateGroup(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$credentials['username'],
+			$credentials['password'],
+			$groupId,
+			$newGroup
+		);
+	}
+
+	/**
+	 * @When user :user renames group :oldGroup to :newGroup using the Graph API
+	 *
+	 * @param string $user
+	 * @param string $oldGroup
+	 * @param string $newGroup
+	 *
+	 * @return void
+	 */
+	public function userRenamesGroupUsingTheGraphApi(string $user, string $oldGroup, string $newGroup): void {
+		$this->featureContext->setResponse($this->renameGroup($oldGroup, $newGroup, $user));
+	}
 }


### PR DESCRIPTION
## Description
Added API tests for editing group display name

Added scenarios:
1. `Scenario Outline: admin user renames a group`
```feature
      | grp1      | grp101        |
      | grp1      | España§àôœ€   |
      | grp1      | नेपाली          |
      | grp1      | $x<=>[y*z^2]! |
      | grp1      | staff?group   |
      | grp1      | 50%pass       |
```

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/4937

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
