### PR TITLE
graph: Allow creating users without email (#5253)

### DIFF
--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -188,10 +188,6 @@ func (g Graph) PostUser(w http.ResponseWriter, r *http.Request) {
 			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("%v is not a valid email address", *u.Mail))
 			return
 		}
-	} else {
-		logger.Debug().Interface("user", u).Msg("could not create user: missing required Attribute: 'mail'")
-		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing required Attribute: 'mail'")
-		return
 	}
 
 	// Disallow user-supplied IDs. It's supposed to be readonly. We're either

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -512,9 +512,6 @@ var _ = Describe("Users", func() {
 		})
 
 		It("handles bad Mails", func() {
-			user.Mail = nil
-			assertHandleBadAttributes(user)
-
 			user.SetMail("not-a-mail-address")
 			assertHandleBadAttributes(user)
 		})

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -589,7 +589,7 @@ class GraphHelper {
 		$payload['onPremisesSamAccountName'] = $userName;
 		$payload['passwordProfile'] = ['password' => $password];
 		$payload['displayName'] = $displayName ?? $userName;
-		if (!isset($email)) {
+		if (!empty($email)) {
 			$payload['mail'] = $email ?? $userName . '@example.com';
 		}
 		return \json_encode($payload);

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -589,7 +589,9 @@ class GraphHelper {
 		$payload['onPremisesSamAccountName'] = $userName;
 		$payload['passwordProfile'] = ['password' => $password];
 		$payload['displayName'] = $displayName ?? $userName;
-		$payload['mail'] = $email ?? $userName . '@example.com';
+		if (!isset($email)) {
+			$payload['mail'] = $email ?? $userName . '@example.com';
+		}
 		return \json_encode($payload);
 	}
 

--- a/tests/acceptance/features/apiGraph/createUser.feature
+++ b/tests/acceptance/features/apiGraph/createUser.feature
@@ -24,7 +24,7 @@ Feature: create user
       | withoutPassSameEmail         | without pass     | alice@example.org   |                              | 200  | should     |
       | name                         | pass with space  | example@example.org | my pass                      | 200  | should     |
       | nameWithCharacters(*:!;_+-&) | user             | new@example.org     | 123                          | 400  | should not |
-      | withoutEmail                 | without email    |                     | 123                          | 400  | should not |
+      | withoutEmail                 | without email    |                     | 123                          | 200  | should     |
       | Alice                        | same userName    | new@example.org     | 123                          | 400  | should     |
       | name with space              | name with space  | example@example.org | 123                          | 400  | should not |
 


### PR DESCRIPTION
## Description
Allow creating users without email via API.

## Related Issue
Fixes https://github.com/owncloud/ocis/issues/5253

## How Has This Been Tested?
Updated acceptance tests to check for this and also tested manually with curl.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests modified
- [ ] Documentation ticket raised:
