### PR TITLE
Make identity errors public.

### DIFF
--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -6,6 +6,15 @@ import (
 
 	cs3 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
+)
+
+// Errors used by the interfaces
+var (
+	// ErrReadOnly signals that the backend is set to read only.
+	ErrReadOnly = errorcode.New(errorcode.NotAllowed, "server is configured read-only")
+	// ErrNotFound signals that the requested resource was not found.
+	ErrNotFound = errorcode.New(errorcode.ItemNotFound, "not found")
 )
 
 // Backend defines the Interface for an IdentityBackend implementation

--- a/services/graph/pkg/identity/ldap_education_user.go
+++ b/services/graph/pkg/identity/ldap_education_user.go
@@ -29,7 +29,7 @@ func (i *LDAP) CreateEducationUser(ctx context.Context, user libregraph.Educatio
 	logger := i.logger.SubloggerWithRequestID(ctx)
 	logger.Debug().Str("backend", "ldap").Msg("CreateEducationUser")
 	if !i.writeEnabled {
-		return nil, errReadOnly
+		return nil, ErrReadOnly
 	}
 
 	ar, err := i.educationUserToAddRequest(user)
@@ -61,7 +61,7 @@ func (i *LDAP) DeleteEducationUser(ctx context.Context, nameOrID string) error {
 	logger := i.logger.SubloggerWithRequestID(ctx)
 	logger.Debug().Str("backend", "ldap").Msg("DeleteEducationUser")
 	if !i.writeEnabled {
-		return errReadOnly
+		return ErrReadOnly
 	}
 	// TODO, implement a proper lookup for education Users here
 	e, err := i.getEducationUserByNameOrID(nameOrID)
@@ -91,7 +91,7 @@ func (i *LDAP) GetEducationUser(ctx context.Context, nameOrID string, queryParam
 	}
 	u := i.createEducationUserModelFromLDAP(e)
 	if u == nil {
-		return nil, errNotFound
+		return nil, ErrNotFound
 	}
 	return u, nil
 }
@@ -165,6 +165,7 @@ func (i *LDAP) educationUserToUser(eduUser libregraph.EducationUser) *libregraph
 	user.Mail = eduUser.Mail
 	return user
 }
+
 func (i *LDAP) userToEducationUser(user libregraph.User, e *ldap.Entry) *libregraph.EducationUser {
 	eduUser := libregraph.NewEducationUser()
 	eduUser.Id = user.Id

--- a/services/graph/pkg/identity/ldap_school.go
+++ b/services/graph/pkg/identity/ldap_school.go
@@ -92,7 +92,7 @@ func (i *LDAP) CreateEducationSchool(ctx context.Context, school libregraph.Educ
 	logger := i.logger.SubloggerWithRequestID(ctx)
 	logger.Debug().Str("backend", "ldap").Msg("CreateEducationSchool")
 	if !i.writeEnabled {
-		return nil, errReadOnly
+		return nil, ErrReadOnly
 	}
 
 	dn := fmt.Sprintf("%s=%s,%s",
@@ -133,7 +133,7 @@ func (i *LDAP) DeleteEducationSchool(ctx context.Context, id string) error {
 	logger := i.logger.SubloggerWithRequestID(ctx)
 	logger.Debug().Str("backend", "ldap").Msg("DeleteEducationSchool")
 	if !i.writeEnabled {
-		return errReadOnly
+		return ErrReadOnly
 	}
 	e, err := i.getSchoolByNumberOrID(id)
 	if err != nil {
@@ -217,7 +217,7 @@ func (i *LDAP) GetEducationSchoolUsers(ctx context.Context, id string) ([]*libre
 	}
 
 	if schoolEntry == nil {
-		return nil, errNotFound
+		return nil, ErrNotFound
 	}
 	id = ldap.EscapeFilter(id)
 	idFilter := fmt.Sprintf("(%s=%s)", i.educationConfig.memberOfSchoolAttribute, id)
@@ -267,7 +267,7 @@ func (i *LDAP) AddUsersToEducationSchool(ctx context.Context, schoolID string, m
 	}
 
 	if schoolEntry == nil {
-		return errNotFound
+		return ErrNotFound
 	}
 
 	userEntries := make([]*ldap.Entry, 0, len(memberIDs))
@@ -312,7 +312,7 @@ func (i *LDAP) RemoveUserFromEducationSchool(ctx context.Context, schoolID strin
 	}
 
 	if schoolEntry == nil {
-		return errNotFound
+		return ErrNotFound
 	}
 	user, err := i.getEducationUserByNameOrID(memberID)
 	if err != nil {
@@ -385,7 +385,6 @@ func (i *LDAP) getSchoolByFilter(filter string) (*ldap.Entry, error) {
 		Interface("attributes", searchRequest.Attributes).
 		Msg("getSchoolByFilter")
 	res, err := i.conn.Search(searchRequest)
-
 	if err != nil {
 		var errmsg string
 		if lerr, ok := err.(*ldap.Error); ok {
@@ -398,7 +397,7 @@ func (i *LDAP) getSchoolByFilter(filter string) (*ldap.Entry, error) {
 		return nil, errorcode.New(errorcode.ItemNotFound, errmsg)
 	}
 	if len(res.Entries) == 0 {
-		return nil, errNotFound
+		return nil, ErrNotFound
 	}
 
 	return res.Entries[0], nil


### PR DESCRIPTION
This makes the identity errors public so other packages can match on them.

It also moves them to the same file as the interface, as that makes them more discoverable.