### PR TITLE
Add line number and file to log messages when at debug level.

### DIFF
--- a/ocis-pkg/log/log.go
+++ b/ocis-pkg/log/log.go
@@ -132,8 +132,10 @@ func NewLogger(opts ...Option) Logger {
 		Timestamp().
 		Logger().Level(logLevel)
 
-	var lineInfoHook LineInfoHook
-	logger = logger.Hook(lineInfoHook)
+	if logLevel <= zerolog.InfoLevel {
+		var lineInfoHook LineInfoHook
+		logger = logger.Hook(lineInfoHook)
+	}
 
 	return Logger{
 		logger,

--- a/ocis-pkg/log/log.go
+++ b/ocis-pkg/log/log.go
@@ -132,10 +132,8 @@ func NewLogger(opts ...Option) Logger {
 		Timestamp().
 		Logger().Level(logLevel)
 
-	if logLevel == zerolog.DebugLevel {
-		var lineInfoHook LineInfoHook
-		logger = logger.Hook(lineInfoHook)
-	}
+	var lineInfoHook LineInfoHook
+	logger = logger.Hook(lineInfoHook)
 
 	return Logger{
 		logger,

--- a/ocis-pkg/log/log.go
+++ b/ocis-pkg/log/log.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -19,10 +18,6 @@ import (
 
 var (
 	RequestIDString = "request-id"
-
-	// Match all paths outside of ocis. Will break if path does not include '/ocis/',
-	// but this is intended for debugging purposes.
-	pathRegex = regexp.MustCompile(`.*/ocis/`)
 )
 
 func init() {
@@ -78,7 +73,6 @@ type LineInfoHook struct{}
 func (h LineInfoHook) Run(e *zerolog.Event, l zerolog.Level, msg string) {
 	_, file, line, ok := runtime.Caller(3)
 	if ok {
-		file := pathRegex.ReplaceAllString(file, "")
 		e.Str("line", fmt.Sprintf("%s:%d", file, line))
 	}
 }


### PR DESCRIPTION
## Description
Add a runtime hook for the zerolog setup to log line number and file when log level is set to debug.

## Motivation and Context
I was trying to run ocis and to add users via /graph/v1.0/users API, but some environment variable or configuration was wrong and I was getting 500 errors. In the log I only saw this:
```
2023-01-26T11:33:40+01:00 ERR error initializing metadata client error="error: not found: create container: error: not found: f1bdd61a-da7c-49fc-8203-0558109d1b4f!f1bdd61a-da7c-49fc-8203-0558109d1b4f/settings" service=ocis
2023-01-26T11:33:40+01:00 ERR Could not load roles error="{\"id\":\"go.micro.server\",\"code\":500,\"detail\":\"panic recovered: runtime error: invalid memory address or nil pointer dereference\",\"status\":\"Internal Server Error\"}" service=proxy
2023-01-26T11:33:40+01:00 ERR Could not get user by claim error="{\"id\":\"go.micro.server\",\"code\":500,\"detail\":\"panic recovered: runtime error: invalid memory address or nil pointer dereference\",\"status\":\"Internal Server Error\"}" service=proxy
```
As this was not really helpful in telling me what was going wrong, I decided to add line number and file info to the messages.

## How Has This Been Tested?
Tested by running locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
