### PR TITLE
corrected storagedrives.md path in the doc

### DIFF
--- a/docs/ocis/storage/storagedrivers.md
+++ b/docs/ocis/storage/storagedrivers.md
@@ -4,7 +4,7 @@ date: 2020-04-27T18:46:00+01:00
 weight: 12
 geekdocRepo: https://github.com/owncloud/ocis
 geekdocEditPath: edit/master/docs/ocis/storage
-geekdocFilePath: storages.md
+geekdocFilePath: storagedrivers.md
 ---
 
 A *storage driver* implements access to a [*storage system*]({{< ref "#storage-systems" >}}):


### PR DESCRIPTION
Corrected path in docs Storage drivers section `<a href="https://github.com/owncloud/ocis/edit/master/docs/ocis/storage/storages.md">Edit page</a>` to `<a href="https://github.com/owncloud/ocis/edit/master/docs/ocis/storage/storagedrivers">Edit page</a>`
