### PR TITLE
[tests-only] ApiTest. restore file while quota is exceeded

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,5 +1,5 @@
 # The test runner source for API tests
-CORE_COMMITID=da916036018eb68ca08822d7abc1e1aac9e4f9e1
+CORE_COMMITID=8cc1640f56fdeb25dde18c9901dced1b29296f9e
 CORE_BRANCH=master
 
 # The test runner source for UI tests

--- a/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
@@ -1,68 +1,101 @@
 @api @skipOnOcV10
 Feature: Restore files, folder
-    As a user with manager and editor role
-    I want to be able to restore files, folders
-    Users with the viewer role cannot restore objects
+  As a user with manager and editor role
+  I want to be able to restore files, folders
+  Users with the viewer role cannot restore objects
 
-    Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
-    See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
+  Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
+  See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
 
-    Background:
-        Given these users have been created with default attributes and without skeleton files:
-            | username |
-            | Alice    |
-            | Brian    |
-            | Bob      |
-            | Carol    |
-        And using spaces DAV path
-        And the administrator has given "Alice" the role "Space Admin" using the settings api
-        And user "Alice" creates a space "restore objects" of type "project" with the default quota using the GraphApi
-        And user "Alice" has created a folder "newFolder" in space "restore objects"
-        And user "Alice" has uploaded a file inside space "restore objects" with content "test" to "newFolder/file.txt"
-
-
-    Scenario Outline: An user with different role can see deleted objects in trash bin of the space via the webDav API
-        Given user "Alice" has shared a space "restore objects" to user "Brian" with role "<role>"
-        And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
-        And user "Alice" has removed the folder "newFolder" from space "restore objects"
-        When user "<user>" lists all deleted files in the trash bin of the space "restore objects"
-        Then the HTTP status code should be "207"
-        And as "<user>" folder "newFolder" should exist in the trashbin of the space "restore objects"
-        And as "<user>" file "file.txt" should exist in the trashbin of the space "restore objects"
-        Examples:
-            | user  | role    |
-            | Brian | manager |
-            | Brian | editor  |
-            | Brian | viewer  |
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Bob      |
+      | Carol    |
+    And using spaces DAV path
+    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And user "Alice" creates a space "restore objects" of type "project" with the default quota using the GraphApi
+    And user "Alice" has created a folder "newFolder" in space "restore objects"
+    And user "Alice" has uploaded a file inside space "restore objects" with content "test" to "newFolder/file.txt"
 
 
-    Scenario Outline: An user restores a folder with some objects from the trash via the webDav API
-        Given user "Alice" has shared a space "restore objects" to user "Brian" with role "<role>"
-        And user "Alice" has removed the folder "newFolder" from space "restore objects"
-        When user "<user>" restores the folder "newFolder" from the trash of the space "restore objects" to "/newFolder"
-        Then the HTTP status code should be "<code>"
-        And for user "<user>" the space "restore objects" <shouldOrNotBeInSpace> contain these entries:
-            | newFolder |
-        And as "<user>" folder "newFolder" <shouldOrNotBeInTrash> exist in the trashbin of the space "restore objects"
-        Examples:
-            | user  | role    | code | shouldOrNotBeInSpace | shouldOrNotBeInTrash |
-            | Alice | manager | 201  | should               | should not           |
-            | Brian | manager | 201  | should               | should not           |
-            | Brian | editor  | 201  | should               | should not           |
-            | Brian | viewer  | 403  | should not           | should               |
+  Scenario Outline: The user with different role can see deleted objects in trash bin of the space via the webDav API
+    Given user "Alice" has shared a space "restore objects" to user "Brian" with role "<role>"
+    And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
+    And user "Alice" has removed the folder "newFolder" from space "restore objects"
+    When user "<user>" lists all deleted files in the trash bin of the space "restore objects"
+    Then the HTTP status code should be "207"
+    And as "<user>" folder "newFolder" should exist in the trashbin of the space "restore objects"
+    And as "<user>" file "file.txt" should exist in the trashbin of the space "restore objects"
+    Examples:
+      | user  | role    |
+      | Brian | manager |
+      | Brian | editor  |
+      | Brian | viewer  |
 
 
-    Scenario Outline: An user restores a file from the trash via the webDav API
-        Given user "Alice" has shared a space "restore objects" to user "Brian" with role "<role>"
-        And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
-        When user "<user>" restores the file "file.txt" from the trash of the space "restore objects" to "newFolder/file.txt"
-        Then the HTTP status code should be "<code>"
-        And for user "<user>" folder "newFolder" of the space "restore objects" <shouldOrNotBeInSpace> contain these files:
-            | file.txt |
-        And as "<user>" file "file.txt" <shouldOrNotBeInTrash> exist in the trashbin of the space "restore objects"
-        Examples:
-            | user  | role    | code | shouldOrNotBeInSpace | shouldOrNotBeInTrash |
-            | Alice | manager | 201  | should               | should not           |
-            | Brian | manager | 201  | should               | should not           |
-            | Brian | editor  | 201  | should               | should not           |
-            | Brian | viewer  | 403  | should not           | should               |
+  Scenario Outline: The user can restore a folder with some objects from the trash via the webDav API
+    Given user "Alice" has shared a space "restore objects" to user "Brian" with role "<role>"
+    And user "Alice" has removed the folder "newFolder" from space "restore objects"
+    When user "<user>" restores the folder "newFolder" from the trash of the space "restore objects" to "/newFolder"
+    Then the HTTP status code should be "<code>"
+    And for user "<user>" the space "restore objects" <shouldOrNotBeInSpace> contain these entries:
+      | newFolder |
+    And as "<user>" folder "newFolder" <shouldOrNotBeInTrash> exist in the trashbin of the space "restore objects"
+    Examples:
+      | user  | role    | code | shouldOrNotBeInSpace | shouldOrNotBeInTrash |
+      | Alice | manager | 201  | should               | should not           |
+      | Brian | manager | 201  | should               | should not           |
+      | Brian | editor  | 201  | should               | should not           |
+      | Brian | viewer  | 403  | should not           | should               |
+
+
+  Scenario Outline: The user can restore a file from the trash via the webDav API
+    Given user "Alice" has shared a space "restore objects" to user "Brian" with role "<role>"
+    And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
+    When user "<user>" restores the file "file.txt" from the trash of the space "restore objects" to "newFolder/file.txt"
+    Then the HTTP status code should be "<code>"
+    And for user "<user>" folder "newFolder" of the space "restore objects" <shouldOrNotBeInSpace> contain these files:
+      | file.txt |
+    And as "<user>" file "file.txt" <shouldOrNotBeInTrash> exist in the trashbin of the space "restore objects"
+    Examples:
+      | user  | role    | code | shouldOrNotBeInSpace | shouldOrNotBeInTrash |
+      | Alice | manager | 201  | should               | should not           |
+      | Brian | manager | 201  | should               | should not           |
+      | Brian | editor  | 201  | should               | should not           |
+      | Brian | viewer  | 403  | should not           | should               |
+
+
+  Scenario: The user can restore a file even if there is not enough quota to do so
+    Given user "Admin" has changed the quota of the "Brian Murphy" space to "30"
+    And user "Brian" has uploaded file with content "file is less than 30 bytes" to "/file.txt"
+    And user "Brian" has uploaded file with content "reduceContent" to "/file.txt"
+    And user "Brian" has uploaded file with content "some content" to "newFile.txt"
+    When user "Brian" restores version index "1" of file "/file.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/file.txt" for user "Brian" should be "file is less than 30 bytes"
+    And the user "Brian" should have a space called "Brian Murphy" with these key and value pairs:
+      | key           | value    |
+      | quota@@@total | 30       |
+      | quota@@@used  | 38       |
+      | quota@@@state | exceeded |
+
+
+  Scenario: The recipient can restore a file even if there is not enough owner's quota to do so
+    Given user "Admin" has changed the quota of the "Brian Murphy" space to "30"
+    And user "Brian" has uploaded file with content "file is less than 30 bytes" to "/file.txt"
+    And user "Brian" has uploaded file with content "reduceContent" to "/file.txt"
+    And user "Brian" has uploaded file with content "some content" to "newFile.txt"
+    And user "Brian" has shared file "file.txt" with user "Alice"
+    And user "Alice" has accepted share "/file.txt" offered by user "Brian"
+    And using new DAV path
+    When user "Alice" restores version index "1" of file "/Shares/file.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/Shares/file.txt" for user "Alice" should be "file is less than 30 bytes"
+    And the user "Brian" should have a space called "Brian Murphy" with these key and value pairs:
+      | key           | value    |
+      | quota@@@total | 30       |
+      | quota@@@used  | 38       |
+      | quota@@@state | exceeded |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1332,6 +1332,7 @@ class SpacesContext implements Context {
 
 	/**
 	 * @Given /^user "([^"]*)" has changed the quota of the personal space of "([^"]*)" space to "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has changed the quota of the "([^"]*)" space to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -1352,7 +1353,7 @@ class SpacesContext implements Context {
 			"Expected response status code should be 200"
 		);
 	}
-
+  
 	/**
 	 * @When /^user "([^"]*)" sets the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/
 	 *


### PR DESCRIPTION
related: https://github.com/owncloud/ocis/issues/5144#issuecomment-1329753744

add checking that the user or recipient can restore a file even if there is not enough quota to do so