### PR TITLE
graph: Allow provisioning users with legacy names (#5255)

### DIFF
--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -92,7 +92,8 @@ type Identity struct {
 
 // API represents API configuration parameters.
 type API struct {
-	GroupMembersPatchLimit int `yaml:"group_members_patch_limit" env:"GRAPH_GROUP_MEMBERS_PATCH_LIMIT" desc:"The amount of group members allowed to be added with a single patch request."`
+	GroupMembersPatchLimit int    `yaml:"group_members_patch_limit" env:"GRAPH_GROUP_MEMBERS_PATCH_LIMIT" desc:"The amount of group members allowed to be added with a single patch request."`
+	UsernameMatch          string `yaml:"graph_username_match" env:"GRAPH_USERNAME_MATCH" desc:"Option to allow legacy usernames. Supported options are 'default' and 'none'."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -36,6 +36,7 @@ func DefaultConfig() *config.Config {
 		},
 		API: config.API{
 			GroupMembersPatchLimit: 20,
+			UsernameMatch:          "default",
 		},
 		Reva: shared.DefaultRevaConfig(),
 		Spaces: config.Spaces{

--- a/services/graph/pkg/config/parser/parse.go
+++ b/services/graph/pkg/config/parser/parse.go
@@ -52,5 +52,15 @@ func Validate(cfg *config.Config) error {
 			"graph", defaults2.BaseConfigPath())
 	}
 
+	switch cfg.API.UsernameMatch {
+	case "default", "none":
+	default:
+		return fmt.Errorf("The username match validator is invalid for %s. "+
+			"Make sure your %s config contains the proper values "+
+			"(e.g. by running ocis init or setting it manually in "+
+			"the config/corresponding environment variable).",
+			"graph", defaults2.BaseConfigPath())
+	}
+
 	return nil
 }

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -112,7 +112,7 @@ func (g Graph) PostEducationUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if accountName, ok := u.GetOnPremisesSamAccountNameOk(); ok {
-		if !isValidUsername(*accountName) {
+		if !g.isValidUsername(*accountName) {
 			logger.Debug().Str("username", *accountName).Msg("could not create education user: username must be at least the local part of an email")
 			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("username %s must be at least the local part of an email", *u.OnPremisesSamAccountName))
 			return


### PR DESCRIPTION
## Description
Via configuration you can now configure to skip the validation of username and instead decide to trust the upstream system that is adding users.

## Related Issue
- Fixes #5255 

## How Has This Been Tested?
I have added two tests for checking that bypassing the default regex works.

Also did some exploratory testing with adding users with spaces in the username. I did not test that extensively, but found some bugs.

```
Exploratory testing notes:
--------------------------

After adding a user with spaces in the name, I can log in with that user in the UI.

Sharing a text file from user with spaces in the name works.

Sharing an image to/from user with spaces works 

Sharing a gif to a user with spaces in the name does not work.

Looking in the UI gives a 500 when trying to get thumbnail:
<d:error xmlns:d="DAV" xmlns:s="http://sabredav.org/ns"><s:exception></s:exception><s:message>{&#34;id&#34;:&#34;go.micro.client&#34;,&#34;code&#34;:500,&#34;detail&#34;:&#34;can&#39;t encode this type&#34;,&#34;status&#34;:&#34;Internal Server Error&#34;}</s:message></d:error>

{"level":"warn","service":"thumbnails","method":"Thumbnails.GetThumbnail","duration":25.149446,"error":"can't encode this type","time":"2023-01-13T14:17:27.201644857+07:00","message":"Failed to execute"}
{"level":"debug","service":"webdav","request-id":"14cd90ec-c978-452a-ad36-b833b896417d","error":"{\"id\":\"go.micro.client\",\"code\":500,\"detail\":\"can't encode this type\",\"status\":\"Internal Server Error\"}","time":"2023-01-13T14:17:27.201849422+07:00","message":"could not get thumbnail"}


Clicking on "Actions" and "download" works.

Preview does not work.

Download from preview works.

--

Sharing a gif from a user with spaces in name works if shared via link.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
