### PR TITLE
Fix Postprocessing service

### DIFF
--- a/changelog/unreleased/fix-postprocessing.md
+++ b/changelog/unreleased/fix-postprocessing.md
@@ -1,0 +1,5 @@
+Bugfix: Fix Postprocessing events
+
+Postprocessing service did not want to play with non-tls events. That is fixed now
+
+https://github.com/owncloud/ocis/pull/5269

--- a/services/postprocessing/pkg/command/server.go
+++ b/services/postprocessing/pkg/command/server.go
@@ -36,7 +36,7 @@ func Server(cfg *config.Config) *cli.Command {
 			evtsCfg := cfg.Postprocessing.Events
 			var tlsConf *tls.Config
 
-			if !evtsCfg.TLSInsecure {
+			if evtsCfg.EnableTLS {
 				var rootCAPool *x509.CertPool
 				if evtsCfg.TLSRootCACertificate != "" {
 					rootCrtFile, err := os.Open(evtsCfg.TLSRootCACertificate)

--- a/services/postprocessing/pkg/config/config.go
+++ b/services/postprocessing/pkg/config/config.go
@@ -32,6 +32,7 @@ type Events struct {
 	Endpoint string `yaml:"endpoint" env:"POSTPROCESSING_EVENTS_ENDPOINT" desc:"Endpoint of the event system."`
 	Cluster  string `yaml:"cluster" env:"POSTPROCESSING_EVENTS_CLUSTER" desc:"Cluster ID of the event system."`
 
-	TLSInsecure          bool   `yaml:"tls_insecure" env:"OCIS_INSECURE;SEARCH_EVENTS_TLS_INSECURE" desc:"Whether to verify the server TLS certificates."`
-	TLSRootCACertificate string `yaml:"tls_root_ca_certificate" env:"SEARCH_EVENTS_TLS_ROOT_CA_CERTIFICATE" desc:"The root CA certificate used to validate the server's TLS certificate. If provided SEARCH_EVENTS_TLS_INSECURE will be seen as false."`
+	TLSInsecure          bool   `yaml:"tls_insecure" env:"OCIS_INSECURE;POSTPROCESSING_EVENTS_TLS_INSECURE" desc:"Whether to verify the server TLS certificates."`
+	TLSRootCACertificate string `yaml:"tls_root_ca_certificate" env:"POSTPROCESSING_EVENTS_TLS_ROOT_CA_CERTIFICATE" desc:"The root CA certificate used to validate the server's TLS certificate. If provided POSTPROCESSING_EVENTS_TLS_INSECURE will be seen as false."`
+	EnableTLS            bool   `yaml:"enable_tls" env:"OCIS_EVENTS_ENABLE_TLS;POSTPROCESSING_EVENTS_ENABLE_TLS" desc:"Enable TLS for the connection to the events broker. The events broker is the ocis service which receives and delivers events between the services.."`
 }


### PR DESCRIPTION
Makes it possible to use postprocessing service without `OCIS_INSECURE` flag