### PR TITLE
[full-ci] bump web to v7.0.0-rc.11

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=087d56495474ef34b9f847bd30a23613ec0daacd
+WEB_COMMITID=99028c2d3dde103e5bab6636396ea92f2d9fbcea
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.10
+WEB_ASSETS_VERSION = v7.0.0-rc.11
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bump web to v7.0.0-rc.11. One of the things it brings are the web changes for space member expirations. So this should unblock https://github.com/owncloud/ocis/pull/5453