### PR TITLE
fix populating user drive and drives

### DIFF
--- a/changelog/unreleased/populate-expanded-properties.md
+++ b/changelog/unreleased/populate-expanded-properties.md
@@ -4,3 +4,4 @@ We now return an empty array when an expanded relation has no entries. This make
 
 https://github.com/owncloud/ocis/pull/5421
 https://github.com/owncloud/ocis/issues/5419
+https://github.com/owncloud/ocis/pull/5426

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -372,6 +372,7 @@ var _ = Describe("Users", func() {
 					},
 					{
 						Id:        &provider.StorageSpaceId{OpaqueId: "personal"},
+						Owner:     &userv1beta1.User{Id: &userv1beta1.UserId{OpaqueId: "user1"}},
 						Root:      &provider.ResourceId{SpaceId: "personal", OpaqueId: "personal"},
 						SpaceType: "personal",
 					},
@@ -391,7 +392,7 @@ var _ = Describe("Users", func() {
 			err = json.Unmarshal(data, &responseUser)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(responseUser.GetId()).To(Equal("user1"))
-			Expect(*responseUser.GetDrive().Id).To(Equal("personal"))
+			Expect(responseUser.GetDrive().Id).To(Equal("personal"))
 		})
 
 		It("includes the drives if requested", func() {

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -392,7 +392,7 @@ var _ = Describe("Users", func() {
 			err = json.Unmarshal(data, &responseUser)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(responseUser.GetId()).To(Equal("user1"))
-			Expect(responseUser.GetDrive().Id).To(Equal("personal"))
+			Expect(*responseUser.GetDrive().Id).To(Equal("personal"))
 		})
 
 		It("includes the drives if requested", func() {


### PR DESCRIPTION
continuation of https://github.com/owncloud/ocis/pull/5421

The personal `drive` should not be part of the `drives` list.

And when decomposedfs supports the space owner filter we should use that instead of a user + space type "personal" filter, but not part of this PR.