### PR TITLE
add "daily" deployments to the continuous deployment

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2122,7 +2122,7 @@ def skipIfUnchanged(ctx, type):
     }]
 
 def example_deploys(ctx):
-    latest_configs = [
+    on_merge_deploy = [
         "ocis_ldap/latest.yml",
         "ocis_keycloak/latest.yml",
         "ocis_traefik/latest.yml",
@@ -2131,23 +2131,25 @@ def example_deploys(ctx):
         "ocis_s3/latest.yml",
         "oc10_ocis_parallel/latest.yml",
     ]
-    released_configs = [
+    nightly_deploy = [
         "ocis_ldap/released.yml",
         "ocis_keycloak/released.yml",
         "ocis_traefik/released.yml",
         "ocis_wopi/released.yml",
+        "ocis_traefik/daily.yml",
+        "ocis_wopi/daily.yml",
     ]
 
     # if on master branch:
-    configs = latest_configs
+    configs = on_merge_deploy
     rebuild = "false"
 
     if ctx.build.event == "tag":
-        configs = released_configs
+        configs = nightly_deploy
         rebuild = "false"
 
     if ctx.build.event == "cron":
-        configs = latest_configs + released_configs
+        configs = on_merge_deploy + nightly_deploy
         rebuild = "true"
 
     deploys = []

--- a/deployments/continuous-deployment-config/oc10_ocis_parallel/latest.yml
+++ b/deployments/continuous-deployment-config/oc10_ocis_parallel/latest.yml
@@ -20,7 +20,6 @@
     os_env_umask: 022 # https://github.com/dev-sec/ansible-collection-hardening/blob/master/roles/os_hardening/README.md#variables
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_hello/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_hello/latest.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_keycloak/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_keycloak/latest.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_keycloak/released.yml
+++ b/deployments/continuous-deployment-config/ocis_keycloak/released.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_ldap/released.yml
+++ b/deployments/continuous-deployment-config/ocis_ldap/released.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_s3/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_s3/latest.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_traefik/daily.yml
+++ b/deployments/continuous-deployment-config/ocis_traefik/daily.yml
@@ -1,5 +1,5 @@
 ---
-- name: continuous-deployment-ocis-ldap-latest
+- name: continuous-deployment-ocis-traefik-daily
   server:
     server_type: cx21
     image: ubuntu-20.04
@@ -14,7 +14,7 @@
       - /var/lib/docker/volumes/ocis_certs
 
   domains:
-    - "*.ocis-ldap.latest.owncloud.works"
+    - "*.ocis-traefik.daily.owncloud.works"
 
   vars:
     ssh_authorized_keys:
@@ -27,21 +27,22 @@
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git
         ref: master
-        docker_compose_path: deployments/examples/ocis_ldap
+        docker_compose_path: deployments/examples/ocis_traefik
         env:
           INSECURE: "false"
           TRAEFIK_ACME_MAIL: wkloucek@owncloud.com
           OCIS_DOCKER_TAG: latest
-          OCIS_DOMAIN: ocis.ocis-ldap.latest.owncloud.works
-          LDAP_MANAGER_DOMAIN: ldap.ocis-ldap.latest.owncloud.works
+          OCIS_DOMAIN: ocis.ocis-traefik.daily.owncloud.works
+          DEMO_USERS: "true"
+          INBUCKET_DOMAIN: mail.ocis-traefik.daily.owncloud.works
           COMPOSE_FILE: docker-compose.yml:monitoring_tracing/docker-compose-additions.yml
       - name: monitoring
         git_url: https://github.com/owncloud-devops/monitoring-tracing-client.git
         ref: master
         env:
           NETWORK_NAME: ocis-net
-          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-ldap.latest.owncloud.works
+          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-traefik.daily.owncloud.works
           JAEGER_COLLECTOR: jaeger-collector.infra.owncloud.works:443
           TELEGRAF_SPECIFIC_CONFIG: ocis_single_container
-          OCIS_URL: ocis.ocis-ldap.latest.owncloud.works
-          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-ldap-latest
+          OCIS_URL: ocis.ocis-traefik.daily.owncloud.works
+          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-traefik-daily

--- a/deployments/continuous-deployment-config/ocis_traefik/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_traefik/latest.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_traefik/released.yml
+++ b/deployments/continuous-deployment-config/ocis_traefik/released.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_wopi/daily.yml
+++ b/deployments/continuous-deployment-config/ocis_wopi/daily.yml
@@ -1,5 +1,5 @@
 ---
-- name: continuous-deployment-ocis-ldap-latest
+- name: continuous-deployment-ocis-wopi-daily
   server:
     server_type: cx21
     image: ubuntu-20.04
@@ -14,7 +14,7 @@
       - /var/lib/docker/volumes/ocis_certs
 
   domains:
-    - "*.ocis-ldap.latest.owncloud.works"
+    - "*.ocis-wopi.daily.owncloud.works"
 
   vars:
     ssh_authorized_keys:
@@ -27,21 +27,25 @@
       - name: ocis
         git_url: https://github.com/owncloud/ocis.git
         ref: master
-        docker_compose_path: deployments/examples/ocis_ldap
+        docker_compose_path: deployments/examples/ocis_wopi
         env:
           INSECURE: "false"
           TRAEFIK_ACME_MAIL: wkloucek@owncloud.com
           OCIS_DOCKER_TAG: latest
-          OCIS_DOMAIN: ocis.ocis-ldap.latest.owncloud.works
-          LDAP_MANAGER_DOMAIN: ldap.ocis-ldap.latest.owncloud.works
+          OCIS_DOMAIN: ocis.ocis-wopi.daily.owncloud.works
+          WOPISERVER_DOMAIN: wopiserver.ocis-wopi.daily.owncloud.works
+          COLLABORA_DOMAIN: collabora.ocis-wopi.daily.owncloud.works
+          ONLYOFFICE_DOMAIN: onlyoffice.ocis-wopi.daily.owncloud.works
+          INBUCKET_DOMAIN: mail.ocis-wopi.daily.owncloud.works
+          DEMO_USERS: "true"
           COMPOSE_FILE: docker-compose.yml:monitoring_tracing/docker-compose-additions.yml
       - name: monitoring
         git_url: https://github.com/owncloud-devops/monitoring-tracing-client.git
         ref: master
         env:
           NETWORK_NAME: ocis-net
-          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-ldap.latest.owncloud.works
+          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-wopi.daily.owncloud.works
           JAEGER_COLLECTOR: jaeger-collector.infra.owncloud.works:443
-          TELEGRAF_SPECIFIC_CONFIG: ocis_single_container
-          OCIS_URL: ocis.ocis-ldap.latest.owncloud.works
-          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-ldap-latest
+          TELEGRAF_SPECIFIC_CONFIG: ocis_wopi
+          OCIS_URL: ocis.ocis-wopi.daily.owncloud.works
+          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-wopi-daily

--- a/deployments/continuous-deployment-config/ocis_wopi/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_wopi/latest.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/continuous-deployment-config/ocis_wopi/released.yml
+++ b/deployments/continuous-deployment-config/ocis_wopi/released.yml
@@ -19,7 +19,6 @@
   vars:
     ssh_authorized_keys:
       - https://github.com/butonic.keys
-      - https://github.com/C0rby.keys
       - https://github.com/fschade.keys
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       IDM_ADMIN_PASSWORD: "${ADMIN_PASSWORD:-admin}" # this overrides the admin password from the configuration file
       # demo users
       IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
+      # fulltext search
       SEARCH_EXTRACTOR_TYPE: tika
       SEARCH_EXTRACTOR_TIKA_TIKA_URL: http://tika:9998
       # email server (in this case inbucket acts as mail catcher)

--- a/docs/ocis/deployment/continuous_deployment.md
+++ b/docs/ocis/deployment/continuous_deployment.md
@@ -12,6 +12,7 @@ geekdocFilePath: continuous_deployment.md
 We are continuously deploying the following deployment examples. Every example is deployed in two flavors:
 
 - Latest: reflects the current master branch state of oCIS and will be updated with every commit to master
+- Daily: reflects the master branch state of oCIS as of the time of deployment
 - Released: reflects the newest release state (currently latest release of version 1) and will be updated with every release
 
 The configuration for the continuous deployment can be found in the [oCIS repository](https://github.com/owncloud/ocis/tree/master/deployments/continuous-deployment-config).
@@ -27,6 +28,11 @@ Credentials:
 - oCIS: [ocis.ocis-traefik.latest.owncloud.works](https://ocis.ocis-traefik.latest.owncloud.works)
 - Mail: [mail.ocis-traefik.latest.owncloud.works](https://mail.ocis-traefik.latest.owncloud.works)
 
+## Daily
+
+- oCIS: [ocis.ocis-traefik.daily.owncloud.works](https://ocis.ocis-traefik.daily.owncloud.works)
+- Mail: [mail.ocis-traefik.daily.owncloud.works](https://mail.ocis-traefik.daily.owncloud.works)
+
 ## Released
 
 - oCIS: [ocis.ocis-traefik.released.owncloud.works](https://ocis.ocis-traefik.released.owncloud.works)
@@ -41,10 +47,17 @@ Credentials:
 ## Latest
 
 - oCIS: [ocis.ocis-wopi.latest.owncloud.works](https://ocis.ocis-wopi.latest.owncloud.works)
+- Mail: [mail.ocis-wopi.latest.owncloud.works](https://mail.ocis-wopi.latest.owncloud.works)
+
+## Daily
+
+- oCIS: [ocis.ocis-wopi.daily.owncloud.works](https://ocis.ocis-wopi.daily.owncloud.works)
+- Mail: [mail.ocis-wopi.daily.owncloud.works](https://mail.ocis-wopi.daily.owncloud.works)
 
 ## Released
 
 - oCIS: [ocis.ocis-wopi.released.owncloud.works](https://ocis.ocis-wopi.released.owncloud.works)
+- Mail: [mail.ocis-wopi.released.owncloud.works](https://mail.ocis-wopi.released.owncloud.works)
 
 # oCIS with latest ownCloud Web
 
@@ -55,6 +68,10 @@ Credentials:
 ## Latest
 
 - oCIS: [ocis.ocis-web.latest.owncloud.works](https://ocis.ocis-web.latest.owncloud.works)
+
+## Daily
+
+- oCIS: [ocis.ocis-web.daily.owncloud.works](https://ocis.ocis-web.daily.owncloud.works)
 
 # oCIS with Keycloak
 


### PR DESCRIPTION
## Description
add "daily" deployments to the continuous deployment to provide a more stable up-to-date alternative to "latest" deployments

## Related Issue
- Web part https://github.com/owncloud/web/pull/8346 

## Motivation and Context
provide more stable, but up-to-date deployments

## How Has This Been Tested?
- -


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
