### PR TITLE
Create extended_configvars.adoc

### DIFF
--- a/services/_includes/adoc/extended_configvars.adoc
+++ b/services/_includes/adoc/extended_configvars.adoc
@@ -1,0 +1,55 @@
+// collected through docs/helpers/rougeEnv.go
+
+[caption=]
+.Environment variables with extended scope not included in a service
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Description
+    
+    
+
+a| `MICRO_LOG_LEVEL` +
+a| [subs=-attributes]
+++string ++
+a| [subs=-attributes]
+++Error ++
+a| [subs=-attributes]
+++Set the log level for the internal go micro framework. Only change on supervision of ownCloud Support. ++
+    
+
+a| `MICRO_REGISTRY` +
+a| [subs=-attributes]
+++string ++
+a| [subs=-attributes]
+++ ++
+a| [subs=-attributes]
+++Go micro registry type to use. Supported types are: 'nats', 'kubernetes', 'etcd', 'consul' and 'memory'. Will be selected automatically. Only change on supervision of ownCloud Support. ++
+
+a| `MICRO_REGISTRY_ADDRESS` +
+a| [subs=-attributes]
+++string ++
+a| [subs=-attributes]
+++ ++
+a| [subs=-attributes]
+++The bind address of the internal go micro framework. Only change on supervision of ownCloud Support. ++
+
+a| `OCIS_BASE_DATA_PATH` +
+a| [subs=-attributes]
+++string ++
+a| [subs=-attributes]
+++'/var/lib/ocis' or '$HOME/.ocis/' ++
+a| [subs=-attributes]
+++The base directory location used by several services and for user data. Predefined to '/var/lib/ocis' for container images (inside the container) or '$HOME/.ocis/' for binary releases. Services can have, if available, an individual setting with an own environment variable. ++
+
+a| `OCIS_CONFIG_DIR` +
+a| [subs=-attributes]
+++string ++
+a| [subs=-attributes]
+++'/etc/ocis' or '$HOME/.ocis/config' ++
+a| [subs=-attributes]
+++The default directory location for config files. Predefined to '/etc/ocis' for container images (inside the container) or '$HOME/.ocis/config' for binary releases. ++
+    
+|===


### PR DESCRIPTION
References: #5293

This file has been created in the `docs` branch and needs to be availabe in the `docs-stable-2.0` branch.
It is part of the documentation but has been created post this branch was made.
Neccessary for the docs-ocis repo showing the file as part of the 2.0 version.