### PR TITLE
store generated application id

### DIFF
--- a/services/graph/pkg/config/application.go
+++ b/services/graph/pkg/config/application.go
@@ -2,6 +2,6 @@ package config
 
 // Application defines the available graph application configuration.
 type Application struct {
-	ID          string `yaml:"id" env:"GRAPH_APPLICATION_ID" desc:"The ocis application id shown in the graph. All app roles are tied to this."`
+	ID          string // is read from store
 	DisplayName string `yaml:"displayname" env:"GRAPH_APPLICATION_DISPLAYNAME" desc:"The oCIS application name"`
 }

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -17,6 +17,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	searchsvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/search/v0"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
+	storesvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/store/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/identity"
 	"go-micro.dev/v4/client"
@@ -104,6 +105,7 @@ type Graph struct {
 	spacePropertiesCache     *ttlcache.Cache[string, interface{}]
 	usersCache               *ttlcache.Cache[string, libregraph.User]
 	groupsCache              *ttlcache.Cache[string, libregraph.Group]
+	store                    storesvc.StoreService
 	eventsPublisher          events.Publisher
 	searchService            searchsvc.SearchProviderService
 }


### PR DESCRIPTION
I think we should persist non security critical properties that are generated or read from env vars from the store.

The applicationid I introduced with https://github.com/owncloud/ocis/pull/5318 for the graph really does not need to be configured by the admin. I see no problem with generating and persisting it. That the store service may needs another backend is a different issue.

Same goes IMO for the reva storage provider ids. And maybe more. 

- [ ] get rid of the ocis init code again

