### PR TITLE
drop superflous /me in test urls

### DIFF
--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -94,6 +94,7 @@ var _ = Describe("Graph", func() {
 				svc.GetDrives(rr, r)
 				Expect(rr.Code).To(Equal(http.StatusOK))
 			})
+
 			It("can list an empty list of all spaces", func() {
 				gatewayClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Times(1).Return(&provider.ListStorageSpacesResponse{
 					Status:        status.NewOK(ctx),
@@ -726,7 +727,7 @@ var _ = Describe("Graph", func() {
 		})
 
 		It("handles missing drive id", func() {
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/{driveID}/", nil)
 			svc.GetSingleDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
@@ -737,7 +738,7 @@ var _ = Describe("Graph", func() {
 				StorageSpaces: []*provider.StorageSpace{},
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -767,7 +768,7 @@ var _ = Describe("Graph", func() {
 				StorageSpaces: []*provider.StorageSpace{space, space},
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -781,7 +782,7 @@ var _ = Describe("Graph", func() {
 				StorageSpaces: []*provider.StorageSpace{},
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -817,7 +818,7 @@ var _ = Describe("Graph", func() {
 					},
 				}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -856,7 +857,7 @@ var _ = Describe("Graph", func() {
 					},
 				}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -917,7 +918,7 @@ var _ = Describe("Graph", func() {
 					},
 				}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -945,11 +946,11 @@ var _ = Describe("Graph", func() {
 		})
 
 		It("fails on missing drive id", func() {
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/drives/{driveID}/", nil)
 			svc.UpdateDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
-			r = httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r = httptest.NewRequest(http.MethodPatch, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -958,7 +959,7 @@ var _ = Describe("Graph", func() {
 		})
 
 		It("fails on bad payload", func() {
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBufferString("{invalid"))
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/drives/{driveID}/", bytes.NewBufferString("{invalid"))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -981,7 +982,7 @@ var _ = Describe("Graph", func() {
 				}
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBuffer(driveJson))
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/drives/{driveID}/", bytes.NewBuffer(driveJson))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -1007,7 +1008,7 @@ var _ = Describe("Graph", func() {
 				}
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBuffer(driveJson))
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/drives/{driveID}/", bytes.NewBuffer(driveJson))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -1041,7 +1042,7 @@ var _ = Describe("Graph", func() {
 				},
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/drives/{driveID}/", bytes.NewBuffer(driveJson))
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/drives/{driveID}/", bytes.NewBuffer(driveJson))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -1056,11 +1057,11 @@ var _ = Describe("Graph", func() {
 
 	Describe("Delete a drive", func() {
 		It("fails on invalid drive ids", func() {
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/drives/{driveID}/", nil)
 			svc.DeleteDrive(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
-			r = httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r = httptest.NewRequest(http.MethodDelete, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -1073,7 +1074,7 @@ var _ = Describe("Graph", func() {
 				Status: status.NewOK(ctx),
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -1090,7 +1091,7 @@ var _ = Describe("Graph", func() {
 				Status: status.NewOK(ctx),
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/drives/{driveID}/", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/drives/{driveID}/", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("driveID", "spaceid")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))

--- a/services/graph/pkg/service/v0/groups_test.go
+++ b/services/graph/pkg/service/v0/groups_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Groups", func() {
 
 	Describe("GetGroups", func() {
 		It("handles invalid ODATA parameters", func() {
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups?§foo=bar", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups?§foo=bar", nil)
 			svc.GetGroups(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -89,7 +89,7 @@ var _ = Describe("Groups", func() {
 		It("handles invalid sorting queries", func() {
 			identityBackend.On("GetGroups", ctx, mock.Anything).Return([]*libregraph.Group{newGroup}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups?$orderby=invalid", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups?$orderby=invalid", nil)
 			svc.GetGroups(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -105,7 +105,7 @@ var _ = Describe("Groups", func() {
 		It("handles unknown backend errors", func() {
 			identityBackend.On("GetGroups", ctx, mock.Anything).Return(nil, errors.New("failed"))
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups", nil)
 			svc.GetGroups(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
 			data, err := io.ReadAll(rr.Body)
@@ -120,7 +120,7 @@ var _ = Describe("Groups", func() {
 		It("handles backend errors", func() {
 			identityBackend.On("GetGroups", ctx, mock.Anything).Return(nil, errorcode.New(errorcode.AccessDenied, "access denied"))
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups", nil)
 			svc.GetGroups(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
@@ -136,7 +136,7 @@ var _ = Describe("Groups", func() {
 		It("renders an empty list of groups", func() {
 			identityBackend.On("GetGroups", ctx, mock.Anything).Return([]*libregraph.Group{}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups", nil)
 			svc.GetGroups(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -152,7 +152,7 @@ var _ = Describe("Groups", func() {
 		It("renders a list of groups", func() {
 			identityBackend.On("GetGroups", ctx, mock.Anything).Return([]*libregraph.Group{newGroup}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups", nil)
 			svc.GetGroups(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -170,12 +170,12 @@ var _ = Describe("Groups", func() {
 
 	Describe("GetGroup", func() {
 		It("handles missing or empty group id", func() {
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups", nil)
 			svc.GetGroup(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
-			r = httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups", nil)
+			r = httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", "")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -190,7 +190,7 @@ var _ = Describe("Groups", func() {
 			})
 
 			It("gets the group", func() {
-				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups/"+*newGroup.Id, nil)
+				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups/"+*newGroup.Id, nil)
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
 				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
@@ -204,7 +204,7 @@ var _ = Describe("Groups", func() {
 
 	Describe("PostGroup", func() {
 		It("handles invalid body", func() {
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/", bytes.NewBufferString("{invalid"))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/", bytes.NewBufferString("{invalid"))
 
 			svc.PostGroup(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -217,7 +217,7 @@ var _ = Describe("Groups", func() {
 			newGroupJson, err := json.Marshal(newGroup)
 			Expect(err).ToNot(HaveOccurred())
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/", bytes.NewBuffer(newGroupJson))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/", bytes.NewBuffer(newGroupJson))
 
 			svc.PostGroup(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -231,7 +231,7 @@ var _ = Describe("Groups", func() {
 			newGroupJson, err := json.Marshal(newGroup)
 			Expect(err).ToNot(HaveOccurred())
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/", bytes.NewBuffer(newGroupJson))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/", bytes.NewBuffer(newGroupJson))
 
 			svc.PostGroup(rr, r)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -245,7 +245,7 @@ var _ = Describe("Groups", func() {
 
 			identityBackend.On("CreateGroup", mock.Anything, mock.Anything).Return(newGroup, nil)
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/", bytes.NewBuffer(newGroupJson))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/", bytes.NewBuffer(newGroupJson))
 
 			svc.PostGroup(rr, r)
 
@@ -254,7 +254,7 @@ var _ = Describe("Groups", func() {
 	})
 	Describe("PatchGroup", func() {
 		It("handles invalid body", func() {
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups/", bytes.NewBufferString("{invalid"))
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups/", bytes.NewBufferString("{invalid"))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -263,12 +263,12 @@ var _ = Describe("Groups", func() {
 		})
 
 		It("handles missing or empty group id", func() {
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", nil)
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", nil)
 			svc.PatchGroup(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 
-			r = httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", nil)
+			r = httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", "")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -292,7 +292,7 @@ var _ = Describe("Groups", func() {
 				updatedGroupJson, err := json.Marshal(updatedGroup)
 				Expect(err).ToNot(HaveOccurred())
 
-				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
+				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
 				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -323,7 +323,7 @@ var _ = Describe("Groups", func() {
 					service.WithIdentityBackend(identityBackend),
 				)
 
-				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
+				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
 				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -343,7 +343,7 @@ var _ = Describe("Groups", func() {
 				updatedGroupJson, err := json.Marshal(updatedGroup)
 				Expect(err).ToNot(HaveOccurred())
 
-				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
+				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
 				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -359,7 +359,7 @@ var _ = Describe("Groups", func() {
 				updatedGroupJson, err := json.Marshal(updatedGroup)
 				Expect(err).ToNot(HaveOccurred())
 
-				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
+				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
 				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -377,7 +377,7 @@ var _ = Describe("Groups", func() {
 				updatedGroupJson, err := json.Marshal(updatedGroup)
 				Expect(err).ToNot(HaveOccurred())
 
-				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", bytes.NewBuffer(updatedGroupJson))
+				r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", bytes.NewBuffer(updatedGroupJson))
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("groupID", *newGroup.Id)
 				r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -398,7 +398,7 @@ var _ = Describe("Groups", func() {
 
 		It("deletes the group", func() {
 			identityBackend.On("DeleteGroup", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/groups", nil)
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/groups", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -416,7 +416,7 @@ var _ = Describe("Groups", func() {
 			user.SetId("user")
 			identityBackend.On("GetGroupMembers", mock.Anything, mock.Anything, mock.Anything).Return([]*libregraph.User{user}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/groups/{groupID}/members", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups/{groupID}/members", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -437,7 +437,7 @@ var _ = Describe("Groups", func() {
 
 	Describe("PostGroupMembers", func() {
 		It("fails on invalid body", func() {
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBufferString("{invalid"))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/{groupID}/members", bytes.NewBufferString("{invalid"))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -450,7 +450,7 @@ var _ = Describe("Groups", func() {
 			data, err := json.Marshal(member)
 			Expect(err).ToNot(HaveOccurred())
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBuffer(data))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/{groupID}/members", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -464,7 +464,7 @@ var _ = Describe("Groups", func() {
 			data, err := json.Marshal(member)
 			Expect(err).ToNot(HaveOccurred())
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBuffer(data))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/{groupID}/members", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -479,7 +479,7 @@ var _ = Describe("Groups", func() {
 			Expect(err).ToNot(HaveOccurred())
 			identityBackend.On("AddMembersToGroup", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/groups/{groupID}/members", bytes.NewBuffer(data))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/groups/{groupID}/members", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -492,7 +492,7 @@ var _ = Describe("Groups", func() {
 
 	Describe("DeleteGroupMembers", func() {
 		It("handles missing or empty member id", func() {
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/groups/{groupID}/members/{memberID}/$ref", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/groups/{groupID}/members/{memberID}/$ref", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -500,7 +500,7 @@ var _ = Describe("Groups", func() {
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
 		It("handles missing or empty member id", func() {
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/groups/{groupID}/members/{memberID}/$ref", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/groups/{groupID}/members/{memberID}/$ref", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("memberID", "/users/user")
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -511,7 +511,7 @@ var _ = Describe("Groups", func() {
 		It("deletes members", func() {
 			identityBackend.On("RemoveMemberFromGroup", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/groups/{groupID}/members/{memberID}/$ref", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/groups/{groupID}/members/{memberID}/$ref", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("groupID", *newGroup.Id)
 			rctx.URLParams.Add("memberID", "/users/user1")

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Users", func() {
 
 	Describe("GetUsers", func() {
 		It("handles invalid requests", func() {
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users?$invalid=true", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users?$invalid=true", nil)
 			svc.GetUsers(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -171,7 +171,7 @@ var _ = Describe("Users", func() {
 
 			identityBackend.On("GetUsers", mock.Anything, mock.Anything, mock.Anything).Return(users, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users", nil)
 			svc.GetUsers(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -216,52 +216,52 @@ var _ = Describe("Users", func() {
 				return res.Value
 			}
 
-			unsorted := getUsers("/graph/v1.0/me/users")
+			unsorted := getUsers("/graph/v1.0/users")
 			Expect(len(unsorted)).To(Equal(2))
 			Expect(unsorted[0].GetId()).To(Equal("user1"))
 			Expect(unsorted[1].GetId()).To(Equal("user2"))
 
-			byMail := getUsers("/graph/v1.0/me/users?$orderby=mail")
+			byMail := getUsers("/graph/v1.0/users?$orderby=mail")
 			Expect(len(byMail)).To(Equal(2))
 			Expect(byMail[0].GetId()).To(Equal("user2"))
 			Expect(byMail[1].GetId()).To(Equal("user1"))
-			byMail = getUsers("/graph/v1.0/me/users?$orderby=mail%20asc")
+			byMail = getUsers("/graph/v1.0/users?$orderby=mail%20asc")
 			Expect(len(byMail)).To(Equal(2))
 			Expect(byMail[0].GetId()).To(Equal("user2"))
 			Expect(byMail[1].GetId()).To(Equal("user1"))
-			byMail = getUsers("/graph/v1.0/me/users?$orderby=mail%20desc")
+			byMail = getUsers("/graph/v1.0/users?$orderby=mail%20desc")
 			Expect(len(byMail)).To(Equal(2))
 			Expect(byMail[0].GetId()).To(Equal("user1"))
 			Expect(byMail[1].GetId()).To(Equal("user2"))
 
-			byDisplayName := getUsers("/graph/v1.0/me/users?$orderby=displayName")
+			byDisplayName := getUsers("/graph/v1.0/users?$orderby=displayName")
 			Expect(len(byDisplayName)).To(Equal(2))
 			Expect(byDisplayName[0].GetId()).To(Equal("user2"))
 			Expect(byDisplayName[1].GetId()).To(Equal("user1"))
-			byDisplayName = getUsers("/graph/v1.0/me/users?$orderby=displayName%20asc")
+			byDisplayName = getUsers("/graph/v1.0/users?$orderby=displayName%20asc")
 			Expect(len(byDisplayName)).To(Equal(2))
 			Expect(byDisplayName[0].GetId()).To(Equal("user2"))
 			Expect(byDisplayName[1].GetId()).To(Equal("user1"))
-			byDisplayName = getUsers("/graph/v1.0/me/users?$orderby=displayName%20desc")
+			byDisplayName = getUsers("/graph/v1.0/users?$orderby=displayName%20desc")
 			Expect(len(byDisplayName)).To(Equal(2))
 			Expect(byDisplayName[0].GetId()).To(Equal("user1"))
 			Expect(byDisplayName[1].GetId()).To(Equal("user2"))
 
-			byOnPremisesSamAccountName := getUsers("/graph/v1.0/me/users?$orderby=onPremisesSamAccountName")
+			byOnPremisesSamAccountName := getUsers("/graph/v1.0/users?$orderby=onPremisesSamAccountName")
 			Expect(len(byOnPremisesSamAccountName)).To(Equal(2))
 			Expect(byOnPremisesSamAccountName[0].GetId()).To(Equal("user2"))
 			Expect(byOnPremisesSamAccountName[1].GetId()).To(Equal("user1"))
-			byOnPremisesSamAccountName = getUsers("/graph/v1.0/me/users?$orderby=onPremisesSamAccountName%20asc")
+			byOnPremisesSamAccountName = getUsers("/graph/v1.0/users?$orderby=onPremisesSamAccountName%20asc")
 			Expect(len(byOnPremisesSamAccountName)).To(Equal(2))
 			Expect(byOnPremisesSamAccountName[0].GetId()).To(Equal("user2"))
 			Expect(byOnPremisesSamAccountName[1].GetId()).To(Equal("user1"))
-			byOnPremisesSamAccountName = getUsers("/graph/v1.0/me/users?$orderby=onPremisesSamAccountName%20desc")
+			byOnPremisesSamAccountName = getUsers("/graph/v1.0/users?$orderby=onPremisesSamAccountName%20desc")
 			Expect(len(byOnPremisesSamAccountName)).To(Equal(2))
 			Expect(byOnPremisesSamAccountName[0].GetId()).To(Equal("user1"))
 			Expect(byOnPremisesSamAccountName[1].GetId()).To(Equal("user2"))
 
 			// Handles invalid sort field
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users?$orderby=invalid", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users?$orderby=invalid", nil)
 			svc.GetUsers(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -326,7 +326,7 @@ var _ = Describe("Users", func() {
 
 	Describe("GetUser", func() {
 		It("handles missing userids", func() {
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users", nil)
 			svc.GetUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -337,7 +337,7 @@ var _ = Describe("Users", func() {
 			user.SetId("user1")
 
 			identityBackend.On("GetUser", mock.Anything, mock.Anything, mock.Anything).Return(user, nil)
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", *user.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -378,7 +378,7 @@ var _ = Describe("Users", func() {
 				},
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users?$expand=drive", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users?$expand=drive", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", *user.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -413,7 +413,7 @@ var _ = Describe("Users", func() {
 				},
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/users?$expand=drives", nil)
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/users?$expand=drives", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", *user.Id)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -476,7 +476,7 @@ var _ = Describe("Users", func() {
 				userJson, err := json.Marshal(user)
 				Expect(err).ToNot(HaveOccurred())
 
-				r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users", bytes.NewBuffer(userJson))
+				r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users", bytes.NewBuffer(userJson))
 				svc.PostUser(rr, r)
 
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -491,7 +491,7 @@ var _ = Describe("Users", func() {
 		})
 
 		It("handles invalid bodies", func() {
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users?$invalid=true", nil)
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users?$invalid=true", nil)
 			svc.PostUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -533,7 +533,7 @@ var _ = Describe("Users", func() {
 			userJson, err := json.Marshal(user)
 			Expect(err).ToNot(HaveOccurred())
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users", bytes.NewBuffer(userJson))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users", bytes.NewBuffer(userJson))
 			r = r.WithContext(revactx.ContextSetUser(ctx, currentUser))
 			svc.PostUser(rr, r)
 
@@ -543,7 +543,7 @@ var _ = Describe("Users", func() {
 
 	Describe("DeleteUser", func() {
 		It("handles missing userids", func() {
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/users/{userid}", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/users/{userid}", nil)
 			svc.DeleteUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -554,7 +554,7 @@ var _ = Describe("Users", func() {
 			lu.SetId(currentUser.Id.OpaqueId)
 			identityBackend.On("GetUser", mock.Anything, mock.Anything, mock.Anything).Return(&lu, nil)
 
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/users/{userid}", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/users/{userid}", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", currentUser.Id.OpaqueId)
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -590,7 +590,7 @@ var _ = Describe("Users", func() {
 				},
 			}, nil)
 
-			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/me/users/{userid}", nil)
+			r := httptest.NewRequest(http.MethodDelete, "/graph/v1.0/users/{userid}", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", lu.GetId())
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -617,14 +617,14 @@ var _ = Describe("Users", func() {
 		})
 
 		It("handles missing userids", func() {
-			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/me/users/{userid}", nil)
+			r := httptest.NewRequest(http.MethodPatch, "/graph/v1.0/users/{userid}", nil)
 			svc.PatchUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
 
 		It("handles invalid bodies", func() {
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users?$invalid=true", nil)
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users?$invalid=true", nil)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", user.GetId())
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -638,7 +638,7 @@ var _ = Describe("Users", func() {
 			data, err := json.Marshal(user)
 			Expect(err).ToNot(HaveOccurred())
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users?$invalid=true", bytes.NewBuffer(data))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users?$invalid=true", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", user.GetId())
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
@@ -654,7 +654,7 @@ var _ = Describe("Users", func() {
 			data, err := json.Marshal(user)
 			Expect(err).ToNot(HaveOccurred())
 
-			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/me/users?$invalid=true", bytes.NewBuffer(data))
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users?$invalid=true", bytes.NewBuffer(data))
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("userID", user.GetId())
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))


### PR DESCRIPTION
The path part of requests in the tests are not really evaluated because of https://github.com/owncloud/ocis/issues/5209

This PR at corrects the path by removing an accidential c'n'p `/me`