### PR TITLE
[tests-only][full-ci] Add tests with explicit delay post-processing enabled

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -115,6 +115,16 @@ config = {
                 "OCIS_CORS_ALLOW_ORIGINS": "https://aphno.badal",
             },
         },
+        "apiDelayPostprocessing": {
+            "suites": [
+                "apiAsyncUpload",
+            ],
+            "skip": False,
+            "earlyFail": True,
+            "extraServerEnvironment": {
+                "POSTPROCESSING_DELAY": "30s",
+            },
+        },
     },
     "apiTests": {
         "numberOfParts": 10,

--- a/.drone.star
+++ b/.drone.star
@@ -115,7 +115,7 @@ config = {
                 "OCIS_CORS_ALLOW_ORIGINS": "https://aphno.badal",
             },
         },
-        "apiDelayPostprocessing": {
+        "apiDelayPostProcessing": {
             "suites": [
                 "apiAsyncUpload",
             ],

--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -103,7 +103,7 @@ class HttpRequestHelper {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public static function sendRequest(
+	public static function sendRequestOnce(
 		?string $url,
 		?string $xRequestId,
 		?string $method = 'GET',
@@ -144,14 +144,66 @@ class HttpRequestHelper {
 			$debugRequests = false;
 		}
 
-		if ((\getenv('DEBUG_ACCEPTANCE_RESPONSES') !== false) || (\getenv('DEBUG_ACCEPTANCE_API_CALLS') !== false)) {
-			$debugResponses = true;
-		} else {
-			$debugResponses = false;
+		// The exceptions that might happen here include:
+		// ConnectException - in that case there is no response. Don't catch the exception.
+		// RequestException - if there is something in the response then pass it back.
+		//                    otherwise re-throw the exception.
+		// GuzzleException - something else unexpected happened. Don't catch the exception.
+		try {
+			$response = $client->send($request);
+		} catch (RequestException $ex) {
+			$response = $ex->getResponse();
+
+			//if the response was null for some reason do not return it but re-throw
+			if ($response === null) {
+				throw $ex;
+			}
 		}
 
 		if ($debugRequests) {
 			self::debugRequest($request, $user, $password);
+		}
+
+		return $response;
+	}
+
+	/**
+	 *
+	 * @param string|null $url
+	 * @param string|null $xRequestId
+	 * @param string|null $method
+	 * @param string|null $user
+	 * @param string|null $password
+	 * @param array|null $headers ['X-MyHeader' => 'value']
+	 * @param mixed $body
+	 * @param array|null $config
+	 * @param CookieJar|null $cookies
+	 * @param bool $stream Set to true to stream a response rather
+	 *                     than download it all up-front.
+	 * @param int|null $timeout
+	 * @param Client|null $client
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function sendRequest(
+		?string $url,
+		?string $xRequestId,
+		?string $method = 'GET',
+		?string $user = null,
+		?string $password = null,
+		?array $headers = null,
+		$body = null,
+		?array $config = null,
+		?CookieJar $cookies = null,
+		bool $stream = false,
+		?int $timeout = 0,
+		?Client $client =  null
+	):ResponseInterface {
+		if ((\getenv('DEBUG_ACCEPTANCE_RESPONSES') !== false) || (\getenv('DEBUG_ACCEPTANCE_API_CALLS') !== false)) {
+			$debugResponses = true;
+		} else {
+			$debugResponses = false;
 		}
 
 		$sendRetryLimit = self::numRetriesOnHttpTooEarly();
@@ -159,21 +211,23 @@ class HttpRequestHelper {
 		$sendExceptionHappened = false;
 
 		do {
-			// The exceptions that might happen here include:
-			// ConnectException - in that case there is no response. Don't catch the exception.
-			// RequestException - if there is something in the response then pass it back.
-			//                    otherwise re-throw the exception.
-			// GuzzleException - something else unexpected happened. Don't catch the exception.
-			try {
-				$response = $client->send($request);
-			} catch (RequestException $ex) {
-				$sendExceptionHappened = true;
-				$response = $ex->getResponse();
+			$response = self::sendRequestOnce(
+				$url,
+				$xRequestId,
+				$method,
+				$user,
+				$password,
+				$headers,
+				$body,
+				$config,
+				$cookies,
+				$stream,
+				$timeout,
+				$client
+			);
 
-				//if the response was null for some reason do not return it but re-throw
-				if ($response === null) {
-					throw $ex;
-				}
+			if ($response->getStatusCode() >= 400) {
+				$sendExceptionHappened = true;
 			}
 
 			if ($debugResponses) {

--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -226,7 +226,7 @@ class HttpRequestHelper {
 				$client
 			);
 
-			if ($response->getStatusCode() >= 400) {
+			if ($response->getStatusCode() >= 400 && $response->getStatusCode() !== self::HTTP_TOO_EARLY) {
 				$sendExceptionHappened = true;
 			}
 

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -152,6 +152,22 @@ default:
         - OCSContext:
         - TrashbinContext:
 
+    apiAsyncUpload:
+      paths:
+        - '%paths.base%/../features/apiAsyncUpload'
+      context: *common_ldap_suite_context
+      contexts:
+        - SpacesContext:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - WebDavPropertiesContext:
+        - FavoritesContext:
+        - ChecksumContext:
+        - FilesVersionsContext:
+        - OCSContext:
+        - TrashbinContext:
+
+
   extensions:
     rdx\behatvars\BehatVariablesExtension: ~
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -99,10 +99,5 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiAsyncUpload/delayPostprocessing.feature:15](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L15)
 - [apiAsyncUpload/delayPostprocessing.feature:16](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L16)
 
-#### [PROPFIND a file while it's in processing doesn't return 425 code (async uploads)](https://github.com/owncloud/ocis/issues/5327)
-- [apiAsyncUpload/delayPostprocessing.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L24)
-- [apiAsyncUpload/delayPostprocessing.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L25)
-- [apiAsyncUpload/delayPostprocessing.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L26)
-
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -103,3 +103,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiAsyncUpload/delayPostprocessing.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L24)
 - [apiAsyncUpload/delayPostprocessing.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L25)
 - [apiAsyncUpload/delayPostprocessing.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L26)
+
+Note: always have an empty line at the end of this file.
+The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -93,3 +93,13 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [A User can get information of another user with Graph API](https://github.com/owncloud/ocis/issues/5125)
 - [apiGraph/getUser.feature:23](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/getUser.feature#L23)
+
+#### [GET a file while it's in processing doesn't return 425 code (async uploads)](https://github.com/owncloud/ocis/issues/5326)
+- [apiAsyncUpload/delayPostprocessing.feature:14](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L14)
+- [apiAsyncUpload/delayPostprocessing.feature:15](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L15)
+- [apiAsyncUpload/delayPostprocessing.feature:16](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L16)
+
+#### [PROPFIND a file while it's in processing doesn't return 425 code (async uploads)](https://github.com/owncloud/ocis/issues/5327)
+- [apiAsyncUpload/delayPostprocessing.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L24)
+- [apiAsyncUpload/delayPostprocessing.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L25)
+- [apiAsyncUpload/delayPostprocessing.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L26)

--- a/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
+++ b/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
@@ -3,10 +3,10 @@ Feature: delay post-processing of uploaded files
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "uploaded content" to "/file.txt"
 
   @issue-5326
   Scenario Outline: user sends GET request to the file while it's still being processed
+    Given user "Alice" has uploaded file with content "uploaded content" to "/file.txt"
     When user "Alice" requests "<dav_path>" with "GET" without retrying
     Then the HTTP status code should be "425"
     Examples:
@@ -17,6 +17,7 @@ Feature: delay post-processing of uploaded files
 
 
   Scenario Outline: user sends PROPFIND request to the file while it's still being processed
+    Given user "Alice" has uploaded file with content "uploaded content" to "/file.txt"
     When user "Alice" requests "<dav_path>" with "PROPFIND" without retrying
     Then the HTTP status code should be "207"
     And the value of the item "//d:response/d:propstat/d:status" in the response should be "HTTP/1.1 425 TOO EARLY"
@@ -25,3 +26,17 @@ Feature: delay post-processing of uploaded files
       | /remote.php/webdav/file.txt               |
       | /remote.php/dav/files/%username%/file.txt |
       | /dav/spaces/%spaceid%/file.txt            |
+
+
+  Scenario Outline: user sends PROPFIND request to the folder while its some files are still being processed
+    Given user "Alice" has created folder "my_data"
+    And user "Alice" has uploaded file with content "uploaded content" to "/my_data/file.txt"
+    When user "Alice" requests "<dav_path>" with "PROPFIND" without retrying
+    Then the HTTP status code should be "207"
+    And as user "Alice" the value of the item "//d:status" of path "<dav_path>/" in the response should be "HTTP/1.1 200 OK"
+    And as user "Alice" the value of the item "//d:status" of path "<dav_path>/file.txt" in the response should be "HTTP/1.1 425 TOO EARLY"
+    Examples:
+      | dav_path                                 |
+      | /remote.php/webdav/my_data               |
+      | /remote.php/dav/files/%username%/my_data |
+      | /dav/spaces/%spaceid%/my_data            |

--- a/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
+++ b/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
@@ -15,10 +15,11 @@ Feature: delay post-processing of uploaded files
       | /remote.php/dav/files/%username%/file.txt |
       | /dav/spaces/%spaceid%/file.txt            |
 
-  @issue-5327
+
   Scenario Outline: user sends PROPFIND request to the file while it's still being processed
     When user "Alice" requests "<dav_path>" with "PROPFIND" without retrying
-    Then the HTTP status code should be "425"
+    Then the HTTP status code should be "207"
+    And the value of the item "//d:response/d:propstat/d:status" in the response should be "HTTP/1.1 425 TOO EARLY"
     Examples:
       | dav_path                                  |
       | /remote.php/webdav/file.txt               |

--- a/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
+++ b/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
@@ -5,7 +5,7 @@ Feature: delay post-processing of uploaded files
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "uploaded content" to "/file.txt"
 
-
+  @issue-5326
   Scenario Outline: user sends GET request to the file while it's still being processed
     When user "Alice" requests "<dav_path>" with "GET" without retrying
     Then the HTTP status code should be "425"
@@ -15,7 +15,7 @@ Feature: delay post-processing of uploaded files
       | /remote.php/dav/files/%username%/file.txt |
       | /dav/spaces/%spaceid%/file.txt            |
 
-
+  @issue-5327
   Scenario Outline: user sends PROPFIND request to the file while it's still being processed
     When user "Alice" requests "<dav_path>" with "PROPFIND" without retrying
     Then the HTTP status code should be "425"

--- a/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
+++ b/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
@@ -28,7 +28,7 @@ Feature: delay post-processing of uploaded files
       | /dav/spaces/%spaceid%/file.txt            |
 
 
-  Scenario Outline: user sends PROPFIND request to the folder while its some files are still being processed
+  Scenario Outline: user sends PROPFIND request to the folder while files in the folder are still being processed
     Given user "Alice" has created folder "my_data"
     And user "Alice" has uploaded file with content "uploaded content" to "/my_data/file.txt"
     When user "Alice" requests "<dav_path>" with "PROPFIND" without retrying

--- a/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
+++ b/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature
@@ -1,0 +1,26 @@
+@api
+Feature: delay post-processing of uploaded files
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "uploaded content" to "/file.txt"
+
+
+  Scenario Outline: user sends GET request to the file while it's still being processed
+    When user "Alice" requests "<dav_path>" with "GET" without retrying
+    Then the HTTP status code should be "425"
+    Examples:
+      | dav_path                                  |
+      | /remote.php/webdav/file.txt               |
+      | /remote.php/dav/files/%username%/file.txt |
+      | /dav/spaces/%spaceid%/file.txt            |
+
+
+  Scenario Outline: user sends PROPFIND request to the file while it's still being processed
+    When user "Alice" requests "<dav_path>" with "PROPFIND" without retrying
+    Then the HTTP status code should be "425"
+    Examples:
+      | dav_path                                  |
+      | /remote.php/webdav/file.txt               |
+      | /remote.php/dav/files/%username%/file.txt |
+      | /dav/spaces/%spaceid%/file.txt            |

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -1155,4 +1155,34 @@ class AuthContext implements Context {
 			$this->tokenAuthHasBeenSetTo = '';
 		}
 	}
+
+	/**
+	 * @When user :user requests :endpoint with :method without retrying
+	 *
+	 * @param string $user
+	 * @param string $endpoint
+	 * @param string $method
+	 *
+	 * @return void
+	 */
+	public function userRequestsURLWithoutRetry(
+		string $user,
+		string $endpoint,
+		string $method
+	):void {
+		$username = $this->featureContext->getActualUsername($user);
+		$endpoint = $this->featureContext->substituteInLineCodes(
+			$endpoint,
+			$username
+		);
+		$fullUrl = $this->featureContext->getBaseUrl() . $endpoint;
+		$response = HttpRequestHelper::sendRequestOnce(
+			$fullUrl,
+			$this->featureContext->getStepLineRef(),
+			$method,
+			$username,
+			$this->featureContext->getPasswordForUser($user)
+		);
+		$this->featureContext->setResponse($response);
+	}
 }

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -645,6 +645,27 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @Then as user :user the value of the item :xpath of path :path in the response should be :value
+	 *
+	 * @param string $user
+	 * @param string $xpath
+	 * @param string $path
+	 * @param string $expectedValue
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function valueOfItemOfPathShouldBe(string $user, string $xpath, string $path, string $expectedValue):void {
+		$path = $this->featureContext->substituteInLineCodes($path, $user);
+		$fullXpath = "//d:response/d:href[.='$path']/following-sibling::d:propstat$xpath";
+		$this->assertValueOfItemInResponseAboutUserIs(
+			$fullXpath,
+			null,
+			$expectedValue
+		);
+	}
+
+	/**
 	 * @Then the value of the item :xpath in the response about user :user should be :value
 	 *
 	 * @param string $xpath


### PR DESCRIPTION
## Description
Add API tests with delayed postprocessing to check too early response code
- GET a file
- PROPFIND a file
- PROPFIND a folder having file that is in processing

## Related Issue
Closes https://github.com/owncloud/ocis/issues/4095

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
