### PR TITLE
Populate expanded properties

### DIFF
--- a/changelog/unreleased/populate-expanded-properties.md
+++ b/changelog/unreleased/populate-expanded-properties.md
@@ -1,0 +1,6 @@
+Bugfix: Populate expanded properties
+
+We now return an empty array when an expanded relation has no entries. This makes consuming the responses a little easier.
+
+https://github.com/owncloud/ocis/pull/5421
+https://github.com/owncloud/ocis/issues/5419

--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -387,10 +387,7 @@ func (i *LDAP) GetUser(ctx context.Context, nameOrID string, queryParam url.Valu
 		if err != nil {
 			return nil, err
 		}
-		if len(userGroups) > 0 {
-			groups := i.groupsFromLDAPEntries(userGroups)
-			u.MemberOf = groups
-		}
+		u.MemberOf = i.groupsFromLDAPEntries(userGroups)
 	}
 	return u, nil
 }
@@ -454,14 +451,7 @@ func (i *LDAP) GetUsers(ctx context.Context, queryParam url.Values) ([]*libregra
 			if err != nil {
 				return nil, err
 			}
-			if len(userGroups) > 0 {
-				expand := ldap.EscapeFilter(queryParam.Get("expand"))
-				if expand == "" {
-					expand = "false"
-				}
-				groups := i.groupsFromLDAPEntries(userGroups)
-				u.MemberOf = groups
-			}
+			u.MemberOf = i.groupsFromLDAPEntries(userGroups)
 		}
 		users = append(users, u)
 	}

--- a/services/graph/pkg/identity/ldap_group.go
+++ b/services/graph/pkg/identity/ldap_group.go
@@ -41,14 +41,13 @@ func (i *LDAP) GetGroup(ctx context.Context, nameOrID string, queryParam url.Val
 		if err != nil {
 			return nil, err
 		}
+		g.Members = make([]libregraph.User, 0, len(members))
 		if len(members) > 0 {
-			m := make([]libregraph.User, 0, len(members))
 			for _, ue := range members {
 				if u := i.createUserModelFromLDAP(ue); u != nil {
-					m = append(m, *u)
+					g.Members = append(g.Members, *u)
 				}
 			}
-			g.Members = m
 		}
 	}
 	return g, nil
@@ -120,14 +119,13 @@ func (i *LDAP) GetGroups(ctx context.Context, queryParam url.Values) ([]*libregr
 			if err != nil {
 				return nil, err
 			}
+			g.Members = make([]libregraph.User, 0, len(members))
 			if len(members) > 0 {
-				m := make([]libregraph.User, 0, len(members))
 				for _, ue := range members {
 					if u := i.createUserModelFromLDAP(ue); u != nil {
-						m = append(m, *u)
+						g.Members = append(g.Members, *u)
 					}
 				}
-				g.Members = m
 			}
 		}
 		groups = append(groups, g)

--- a/services/graph/pkg/service/v0/drives_test.go
+++ b/services/graph/pkg/service/v0/drives_test.go
@@ -111,7 +111,7 @@ var sortTests = []sortTest{
 }
 
 func drive(ID string, dType string, name string, lastModified *time.Time) *libregraph.Drive {
-	return &libregraph.Drive{Id: libregraph.PtrString(ID), DriveType: libregraph.PtrString(dType), Name: name, LastModifiedDateTime: lastModified}
+	return &libregraph.Drive{Id: libregraph.PtrString(ID), DriveType: libregraph.PtrString(dType), Name: name, LastModifiedDateTime: lastModified, Quota: &libregraph.Quota{}}
 }
 
 // TestSort tests the available orderby queries

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -257,7 +257,7 @@ func (g Graph) GetEducationUser(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				logger.Debug().Err(err).Interface("id", sp.Id).Msg("error calling get quota on drive")
 			}
-			d.Quota = quota
+			d.Quota = &quota
 			if slices.Contains(sel, "drive") || slices.Contains(exp, "drive") {
 				if *d.DriveType == _spaceTypePersonal {
 					user.Drive = d

--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -143,6 +143,7 @@ var _ = Describe("Graph", func() {
 						"driveType":"aspacetype",
 						"id":"pro-1$sameID",
 						"name":"aspacename",
+						"quota": {},
 						"root":{
 							"id":"pro-1$sameID",
 							"webDavUrl":"https://localhost:9200/dav/spaces/pro-1$sameID"
@@ -213,6 +214,7 @@ var _ = Describe("Graph", func() {
 						"driveType":"aspacetype",
 						"id":"pro-1$asameID",
 						"name":"aspacename",
+						"quota": {},
 						"root":{
 							"eTag":"101112131415",
 							"id":"pro-1$asameID",
@@ -225,6 +227,7 @@ var _ = Describe("Graph", func() {
 						"driveType":"bspacetype",
 						"id":"pro-1$bsameID",
 						"name":"bspacename",
+						"quota": {},
 						"root":{
 							"eTag":"123456789",
 							"id":"pro-1$bsameID",


### PR DESCRIPTION
We now return an empty array when an expanded relation has no entries. This makes consuming the responses a little easier.

fixes https://github.com/owncloud/ocis/issues/5419