### PR TITLE
Complete description of STORAGE_USERS_DRIVER

### DIFF
--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 
 	SkipUserGroupsInToken bool `yaml:"skip_user_groups_in_token" env:"STORAGE_USERS_SKIP_USER_GROUPS_IN_TOKEN" desc:"Disables the loading of user's group memberships from the reva access token."`
 
-	Driver           string  `yaml:"driver" env:"STORAGE_USERS_DRIVER" desc:"The storage driver which should be used by the service"`
+	Driver           string  `yaml:"driver" env:"STORAGE_USERS_DRIVER" desc:"The storage driver which should be used by the service. Defaults to 'ocis', Supported values are: 'ocis', 's3ng' and 'owncloudsql'. The 'ocis' driver stores all data (file and meta data) in an POSIX compliant volume. The 's3ng' driver stores all metadata in an POSIX compliant volume and uploads blobs to the s3 bucket."`
 	Drivers          Drivers `yaml:"drivers"`
 	DataServerURL    string  `yaml:"data_server_url" env:"STORAGE_USERS_DATA_SERVER_URL" desc:"URL of the data server, needs to be reachable by the data gateway provided by the frontend service or the user if directly exposed."`
 	DataGatewayURL   string  `yaml:"data_gateway_url" env:"STORAGE_USERS_DATA_GATEWAY_URL" desc:"URL of the data gateway server"`


### PR DESCRIPTION
The description of the `STORAGE_USERS_DRIVER` envvar was incomplete. It missed the `s3ng` and `owncloudsql` driver.

This came up while documenting [s3ng bucket policy](https://github.com/owncloud/docs-ocis/issues/288) (issue in docs-ocis).

When reading the helm chart referenced, also see its [representation in the admin docs](https://doc.owncloud.com/ocis/next/deployment/container/orchestration/tab-pages/values-tab-1.html) (search for `storageUsers:`) you see that we have described in the comment the `ocis` driver but not `s3ng`.
Note that you can see all three values also in the [storage-user](https://doc.owncloud.com/ocis/next/deployment/services/s-list/storage-users.html) documentation (both envvar and yaml). Means, most likely just forgotten - pls check.

Post merging this, we need to transport this change to the ocis/docs-stable-2.0 branch, I will take care.

