### PR TITLE
[tests-only][full-ci]Extend Propfind of space to space-member

### DIFF
--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -6,12 +6,13 @@ Feature: Propfind test
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
+      | Brian    |
     And using spaces DAV path
     And the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
 
 
-  Scenario: check the PROPFIND request of a space
+  Scenario: space-admin check the PROPFIND request of a space
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
     When user "Alice" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -22,3 +23,22 @@ Feature: Propfind test
       | oc:permissions               | SRDNVCKZ         |
       | oc:privatelink               |                  |
       | oc:size                      | 12               |
+
+
+  Scenario Outline: space member with different role check the PROPFIND request of a space
+    Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
+    And user "Alice" has shared a space "new-space" to user "Brian" with role "<role>"
+    When user "Brian" sends PROPFIND request to space "new-space" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And for user "Alice" the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+      | key            | value            |
+      | oc:fileid      | UUIDof:new-space |
+      | oc:name        | new-space        |
+      | oc:permissions | <oc_permission>  |
+      | oc:privatelink |                  |
+      | oc:size        | 12               |
+    Examples:
+      | role    | oc_permission |
+      | manager | SRDNVCKZ      |
+      | editor  | SDNVCK        |
+      | viewer  | S             |

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -30,7 +30,7 @@ Feature: Propfind test
     And user "Alice" has shared a space "new-space" to user "Brian" with role "<role>"
     When user "Brian" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
-    And for user "Brian" the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
       | key            | value            |
       | oc:fileid      | UUIDof:new-space |
       | oc:name        | new-space        |

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -12,7 +12,7 @@ Feature: Propfind test
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
 
 
-  Scenario: space-admin check the PROPFIND request of a space
+  Scenario: space-admin checks the PROPFIND request of a space
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
     When user "Alice" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -25,12 +25,12 @@ Feature: Propfind test
       | oc:size                      | 12               |
 
 
-  Scenario Outline: space member with different role check the PROPFIND request of a space
+  Scenario Outline: space member with a different role checks the PROPFIND request of a space
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
     And user "Alice" has shared a space "new-space" to user "Brian" with role "<role>"
     When user "Brian" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
-    And for user "Alice" the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And for user "Brian" the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
       | key            | value            |
       | oc:fileid      | UUIDof:new-space |
       | oc:name        | new-space        |


### PR DESCRIPTION
### Description
Expanding the `PROPFIND` of a space to not only the space-admin who created it but also to the member of a space with different role.

### Related issue
https://github.com/owncloud/ocis/issues/4937
https://github.com/owncloud/ocis/pull/5138#issuecomment-1357087867