### PR TITLE
[full-ci] chore: bump web to v7.0.0-rc.13

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=6bcdcc5c0ccf7a13bc8f9da2e342073a07744705
+WEB_COMMITID=5f66ccb84634586a34a058cd104ff61f31e46004
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.12
+WEB_ASSETS_VERSION = v7.0.0-rc.13
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bumps web to v7.0.0-rc.13

Contains `group filtering` for the user list in `admin-settings` and the `logo upload / reset` in the appearance section of the `admin-settings`. Should only be merged after following ocis PRs have been merged.
- https://github.com/owncloud/ocis/pull/5559
- https://github.com/owncloud/ocis/pull/5533