### PR TITLE
[full-ci][tests-only]Forward-port refactor share permission in coreApiSharePublicLinkShare

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -222,8 +222,7 @@ cannot share a folder with create permission
 - [coreApiShareOperationsToShares1/gettingShares.feature:222](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature#L222)
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:528](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L528)
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:549](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L549)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:353](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L353)
 
 #### [download previews of other users file](https://github.com/owncloud/ocis/issues/2071)
 
@@ -245,12 +244,6 @@ cannot share a folder with create permission
 - [coreApiWebdavPreviews/previews.feature:164](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L164)
 - [coreApiWebdavPreviews/previews.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L176)
 - [coreApiWebdavPreviews/previews.feature:177](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L177)
-
-#### [creating public links with permissions fails](https://github.com/owncloud/product/issues/252)
-
-- [coreApiSharePublicLink1/changingPublicLinkShare.feature:30](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature#L30)
-- [coreApiSharePublicLink1/changingPublicLinkShare.feature:51](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature#L51)
-- [coreApiSharePublicLink1/changingPublicLinkShare.feature:90](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature#L90)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -428,6 +421,7 @@ API, search, favorites, config, capabilities, not existing endpoints, CORS and o
 - [coreApiAuthOcs/ocsGETAuth.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L121)
 - [coreApiAuthOcs/ocsPOSTAuth.feature:8](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPOSTAuth.feature#L8)
 - [coreApiAuthOcs/ocsPUTAuth.feature:8](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L8)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:343](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L343)
 
 #### [sending MKCOL requests to another user's webDav endpoints as normal user gives 404 instead of 403 ](https://github.com/owncloud/ocis/issues/3872)
 

--- a/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-282
+@api @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-282 @issue-4623 @notToImplementOnOCIS
 Feature: accessing a public link share
 
   Background:

--- a/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-282 @issue-4623 @notToImplementOnOCIS
+@api @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-282
 Feature: accessing a public link share
 
   Background:

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-315 @issue-ocis-reva-316
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-315 @issue-ocis-reva-316 @issue-ocis-2079 @issue-ocis-reva-292
 
 Feature: changing a public link share
 
@@ -18,253 +18,109 @@ Feature: changing a public link share
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | permissions               | http-status-code | should-or-not | public-webdav-api-version |
-      | read,update,create        | 403              | should        | old                       |
-      | read,update,create,delete | 204              | should not    | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | permissions               | http-status-code | should-or-not | public-webdav-api-version |
-      | read,update,create        | 403              | should        | new                       |
+      | read                      | 403              | should        | new                       |
+      | read,create               | 403              | should        | new                       |
+      | create                    | 403              | should        | new                       |
       | read,update,create,delete | 204              | should not    | new                       |
 
 
-  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT            |
-      | permissions | read,update,create |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/PARENT/parent.txt" should exist
-    And as "Alice" file "/PARENT/newparent.txt" should not exist
-
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-  @skipOnRansomwareProtection @issue-ransomware-208
-  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the public WebDAV API
+  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT            |
-      | permissions | read,update,create |
-    When the public uploads file "lorem.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/PARENT/lorem.txt" should not exist
-
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the public WebDAV API
+  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public uploads file "lorem.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public cannot delete file through publicly shared link with password using an invalid password with public WebDAV API
+  Scenario: Public cannot delete file through publicly shared link with password using an invalid password with public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public link share using the password "invalid" and <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the password "invalid" and new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public can delete file through publicly shared link with password using the valid password with the public WebDAV API
+  Scenario: Public can delete file through publicly shared link with password using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public link share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the password "newpasswd" and new public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public tries to rename a file in a password protected share using an invalid password with the public WebDAV API
+  Scenario: Public tries to rename a file in a password protected share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "invalid" and <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "invalid" and new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-  @skipOnRansomwareProtection @issue-ransomware-208
-  Scenario Outline: Public tries to rename a file in a password protected share using the valid password with the public WebDAV API
+  Scenario: Public tries to rename a file in a password protected share using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "newpasswd" and new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public tries to upload to a password protected public share using an invalid password with the public WebDAV API
+  Scenario: Public tries to upload to a password protected public share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the <public-webdav-api-version> public WebDAV API
+    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public tries to upload to a password protected public share using the valid password with the public WebDAV API
+  Scenario: Public tries to upload to a password protected public share using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the <public-webdav-api-version> public WebDAV API
+    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public cannot rename a file in uploadwriteonly public link share with the public WebDAV API
+  Scenario: Public cannot rename a file in uploadwriteonly public link share with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
 
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-
-  Scenario Outline: Public cannot delete a file in uploadwriteonly public link share with the public WebDAV API
+  Scenario: Public cannot delete a file in uploadwriteonly public link share with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public deletes file "parent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
-
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
-      | new                       |

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -14,16 +14,16 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "parent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
 
     Examples:
-      | permissions               | http-status-code | should-or-not | public-webdav-api-version |
-      | read                      | 403              | should        | new                       |
-      | read,create               | 403              | should        | new                       |
-      | create                    | 403              | should        | new                       |
-      | read,update,create,delete | 204              | should not    | new                       |
+      | permissions               | http-status-code | should-or-not |
+      | read                      | 403              | should        |
+      | read,create               | 403              | should        |
+      | create                    | 403              | should        |
+      | read,update,create,delete | 204              | should not    |
 
 
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the public WebDAV API

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -36,38 +36,6 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @notToImplementOnOCIS @issue-ocis-2079
-  Scenario Outline: Creating a new public link share of a file with password using the old public WebDAV API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path     | randomfile.txt |
-      | password | %public%       |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" should include
-      | item_type              | file            |
-      | mimetype               | text/plain      |
-      | file_target            | /randomfile.txt |
-      | path                   | /randomfile.txt |
-      | permissions            | read            |
-      | share_type             | public_link     |
-      | displayname_file_owner | %displayname%   |
-      | displayname_owner      | %displayname%   |
-      | uid_file_owner         | %username%      |
-      | uid_owner              | %username%      |
-      | name                   |                 |
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
-    And the HTTP status code should be "200"
-    And the public download of the last publicly shared file using the old public WebDAV API with password "%regular%" should fail with HTTP status code "401"
-    And the value of the item "//s:message" in the response should be "Cannot authenticate over ajax calls"
-    And the public download of the last publicly shared file using the old public WebDAV API without a password should fail with HTTP status code "401"
-    And the value of the item "//s:message" in the response should be "Cannot authenticate over ajax calls"
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
-
   @smokeTest @issue-ocis-reva-199
   Scenario Outline: Creating a new public link share of a file with password using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
@@ -268,88 +236,6 @@ Feature: create a public link share
       | 2               | 200             |
 
 
-  Scenario Outline: Creating a public link share with read+create permissions is forbidden when public upload is disabled globally
-    Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    And user "Alice" has created folder "/afolder"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path        | /afolder    |
-      | permissions | read,create |
-    Then the OCS status code should be "<ocs_status_code>"
-
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 403             |
-      | 2               | 403             |
-
-
-  Scenario Outline: Creating a public link share with create permissions is forbidden when public upload is disabled globally
-    Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    And user "Alice" has created folder "/afolder"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path        | /afolder |
-      | permissions | create   |
-    Then the OCS status code should be "<ocs_status_code>"
-
-    @notToImplementOnOCIS @issue-ocis-2079 @issue-ocis-reva-41
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 403             |
-      | 2               | 403             |
-
-
-  Scenario Outline: Updating a public link share with read+create permissions is forbidden when public upload is disabled globally
-    Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has created folder "/afolder"
-    And user "Alice" has created a public link share with settings
-      | path        | /afolder |
-      | permissions | read     |
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    When user "Alice" tries to update the last public link share using the sharing API with
-      | permissions | read,create |
-    Then the OCS status code should be "<ocs_status_code>"
-
-    @notToImplementOnOCIS @issue-ocis-2079 @issue-ocis-reva-41
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 403             |
-      | 2               | 403             |
-
-  @issue-ocis-reva-41
-  Scenario Outline: Creating a link share with read+update+create permissions is forbidden when public upload is disabled globally
-    Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    And user "Alice" has created folder "/afolder"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path        | /afolder           |
-      | permissions | read,update,create |
-    Then the OCS status code should be "<ocs_status_code>"
-
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 403             |
-      | 2               | 403             |
-
-  @issue-ocis-reva-41 @skipOnOcis
-  Scenario Outline: Creating a link share with update permissions defaults to read permissions when public upload disabled globally
-    Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    And user "Alice" has created folder "/afolder"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path        | /afolder                  |
-      | permissions | read,update,create,delete |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    And the last response should be empty
-    Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 403             | 200              |
-      | 2               | 403             | 403              |
-
-
   Scenario Outline: Creating a link share with edit permissions keeps it using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -393,20 +279,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-
-  @issue-ocis-reva-283 @notToImplementOnOCIS
-  Scenario Outline: Do not allow public sharing of the root on ownCloud10
-    Given using OCS API version "<ocs_api_version>"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path | / |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 403             | 200              |
-      | 2               | 403             | 403              |
-
-  @issue-ocis-reva-283 @skipOnOcV10
+  @issue-ocis-reva-283 @issue-ocis-2079
   Scenario Outline: Allow public sharing of the root on OCIS when the default permission is read and access using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -428,12 +301,13 @@ Feature: create a public link share
       | name                   |                      |
     And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
     And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
-    @issue-ocis-2079
+
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
+  @issue-ocis-2079
   Scenario Outline: user creates a public link share of a file with file name longer than 64 chars using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
@@ -444,14 +318,12 @@ Feature: create a public link share
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "long file"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "long file"
 
-    @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-
-
+  @issue-ocis-2079
   Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars and access using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
@@ -463,90 +335,31 @@ Feature: create a public link share
     And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "Random data"
     And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
 
-    @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-reva-41
-  Scenario Outline: Create a public link with default expiration date set and max expiration date enforced and access using the public WebDAV API
-    Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path | randomfile.txt |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" should include
-      | file_target | /randomfile.txt |
-      | path        | /randomfile.txt |
-      | item_type   | file            |
-      | share_type  | public_link     |
-      | permissions | read            |
-      | uid_owner   | %username%      |
-      | expiration  | +7 days         |
-    When user "Alice" gets the info of the last public link share using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" should include
-      | file_target | /randomfile.txt |
-      | path        | /randomfile.txt |
-      | item_type   | file            |
-      | share_type  | public_link     |
-      | permissions | read            |
-      | uid_owner   | %username%      |
-      | expiration  | +7 days         |
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
-
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
-
   @issue-ocis-reva-199
-  Scenario Outline: Delete a folder that has been publicly shared and try to access using the public WebDAV API
+  Scenario: Delete a folder that has been publicly shared and try to access using the public WebDAV API
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
     And user "Alice" has created a public link share with settings
       | path        | PARENT |
       | permissions | read   |
-    When user "Alice" deletes folder "PARENT" using the WebDAV API
-    And the public download of file "/parent.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "404"
+    And user "Alice" has deleted folder "PARENT"
+    When the public download of file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API should fail with HTTP status code "404"
 
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
-
-  @issue-ocis-reva-292
-  Scenario Outline: try to download from a public share that has upload only permissions using the public webdav api
+  @issue-ocis-reva-292 @issue-ocis-reva-199
+  Scenario: try to download from a public share that has upload only permissions using the public webdav api
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
     And user "Alice" has created a public link share with settings
       | path        | PARENT          |
       | permissions | uploadwriteonly |
-    When the public downloads file "parent.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
-    Then the value of the item "//s:message" in the response should be "<response>"
+    When the public downloads file "parent.txt" from inside the last public link shared folder using the new public WebDAV API
+    Then the value of the item "//s:message" in the response should be "File not found: parent.txt"
     And the HTTP status code should be "404"
-
-    @notToImplementOnOCIS @issue-ocis-2079
-    Examples:
-      | public-webdav-api-version | response |
-      | old                       |          |
-
-
-    Examples:
-      | public-webdav-api-version | response                   |
-      | new                       | File not found: parent.txt |
 
 
   Scenario: Get the size of a file shared by public link
@@ -611,34 +424,6 @@ Feature: create a public link share
     And as "Alice" file "/testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
-
-  @notToImplementOnOCIS
-  Scenario Outline: Set multiple expiration dates, the expired date shouldn't affect the future expiration date
-    Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path               | /textfile0.txt |
-      | name               | link1          |
-      | expireDateAsString | +6 days        |
-    And user "Alice" creates a public link share using the sharing API with settings
-      | path               | /textfile0.txt |
-      | name               | link2          |
-      | expireDateAsString | +5 days        |
-    And the administrator expires the last created public link share using the testing API
-    Then the HTTP status code should be "<http_status_code>"
-    When user "Alice" gets all the shares from the file "textfile0.txt" using the sharing API
-    Then the HTTP status code should be "<http_status_code>"
-    And the OCS status code should be "<ocs_status_code>"
-    And the fields of the last response to user "Alice" should include
-      | name       | link1   |
-      | expiration | +6 days |
-    But the fields of the last response should not include
-      | name | link2 |
-    Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
 
   @issue-4758
   Scenario: check the href of a public link file

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -301,7 +301,6 @@ Feature: create a public link share
       | name                   |                      |
     And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
     And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
-
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -347,8 +346,8 @@ Feature: create a public link share
     And user "Alice" has created a public link share with settings
       | path        | PARENT |
       | permissions | read   |
-    And user "Alice" has deleted folder "PARENT"
-    When the public download of file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API should fail with HTTP status code "404"
+    When user "Alice" deletes folder "/PARENT" using the WebDAV API
+    Then the public download of file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API should fail with HTTP status code "404"
 
   @issue-ocis-reva-292 @issue-ocis-reva-199
   Scenario: try to download from a public share that has upload only permissions using the public webdav api


### PR DESCRIPTION
## Description
As ownclouders decided https://github.com/owncloud/ocis/issues/4052#issuecomment-1168655027
> It was officially agreed that we do act differently than oc10. If the permissions requested by the client are not applicable we return an error (unlike oc10 which will downgrade permissions to 1)
Share permission behavior is different in oc10 and ocis.

This PR changes coreApiSharePublicLinkShare folder
- refactor public link share permission related scenario
- remove @skipOnOcis tagged scenario

### FILES
- [x] accessToPublicLInkShare.feature (skipped because there is no tech preview feature in ocis verified by kulman) 
       https://github.com/owncloud/ocis/issues/1317    https://github.com/owncloud/ocis/issues/4623 
   we will work on this https://github.com/owncloud/ocis/issues/5519
- [x] changingPublicLinkShare.feature
- [x] createPublicLinkShare.feature
- [x] createPublicLInkShareToShares.feature (NOTHING TO DO)
- [x] deletePublicLinkShare.feature (NOTHING TO DO)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/5249
- https://github.com/owncloud/ocis/pull/5490 (master branch)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
