### PR TITLE
[tests-only] Fix stable ci 2

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -266,7 +266,7 @@ def main(ctx):
             pipelines + \
             pipelinesDependsOn(
                 example_deploys(ctx),
-                pipelines,
+                [purgeBuildArtifactCache(ctx)],
             )
 
     # always append notification step
@@ -1322,7 +1322,7 @@ def dockerRelease(ctx, arch):
         "REVISION=%s" % (ctx.build.commit),
         "VERSION=%s" % (ctx.build.ref.replace("refs/tags/", "") if ctx.build.event == "tag" else "latest"),
     ]
-    depends_on = getPipelineNames(testOcisModules(ctx) + testPipelines(ctx))
+    depends_on = getPipelineNames([purgeBuildArtifactCache(ctx)])
 
     if ctx.build.event == "tag":
         depends_on = []
@@ -1411,7 +1411,7 @@ def binaryReleases(ctx):
 def binaryRelease(ctx, name):
     # uploads binary to https://download.owncloud.com/ocis/ocis/daily/
     target = "/ocis/%s/daily" % (ctx.repo.name.replace("ocis-", ""))
-    depends_on = getPipelineNames(testOcisModules(ctx) + testPipelines(ctx))
+    depends_on = getPipelineNames([purgeBuildArtifactCache(ctx)])
     if ctx.build.event == "tag":
         # uploads binary to eg. https://download.owncloud.com/ocis/ocis/1.0.0-beta9/
         folder = "stable"


### PR DESCRIPTION
## Description

Fix CI on stable-2.0 branch

## Motivation and Context
Drone was not running on the stable-2.0 branch because we were exceeding the `depends_on` limit.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
