### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ OCIS_MODULES = \
 	services/notifications \
 	services/ocdav \
 	services/ocs \
+	services/postprocessing \
 	services/proxy \
 	services/search \
 	services/settings \
@@ -143,6 +144,8 @@ clean:
 
 .PHONY: docs-generate
 docs-generate:
+	# empty the folders first to only have files that are generated without remnants
+	find docs/services/_includes/ -type f \( -name "*" ! -name ".git*" ! -name "_*" \) -delete || exit 1
 	@for mod in $(OCIS_MODULES); do \
         $(MAKE) --no-print-directory -C $$mod docs-generate || exit 1; \
     done


### PR DESCRIPTION
## Description
Makefile needs two updates

* The postprocessing folder was missing in the list of available folders.
This seems to have been forgotten when postprocessing was added.
* Added a command to delete doc files because they are always regenerated to avoid keeping remnants.

## Related Issue
- Part of #5293

## Motivation and Context
Completeness of makefile and to avoid stumbling over remnants

## How Has This Been Tested?
Locally, works fine

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised:
