### PR TITLE
graph: add appRoleAssignments and minimal application resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.7.0
 	github.com/onsi/gomega v1.24.1
 	github.com/orcaman/concurrent-map v1.0.0
-	github.com/owncloud/libre-graph-api-go v1.0.2-0.20230103132919-5c6bf4c6b00e
+	github.com/owncloud/libre-graph-api-go v1.0.2-0.20230105141655-9384face4d5d
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rs/zerolog v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.7.0
 	github.com/onsi/gomega v1.24.1
 	github.com/orcaman/concurrent-map v1.0.0
-	github.com/owncloud/libre-graph-api-go v1.0.1
+	github.com/owncloud/libre-graph-api-go v1.0.2-0.20230103132919-5c6bf4c6b00e
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rs/zerolog v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -1058,8 +1058,8 @@ github.com/oracle/oci-go-sdk v24.3.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35uk
 github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HDbW65HOY=
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
-github.com/owncloud/libre-graph-api-go v1.0.2-0.20230103132919-5c6bf4c6b00e h1:bP/9+DWrIPF87amg0bTp7BknJs/b5Nd32GixgIiCjtM=
-github.com/owncloud/libre-graph-api-go v1.0.2-0.20230103132919-5c6bf4c6b00e/go.mod h1:579sFrPP7aP24LZXGPopLfvE+hAka/2DYHk0+Ij+w+U=
+github.com/owncloud/libre-graph-api-go v1.0.2-0.20230105141655-9384face4d5d h1:aqVf2yJEdSgFQd3k5fnwtYxjTwC/UREAKTZIzeupwHg=
+github.com/owncloud/libre-graph-api-go v1.0.2-0.20230105141655-9384face4d5d/go.mod h1:iKdVH6nYpI8RBeK9sjeLfzrPByST6r9d+NG2IJHoJmU=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/go.sum
+++ b/go.sum
@@ -1058,8 +1058,8 @@ github.com/oracle/oci-go-sdk v24.3.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35uk
 github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HDbW65HOY=
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
-github.com/owncloud/libre-graph-api-go v1.0.1 h1:wj3aQQr/yDPoc97ddg7DCadvMx6ui6N7re/oRV9+yNs=
-github.com/owncloud/libre-graph-api-go v1.0.1/go.mod h1:579sFrPP7aP24LZXGPopLfvE+hAka/2DYHk0+Ij+w+U=
+github.com/owncloud/libre-graph-api-go v1.0.2-0.20230103132919-5c6bf4c6b00e h1:bP/9+DWrIPF87amg0bTp7BknJs/b5Nd32GixgIiCjtM=
+github.com/owncloud/libre-graph-api-go v1.0.2-0.20230103132919-5c6bf4c6b00e/go.mod h1:579sFrPP7aP24LZXGPopLfvE+hAka/2DYHk0+Ij+w+U=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/ocis/pkg/init/init.go
+++ b/ocis/pkg/init/init.go
@@ -50,11 +50,15 @@ type LdapBasedService struct {
 type Events struct {
 	TLSInsecure bool `yaml:"tls_insecure"`
 }
+type GraphApplication struct {
+	ID string `yaml:"id"`
+}
 
 type GraphService struct {
-	Events   Events
-	Spaces   InsecureService
-	Identity LdapBasedService
+	Application GraphApplication
+	Events      Events
+	Spaces      InsecureService
+	Identity    LdapBasedService
 }
 
 type ServiceUserPasswordsSettings struct {
@@ -219,6 +223,7 @@ func CreateConfig(insecure, forceOverwrite bool, configPath, adminPassword strin
 
 	systemUserID := uuid.Must(uuid.NewV4()).String()
 	adminUserID := uuid.Must(uuid.NewV4()).String()
+	graphApplicationID := uuid.Must(uuid.NewV4()).String()
 	storageUsersMountID := uuid.Must(uuid.NewV4()).String()
 
 	idmServicePassword, err := generators.GenerateRandomPassword(passwordLength)
@@ -306,6 +311,9 @@ func CreateConfig(insecure, forceOverwrite bool, configPath, adminPassword strin
 			},
 		},
 		Graph: GraphService{
+			Application: GraphApplication{
+				ID: graphApplicationID,
+			},
 			Identity: LdapBasedService{
 				Ldap: LdapSettings{
 					BindPassword: idmServicePassword,

--- a/services/graph/pkg/config/application.go
+++ b/services/graph/pkg/config/application.go
@@ -1,0 +1,7 @@
+package config
+
+// Application defines the available graph application configuration.
+type Application struct {
+	ID          string `yaml:"id" env:"GRAPH_APPLICATION_ID" desc:"The ocis application id shown in the graph. All app roles are tied to this."`
+	DisplayName string `yaml:"displayname" env:"GRAPH_APPLICATION_DISPLAYNAME" desc:"The oCIS application name"`
+}

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -25,9 +25,10 @@ type Config struct {
 	TokenManager  *TokenManager         `yaml:"token_manager"`
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 
-	Spaces   Spaces   `yaml:"spaces"`
-	Identity Identity `yaml:"identity"`
-	Events   Events   `yaml:"events"`
+	Application Application `yaml:"application"`
+	Spaces      Spaces      `yaml:"spaces"`
+	Identity    Identity    `yaml:"identity"`
+	Events      Events      `yaml:"events"`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -31,9 +31,8 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "graph",
 			// TODO ApplicationID should be randomized on install with init
-			ApplicationID: "14bc9a84-a974-41a6-a948-b19d0a9d7f11",
-			// TODO ApplicationDisplayName should be used in ocis web as well
-			ApplicationDisplayName: "oCIS Web",
+			ApplicationID:          "14bc9a84-a974-41a6-a948-b19d0a9d7f11",
+			ApplicationDisplayName: "ownCloud Infinite Scale",
 		},
 		API: config.API{
 			GroupMembersPatchLimit: 20,

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -30,6 +30,10 @@ func DefaultConfig() *config.Config {
 		},
 		Service: config.Service{
 			Name: "graph",
+			// TODO ApplicationID should be randomized on install with init
+			ApplicationID: "14bc9a84-a974-41a6-a948-b19d0a9d7f11",
+			// TODO ApplicationDisplayName should be used in ocis web as well
+			ApplicationDisplayName: "oCIS Web",
 		},
 		API: config.API{
 			GroupMembersPatchLimit: 20,

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -30,9 +30,9 @@ func DefaultConfig() *config.Config {
 		},
 		Service: config.Service{
 			Name: "graph",
-			// TODO ApplicationID should be randomized on install with init
-			ApplicationID:          "14bc9a84-a974-41a6-a948-b19d0a9d7f11",
-			ApplicationDisplayName: "ownCloud Infinite Scale",
+		},
+		Application: config.Application{
+			DisplayName: "ownCloud Infinite Scale",
 		},
 		API: config.API{
 			GroupMembersPatchLimit: 20,

--- a/services/graph/pkg/config/parser/parse.go
+++ b/services/graph/pkg/config/parser/parse.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
+	defaults2 "github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config/defaults"
@@ -40,6 +42,14 @@ func Validate(cfg *config.Config) error {
 
 	if cfg.Identity.Backend == "ldap" && cfg.Identity.LDAP.BindPassword == "" {
 		return shared.MissingLDAPBindPassword(cfg.Service.Name)
+	}
+
+	if cfg.Application.ID == "" {
+		return fmt.Errorf("The application ID has not been configured for %s. "+
+			"Make sure your %s config contains the proper values "+
+			"(e.g. by running ocis init or setting it manually in "+
+			"the config/corresponding environment variable).",
+			"graph", defaults2.BaseConfigPath())
 	}
 
 	return nil

--- a/services/graph/pkg/config/service.go
+++ b/services/graph/pkg/config/service.go
@@ -3,7 +3,4 @@ package config
 // Service defines the available service configuration.
 type Service struct {
 	Name string `yaml:"-"`
-
-	ApplicationID          string `yaml:"application_id" env:"GRAPH_APPLICATION_ID" desc:"The ocis web application id"` // TODO actually this is the application id for ocis web, and ocis web also needs to know it
-	ApplicationDisplayName string `yaml:"application_displayname" env:"GRAPH_APPLICATION_DISPLAYNAME" desc:"The ocis web application name"`
 }

--- a/services/graph/pkg/config/service.go
+++ b/services/graph/pkg/config/service.go
@@ -3,4 +3,7 @@ package config
 // Service defines the available service configuration.
 type Service struct {
 	Name string `yaml:"-"`
+
+	ApplicationID          string `yaml:"application_id" env:"GRAPH_APPLICATION_ID" desc:"The ocis web application id"` // TODO actually this is the application id for ocis web, and ocis web also needs to know it
+	ApplicationDisplayName string `yaml:"application_displayname" env:"GRAPH_APPLICATION_DISPLAYNAME" desc:"The ocis web application name"`
 }

--- a/services/graph/pkg/service/v0/application.go
+++ b/services/graph/pkg/service/v0/application.go
@@ -30,8 +30,8 @@ func (g Graph) ListApplications(w http.ResponseWriter, r *http.Request) {
 		roles = append(roles, *role)
 	}
 
-	application := libregraph.NewApplication(g.config.Service.ApplicationID)
-	application.SetDisplayName(g.config.Service.ApplicationDisplayName)
+	application := libregraph.NewApplication(g.config.Application.ID)
+	application.SetDisplayName(g.config.Application.DisplayName)
 	application.SetAppRoles(roles)
 
 	applications := []*libregraph.Application{
@@ -49,8 +49,8 @@ func (g Graph) GetApplication(w http.ResponseWriter, r *http.Request) {
 
 	applicationID := chi.URLParam(r, "applicationID")
 
-	if applicationID != g.config.Service.ApplicationID {
-		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, fmt.Sprintf("resource id %s does not match expected application id %v", applicationID, g.config.Service.ApplicationID))
+	if applicationID != g.config.Application.ID {
+		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, fmt.Sprintf("resource id %s does not match expected application id %v", applicationID, g.config.Application.ID))
 		return
 	}
 
@@ -69,7 +69,7 @@ func (g Graph) GetApplication(w http.ResponseWriter, r *http.Request) {
 	}
 
 	application := libregraph.NewApplication(applicationID)
-	application.SetDisplayName(g.config.Service.ApplicationDisplayName)
+	application.SetDisplayName(g.config.Application.DisplayName)
 	application.SetAppRoles(roles)
 
 	render.Status(r, http.StatusOK)

--- a/services/graph/pkg/service/v0/application.go
+++ b/services/graph/pkg/service/v0/application.go
@@ -14,7 +14,7 @@ import (
 // ListApplications implements the Service interface.
 func (g Graph) ListApplications(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
-	logger.Info().Interface("query", r.URL.Query()).Msg("calling get application")
+	logger.Info().Interface("query", r.URL.Query()).Msg("calling list applications")
 
 	lbr, err := g.roleService.ListRoles(r.Context(), &settingssvc.ListBundlesRequest{})
 	if err != nil {
@@ -50,7 +50,7 @@ func (g Graph) GetApplication(w http.ResponseWriter, r *http.Request) {
 	applicationID := chi.URLParam(r, "applicationID")
 
 	if applicationID != g.config.Application.ID {
-		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, fmt.Sprintf("resource id %s does not match expected application id %v", applicationID, g.config.Application.ID))
+		errorcode.ItemNotFound.Render(w, r, http.StatusNotFound, fmt.Sprintf("requested id %s does not match expected application id %v", applicationID, g.config.Application.ID))
 		return
 	}
 

--- a/services/graph/pkg/service/v0/application.go
+++ b/services/graph/pkg/service/v0/application.go
@@ -1,0 +1,42 @@
+package svc
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+)
+
+// GetApplication implements the Service interface.
+func (g Graph) GetApplication(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Interface("query", r.URL.Query()).Msg("calling get application")
+
+	applicationID := chi.URLParam(r, "applicationID")
+
+	role1 := libregraph.NewAppRole("uuid-for-employee-role")
+	role1.SetDisplayName("Employee")
+	role2 := libregraph.NewAppRole("uuid-for-managemer-role")
+	role2.SetDisplayName("Manager")
+	role3 := libregraph.NewAppRole("uuid-for-staff-role")
+	role3.SetDisplayName("Staff")
+	role4 := libregraph.NewAppRole("uuid-for-student-role")
+	role4.SetDisplayName("Student")
+	role5 := libregraph.NewAppRole("uuid-for-admin-role")
+	role5.SetDisplayName("Administrator")
+	role5.SetDescription("Can administrate all aspects of an application")
+	role6 := libregraph.NewAppRole("uuid-for-guest-role")
+	role6.SetDisplayName("Guest")
+	role5.SetDescription("Can access shared resources, but has no personal drive")
+	role7 := libregraph.NewAppRole("uuid-for-configurator-role")
+	role7.SetDisplayName("Configurator")
+
+	application := libregraph.NewApplication(applicationID)
+	application.SetAppRoles([]libregraph.AppRole{
+		*role1, *role2, *role3, *role4, *role5, *role6, *role7,
+	})
+
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, &ListResponse{Value: application})
+}

--- a/services/graph/pkg/service/v0/application.go
+++ b/services/graph/pkg/service/v0/application.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 )
@@ -24,9 +23,7 @@ func (g Graph) GetApplication(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
-
-	lbr, err := s.ListRoles(r.Context(), &settingssvc.ListBundlesRequest{})
+	lbr, err := g.roleService.ListRoles(r.Context(), &settingssvc.ListBundlesRequest{})
 	if err != nil {
 		logger.Error().Err(err).Msg("could not list roles: transport error")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
@@ -45,5 +42,5 @@ func (g Graph) GetApplication(w http.ResponseWriter, r *http.Request) {
 	application.SetAppRoles(roles)
 
 	render.Status(r, http.StatusOK)
-	render.JSON(w, r, &ListResponse{Value: application})
+	render.JSON(w, r, application)
 }

--- a/services/graph/pkg/service/v0/application.go
+++ b/services/graph/pkg/service/v0/application.go
@@ -6,6 +6,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
+	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 )
 
 // GetApplication implements the Service interface.
@@ -13,29 +16,27 @@ func (g Graph) GetApplication(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Interface("query", r.URL.Query()).Msg("calling get application")
 
+	// TODO make application id and name for this instance configurable
 	applicationID := chi.URLParam(r, "applicationID")
 
-	role1 := libregraph.NewAppRole("uuid-for-employee-role")
-	role1.SetDisplayName("Employee")
-	role2 := libregraph.NewAppRole("uuid-for-managemer-role")
-	role2.SetDisplayName("Manager")
-	role3 := libregraph.NewAppRole("uuid-for-staff-role")
-	role3.SetDisplayName("Staff")
-	role4 := libregraph.NewAppRole("uuid-for-student-role")
-	role4.SetDisplayName("Student")
-	role5 := libregraph.NewAppRole("uuid-for-admin-role")
-	role5.SetDisplayName("Administrator")
-	role5.SetDescription("Can administrate all aspects of an application")
-	role6 := libregraph.NewAppRole("uuid-for-guest-role")
-	role6.SetDisplayName("Guest")
-	role5.SetDescription("Can access shared resources, but has no personal drive")
-	role7 := libregraph.NewAppRole("uuid-for-configurator-role")
-	role7.SetDisplayName("Configurator")
+	s := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
+
+	lbr, err := s.ListRoles(r.Context(), &settingssvc.ListBundlesRequest{})
+	if err != nil {
+		logger.Error().Err(err).Msg("could not list roles: transport error")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	roles := make([]libregraph.AppRole, 0, len(lbr.Bundles))
+	for _, bundle := range lbr.GetBundles() {
+		role := libregraph.NewAppRole(bundle.GetId())
+		role.SetDisplayName(bundle.GetDisplayName())
+		roles = append(roles, *role)
+	}
 
 	application := libregraph.NewApplication(applicationID)
-	application.SetAppRoles([]libregraph.AppRole{
-		*role1, *role2, *role3, *role4, *role5, *role6, *role7,
-	})
+	application.SetAppRoles(roles)
 
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, &ListResponse{Value: application})

--- a/services/graph/pkg/service/v0/application_test.go
+++ b/services/graph/pkg/service/v0/application_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Applications", func() {
 		cfg.Application.ID = "some-application-ID"
 
 		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
-		svc = service.NewService(
+		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewayClient(gatewayClient),
 			service.EventsPublisher(&eventsPublisher),

--- a/services/graph/pkg/service/v0/application_test.go
+++ b/services/graph/pkg/service/v0/application_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Applications", func() {
 		cfg.TokenManager.JWTSecret = "loremipsum"
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		cfg.Service.ApplicationID = "some-application-ID"
+		cfg.Application.ID = "some-application-ID"
 
 		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc = service.NewService(
@@ -92,7 +92,7 @@ var _ = Describe("Applications", func() {
 			err = json.Unmarshal(data, &responseList)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(responseList.Value)).To(Equal(1))
-			Expect(responseList.Value[0].Id).To(Equal(cfg.Service.ApplicationID))
+			Expect(responseList.Value[0].Id).To(Equal(cfg.Application.ID))
 			Expect(len(responseList.Value[0].GetAppRoles())).To(Equal(1))
 			Expect(responseList.Value[0].GetAppRoles()[0].GetId()).To(Equal("some-appRole-ID"))
 			Expect(responseList.Value[0].GetAppRoles()[0].GetDisplayName()).To(Equal("A human readable name for a role"))
@@ -113,7 +113,7 @@ var _ = Describe("Applications", func() {
 
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/applications/some-application-ID", nil)
 			rctx := chi.NewRouteContext()
-			rctx.URLParams.Add("applicationID", cfg.Service.ApplicationID)
+			rctx.URLParams.Add("applicationID", cfg.Application.ID)
 			r = r.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
 			svc.GetApplication(rr, r)
 
@@ -125,7 +125,7 @@ var _ = Describe("Applications", func() {
 			application := libregraph.Application{}
 			err = json.Unmarshal(data, &application)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(application.Id).To(Equal(cfg.Service.ApplicationID))
+			Expect(application.Id).To(Equal(cfg.Application.ID))
 			Expect(len(application.GetAppRoles())).To(Equal(1))
 			Expect(application.GetAppRoles()[0].GetId()).To(Equal("some-appRole-ID"))
 			Expect(application.GetAppRoles()[0].GetDisplayName()).To(Equal("A human readable name for a role"))

--- a/services/graph/pkg/service/v0/approleassignments.go
+++ b/services/graph/pkg/service/v0/approleassignments.go
@@ -1,12 +1,15 @@
 package svc
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
+	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 )
@@ -31,17 +34,9 @@ func (g Graph) ListAppRoleAssignments(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	values := make([]*libregraph.AppRoleAssignment, 0, len(lrar.GetAssignments()))
+	values := make([]libregraph.AppRoleAssignment, 0, len(lrar.GetAssignments()))
 	for _, assignment := range lrar.GetAssignments() {
-		appRoleAssignment := libregraph.NewAppRoleAssignmentWithDefaults()
-		appRoleAssignment.SetId(assignment.Id)
-		appRoleAssignment.SetAppRoleId(assignment.RoleId)
-		appRoleAssignment.SetPrincipalType(principalTypeUser)  // currently always assigned to the user
-		appRoleAssignment.SetResourceId("todo-application-id") // TODO read from config
-		// appRoleAssignment.SetResourceDisplayName() // TODO read from config?
-		appRoleAssignment.SetPrincipalId(assignment.AccountUuid)
-		// appRoleAssignment.SetPrincipalDisplayName() // TODO fetch and cache
-		values = append(values, appRoleAssignment)
+		values = append(values, g.assignmentToAppRoleAssignment(assignment))
 	}
 
 	render.Status(r, http.StatusOK)
@@ -55,13 +50,37 @@ func (g Graph) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 
 	userID := chi.URLParam(r, "userID")
 
-	ara := libregraph.NewAppRoleAssignmentWithDefaults()
-	ara.SetAppRoleId("new-appRoleID")
-	ara.SetPrincipalId(userID)
-	ara.SetResourceId("some-application-id")
+	appRoleAssignment := libregraph.NewAppRoleAssignmentWithDefaults()
+	err := json.NewDecoder(r.Body).Decode(appRoleAssignment)
+	if err != nil {
+		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create user: invalid request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err.Error()))
+		return
+	}
+
+	if appRoleAssignment.GetPrincipalId() != userID {
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("user id %s does not match principal id %v", userID, appRoleAssignment.GetPrincipalId()))
+		return
+	}
+	if appRoleAssignment.GetResourceId() != g.config.Service.ApplicationID {
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("resource id %s does not match expected application id %v", userID, g.config.Service.ApplicationID))
+		return
+	}
+
+	s := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
+
+	artur, err := s.AssignRoleToUser(r.Context(), &settingssvc.AssignRoleToUserRequest{
+		AccountUuid: userID,
+		RoleId:      appRoleAssignment.AppRoleId,
+	})
+	if err != nil {
+		logger.Error().Err(err).Msg("could not assign role to user")
+		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
 
 	render.Status(r, http.StatusCreated)
-	render.JSON(w, r, ara)
+	render.JSON(w, r, g.assignmentToAppRoleAssignment(artur.GetAssignment()))
 }
 
 // DeleteAppRoleAssignment implements the Service interface.
@@ -70,4 +89,16 @@ func (g Graph) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 	logger.Info().Interface("body", r.Body).Msg("calling delete appRoleAssignment")
 
 	render.NoContent(w, r)
+}
+
+func (g Graph) assignmentToAppRoleAssignment(assignment *settingsmsg.UserRoleAssignment) libregraph.AppRoleAssignment {
+	appRoleAssignment := libregraph.NewAppRoleAssignmentWithDefaults()
+	appRoleAssignment.SetId(assignment.Id)
+	appRoleAssignment.SetAppRoleId(assignment.RoleId)
+	appRoleAssignment.SetPrincipalType(principalTypeUser) // currently always assigned to the user
+	appRoleAssignment.SetResourceId(g.config.Service.ApplicationID)
+	appRoleAssignment.SetResourceDisplayName(g.config.Service.ApplicationDisplayName)
+	appRoleAssignment.SetPrincipalId(assignment.AccountUuid)
+	// appRoleAssignment.SetPrincipalDisplayName() // TODO fetch and cache
+	return *appRoleAssignment
 }

--- a/services/graph/pkg/service/v0/approleassignments.go
+++ b/services/graph/pkg/service/v0/approleassignments.go
@@ -1,0 +1,55 @@
+package svc
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+)
+
+// ListAppRoleAssignments implements the Service interface.
+func (g Graph) ListAppRoleAssignments(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Interface("query", r.URL.Query()).Msg("calling list appRoleAssignments")
+
+	userID := chi.URLParam(r, "userID")
+
+	ara1 := libregraph.NewAppRoleAssignmentWithDefaults()
+	ara1.SetAppRoleId("appRoleID-1")
+	ara1.SetPrincipalId(userID)
+	ara1.SetResourceId("some-application-id")
+	ara2 := libregraph.NewAppRoleAssignmentWithDefaults()
+	ara2.SetAppRoleId("appRoleID-2")
+	ara2.SetPrincipalId(userID)
+	ara2.SetResourceId("some-application-id")
+
+	values := []*libregraph.AppRoleAssignment{ara1, ara2}
+
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, &ListResponse{Value: values})
+}
+
+// CreateAppRoleAssignment implements the Service interface.
+func (g Graph) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Interface("query", r.URL.Query()).Msg("calling create appRoleAssignment")
+
+	userID := chi.URLParam(r, "userID")
+
+	ara := libregraph.NewAppRoleAssignmentWithDefaults()
+	ara.SetAppRoleId("new-appRoleID")
+	ara.SetPrincipalId(userID)
+	ara.SetResourceId("some-application-id")
+
+	render.Status(r, http.StatusCreated)
+	render.JSON(w, r, ara)
+}
+
+// DeleteAppRoleAssignment implements the Service interface.
+func (g Graph) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	logger := g.logger.SubloggerWithRequestID(r.Context())
+	logger.Info().Interface("body", r.Body).Msg("calling delete appRoleAssignment")
+
+	render.NoContent(w, r)
+}

--- a/services/graph/pkg/service/v0/approleassignments.go
+++ b/services/graph/pkg/service/v0/approleassignments.go
@@ -58,8 +58,8 @@ func (g Graph) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("user id %s does not match principal id %v", userID, appRoleAssignment.GetPrincipalId()))
 		return
 	}
-	if appRoleAssignment.GetResourceId() != g.config.Service.ApplicationID {
-		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("resource id %s does not match expected application id %v", userID, g.config.Service.ApplicationID))
+	if appRoleAssignment.GetResourceId() != g.config.Application.ID {
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("resource id %s does not match expected application id %v", userID, g.config.Application.ID))
 		return
 	}
 
@@ -121,8 +121,8 @@ func (g Graph) assignmentToAppRoleAssignment(assignment *settingsmsg.UserRoleAss
 	appRoleAssignment.SetId(assignment.Id)
 	appRoleAssignment.SetAppRoleId(assignment.RoleId)
 	appRoleAssignment.SetPrincipalType(principalTypeUser) // currently always assigned to the user
-	appRoleAssignment.SetResourceId(g.config.Service.ApplicationID)
-	appRoleAssignment.SetResourceDisplayName(g.config.Service.ApplicationDisplayName)
+	appRoleAssignment.SetResourceId(g.config.Application.ID)
+	appRoleAssignment.SetResourceDisplayName(g.config.Application.DisplayName)
 	appRoleAssignment.SetPrincipalId(assignment.AccountUuid)
 	// appRoleAssignment.SetPrincipalDisplayName() // TODO fetch and cache
 	return *appRoleAssignment

--- a/services/graph/pkg/service/v0/approleassignments.go
+++ b/services/graph/pkg/service/v0/approleassignments.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
@@ -23,9 +22,7 @@ func (g Graph) ListAppRoleAssignments(w http.ResponseWriter, r *http.Request) {
 
 	userID := chi.URLParam(r, "userID")
 
-	s := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
-
-	lrar, err := s.ListRoleAssignments(r.Context(), &settingssvc.ListRoleAssignmentsRequest{
+	lrar, err := g.roleService.ListRoleAssignments(r.Context(), &settingssvc.ListRoleAssignmentsRequest{
 		AccountUuid: userID,
 	})
 	if err != nil {
@@ -66,9 +63,7 @@ func (g Graph) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
-
-	artur, err := s.AssignRoleToUser(r.Context(), &settingssvc.AssignRoleToUserRequest{
+	artur, err := g.roleService.AssignRoleToUser(r.Context(), &settingssvc.AssignRoleToUserRequest{
 		AccountUuid: userID,
 		RoleId:      appRoleAssignment.AppRoleId,
 	})
@@ -86,12 +81,10 @@ func (g Graph) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Interface("body", r.Body).Msg("calling delete appRoleAssignment")
 
-	s := settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
-
 	userID := chi.URLParam(r, "userID")
 
 	// check assignment belongs to the user
-	lrar, err := s.ListRoleAssignments(r.Context(), &settingssvc.ListRoleAssignmentsRequest{
+	lrar, err := g.roleService.ListRoleAssignments(r.Context(), &settingssvc.ListRoleAssignmentsRequest{
 		AccountUuid: userID,
 	})
 	if err != nil {
@@ -112,7 +105,7 @@ func (g Graph) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = s.RemoveRoleFromUser(r.Context(), &settingssvc.RemoveRoleFromUserRequest{
+	_, err = g.roleService.RemoveRoleFromUser(r.Context(), &settingssvc.RemoveRoleFromUserRequest{
 		Id: appRoleAssignmentID,
 	})
 	if err != nil {

--- a/services/graph/pkg/service/v0/approleassignments_test.go
+++ b/services/graph/pkg/service/v0/approleassignments_test.go
@@ -66,7 +66,7 @@ var _ = Describe("AppRoleAssignments", func() {
 		cfg.TokenManager.JWTSecret = "loremipsum"
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		cfg.Service.ApplicationID = "some-application-ID"
+		cfg.Application.ID = "some-application-ID"
 
 		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc = service.NewService(
@@ -110,7 +110,7 @@ var _ = Describe("AppRoleAssignments", func() {
 			Expect(responseList.Value[0].GetId()).ToNot(BeEmpty())
 			Expect(responseList.Value[0].GetAppRoleId()).To(Equal("some-appRole-ID"))
 			Expect(responseList.Value[0].GetPrincipalId()).To(Equal(user.GetId()))
-			Expect(responseList.Value[0].GetResourceId()).To(Equal(cfg.Service.ApplicationID))
+			Expect(responseList.Value[0].GetResourceId()).To(Equal(cfg.Application.ID))
 
 		})
 
@@ -131,7 +131,7 @@ var _ = Describe("AppRoleAssignments", func() {
 			ara := libregraph.NewAppRoleAssignmentWithDefaults()
 			ara.SetAppRoleId("some-appRole-ID")
 			ara.SetPrincipalId(user.GetId())
-			ara.SetResourceId(cfg.Service.ApplicationID)
+			ara.SetResourceId(cfg.Application.ID)
 
 			araJson, err := json.Marshal(ara)
 			Expect(err).ToNot(HaveOccurred())
@@ -153,7 +153,7 @@ var _ = Describe("AppRoleAssignments", func() {
 			Expect(assignment.GetId()).ToNot(BeEmpty())
 			Expect(assignment.GetAppRoleId()).To(Equal("some-appRole-ID"))
 			Expect(assignment.GetPrincipalId()).To(Equal("user1"))
-			Expect(assignment.GetResourceId()).To(Equal(cfg.Service.ApplicationID))
+			Expect(assignment.GetResourceId()).To(Equal(cfg.Application.ID))
 		})
 
 	})
@@ -178,7 +178,7 @@ var _ = Describe("AppRoleAssignments", func() {
 			ara := libregraph.NewAppRoleAssignmentWithDefaults()
 			ara.SetAppRoleId("some-appRole-ID")
 			ara.SetPrincipalId(user.GetId())
-			ara.SetResourceId(cfg.Service.ApplicationID)
+			ara.SetResourceId(cfg.Application.ID)
 
 			araJson, err := json.Marshal(ara)
 			Expect(err).ToNot(HaveOccurred())

--- a/services/graph/pkg/service/v0/approleassignments_test.go
+++ b/services/graph/pkg/service/v0/approleassignments_test.go
@@ -1,0 +1,198 @@
+package svc_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/go-chi/chi/v5"
+	"github.com/golang/protobuf/ptypes/empty"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+
+	libregraph "github.com/owncloud/libre-graph-api-go"
+	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
+	settings "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
+	"github.com/owncloud/ocis/v2/services/graph/mocks"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/config/defaults"
+	identitymocks "github.com/owncloud/ocis/v2/services/graph/pkg/identity/mocks"
+	service "github.com/owncloud/ocis/v2/services/graph/pkg/service/v0"
+)
+
+type assignmentList struct {
+	Value []*libregraph.AppRoleAssignment
+}
+
+var _ = Describe("AppRoleAssignments", func() {
+	var (
+		svc             service.Service
+		ctx             context.Context
+		cfg             *config.Config
+		gatewayClient   *mocks.GatewayClient
+		eventsPublisher mocks.Publisher
+		roleService     *mocks.RoleService
+		identityBackend *identitymocks.Backend
+
+		rr *httptest.ResponseRecorder
+
+		currentUser = &userv1beta1.User{
+			Id: &userv1beta1.UserId{
+				OpaqueId: "user",
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		eventsPublisher.On("Publish", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		identityBackend = &identitymocks.Backend{}
+		roleService = &mocks.RoleService{}
+		gatewayClient = &mocks.GatewayClient{}
+
+		rr = httptest.NewRecorder()
+		ctx = context.Background()
+
+		cfg = defaults.FullDefaultConfig()
+		cfg.Identity.LDAP.CACert = "" // skip the startup checks, we don't use LDAP at all in this tests
+		cfg.TokenManager.JWTSecret = "loremipsum"
+		cfg.Commons = &shared.Commons{}
+		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
+		cfg.Service.ApplicationID = "some-application-ID"
+
+		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
+		svc = service.NewService(
+			service.Config(cfg),
+			service.WithGatewayClient(gatewayClient),
+			service.EventsPublisher(&eventsPublisher),
+			service.WithIdentityBackend(identityBackend),
+			service.WithRoleService(roleService),
+		)
+	})
+
+	Describe("ListAppRoleAssignments", func() {
+		It("lists the appRoleAssignments", func() {
+			user := &libregraph.User{
+				Id: libregraph.PtrString("user1"),
+			}
+			assignments := []*settingsmsg.UserRoleAssignment{
+				{
+					Id:          "some-appRoleAssignment-ID",
+					AccountUuid: user.GetId(),
+					RoleId:      "some-appRole-ID",
+				},
+			}
+			roleService.On("ListRoleAssignments", mock.Anything, mock.Anything, mock.Anything).Return(&settings.ListRoleAssignmentsResponse{Assignments: assignments}, nil)
+
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users/user1/appRoleAssignments", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("userID", user.GetId())
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			svc.ListAppRoleAssignments(rr, r)
+
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			data, err := io.ReadAll(rr.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			responseList := assignmentList{}
+			err = json.Unmarshal(data, &responseList)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(responseList.Value)).To(Equal(1))
+			Expect(responseList.Value[0].GetId()).ToNot(BeEmpty())
+			Expect(responseList.Value[0].GetAppRoleId()).To(Equal("some-appRole-ID"))
+			Expect(responseList.Value[0].GetPrincipalId()).To(Equal(user.GetId()))
+			Expect(responseList.Value[0].GetResourceId()).To(Equal(cfg.Service.ApplicationID))
+
+		})
+
+	})
+
+	Describe("CreateAppRoleAssignment", func() {
+		It("creates an appRoleAssignment", func() {
+			user := &libregraph.User{
+				Id: libregraph.PtrString("user1"),
+			}
+			userRoleAssignment := &settingsmsg.UserRoleAssignment{
+				Id:          "some-appRoleAssignment-ID",
+				AccountUuid: user.GetId(),
+				RoleId:      "some-appRole-ID",
+			}
+			roleService.On("AssignRoleToUser", mock.Anything, mock.Anything, mock.Anything).Return(&settings.AssignRoleToUserResponse{Assignment: userRoleAssignment}, nil)
+
+			ara := libregraph.NewAppRoleAssignmentWithDefaults()
+			ara.SetAppRoleId("some-appRole-ID")
+			ara.SetPrincipalId(user.GetId())
+			ara.SetResourceId(cfg.Service.ApplicationID)
+
+			araJson, err := json.Marshal(ara)
+			Expect(err).ToNot(HaveOccurred())
+
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users/user1/appRoleAssignments", bytes.NewBuffer(araJson))
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("userID", user.GetId())
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			svc.CreateAppRoleAssignment(rr, r)
+
+			Expect(rr.Code).To(Equal(http.StatusCreated))
+
+			data, err := io.ReadAll(rr.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			assignment := libregraph.AppRoleAssignment{}
+			err = json.Unmarshal(data, &assignment)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(assignment.GetId()).ToNot(BeEmpty())
+			Expect(assignment.GetAppRoleId()).To(Equal("some-appRole-ID"))
+			Expect(assignment.GetPrincipalId()).To(Equal("user1"))
+			Expect(assignment.GetResourceId()).To(Equal(cfg.Service.ApplicationID))
+		})
+
+	})
+
+	Describe("DeleteAppRoleAssignment", func() {
+		It("deletes an appRoleAssignment", func() {
+			user := &libregraph.User{
+				Id: libregraph.PtrString("user1"),
+			}
+
+			assignments := []*settingsmsg.UserRoleAssignment{
+				{
+					Id:          "some-appRoleAssignment-ID",
+					AccountUuid: user.GetId(),
+					RoleId:      "some-appRole-ID",
+				},
+			}
+			roleService.On("ListRoleAssignments", mock.Anything, mock.Anything, mock.Anything).Return(&settings.ListRoleAssignmentsResponse{Assignments: assignments}, nil)
+
+			roleService.On("RemoveRoleFromUser", mock.Anything, mock.Anything, mock.Anything).Return(&empty.Empty{}, nil)
+
+			ara := libregraph.NewAppRoleAssignmentWithDefaults()
+			ara.SetAppRoleId("some-appRole-ID")
+			ara.SetPrincipalId(user.GetId())
+			ara.SetResourceId(cfg.Service.ApplicationID)
+
+			araJson, err := json.Marshal(ara)
+			Expect(err).ToNot(HaveOccurred())
+
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users/user1/appRoleAssignments/some-appRoleAssignment-ID", bytes.NewBuffer(araJson))
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("userID", user.GetId())
+			rctx.URLParams.Add("appRoleAssignmentID", "some-appRoleAssignment-ID")
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			svc.DeleteAppRoleAssignment(rr, r)
+
+			Expect(rr.Code).To(Equal(http.StatusNoContent))
+
+		})
+
+	})
+})

--- a/services/graph/pkg/service/v0/approleassignments_test.go
+++ b/services/graph/pkg/service/v0/approleassignments_test.go
@@ -69,7 +69,7 @@ var _ = Describe("AppRoleAssignments", func() {
 		cfg.Application.ID = "some-application-ID"
 
 		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
-		svc = service.NewService(
+		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewayClient(gatewayClient),
 			service.EventsPublisher(&eventsPublisher),

--- a/services/graph/pkg/service/v0/educationuser_test.go
+++ b/services/graph/pkg/service/v0/educationuser_test.go
@@ -74,7 +74,7 @@ var _ = Describe("EducationUsers", func() {
 			service.WithGatewayClient(gatewayClient),
 			service.EventsPublisher(&eventsPublisher),
 			service.WithIdentityEducationBackend(identityEducationBackend),
-			//service.WithRoleService(roleService),
+			service.WithRoleService(roleService),
 		)
 	})
 

--- a/services/graph/pkg/service/v0/instrument.go
+++ b/services/graph/pkg/service/v0/instrument.go
@@ -24,9 +24,14 @@ func (i instrument) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	i.next.ServeHTTP(w, r)
 }
 
+// ListApplications implements the Service interface.
+func (i instrument) ListApplications(w http.ResponseWriter, r *http.Request) {
+	i.next.ListApplications(w, r)
+}
+
 // GetApplication implements the Service interface.
 func (i instrument) GetApplication(w http.ResponseWriter, r *http.Request) {
-	i.next.GetMe(w, r)
+	i.next.GetApplication(w, r)
 }
 
 // GetMe implements the Service interface.

--- a/services/graph/pkg/service/v0/instrument.go
+++ b/services/graph/pkg/service/v0/instrument.go
@@ -59,6 +59,21 @@ func (i instrument) ChangeOwnPassword(w http.ResponseWriter, r *http.Request) {
 	i.next.ChangeOwnPassword(w, r)
 }
 
+// ListAppRoleAssignments implements the Service interface.
+func (i instrument) ListAppRoleAssignments(w http.ResponseWriter, r *http.Request) {
+	i.next.ListAppRoleAssignments(w, r)
+}
+
+// CreateAppRoleAssignment implements the Service interface.
+func (i instrument) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	i.next.CreateAppRoleAssignment(w, r)
+}
+
+// DeleteAppRoleAssignment implements the Service interface.
+func (i instrument) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	i.next.DeleteAppRoleAssignment(w, r)
+}
+
 // GetGroups implements the Service interface.
 func (i instrument) GetGroups(w http.ResponseWriter, r *http.Request) {
 	i.next.GetGroups(w, r)

--- a/services/graph/pkg/service/v0/instrument.go
+++ b/services/graph/pkg/service/v0/instrument.go
@@ -24,6 +24,11 @@ func (i instrument) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	i.next.ServeHTTP(w, r)
 }
 
+// GetApplication implements the Service interface.
+func (i instrument) GetApplication(w http.ResponseWriter, r *http.Request) {
+	i.next.GetMe(w, r)
+}
+
 // GetMe implements the Service interface.
 func (i instrument) GetMe(w http.ResponseWriter, r *http.Request) {
 	i.next.GetMe(w, r)

--- a/services/graph/pkg/service/v0/logging.go
+++ b/services/graph/pkg/service/v0/logging.go
@@ -24,9 +24,14 @@ func (l logging) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l.next.ServeHTTP(w, r)
 }
 
+// ListApplications implements the Service interface.
+func (l logging) ListApplications(w http.ResponseWriter, r *http.Request) {
+	l.next.ListApplications(w, r)
+}
+
 // GetApplication implements the Service interface.
 func (l logging) GetApplication(w http.ResponseWriter, r *http.Request) {
-	l.next.GetMe(w, r)
+	l.next.GetApplication(w, r)
 }
 
 // GetMe implements the Service interface.

--- a/services/graph/pkg/service/v0/logging.go
+++ b/services/graph/pkg/service/v0/logging.go
@@ -59,6 +59,21 @@ func (l logging) ChangeOwnPassword(w http.ResponseWriter, r *http.Request) {
 	l.next.ChangeOwnPassword(w, r)
 }
 
+// ListAppRoleAssignments implements the Service interface.
+func (l logging) ListAppRoleAssignments(w http.ResponseWriter, r *http.Request) {
+	l.next.ListAppRoleAssignments(w, r)
+}
+
+// CreateAppRoleAssignment implements the Service interface.
+func (l logging) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	l.next.CreateAppRoleAssignment(w, r)
+}
+
+// DeleteAppRoleAssignment implements the Service interface.
+func (l logging) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	l.next.DeleteAppRoleAssignment(w, r)
+}
+
 // GetGroups implements the Service interface.
 func (l logging) GetGroups(w http.ResponseWriter, r *http.Request) {
 	l.next.GetGroups(w, r)

--- a/services/graph/pkg/service/v0/logging.go
+++ b/services/graph/pkg/service/v0/logging.go
@@ -24,6 +24,11 @@ func (l logging) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l.next.ServeHTTP(w, r)
 }
 
+// GetApplication implements the Service interface.
+func (l logging) GetApplication(w http.ResponseWriter, r *http.Request) {
+	l.next.GetMe(w, r)
+}
+
 // GetMe implements the Service interface.
 func (l logging) GetMe(w http.ResponseWriter, r *http.Request) {
 	l.next.GetMe(w, r)

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -312,6 +312,7 @@ func NewService(opts ...Option) (Graph, error) {
 					})
 				})
 			})
+			r.Get("/applications/{applicationID}", svc.GetApplication)
 		})
 	})
 

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -32,6 +32,9 @@ const (
 // Service defines the service handlers.
 type Service interface {
 	ServeHTTP(http.ResponseWriter, *http.Request)
+
+	GetApplication(http.ResponseWriter, *http.Request)
+
 	GetMe(http.ResponseWriter, *http.Request)
 	GetUsers(http.ResponseWriter, *http.Request)
 	GetUser(http.ResponseWriter, *http.Request)

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -243,6 +243,11 @@ func NewService(opts ...Option) (Graph, error) {
 					r.Get("/", svc.GetUser)
 					r.With(requireAdmin).Delete("/", svc.DeleteUser)
 					r.With(requireAdmin).Patch("/", svc.PatchUser)
+					r.With(requireAdmin).Route("/appRoleAssignments", func(r chi.Router) {
+						r.Get("/", svc.ListAppRoleAssignments)
+						r.Post("/", svc.CreateAppRoleAssignment)
+						r.Delete("/{appRoleAssignmentID}", svc.DeleteAppRoleAssignment)
+					})
 				})
 			})
 			r.Route("/groups", func(r chi.Router) {

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -33,6 +33,7 @@ const (
 type Service interface {
 	ServeHTTP(http.ResponseWriter, *http.Request)
 
+	ListApplications(w http.ResponseWriter, r *http.Request)
 	GetApplication(http.ResponseWriter, *http.Request)
 
 	GetMe(http.ResponseWriter, *http.Request)
@@ -243,6 +244,10 @@ func NewService(opts ...Option) (Graph, error) {
 				r.Put("/tags", svc.AssignTags)
 				r.Delete("/tags", svc.UnassignTags)
 			})
+			r.Route("/applications", func(r chi.Router) {
+				r.Get("/", svc.ListApplications)
+				r.Get("/{applicationID}", svc.GetApplication)
+			})
 			r.Route("/me", func(r chi.Router) {
 				r.Get("/", svc.GetMe)
 				r.Get("/drives", svc.GetDrives)
@@ -325,7 +330,6 @@ func NewService(opts ...Option) (Graph, error) {
 					})
 				})
 			})
-			r.Get("/applications/{applicationID}", svc.GetApplication)
 		})
 	})
 

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -40,6 +40,10 @@ type Service interface {
 	PatchUser(http.ResponseWriter, *http.Request)
 	ChangeOwnPassword(http.ResponseWriter, *http.Request)
 
+	ListAppRoleAssignments(http.ResponseWriter, *http.Request)
+	CreateAppRoleAssignment(http.ResponseWriter, *http.Request)
+	DeleteAppRoleAssignment(http.ResponseWriter, *http.Request)
+
 	GetGroups(http.ResponseWriter, *http.Request)
 	GetGroup(http.ResponseWriter, *http.Request)
 	PostGroup(http.ResponseWriter, *http.Request)

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -200,6 +200,12 @@ func NewService(opts ...Option) (Graph, error) {
 		svc.permissionsService = options.PermissionService
 	}
 
+	if options.RoleService == nil {
+		svc.roleService = settingssvc.NewRoleService("com.owncloud.api.settings", grpc.DefaultClient())
+	} else {
+		svc.roleService = options.RoleService
+	}
+
 	roleManager := options.RoleManager
 	if roleManager == nil {
 		storeOptions := store.OcisStoreOptions{

--- a/services/graph/pkg/service/v0/tracing.go
+++ b/services/graph/pkg/service/v0/tracing.go
@@ -20,6 +20,11 @@ func (t tracing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t.next.ServeHTTP(w, r)
 }
 
+// GetApplication implements the Service interface.
+func (t tracing) GetApplication(w http.ResponseWriter, r *http.Request) {
+	t.next.GetMe(w, r)
+}
+
 // GetMe implements the Service interface.
 func (t tracing) GetMe(w http.ResponseWriter, r *http.Request) {
 	t.next.GetMe(w, r)

--- a/services/graph/pkg/service/v0/tracing.go
+++ b/services/graph/pkg/service/v0/tracing.go
@@ -20,9 +20,14 @@ func (t tracing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t.next.ServeHTTP(w, r)
 }
 
+// ListApplications implements the Service interface.
+func (t tracing) ListApplications(w http.ResponseWriter, r *http.Request) {
+	t.next.ListApplications(w, r)
+}
+
 // GetApplication implements the Service interface.
 func (t tracing) GetApplication(w http.ResponseWriter, r *http.Request) {
-	t.next.GetMe(w, r)
+	t.next.GetApplication(w, r)
 }
 
 // GetMe implements the Service interface.

--- a/services/graph/pkg/service/v0/tracing.go
+++ b/services/graph/pkg/service/v0/tracing.go
@@ -55,6 +55,21 @@ func (t tracing) ChangeOwnPassword(w http.ResponseWriter, r *http.Request) {
 	t.next.ChangeOwnPassword(w, r)
 }
 
+// ListAppRoleAssignments implements the Service interface.
+func (t tracing) ListAppRoleAssignments(w http.ResponseWriter, r *http.Request) {
+	t.next.ListAppRoleAssignments(w, r)
+}
+
+// CreateAppRoleAssignment implements the Service interface.
+func (t tracing) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	t.next.CreateAppRoleAssignment(w, r)
+}
+
+// DeleteAppRoleAssignment implements the Service interface.
+func (t tracing) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
+	t.next.DeleteAppRoleAssignment(w, r)
+}
+
 // GetGroups implements the Service interface.
 func (t tracing) GetGroups(w http.ResponseWriter, r *http.Request) {
 	t.next.GetGroups(w, r)

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Users", func() {
 		cfg.TokenManager.JWTSecret = "loremipsum"
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		cfg.Service.ApplicationID = "some-application-ID"
+		cfg.Application.ID = "some-application-ID"
 
 		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(

--- a/services/settings/pkg/service/v0/service.go
+++ b/services/settings/pkg/service/v0/service.go
@@ -79,7 +79,7 @@ func (g Service) CheckPermission(ctx context.Context, req *permissions.CheckPerm
 
 	permission, err := g.manager.ReadPermissionByName(req.Permission, roleIDs)
 	if err != nil {
-		if !errors.Is(err, settings.ErrPermissionNotFound) {
+		if !errors.Is(err, settings.ErrNotFound) {
 			return &permissions.CheckPermissionResponse{
 				Status: status.NewInternal(ctx, err.Error()),
 			}, nil

--- a/services/settings/pkg/settings/settings.go
+++ b/services/settings/pkg/settings/settings.go
@@ -12,7 +12,12 @@ var (
 	Registry = map[string]RegisterFunc{}
 
 	// ErrPermissionNotFound defines a new error for when a permission was not found
+	//
+	// Deprecated use the more generic ErrNotFound
 	ErrPermissionNotFound = errors.New("permission not found")
+
+	// ErrNotFound is the error to use when a resource was not found.
+	ErrNotFound = errors.New("not found")
 )
 
 // RegisterFunc stores store constructors

--- a/services/settings/pkg/store/errortypes/errortypes.go
+++ b/services/settings/pkg/store/errortypes/errortypes.go
@@ -1,6 +1,8 @@
 package errortypes
 
 // BundleNotFound is the error to use when a bundle is not found.
+//
+// Deprecated: use the genreric services/settings/pkg/settings.NotFound error
 type BundleNotFound string
 
 func (e BundleNotFound) Error() string { return "error: bundle not found: " + string(e) }

--- a/services/settings/pkg/store/filesystem/bundles.go
+++ b/services/settings/pkg/store/filesystem/bundles.go
@@ -2,6 +2,7 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,7 +10,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
-	"github.com/owncloud/ocis/v2/services/settings/pkg/store/errortypes"
+	"github.com/owncloud/ocis/v2/services/settings/pkg/settings"
 )
 
 var m = &sync.RWMutex{}
@@ -111,7 +112,7 @@ func (s Store) WriteBundle(record *settingsmsg.Bundle) (*settingsmsg.Bundle, err
 func (s Store) AddSettingToBundle(bundleID string, setting *settingsmsg.Setting) (*settingsmsg.Setting, error) {
 	bundle, err := s.ReadBundle(bundleID)
 	if err != nil {
-		if _, notFound := err.(errortypes.BundleNotFound); !notFound {
+		if !errors.Is(err, settings.ErrNotFound) {
 			return nil, err
 		}
 		bundle = new(settingsmsg.Bundle)

--- a/services/settings/pkg/store/filesystem/io.go
+++ b/services/settings/pkg/store/filesystem/io.go
@@ -1,10 +1,11 @@
 package store
 
 import (
+	"fmt"
 	"io"
 	"os"
 
-	"github.com/owncloud/ocis/v2/services/settings/pkg/store/errortypes"
+	"github.com/owncloud/ocis/v2/services/settings/pkg/settings"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -13,7 +14,7 @@ import (
 func (s Store) parseRecordFromFile(record proto.Message, filePath string) error {
 	_, err := os.Stat(filePath)
 	if err != nil {
-		return errortypes.BundleNotFound(err.Error())
+		return fmt.Errorf("%q: %w", filePath, settings.ErrNotFound)
 	}
 
 	file, err := os.Open(filePath)
@@ -28,7 +29,7 @@ func (s Store) parseRecordFromFile(record proto.Message, filePath string) error 
 	}
 
 	if len(b) == 0 {
-		return errortypes.BundleNotFound(filePath)
+		return fmt.Errorf("%q: %w", filePath, settings.ErrNotFound)
 	}
 
 	if err := protojson.Unmarshal(b, record); err != nil {

--- a/services/settings/pkg/store/filesystem/permissions.go
+++ b/services/settings/pkg/store/filesystem/permissions.go
@@ -55,7 +55,7 @@ func (s Store) ReadPermissionByName(name string, roleIDs []string) (*settingsmsg
 			}
 		}
 	}
-	return nil, settings.ErrPermissionNotFound
+	return nil, settings.ErrNotFound
 }
 
 // extractPermissionsByResource collects all permissions from the provided role that match the requested resource

--- a/services/settings/pkg/store/metadata/assignments.go
+++ b/services/settings/pkg/store/metadata/assignments.go
@@ -19,7 +19,7 @@ func (s *Store) ListRoleAssignments(accountUUID string) ([]*settingsmsg.UserRole
 	switch err.(type) {
 	case nil:
 		// continue
-	case errtypes.NotFound:
+	case errtypes.NotFound: // FIXME this won't trigger on the disk based implementation
 		return make([]*settingsmsg.UserRoleAssignment, 0), nil
 	default:
 		return nil, err

--- a/services/settings/pkg/store/metadata/permissions.go
+++ b/services/settings/pkg/store/metadata/permissions.go
@@ -55,7 +55,7 @@ func (s *Store) ReadPermissionByName(name string, roleIDs []string) (*settingsms
 			}
 		}
 	}
-	return nil, settings.ErrPermissionNotFound
+	return nil, settings.ErrNotFound
 }
 
 // extractPermissionsByResource collects all permissions from the provided role that match the requested resource

--- a/services/settings/pkg/store/metadata/store_test.go
+++ b/services/settings/pkg/store/metadata/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config/defaults"
 )
 
@@ -53,9 +54,12 @@ func NewMDC(s *Store) error {
 	return s.initMetadataClient(mdc)
 }
 
-// SimpleDownload returns nil if not found
+// SimpleDownload returns errtypes.NotFound if not found
 func (m *MockedMetadataClient) SimpleDownload(_ context.Context, id string) ([]byte, error) {
-	return m.data[id], nil
+	if data, ok := m.data[id]; ok {
+		return data, nil
+	}
+	return nil, errtypes.NotFound("not found")
 }
 
 // SimpleUpload can't error


### PR DESCRIPTION
- [x] bump libregraph go dependency
- [x] add appRoleAssignment stub
- [x] add application stub
- [x] add positive test cases
- [ ] add failure test cases
- [x] wire up settings service
- [x] make applicationid configurable

For now, I decided to intdroduce an application that is configured with `GRAPH_APPLICATION_ID` and `GRAPH_APPLICATION_DISPLAYNAME`. They are necessary to represent an application that owns the roles. In our case that is oCIS.

First question: is it only oCIS Web? I currently default to `"oCIS Web"`. 

Second question: the application id should be randomized on init. AFAICT it resembles the oc10 instance id. Although I'm not sure if it is the web client or the server side, see first question. The more I type the more I think it is the server side.

Third question: if we make the id configurable then we require clients to know the application id in advance. Should we implement listing applications at `/applications`? That way clients could discover the applications that are available. The WebUI could discover not only ocis web, but also onlyoffice and other applications. I strongly encourage everyone to check out the [MS Graph Application Properties](https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0#properties). It has things like a logo stream, endpoints for redirects of web applications, links to terms of service, support urls, ... If we entertain a publicly hosted oCIS web instance that could discover a graph endpoint using webfinger, similar to the openid connect discovery, being able to discover the application id, a displayname and a logo is desireable. Also ... I don't want to have to configure the wab ui to know the application id in advance.  An in case the user management web ui (soon to become admin web ui) encounters multiple applications it will have to be able to deal with more than one application and multiple sets of appRoleIDs.

In light of the above, I propose to use just `"oCIS"` as the default application name, roll a uuid for the applcation id on `ocis init` and implement the ListApplications endpoint.

@kulmann @michaelstingl @felix-schwarz I just noticed how ms graph allows applications to register as a handler for certain filetypes: 

<html>
<body>
<!--StartFragment-->

Property | Type | Description
-- | -- | --
addIns | [addIn](https://learn.microsoft.com/en-us/graph/api/resources/addin?view=graph-rest-1.0) collection | Defines custom behavior that a consuming service can use to call an app in specific contexts. For example, applications that can render file streams [may set the addIns property](https://learn.microsoft.com/en-us/onedrive/developer/file-handlers) for its "FileHandler" functionality. This will let services like Office 365 call the application in the context of a document the user is working on.

<!--EndFragment-->
</body>
</html>


