### PR TITLE
add identitySet displayName property to the group and user sets

### DIFF
--- a/changelog/unreleased/enhancement-identity-set-display-name.md
+++ b/changelog/unreleased/enhancement-identity-set-display-name.md
@@ -1,0 +1,7 @@
+Enhancement: Graph Drives IdentitySet displayName
+
+We've added the IdentitySet displayName property to the group and user sets for the graph drives endpoint.
+The values for groups and users get cached.
+
+https://github.com/owncloud/ocis/pull/5347
+https://github.com/owncloud/web/pull/8178

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0
 	github.com/jellydator/ttlcache/v2 v2.11.1
+	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/justinas/alice v1.2.0
 	github.com/libregraph/idm v0.3.1-0.20220808071235-17bb032176de
 	github.com/libregraph/lico v0.54.1-0.20220325072321-31efc3995d63

--- a/go.sum
+++ b/go.sum
@@ -822,6 +822,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jellydator/ttlcache/v2 v2.11.1 h1:AZGME43Eh2Vv3giG6GeqeLeFXxwxn1/qHItqWZl6U64=
 github.com/jellydator/ttlcache/v2 v2.11.1/go.mod h1:RtE5Snf0/57e+2cLWFYWCCsLas2Hy3c5Z4n14XmSvTI=
+github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
+github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 )
@@ -31,10 +32,12 @@ type Config struct {
 }
 
 type Spaces struct {
-	WebDavBase                      string `yaml:"webdav_base" env:"OCIS_URL;GRAPH_SPACES_WEBDAV_BASE" desc:"The public facing URL of WebDAV."`
-	WebDavPath                      string `yaml:"webdav_path" env:"GRAPH_SPACES_WEBDAV_PATH" desc:"The WebDAV subpath for spaces."`
-	DefaultQuota                    string `yaml:"default_quota" env:"GRAPH_SPACES_DEFAULT_QUOTA" desc:"The default quota in bytes."`
-	ExtendedSpacePropertiesCacheTTL int    `yaml:"extended_space_properties_cache_ttl" env:"GRAPH_SPACES_EXTENDED_SPACE_PROPERTIES_CACHE_TTL" desc:"Max TTL in seconds for the spaces property cache."`
+	WebDavBase                      string        `yaml:"webdav_base" env:"OCIS_URL;GRAPH_SPACES_WEBDAV_BASE" desc:"The public facing URL of WebDAV."`
+	WebDavPath                      string        `yaml:"webdav_path" env:"GRAPH_SPACES_WEBDAV_PATH" desc:"The WebDAV subpath for spaces."`
+	DefaultQuota                    string        `yaml:"default_quota" env:"GRAPH_SPACES_DEFAULT_QUOTA" desc:"The default quota in bytes."`
+	ExtendedSpacePropertiesCacheTTL time.Duration `yaml:"extended_space_properties_cache_ttl" env:"GRAPH_SPACES_EXTENDED_SPACE_PROPERTIES_CACHE_TTL" desc:"Max TTL in seconds for the spaces property cache."`
+	UsersCacheTTL                   time.Duration `yaml:"users_cache_ttl" env:"GRAPH_SPACES_USERS_CACHE_TTL" desc:"Max TTL in seconds for the spaces users cache."`
+	GroupsCacheTTL                  time.Duration `yaml:"groups_cache_ttl" env:"GRAPH_SPACES_GROUPS_CACHE_TTL" desc:"Max TTL in seconds for the spaces groups cache."`
 }
 
 type LDAP struct {

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -3,6 +3,7 @@ package defaults
 import (
 	"path"
 	"strings"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
@@ -32,9 +33,11 @@ func DefaultConfig() *config.Config {
 		},
 		Reva: shared.DefaultRevaConfig(),
 		Spaces: config.Spaces{
-			WebDavBase:   "https://localhost:9200",
-			WebDavPath:   "/dav/spaces/",
-			DefaultQuota: "1000000000",
+			WebDavBase:     "https://localhost:9200",
+			WebDavPath:     "/dav/spaces/",
+			DefaultQuota:   "1000000000",
+			GroupsCacheTTL: 30 * time.Minute,
+			UsersCacheTTL:  30 * time.Minute,
 		},
 		Identity: config.Identity{
 			Backend: "ldap",

--- a/services/graph/pkg/server/http/server.go
+++ b/services/graph/pkg/server/http/server.go
@@ -122,7 +122,8 @@ func Server(opts ...Option) (http.Service, error) {
 		// no gatewayclient needed
 	}
 
-	handle := svc.NewService(
+	var handle svc.Service
+	handle, err = svc.NewService(
 		svc.Logger(options.Logger),
 		svc.Config(options.Config),
 		svc.Middleware(middlewares...),
@@ -133,7 +134,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.WithSearchService(searchsvc.NewSearchProviderService("com.owncloud.api.search", grpc.DefaultClient())),
 	)
 
-	if handle == nil {
+	if err != nil {
 		return http.Service{}, errors.New("could not initialize graph service")
 	}
 

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -3,6 +3,7 @@ package svc
 import (
 	"context"
 	"errors"
+	libregraph "github.com/owncloud/libre-graph-api-go"
 	"net/http"
 	"net/url"
 	"path"
@@ -12,7 +13,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/go-chi/chi/v5"
-	"github.com/jellydator/ttlcache/v2"
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	searchsvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/search/v0"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
@@ -100,7 +101,9 @@ type Graph struct {
 	gatewayClient            GatewayClient
 	roleService              RoleService
 	permissionsService       Permissions
-	spacePropertiesCache     *ttlcache.Cache
+	spacePropertiesCache     *ttlcache.Cache[string, interface{}]
+	usersCache               *ttlcache.Cache[string, libregraph.User]
+	groupsCache              *ttlcache.Cache[string, libregraph.Group]
 	eventsPublisher          events.Publisher
 	searchService            searchsvc.SearchProviderService
 }

--- a/services/graph/pkg/service/v0/instrument.go
+++ b/services/graph/pkg/service/v0/instrument.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewInstrument returns a service that instruments metrics.
-func NewInstrument(next Service, metrics *metrics.Metrics) Service {
+func NewInstrument(next Service, metrics *metrics.Metrics) instrument {
 	return instrument{
 		next:    next,
 		metrics: metrics,

--- a/services/graph/pkg/service/v0/logging.go
+++ b/services/graph/pkg/service/v0/logging.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewLogging returns a service that logs messages.
-func NewLogging(next Service, logger log.Logger) Service {
+func NewLogging(next Service, logger log.Logger) logging {
 	return logging{
 		next:   next,
 		logger: logger,

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -3,14 +3,16 @@ package svc
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/jellydator/ttlcache/v2"
-
+	"github.com/jellydator/ttlcache/v3"
+	libregraph "github.com/owncloud/libre-graph-api-go"
 	ocisldap "github.com/owncloud/ocis/v2/ocis-pkg/ldap"
 	"github.com/owncloud/ocis/v2/ocis-pkg/roles"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
@@ -76,17 +78,34 @@ type Service interface {
 }
 
 // NewService returns a service implementation for Service.
-func NewService(opts ...Option) Service {
+func NewService(opts ...Option) (Graph, error) {
 	options := newOptions(opts...)
 
 	m := chi.NewMux()
 	m.Use(options.Middleware...)
 
+	spacePropertiesCache := ttlcache.New[string, interface{}](
+		ttlcache.WithTTL[string, interface{}](options.Config.Spaces.ExtendedSpacePropertiesCacheTTL * time.Second),
+	)
+	go spacePropertiesCache.Start()
+
+	usersCache := ttlcache.New[string, libregraph.User](
+		ttlcache.WithTTL[string, libregraph.User](options.Config.Spaces.UsersCacheTTL * time.Second),
+	)
+	go usersCache.Start()
+
+	groupsCache := ttlcache.New[string, libregraph.Group](
+		ttlcache.WithTTL[string, libregraph.Group](options.Config.Spaces.GroupsCacheTTL * time.Second),
+	)
+	go groupsCache.Start()
+
 	svc := Graph{
 		config:                   options.Config,
 		mux:                      m,
 		logger:                   &options.Logger,
-		spacePropertiesCache:     ttlcache.NewCache(),
+		spacePropertiesCache:     spacePropertiesCache,
+		usersCache:               usersCache,
+		groupsCache:              groupsCache,
 		eventsPublisher:          options.EventsPublisher,
 		gatewayClient:            options.GatewayClient,
 		searchService:            options.SearchService,
@@ -129,11 +148,11 @@ func NewService(opts ...Option) Service {
 				pemData, err := os.ReadFile(options.Config.Identity.LDAP.CACert)
 				if err != nil {
 					options.Logger.Error().Err(err).Msgf("Error initializing LDAP Backend")
-					return nil
+					return svc, err
 				}
 				if !certs.AppendCertsFromPEM(pemData) {
 					options.Logger.Error().Msgf("Error initializing LDAP Backend. Adding CA cert failed")
-					return nil
+					return svc, err
 				}
 				tlsConf.RootCAs = certs
 			}
@@ -149,7 +168,7 @@ func NewService(opts ...Option) Service {
 			lb, err := identity.NewLDAPBackend(conn, options.Config.Identity.LDAP, &options.Logger)
 			if err != nil {
 				options.Logger.Error().Msgf("Error initializing LDAP Backend: '%s'", err)
-				return nil
+				return svc, err
 			}
 			svc.identityBackend = lb
 			if options.IdentityEducationBackend == nil {
@@ -161,8 +180,9 @@ func NewService(opts ...Option) Service {
 				}
 			}
 		default:
-			options.Logger.Error().Msgf("Unknown Identity Backend: '%s'", options.Config.Identity.Backend)
-			return nil
+			err := fmt.Errorf("Unknown Identity Backend: '%s'", options.Config.Identity.Backend)
+			options.Logger.Err(err)
+			return svc, err
 		}
 	} else {
 		svc.identityBackend = options.IdentityBackend
@@ -284,7 +304,7 @@ func NewService(opts ...Option) Service {
 		})
 	})
 
-	return svc
+	return svc, nil
 }
 
 // parseHeaderPurge parses the 'Purge' header.

--- a/services/graph/pkg/service/v0/tracing.go
+++ b/services/graph/pkg/service/v0/tracing.go
@@ -5,7 +5,7 @@ import (
 )
 
 // NewTracing returns a service that instruments traces.
-func NewTracing(next Service) Service {
+func NewTracing(next Service) tracing {
 	return tracing{
 		next: next,
 	}


### PR DESCRIPTION
## Description
The [graph identity spec](https://learn.microsoft.com/en-us/graph/api/resources/identity?view=graph-rest-1.0) intended the displayName property for identity types.

The value is used in the graph drives endpoint for a single identitySet object.
This PR adds that value to the groups and users sets.

## Related Issue
- Fixes https://github.com/owncloud/web/pull/8178#issuecomment-1371106370

## Motivation and Context
the new admin ui in web needs to list details about each user and group, therefore to reduce requests the property has to be part of the drive response.