### PR TITLE
align revactx package import

### DIFF
--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -18,7 +18,7 @@ import (
 	cs3rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/go-chi/chi/v5"
@@ -218,7 +218,7 @@ func (g Graph) canCreateSpace(ctx context.Context, ownPersonalHome bool) bool {
 func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("calling create drive")
-	us, ok := ctxpkg.ContextGetUser(r.Context())
+	us, ok := revactx.ContextGetUser(r.Context())
 	if !ok {
 		logger.Debug().Msg("could not create drive: invalid user")
 		errorcode.NotAllowed.Render(w, r, http.StatusUnauthorized, "invalid user")
@@ -397,7 +397,7 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if drive.Quota.HasTotal() {
-		user := ctxpkg.ContextMustGetUser(r.Context())
+		user := revactx.ContextMustGetUser(r.Context())
 		canSetSpaceQuota, err := g.canSetSpaceQuota(r.Context(), user)
 		if err != nil {
 			logger.Error().Err(err).Msg("could not update drive: failed to check if the user can set space quota")

--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -16,7 +16,7 @@ import (
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/go-chi/chi/v5"
@@ -57,7 +57,7 @@ var _ = Describe("Graph", func() {
 	BeforeEach(func() {
 		rr = httptest.NewRecorder()
 
-		ctx = ctxpkg.ContextSetUser(context.Background(), &userprovider.User{Id: &userprovider.UserId{Type: userprovider.UserType_USER_TYPE_PRIMARY, OpaqueId: "testuser"}, Username: "testuser"})
+		ctx = revactx.ContextSetUser(context.Background(), &userprovider.User{Id: &userprovider.UserId{Type: userprovider.UserType_USER_TYPE_PRIMARY, OpaqueId: "testuser"}, Username: "testuser"})
 		cfg = defaults.FullDefaultConfig()
 		cfg.Identity.LDAP.CACert = "" // skip the startup checks, we don't use LDAP at all in this tests
 		cfg.TokenManager.JWTSecret = "loremipsum"
@@ -741,7 +741,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.GetSingleDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNotFound))
 		})
@@ -771,7 +771,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.GetSingleDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
 		})
@@ -785,7 +785,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.GetSingleDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNotFound))
 		})
@@ -821,7 +821,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.GetSingleDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
@@ -860,7 +860,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.GetSingleDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
@@ -921,7 +921,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.GetSingleDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
@@ -953,7 +953,7 @@ var _ = Describe("Graph", func() {
 			r = httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.UpdateDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -962,7 +962,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBufferString("{invalid"))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.UpdateDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -985,7 +985,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBuffer(driveJson))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.UpdateDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
@@ -1011,7 +1011,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBuffer(driveJson))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			r.Header.Add("Restore", "1")
 			svc.UpdateDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -1045,7 +1045,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBuffer(driveJson))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.UpdateDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
@@ -1064,7 +1064,7 @@ var _ = Describe("Graph", func() {
 			r = httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.DeleteDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -1077,7 +1077,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.DeleteDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
 
@@ -1094,7 +1094,7 @@ var _ = Describe("Graph", func() {
 			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			r.Header.Add("Purge", "1")
 			svc.DeleteDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNoContent))

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -13,7 +13,7 @@ import (
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -89,7 +89,7 @@ func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if grp != nil && grp.Id != nil {
-		currentUser := ctxpkg.ContextMustGetUser(r.Context())
+		currentUser := revactx.ContextMustGetUser(r.Context())
 		g.publishEvent(events.GroupCreated{Executant: currentUser.Id, GroupID: *grp.Id})
 	}
 	render.Status(r, http.StatusOK)
@@ -239,7 +239,7 @@ func (g Graph) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentUser := ctxpkg.ContextMustGetUser(r.Context())
+	currentUser := revactx.ContextMustGetUser(r.Context())
 	g.publishEvent(events.GroupDeleted{Executant: currentUser.Id, GroupID: groupID})
 	render.Status(r, http.StatusNoContent)
 	render.NoContent(w, r)
@@ -344,7 +344,7 @@ func (g Graph) PostGroupMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentUser := ctxpkg.ContextMustGetUser(r.Context())
+	currentUser := revactx.ContextMustGetUser(r.Context())
 	g.publishEvent(events.GroupMemberAdded{Executant: currentUser.Id, GroupID: groupID, UserID: id})
 	render.Status(r, http.StatusNoContent)
 	render.NoContent(w, r)
@@ -395,7 +395,7 @@ func (g Graph) DeleteGroupMember(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	currentUser := ctxpkg.ContextMustGetUser(r.Context())
+	currentUser := revactx.ContextMustGetUser(r.Context())
 	g.publishEvent(events.GroupMemberRemoved{Executant: currentUser.Id, GroupID: groupID, UserID: memberID})
 	render.Status(r, http.StatusNoContent)
 	render.NoContent(w, r)

--- a/services/graph/pkg/service/v0/groups_test.go
+++ b/services/graph/pkg/service/v0/groups_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -177,7 +177,7 @@ var _ = Describe("Groups", func() {
 			r = httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", "")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 			svc.GetGroup(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -192,7 +192,7 @@ var _ = Describe("Groups", func() {
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups/"+*newGroup.Id, nil)
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
-				r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
 
 				svc.GetGroup(rr, r)
 
@@ -256,7 +256,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups/", bytes.NewBufferString("{invalid"))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PatchGroup(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -270,7 +270,7 @@ var _ = Describe("Groups", func() {
 			r = httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", "")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PatchGroup(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -292,7 +292,7 @@ var _ = Describe("Groups", func() {
 				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
-				r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 				svc.PatchGroup(rr, r)
 
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -308,7 +308,7 @@ var _ = Describe("Groups", func() {
 				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
-				r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 				svc.PatchGroup(rr, r)
 
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -324,7 +324,7 @@ var _ = Describe("Groups", func() {
 				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
-				r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 				svc.PatchGroup(rr, r)
 
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -342,7 +342,7 @@ var _ = Describe("Groups", func() {
 				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
-				r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 				svc.PatchGroup(rr, r)
 
 				Expect(rr.Code).To(Equal(http.StatusNoContent))
@@ -363,7 +363,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.DeleteGroup(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
@@ -381,7 +381,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups/{groupID}/members", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.GetGroupMembers(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
@@ -402,7 +402,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBufferString("{invalid"))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PostGroupMember(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -415,7 +415,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PostGroupMember(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -429,7 +429,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PostGroupMember(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -444,7 +444,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PostGroupMember(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
 
@@ -457,7 +457,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/groups/{groupID}/members/{memberID}/$ref", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.DeleteGroupMember(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -465,7 +465,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/groups/{groupID}/members/{memberID}/$ref", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("memberID", "/users/user")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.DeleteGroupMember(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -477,7 +477,7 @@ var _ = Describe("Groups", func() {
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			rctx.URLParams.Add("memberID", "/users/user1")
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.DeleteGroupMember(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
 

--- a/services/graph/pkg/service/v0/password.go
+++ b/services/graph/pkg/service/v0/password.go
@@ -8,7 +8,6 @@ import (
 	"github.com/CiscoM31/godata"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	cs3rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/go-chi/render"
@@ -91,7 +90,7 @@ func (g Graph) ChangeOwnPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentUser := ctxpkg.ContextMustGetUser(r.Context())
+	currentUser := revactx.ContextMustGetUser(r.Context())
 	g.publishEvent(
 		events.UserFeatureChanged{
 			Executant: currentUser.Id,

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -13,7 +13,6 @@ import (
 	"github.com/CiscoM31/godata"
 	cs3rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
@@ -177,7 +176,7 @@ func (g Graph) PostUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentUser := ctxpkg.ContextMustGetUser(r.Context())
+	currentUser := revactx.ContextMustGetUser(r.Context())
 	g.publishEvent(events.UserCreated{Executant: currentUser.Id, UserID: *u.Id})
 
 	render.Status(r, http.StatusOK)
@@ -308,7 +307,7 @@ func (g Graph) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentUser := ctxpkg.ContextMustGetUser(r.Context())
+	currentUser := revactx.ContextMustGetUser(r.Context())
 
 	if currentUser.GetId().GetOpaqueId() == user.GetId() {
 		logger.Debug().Msg("could not delete user: self deletion forbidden")
@@ -444,7 +443,7 @@ func (g Graph) PatchUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	currentUser := ctxpkg.ContextMustGetUser(r.Context())
+	currentUser := revactx.ContextMustGetUser(r.Context())
 	g.publishEvent(
 		events.UserFeatureChanged{
 			Executant: currentUser.Id,

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -11,7 +11,7 @@ import (
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
 	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
@@ -88,7 +88,7 @@ var _ = Describe("Users", func() {
 
 		It("gets the information", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me", nil)
-			r = r.WithContext(ctxpkg.ContextSetUser(ctx, currentUser))
+			r = r.WithContext(revactx.ContextSetUser(ctx, currentUser))
 			svc.GetMe(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -99,7 +99,7 @@ var _ = Describe("Users", func() {
 			identityBackend.On("GetUser", mock.Anything, mock.Anything, mock.Anything).Return(user, nil)
 
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me?$expand=memberOf", nil)
-			r = r.WithContext(ctxpkg.ContextSetUser(ctx, currentUser))
+			r = r.WithContext(revactx.ContextSetUser(ctx, currentUser))
 			svc.GetMe(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -234,7 +234,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", *user.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.GetUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -275,7 +275,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users?$expand=drive", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", *user.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.GetUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -310,7 +310,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users?$expand=drives", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", *user.Id)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.GetUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -390,7 +390,7 @@ var _ = Describe("Users", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users", bytes.NewBuffer(userJson))
-			r = r.WithContext(ctxpkg.ContextSetUser(ctx, currentUser))
+			r = r.WithContext(revactx.ContextSetUser(ctx, currentUser))
 			svc.PostUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -413,7 +413,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/users/{userid}", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", currentUser.Id.OpaqueId)
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.DeleteUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusForbidden))
@@ -449,7 +449,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/users/{userid}", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", lu.GetId())
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.DeleteUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
@@ -483,7 +483,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users?$invalid=true", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", user.GetId())
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PatchUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -497,7 +497,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users?$invalid=true", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", user.GetId())
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PatchUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -513,7 +513,7 @@ var _ = Describe("Users", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users?$invalid=true", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", user.GetId())
-			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.PatchUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))

--- a/services/notifications/pkg/service/service.go
+++ b/services/notifications/pkg/service/service.go
@@ -13,7 +13,7 @@ import (
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
@@ -93,7 +93,7 @@ func (s eventsNotifier) handleSpaceShared(e events.SpaceShared) {
 	}
 
 	// Get auth context
-	ownerCtx := ctxpkg.ContextSetUser(context.Background(), sharerUserResponse.User)
+	ownerCtx := revactx.ContextSetUser(context.Background(), sharerUserResponse.User)
 	authRes, err := s.gwClient.Authenticate(ownerCtx, &gateway.AuthenticateRequest{
 		Type:         "machine",
 		ClientId:     "userid:" + e.Executant.OpaqueId,
@@ -114,7 +114,7 @@ func (s eventsNotifier) handleSpaceShared(e events.SpaceShared) {
 			Msg("could not get authenticated context for user")
 		return
 	}
-	ownerCtx = metadata.AppendToOutgoingContext(ownerCtx, ctxpkg.TokenHeader, authRes.Token)
+	ownerCtx = metadata.AppendToOutgoingContext(ownerCtx, revactx.TokenHeader, authRes.Token)
 
 	resourceID, err := storagespace.ParseID(e.ID.OpaqueId)
 	if err != nil {
@@ -251,7 +251,7 @@ func (s eventsNotifier) handleShareCreated(e events.ShareCreated) {
 	}
 
 	// Get auth context
-	ownerCtx := ctxpkg.ContextSetUser(context.Background(), sharerUserResponse.User)
+	ownerCtx := revactx.ContextSetUser(context.Background(), sharerUserResponse.User)
 	authRes, err := s.gwClient.Authenticate(ownerCtx, &gateway.AuthenticateRequest{
 		Type:         "machine",
 		ClientId:     "userid:" + e.Sharer.OpaqueId,
@@ -272,7 +272,7 @@ func (s eventsNotifier) handleShareCreated(e events.ShareCreated) {
 			Msg("could not get authenticated context for user")
 		return
 	}
-	ownerCtx = metadata.AppendToOutgoingContext(ownerCtx, ctxpkg.TokenHeader, authRes.Token)
+	ownerCtx = metadata.AppendToOutgoingContext(ownerCtx, revactx.TokenHeader, authRes.Token)
 
 	// TODO: maybe cache this stat to reduce storage iops
 	md, err := s.gwClient.Stat(ownerCtx, &providerv1beta1.StatRequest{

--- a/services/search/pkg/search/provider/events.go
+++ b/services/search/pkg/search/provider/events.go
@@ -10,7 +10,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
@@ -185,7 +185,7 @@ func (p *Provider) getPath(ctx context.Context, id *provider.ResourceId, owner *
 }
 
 func (p *Provider) getAuthContext(owner *user.User) (context.Context, error) {
-	ownerCtx := ctxpkg.ContextSetUser(context.Background(), owner)
+	ownerCtx := revactx.ContextSetUser(context.Background(), owner)
 	authRes, err := p.gwClient.Authenticate(ownerCtx, &gateway.AuthenticateRequest{
 		Type:         "machine",
 		ClientId:     "userid:" + owner.GetId().GetOpaqueId(),
@@ -198,5 +198,5 @@ func (p *Provider) getAuthContext(owner *user.User) (context.Context, error) {
 		p.logger.Error().Err(err).Interface("owner", owner).Interface("authRes", authRes).Msg("error using machine auth")
 		return nil, err
 	}
-	return metadata.AppendToOutgoingContext(ownerCtx, ctxpkg.TokenHeader, authRes.Token), nil
+	return metadata.AppendToOutgoingContext(ownerCtx, revactx.TokenHeader, authRes.Token), nil
 }

--- a/services/search/pkg/search/provider/searchprovider.go
+++ b/services/search/pkg/search/provider/searchprovider.go
@@ -16,7 +16,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/events"
 	sdk "github.com/cs3org/reva/v2/pkg/sdk/common"
@@ -290,7 +290,7 @@ func (p *Provider) doIndexSpace(ctx context.Context, spaceID *provider.StorageSp
 	if authRes.GetStatus().GetCode() != rpc.Code_CODE_OK {
 		return fmt.Errorf("could not get authenticated context for user")
 	}
-	ownerCtx := metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, authRes.Token)
+	ownerCtx := metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, authRes.Token)
 
 	// Walk the space and index all files
 	walker := walker.NewWalker(p.gwClient)


### PR DESCRIPTION
we had some duplicate imports, this PR removes the `ctxpkg` in favor of the more expressive `revactx`