### PR TITLE
enable tags in capabilities

### DIFF
--- a/changelog/unreleased/enhancement-tags.md
+++ b/changelog/unreleased/enhancement-tags.md
@@ -5,4 +5,5 @@ Tags can be added (put request) and removed (delete request) from a resource,
 a list of available tags can also be requested by sending a get request to the graph endpoint.
 
 https://github.com/owncloud/ocis/pull/5227
+https://github.com/owncloud/ocis/pull/5271
 https://github.com/owncloud/ocis/issues/5184

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -47,6 +47,7 @@ func FrontendConfigFromStruct(cfg *config.Config) (map[string]interface{}, error
 		"blacklisted_files": []string{},
 		"undelete":          true,
 		"versioning":        true,
+		"tags":              true,
 		"archivers":         archivers,
 		"app_providers":     appProviders,
 		"favorites":         cfg.EnableFavorites,


### PR DESCRIPTION
## Description
tags are technically ported but where not enabled in the capabilities.
This is fixed now.

## Related Issue
- Extends https://github.com/owncloud/ocis/pull/5227