### PR TITLE
Ocis With EOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -284,3 +284,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	stash.kopano.io/kgol/kcc-go/v5 v5.0.1 // indirect
 )
+
+replace github.com/cs3org/reva/v2 => github.com/kobergj/reva/v2 v2.0.0-20221201141116-c82234d00269

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,6 @@ github.com/crewjam/saml v0.4.6 h1:XCUFPkQSJLvzyl4cW9OvpWUbRf0gE7VUpU8ZnilbeM4=
 github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD96t1A=
 github.com/cs3org/go-cs3apis v0.0.0-20221012090518-ef2996678965 h1:y4n2j68LLnvac+zw/al8MfPgO5aQiIwLmHM/JzYN8AM=
 github.com/cs3org/go-cs3apis v0.0.0-20221012090518-ef2996678965/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/reva/v2 v2.12.0 h1:KGQnNje13BbWuQBnxnWKyk+JjYTrETE8Q71KqKpzQQo=
-github.com/cs3org/reva/v2 v2.12.0/go.mod h1:+lH5G0UmNjMNj4F0bDhbh+HqL1UihlbL8zPBa57Y2QI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -865,6 +863,8 @@ github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0 h1:eyi1Ad2aNJMW95zcSbmGg7Cg6cq3ADwLpMAP96d8rF0=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/kobergj/reva/v2 v2.0.0-20221201141116-c82234d00269 h1:lOg69BlWb/+ADPHLV9SDsl11/H0pPxqC3cvCkhBm+Xw=
+github.com/kobergj/reva/v2 v2.0.0-20221201141116-c82234d00269/go.mod h1:+lH5G0UmNjMNj4F0bDhbh+HqL1UihlbL8zPBa57Y2QI=
 github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b/go.mod h1:o03bZfuBwAXHetKXuInt4S7omeXUu62/A845kiycsSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -472,7 +472,8 @@ func (g Graph) formatDrives(ctx context.Context, baseURL *url.URL, storageSpaces
 			res.Special = g.getExtendedSpaceProperties(ctx, baseURL, storageSpace)
 			res.Quota, err = g.getDriveQuota(ctx, storageSpace)
 			if err != nil {
-				return nil, err
+				//TODO: Handle error
+				//return nil, err
 			}
 		}
 		responses = append(responses, res)

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -40,7 +40,8 @@ func DefaultConfig() *config.Config {
 		Reva:             shared.DefaultRevaConfig(),
 		DataServerURL:    "http://localhost:9158/data",
 		UploadExpiration: 24 * 60 * 60,
-		Driver:           "ocis",
+		Driver:           "eosgrpc",
+		//Driver: "ocis",
 		Drivers: config.Drivers{
 			OwnCloudSQL: config.OwnCloudSQLDriver{
 				Root:                  filepath.Join(defaults.BaseDataPath(), "storage", "owncloud"),
@@ -74,6 +75,13 @@ func DefaultConfig() *config.Config {
 				PermissionsEndpoint:        "127.0.0.1:9191",
 				MaxAcquireLockCycles:       20,
 				LockCycleDurationFactor:    30,
+			},
+			EOS: config.EOSDriver{
+				GRPCURI:   "localhost:50051",
+				MasterURL: "http://localhost:9158/data",
+				//SingleUsername:      "3f44740b-f40f-4f05-a1d4-d6f3bbc1677e",
+				//ForceSingleUserMode: true,
+				Root: "ocis",
 			},
 		},
 		Events: config.Events{


### PR DESCRIPTION
Draft to run ocis with eos

To run eos-powered ocis:
- start eos as described here: https://gitlab.cern.ch/eos/eos-charts
- forward port 50051(for grpc)
```
kubectl port-forward pods/eos-mgm-0 50051
```
- start ocis from this branch