### PR TITLE
Adding so education PATCH updates school name or number.

### DIFF
--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -51,6 +51,8 @@ type EducationBackend interface {
 	GetEducationSchool(ctx context.Context, nameOrID string, queryParam url.Values) (*libregraph.EducationSchool, error)
 	// GetEducationSchools lists all schools
 	GetEducationSchools(ctx context.Context, queryParam url.Values) ([]*libregraph.EducationSchool, error)
+	// UpdateEducationSchool updates attributes of a school
+	UpdateEducationSchool(ctx context.Context, numberOrID string, school libregraph.EducationSchool) (*libregraph.EducationSchool, error)
 	// GetEducationSchoolUsers lists all members of a school
 	GetEducationSchoolUsers(ctx context.Context, id string) ([]*libregraph.EducationUser, error)
 	// AddUsersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.

--- a/services/graph/pkg/identity/err_school.go
+++ b/services/graph/pkg/identity/err_school.go
@@ -30,6 +30,11 @@ func (i *ErrEducationBackend) GetEducationSchools(ctx context.Context, queryPara
 	return nil, errNotImplemented
 }
 
+// UpdateEducationSchool implements the EducationBackend interface for the ErrEducationBackend backend.
+func (i *ErrEducationBackend) UpdateEducationSchool(ctx context.Context, numberOrID string, school libregraph.EducationSchool) (*libregraph.EducationSchool, error) {
+	return nil, errNotImplemented
+}
+
 // GetEducationSchoolUsers implements the EducationBackend interface for the ErrEducationBackend backend.
 func (i *ErrEducationBackend) GetEducationSchoolUsers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
 	return nil, errNotImplemented

--- a/services/graph/pkg/identity/ldap_school_test.go
+++ b/services/graph/pkg/identity/ldap_school_test.go
@@ -81,37 +81,39 @@ func TestCreateEducationSchool(t *testing.T) {
 }
 
 func TestUpdateEducationSchoolOperation(t *testing.T) {
+	testSchoolName := "A name"
+	testSchoolNumber := "1234"
 	tests := []struct {
 		name              string
 		displayName       string
 		schoolNumber      string
-		expectedOperation SchoolUpdateOperation
+		expectedOperation schoolUpdateOperation
 	}{
 		{
 			name:              "Test using school with both number and name",
-			displayName:       "A name",
-			schoolNumber:      "1234",
-			expectedOperation: TooManyValues,
+			displayName:       testSchoolName,
+			schoolNumber:      testSchoolNumber,
+			expectedOperation: tooManyValues,
 		},
 		{
 			name:              "Test with unchanged number",
-			schoolNumber:      "1234",
-			expectedOperation: SchoolUnchanged,
+			schoolNumber:      testSchoolNumber,
+			expectedOperation: schoolUnchanged,
 		},
 		{
 			name:              "Test with unchanged name",
-			displayName:       "A name",
-			expectedOperation: SchoolUnchanged,
+			displayName:       testSchoolName,
+			expectedOperation: schoolUnchanged,
 		},
 		{
 			name:              "Test new name",
 			displayName:       "Something new",
-			expectedOperation: DisplayNameUpdated,
+			expectedOperation: displayNameUpdated,
 		},
 		{
 			name:              "Test new number",
 			schoolNumber:      "9876",
-			expectedOperation: SchoolNumberUpdated,
+			expectedOperation: schoolNumberUpdated,
 		},
 	}
 

--- a/services/graph/pkg/identity/mocks/education_backend.go
+++ b/services/graph/pkg/identity/mocks/education_backend.go
@@ -234,6 +234,29 @@ func (_m *EducationBackend) RemoveUserFromEducationSchool(ctx context.Context, s
 	return r0
 }
 
+// UpdateEducationSchool provides a mock function with given fields: ctx, numberOrID, school
+func (_m *EducationBackend) UpdateEducationSchool(ctx context.Context, numberOrID string, school libregraph.EducationSchool) (*libregraph.EducationSchool, error) {
+	ret := _m.Called(ctx, numberOrID, school)
+
+	var r0 *libregraph.EducationSchool
+	if rf, ok := ret.Get(0).(func(context.Context, string, libregraph.EducationSchool) *libregraph.EducationSchool); ok {
+		r0 = rf(ctx, numberOrID, school)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*libregraph.EducationSchool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, libregraph.EducationSchool) error); ok {
+		r1 = rf(ctx, numberOrID, school)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateEducationUser provides a mock function with given fields: ctx, nameOrID, user
 func (_m *EducationBackend) UpdateEducationUser(ctx context.Context, nameOrID string, user libregraph.EducationUser) (*libregraph.EducationUser, error) {
 	ret := _m.Called(ctx, nameOrID, user)

--- a/services/graph/pkg/service/v0/educationschools_test.go
+++ b/services/graph/pkg/service/v0/educationschools_test.go
@@ -315,6 +315,8 @@ var _ = Describe("Schools", func() {
 			newSchoolJson, err := json.Marshal(newSchool)
 			Expect(err).ToNot(HaveOccurred())
 
+			identityEducationBackend.On("UpdateEducationSchool", mock.Anything, mock.Anything, mock.Anything).Return(newSchool, nil)
+
 			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/education/schools/schoolid", bytes.NewBuffer(newSchoolJson))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("schoolID", "school-id")
@@ -322,7 +324,7 @@ var _ = Describe("Schools", func() {
 
 			svc.PatchEducationSchool(rr, r)
 
-			Expect(rr.Code).To(Equal(http.StatusNoContent))
+			Expect(rr.Code).To(Equal(http.StatusOK))
 		})
 	})
 


### PR DESCRIPTION
## Description

This adds the missing PATCH functionality for updating a school using a school name or number.

As we can't have an atomic operation when updating the OU and another property, this only allows mutually exclusive updates of school number or name.

Note: The ldap update functions themselves do not have tests, but rather the "glue" function to select which operation to perform in UpdateEducationUser.

## Related Issue
- Fixes #5245 

## Motivation and Context
This adds the missing update implementation.

## How Has This Been Tested?
I tested this locally with curl and added testcases for the different input data scenarios.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
