### PR TITLE
fix failing master unit tests that arose during the merge

### DIFF
--- a/services/graph/pkg/service/v0/groups_test.go
+++ b/services/graph/pkg/service/v0/groups_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Groups", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				cfg.API.GroupMembersPatchLimit = 21
-				svc = service.NewService(
+				svc, _ = service.NewService(
 					service.Config(cfg),
 					service.WithGatewayClient(gatewayClient),
 					service.EventsPublisher(&eventsPublisher),


### PR DESCRIPTION
## Description
since https://github.com/owncloud/ocis/pull/5347, NewService also returns a [error](https://github.com/owncloud/ocis/blob/0a97af2793416e113284931ec2a624f59126902b/services/graph/pkg/service/v0/service.go#L81). 

The pipeline was green but https://github.com/owncloud/ocis/commit/43a98c0485c86bc09c9985a98f15486977617a83 introduced a new test which fails (no err return value).

bad luck :cry.