### PR TITLE
Add blank comment lines

### DIFF
--- a/protogen/gen/ocis/messages/settings/v0/settings.pb.go
+++ b/protogen/gen/ocis/messages/settings/v0/settings.pb.go
@@ -589,6 +589,7 @@ type Setting struct {
 	DisplayName string `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
 	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
 	// Types that are assignable to Value:
+	//
 	//	*Setting_IntValue
 	//	*Setting_StringValue
 	//	*Setting_BoolValue

--- a/protogen/gen/ocis/services/thumbnails/v0/thumbnails.pb.go
+++ b/protogen/gen/ocis/services/thumbnails/v0/thumbnails.pb.go
@@ -37,6 +37,7 @@ type GetThumbnailRequest struct {
 	// The height of the thumbnail
 	Height int32 `protobuf:"varint,4,opt,name=height,proto3" json:"height,omitempty"`
 	// Types that are assignable to Source:
+	//
 	//	*GetThumbnailRequest_WebdavSource
 	//	*GetThumbnailRequest_Cs3Source
 	Source isGetThumbnailRequest_Source `protobuf_oneof:"source"`


### PR DESCRIPTION
When running `make docs-generate` two files always get blank comment lines added. This is annoying when running make locally as the files pop up as change.

By adding the blank comment lines by default, we get rid of the unrelated change note when running the make command.