### PR TITLE
[test-only] api tests for getting group info of user

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -311,6 +311,32 @@ class GraphHelper {
 	/**
 	 * @param string $baseUrl
 	 * @param string $xRequestId
+	 * @param string $byUser
+	 * @param string $userPassword
+	 * @param string|null $user
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function getUserWithGroupInformation(
+		string $baseUrl,
+		string $xRequestId,
+		string $byUser,
+		string $userPassword,
+		?string $user = null
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, 'users/' . $user . '?%24expand=memberOf');
+		return HttpRequestHelper::get(
+			$url,
+			$xRequestId,
+			$byUser,
+			$userPassword,
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
 	 * @param string $adminUser
 	 * @param string $adminPassword
 	 * @param string $groupName

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -93,6 +93,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [A User can get information of another user with Graph API](https://github.com/owncloud/ocis/issues/5125)
 - [apiGraph/getUser.feature:23](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/getUser.feature#L23)
+- [apiGraph/getUser.feature:92](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/getUser.feature#L92)
 
 #### [GET a file while it's in processing doesn't return 425 code (async uploads)](https://github.com/owncloud/ocis/issues/5326)
 - [apiAsyncUpload/delayPostprocessing.feature:14](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature#L14)

--- a/tests/acceptance/features/apiGraph/getUser.feature
+++ b/tests/acceptance/features/apiGraph/getUser.feature
@@ -75,3 +75,15 @@ Feature: get users
       | root@@@id         | %space_id%                       |
       | root@@@webDavUrl  | %base_url%/dav/spaces/%space_id% |
       | webUrl            | %base_url%/f/%space_id%          |
+
+
+  Scenario: admin user gets the group information of a user
+    Given group "tea-lover" has been created
+    And group "coffee-lover" has been created
+    And user "Brian" has been added to group "tea-lover"
+    And user "Brian" has been added to group "coffee-lover"
+    When the user "Alice" gets user "Brian" along with his group information using Graph API
+    Then the HTTP status code should be "200"
+    And the user retrieve API response should contain the following information:
+      | displayName  | id        | mail              | onPremisesSamAccountName | memberOf                |
+      | Brian Murphy | %uuid_v4% | brian@example.org | Brian                    | tea-lover, coffee-lover |

--- a/tests/acceptance/features/apiGraph/getUser.feature
+++ b/tests/acceptance/features/apiGraph/getUser.feature
@@ -87,3 +87,13 @@ Feature: get users
     And the user retrieve API response should contain the following information:
       | displayName  | id        | mail              | onPremisesSamAccountName | memberOf                |
       | Brian Murphy | %uuid_v4% | brian@example.org | Brian                    | tea-lover, coffee-lover |
+
+
+  Scenario: non-admin user tries to get the group information of a user
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And group "coffee-lover" has been created
+    And user "Brian" has been added to group "coffee-lover"
+    When the user "Carol" gets user "Brian" along with his group information using Graph API
+    Then the HTTP status code should be "401"
+    And the last response should be an unauthorized response
+    

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -1334,6 +1334,29 @@ class GraphContext implements Context {
 	}
 
 	/**
+	 * @param string $byUser
+	 * @param string|null $user
+	 *
+	 * @return ResponseInterface
+	 * @throws JsonException
+	 * @throws GuzzleException
+	 */
+	public function retrieveUserInformationAlongWithGroupUsingGraphApi(
+		string $byUser,
+		?string $user = null
+	):ResponseInterface {
+		$user = $user ?? $byUser;
+		$credentials = $this->getAdminOrUserCredentials($user);
+		return GraphHelper::getUserWithGroupInformation(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$credentials["username"],
+			$credentials["password"],
+			$user
+		);
+	}
+
+	/**
 	 * @When /^the user "([^"]*)" gets user "([^"]*)" along with (his|her) drive information using Graph API$/
 	 *
 	 * @param string $byUser
@@ -1343,6 +1366,19 @@ class GraphContext implements Context {
 	 */
 	public function userTriesToGetInformationOfUserAlongWithHisDriveData(string $byUser, string $user) {
 		$response = $this->retrieveUserInformationAlongWithDriveUsingGraphApi($byUser, $user);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When /^the user "([^"]*)" gets user "([^"]*)" along with (his|her) group information using Graph API$/
+	 *
+	 * @param string $byUser
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userTriesToGetInformationOfUserAlongWithHisGroup(string $byUser, string $user) {
+		$response = $this->retrieveUserInformationAlongWithGroupUsingGraphApi($byUser, $user);
 		$this->featureContext->setResponse($response);
 	}
 


### PR DESCRIPTION
I added test for getting group info of the user: `curl -X GET 'https://localhost:9200/graph/v1.0/users/2569c4ad-4abc-4f40-9490-5db0b66dcedc?%24expand=memberOf' -uadmin:admin -vk`