### PR TITLE
allow GETing a users personal drive

### DIFF
--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -186,6 +186,7 @@ func NewService(opts ...Option) (Graph, error) {
 			})
 			r.Route("/me", func(r chi.Router) {
 				r.Get("/", svc.GetMe)
+				r.Get("/drive", svc.GetUserDrive)
 				r.Get("/drives", svc.GetDrives)
 				r.Get("/drive/root/children", svc.GetRootDriveChildren)
 				r.Post("/changePassword", svc.ChangeOwnPassword)
@@ -195,6 +196,7 @@ func NewService(opts ...Option) (Graph, error) {
 				r.With(requireAdmin).Post("/", svc.PostUser)
 				r.Route("/{userID}", func(r chi.Router) {
 					r.Get("/", svc.GetUser)
+					r.Get("/drive", svc.GetUserDrive)
 					r.With(requireAdmin).Delete("/", svc.DeleteUser)
 					r.With(requireAdmin).Patch("/", svc.PatchUser)
 					if svc.roleService != nil {


### PR DESCRIPTION
This PR adds two endpoints:
```
GET /graph/v1.0/me/drive
GET /graph/v1.0/users/{userid}/drive
```
which will return the users drive:
```
{
    "driveAlias": "personal/einstein",
    "driveType": "personal",
    "id": "1284d238-aa92-42ce-bdc4-0b0000009157$4c510ada-c86b-4815-8820-42cdf82c3d51",
    "lastModifiedDateTime": "2023-02-09T11:02:01.958840593Z",
    "name": "Albert Einstein",
    "owner": {
        "user": {
            "displayName": "",
            "id": "4c510ada-c86b-4815-8820-42cdf82c3d51"
        }
    },
    "quota": {
        "remaining": 160010825728,
        "state": "normal",
        "total": 0,
        "used": 0
    },
    "root": {
        "eTag": "\"8d566fda9a7d143f7e6c16fe78230e71\"",
        "id": "1284d238-aa92-42ce-bdc4-0b0000009157$4c510ada-c86b-4815-8820-42cdf82c3d51",
        "webDavUrl": "https://cloud.ocis.test/dav/spaces/1284d238-aa92-42ce-bdc4-0b0000009157$4c510ada-c86b-4815-8820-42cdf82c3d51"
    },
    "webUrl": "https://cloud.ocis.test/f/1284d238-aa92-42ce-bdc4-0b0000009157$4c510ada-c86b-4815-8820-42cdf82c3d51"
}
```

$select, $filter or $expand are not supported, yet.

CC @lookacat @JanAckermann 