### PR TITLE
Improve extended env var description

### DIFF
--- a/docs/helpers/extended_vars.yaml
+++ b/docs/helpers/extended_vars.yaml
@@ -59,7 +59,7 @@ variables:
   default_value: '''/var/lib/ocis'' or ''$HOME/.ocis/'''
   description: The base directory location used by several services and for user data.
     Predefined to '/var/lib/ocis' for container images (inside the container) or '$HOME/.ocis/'
-    for binary releases. Can be adapted for services individually.
+    for binary releases. Services can have, if available, an individual setting with an own environment variable.
   do_ignore: false
 - rawname: OCIS_CONFIG_DIR
   path: ocis-pkg/config/defaults/paths.go:56

--- a/docs/templates/ADOC_global.tmpl
+++ b/docs/templates/ADOC_global.tmpl
@@ -1,7 +1,7 @@
 // collected through docs/helpers/rougeEnv.go
 
 [caption=]
-.Environment variables with global scope not included in a service
+.Environment variables with extended scope not included in a service
 [width="100%",cols="~,~,~,~",options="header"]
 |===
 | Name


### PR DESCRIPTION
Just a small update of an:
* extended envvar description to be more precise and avoid misinterpretation.
* use the correct word in the table headline (extended instead of global, was a remnant)