### PR TITLE
[tests-only] update golangci-lint to v1.51.1

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -47,11 +47,11 @@ $(GO_LICENSES): $(BINGO_DIR)/go-licenses.mod
 	@echo "(re)installing $(GOBIN)/go-licenses-v1.5.0"
 	@cd $(BINGO_DIR) && GOWORK=off $(GO) build -mod=mod -modfile=go-licenses.mod -o=$(GOBIN)/go-licenses-v1.5.0 "github.com/google/go-licenses"
 
-GOLANGCI_LINT := $(GOBIN)/golangci-lint-v1.47.3
+GOLANGCI_LINT := $(GOBIN)/golangci-lint-v1.51.1
 $(GOLANGCI_LINT): $(BINGO_DIR)/golangci-lint.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
-	@echo "(re)installing $(GOBIN)/golangci-lint-v1.47.3"
-	@cd $(BINGO_DIR) && GOWORK=off $(GO) build -mod=mod -modfile=golangci-lint.mod -o=$(GOBIN)/golangci-lint-v1.47.3 "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	@echo "(re)installing $(GOBIN)/golangci-lint-v1.51.1"
+	@cd $(BINGO_DIR) && GOWORK=off $(GO) build -mod=mod -modfile=golangci-lint.mod -o=$(GOBIN)/golangci-lint-v1.51.1 "github.com/golangci/golangci-lint/cmd/golangci-lint"
 
 HUGO := $(GOBIN)/hugo-v0.94.0
 $(HUGO): $(BINGO_DIR)/hugo.mod

--- a/.bingo/variables.env
+++ b/.bingo/variables.env
@@ -18,7 +18,7 @@ CALENS="${GOBIN}/calens-v0.2.0"
 
 GO_LICENSES="${GOBIN}/go-licenses-v1.5.0"
 
-GOLANGCI_LINT="${GOBIN}/golangci-lint-v1.47.3"
+GOLANGCI_LINT="${GOBIN}/golangci-lint-v1.51.1"
 
 HUGO="${GOBIN}/hugo-v0.94.0"
 


### PR DESCRIPTION
## Description
update golangci-lint to the newest version

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
CI is currently very unstable and often fails in the linting phase, see if that fixes it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
