### PR TITLE
decomposedfs increase filelock duration factor

### DIFF
--- a/changelog/unreleased/filelock-duration-factor-config.md
+++ b/changelog/unreleased/filelock-duration-factor-config.md
@@ -1,0 +1,6 @@
+Bugfix: decomposedfs increase filelock duration factor
+
+We made the file lock duration per lock cycle for decomposedfs configurable and increased it to make locks work on top of NFS.
+
+https://github.com/owncloud/ocis/pull/5130
+https://github.com/owncloud/ocis/issues/5024

--- a/services/storage-system/pkg/config/config.go
+++ b/services/storage-system/pkg/config/config.go
@@ -75,4 +75,7 @@ type Drivers struct {
 type OCISDriver struct {
 	// Root is the absolute path to the location of the data
 	Root string `yaml:"root" env:"STORAGE_SYSTEM_OCIS_ROOT" desc:"Path for the directory where the STORAGE-SYSTEM service stores it's persistent data."`
+
+	MaxAcquireLockCycles    int `yaml:"max_acquire_lock_cycles" env:"STORAGE_SYSTEM_OCIS_MAX_ACQUIRE_LOCK_CYCLES" desc:"When trying to lock files, ocis will try this amount of times to acquire the lock before failing. After each try it will wait for an increasing amount of time. Values of 0 or below will be ignored and the default value of 20 will be used."`
+	LockCycleDurationFactor int `yaml:"lock_cycle_duration_factor" env:"STORAGE_SYSTEM_OCIS_LOCK_CYCLE_DURATION_FACTOR" desc:"When trying to lock files, ocis will multiply the cycle with this factor and use it as a millisecond timeout. Values of 0 or below will be ignored and the default value of 30 will be used."`
 }

--- a/services/storage-system/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-system/pkg/config/defaults/defaultconfig.go
@@ -41,7 +41,9 @@ func DefaultConfig() *config.Config {
 		Driver:        "ocis",
 		Drivers: config.Drivers{
 			OCIS: config.OCISDriver{
-				Root: filepath.Join(defaults.BaseDataPath(), "storage", "metadata"),
+				Root:                    filepath.Join(defaults.BaseDataPath(), "storage", "metadata"),
+				MaxAcquireLockCycles:    20,
+				LockCycleDurationFactor: 30,
 			},
 		},
 	}

--- a/services/storage-system/pkg/revaconfig/config.go
+++ b/services/storage-system/pkg/revaconfig/config.go
@@ -153,11 +153,13 @@ func StorageSystemFromStruct(cfg *config.Config) map[string]interface{} {
 func metadataDrivers(cfg *config.Config) map[string]interface{} {
 	return map[string]interface{}{
 		"ocis": map[string]interface{}{
-			"root":                cfg.Drivers.OCIS.Root,
-			"user_layout":         "{{.Id.OpaqueId}}",
-			"treetime_accounting": false,
-			"treesize_accounting": false,
-			"permissionssvc":      cfg.GRPC.Addr,
+			"root":                       cfg.Drivers.OCIS.Root,
+			"user_layout":                "{{.Id.OpaqueId}}",
+			"treetime_accounting":        false,
+			"treesize_accounting":        false,
+			"permissionssvc":             cfg.GRPC.Addr,
+			"max_acquire_lock_cycles":    cfg.Drivers.OCIS.MaxAcquireLockCycles,
+			"lock_cycle_duration_factor": cfg.Drivers.OCIS.LockCycleDurationFactor,
 		},
 	}
 }

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -94,9 +94,10 @@ type OCISDriver struct {
 	// GeneralSpaceAliasTemplate contains the template used to construct
 	// the general space alias, eg: `{{.SpaceType}}/{{.SpaceName | replace " " "-" | lower}}`
 	GeneralSpaceAliasTemplate string `yaml:"generalspacealias_template" env:"STORAGE_USERS_OCIS_GENERAL_SPACE_ALIAS_TEMPLATE" desc:"Template string to construct general space aliases."`
-	//ShareFolder defines the name of the folder jailing all shares
-	ShareFolder          string `yaml:"share_folder" env:"STORAGE_USERS_OCIS_SHARE_FOLDER" desc:"Name of the folder jailing all shares."`
-	MaxAcquireLockCycles int    `yaml:"max_acquire_lock_cycles" env:"STORAGE_USERS_OCIS_MAX_ACQUIRE_LOCK_CYCLES" desc:"When trying to lock files, ocis will try this amount of times to acquire the lock before failing. After each try it will wait for an increasing amount of time. Values of 0 or below will be ignored and the default value of 25 will be used"`
+	// ShareFolder defines the name of the folder jailing all shares
+	ShareFolder             string `yaml:"share_folder" env:"STORAGE_USERS_OCIS_SHARE_FOLDER" desc:"Name of the folder jailing all shares."`
+	MaxAcquireLockCycles    int    `yaml:"max_acquire_lock_cycles" env:"STORAGE_USERS_OCIS_MAX_ACQUIRE_LOCK_CYCLES" desc:"When trying to lock files, ocis will try this amount of times to acquire the lock before failing. After each try it will wait for an increasing amount of time. Values of 0 or below will be ignored and the default value of 20 will be used."`
+	LockCycleDurationFactor int    `yaml:"lock_cycle_duration_factor" env:"STORAGE_USERS_OCIS_LOCK_CYCLE_DURATION_FACTOR" desc:"When trying to lock files, ocis will multiply the cycle with this factor and use it as a millisecond timeout. Values of 0 or below will be ignored and the default value of 30 will be used."`
 }
 
 type S3NGDriver struct {
@@ -116,7 +117,9 @@ type S3NGDriver struct {
 	// the general space alias, eg: `{{.SpaceType}}/{{.SpaceName | replace " " "-" | lower}}`
 	GeneralSpaceAliasTemplate string `yaml:"generalspacealias_template" env:"STORAGE_USERS_S3NG_GENERAL_SPACE_ALIAS_TEMPLATE" desc:"Template string to construct general space aliases."`
 	//ShareFolder defines the name of the folder jailing all shares
-	ShareFolder string `yaml:"share_folder" env:"STORAGE_USERS_S3NG_SHARE_FOLDER" desc:"Name of the folder jailing all shares."`
+	ShareFolder             string `yaml:"share_folder" env:"STORAGE_USERS_S3NG_SHARE_FOLDER" desc:"Name of the folder jailing all shares."`
+	MaxAcquireLockCycles    int    `yaml:"max_acquire_lock_cycles" env:"STORAGE_USERS_S3NG_MAX_ACQUIRE_LOCK_CYCLES" desc:"When trying to lock files, ocis will try this amount of times to acquire the lock before failing. After each try it will wait for an increasing amount of time. Values of 0 or below will be ignored and the default value of 20 will be used."`
+	LockCycleDurationFactor int    `yaml:"lock_cycle_duration_factor" env:"STORAGE_USERS_S3NG_LOCK_CYCLE_DURATION_FACTOR" desc:"When trying to lock files, ocis will multiply the cycle with this factor and use it as a millisecond timeout. Values of 0 or below will be ignored and the default value of 30 will be used."`
 }
 
 type OwnCloudSQLDriver struct {

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -62,6 +62,8 @@ func DefaultConfig() *config.Config {
 				PersonalSpaceAliasTemplate: "{{.SpaceType}}/{{.User.Username | lower}}",
 				GeneralSpaceAliasTemplate:  "{{.SpaceType}}/{{.SpaceName | replace \" \" \"-\" | lower}}",
 				PermissionsEndpoint:        "127.0.0.1:9191",
+				MaxAcquireLockCycles:       20,
+				LockCycleDurationFactor:    30,
 			},
 			OCIS: config.OCISDriver{
 				Root:                       filepath.Join(defaults.BaseDataPath(), "storage", "users"),
@@ -70,7 +72,8 @@ func DefaultConfig() *config.Config {
 				PersonalSpaceAliasTemplate: "{{.SpaceType}}/{{.User.Username | lower}}",
 				GeneralSpaceAliasTemplate:  "{{.SpaceType}}/{{.SpaceName | replace \" \" \"-\" | lower}}",
 				PermissionsEndpoint:        "127.0.0.1:9191",
-				MaxAcquireLockCycles:       25,
+				MaxAcquireLockCycles:       20,
+				LockCycleDurationFactor:    30,
 			},
 		},
 		Events: config.Events{

--- a/services/storage-users/pkg/revaconfig/user.go
+++ b/services/storage-users/pkg/revaconfig/user.go
@@ -97,6 +97,7 @@ func UserDrivers(cfg *config.Config) map[string]interface{} {
 			"permissionssvc":              cfg.Drivers.OCIS.PermissionsEndpoint,
 			"permissionssvc_tls_mode":     cfg.Commons.GRPCClientTLS.Mode,
 			"max_acquire_lock_cycles":     cfg.Drivers.OCIS.MaxAcquireLockCycles,
+			"lock_cycle_duration_factor":  cfg.Drivers.OCIS.LockCycleDurationFactor,
 		},
 		"s3": map[string]interface{}{
 			"enable_home": false,
@@ -122,7 +123,8 @@ func UserDrivers(cfg *config.Config) map[string]interface{} {
 			"s3.secret_key":               cfg.Drivers.S3NG.SecretKey,
 			"s3.endpoint":                 cfg.Drivers.S3NG.Endpoint,
 			"s3.bucket":                   cfg.Drivers.S3NG.Bucket,
-			"max_acquire_lock_cycles":     cfg.Drivers.OCIS.MaxAcquireLockCycles,
+			"max_acquire_lock_cycles":     cfg.Drivers.S3NG.MaxAcquireLockCycles,
+			"lock_cycle_duration_factor":  cfg.Drivers.S3NG.LockCycleDurationFactor,
 		},
 	}
 }


### PR DESCRIPTION
We made the file lock duration per lock cycle for decomposedfs configurable and increased it to make locks work on top of NFS.

see https://github.com/owncloud/ocis/issues/5024

This PR does not bump reva, but it will add the necessary config which will be picked up when bumping it as soon as https://github.com/cs3org/reva/pull/3493 is merged

