### PR TITLE
[tests-only] [full-ci] Refactor the response should contain

### DIFF
--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -15,7 +15,7 @@ Feature: Propfind test
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
     When user "Alice" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
-    And for user "Alice" the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
       | key                          | value            |
       | oc:fileid                    | UUIDof:new-space |
       | oc:name                      | new-space        |

--- a/tests/acceptance/features/apiContract/report.feature
+++ b/tests/acceptance/features/apiContract/report.feature
@@ -23,7 +23,7 @@ Feature: Report test
     And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
-    And for user "Brian" the "REPORT" response should contain a mountpoint "folderMain" with these key and value pairs:
+    And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:SubFolder1    |
       | oc:file-parent   | UUIDof:folderMain    |
@@ -39,7 +39,7 @@ Feature: Report test
     And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "insideTheFolder.txt" using the WebDAV API
     Then the HTTP status code should be "207"
-    And for user "Brian" the "REPORT" response should contain a mountpoint "folderMain" with these key and value pairs:
+    And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key                | value                                            |
       | oc:fileid          | UUIDof:SubFolder1/subFOLDER2/insideTheFolder.txt |
       | oc:file-parent     | UUIDof:SubFolder1/subFOLDER2                     |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3018,14 +3018,14 @@ class SpacesContext implements Context {
 	/**
 	 * @param string $method # method should be either PROPFIND or REPORT
 	 * @param string $user
-	 * @param string $mountPoint # an entity inside a space, or the space itself
+	 * @param string $spaceNameOrMountPoint # an entity inside a space, or the space name itself
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function theResponseShouldContain(string $method, string $user, string $mountPoint, TableNode $table): void {
+	public function theResponseShouldContain(string $method, string $user, string $spaceNameOrMountPoint, TableNode $table): void {
 		$xmlRes = $this->featureContext->getResponseXml();
 		foreach ($table->getHash() as $row) {
 			$findItem = $row['key'];
@@ -3037,23 +3037,23 @@ class SpacesContext implements Context {
 					$resourceType = $xmlRes->xpath("//d:response/d:propstat/d:prop/d:getcontenttype")[0]->__toString();
 					if ($method === 'PROPFIND') {
 						if (!$resourceType) {
-							Assert::assertEquals($this->getFolderId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFolderId($user, $spaceNameOrMountPoint, $value), $responseValue, 'wrong fileId in the response');
 						} else {
-							Assert::assertEquals($this->getFileId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFileId($user, $spaceNameOrMountPoint, $value), $responseValue, 'wrong fileId in the response');
 						}
 					} else {
 						if ($resourceType === 'httpd/unix-directory') {
-							Assert::assertEquals($this->getFolderId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFolderId($user, $spaceNameOrMountPoint, $value), $responseValue, 'wrong fileId in the response');
 						} else {
-							Assert::assertEquals($this->getFileId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFileId($user, $spaceNameOrMountPoint, $value), $responseValue, 'wrong fileId in the response');
 						}
 					}
 					break;
 				case "oc:file-parent":
-					Assert::assertEquals($this->getFolderId($user, $mountPoint, $value), $responseValue, 'wrong file-parentId in the response');
+					Assert::assertEquals($this->getFolderId($user, $spaceNameOrMountPoint, $value), $responseValue, 'wrong file-parentId in the response');
 					break;
 				case "oc:privatelink":
-					Assert::assertEquals($this->getPrivateLink($user, $mountPoint), $responseValue, 'cannot find private link for space or resource in the response');
+					Assert::assertEquals($this->getPrivateLink($user, $spaceNameOrMountPoint), $responseValue, 'cannot find private link for space or resource in the response');
 					break;
 				default:
 					Assert::assertEquals($value, $responseValue, "wrong $findItem in the response");

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1392,7 +1392,7 @@ class SpacesContext implements Context {
 			"Expected response status code should be 200"
 		);
 	}
-  
+
 	/**
 	 * @When /^user "([^"]*)" sets the file "([^"]*)" as a (description|space image)\s? in a special section of the "([^"]*)" space$/
 	 *
@@ -1518,6 +1518,7 @@ class SpacesContext implements Context {
 				$body
 			)
 		);
+		$this->setSpaceCreator($spaceName, $user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201 (Created)"
@@ -2982,9 +2983,8 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" the "([^"]*)" response should contain a (?:space|mountpoint) "([^"]*)" with these key and value pairs:$/
+	 * @Then /^the "([^"]*)" response should contain a space "([^"]*)" with these key and value pairs:$/
 	 *
-	 * @param string $user
 	 * @param string $method # method should be either PROPFIND or REPORT
 	 * @param string $space
 	 * @param TableNode $table
@@ -2993,8 +2993,39 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function theResponseShouldContain(string $user, string $method, string $space, TableNode $table): void {
+	public function theResponseShouldContainSpace(string $method, string $space, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
+		$this->theResponseShouldContain($method, $this->getSpaceCreator($space), $space, $table);
+	}
+
+	/**
+	 * @Then /^the "([^"]*)" response to user "([^"]*)" should contain a mountpoint "([^"]*)" with these key and value pairs:$/
+	 *
+	 * @param string $method # method should be either PROPFIND or REPORT
+	 * @param string $user
+	 * @param string $mountPoint
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function theResponseShouldContainMountPoint(string $method, string $user, string $mountPoint, TableNode $table): void {
+		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
+		$this->theResponseShouldContain($method, $user, $mountPoint, $table);
+	}
+
+	/**
+	 * @param string $method # method should be either PROPFIND or REPORT
+	 * @param string $user
+	 * @param string $mountPoint # an entity inside a space, or the space itself
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function theResponseShouldContain(string $method, string $user, string $mountPoint, TableNode $table): void {
 		$xmlRes = $this->featureContext->getResponseXml();
 		foreach ($table->getHash() as $row) {
 			$findItem = $row['key'];
@@ -3006,23 +3037,23 @@ class SpacesContext implements Context {
 					$resourceType = $xmlRes->xpath("//d:response/d:propstat/d:prop/d:getcontenttype")[0]->__toString();
 					if ($method === 'PROPFIND') {
 						if (!$resourceType) {
-							Assert::assertEquals($this->getFolderId($user, $space, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFolderId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
 						} else {
-							Assert::assertEquals($this->getFileId($user, $space, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFileId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
 						}
 					} else {
 						if ($resourceType === 'httpd/unix-directory') {
-							Assert::assertEquals($this->getFolderId($user, $space, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFolderId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
 						} else {
-							Assert::assertEquals($this->getFileId($user, $space, $value), $responseValue, 'wrong fileId in the response');
+							Assert::assertEquals($this->getFileId($user, $mountPoint, $value), $responseValue, 'wrong fileId in the response');
 						}
 					}
 					break;
 				case "oc:file-parent":
-					Assert::assertEquals($this->getFolderId($user, $space, $value), $responseValue, 'wrong file-parentId in the response');
+					Assert::assertEquals($this->getFolderId($user, $mountPoint, $value), $responseValue, 'wrong file-parentId in the response');
 					break;
 				case "oc:privatelink":
-					Assert::assertEquals($this->getPrivateLink($user, $space), $responseValue, 'cannot find private link for space or resource in the response');
+					Assert::assertEquals($this->getPrivateLink($user, $mountPoint), $responseValue, 'cannot find private link for space or resource in the response');
 					break;
 				default:
 					Assert::assertEquals($value, $responseValue, "wrong $findItem in the response");


### PR DESCRIPTION
## Description
We don't really need to mention the user name in the step:
```
    Then for user "Alice" the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
```

That user is used to find out information about the space, and compare it with what came in a previous response (which was remembered from the result of a When step). We already remember the user who created each space, so we can use that user inside the Then step, when we want to do any extra requests about the space.

IMO this reduces confusion a bit when reading the scenarios.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
