### PR TITLE
[full-ci] graph: Initial LDAP support for /education/users

### DIFF
--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -42,12 +42,12 @@ type EducationBackend interface {
 	GetEducationSchool(ctx context.Context, nameOrID string, queryParam url.Values) (*libregraph.EducationSchool, error)
 	// GetEducationSchools lists all schools
 	GetEducationSchools(ctx context.Context, queryParam url.Values) ([]*libregraph.EducationSchool, error)
-	// GetEducationSchoolMembers lists all members of a school
-	GetEducationSchoolMembers(ctx context.Context, id string) ([]*libregraph.EducationUser, error)
-	// AddMembersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.
-	AddMembersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error
-	// RemoveMemberFromEducationSchool removes a single member (by ID) from a school
-	RemoveMemberFromEducationSchool(ctx context.Context, schoolID string, memberID string) error
+	// GetEducationSchoolUsers lists all members of a school
+	GetEducationSchoolUsers(ctx context.Context, id string) ([]*libregraph.EducationUser, error)
+	// AddUsersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.
+	AddUsersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error
+	// RemoveUserFromEducationSchool removes a single member (by ID) from a school
+	RemoveUserFromEducationSchool(ctx context.Context, schoolID string, memberID string) error
 
 	// CreateEducationUser creates a given education user in the identity backend.
 	CreateEducationUser(ctx context.Context, user libregraph.EducationUser) (*libregraph.EducationUser, error)

--- a/services/graph/pkg/identity/err_school.go
+++ b/services/graph/pkg/identity/err_school.go
@@ -30,18 +30,18 @@ func (i *ErrEducationBackend) GetEducationSchools(ctx context.Context, queryPara
 	return nil, errNotImplemented
 }
 
-// GetEducationSchoolMembers implements the EducationBackend interface for the ErrEducationBackend backend.
-func (i *ErrEducationBackend) GetEducationSchoolMembers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
+// GetEducationSchoolUsers implements the EducationBackend interface for the ErrEducationBackend backend.
+func (i *ErrEducationBackend) GetEducationSchoolUsers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
 	return nil, errNotImplemented
 }
 
-// AddMembersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.
-func (i *ErrEducationBackend) AddMembersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error {
+// AddUsersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.
+func (i *ErrEducationBackend) AddUsersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error {
 	return errNotImplemented
 }
 
-// RemoveMemberFromEducationSchool removes a single member (by ID) from a school
-func (i *ErrEducationBackend) RemoveMemberFromEducationSchool(ctx context.Context, schoolID string, memberID string) error {
+// RemoveUserFromEducationSchool removes a single member (by ID) from a school
+func (i *ErrEducationBackend) RemoveUserFromEducationSchool(ctx context.Context, schoolID string, memberID string) error {
 	return errNotImplemented
 }
 

--- a/services/graph/pkg/identity/ldap_education_user.go
+++ b/services/graph/pkg/identity/ldap_education_user.go
@@ -2,19 +2,78 @@ package identity
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/url"
+	"strings"
 
+	"github.com/go-ldap/ldap/v3"
 	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 )
+
+type educationUserAttributeMap struct {
+	identities  string
+	primaryRole string
+}
+
+func newEducationUserAttributeMap() educationUserAttributeMap {
+	return educationUserAttributeMap{
+		identities:  "oCExternalIdentity",
+		primaryRole: "userClass",
+	}
+}
 
 // CreateEducationUser creates a given education user in the identity backend.
 func (i *LDAP) CreateEducationUser(ctx context.Context, user libregraph.EducationUser) (*libregraph.EducationUser, error) {
-	return nil, errNotImplemented
+	logger := i.logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "ldap").Msg("CreateEducationUser")
+	if !i.writeEnabled {
+		return nil, errReadOnly
+	}
+
+	ar, err := i.educationUserToAddRequest(user)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := i.conn.Add(ar); err != nil {
+		var lerr *ldap.Error
+		logger.Debug().Err(err).Msg("error adding user")
+		if errors.As(err, &lerr) {
+			if lerr.ResultCode == ldap.LDAPResultEntryAlreadyExists {
+				err = errorcode.New(errorcode.NameAlreadyExists, lerr.Error())
+			}
+		}
+		return nil, err
+	}
+
+	// Read	back user from LDAP to get the generated UUID
+	e, err := i.getEducationUserByDN(ar.DN)
+	if err != nil {
+		return nil, err
+	}
+	return i.createEducationUserModelFromLDAP(e), nil
 }
 
 // DeleteEducationUser deletes a given educationuser, identified by username or id, from the backend
 func (i *LDAP) DeleteEducationUser(ctx context.Context, nameOrID string) error {
-	return errNotImplemented
+	logger := i.logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "ldap").Msg("DeleteEducationUser")
+	if !i.writeEnabled {
+		return errReadOnly
+	}
+	// TODO, implement a proper lookup for education Users here
+	e, err := i.getEducationUserByNameOrID(nameOrID)
+	if err != nil {
+		return err
+	}
+
+	dr := ldap.DelRequest{DN: e.DN}
+	if err = i.conn.Del(&dr); err != nil {
+		return err
+	}
+	return nil
 }
 
 // UpdateEducationUser applies changes to given education user, identified by username or id
@@ -24,10 +83,192 @@ func (i *LDAP) UpdateEducationUser(ctx context.Context, nameOrID string, user li
 
 // GetEducationUser implements the EducationBackend interface for the LDAP backend.
 func (i *LDAP) GetEducationUser(ctx context.Context, nameOrID string, queryParam url.Values) (*libregraph.EducationUser, error) {
-	return nil, errNotImplemented
+	logger := i.logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "ldap").Msg("GetEducationUser")
+	e, err := i.getEducationUserByNameOrID(nameOrID)
+	if err != nil {
+		return nil, err
+	}
+	u := i.createEducationUserModelFromLDAP(e)
+	if u == nil {
+		return nil, errNotFound
+	}
+	return u, nil
 }
 
 // GetEducationUsers implements the EducationBackend interface for the LDAP backend.
 func (i *LDAP) GetEducationUsers(ctx context.Context, queryParam url.Values) ([]*libregraph.EducationUser, error) {
-	return nil, errNotImplemented
+	logger := i.logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "ldap").Msg("GetEducationUsers")
+
+	search := queryParam.Get("search")
+	if search == "" {
+		search = queryParam.Get("$search")
+	}
+	var userFilter string
+	if search != "" {
+		search = ldap.EscapeFilter(search)
+		userFilter = fmt.Sprintf(
+			"(|(%s=%s*)(%s=%s*)(%s=%s*))",
+			i.userAttributeMap.userName, search,
+			i.userAttributeMap.mail, search,
+			i.userAttributeMap.displayName, search,
+		)
+	}
+
+	if userFilter == "" && i.userFilter == "" {
+		userFilter = fmt.Sprintf("(objectClass=%s)", i.educationConfig.userObjectClass)
+	} else {
+		userFilter = fmt.Sprintf("(&%s(objectClass=%s)%s)", i.userFilter, i.educationConfig.userObjectClass, userFilter)
+	}
+
+	searchRequest := ldap.NewSearchRequest(
+		i.userBaseDN,
+		i.userScope,
+		ldap.NeverDerefAliases, 0, 0, false,
+		userFilter,
+		i.getEducationUserAttrTypes(),
+		nil,
+	)
+	logger.Debug().Str("backend", "ldap").
+		Str("base", searchRequest.BaseDN).
+		Str("filter", searchRequest.Filter).
+		Int("scope", searchRequest.Scope).
+		Int("sizelimit", searchRequest.SizeLimit).
+		Interface("attributes", searchRequest.Attributes).
+		Msg("GetEducationUsers")
+	res, err := i.conn.Search(searchRequest)
+	if err != nil {
+		return nil, errorcode.New(errorcode.ItemNotFound, err.Error())
+	}
+
+	users := make([]*libregraph.EducationUser, 0, len(res.Entries))
+
+	for _, e := range res.Entries {
+		u := i.createEducationUserModelFromLDAP(e)
+		// Skip invalid LDAP users
+		if u == nil {
+			continue
+		}
+		users = append(users, u)
+	}
+	return users, nil
+}
+
+func (i *LDAP) educationUserToUser(eduUser libregraph.EducationUser) *libregraph.User {
+	user := libregraph.NewUser()
+	user.OnPremisesSamAccountName = eduUser.OnPremisesSamAccountName
+	user.Surname = eduUser.Surname
+	user.AccountEnabled = eduUser.AccountEnabled
+	user.GivenName = eduUser.GivenName
+	user.DisplayName = eduUser.DisplayName
+	user.Mail = eduUser.Mail
+	return user
+}
+func (i *LDAP) userToEducationUser(user libregraph.User, e *ldap.Entry) *libregraph.EducationUser {
+	eduUser := libregraph.NewEducationUser()
+	eduUser.Id = user.Id
+	eduUser.OnPremisesSamAccountName = user.OnPremisesSamAccountName
+	eduUser.Surname = user.Surname
+	eduUser.AccountEnabled = user.AccountEnabled
+	eduUser.GivenName = user.GivenName
+	eduUser.DisplayName = user.DisplayName
+	eduUser.Mail = user.Mail
+
+	if e != nil {
+		// Set the education User specific Attributes from the supplied LDAP Entry
+		if primaryRole := e.GetEqualFoldAttributeValue(i.educationConfig.userAttributeMap.primaryRole); primaryRole != "" {
+			eduUser.SetPrimaryRole(primaryRole)
+		}
+		var identities []libregraph.ObjectIdentity
+		for _, identityStr := range e.GetEqualFoldAttributeValues(i.educationConfig.userAttributeMap.identities) {
+			parts := strings.SplitN(identityStr, "$", 3)
+			identity := libregraph.NewObjectIdentity()
+			identity.SetIssuer(strings.TrimSpace(parts[1]))
+			identity.SetIssuerAssignedId(strings.TrimSpace(parts[2]))
+			identities = append(identities, *identity)
+		}
+		if len(identities) > 0 {
+			eduUser.SetIdentities(identities)
+		}
+	}
+
+	return eduUser
+}
+
+func (i *LDAP) educationUserToLDAPAttrValues(user libregraph.EducationUser, attrs ldapAttributeValues) (ldapAttributeValues, error) {
+	if role, ok := user.GetPrimaryRoleOk(); ok {
+		attrs[i.educationConfig.userAttributeMap.primaryRole] = []string{*role}
+	}
+	if identities, ok := user.GetIdentitiesOk(); ok {
+		for _, identity := range identities {
+			// TODO add support for the "signInType" of objectIdentity
+			if identity.GetIssuer() == "" || identity.GetIssuerAssignedId() == "" {
+				return nil, fmt.Errorf("missing Attribute for objectIdentity")
+			}
+			identityStr := fmt.Sprintf(" $ %s $ %s", identity.GetIssuer(), identity.GetIssuerAssignedId())
+			attrs[i.educationConfig.userAttributeMap.identities] = append(
+				attrs[i.educationConfig.userAttributeMap.identities],
+				identityStr,
+			)
+		}
+	}
+	attrs["objectClass"] = append(attrs["objectClass"], i.educationConfig.userObjectClass)
+	return attrs, nil
+}
+
+func (i *LDAP) educationUserToAddRequest(user libregraph.EducationUser) (*ldap.AddRequest, error) {
+	plainUser := i.educationUserToUser(user)
+	ldapAttrs, err := i.userToLDAPAttrValues(*plainUser)
+	if err != nil {
+		return nil, err
+	}
+	ldapAttrs, err = i.educationUserToLDAPAttrValues(user, ldapAttrs)
+	if err != nil {
+		return nil, err
+	}
+
+	ar := ldap.NewAddRequest(i.getUserLDAPDN(*plainUser), nil)
+
+	for attrType, values := range ldapAttrs {
+		ar.Attribute(attrType, values)
+	}
+	return ar, nil
+}
+
+func (i *LDAP) createEducationUserModelFromLDAP(e *ldap.Entry) *libregraph.EducationUser {
+	user := i.createUserModelFromLDAP(e)
+	return i.userToEducationUser(*user, e)
+}
+
+func (i *LDAP) getEducationUserAttrTypes() []string {
+	return []string{
+		i.userAttributeMap.displayName,
+		i.userAttributeMap.id,
+		i.userAttributeMap.mail,
+		i.userAttributeMap.userName,
+		i.educationConfig.userAttributeMap.identities,
+		i.educationConfig.userAttributeMap.primaryRole,
+	}
+}
+
+func (i *LDAP) getEducationUserByDN(dn string) (*ldap.Entry, error) {
+	filter := fmt.Sprintf("(objectClass=%s)", i.educationConfig.userObjectClass)
+
+	if i.userFilter != "" {
+		filter = fmt.Sprintf("(&%s(%s))", filter, i.userFilter)
+	}
+
+	return i.getEntryByDN(dn, i.getEducationUserAttrTypes(), filter)
+}
+
+func (i *LDAP) getEducationUserByNameOrID(nameOrID string) (*ldap.Entry, error) {
+	nameOrID = ldap.EscapeFilter(nameOrID)
+	filter := fmt.Sprintf("(|(%s=%s)(%s=%s))", i.userAttributeMap.userName, nameOrID, i.userAttributeMap.id, nameOrID)
+	return i.getEducationUserByFilter(filter)
+}
+
+func (i *LDAP) getEducationUserByFilter(filter string) (*ldap.Entry, error) {
+	filter = fmt.Sprintf("(&%s(objectClass=%s)%s)", i.userFilter, i.educationConfig.userObjectClass, filter)
+	return i.searchLDAPEntryByFilter(i.userBaseDN, i.getEducationUserAttrTypes(), filter)
 }

--- a/services/graph/pkg/identity/ldap_education_user.go
+++ b/services/graph/pkg/identity/ldap_education_user.go
@@ -249,6 +249,7 @@ func (i *LDAP) getEducationUserAttrTypes() []string {
 		i.userAttributeMap.userName,
 		i.educationConfig.userAttributeMap.identities,
 		i.educationConfig.userAttributeMap.primaryRole,
+		i.educationConfig.memberOfSchoolAttribute,
 	}
 }
 

--- a/services/graph/pkg/identity/ldap_education_user_test.go
+++ b/services/graph/pkg/identity/ldap_education_user_test.go
@@ -1,0 +1,132 @@
+package identity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/services/graph/mocks"
+	"github.com/test-go/testify/assert"
+	"github.com/test-go/testify/mock"
+)
+
+var eduUserEntry = ldap.NewEntry("uid=user,ou=people,dc=test",
+	map[string][]string{
+		"uid":         {"testuser"},
+		"displayname": {"Test User"},
+		"mail":        {"user@example"},
+		"entryuuid":   {"abcd-defg"},
+		"userClass":   {"student"},
+		"oCExternalIdentity": {
+			"$ http://idp $ testuser",
+			"xxx $ http://idpnew $ xxxxx-xxxxx-xxxxx",
+		},
+	})
+
+var sr1 *ldap.SearchRequest = &ldap.SearchRequest{
+	BaseDN:     "ou=people,dc=test",
+	Scope:      2,
+	SizeLimit:  1,
+	Filter:     "(&(objectClass=ocEducationUser)(|(uid=abcd-defg)(entryUUID=abcd-defg)))",
+	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass"},
+	Controls:   []ldap.Control(nil),
+}
+var sr2 *ldap.SearchRequest = &ldap.SearchRequest{
+	BaseDN:     "ou=people,dc=test",
+	Scope:      2,
+	SizeLimit:  1,
+	Filter:     "(&(objectClass=ocEducationUser)(|(uid=xxxx-xxxx)(entryUUID=xxxx-xxxx)))",
+	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass"},
+	Controls:   []ldap.Control(nil),
+}
+
+func TestCreateEducationUser(t *testing.T) {
+	lm := &mocks.Client{}
+	b, err := getMockedBackend(lm, eduConfig, &logger)
+	assert.Nil(t, err)
+	//assert.NotEqual(t, "", b.educationConfig.schoolObjectClass)
+	lm.On("Add", mock.Anything).Return(nil)
+
+	lm.On("Search", mock.Anything).
+		Return(
+			&ldap.SearchResult{
+				Entries: []*ldap.Entry{
+					eduUserEntry,
+				},
+			},
+			nil)
+	user := libregraph.NewEducationUser()
+	user.SetDisplayName("Test User")
+	user.SetOnPremisesSamAccountName("testuser")
+	user.SetMail("testuser@example.org")
+	user.SetPrimaryRole("student")
+	eduUser, err := b.CreateEducationUser(context.Background(), *user)
+	lm.AssertNumberOfCalls(t, "Add", 1)
+	lm.AssertNumberOfCalls(t, "Search", 1)
+	assert.NotNil(t, eduUser)
+	assert.Nil(t, err)
+	assert.Equal(t, eduUser.GetDisplayName(), user.GetDisplayName())
+	assert.Equal(t, eduUser.GetOnPremisesSamAccountName(), user.GetOnPremisesSamAccountName())
+	assert.Equal(t, "abcd-defg", eduUser.GetId())
+	assert.Equal(t, eduUser.GetPrimaryRole(), user.GetPrimaryRole())
+}
+
+func TestDeleteEducationUser(t *testing.T) {
+	lm := &mocks.Client{}
+
+	lm.On("Search", sr1).Return(&ldap.SearchResult{Entries: []*ldap.Entry{eduUserEntry}}, nil)
+	lm.On("Search", sr2).Return(&ldap.SearchResult{Entries: []*ldap.Entry{}}, nil)
+	dr1 := &ldap.DelRequest{
+		DN: "uid=user,ou=people,dc=test",
+	}
+	lm.On("Del", dr1).Return(nil)
+	b, err := getMockedBackend(lm, eduConfig, &logger)
+	assert.Nil(t, err)
+	err = b.DeleteEducationUser(context.Background(), "abcd-defg")
+	lm.AssertNumberOfCalls(t, "Search", 1)
+	lm.AssertNumberOfCalls(t, "Del", 1)
+	assert.Nil(t, err)
+
+	err = b.DeleteEducationUser(context.Background(), "xxxx-xxxx")
+	lm.AssertNumberOfCalls(t, "Search", 2)
+	lm.AssertNumberOfCalls(t, "Del", 1)
+	assert.NotNil(t, err)
+	assert.Equal(t, "itemNotFound", err.Error())
+}
+
+func TestGetEducationUser(t *testing.T) {
+	lm := &mocks.Client{}
+	lm.On("Search", sr1).Return(&ldap.SearchResult{Entries: []*ldap.Entry{eduUserEntry}}, nil)
+	lm.On("Search", sr2).Return(&ldap.SearchResult{Entries: []*ldap.Entry{}}, nil)
+	b, err := getMockedBackend(lm, eduConfig, &logger)
+	assert.Nil(t, err)
+	user, err := b.GetEducationUser(context.Background(), "abcd-defg", nil)
+	lm.AssertNumberOfCalls(t, "Search", 1)
+	assert.Nil(t, err)
+	assert.Equal(t, "Test User", user.GetDisplayName())
+	assert.Equal(t, "abcd-defg", user.GetId())
+
+	user, err = b.GetEducationUser(context.Background(), "xxxx-xxxx", nil)
+	lm.AssertNumberOfCalls(t, "Search", 2)
+	assert.NotNil(t, err)
+	assert.Equal(t, "itemNotFound", err.Error())
+}
+
+func TestGetEducationUsers(t *testing.T) {
+	lm := &mocks.Client{}
+	sr := &ldap.SearchRequest{
+		BaseDN:     "ou=people,dc=test",
+		Scope:      2,
+		SizeLimit:  0,
+		Filter:     "(objectClass=ocEducationUser)",
+		Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass"},
+		Controls:   []ldap.Control(nil),
+	}
+	lm.On("Search", sr).Return(&ldap.SearchResult{Entries: []*ldap.Entry{eduUserEntry}}, nil)
+	b, err := getMockedBackend(lm, eduConfig, &logger)
+	assert.Nil(t, err)
+	_, err = b.GetEducationUsers(context.Background(), nil)
+	lm.AssertNumberOfCalls(t, "Search", 1)
+	assert.Nil(t, err)
+}

--- a/services/graph/pkg/identity/ldap_education_user_test.go
+++ b/services/graph/pkg/identity/ldap_education_user_test.go
@@ -23,13 +23,26 @@ var eduUserEntry = ldap.NewEntry("uid=user,ou=people,dc=test",
 			"xxx $ http://idpnew $ xxxxx-xxxxx-xxxxx",
 		},
 	})
+var eduUserEntryWithSchool = ldap.NewEntry("uid=user,ou=people,dc=test",
+	map[string][]string{
+		"uid":              {"testuser"},
+		"displayname":      {"Test User"},
+		"mail":             {"user@example"},
+		"entryuuid":        {"abcd-defg"},
+		"userClass":        {"student"},
+		"ocMemberOfSchool": {"abcd-defg"},
+		"oCExternalIdentity": {
+			"$ http://idp $ testuser",
+			"xxx $ http://idpnew $ xxxxx-xxxxx-xxxxx",
+		},
+	})
 
 var sr1 *ldap.SearchRequest = &ldap.SearchRequest{
 	BaseDN:     "ou=people,dc=test",
 	Scope:      2,
 	SizeLimit:  1,
 	Filter:     "(&(objectClass=ocEducationUser)(|(uid=abcd-defg)(entryUUID=abcd-defg)))",
-	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass"},
+	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass", "ocMemberOfSchool"},
 	Controls:   []ldap.Control(nil),
 }
 var sr2 *ldap.SearchRequest = &ldap.SearchRequest{
@@ -37,7 +50,7 @@ var sr2 *ldap.SearchRequest = &ldap.SearchRequest{
 	Scope:      2,
 	SizeLimit:  1,
 	Filter:     "(&(objectClass=ocEducationUser)(|(uid=xxxx-xxxx)(entryUUID=xxxx-xxxx)))",
-	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass"},
+	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass", "ocMemberOfSchool"},
 	Controls:   []ldap.Control(nil),
 }
 
@@ -120,7 +133,7 @@ func TestGetEducationUsers(t *testing.T) {
 		Scope:      2,
 		SizeLimit:  0,
 		Filter:     "(objectClass=ocEducationUser)",
-		Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass"},
+		Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass", "ocMemberOfSchool"},
 		Controls:   []ldap.Control(nil),
 	}
 	lm.On("Search", sr).Return(&ldap.SearchResult{Entries: []*ldap.Entry{eduUserEntry}}, nil)

--- a/services/graph/pkg/identity/ldap_school.go
+++ b/services/graph/pkg/identity/ldap_school.go
@@ -20,6 +20,9 @@ type educationConfig struct {
 	schoolObjectClass  string
 	schoolScope        int
 	schoolAttributeMap schoolAttributeMap
+
+	userObjectClass  string
+	userAttributeMap educationUserAttributeMap
 }
 
 type schoolAttributeMap struct {
@@ -33,6 +36,9 @@ func defaultEducationConfig() educationConfig {
 		schoolObjectClass:  "ocEducationSchool",
 		schoolScope:        ldap.ScopeWholeSubtree,
 		schoolAttributeMap: newSchoolAttributeMap(),
+
+		userObjectClass:  "ocEducationUser",
+		userAttributeMap: newEducationUserAttributeMap(),
 	}
 }
 

--- a/services/graph/pkg/identity/ldap_school.go
+++ b/services/graph/pkg/identity/ldap_school.go
@@ -206,15 +206,15 @@ func (i *LDAP) GetEducationSchools(ctx context.Context, queryParam url.Values) (
 	return schools, nil
 }
 
-// GetEducationSchoolMembers implements the EducationBackend interface for the LDAP backend.
-func (i *LDAP) GetEducationSchoolMembers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
+// GetEducationSchoolUsers implements the EducationBackend interface for the LDAP backend.
+func (i *LDAP) GetEducationSchoolUsers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
 	return nil, errNotImplemented
 }
 
-// AddMembersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.
-func (i *LDAP) AddMembersToEducationSchool(ctx context.Context, schoolID string, memberIDs []string) error {
+// AddUsersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.
+func (i *LDAP) AddUsersToEducationSchool(ctx context.Context, schoolID string, memberIDs []string) error {
 	logger := i.logger.SubloggerWithRequestID(ctx)
-	logger.Debug().Str("backend", "ldap").Msg("AddMembersToEducationSchool")
+	logger.Debug().Str("backend", "ldap").Msg("AddUsersToEducationSchool")
 
 	schoolEntry, err := i.getSchoolByID(schoolID)
 	if err != nil {

--- a/services/graph/pkg/identity/ldap_school_test.go
+++ b/services/graph/pkg/identity/ldap_school_test.go
@@ -212,7 +212,7 @@ func TestAddUsersToEducationSchool(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestRemoveMemberFromEducationSchoo(t *testing.T) {
+func TestRemoveMemberFromEducationSchool(t *testing.T) {
 	lm := &mocks.Client{}
 	lm.On("Search", schoolByIDSearch1).Return(&ldap.SearchResult{Entries: []*ldap.Entry{schoolEntry, schoolEntry1}}, nil)
 	lm.On("Search", userByIDSearch1).Return(&ldap.SearchResult{Entries: []*ldap.Entry{eduUserEntryWithSchool}}, nil)
@@ -228,4 +228,23 @@ func TestRemoveMemberFromEducationSchoo(t *testing.T) {
 	lm.AssertNumberOfCalls(t, "Search", 4)
 	lm.AssertNumberOfCalls(t, "Modify", 1)
 	assert.Nil(t, err)
+}
+
+var usersBySchoolIDSearch *ldap.SearchRequest = &ldap.SearchRequest{
+	BaseDN:     "ou=people,dc=test",
+	Scope:      2,
+	SizeLimit:  0,
+	Filter:     "(&(objectClass=ocEducationUser)(ocMemberOfSchool=abcd-defg))",
+	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass", "ocMemberOfSchool"},
+	Controls:   []ldap.Control(nil),
+}
+
+func TestGetEducationSchoolUsers(t *testing.T) {
+	lm := &mocks.Client{}
+	lm.On("Search", schoolByIDSearch1).Return(&ldap.SearchResult{Entries: []*ldap.Entry{schoolEntry, schoolEntry1}}, nil)
+	lm.On("Search", usersBySchoolIDSearch).Return(&ldap.SearchResult{Entries: []*ldap.Entry{eduUserEntryWithSchool}}, nil)
+	b, err := getMockedBackend(lm, eduConfig, &logger)
+	users, err := b.GetEducationSchoolUsers(context.Background(), "abcd-defg")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(users))
 }

--- a/services/graph/pkg/identity/mocks/education_backend.go
+++ b/services/graph/pkg/identity/mocks/education_backend.go
@@ -17,8 +17,8 @@ type EducationBackend struct {
 	mock.Mock
 }
 
-// AddMembersToEducationSchool provides a mock function with given fields: ctx, schoolID, memberID
-func (_m *EducationBackend) AddMembersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error {
+// AddUsersToEducationSchool provides a mock function with given fields: ctx, schoolID, memberID
+func (_m *EducationBackend) AddUsersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error {
 	ret := _m.Called(ctx, schoolID, memberID)
 
 	var r0 error
@@ -128,8 +128,8 @@ func (_m *EducationBackend) GetEducationSchool(ctx context.Context, nameOrID str
 	return r0, r1
 }
 
-// GetEducationSchoolMembers provides a mock function with given fields: ctx, id
-func (_m *EducationBackend) GetEducationSchoolMembers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
+// GetEducationSchoolUsers provides a mock function with given fields: ctx, id
+func (_m *EducationBackend) GetEducationSchoolUsers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
 	ret := _m.Called(ctx, id)
 
 	var r0 []*libregraph.EducationUser
@@ -220,8 +220,8 @@ func (_m *EducationBackend) GetEducationUsers(ctx context.Context, queryParam ur
 	return r0, r1
 }
 
-// RemoveMemberFromEducationSchool provides a mock function with given fields: ctx, schoolID, memberID
-func (_m *EducationBackend) RemoveMemberFromEducationSchool(ctx context.Context, schoolID string, memberID string) error {
+// RemoveUserFromEducationSchool provides a mock function with given fields: ctx, schoolID, memberID
+func (_m *EducationBackend) RemoveUserFromEducationSchool(ctx context.Context, schoolID string, memberID string) error {
 	ret := _m.Called(ctx, schoolID, memberID)
 
 	var r0 error

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -221,28 +221,28 @@ func (g Graph) DeleteEducationSchool(w http.ResponseWriter, r *http.Request) {
 	render.NoContent(w, r)
 }
 
-// GetEducationSchoolMembers implements the Service interface.
-func (g Graph) GetEducationSchoolMembers(w http.ResponseWriter, r *http.Request) {
+// GetEducationSchoolUsers implements the Service interface.
+func (g Graph) GetEducationSchoolUsers(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
-	logger.Info().Msg("calling get school members")
+	logger.Info().Msg("calling get school users")
 	schoolID := chi.URLParam(r, "schoolID")
 	schoolID, err := url.PathUnescape(schoolID)
 	if err != nil {
-		logger.Debug().Str("id", schoolID).Msg("could not get school members: unescaping school id failed")
+		logger.Debug().Str("id", schoolID).Msg("could not get school users: unescaping school id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping school id failed")
 		return
 	}
 
 	if schoolID == "" {
-		logger.Debug().Msg("could not get school members: missing school id")
+		logger.Debug().Msg("could not get school users: missing school id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing school id")
 		return
 	}
 
-	logger.Debug().Str("id", schoolID).Msg("calling get school members on backend")
-	members, err := g.identityEducationBackend.GetEducationSchoolMembers(r.Context(), schoolID)
+	logger.Debug().Str("id", schoolID).Msg("calling get school users on backend")
+	users, err := g.identityEducationBackend.GetEducationSchoolUsers(r.Context(), schoolID)
 	if err != nil {
-		logger.Debug().Err(err).Msg("could not get school members: backend error")
+		logger.Debug().Err(err).Msg("could not get school users: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -253,13 +253,13 @@ func (g Graph) GetEducationSchoolMembers(w http.ResponseWriter, r *http.Request)
 	}
 
 	render.Status(r, http.StatusOK)
-	render.JSON(w, r, members)
+	render.JSON(w, r, users)
 }
 
-// PostEducationSchoolMember implements the Service interface.
-func (g Graph) PostEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
+// PostEducationSchoolUser implements the Service interface.
+func (g Graph) PostEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
-	logger.Info().Msg("Calling post school member")
+	logger.Info().Msg("Calling post school user")
 
 	schoolID := chi.URLParam(r, "schoolID")
 	schoolID, err := url.PathUnescape(schoolID)
@@ -267,13 +267,13 @@ func (g Graph) PostEducationSchoolMember(w http.ResponseWriter, r *http.Request)
 		logger.Debug().
 			Err(err).
 			Str("id", schoolID).
-			Msg("could not add member to school: unescaping school id failed")
+			Msg("could not add user to school: unescaping school id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping school id failed")
 		return
 	}
 
 	if schoolID == "" {
-		logger.Debug().Msg("could not add school member: missing school id")
+		logger.Debug().Msg("could not add school user: missing school id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing school id")
 		return
 	}
@@ -283,35 +283,35 @@ func (g Graph) PostEducationSchoolMember(w http.ResponseWriter, r *http.Request)
 		logger.Debug().
 			Err(err).
 			Interface("body", r.Body).
-			Msg("could not add school member: invalid request body")
+			Msg("could not add school user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
 	memberRefURL, ok := memberRef.GetOdataIdOk()
 	if !ok {
-		logger.Debug().Msg("could not add school member: @odata.id reference is missing")
+		logger.Debug().Msg("could not add school user: @odata.id reference is missing")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "@odata.id reference is missing")
 		return
 	}
 	memberType, id, err := g.parseMemberRef(*memberRefURL)
 	if err != nil {
-		logger.Debug().Err(err).Msg("could not add school member: error parsing @odata.id url")
+		logger.Debug().Err(err).Msg("could not add school user: error parsing @odata.id url")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Error parsing @odata.id url")
 		return
 	}
 	// The MS Graph spec allows "directoryObject", "user", "school" and "organizational Contact"
 	// we restrict this to users for now. Might add Schools as members later
 	if memberType != "users" {
-		logger.Debug().Str("type", memberType).Msg("could not add school member: Only users are allowed as school members")
+		logger.Debug().Str("type", memberType).Msg("could not add school user: Only users are allowed as school members")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Only users are allowed as school members")
 		return
 	}
 
-	logger.Debug().Str("memberType", memberType).Str("id", id).Msg("calling add member on backend")
-	err = g.identityEducationBackend.AddMembersToEducationSchool(r.Context(), schoolID, []string{id})
+	logger.Debug().Str("memberType", memberType).Str("id", id).Msg("calling add user on backend")
+	err = g.identityEducationBackend.AddUsersToEducationSchool(r.Context(), schoolID, []string{id})
 
 	if err != nil {
-		logger.Debug().Err(err).Msg("could not add school member: backend error")
+		logger.Debug().Err(err).Msg("could not add school user: backend error")
 		var errcode errorcode.Error
 		if errors.As(err, &errcode) {
 			errcode.Render(w, r)
@@ -333,8 +333,8 @@ func (g Graph) PostEducationSchoolMember(w http.ResponseWriter, r *http.Request)
 	render.NoContent(w, r)
 }
 
-// DeleteEducationSchoolMember implements the Service interface.
-func (g Graph) DeleteEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
+// DeleteEducationSchoolUser implements the Service interface.
+func (g Graph) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("calling delete school member")
 
@@ -352,21 +352,21 @@ func (g Graph) DeleteEducationSchoolMember(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	memberID := chi.URLParam(r, "memberID")
-	memberID, err = url.PathUnescape(memberID)
+	userID := chi.URLParam(r, "userID")
+	userID, err = url.PathUnescape(userID)
 	if err != nil {
-		logger.Debug().Err(err).Str("id", memberID).Msg("could not delete school member: unescaping member id failed")
+		logger.Debug().Err(err).Str("id", userID).Msg("could not delete school member: unescaping member id failed")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "unescaping member id failed")
 		return
 	}
 
-	if memberID == "" {
+	if userID == "" {
 		logger.Debug().Msg("could not delete school member: missing member id")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing member id")
 		return
 	}
-	logger.Debug().Str("schoolID", schoolID).Str("memberID", memberID).Msg("calling delete member on backend")
-	err = g.identityEducationBackend.RemoveMemberFromEducationSchool(r.Context(), schoolID, memberID)
+	logger.Debug().Str("schoolID", schoolID).Str("userID", userID).Msg("calling delete member on backend")
+	err = g.identityEducationBackend.RemoveUserFromEducationSchool(r.Context(), schoolID, userID)
 
 	if err != nil {
 		logger.Debug().Err(err).Msg("could not delete school member: backend error")
@@ -380,7 +380,7 @@ func (g Graph) DeleteEducationSchoolMember(w http.ResponseWriter, r *http.Reques
 	}
 
 	/* TODO requires reva changes
-	e := events.SchoolMemberRemoved{SchoolID: schoolID, UserID: memberID}
+	e := events.SchoolMemberRemoved{SchoolID: schoolID, UserID: userID}
 	if currentUser, ok := ctxpkg.ContextGetUser(r.Context()); ok {
 		e.Executant = currentUser.GetId()
 	}

--- a/services/graph/pkg/service/v0/educationschools_test.go
+++ b/services/graph/pkg/service/v0/educationschools_test.go
@@ -347,17 +347,17 @@ var _ = Describe("Schools", func() {
 		})
 	})
 
-	Describe("GetEducationSchoolMembers", func() {
+	Describe("GetEducationSchoolUsers", func() {
 		It("gets the list of members", func() {
 			user := libregraph.NewEducationUser()
 			user.SetId("user")
-			identityEducationBackend.On("GetEducationSchoolMembers", mock.Anything, mock.Anything, mock.Anything).Return([]*libregraph.EducationUser{user}, nil)
+			identityEducationBackend.On("GetEducationSchoolUsers", mock.Anything, mock.Anything, mock.Anything).Return([]*libregraph.EducationUser{user}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/education/schools/{schoolID}/members", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/education/schools/{schoolID}/users", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", *newSchool.Id)
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.GetEducationSchoolMembers(rr, r)
+			svc.GetEducationSchoolUsers(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
 			data, err := io.ReadAll(rr.Body)
@@ -372,13 +372,13 @@ var _ = Describe("Schools", func() {
 		})
 	})
 
-	Describe("PostEducationSchoolMembers", func() {
+	Describe("PostEducationSchoolUsers", func() {
 		It("fails on invalid body", func() {
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/education/schools/{schoolID}/members", bytes.NewBufferString("{invalid"))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", *newSchool.Id)
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.PostEducationSchoolMember(rr, r)
+			svc.PostEducationSchoolUser(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
 
@@ -391,7 +391,7 @@ var _ = Describe("Schools", func() {
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", *newSchool.Id)
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.PostEducationSchoolMember(rr, r)
+			svc.PostEducationSchoolUser(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
 
@@ -405,7 +405,7 @@ var _ = Describe("Schools", func() {
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", *newSchool.Id)
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.PostEducationSchoolMember(rr, r)
+			svc.PostEducationSchoolUser(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
 
@@ -414,49 +414,49 @@ var _ = Describe("Schools", func() {
 			member.SetOdataId("/users/user")
 			data, err := json.Marshal(member)
 			Expect(err).ToNot(HaveOccurred())
-			identityEducationBackend.On("AddMembersToEducationSchool", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			identityEducationBackend.On("AddUsersToEducationSchool", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/education/schools/{schoolID}/members", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", *newSchool.Id)
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.PostEducationSchoolMember(rr, r)
+			svc.PostEducationSchoolUser(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
 
-			identityEducationBackend.AssertNumberOfCalls(GinkgoT(), "AddMembersToEducationSchool", 1)
+			identityEducationBackend.AssertNumberOfCalls(GinkgoT(), "AddUsersToEducationSchool", 1)
 		})
 	})
 
-	Describe("DeleteEducationSchoolMembers", func() {
+	Describe("DeleteEducationSchoolUsers", func() {
 		It("handles missing or empty member id", func() {
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/education/schools/{schoolID}/members/{memberID}/$ref", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/education/schools/{schoolID}/members/{userID}/$ref", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", *newSchool.Id)
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.DeleteEducationSchoolMember(rr, r)
+			svc.DeleteEducationSchoolUser(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
 		It("handles missing or empty member id", func() {
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/education/schools/{schoolID}/members/{memberID}/$ref", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/education/schools/{schoolID}/members/{userID}/$ref", nil)
 			rctx := chi.NewRouteContext()
-			rctx.URLParams.Add("memberID", "/users/user")
+			rctx.URLParams.Add("userID", "/users/user")
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.DeleteEducationSchoolMember(rr, r)
+			svc.DeleteEducationSchoolUser(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
 
 		It("deletes members", func() {
-			identityEducationBackend.On("RemoveMemberFromEducationSchool", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			identityEducationBackend.On("RemoveUserFromEducationSchool", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/education/schools/{schoolID}/members/{memberID}/$ref", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/education/schools/{schoolID}/members/{userID}/$ref", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", *newSchool.Id)
-			rctx.URLParams.Add("memberID", "/users/user1")
+			rctx.URLParams.Add("userID", "/users/user1")
 			r = r.WithContext(context.WithValue(ctxpkg.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
-			svc.DeleteEducationSchoolMember(rr, r)
+			svc.DeleteEducationSchoolUser(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
 
-			identityEducationBackend.AssertNumberOfCalls(GinkgoT(), "RemoveMemberFromEducationSchool", 1)
+			identityEducationBackend.AssertNumberOfCalls(GinkgoT(), "RemoveUserFromEducationSchool", 1)
 		})
 	})
 })

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -259,7 +259,7 @@ func (g Graph) GetEducationUser(w http.ResponseWriter, r *http.Request) {
 			}
 			d.Quota = quota
 			if slices.Contains(sel, "drive") || slices.Contains(exp, "drive") {
-				if *d.DriveType == "personal" {
+				if *d.DriveType == _spaceTypePersonal {
 					user.Drive = d
 				}
 			} else {
@@ -330,7 +330,7 @@ func (g Graph) DeleteEducationUser(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, sp := range lspr.GetStorageSpaces() {
-			if !(sp.SpaceType == "personal" && sp.Owner.Id.OpaqueId == user.GetId()) {
+			if !(sp.SpaceType == _spaceTypePersonal && sp.Owner.Id.OpaqueId == user.GetId()) {
 				continue
 			}
 			// TODO: check if request contains a homespace and if, check if requesting user has the privilege to

--- a/services/graph/pkg/service/v0/instrument.go
+++ b/services/graph/pkg/service/v0/instrument.go
@@ -124,19 +124,19 @@ func (i instrument) DeleteEducationSchool(w http.ResponseWriter, r *http.Request
 	i.next.DeleteEducationSchool(w, r)
 }
 
-// GetEducationSchoolMembers implements the Service interface.
-func (i instrument) GetEducationSchoolMembers(w http.ResponseWriter, r *http.Request) {
-	i.next.GetEducationSchoolMembers(w, r)
+// GetEducationSchoolUsers implements the Service interface.
+func (i instrument) GetEducationSchoolUsers(w http.ResponseWriter, r *http.Request) {
+	i.next.GetEducationSchoolUsers(w, r)
 }
 
-// PostEducationSchoolMember implements the Service interface.
-func (i instrument) PostEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
-	i.next.PostEducationSchoolMember(w, r)
+// PostEducationSchoolUser implements the Service interface.
+func (i instrument) PostEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
+	i.next.PostEducationSchoolUser(w, r)
 }
 
-// DeleteEducationSchoolMember implements the Service interface.
-func (i instrument) DeleteEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
-	i.next.DeleteEducationSchoolMember(w, r)
+// DeleteEducationSchoolUser implements the Service interface.
+func (i instrument) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
+	i.next.DeleteEducationSchoolUser(w, r)
 }
 
 // GetEducationUsers implements the Service interface.

--- a/services/graph/pkg/service/v0/logging.go
+++ b/services/graph/pkg/service/v0/logging.go
@@ -124,19 +124,19 @@ func (l logging) DeleteEducationSchool(w http.ResponseWriter, r *http.Request) {
 	l.next.DeleteEducationSchool(w, r)
 }
 
-// GetEducationSchoolMembers implements the Service interface.
-func (l logging) GetEducationSchoolMembers(w http.ResponseWriter, r *http.Request) {
-	l.next.GetEducationSchoolMembers(w, r)
+// GetEducationSchoolUsers implements the Service interface.
+func (l logging) GetEducationSchoolUsers(w http.ResponseWriter, r *http.Request) {
+	l.next.GetEducationSchoolUsers(w, r)
 }
 
-// PostEducationSchoolMember implements the Service interface.
-func (l logging) PostEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
-	l.next.PostEducationSchoolMember(w, r)
+// PostEducationSchoolUser implements the Service interface.
+func (l logging) PostEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
+	l.next.PostEducationSchoolUser(w, r)
 }
 
-// DeleteEducationSchoolMember implements the Service interface.
-func (l logging) DeleteEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
-	l.next.DeleteEducationSchoolMember(w, r)
+// DeleteEducationSchoolUser implements the Service interface.
+func (l logging) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
+	l.next.DeleteEducationSchoolUser(w, r)
 }
 
 // GetEducationUsers implements the Service interface.

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -52,9 +52,9 @@ type Service interface {
 	PostEducationSchool(http.ResponseWriter, *http.Request)
 	PatchEducationSchool(http.ResponseWriter, *http.Request)
 	DeleteEducationSchool(http.ResponseWriter, *http.Request)
-	GetEducationSchoolMembers(http.ResponseWriter, *http.Request)
-	PostEducationSchoolMember(http.ResponseWriter, *http.Request)
-	DeleteEducationSchoolMember(http.ResponseWriter, *http.Request)
+	GetEducationSchoolUsers(http.ResponseWriter, *http.Request)
+	PostEducationSchoolUser(http.ResponseWriter, *http.Request)
+	DeleteEducationSchoolUser(http.ResponseWriter, *http.Request)
 
 	GetEducationUsers(http.ResponseWriter, *http.Request)
 	GetEducationUser(http.ResponseWriter, *http.Request)
@@ -250,10 +250,10 @@ func NewService(opts ...Option) Service {
 						r.Get("/", svc.GetEducationSchool)
 						r.Delete("/", svc.DeleteEducationSchool)
 						r.Patch("/", svc.PatchEducationSchool)
-						r.Route("/members", func(r chi.Router) {
-							r.Get("/", svc.GetEducationSchoolMembers)
-							r.Post("/$ref", svc.PostEducationSchoolMember)
-							r.Delete("/{memberID}/$ref", svc.DeleteEducationSchoolMember)
+						r.Route("/users", func(r chi.Router) {
+							r.Get("/", svc.GetEducationSchoolUsers)
+							r.Post("/$ref", svc.PostEducationSchoolUser)
+							r.Delete("/{userID}/$ref", svc.DeleteEducationSchoolUser)
 						})
 					})
 				})

--- a/services/graph/pkg/service/v0/tracing.go
+++ b/services/graph/pkg/service/v0/tracing.go
@@ -120,19 +120,19 @@ func (t tracing) DeleteEducationSchool(w http.ResponseWriter, r *http.Request) {
 	t.next.DeleteEducationSchool(w, r)
 }
 
-// GetEducationSchoolMembers implements the Service interface.
-func (t tracing) GetEducationSchoolMembers(w http.ResponseWriter, r *http.Request) {
-	t.next.GetEducationSchoolMembers(w, r)
+// GetEducationSchoolUsers implements the Service interface.
+func (t tracing) GetEducationSchoolUsers(w http.ResponseWriter, r *http.Request) {
+	t.next.GetEducationSchoolUsers(w, r)
 }
 
-// PostEducationSchoolMember implements the Service interface.
-func (t tracing) PostEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
-	t.next.PostEducationSchoolMember(w, r)
+// PostEducationSchoolUser implements the Service interface.
+func (t tracing) PostEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
+	t.next.PostEducationSchoolUser(w, r)
 }
 
-// DeleteEducationSchoolMember implements the Service interface.
-func (t tracing) DeleteEducationSchoolMember(w http.ResponseWriter, r *http.Request) {
-	t.next.DeleteEducationSchoolMember(w, r)
+// DeleteEducationSchoolUser implements the Service interface.
+func (t tracing) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
+	t.next.DeleteEducationSchoolUser(w, r)
 }
 
 // GetEducationUsers implements the Service interface.


### PR DESCRIPTION
This implements GetEducationUser, GetEducationUsers, DeleteEducationUser and  CreateEducationUser methods for the LDAP backend. It's still very basic and  no fancy filtering or expanding is there yet.:

Note: This is currently based on #5213.  Let's get that merged first.