### PR TITLE
Backport of STORAGE_USERS_DRIVER description changes to docs-stable-2.0

### DIFF
--- a/services/_includes/adoc/storage-users_configvars.adoc
+++ b/services/_includes/adoc/storage-users_configvars.adoc
@@ -257,7 +257,7 @@ a| [subs=-attributes]
 a| [subs=-attributes]
 ++ocis ++
 a| [subs=-attributes]
-The storage driver which should be used by the service
+The storage driver which should be used by the service. Defaults to 'ocis', Supported values are: 'ocis', 's3ng' and 'owncloudsql'. The 'ocis' driver stores all data (file and meta data) in an POSIX compliant volume. The 's3ng' driver stores all metadata in an POSIX compliant volume and uploads blobs to the s3 bucket.
 
 a|`STORAGE_USERS_OCIS_ROOT` +
 


### PR DESCRIPTION
References: #5345 (Complete description of STORAGE_USERS_DRIVER)

Backports the above PR to the `docs-stable-2.0` branch
