### PR TITLE
[tests-only][full-ci] Add CORS API tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -692,56 +692,6 @@ def codestyle(ctx):
 def localApiTestPipeline(ctx):
     pipelines = []
 
-<<<<<<< HEAD
-    return {
-        "kind": "pipeline",
-        "type": "docker",
-        "name": "localApiTests-%s-%s" % (suite, storage),
-        "platform": {
-            "os": "linux",
-            "arch": "amd64",
-        },
-        "steps": skipIfUnchanged(ctx, "acceptance-tests") +
-                 restoreBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin") +
-                 ocisServer(storage, accounts_hash_difficulty) +
-                 restoreBuildArtifactCache(ctx, "testrunner", dirs["core"]) +
-                 [
-                     {
-                         "name": "localApiTests-%s-%s" % (suite, storage),
-                         "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
-                         "environment": {
-                             "TEST_WITH_GRAPH_API": "true",
-                             "PATH_TO_OCIS": dirs["base"],
-                             "PATH_TO_CORE": "%s/%s" % (dirs["base"], dirs["core"]),
-                             "TEST_SERVER_URL": "https://ocis-server:9200",
-                             "OCIS_REVA_DATA_ROOT": "%s" % (dirs["ocisRevaDataRoot"] if storage == "owncloud" else ""),
-                             "OCIS_SKELETON_STRATEGY": "%s" % ("copy" if storage == "owncloud" else "upload"),
-                             "TEST_OCIS": "true",
-                             "SEND_SCENARIO_LINE_REFERENCES": "true",
-                             "STORAGE_DRIVER": storage,
-                             "BEHAT_SUITE": suite,
-                             "BEHAT_FILTER_TAGS": "~@skip&&~@skipOnGraph&&~@skipOnOcis-%s-Storage" % ("OC" if storage == "owncloud" else "OCIS"),
-                             "EXPECTED_FAILURES_FILE": "%s/tests/acceptance/expected-failures-localAPI-on-%s-storage.md" % (dirs["base"], storage.upper()),
-                             "UPLOAD_DELETE_WAIT_TIME": "1" if storage == "owncloud" else 0,
-                         },
-                         "commands": [
-                             "pwd",
-                             "ls -la",
-                             "make test-acceptance-api",
-                         ],
-                     },
-                 ] + failEarly(ctx, early_fail),
-        "services": redisForOCStorage(storage),
-        "depends_on": getPipelineNames([buildOcisBinaryForTesting(ctx)]) +
-                      getPipelineNames(cacheCoreReposForTesting(ctx)),
-        "trigger": {
-            "ref": [
-                "refs/heads/master",
-                "refs/heads/stable-*",
-                "refs/pull/**",
-            ],
-        },
-=======
     defaults = {
         "suites": {},
         "skip": False,
@@ -750,7 +700,6 @@ def localApiTestPipeline(ctx):
         "extraServerEnvironment": {},
         "storages": ["ocis"],
         "accounts_hash_difficulty": 4,
->>>>>>> 616ab07f4 (add cors tests pipeline in drone config)
     }
 
     if "localApiTests" in config:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -136,5 +136,20 @@ default:
         - TUSContext:
         - SpacesTUSContext:
 
+    apiCors:
+      paths:
+        - '%paths.base%/../features/apiCors'
+      context: *common_ldap_suite_context
+      contexts:
+        - SpacesContext:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - WebDavPropertiesContext:
+        - FavoritesContext:
+        - ChecksumContext:
+        - FilesVersionsContext:
+        - OCSContext:
+        - TrashbinContext:
+
   extensions:
     Cjm\Behat\StepThroughExtension: ~

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -600,18 +600,6 @@ And other missing implementation of favorites
 - [apiWebdavOperations/refuseAccess.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L22)
 - [apiWebdavOperations/refuseAccess.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L23)
 
-#### [CORS headers are not identical with oC10 headers](https://github.com/owncloud/ocis/issues/5195)
-
-- [apiAuth/cors.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L24)
-- [apiAuth/cors.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L25)
-- [apiAuth/cors.feature:56](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L56)
-- [apiAuth/cors.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L57)
-
-#### [Requests with invalid credentials do not return CORS headers](https://github.com/owncloud/ocis/issues/5194)
-
-- [apiAuth/cors.feature:204](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L204)
-- [apiAuth/cors.feature:205](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L205)
-
 #### [App Passwords/Tokens for legacy WebDAV clients](https://github.com/owncloud/ocis/issues/197)
 
 - [apiAuthWebDav/webDavDELETEAuth.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L135)

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -600,6 +600,18 @@ And other missing implementation of favorites
 - [apiWebdavOperations/refuseAccess.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L22)
 - [apiWebdavOperations/refuseAccess.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L23)
 
+#### [CORS headers are not identical with oC10 headers](https://github.com/owncloud/ocis/issues/5195)
+
+- [apiAuth/cors.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L24)
+- [apiAuth/cors.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L25)
+- [apiAuth/cors.feature:56](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L56)
+- [apiAuth/cors.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L57)
+
+#### [Requests with invalid credentials do not return CORS headers](https://github.com/owncloud/ocis/issues/5194)
+
+- [apiAuth/cors.feature:204](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L204)
+- [apiAuth/cors.feature:205](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L205)
+
 #### [App Passwords/Tokens for legacy WebDAV clients](https://github.com/owncloud/ocis/issues/197)
 
 - [apiAuthWebDav/webDavDELETEAuth.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L135)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -70,11 +70,11 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/editGroup.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L25)
 
 #### [CORS headers are not identical with oC10 headers](https://github.com/owncloud/ocis/issues/5195)
+- [apiCors/cors.feature:23](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L23)
 - [apiCors/cors.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L24)
 - [apiCors/cors.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L25)
 - [apiCors/cors.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L26)
-- [apiCors/cors.feature:27](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L27)
 
 #### [Requests with invalid credentials do not return CORS headers](https://github.com/owncloud/ocis/issues/5194)
-- [apiCors/cors.feature:68](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L68)
-- [apiCors/cors.feature:69](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L69)
+- [apiCors/cors.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L65)
+- [apiCors/cors.feature:66](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L66)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -70,11 +70,11 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/editGroup.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L25)
 
 #### [CORS headers are not identical with oC10 headers](https://github.com/owncloud/ocis/issues/5195)
-- [apiCors/cors.feature:23](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L23)
-- [apiCors/cors.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L24)
 - [apiCors/cors.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L25)
 - [apiCors/cors.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L26)
+- [apiCors/cors.feature:27](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L27)
+- [apiCors/cors.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L28)
 
 #### [Requests with invalid credentials do not return CORS headers](https://github.com/owncloud/ocis/issues/5194)
-- [apiCors/cors.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L65)
-- [apiCors/cors.feature:66](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L66)
+- [apiCors/cors.feature:67](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L67)
+- [apiCors/cors.feature:68](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L68)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -68,3 +68,13 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/editGroup.feature:23](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L23)
 - [apiGraph/editGroup.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L24)
 - [apiGraph/editGroup.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L25)
+
+#### [CORS headers are not identical with oC10 headers](https://github.com/owncloud/ocis/issues/5195)
+- [apiCors/cors.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L24)
+- [apiCors/cors.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L25)
+- [apiCors/cors.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L26)
+- [apiCors/cors.feature:27](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L27)
+
+#### [Requests with invalid credentials do not return CORS headers](https://github.com/owncloud/ocis/issues/5194)
+- [apiCors/cors.feature:68](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L68)
+- [apiCors/cors.feature:69](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiCors/cors.feature#L69)

--- a/tests/acceptance/features/apiCors/cors.feature
+++ b/tests/acceptance/features/apiCors/cors.feature
@@ -1,3 +1,5 @@
+# NOTE: for running this feature locally, you need to run oCIS with the following env var:
+# CORS_ALLOWED_ORIGINS=https://aphno.badal
 @api @skipOnOcV10
 Feature: CORS headers
 
@@ -26,7 +28,7 @@ Feature: CORS headers
       | 2               | /apps/files_sharing/api/v1/shares | 200      | 200       |
 
 
-  Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header
+  Scenario Outline: CORS headers should not be returned when CORS domain does not match Origin header
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
       | header | value               |
@@ -47,13 +49,13 @@ Feature: CORS headers
       | 2               | /apps/files_sharing/api/v1/shares | 200      | 200       |
 
 
-  Scenario Outline: CORS headers should be returned when invalid password is used
+  Scenario Outline: CORS headers should be returned when an invalid password is used
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
       | header | value               |
       | Origin | https://aphno.badal |
-    Then the OCS status code should be "<ocs-code>"
-    And the HTTP status code should be "<http-code>"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
     And the following headers should be set
       | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
       | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,OC-RequestAppPassword,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,Cache-Control,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
@@ -61,6 +63,6 @@ Feature: CORS headers
       | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
       | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
     Examples:
-      | ocs_api_version | endpoint                          | ocs-code | http-code |
-      | 1               | /apps/files_sharing/api/v1/shares | 997      | 401       |
-      | 2               | /apps/files_sharing/api/v1/shares | 997      | 401       |
+      | ocs_api_version | endpoint                          |
+      | 1               | /apps/files_sharing/api/v1/shares |
+      | 2               | /apps/files_sharing/api/v1/shares |

--- a/tests/acceptance/features/apiCors/cors.feature
+++ b/tests/acceptance/features/apiCors/cors.feature
@@ -1,0 +1,66 @@
+@api @skipOnOcV10
+Feature: CORS headers
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
+      | header | value               |
+      | Origin | https://aphno.badal |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    And the following headers should be set
+      | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,OC-RequestAppPassword,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,Cache-Control,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,OC-RequestAppPassword,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+    Examples:
+      | ocs_api_version | endpoint                          | ocs-code | http-code |
+      | 1               | /config                           | 100      | 200       |
+      | 2               | /config                           | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/shares | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/shares | 200      | 200       |
+
+
+  Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
+      | header | value               |
+      | Origin | https://mero.badal  |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    And the following headers should not be set
+      | header                        |
+      | Access-Control-Allow-Headers  |
+      | Access-Control-Expose-Headers |
+      | Access-Control-Allow-Origin   |
+      | Access-Control-Allow-Methods  |
+    Examples:
+      | ocs_api_version | endpoint                          | ocs-code | http-code |
+      | 1               | /config                           | 100      | 200       |
+      | 2               | /config                           | 200      | 200       |
+      | 1               | /apps/files_sharing/api/v1/shares | 100      | 200       |
+      | 2               | /apps/files_sharing/api/v1/shares | 200      | 200       |
+
+
+  Scenario Outline: CORS headers should be returned when invalid password is used
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
+      | header | value               |
+      | Origin | https://aphno.badal |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    And the following headers should be set
+      | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,OC-RequestAppPassword,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,Cache-Control,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,OC-RequestAppPassword,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+    Examples:
+      | ocs_api_version | endpoint                          | ocs-code | http-code |
+      | 1               | /apps/files_sharing/api/v1/shares | 997      | 401       |
+      | 2               | /apps/files_sharing/api/v1/shares | 997      | 401       |


### PR DESCRIPTION
## Description
Skipping core CORS API tests in https://github.com/owncloud/core/pull/40527
So adding cors tests locally here.

## Related Issue
- part of https://github.com/owncloud/core/issues/40104
- Depends on: https://github.com/owncloud/core/pull/40527

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
