### PR TITLE
Support givenName graph attribute.

### DIFF
--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -993,6 +993,11 @@ func (i *LDAP) userToLDAPAttrValues(user libregraph.User) (map[string][]string, 
 	}
 	attrs["sn"] = []string{sn}
 
+	// When we get a givenName, we set the attribute.
+	if user.GivenName != nil && *user.GivenName != "" {
+		attrs["givenname"] = []string{*user.GivenName}
+	}
+
 	if !i.usePwModifyExOp && user.PasswordProfile != nil && user.PasswordProfile.Password != nil {
 		// Depending on the LDAP server implementation this might cause the
 		// password to be stored in cleartext in the LDAP database. Using the


### PR DESCRIPTION
This sets the LDAP `givenname` attribute when the libe-graph `givenName`
attribute exists.

Fixes #5210