### PR TITLE
[tests-only] Cache go/bin as a long term cache

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -366,9 +366,11 @@ def testOcisModule(ctx, module):
             "name": "golangci-lint",
             "image": OC_CI_GOLANG,
             "commands": [
+                "du -hs /go",
                 "mkdir -p cache/checkstyle",
                 "retry -t 5 -m 10 -x 240 'make -C %s ci-golangci-lint'" % (module),
                 "mv %s/checkstyle.xml cache/checkstyle/$(basename %s)_checkstyle.xml" % (module, module),
+                "du -hs /go",
             ],
             "volumes": [stepVolumeGo],
         },

--- a/.drone.star
+++ b/.drone.star
@@ -390,8 +390,8 @@ def bingoGet():
             "commands": [
                 "du -hs /go",
                 "make bingo-update",
-                "du -hs /go"
-                ],
+                "du -hs /go",
+            ],
             "volumes": [stepVolumeGo],
         },
     ]
@@ -2386,7 +2386,7 @@ def genericCache(name, action, mounts, cache_path):
             "path": cache_path,
             "fallback_path": cache_path,
         },
-        "volumes": [stepVolumeGo]
+        "volumes": [stepVolumeGo],
     }
     return step
 

--- a/.drone.star
+++ b/.drone.star
@@ -2386,6 +2386,7 @@ def genericCache(name, action, mounts, cache_path):
             "path": cache_path,
             "fallback_path": cache_path,
         },
+        "volumes": [stepVolumeGo]
     }
     return step
 

--- a/.drone.star
+++ b/.drone.star
@@ -367,7 +367,7 @@ def testOcisModule(ctx, module):
             "image": OC_CI_GOLANG,
             "commands": [
                 "mkdir -p cache/checkstyle",
-                "retry -t 3 -m 10 -x 240 'make -C %s ci-golangci-lint'" % (module),
+                "retry -t 5 -m 10 -x 240 'make -C %s ci-golangci-lint'" % (module),
                 "mv %s/checkstyle.xml cache/checkstyle/$(basename %s)_checkstyle.xml" % (module, module),
             ],
             "volumes": [stepVolumeGo],

--- a/.drone.star
+++ b/.drone.star
@@ -388,7 +388,9 @@ def bingoGet():
             "name": "bingo-get",
             "image": OC_CI_GOLANG,
             "commands": [
+                "du -hs /go",
                 "make bingo-update",
+                "du -hs /go"
                 ],
             "volumes": [stepVolumeGo],
         },

--- a/.drone.star
+++ b/.drone.star
@@ -1980,6 +1980,8 @@ def makeGoGenerate(module):
             "name": "generate go",
             "image": OC_CI_GOLANG,
             "commands": [
+                "ls -lh /",
+                "du -hs /go",
                 "retry -t 3 -m 10 -x 240 '%s ci-go-generate'" % (make),
             ],
             "volumes": [stepVolumeGo],

--- a/.drone.star
+++ b/.drone.star
@@ -367,7 +367,7 @@ def testOcisModule(ctx, module):
             "image": OC_CI_GOLANG,
             "commands": [
                 "mkdir -p cache/checkstyle",
-                "retry -t 3 'make -C %s ci-golangci-lint'" % (module),
+                "retry -t 3 -m 10 -x 240 'make -C %s ci-golangci-lint'" % (module),
                 "mv %s/checkstyle.xml cache/checkstyle/$(basename %s)_checkstyle.xml" % (module, module),
             ],
             "volumes": [stepVolumeGo],
@@ -1190,7 +1190,7 @@ def settingsUITests(ctx, storage = "ocis", accounts_hash_difficulty = 4):
                              # they shouldn't be needed since we could also use them from web:/tests/acceptance/package.json
                              "cd %s/services/settings" % dirs["base"],
                              "pnpm config set store-dir ./.pnpm-store",
-                             "retry -t 3 'pnpm install'",
+                             "retry -t 3 -m 10 -x 240 'pnpm install'",
                              "make test-acceptance-webui",
                          ],
                          "volumes": [{
@@ -1922,7 +1922,7 @@ def makeNodeGenerate(module):
             },
             "commands": [
                 "pnpm config set store-dir ./.pnpm-store",
-                "retry -t 3 '%s ci-node-generate'" % (make),
+                "retry -t 3 -m 10 -x 240 '%s ci-node-generate'" % (make),
             ],
             "volumes": [stepVolumeGo],
         },
@@ -1938,7 +1938,7 @@ def makeGoGenerate(module):
             "name": "generate go",
             "image": OC_CI_GOLANG,
             "commands": [
-                "retry -t 3 '%s ci-go-generate'" % (make),
+                "retry -t 3 -m 10 -x 240 '%s ci-go-generate'" % (make),
             ],
             "volumes": [stepVolumeGo],
         },
@@ -2143,7 +2143,7 @@ def build():
             "name": "build",
             "image": OC_CI_GOLANG,
             "commands": [
-                "retry -t 3 'make -C ocis build'",
+                "retry -t 3 -m 10 -x 240 'make -C ocis build'",
             ],
             "volumes": [stepVolumeGo],
         },
@@ -2710,7 +2710,7 @@ def generateWebPnpmCache(ctx):
             "commands": [
                 "cd %s" % dirs["web"],
                 "pnpm config set store-dir ./.pnpm-store",
-                "retry -t 3 'pnpm install'",
+                "retry -t 3 -m 10 -x 240 'pnpm install'",
             ],
         },
         {
@@ -2801,6 +2801,6 @@ def restoreWebPnpmCache():
             "rm -rf .pnpm-store",
             "tar -xvf %s" % dirs["webPnpmZip"],
             "pnpm config set store-dir ./.pnpm-store",
-            "retry -t 3 'pnpm install'",
+            "retry -t 3 -m 10 -x 240 'pnpm install'",
         ],
     }]

--- a/.drone.star
+++ b/.drone.star
@@ -449,7 +449,7 @@ def testOcisModule(ctx, module):
             "image": OC_CI_GOLANG,
             "commands": [
                 "mkdir -p cache/checkstyle",
-                "retry -t 5 -m 10 -x 240 'make -C %s ci-golangci-lint'" % (module),
+                "make -C %s ci-golangci-lint" % (module),
                 "mv %s/checkstyle.xml cache/checkstyle/$(basename %s)_checkstyle.xml" % (module, module),
             ],
             "volumes": [stepVolumeGo],
@@ -1273,7 +1273,7 @@ def settingsUITests(ctx, storage = "ocis", accounts_hash_difficulty = 4):
                              # they shouldn't be needed since we could also use them from web:/tests/acceptance/package.json
                              "cd %s/services/settings" % dirs["base"],
                              "pnpm config set store-dir ./.pnpm-store",
-                             "retry -t 3 -m 10 -x 240 'pnpm install'",
+                             "retry -t 3 'pnpm install'",
                              "make test-acceptance-webui",
                          ],
                          "volumes": [{
@@ -2005,7 +2005,7 @@ def makeNodeGenerate(module):
             },
             "commands": [
                 "pnpm config set store-dir ./.pnpm-store",
-                "retry -t 3 -m 10 -x 240 '%s ci-node-generate'" % (make),
+                "retry -t 3 '%s ci-node-generate'" % (make),
             ],
             "volumes": [stepVolumeGo],
         },
@@ -2021,7 +2021,7 @@ def makeGoGenerate(module):
             "name": "generate go",
             "image": OC_CI_GOLANG,
             "commands": [
-                "retry -t 3 -m 10 -x 240 '%s ci-go-generate'" % (make),
+                "retry -t 3 '%s ci-go-generate'" % (make),
             ],
             "volumes": [stepVolumeGo],
         },
@@ -2226,7 +2226,7 @@ def build():
             "name": "build",
             "image": OC_CI_GOLANG,
             "commands": [
-                "retry -t 3 -m 10 -x 240 'make -C ocis build'",
+                "retry -t 3 'make -C ocis build'",
             ],
             "volumes": [stepVolumeGo],
         },
@@ -2793,7 +2793,7 @@ def generateWebPnpmCache(ctx):
             "commands": [
                 "cd %s" % dirs["web"],
                 "pnpm config set store-dir ./.pnpm-store",
-                "retry -t 3 -m 10 -x 240 'pnpm install'",
+                "retry -t 3 'pnpm install'",
             ],
         },
         {
@@ -2884,6 +2884,6 @@ def restoreWebPnpmCache():
             "rm -rf .pnpm-store",
             "tar -xvf %s" % dirs["webPnpmZip"],
             "pnpm config set store-dir ./.pnpm-store",
-            "retry -t 3 -m 10 -x 240 'pnpm install'",
+            "retry -t 3 'pnpm install'",
         ],
     }]

--- a/.drone.star
+++ b/.drone.star
@@ -412,7 +412,7 @@ def checkGoBinCache():
             },
         },
         "commands": [
-            "bash -x check_go_bin_cache.sh",
+            "bash -x %s/tests/config/drone/check_go_bin_cache.sh" % dirs["base"],
         ],
     }]
 

--- a/.drone.star
+++ b/.drone.star
@@ -423,9 +423,7 @@ def cacheGoBin():
             "commands": [
                 # cache using the minio/mc client to the public bucket (long term bucket)
                 "BINGO_HASH=$(cat %s/.bingo_hash)" % dirs["base"],
-                "echo $BINGO_HASH",
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                "mc rm -r --force s3/$CACHE_BUCKET/ocis/go-bin",
                 "mc cp -r /go/bin s3/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH",
             ],
             "volumes": [stepVolumeGo],
@@ -439,25 +437,13 @@ def restoreGoBinCache():
             "image": MINIO_MC,
             "environment": MINIO_MC_ENV,
             "commands": [
-                "mkdir -p /go",
                 "BINGO_HASH=$(" + SHA256_HASH_COMMAND % dirs["base"] + ")",
-                "echo $BINGO_HASH",
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                "mc ls -r s3/$CACHE_BUCKET/ocis/go-bin",
                 "mc cp -r -a s3/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/bin /go",
-                "ls -al",
-                "ls -al /go",
-                "ls -al /go/bin",
+                "chmod +x /go/bin/*",
             ],
             "volumes": [stepVolumeGo],
         },
-        # {
-        #     "name": "unzip-web-cache",
-        #     "image": OC_UBUNTU,
-        #     "commands": [
-        #         "tar -xvf %s -C ." % dirs["webZip"],
-        #     ],
-        # },
     ]
 
 def testOcisModule(ctx, module):

--- a/.drone.star
+++ b/.drone.star
@@ -226,6 +226,7 @@ def main(ctx):
         cancelPreviousBuilds() + \
         codestyle(ctx) + \
         buildWebCache(ctx) + \
+        [getGoDepsForTesting(ctx)] + \
         [buildOcisBinaryForTesting(ctx)] + \
         testOcisModules(ctx) + \
         testPipelines(ctx)
@@ -307,7 +308,7 @@ def testOcisModules(ctx):
     scan_result_upload = uploadScanResults(ctx)
     scan_result_upload["depends_on"] = getPipelineNames(pipelines)
 
-    return [getGoDepsForTesting(ctx)] + pipelines + [scan_result_upload]
+    return pipelines + [scan_result_upload]
 
 def cancelPreviousBuilds():
     return [{
@@ -473,6 +474,7 @@ def buildOcisBinaryForTesting(ctx):
         },
         "steps": skipIfUnchanged(ctx, "acceptance-tests") +
                  makeNodeGenerate("") +
+                 restoreBuildArtifactCache(ctx, "go-deps-for-testing", "/go") +
                  makeGoGenerate("") +
                  build() +
                  rebuildBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin"),
@@ -483,6 +485,7 @@ def buildOcisBinaryForTesting(ctx):
                 "refs/pull/**",
             ],
         },
+        "depends_on": getPipelineNames([getGoDepsForTesting(ctx)]),
         "volumes": [pipelineVolumeGo],
     }
 

--- a/.drone.star
+++ b/.drone.star
@@ -379,7 +379,7 @@ def getGoDepsForTesting(ctx):
                 "refs/pull/**",
             ],
         },
-        "volumes": [stepVolumeGo],
+        "volumes": [pipelineVolumeGo],
     }
 
 def bingoGet():

--- a/.drone.star
+++ b/.drone.star
@@ -1978,7 +1978,9 @@ def makeGoGenerate(module):
             "image": OC_CI_GOLANG,
             "commands": [
                 "ls -lh /",
+                "ls -lh",
                 "du -hs /go",
+                "du -hs ./go",
                 "retry -t 3 -m 10 -x 240 '%s ci-go-generate'" % (make),
             ],
             "volumes": [stepVolumeGo],

--- a/.drone.star
+++ b/.drone.star
@@ -53,36 +53,36 @@ config = {
     "modules": [
         # if you add a module here please also add it to the root level Makefile
         "services/app-provider",
-        "services/app-registry",
-        "services/audit",
-        "services/auth-basic",
-        "services/auth-bearer",
-        "services/auth-machine",
-        "services/frontend",
-        "services/gateway",
-        "services/graph",
-        "services/groups",
-        "services/idm",
-        "services/idp",
-        "services/nats",
-        "services/notifications",
-        "services/ocdav",
-        "services/ocs",
-        "services/proxy",
-        "services/search",
-        "services/settings",
-        "services/sharing",
-        "services/storage-system",
-        "services/storage-publiclink",
-        "services/storage-shares",
-        "services/storage-users",
-        "services/store",
-        "services/thumbnails",
-        "services/users",
-        "services/web",
-        "services/webdav",
-        "ocis-pkg",
-        "ocis",
+        # "services/app-registry",
+        # "services/audit",
+        # "services/auth-basic",
+        # "services/auth-bearer",
+        # "services/auth-machine",
+        # "services/frontend",
+        # "services/gateway",
+        # "services/graph",
+        # "services/groups",
+        # "services/idm",
+        # "services/idp",
+        # "services/nats",
+        # "services/notifications",
+        # "services/ocdav",
+        # "services/ocs",
+        # "services/proxy",
+        # "services/search",
+        # "services/settings",
+        # "services/sharing",
+        # "services/storage-system",
+        # "services/storage-publiclink",
+        # "services/storage-shares",
+        # "services/storage-users",
+        # "services/store",
+        # "services/thumbnails",
+        # "services/users",
+        # "services/web",
+        # "services/webdav",
+        # "ocis-pkg",
+        # "ocis",
     ],
     "cs3ApiTests": {
         "skip": False,
@@ -219,6 +219,8 @@ def main(ctx):
     Returns:
       none
     """
+
+    return cancelPreviousBuilds() + getGoBinForTesting(ctx)
 
     pipelines = []
 
@@ -372,7 +374,7 @@ def getGoBinForTesting(ctx):
         },
         "steps": skipIfUnchanged(ctx, "unit-tests") +
                  checkGoBinCache() +
-                 bingoGet() +
+                 #  bingoGet() +
                  cacheGoBin(),
         #  rebuildBuildArtifactCache(ctx, "go-bin", "/go/bin"),
         "trigger": {

--- a/.drone.star
+++ b/.drone.star
@@ -49,7 +49,8 @@ dirs = {
 }
 
 # command to get the hash of a directory
-SHA256_HASH_COMMAND = "find %s/.bingo -type f -exec sha256sum {} \\\\; | sort -k 2 | sha256sum | cut -d ' ' -f 1"
+# SHA256_HASH_COMMAND = "find %s/.bingo -type f -exec sha256sum {} \\\\; | sort -k 2 | sha256sum | cut -d ' ' -f 1"
+SHA256_HASH_COMMAND = "cat $(ls -ad %s/.bingo/*) | sha256sum | cut -d ' ' -f 1"
 
 # configuration
 config = {
@@ -539,7 +540,6 @@ def buildOcisBinaryForTesting(ctx):
         },
         "steps": skipIfUnchanged(ctx, "acceptance-tests") +
                  makeNodeGenerate("") +
-                 restoreGoCache(ctx, "go-deps-for-testing", "/go") +
                  makeGoGenerate("") +
                  build() +
                  rebuildBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin"),
@@ -550,7 +550,6 @@ def buildOcisBinaryForTesting(ctx):
                 "refs/pull/**",
             ],
         },
-        "depends_on": getPipelineNames(getGoBinForTesting(ctx)),
         "volumes": [pipelineVolumeGo],
     }
 
@@ -2520,20 +2519,20 @@ def rebuildBuildArtifactCache(ctx, name, path):
 def purgeBuildArtifactCache(ctx):
     return genericBuildArtifactCache(ctx, "", "purge", [])
 
-def restoreGoCache(ctx, name, path):
-    return restoreBuildArtifactCache(ctx, name, path) + [
-        {
-            "name": "move-go-cache",
-            "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
-            "commands": [
-                "du -sh ./go/*",
-                "rsync -a --remove-source-files %s/go/ /go" % dirs["base"],
-                "rm -rf %s/go" % dirs["base"],
-                "du -sh /go/*",
-            ],
-            "volumes": [stepVolumeGo],
-        },
-    ]
+# def restoreGoCache(ctx, name, path):
+#     return restoreBuildArtifactCache(ctx, name, path) + [
+#         {
+#             "name": "move-go-cache",
+#             "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
+#             "commands": [
+#                 "du -sh ./go/*",
+#                 "rsync -a --remove-source-files %s/go/ /go" % dirs["base"],
+#                 "rm -rf %s/go" % dirs["base"],
+#                 "du -sh /go/*",
+#             ],
+#             "volumes": [stepVolumeGo],
+#         },
+#     ]
 
 def pipelineSanityChecks(ctx, pipelines):
     """pipelineSanityChecks helps the CI developers to find errors before running it

--- a/.drone.star
+++ b/.drone.star
@@ -367,7 +367,7 @@ def testOcisModule(ctx, module):
             "image": OC_CI_GOLANG,
             "commands": [
                 "mkdir -p cache/checkstyle",
-                "make -C %s ci-golangci-lint" % (module),
+                "retry -t 3 'make -C %s ci-golangci-lint'" % (module),
                 "mv %s/checkstyle.xml cache/checkstyle/$(basename %s)_checkstyle.xml" % (module, module),
             ],
             "volumes": [stepVolumeGo],

--- a/.drone.star
+++ b/.drone.star
@@ -372,7 +372,7 @@ def getGoDepsForTesting(ctx):
         },
         "steps": skipIfUnchanged(ctx, "unit-tests") +
                  bingoGet() +
-                 rebuildBuildArtifactCache(ctx, "go-deps-for-testing", "/go"),
+                 rebuildBuildArtifactCache(ctx, "go-deps-for-testing", "/go/bin"),
         "trigger": {
             "ref": [
                 "refs/heads/master",
@@ -2457,8 +2457,10 @@ def restoreGoCache(ctx, name, path):
             "name": "move-go-cache",
             "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
             "commands": [
+                "du -sh ./go/*",
                 "rsync -a --remove-source-files %s/go/ /go" % dirs["base"],
                 "rm -rf %s/go" % dirs["base"],
+                "du -sh /go/*",
             ],
             "volumes": [stepVolumeGo],
         },

--- a/.drone.star
+++ b/.drone.star
@@ -53,36 +53,36 @@ config = {
     "modules": [
         # if you add a module here please also add it to the root level Makefile
         "services/app-provider",
-        "services/app-registry",
-        "services/audit",
-        "services/auth-basic",
-        "services/auth-bearer",
-        "services/auth-machine",
-        "services/frontend",
-        "services/gateway",
-        "services/graph",
-        "services/groups",
-        "services/idm",
-        "services/idp",
-        "services/nats",
-        "services/notifications",
-        "services/ocdav",
-        "services/ocs",
-        "services/proxy",
-        "services/search",
-        "services/settings",
-        "services/sharing",
-        "services/storage-system",
-        "services/storage-publiclink",
-        "services/storage-shares",
-        "services/storage-users",
-        "services/store",
-        "services/thumbnails",
-        "services/users",
-        "services/web",
-        "services/webdav",
-        "ocis-pkg",
-        "ocis",
+        # "services/app-registry",
+        # "services/audit",
+        # "services/auth-basic",
+        # "services/auth-bearer",
+        # "services/auth-machine",
+        # "services/frontend",
+        # "services/gateway",
+        # "services/graph",
+        # "services/groups",
+        # "services/idm",
+        # "services/idp",
+        # "services/nats",
+        # "services/notifications",
+        # "services/ocdav",
+        # "services/ocs",
+        # "services/proxy",
+        # "services/search",
+        # "services/settings",
+        # "services/sharing",
+        # "services/storage-system",
+        # "services/storage-publiclink",
+        # "services/storage-shares",
+        # "services/storage-users",
+        # "services/store",
+        # "services/thumbnails",
+        # "services/users",
+        # "services/web",
+        # "services/webdav",
+        # "ocis-pkg",
+        # "ocis",
     ],
     "cs3ApiTests": {
         "skip": False,
@@ -224,12 +224,8 @@ def main(ctx):
 
     test_pipelines = \
         cancelPreviousBuilds() + \
-        codestyle(ctx) + \
-        buildWebCache(ctx) + \
         [getGoDepsForTesting(ctx)] + \
-        [buildOcisBinaryForTesting(ctx)] + \
-        testOcisModules(ctx) + \
-        testPipelines(ctx)
+        testOcisModules(ctx)
 
     build_release_pipelines = \
         [licenseCheck(ctx)] + \
@@ -245,11 +241,12 @@ def main(ctx):
     test_pipelines.append(
         pipelineDependsOn(
             purgeBuildArtifactCache(ctx),
-            testPipelines(ctx),
+            # testPipelines(ctx),
+            testOcisModules(ctx),
         ),
     )
 
-    pipelines = test_pipelines + build_release_pipelines + build_release_helpers
+    pipelines = test_pipelines  # + build_release_pipelines + build_release_helpers
 
     if ctx.build.event == "cron":
         pipelines = \
@@ -271,7 +268,7 @@ def main(ctx):
         ),
     )
 
-    pipelines += checkStarlark()
+    # pipelines += checkStarlark()
     pipelineSanityChecks(ctx, pipelines)
     return pipelines
 

--- a/.drone.star
+++ b/.drone.star
@@ -57,36 +57,36 @@ config = {
     "modules": [
         # if you add a module here please also add it to the root level Makefile
         "services/app-provider",
-        # "services/app-registry",
-        # "services/audit",
-        # "services/auth-basic",
-        # "services/auth-bearer",
-        # "services/auth-machine",
-        # "services/frontend",
-        # "services/gateway",
-        # "services/graph",
-        # "services/groups",
-        # "services/idm",
-        # "services/idp",
-        # "services/nats",
-        # "services/notifications",
-        # "services/ocdav",
-        # "services/ocs",
-        # "services/proxy",
-        # "services/search",
-        # "services/settings",
-        # "services/sharing",
-        # "services/storage-system",
-        # "services/storage-publiclink",
-        # "services/storage-shares",
-        # "services/storage-users",
-        # "services/store",
-        # "services/thumbnails",
-        # "services/users",
-        # "services/web",
-        # "services/webdav",
-        # "ocis-pkg",
-        # "ocis",
+        "services/app-registry",
+        "services/audit",
+        "services/auth-basic",
+        "services/auth-bearer",
+        "services/auth-machine",
+        "services/frontend",
+        "services/gateway",
+        "services/graph",
+        "services/groups",
+        "services/idm",
+        "services/idp",
+        "services/nats",
+        "services/notifications",
+        "services/ocdav",
+        "services/ocs",
+        "services/proxy",
+        "services/search",
+        "services/settings",
+        "services/sharing",
+        "services/storage-system",
+        "services/storage-publiclink",
+        "services/storage-shares",
+        "services/storage-users",
+        "services/store",
+        "services/thumbnails",
+        "services/users",
+        "services/web",
+        "services/webdav",
+        "ocis-pkg",
+        "ocis",
     ],
     "cs3ApiTests": {
         "skip": False,
@@ -223,8 +223,6 @@ def main(ctx):
     Returns:
       none
     """
-
-    return cancelPreviousBuilds() + getGoBinForTesting(ctx) + testOcisModules(ctx)
 
     pipelines = []
 
@@ -2438,7 +2436,6 @@ def genericCache(name, action, mounts, cache_path):
             "path": cache_path,
             "fallback_path": cache_path,
         },
-        "volumes": [stepVolumeGo],
     }
     return step
 

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ golangci-lint-fix:
 
 .PHONY: bingo-update
 bingo-update: $(BINGO)
-	$(BINGO) get -l
+	$(BINGO) get -l -v
 
 .PHONY: check-licenses
 check-licenses: ci-go-check-licenses ci-node-check-licenses

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ golangci-lint-fix:
 
 .PHONY: bingo-update
 bingo-update: $(BINGO)
-	$(BINGO) get -l -u
+	$(BINGO) get -l
 
 .PHONY: check-licenses
 check-licenses: ci-go-check-licenses ci-node-check-licenses

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -1,7 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+#
+# $1 - root path where .bingo resides
+#
+
+ROOT_PATH="$1"
+if [ -z "$1" ]; then
+    ROOT_PATH="/drone/src"
+fi
+BINGO_DIR="$ROOT_PATH/.bingo"
 
 # generate hash for .bingo folder
-BINGO_HASH=$(find .bingo -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
+BINGO_HASH=$(find "$BINGO_DIR" -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
 
 echo "[INOF] BINGO_HASH: $BINGO_HASH"
 
@@ -15,5 +25,6 @@ if curl --output /dev/null --silent --head --fail "$URL"; then
     # exit a Pipeline early without failing
     exit 78
 else
+    echo "$BINGO_HASH" >"$ROOT_PATH/.bingo_hash"
     echo "[INFO] Go bin cache with has '$BINGO_HASH' does not exist."
 fi

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -16,7 +16,7 @@ BINGO_HASH=$(cat $(ls -ad "$BINGO_DIR"/*) | sha256sum | cut -d ' ' -f 1)
 
 echo "[INOF] BINGO_HASH: $BINGO_HASH"
 
-URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH.tar.gz"
+URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH"
 
 echo "[INFO] Checking for the go bin cache at '$URL'."
 

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -11,7 +11,7 @@ fi
 BINGO_DIR="$ROOT_PATH/.bingo"
 
 # generate hash of a .bingo folder
-BINGO_HASH=$(find "$BINGO_DIR" -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
+BINGO_HASH=$(cat "$BINGO_DIR"/* | sha256sum | cut -d ' ' -f 1)
 
 URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/bin/golangci-lint"
 if curl --output /dev/null --silent --head --fail "$URL"; then

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -10,22 +10,17 @@ if [ -z "$1" ]; then
 fi
 BINGO_DIR="$ROOT_PATH/.bingo"
 
-# generate hash from the contents of .bingo folder
-# BINGO_HASH=$(find "$BINGO_DIR" -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
-BINGO_HASH=$(cat $(ls -ad "$BINGO_DIR"/*) | sha256sum | cut -d ' ' -f 1)
-
-echo "[INOF] BINGO_HASH: $BINGO_HASH"
+# generate hash of a .bingo folder
+BINGO_HASH=$(find "$BINGO_DIR" -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
 
 URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/bin/golangci-lint"
-
-echo "[INFO] Checking for the go bin cache at '$URL'."
-
 if curl --output /dev/null --silent --head --fail "$URL"; then
     echo "[INFO] Go bin cache with has '$BINGO_HASH' exists."
     # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
     # exit a Pipeline early without failing
     exit 78
 else
+    # stored hash of a .bingo folder to '.bingo_hash' file
     echo "$BINGO_HASH" >"$ROOT_PATH/.bingo_hash"
     echo "[INFO] Go bin cache with has '$BINGO_HASH' does not exist."
 fi

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -10,13 +10,13 @@ if [ -z "$1" ]; then
 fi
 BINGO_DIR="$ROOT_PATH/.bingo"
 
-# generate hash for .bingo folder
+# generate hash from the contents of .bingo folder
 # BINGO_HASH=$(find "$BINGO_DIR" -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
 BINGO_HASH=$(cat $(ls -ad "$BINGO_DIR"/*) | sha256sum | cut -d ' ' -f 1)
 
 echo "[INOF] BINGO_HASH: $BINGO_HASH"
 
-URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH"
+URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/bin/golangci-lint"
 
 echo "[INFO] Checking for the go bin cache at '$URL'."
 

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -11,7 +11,8 @@ fi
 BINGO_DIR="$ROOT_PATH/.bingo"
 
 # generate hash for .bingo folder
-BINGO_HASH=$(find "$BINGO_DIR" -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
+# BINGO_HASH=$(find "$BINGO_DIR" -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
+BINGO_HASH=$(cat $(ls -ad "$BINGO_DIR"/*) | sha256sum | cut -d ' ' -f 1)
 
 echo "[INOF] BINGO_HASH: $BINGO_HASH"
 

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# generate hash for .bingo folder
+BINGO_HASH=$(find .bingo -type f -exec sha256sum {} \; | sort -k 2 | sha256sum | cut -d ' ' -f 1)
+
+echo "[INOF] BINGO_HASH: $BINGO_HASH"
+
+URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH.tar.gz"
+
+echo "[INFO] Checking for the go bin cache at '$URL'."
+
+if curl --output /dev/null --silent --head --fail "$URL"; then
+    echo "[INFO] Go bin cache with has '$BINGO_HASH' exists."
+    # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+    # exit a Pipeline early without failing
+    exit 78
+else
+    echo "[INFO] Go bin cache with has '$BINGO_HASH' does not exist."
+fi


### PR DESCRIPTION
## Description
Caching `/go/bin` binaries as a long-term cache so that each linting and unit-testing pipeline won't have to rebuild the binaries again and again. This also makes the pipeline faster due to not having to rebuild the 

## Motivation and Context
make work more efficient
annoy developers less

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- running CI multiple times

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
