### PR TITLE
[tests-only][full-ci] Fix stable2 nightly CI trigger

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -731,6 +731,7 @@ def localApiTestPipeline(ctx):
                             "trigger": {
                                 "ref": [
                                     "refs/heads/master",
+                                    "refs/heads/stable-*",
                                     "refs/pull/**",
                                 ],
                             },


### PR DESCRIPTION
The local API tests were not running nightly after PR #5187. This PR has the fix for the CI trigger.
Nightly run: https://drone.owncloud.com/owncloud/ocis/17544