### PR TITLE
Ocis with eos

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,8 @@
                 "GATEWAY_STORAGE_USERS_MOUNT_ID": "storage-users-1",
                 "STORAGE_USERS_MOUNT_ID": "storage-users-1",
                 // graph application ID
-                "GRAPH_APPLICATION_ID": "application-1"
+                "GRAPH_APPLICATION_ID": "application-1",
+                "STORAGE_USERS_EOSFS_KEYTAB": "${env:HOME}/eos.keytab",
             }
         }
     ]

--- a/services/gateway/pkg/revaconfig/config.go
+++ b/services/gateway/pkg/revaconfig/config.go
@@ -129,8 +129,8 @@ func spacesProviders(cfg *config.Config, logger log.Logger) map[string]map[strin
 			"providerid": cfg.StorageRegistry.StorageUsersMountID,
 			"spaces": map[string]interface{}{
 				"personal": map[string]interface{}{
-					"mount_point":   "/users",
-					"path_template": "/users/{{.Space.Owner.Id.OpaqueId}}",
+					"mount_point":   "/",
+					"path_template": "/{{.Space.Owner.Id.OpaqueId}}",
 				},
 				"project": map[string]interface{}{
 					"mount_point":   "/projects",

--- a/services/gateway/pkg/revaconfig/config.go
+++ b/services/gateway/pkg/revaconfig/config.go
@@ -129,8 +129,8 @@ func spacesProviders(cfg *config.Config, logger log.Logger) map[string]map[strin
 			"providerid": cfg.StorageRegistry.StorageUsersMountID,
 			"spaces": map[string]interface{}{
 				"personal": map[string]interface{}{
-					"mount_point":   "/",
-					"path_template": "/{{.Space.Owner.Id.OpaqueId}}",
+					"mount_point":   "/users",
+					"path_template": "/users/{{.Space.Owner.Username}}",
 				},
 				"project": map[string]interface{}{
 					"mount_point":   "/projects",

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -478,12 +478,8 @@ func (g Graph) formatDrives(ctx context.Context, baseURL *url.URL, storageSpaces
 		// can't access disabled space
 		if utils.ReadPlainFromOpaque(storageSpace.Opaque, "trashed") != "trashed" {
 			res.Special = g.getExtendedSpaceProperties(ctx, baseURL, storageSpace)
-			quota, err := g.getDriveQuota(ctx, storageSpace)
-			res.Quota = &quota
-			if err != nil {
-				//TODO: Handle error
-				//return nil, err
-			}
+		} else {
+			res.Quota = nil
 		}
 		responses = append(responses, res)
 	}

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -481,8 +481,8 @@ func (g Graph) formatDrives(ctx context.Context, baseURL *url.URL, storageSpaces
 			quota, err := g.getDriveQuota(ctx, storageSpace)
 			res.Quota = &quota
 			if err != nil {
-				//logger.Debug().Err(err).Interface("id", sp.Id).Msg("error calling get quota on drive")
-				return nil, err
+				//TODO: Handle error
+				//return nil, err
 			}
 		}
 		responses = append(responses, res)

--- a/services/idm/ldif/base.ldif.tmpl
+++ b/services/idm/ldif/base.ldif.tmpl
@@ -36,6 +36,8 @@ objectClass: account
 objectClass: simpleSecurityObject
 uid: {{ .Name }}
 {{ end -}}
+uidNumber: {{ .UidNumber }}
+gidNumber: {{ .GidNumber }}
 userPassword:: {{ .Password }}
 
 {{ end -}}

--- a/services/idm/ldif/demousers.ldif
+++ b/services/idm/ldif/demousers.ldif
@@ -5,6 +5,8 @@ objectClass: ownCloud
 objectClass: person
 objectClass: top
 uid: einstein
+uidNumber: 2100
+gidNumber: 2100
 givenName: Albert
 sn: Einstein
 cn: einstein
@@ -25,6 +27,8 @@ uid: marie
 givenName: Marie
 sn: Curie
 cn: marie
+uidNumber: 2101
+gidNumber: 2101
 displayName: Marie Skłodowska Curie
 description: A Polish and naturalized-French physicist and chemist who conducted pioneering research on radioactivity.
 mail: marie@example.org
@@ -39,6 +43,8 @@ objectClass: ownCloud
 objectClass: person
 objectClass: top
 uid: katherine
+uidNumber: 2102
+gidNumber: 2102
 givenName: Katherine
 sn: Johnson
 cn: katherine
@@ -56,6 +62,8 @@ objectClass: ownCloud
 objectClass: person
 objectClass: top
 uid: richard
+uidNumber: 2103
+gidNumber: 2103
 givenName: Richard
 sn: Feynman
 cn: richard
@@ -73,6 +81,8 @@ objectClass: ownCloud
 objectClass: person
 objectClass: top
 uid: moss
+uidNumber: 2104
+gidNumber: 2104
 givenName: Maurice
 sn: Moss
 cn: moss

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -85,28 +85,38 @@ func bootstrap(logger log.Logger, cfg *config.Config, srvcfg server.Config) erro
 	var err error
 
 	type svcUser struct {
-		Name     string
-		Password string
-		ID       string
+		Name      string
+		Password  string
+		ID        string
+		UidNumber int
+		GidNumber int
 	}
 
 	serviceUsers := []svcUser{
 		{
-			Name:     "admin",
-			Password: cfg.ServiceUserPasswords.OcisAdmin,
-			ID:       cfg.AdminUserID,
+			Name:      "admin",
+			Password:  cfg.ServiceUserPasswords.OcisAdmin,
+			ID:        cfg.AdminUserID,
+			UidNumber: 2000,
+			GidNumber: 2000,
 		},
 		{
-			Name:     "libregraph",
-			Password: cfg.ServiceUserPasswords.Idm,
+			Name:      "libregraph",
+			Password:  cfg.ServiceUserPasswords.Idm,
+			UidNumber: 2001,
+			GidNumber: 2001,
 		},
 		{
-			Name:     "idp",
-			Password: cfg.ServiceUserPasswords.Idp,
+			Name:      "idp",
+			Password:  cfg.ServiceUserPasswords.Idp,
+			UidNumber: 2002,
+			GidNumber: 2002,
 		},
 		{
-			Name:     "reva",
-			Password: cfg.ServiceUserPasswords.Reva,
+			Name:      "reva",
+			Password:  cfg.ServiceUserPasswords.Reva,
+			UidNumber: 2003,
+			GidNumber: 2003,
 		},
 	}
 

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -190,7 +190,7 @@ type EOSDriver struct {
 	// SecProtocol specifies the xrootd security protocol to use between the server and EOS.
 	SecProtocol string `yaml:"sec_protocol"`
 	// Keytab specifies the location of the keytab to use to authenticate to EOS.
-	Keytab string `yaml:"keytab"`
+	Keytab string `yaml:"keytab" env:"STORAGE_USERS_EOSFS_KEYTAB"`
 	// SingleUsername is the username to use when SingleUserMode is enabled
 	SingleUsername string `yaml:"single_username"`
 	// Enables logging of the commands executed

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -213,7 +213,7 @@ type EOSDriver struct {
 	// ForceSingleUserMode will force connections to EOS to use SingleUsername
 	ForceSingleUserMode bool `yaml:"force_single_user_mode"`
 	// UseKeyTabAuth changes will authenticate requests by using an EOS keytab.
-	UseKeytab bool `yaml:"user_keytab"`
+	UseKeytab bool `yaml:"use_keytab"`
 	// gateway service to use for uid lookups
 	GatewaySVC string `yaml:"gateway_svc"`
 	//ShareFolder defines the name of the folder jailing all shares

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -165,6 +165,17 @@ type S3Driver struct {
 	Endpoint  string `yaml:"endpoint"`
 	Bucket    string `yaml:"bucket"`
 }
+
+type SpacesDbConfig struct {
+	Enabled    bool   `mapstructure:"enabled" yaml:"enabled" env:"STORAGE_USERS_EOSFS_SPACES_ENABLED" desc:"Enables the spaces config for eosfs driver."`
+	DbUsername string `mapstructure:"db_username" yaml:"db_username" env:"STORAGE_USERS_EOSFS_SPACES_DBUSERNAME" desc:"eosfs storage space database username."`
+	DbPassword string `mapstructure:"db_password" yaml:"db_password" env:"STORAGE_USERS_EOSFS_SPACES_DBPASSWORD" desc:"eosfs storage space database password."`
+	DbHost     string `mapstructure:"db_host" yaml:"db_host" env:"STORAGE_USERS_EOSFS_SPACES_DBHOST" desc:"eosfs storage space database host."`
+	DbName     string `mapstructure:"db_name" yaml:"db_name" env:"STORAGE_USERS_EOSFS_SPACES_DBNAME" desc:"eosfs storage space database name."`
+	DbTable    string `mapstructure:"db_table" yaml:"db_table" env:"STORAGE_USERS_EOSFS_SPACES_DBTABLENAME" desc:"eosfs storage space database talbe name."`
+	DbPort     int    `mapstructure:"db_port" yaml:"db_port" env:"STORAGE_USERS_EOSFS_SPACES_DBPORT" desc:"eosfs storage space database port."`
+}
+
 type EOSDriver struct {
 	// Root is the absolute path to the location of the data
 	Root string `yaml:"root"`
@@ -206,10 +217,11 @@ type EOSDriver struct {
 	// gateway service to use for uid lookups
 	GatewaySVC string `yaml:"gateway_svc"`
 	//ShareFolder defines the name of the folder jailing all shares
-	ShareFolder string `yaml:"share_folder"`
-	GRPCURI     string
-	GRPCAuthKey string `yaml:"grpc_authkey" env:"STORAGE_USERS_EOSFS_GRPC_AUTHKEY" desc:"The token used to authenticate the grpc requests."`
-	UserLayout  string
+	ShareFolder  string `yaml:"share_folder"`
+	GRPCURI      string
+	GRPCAuthKey  string `yaml:"grpc_authkey" env:"STORAGE_USERS_EOSFS_GRPC_AUTHKEY" desc:"The token used to authenticate the grpc requests."`
+	UserLayout   string
+	SpacesConfig SpacesDbConfig `yaml:"spaces_config"`
 }
 
 type LocalDriver struct {

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -219,8 +219,8 @@ type EOSDriver struct {
 	//ShareFolder defines the name of the folder jailing all shares
 	ShareFolder  string `yaml:"share_folder"`
 	GRPCURI      string
-	GRPCAuthKey  string `yaml:"grpc_authkey" env:"STORAGE_USERS_EOSFS_GRPC_AUTHKEY" desc:"The token used to authenticate the grpc requests."`
-	UserLayout   string
+	GRPCAuthKey  string         `yaml:"grpc_authkey" env:"STORAGE_USERS_EOSFS_GRPC_AUTHKEY" desc:"The token used to authenticate the grpc requests."`
+	UserLayout   string         `yaml:"user_layout" env:"STORAGE_USERS_EOSFS_USER_LAYOUT" desc:"Template string for the user storage layout in the user directory."`
 	SpacesConfig SpacesDbConfig `yaml:"spaces_config"`
 }
 

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -208,6 +208,7 @@ type EOSDriver struct {
 	//ShareFolder defines the name of the folder jailing all shares
 	ShareFolder string `yaml:"share_folder"`
 	GRPCURI     string
+	GRPCAuthKey string `yaml:"grpc_authkey" env:"STORAGE_USERS_EOSFS_GRPC_AUTHKEY" desc:"The token used to authenticate the grpc requests."`
 	UserLayout  string
 }
 

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -80,7 +80,7 @@ func DefaultConfig() *config.Config {
 			},
 			EOS: config.EOSDriver{
 				GRPCURI:   "localhost:50051",
-				MasterURL: "http://localhost:9158/data",
+				MasterURL: "http://localhost:8000",
 				//SingleUsername:      "3f44740b-f40f-4f05-a1d4-d6f3bbc1677e",
 				//ForceSingleUserMode: true,
 				Root: "/ocis",

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -91,6 +91,15 @@ func DefaultConfig() *config.Config {
 				MasterURL:     "root://localhost:1094",
 				XrdcopyBinary: "/usr/bin/xrdcopy",
 				Root:          "/ocis",
+				SpacesConfig: config.SpacesDbConfig{
+					Enabled:    true,
+					DbUsername: "root",
+					DbPassword: "",
+					DbHost:     "localhost",
+					DbName:     "eosspaces",
+					DbTable:    "projectspaces",
+					DbPort:     3306,
+				},
 			},
 		},
 		Events: config.Events{

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -90,7 +90,7 @@ func DefaultConfig() *config.Config {
 				SecProtocol:   "sss",
 				MasterURL:     "root://localhost:1094",
 				XrdcopyBinary: "/usr/bin/xrdcopy",
-				Root:          "/ocis",
+				Root:          "/o/c/is",
 				SpacesConfig: config.SpacesDbConfig{
 					Enabled:    true,
 					DbUsername: "root",

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -42,7 +42,7 @@ func DefaultConfig() *config.Config {
 		DataGatewayURL:   "https://localhost:9200/data",
 		TransferExpires:  86400,
 		UploadExpiration: 24 * 60 * 60,
-		Driver:           "eosgrpc",
+		Driver:           "eos",
 		//Driver: "ocis",
 		Drivers: config.Drivers{
 			OwnCloudSQL: config.OwnCloudSQLDriver{
@@ -79,11 +79,18 @@ func DefaultConfig() *config.Config {
 				LockCycleDurationFactor:    30,
 			},
 			EOS: config.EOSDriver{
-				GRPCURI:   "localhost:50051",
-				MasterURL: "http://localhost:8000",
-				//SingleUsername:      "3f44740b-f40f-4f05-a1d4-d6f3bbc1677e",
-				//ForceSingleUserMode: true,
-				Root: "/ocis",
+				// GRPC config
+				// GRPCURI:   "localhost:50051",
+				// MasterURL: "http://localhost:8000",
+				// Root:          "/ocis",
+
+				// Binary  config
+				UseKeytab:     true,
+				Keytab:        "/etc/eos/eos.keytab",
+				SecProtocol:   "sss",
+				MasterURL:     "root://localhost:1094",
+				XrdcopyBinary: "/usr/bin/xrdcopy",
+				Root:          "/ocis",
 			},
 		},
 		Events: config.Events{

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -83,7 +83,7 @@ func DefaultConfig() *config.Config {
 				MasterURL: "http://localhost:9158/data",
 				//SingleUsername:      "3f44740b-f40f-4f05-a1d4-d6f3bbc1677e",
 				//ForceSingleUserMode: true,
-				Root: "ocis",
+				Root: "/ocis",
 			},
 		},
 		Events: config.Events{

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -42,7 +42,8 @@ func DefaultConfig() *config.Config {
 		DataGatewayURL:   "https://localhost:9200/data",
 		TransferExpires:  86400,
 		UploadExpiration: 24 * 60 * 60,
-		Driver:           "ocis",
+		Driver:           "eosgrpc",
+		//Driver: "ocis",
 		Drivers: config.Drivers{
 			OwnCloudSQL: config.OwnCloudSQLDriver{
 				Root:                  filepath.Join(defaults.BaseDataPath(), "storage", "owncloud"),
@@ -76,6 +77,13 @@ func DefaultConfig() *config.Config {
 				PermissionsEndpoint:        "127.0.0.1:9191",
 				MaxAcquireLockCycles:       20,
 				LockCycleDurationFactor:    30,
+			},
+			EOS: config.EOSDriver{
+				GRPCURI:   "localhost:50051",
+				MasterURL: "http://localhost:9158/data",
+				//SingleUsername:      "3f44740b-f40f-4f05-a1d4-d6f3bbc1677e",
+				//ForceSingleUserMode: true,
+				Root: "ocis",
 			},
 		},
 		Events: config.Events{

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -17,6 +17,7 @@ func EOS(cfg *config.Config) map[string]interface{} {
 		"sec_protocol":           cfg.Drivers.EOS.SecProtocol,
 		"keytab":                 cfg.Drivers.EOS.Keytab,
 		"single_username":        cfg.Drivers.EOS.SingleUsername,
+		"user_layout":            cfg.Drivers.EOS.UserLayout,
 		"enable_logging":         cfg.Drivers.EOS.EnableLogging,
 		"show_hidden_sys_files":  cfg.Drivers.EOS.ShowHiddenSysFiles,
 		"force_single_user_mode": cfg.Drivers.EOS.ForceSingleUserMode,

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -46,6 +46,7 @@ func EOSHome(cfg *config.Config) map[string]interface{} {
 		"force_single_user_mode": cfg.Drivers.EOS.ForceSingleUserMode,
 		"use_keytab":             cfg.Drivers.EOS.UseKeytab,
 		"gatewaysvc":             cfg.Drivers.EOS.GatewaySVC,
+		"spaces_config":          cfg.Drivers.EOS.SpacesConfig,
 	}
 }
 
@@ -71,6 +72,7 @@ func EOSGRPC(cfg *config.Config) map[string]interface{} {
 		"use_keytab":             cfg.Drivers.EOS.UseKeytab,
 		"enable_home":            false,
 		"gatewaysvc":             cfg.Drivers.EOS.GatewaySVC,
+		"spaces_config":          cfg.Drivers.EOS.SpacesConfig,
 	}
 }
 


### PR DESCRIPTION
## Draft to run ocis with eos

To run eos-powered ocis:
- start eos as described here: https://gitlab.cern.ch/eos/eos-charts
- scale down the fst statefulset to just one replica
```
kubectl scale statefulsets eos-fst --replicas=1
```
- make sure that the fst service can be resolved, e.g.
```
echo "127.0.0.1       eos-fst-0.eos-fst.default.svc.cluster.local" >> /etc/hosts
```
- forward port 50051(for grpc) and 8000 (for http) to the mgm, 8001 (for http) to fst
```
kubectl port-forward pods/eos-mgm-0 8000
kubectl port-forward pods/eos-fst-0 8001
```
- Enable checksums in the default space
```
kubectl exec pods/eos-mgm-0 -c eos-mgm -- eos space config default space.policy.checksum=adler
```
- Grant eos sudo rights to the user with uid 0
```
kubectl exec -it pods/eos-mgm-0 -c eos-mgm -- bash -c 'eos vid set membership 0 +sudo'
```

### For xrootd based access:

- Forward the xroot ports
```
kubectl port-forward pods/eos-mgm-0 1094
kubectl port-forward pods/eos-fst-0 1095
```
- Create a keytab file and make it known to the eos binary driver
```
keytabfile=~/eos.keytab
cat >$keytabfile <<EOF
0 u:eosnobody g:eosnobody n:eosnobody-test+ N:6964297016721539074 c:1621501757 e:0 f:0 k:f3b1aa51cba0367f77892e1754385fcc0dfed1f5c19a4122519d2e6cf0dd2a0d
0 u:daemon g:daemon n:eos-charts+ N:6977744108353748993 c:1624632652 e:0 f:0 k:a1c27792adc9e2aa476283bf1bb7983499923abceeeff969c0bda1621a9e5d4b
EOF
chmod 600 $keytabfile
export STORAGE_USERS_EOSFS_KEYTAB=$keytabfile
```

### For grpc based access:
- Forward the grpc port to the mgm pod
```
kubectl port-forward pods/eos-mgm-0 50051
```
- Set up an authkey for root access via grpc
```
kubectl exec pods/eos-mgm-0 -c eos-mgm -- eos vid add gateway "127.0.0.1" grpc
kubectl exec pods/eos-mgm-0 -c eos-mgm -- eos vid add gateway "[:1]" grpc
kubectl exec pods/eos-mgm-0 -c eos-mgm -- eos vid add gateway "[::1]" grpc
kubectl exec pods/eos-mgm-0 -c eos-mgm -- bash -c 'authkey=`uuidgen`; eos vid set map -grpc key:$authkey vuid:0; eos vid set map -grpc key:$authkey vgid:0; echo "authkey: $authkey"'
```
and pass the generated authkey to ocis using the `STORAGE_USERS_EOSFS_GRPC_AUTHKEY` env variable.


- start ocis from this branch