### PR TITLE
[full-ci] update web assets to v7.0.0-rc.6

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=f2b928be7e6ce85265868660049a4ff15caa74bc
+WEB_COMMITID=516e1ba14e83f1c1396f812fba69aa9fdadf7284
 WEB_BRANCH=master

--- a/services/settings/ui/components/settings/SettingMultiChoice.vue
+++ b/services/settings/ui/components/settings/SettingMultiChoice.vue
@@ -2,8 +2,8 @@
   <oc-select
       :clearable="false"
       :options="displayOptions"
-      :value="selectedOptions"
-      @input="onSelectedOption"
+      :model-value="selectedOption"
+      @update:modelValue="onSelectedOption"
       multiple
   />
 </template>

--- a/services/settings/ui/components/settings/SettingSingleChoice.vue
+++ b/services/settings/ui/components/settings/SettingSingleChoice.vue
@@ -3,8 +3,8 @@
     <oc-select
         :clearable="false"
         :options="displayOptions"
-        :value="selectedOption"
-        @input="onSelectedOption"
+        :model-value="selectedOption"
+        @update:modelValue="onSelectedOption"
        />
   </div>
 </template>

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.5
+WEB_ASSETS_VERSION = v7.0.0-rc.6
 
 include ../../.make/recursion.mk
 

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -47,7 +47,7 @@ func DefaultConfig() *config.Config {
 					ResponseType: "code",
 					Scope:        "openid profile email",
 				},
-				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "user-management"},
+				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings"},
 				ExternalApps: []config.ExternalApp{
 					{
 						ID:   "settings",

--- a/tests/config/drone/ocis-config.json
+++ b/tests/config/drone/ocis-config.json
@@ -25,7 +25,8 @@
     "markdown-editor",
     "media-viewer",
     "pdf-viewer",
-    "search"
+    "search",
+    "admin-settings"
   ],
   "external_apps": [
     {


### PR DESCRIPTION
This PR updates ownCloud Web to v7.0.0-rc.6. Which is the first version of ownCloud Web running on vue3 in compat mode.

@dschmidt could you please push fixes for the settings ui into this branch?