### PR TITLE
Make amount of group members in patch configurable.

### DIFF
--- a/changelog/unreleased/enhancement-add-configurable-group-members-patch-limit.md
+++ b/changelog/unreleased/enhancement-add-configurable-group-members-patch-limit.md
@@ -1,0 +1,8 @@
+Enhancement: Make the group members addition limit configurable
+
+It's now possible to configure the limit of group members addition by PATCHing `/graph/v1.0/groups/{groupID}`.
+It still defaults to 20 as defined in the spec but it can be configured via `.graph.api.group_members_patch_limit`
+in `ocis.yaml` or via the `GRAPH_GROUP_MEMBERS_PATCH_LIMIT` environment variable.
+
+https://github.com/owncloud/ocis/pull/5357
+https://github.com/owncloud/ocis/issues/5262

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -89,7 +89,7 @@ type Identity struct {
 
 // API represents API configuration parameters.
 type API struct {
-	UserPatchLimit int `yaml:"user_patch_limit" env:"GRAPH_USER_PATCH_LIMIT" desc:"The amount of users allowed to be changed in PATCH requests."`
+	GroupMembersPatchLimit int `yaml:"group_members_patch_limit" env:"GRAPH_GROUP_MEMBERS_PATCH_LIMIT" desc:"The amount of group members allowed to be added with a single patch request."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -19,6 +19,8 @@ type Config struct {
 
 	HTTP HTTP `yaml:"http"`
 
+	API API `yaml:"api"`
+
 	Reva          *shared.Reva          `yaml:"reva"`
 	TokenManager  *TokenManager         `yaml:"token_manager"`
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
@@ -83,6 +85,11 @@ type LDAPEducationConfig struct {
 type Identity struct {
 	Backend string `yaml:"backend" env:"GRAPH_IDENTITY_BACKEND" desc:"The user identity backend to use. Supported backend types are 'ldap' and 'cs3'."`
 	LDAP    LDAP   `yaml:"ldap"`
+}
+
+// API represents API configuration parameters.
+type API struct {
+	UserPatchLimit int `yaml:"user_patch_limit" env:"GRAPH_USER_PATCH_LIMIT" desc:"The amount of users allowed to be changed in PATCH requests."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -30,6 +30,9 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "graph",
 		},
+		API: config.API{
+			UserPatchLimit: 20,
+		},
 		Reva: shared.DefaultRevaConfig(),
 		Spaces: config.Spaces{
 			WebDavBase:   "https://localhost:9200",

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -31,7 +31,7 @@ func DefaultConfig() *config.Config {
 			Name: "graph",
 		},
 		API: config.API{
-			UserPatchLimit: 20,
+			GroupMembersPatchLimit: 20,
 		},
 		Reva: shared.DefaultRevaConfig(),
 		Spaces: config.Spaces{

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -123,13 +123,13 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 	if memberRefs, ok := changes.GetMembersodataBindOk(); ok {
 		// The spec defines a limit of 20 members maxium per Request
-		if len(memberRefs) > g.config.API.UserPatchLimit {
+		if len(memberRefs) > g.config.API.GroupMembersPatchLimit {
 			logger.Debug().
 				Int("number", len(memberRefs)).
-				Int("limit", g.config.API.UserPatchLimit).
+				Int("limit", g.config.API.GroupMembersPatchLimit).
 				Msg("could not create group, exceeded members limit")
 			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
-				fmt.Sprintf("Request is limited to %d members", g.config.API.UserPatchLimit))
+				fmt.Sprintf("Request is limited to %d members", g.config.API.GroupMembersPatchLimit))
 			return
 		}
 		memberIDs := make([]string, 0, len(memberRefs))

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-chi/render"
 )
 
-const memberRefsLimit = 20
 const memberTypeUsers = "users"
 
 // GetGroups implements the Service interface.
@@ -124,13 +123,13 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 	if memberRefs, ok := changes.GetMembersodataBindOk(); ok {
 		// The spec defines a limit of 20 members maxium per Request
-		if len(memberRefs) > memberRefsLimit {
+		if len(memberRefs) > g.config.API.UserPatchLimit {
 			logger.Debug().
 				Int("number", len(memberRefs)).
-				Int("limit", memberRefsLimit).
+				Int("limit", g.config.API.UserPatchLimit).
 				Msg("could not create group, exceeded members limit")
 			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
-				fmt.Sprintf("Request is limited to %d members", memberRefsLimit))
+				fmt.Sprintf("Request is limited to %d members", g.config.API.UserPatchLimit))
 			return
 		}
 		memberIDs := make([]string, 0, len(memberRefs))


### PR DESCRIPTION
This PR changes the following:

* Create an API config section for API configurables.
* Add a setting `UserPatchLimit` that controls how many users can be changed in a PATCH request.
* Use this setting in the API to limit the amount of users that can be changed.