### PR TITLE
[docs-only] Fix formatting in the docs related to testing

### DIFF
--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -134,10 +134,15 @@ TEST_OCIS=true \
 Make sure to adjust the settings `TEST_SERVER_URL` according to your environment.
 
 To run a single feature add `BEHAT_FEATURE=<feature file>` 
+
 example: `BEHAT_SUITE=tests/acceptance/features/apiGraph/createUser.feature`
+
 To run a single test add `BEHAT_FEATURE=<file.feature:(line number)>`
+
 example: `BEHAT_SUITE=tests/acceptance/features/apiGraph/createUser.feature:12`
+
 To run a single suite add `BEHAT_SUITE=<test suite>`
+
 example: `BEHAT_SUITE=apiGraph`
 
 To run tests with a different storage driver set `STORAGE_DRIVER` to the correct value. It can be set to `OCIS` or `OWNCLOUD` and uses `OWNCLOUD` as the default value.


### PR DESCRIPTION
The formatting seemed off in the docs. It looked like this 
![Screenshot from 2023-01-24 09-46-39](https://user-images.githubusercontent.com/41103328/214210110-6b61b77d-dc15-40f0-8f8f-e50584006255.png)

This Pr adds a line break to make it look nicer
![Screenshot from 2023-01-24 09-47-08](https://user-images.githubusercontent.com/41103328/214210141-82dee5cf-63d1-4979-a2db-9decd99faff3.png)
