### PR TITLE
Update the docker-compose example for wopi

### DIFF
--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -136,6 +136,7 @@ services:
     logging:
       driver: "local"
     restart: always
+
   wopiserver:
     image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-v9.3.0}
     networks:


### PR DESCRIPTION
Just adding a blank line between the last entry of the `ocis-appdriver-onlyoffice` block and the start of `wopiserver` for ease of readability.