### PR TITLE
[test-only]ApiTest. tests for spaceManagement

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -103,5 +103,8 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 #### [Sharing to a group with an expiration date does not work #5442](https://github.com/owncloud/ocis/issues/5442)
 - [apiSpacesShares/shareSubItemOfSpace.feature:99](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature#L99)
 
+#### [Space admin should not not be able to change the user quota](https://github.com/owncloud/ocis/issues/5475)
+- [apiSpaces/spaceManagement.feature:69](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/spaceManagement.feature#L69)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSpaces/restoreSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaces.feature
@@ -57,7 +57,7 @@ Feature: Restoring space
   Scenario Outline: User without space manager role cannot restore space
     Given user "Alice" has shared a space "restore a space" to user "Brian" with role "<role>"
     And user "Alice" has disabled a space "restore a space"
-    When user "Brian" restores a disabled space "restore a space" without manager rights
+    When user "Brian" restores a disabled space "restore a space" owned by user "Alice"
     Then the HTTP status code should be "404"
     Examples:
       | role   |

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -1,0 +1,171 @@
+@api @skipOnOcV10
+Feature: Space management
+  As a user with space admin permission
+  I want to be able to manage all existing project space
+  - I can get all project space where I am not member using "graph/v1.0/drives" endpoint
+  - I can edit space: change quota, name, description
+  - I can enable, disable, delete space
+
+  Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
+  See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+    And using spaces DAV path
+    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has given "Brian" the role "Space Admin" using the settings api
+    And user "Alice" has created a space "Project" of type "project" with quota "10"
+
+
+  Scenario: The space admin user can see another project space even if he is not member of the space
+    When user "Brian" lists all spaces via the GraphApi with query "$filter=driveType eq 'project'"
+    Then the HTTP status code should be "200"
+    And the json responded should contain a space "Project" with these key and value pairs:
+      | key       | value      |
+      | driveType | project    |
+      | id        | %space_id% |
+      | name      | Project    |
+    And the json responded should not contain a space with name "Alice Hansen"
+
+
+  Scenario: The space admin user can see another personal spaces
+    When user "Brian" lists all spaces via the GraphApi with query "$filter=driveType eq 'personal'"
+    Then the HTTP status code should be "200"
+    And the json responded should contain a space "Alice Hansen" with these key and value pairs:
+      | key       | value        |
+      | driveType | personal     |
+      | id        | %space_id%   |
+      | name      | Alice Hansen |
+    And the json responded should not contain a space with name "Project"
+
+
+  Scenario: The user without space admin permissions cannot see another spaces
+    When user "Carol" tries to list all spaces via the GraphApi
+    Then the HTTP status code should be "200"
+    And the json responded should not contain a space with name "Project"
+    And the json responded should not contain a space with name "Alice Hansen"
+
+
+  Scenario: The space admin user changes the quota of the project space
+    When user "Brian" changes the quota of the "Project" space to "20" owned by user "Alice"
+    Then the HTTP status code should be "200"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key           | value |
+      | quota@@@total | 20    |
+
+
+  Scenario: The user without space admin permissions tries to change the quota of the project space
+    When user "Carol" tries to change the quota of the "Project" space to "20" owned by user "Alice"
+    Then the HTTP status code should be "401"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key           | value |
+      | quota@@@total | 10    |
+
+
+  Scenario: The space admin user changes the quota of the personal space
+    When user "Brian" changes the quota of the "Alice Hansen" space to "20" owned by user "Alice"
+    Then the HTTP status code should be "200"
+    And the user "Alice" should have a space called "Alice Hansen" with these key and value pairs:
+      | key           | value |
+      | quota@@@total | 20    |
+
+
+  Scenario: The user without space admin permissions tries to change the quota of the personal space
+    When user "Carol" tries to change the quota of the "Alice Hansen" space to "20" owned by user "Alice"
+    Then the HTTP status code should be "401"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key           | value |
+      | quota@@@total | 10    |
+
+
+  Scenario: The space admin user changes the name of the project space
+    When user "Brian" changes the name of the "Project" space to "New Name" owned by user "Alice"
+    Then the HTTP status code should be "200"
+    And the user "Alice" should have a space called "New Name" with these key and value pairs:
+      | key  | value    |
+      | name | New Name |
+
+
+  Scenario: The user without space admin permissions tries to change the name of the project space
+    When user "Carol" tries to change the name of the "Project" space to "New Name" owned by user "Alice"
+    Then the HTTP status code should be "403"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key  | value   |
+      | name | Project |
+
+
+  Scenario: The space admin user changes the description of the project space
+    When user "Brian" changes the description of the "Project" space to "New description" owned by user "Alice"
+    Then the HTTP status code should be "200"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key         | value           |
+      | description | New description |
+
+
+  Scenario: The user without space admin permissions tries to change the description of the project space
+    Given user "Alice" has changed the description of the "Project" space to "old description"
+    When user "Carol" tries to change the description of the "Project" space to "New description" owned by user "Alice"
+    Then the HTTP status code should be "403"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key         | value           |
+      | description | old description |
+
+
+  Scenario: The space admin user disables the project space
+    When user "Brian" disables a space "Project" owned by user "Alice"
+    Then the HTTP status code should be "204"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key                    | value   |
+      | name                   | Project |
+      | root@@@deleted@@@state | trashed |
+
+
+  Scenario: The user without space admin permissions tries to disable the project space
+    When user "Carol" tries to disable a space "Project" owned by user "Alice"
+    Then the HTTP status code should be "403"
+
+
+  Scenario Outline: The space admin user tries to disable the personal space
+    When user "<user>" disables a space "Alice Hansen" owned by user "Alice"
+    Then the HTTP status code should be "403"
+    Examples:
+      | user  |
+      | Brian |
+      | Carol |
+
+
+  Scenario: The space admin user deletes the project space
+    Given user "Alice" has disabled a space "Project"
+    When user "Brian" deletes a space "Project" owned by user "Alice"
+    Then the HTTP status code should be "204"
+    And the user "Alice" should not have a space called "Project"
+
+
+  Scenario: The user without space admin permissions tries to delete the project space
+    Given user "Alice" has disabled a space "Project"
+    When user "Carol" tries to delete a space "Project" owned by user "Alice"
+    Then the HTTP status code should be "403"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key                    | value   |
+      | name                   | Project |
+      | root@@@deleted@@@state | trashed |
+
+
+  Scenario: The space admin user enables the project space
+    Given user "Alice" has disabled a space "Project"
+    When user "Brian" restores a disabled space "Project" owned by user "Alice"
+    Then the HTTP status code should be "200"
+
+
+  Scenario: The user without space admin permissions tries to enable the project space
+    Given user "Alice" has disabled a space "Project"
+    When user "Carol" tries to restore a disabled space "Project" owned by user "Alice"
+    Then the HTTP status code should be "404"
+    And the user "Alice" should have a space called "Project" with these key and value pairs:
+      | key                    | value   |
+      | name                   | Project |
+      | root@@@deleted@@@state | trashed |

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -66,12 +66,12 @@ Feature: Space management
       | quota@@@total | 10    |
 
 
-  Scenario: The space admin user changes the quota of the personal space
-    When user "Brian" changes the quota of the "Alice Hansen" space to "20" owned by user "Alice"
-    Then the HTTP status code should be "200"
+  Scenario: The space admin user tries to change the quota of the personal space
+    When user "Brian" tries to change the quota of the "Alice Hansen" space to "20" owned by user "Alice"
+    Then the HTTP status code should be "401"
     And the user "Alice" should have a space called "Alice Hansen" with these key and value pairs:
       | key           | value |
-      | quota@@@total | 20    |
+      | quota@@@total | 10    |
 
 
   Scenario: The user without space admin permissions tries to change the quota of the personal space

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -222,8 +222,7 @@ Feature: Tag
     Given user "Alice" has created the following tags for folder "folderMain" of the space "use-tag":
       | folderTag |
       | marketing |
-    When user "Alice" disables a space "use-tag"
-    Then the HTTP status code should be "204"
+    And user "Alice" has disabled a space "use-tag"
     When user "Alice" lists all available tags via the GraphApi
     Then the HTTP status code should be "200"
     And the response should contain following tags:


### PR DESCRIPTION
related https://github.com/owncloud/ocis/pull/5441
created tests in which a user with space administrator rights can:
-  get all project spaces
- get all personal spaces - not secure
- edit the space name
- edit the space description
- edit quota of project spaces
- edit quota personal spaces - I have my doubts here @micbar . I think this should only be available to the administrator/ created bug https://github.com/owncloud/ocis/issues/5475
- disable spaces
- disable personal space
- enable spaces
- delete a space
