### PR TITLE
switch to a more recent alpine image for image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=generate /ocis /ocis
 WORKDIR /ocis/ocis
 RUN make ci-go-generate build
 
-FROM alpine:3.15
+FROM alpine:3.17
 
 RUN apk add --no-cache ca-certificates mailcap tree attr curl && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf

--- a/ocis/docker/Dockerfile.linux.amd64
+++ b/ocis/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM amd64/alpine:3.15
+FROM amd64/alpine:3.17
 
 ARG VERSION=""
 ARG REVISION=""

--- a/ocis/docker/Dockerfile.linux.arm
+++ b/ocis/docker/Dockerfile.linux.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine:3.15
+FROM arm32v6/alpine:3.17
 
 ARG VERSION=""
 ARG REVISION=""

--- a/ocis/docker/Dockerfile.linux.arm64
+++ b/ocis/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.15
+FROM arm64v8/alpine:3.17
 
 ARG VERSION=""
 ARG REVISION=""


### PR DESCRIPTION
## Description
switches the base image for image builds to a more recent version of alpine

## Related Issue

## Motivation and Context
keep things up to date

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- using dev image with the ocis-traefik deployment example

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
