### PR TITLE
[test-only] Apitest. check Copy response headers test

### DIFF
--- a/tests/acceptance/features/apiContract/copy.feature
+++ b/tests/acceptance/features/apiContract/copy.feature
@@ -9,14 +9,13 @@ Feature: Copy test
     And using spaces DAV path
     And the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
-    
+
 
   Scenario: check the COPY response headers
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
     And user "Alice" has created a folder "new" in space "new-space"
     When user "Alice" copies file "testfile.txt" from space "new-space" to "/new/testfile.txt" inside space "new-space" using the WebDAV API
     Then the HTTP status code should be "201"
-    And for user "Alice" the COPY response headers for the space "new-space" should contain these key and value pairs:
-      | key                         | value                    |
-      | Access-Control-Allow-Origin | *                        |
-      | Oc-Fileid                   | UUIDof:/new/testfile.txt |
+    And the following headers should match these regular expressions
+      | Oc-Fileid                   | /^[a-f0-9!\$\-]{110}$/ |
+      | Access-Control-Allow-Origin | /^[*]{1}$/             |

--- a/tests/acceptance/features/apiContract/copy.feature
+++ b/tests/acceptance/features/apiContract/copy.feature
@@ -1,0 +1,22 @@
+@api @skipOnOcV10
+Feature: Copy test
+  check that the Copy response contains all the relevant values
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And using spaces DAV path
+    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And user "Alice" has created a space "new-space" with the default quota using the GraphApi
+    
+
+  Scenario: check the COPY response headers
+    Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
+    And user "Alice" has created a folder "new" in space "new-space"
+    When user "Alice" copies file "testfile.txt" from space "new-space" to "/new/testfile.txt" inside space "new-space" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And for user "Alice" the COPY response headers for the space "new-space" should contain these key and value pairs:
+      | key                         | value                    |
+      | Access-Control-Allow-Origin | *                        |
+      | Oc-Fileid                   | UUIDof:/new/testfile.txt |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3059,38 +3059,4 @@ class SpacesContext implements Context {
 			)
 		);
 	}
-
-	/**
-	 * @Then /^for user "([^"]*)" the (?:COPY|MOVE) response headers for the (?:space|mountpoint) "([^"]*)" should contain these key and value pairs:$/
-	 *
-	 * @param string $user
-	 * @param string $space
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 * @throws JsonException
-	 */
-	public function theCopyResponseHeadersShouldContain(string $user, string $space, TableNode $table): void {
-		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
-		$headers = $this->featureContext->getResponse()->getHeaders();
-	
-		foreach ($table->getHash() as $row) {
-			$findItem = $row['key'];
-			$value = str_replace('UUIDof:', '', $row['value']);
-
-			foreach ($headers as $headerName => $headerValues) {
-				if ($headerName === $findItem) {
-          switch ($findItem) {
-            case "Oc-Fileid":
-			      Assert::assertEquals($this->getFileId($user, $space, $value), $headerValues[0], 'wrong fileId in the response header');
-			      break;
-          default:
-            Assert::assertEquals($value, $headerValues[0], "wrong $findItem in the response header");
-            break;
-          }
-				}
-			}
-		}
-	}
 }

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3059,4 +3059,38 @@ class SpacesContext implements Context {
 			)
 		);
 	}
+
+	/**
+	 * @Then /^for user "([^"]*)" the (?:COPY|MOVE) response headers for the (?:space|mountpoint) "([^"]*)" should contain these key and value pairs:$/
+	 *
+	 * @param string $user
+	 * @param string $space
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function theCopyResponseHeadersShouldContain(string $user, string $space, TableNode $table): void {
+		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
+		$headers = $this->featureContext->getResponse()->getHeaders();
+	
+		foreach ($table->getHash() as $row) {
+			$findItem = $row['key'];
+			$value = str_replace('UUIDof:', '', $row['value']);
+
+			foreach ($headers as $headerName => $headerValues) {
+				if ($headerName === $findItem) {
+          switch ($findItem) {
+            case "Oc-Fileid":
+			      Assert::assertEquals($this->getFileId($user, $space, $value), $headerValues[0], 'wrong fileId in the response header');
+			      break;
+          default:
+            Assert::assertEquals($value, $headerValues[0], "wrong $findItem in the response header");
+            break;
+          }
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
- I check the value of the response headers in the test
- I did not add a folder copy test because there is no folder ID in the response headers.
- I'm not sure which items I should test (maybe hint in the review process): 
<img width="329" alt="Screenshot 2022-12-20 at 17 37 42" src="https://user-images.githubusercontent.com/84779829/208720042-734f0541-3e66-4866-bfb5-931028d3a14e.png">
- `content-length = 0` though file isn't 0 bytes - Probably it's bug

and I have lint error `make: *** [test-php-style] Error 8` when I run `make test-php-style-fix`
 