### PR TITLE
[tests-only][full-ci] Added tests for checking version of file uploaded with same mtime twice

### DIFF
--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -531,3 +531,18 @@ Feature: dav-versions
     When user "Alice" restores version index "1" of file "/davtest.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/davtest.txt" for user "Alice" should be "Old Test Content."
+
+  @issue-5010
+  Scenario: Upload a file twice with the same mtime and a version is available
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the version folder of file "/file.txt" for user "Alice" should contain "1" element
+
+  @issue-5010
+  Scenario: Upload a file twice with the same mtime and no version after restoring
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    When user "Alice" restores version index "1" of file "/file.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the version folder of file "/file.txt" for user "Alice" should contain "0" element

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -533,14 +533,22 @@ Feature: dav-versions
     And the content of file "/davtest.txt" for user "Alice" should be "Old Test Content."
 
   @issue-5010
-  Scenario: Upload a file twice with the same mtime and a version is available
+  Scenario: Upload the same file twice with the same mtime and a version is available
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     Then the HTTP status code should be "204"
     And the version folder of file "/file.txt" for user "Alice" should contain "1" element
 
   @issue-5010
-  Scenario: Upload a file twice with the same mtime and no version after restoring
+  Scenario: Upload the same file more than twice with the same mtime and only one version is available
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the version folder of file "/file.txt" for user "Alice" should contain "1" element
+
+  @issue-5010
+  Scenario: Upload the same file twice with the same mtime and no version after restoring
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" restores version index "1" of file "/file.txt" using the WebDAV API


### PR DESCRIPTION
## Description
Added these scenarios:
```feature
Scenario: Upload the same file twice with the same mtime and a version is available
Scenario: Upload the same file more than twice with the same mtime and only one version is available
Scenario: Upload the same file twice with the same mtime and no version after restoring
```

## Related Issue
Test added for https://github.com/owncloud/ocis/issues/5010

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
