### PR TITLE
Allow assiging/unassigning classes to schools

### DIFF
--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -60,6 +60,13 @@ type EducationBackend interface {
 	// RemoveUserFromEducationSchool removes a single member (by ID) from a school
 	RemoveUserFromEducationSchool(ctx context.Context, schoolID string, memberID string) error
 
+	// GetEducationSchoolClasses lists all classes in a chool
+	GetEducationSchoolClasses(ctx context.Context, schoolNumberOrID string) ([]*libregraph.EducationClass, error)
+	// AddClassesToEducationSchool adds new classes (referenced by a slice of IDs) to supplied school in the identity backend.
+	AddClassesToEducationSchool(ctx context.Context, schoolNumberOrID string, memberIDs []string) error
+	// RemoveClassFromEducationSchool removes a class from a school.
+	RemoveClassFromEducationSchool(ctx context.Context, schoolNumberOrID string, memberID string) error
+
 	// GetEducationClasses lists all classes
 	GetEducationClasses(ctx context.Context, queryParam url.Values) ([]*libregraph.EducationClass, error)
 	// GetEducationClasses reads a given class by id

--- a/services/graph/pkg/identity/err_education.go
+++ b/services/graph/pkg/identity/err_education.go
@@ -40,6 +40,21 @@ func (i *ErrEducationBackend) GetEducationSchoolUsers(ctx context.Context, id st
 	return nil, errNotImplemented
 }
 
+// GetEducationSchoolClasses implements the EducationBackend interface for the ErrEducationBackend backend.
+func (i *ErrEducationBackend) GetEducationSchoolClasses(ctx context.Context, schoolNumberOrID string) ([]*libregraph.EducationClass, error) {
+	return nil, errNotImplemented
+}
+
+// AddClassesToEducationSchool implements the EducationBackend interface for the ErrEducationBackend backend.
+func (i *ErrEducationBackend) AddClassesToEducationSchool(ctx context.Context, schoolNumberOrID string, memberIDs []string) error {
+	return errNotImplemented
+}
+
+// RemoveClassFromEducationSchool implements the EducationBackend interface for the ErrEducationBackend backend.
+func (i *ErrEducationBackend) RemoveClassFromEducationSchool(ctx context.Context, schoolNumberOrID string, memberID string) error {
+	return errNotImplemented
+}
+
 // AddUsersToEducationSchool adds new members (reference by a slice of IDs) to supplied school in the identity backend.
 func (i *ErrEducationBackend) AddUsersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error {
 	return errNotImplemented

--- a/services/graph/pkg/identity/ldap_education_class.go
+++ b/services/graph/pkg/identity/ldap_education_class.go
@@ -344,8 +344,8 @@ func (i *LDAP) getEducationClassLDAPDN(class libregraph.EducationClass) string {
 func (i *LDAP) getEducationClassByID(nameOrID string, requestMembers bool) (*ldap.Entry, error) {
 	return i.getEducationObjectByNameOrID(
 		nameOrID,
-		i.groupAttributeMap.name,
-		i.groupAttributeMap.id,
+		i.userAttributeMap.id,
+		i.educationConfig.classAttributeMap.externalID,
 		i.groupFilter,
 		i.educationConfig.classObjectClass,
 		i.groupBaseDN,

--- a/services/graph/pkg/identity/ldap_education_class.go
+++ b/services/graph/pkg/identity/ldap_education_class.go
@@ -341,16 +341,14 @@ func (i *LDAP) getEducationClassLDAPDN(class libregraph.EducationClass) string {
 	return fmt.Sprintf("ocEducationExternalId=%s,%s", oldap.EscapeDNAttributeValue(class.GetExternalId()), i.groupBaseDN)
 }
 
-// getEducationClassByID looks up a class by id (and be ID or externalID)
-func (i *LDAP) getEducationClassByID(id string, requestMembers bool) (*ldap.Entry, error) {
-	id = ldap.EscapeFilter(id)
-	filter := fmt.Sprintf("(|(%s=%s)(%s=%s))",
-		i.groupAttributeMap.id, id,
-		i.educationConfig.classAttributeMap.externalID, id)
-	return i.getEducationClassByFilter(filter, requestMembers)
-}
-
-func (i *LDAP) getEducationClassByFilter(filter string, requestMembers bool) (*ldap.Entry, error) {
-	filter = fmt.Sprintf("(&%s(objectClass=%s)%s)", i.groupFilter, i.educationConfig.classObjectClass, filter)
-	return i.searchLDAPEntryByFilter(i.groupBaseDN, i.getEducationClassAttrTypes(requestMembers), filter)
+func (i *LDAP) getEducationClassByID(nameOrID string, requestMembers bool) (*ldap.Entry, error) {
+	return i.getEducationObjectByNameOrID(
+		nameOrID,
+		i.groupAttributeMap.name,
+		i.groupAttributeMap.id,
+		i.groupFilter,
+		i.educationConfig.classObjectClass,
+		i.groupBaseDN,
+		i.getEducationClassAttrTypes(requestMembers),
+	)
 }

--- a/services/graph/pkg/identity/ldap_education_class.go
+++ b/services/graph/pkg/identity/ldap_education_class.go
@@ -298,6 +298,7 @@ func (i *LDAP) getEducationClassAttrTypes(requestMembers bool) []string {
 		i.groupAttributeMap.id,
 		i.educationConfig.classAttributeMap.classification,
 		i.educationConfig.classAttributeMap.externalID,
+		i.educationConfig.memberOfSchoolAttribute,
 	}
 	if requestMembers {
 		attrs = append(attrs, i.groupAttributeMap.member)

--- a/services/graph/pkg/identity/ldap_education_class_test.go
+++ b/services/graph/pkg/identity/ldap_education_class_test.go
@@ -21,6 +21,15 @@ var classEntry = ldap.NewEntry("ocEducationExternalId=Math0123",
 		"entryUUID":             {"abcd-defg"},
 	})
 
+var classEntryWithSchool = ldap.NewEntry("ocEducationExternalId=Math0123",
+	map[string][]string{
+		"cn":                    {"Math"},
+		"ocEducationExternalId": {"Math0123"},
+		"ocEducationClassType":  {"course"},
+		"entryUUID":             {"abcd-defg"},
+		"ocMemberOfSchool":      {"abcd-defg"},
+	})
+
 var classEntryWithMember = ldap.NewEntry("ocEducationExternalId=Math0123",
 	map[string][]string{
 		"cn":                    {"Math"},

--- a/services/graph/pkg/identity/ldap_education_class_test.go
+++ b/services/graph/pkg/identity/ldap_education_class_test.go
@@ -140,7 +140,7 @@ func TestGetEducationClass(t *testing.T) {
 			Scope:      2,
 			SizeLimit:  1,
 			Filter:     tt.filter,
-			Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId"},
+			Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId", "ocMemberOfSchool"},
 			Controls:   []ldap.Control(nil),
 		}
 		if tt.expectedItemNotFound {
@@ -207,7 +207,7 @@ func TestDeleteEducationClass(t *testing.T) {
 			Scope:      2,
 			SizeLimit:  1,
 			Filter:     tt.filter,
-			Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId"},
+			Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId", "ocMemberOfSchool"},
 			Controls:   []ldap.Control(nil),
 		}
 		if tt.expectedItemNotFound {
@@ -285,7 +285,7 @@ func TestGetEducationClassMembers(t *testing.T) {
 			Scope:      2,
 			SizeLimit:  1,
 			Filter:     tt.filter,
-			Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId", "member"},
+			Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId", "ocMemberOfSchool", "member"},
 			Controls:   []ldap.Control(nil),
 		}
 		if tt.expectedItemNotFound {

--- a/services/graph/pkg/identity/ldap_education_school.go
+++ b/services/graph/pkg/identity/ldap_education_school.go
@@ -354,7 +354,7 @@ func (i *LDAP) GetEducationSchoolUsers(ctx context.Context, schoolNumberOrID str
 	logger.Debug().Str("backend", "ldap").Msg("GetEducationSchoolUsers")
 
 	entries, err := i.getEducationSchoolEntries(
-		schoolNumberOrID, i.userFilter, i.educationConfig.userObjectClass, i.userBaseDN, i.userScope, i.getUserAttrTypes(), logger,
+		schoolNumberOrID, i.userFilter, i.educationConfig.userObjectClass, i.userBaseDN, i.userScope, i.getEducationUserAttrTypes(), logger,
 	)
 	if err != nil {
 		return nil, err

--- a/services/graph/pkg/identity/ldap_education_school_test.go
+++ b/services/graph/pkg/identity/ldap_education_school_test.go
@@ -461,7 +461,7 @@ var classesBySchoolIDSearch *ldap.SearchRequest = &ldap.SearchRequest{
 	Scope:      2,
 	SizeLimit:  0,
 	Filter:     "(&(objectClass=ocEducationClass)(ocMemberOfSchool=abcd-defg))",
-	Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId"},
+	Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId", "ocMemberOfSchool"},
 	Controls:   []ldap.Control(nil),
 }
 
@@ -484,7 +484,7 @@ var classesByUUIDSearchNotFound *ldap.SearchRequest = &ldap.SearchRequest{
 	Scope:      2,
 	SizeLimit:  1,
 	Filter:     "(&(objectClass=ocEducationClass)(|(entryUUID=does-not-exist)(ocEducationExternalId=does-not-exist)))",
-	Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId"},
+	Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId", "ocMemberOfSchool"},
 	Controls:   []ldap.Control(nil),
 }
 
@@ -493,7 +493,7 @@ var classesByUUIDSearchFound *ldap.SearchRequest = &ldap.SearchRequest{
 	Scope:      2,
 	SizeLimit:  1,
 	Filter:     "(&(objectClass=ocEducationClass)(|(entryUUID=abcd-defg)(ocEducationExternalId=abcd-defg)))",
-	Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId"},
+	Attributes: []string{"cn", "entryUUID", "ocEducationClassType", "ocEducationExternalId", "ocMemberOfSchool"},
 	Controls:   []ldap.Control(nil),
 }
 

--- a/services/graph/pkg/identity/ldap_education_user.go
+++ b/services/graph/pkg/identity/ldap_education_user.go
@@ -265,12 +265,24 @@ func (i *LDAP) getEducationUserByDN(dn string) (*ldap.Entry, error) {
 }
 
 func (i *LDAP) getEducationUserByNameOrID(nameOrID string) (*ldap.Entry, error) {
-	nameOrID = ldap.EscapeFilter(nameOrID)
-	filter := fmt.Sprintf("(|(%s=%s)(%s=%s))", i.userAttributeMap.userName, nameOrID, i.userAttributeMap.id, nameOrID)
-	return i.getEducationUserByFilter(filter)
+	return i.getEducationObjectByNameOrID(
+		nameOrID,
+		i.userAttributeMap.userName,
+		i.userAttributeMap.id,
+		i.userFilter,
+		i.educationConfig.userObjectClass,
+		i.userBaseDN,
+		i.getEducationUserAttrTypes(),
+	)
 }
 
-func (i *LDAP) getEducationUserByFilter(filter string) (*ldap.Entry, error) {
-	filter = fmt.Sprintf("(&%s(objectClass=%s)%s)", i.userFilter, i.educationConfig.userObjectClass, filter)
-	return i.searchLDAPEntryByFilter(i.userBaseDN, i.getEducationUserAttrTypes(), filter)
+func (i *LDAP) getEducationObjectByNameOrID(nameOrID, nameAttribute, idAttribute, objectFilter, objectClass, baseDN string, attributes []string) (*ldap.Entry, error) {
+	nameOrID = ldap.EscapeFilter(nameOrID)
+	filter := fmt.Sprintf("(|(%s=%s)(%s=%s))", nameAttribute, nameOrID, idAttribute, nameOrID)
+	return i.getEducationObjectByFilter(filter, baseDN, objectFilter, objectClass, attributes)
+}
+
+func (i *LDAP) getEducationObjectByFilter(filter, baseDN, objectFilter, objectClass string, attributes []string) (*ldap.Entry, error) {
+	filter = fmt.Sprintf("(&%s(objectClass=%s)%s)", objectFilter, objectClass, filter)
+	return i.searchLDAPEntryByFilter(baseDN, attributes, filter)
 }

--- a/services/graph/pkg/identity/mocks/education_backend.go
+++ b/services/graph/pkg/identity/mocks/education_backend.go
@@ -17,6 +17,20 @@ type EducationBackend struct {
 	mock.Mock
 }
 
+// AddClassesToEducationSchool provides a mock function with given fields: ctx, schoolNumberOrID, memberIDs
+func (_m *EducationBackend) AddClassesToEducationSchool(ctx context.Context, schoolNumberOrID string, memberIDs []string) error {
+	ret := _m.Called(ctx, schoolNumberOrID, memberIDs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string) error); ok {
+		r0 = rf(ctx, schoolNumberOrID, memberIDs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // AddUsersToEducationSchool provides a mock function with given fields: ctx, schoolID, memberID
 func (_m *EducationBackend) AddUsersToEducationSchool(ctx context.Context, schoolID string, memberID []string) error {
 	ret := _m.Called(ctx, schoolID, memberID)
@@ -234,6 +248,29 @@ func (_m *EducationBackend) GetEducationSchool(ctx context.Context, nameOrID str
 	return r0, r1
 }
 
+// GetEducationSchoolClasses provides a mock function with given fields: ctx, schoolNumberOrID
+func (_m *EducationBackend) GetEducationSchoolClasses(ctx context.Context, schoolNumberOrID string) ([]*libregraph.EducationClass, error) {
+	ret := _m.Called(ctx, schoolNumberOrID)
+
+	var r0 []*libregraph.EducationClass
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*libregraph.EducationClass); ok {
+		r0 = rf(ctx, schoolNumberOrID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*libregraph.EducationClass)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, schoolNumberOrID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetEducationSchoolUsers provides a mock function with given fields: ctx, id
 func (_m *EducationBackend) GetEducationSchoolUsers(ctx context.Context, id string) ([]*libregraph.EducationUser, error) {
 	ret := _m.Called(ctx, id)
@@ -324,6 +361,20 @@ func (_m *EducationBackend) GetEducationUsers(ctx context.Context, queryParam ur
 	}
 
 	return r0, r1
+}
+
+// RemoveClassFromEducationSchool provides a mock function with given fields: ctx, schoolNumberOrID, memberID
+func (_m *EducationBackend) RemoveClassFromEducationSchool(ctx context.Context, schoolNumberOrID string, memberID string) error {
+	ret := _m.Called(ctx, schoolNumberOrID, memberID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, schoolNumberOrID, memberID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // RemoveUserFromEducationSchool provides a mock function with given fields: ctx, schoolID, memberID

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -423,7 +423,7 @@ func (g Graph) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Request)
 	render.NoContent(w, r)
 }
 
-// GetEducationSchoolUsers implements the Service interface.
+// GetEducationSchoolClasses implements the Service interface.
 func (g Graph) GetEducationSchoolClasses(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("calling get school classes")
@@ -458,7 +458,7 @@ func (g Graph) GetEducationSchoolClasses(w http.ResponseWriter, r *http.Request)
 	render.JSON(w, r, classes)
 }
 
-// PostEducationSchoolUser implements the Service interface.
+// PostEducationSchoolClass implements the Service interface.
 func (g Graph) PostEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("Calling post school class")

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -535,7 +535,7 @@ func (g Graph) PostEducationSchoolClass(w http.ResponseWriter, r *http.Request) 
 	render.NoContent(w, r)
 }
 
-// DeleteEducationSchoolUser implements the Service interface.
+// DeleteEducationSchoolClass implements the Service interface.
 func (g Graph) DeleteEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("calling delete school class")
@@ -567,7 +567,7 @@ func (g Graph) DeleteEducationSchoolClass(w http.ResponseWriter, r *http.Request
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing class id")
 		return
 	}
-	logger.Debug().Str("schoolID", schoolID).Str("userID", classID).Msg("calling delete class on backend")
+	logger.Debug().Str("schoolID", schoolID).Str("classID", classID).Msg("calling delete class on backend")
 	err = g.identityEducationBackend.RemoveClassFromEducationSchool(r.Context(), schoolID, classID)
 
 	if err != nil {

--- a/services/graph/pkg/service/v0/instrument.go
+++ b/services/graph/pkg/service/v0/instrument.go
@@ -164,6 +164,21 @@ func (i instrument) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Req
 	i.next.DeleteEducationSchoolUser(w, r)
 }
 
+// GetEducationSchoolClasses implements the Service interface.
+func (i instrument) GetEducationSchoolClasses(w http.ResponseWriter, r *http.Request) {
+	i.next.GetEducationSchoolClasses(w, r)
+}
+
+// PostEducationSchoolClass implements the Service interface.
+func (i instrument) PostEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
+	i.next.PostEducationSchoolClass(w, r)
+}
+
+// DeleteEducationSchoolClass implements the Service interface.
+func (i instrument) DeleteEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
+	i.next.DeleteEducationSchoolClass(w, r)
+}
+
 // GetEducationClasses implements the Service interface.
 func (i instrument) GetEducationClasses(w http.ResponseWriter, r *http.Request) {
 	i.next.GetEducationClasses(w, r)

--- a/services/graph/pkg/service/v0/logging.go
+++ b/services/graph/pkg/service/v0/logging.go
@@ -164,6 +164,21 @@ func (l logging) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Reques
 	l.next.DeleteEducationSchoolUser(w, r)
 }
 
+// GetEducationSchoolClasses implements the Service interface.
+func (l logging) GetEducationSchoolClasses(w http.ResponseWriter, r *http.Request) {
+	l.next.GetEducationSchoolClasses(w, r)
+}
+
+// PostEducationSchoolClass implements the Service interface.
+func (l logging) PostEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
+	l.next.PostEducationSchoolClass(w, r)
+}
+
+// DeleteEducationSchoolClass implements the Service interface.
+func (l logging) DeleteEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
+	l.next.DeleteEducationSchoolClass(w, r)
+}
+
 // GetEducationClasses implements the Service interface.
 func (l logging) GetEducationClasses(w http.ResponseWriter, r *http.Request) {
 	l.next.GetEducationClasses(w, r)

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -241,6 +241,11 @@ func NewService(opts ...Option) (Graph, error) {
 							r.Post("/$ref", svc.PostEducationSchoolUser)
 							r.Delete("/{userID}/$ref", svc.DeleteEducationSchoolUser)
 						})
+						r.Route("/classes", func(r chi.Router) {
+							r.Get("/", svc.GetEducationSchoolClasses)
+							r.Post("/$ref", svc.PostEducationSchoolClass)
+							r.Delete("/{classID}/$ref", svc.DeleteEducationSchoolClass)
+						})
 					})
 				})
 				r.Route("/users", func(r chi.Router) {

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -65,6 +65,9 @@ type Service interface {
 	GetEducationSchoolUsers(http.ResponseWriter, *http.Request)
 	PostEducationSchoolUser(http.ResponseWriter, *http.Request)
 	DeleteEducationSchoolUser(http.ResponseWriter, *http.Request)
+	GetEducationSchoolClasses(http.ResponseWriter, *http.Request)
+	PostEducationSchoolClass(http.ResponseWriter, *http.Request)
+	DeleteEducationSchoolClass(http.ResponseWriter, *http.Request)
 
 	GetEducationClasses(http.ResponseWriter, *http.Request)
 	GetEducationClass(http.ResponseWriter, *http.Request)

--- a/services/graph/pkg/service/v0/tracing.go
+++ b/services/graph/pkg/service/v0/tracing.go
@@ -160,6 +160,21 @@ func (t tracing) DeleteEducationSchoolUser(w http.ResponseWriter, r *http.Reques
 	t.next.DeleteEducationSchoolUser(w, r)
 }
 
+// GetEducationSchoolClasses implements the Service interface.
+func (t tracing) GetEducationSchoolClasses(w http.ResponseWriter, r *http.Request) {
+	t.next.GetEducationSchoolClasses(w, r)
+}
+
+// PostEducationSchoolClass implements the Service interface.
+func (t tracing) PostEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
+	t.next.PostEducationSchoolClass(w, r)
+}
+
+// DeleteEducationSchoolClass implements the Service interface.
+func (t tracing) DeleteEducationSchoolClass(w http.ResponseWriter, r *http.Request) {
+	t.next.DeleteEducationSchoolClass(w, r)
+}
+
 // GetEducationClasses implements the Service interface.
 func (t tracing) GetEducationClasses(w http.ResponseWriter, r *http.Request) {
 	t.next.GetEducationClasses(w, r)


### PR DESCRIPTION
This PR does the following:

Adds handlers for `/education/schools/{schoolID}/classes/{$ref,classID,}` to allow the requesting and manipulation of classes.

This fixes #5412 