### PR TITLE
Update extended envvar yaml file

### DIFF
--- a/docs/helpers/extended_vars.yaml
+++ b/docs/helpers/extended_vars.yaml
@@ -59,7 +59,8 @@ variables:
   default_value: '''/var/lib/ocis'' or ''$HOME/.ocis/'''
   description: The base directory location used by several services and for user data.
     Predefined to '/var/lib/ocis' for container images (inside the container) or '$HOME/.ocis/'
-    for binary releases. Services can have, if available, an individual setting with an own environment variable.
+    for binary releases. Services can have, if available, an individual setting with
+    an own environment variable.
   do_ignore: false
 - rawname: OCIS_CONFIG_DIR
   path: ocis-pkg/config/defaults/paths.go:56


### PR DESCRIPTION
The extended envvar yaml file needs a small update because `make docs-generate` adds a linebreak. This would pop up as change on every lokal make run 😢 