### PR TITLE
fix HTTP1.1 RFC 2616 for 401s

### DIFF
--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -113,7 +113,7 @@ func Authentication(auths []Authenticator, opts ...Option) func(next http.Handle
 				// https://github.com/golang/go/issues/15527
 
 				defer r.Body.Close()
-				io.Copy(ioutil.Discard, r.Body)
+				_, _ = io.Copy(ioutil.Discard, r.Body)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
fix HTTP1.1 RFC 2616 for bodies when we issue a 401 because of invalid auth


from RFC 2616:
```
        If an origin server receives a request that does not include an
        Expect request-header field with the "100-continue" expectation,
        the request includes a request body, and the server responds
        with a final status code before reading the entire request body
        from the transport connection, then the server SHOULD NOT close
        the transport connection until it has read the entire request,
        or until the client closes the connection. Otherwise, the client
        might not reliably receive the response message. However, this
        requirement is not be construed as preventing a server from
        defending itself against denial-of-service attacks, or from
        badly broken client implementations.
```

see also
- https://github.com/golang/go/blob/d5de62df152baf4de6e9fe81933319b86fd95ae4/src/net/http/server.go#L1089-L1098
- https://www.rfc-editor.org/rfc/rfc7230#section-6.5 Failures and Timeouts
- https://www.rfc-editor.org/rfc/rfc7230#section-6.6 Teardown

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/5066

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- set low access token lifetime (IDP_ACCESS_TOKEN_EXPIRATION=20) and sync a largish folder with the Desktop Client 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
