### PR TITLE
[tests-only][full-ci]Add api tests to assign role using graph api

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1129,4 +1129,67 @@ class GraphHelper {
 			self::getRequestHeaders()
 		);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $appRoleId
+	 * @param string $applicationId
+	 * @param string $userId
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function assignRole(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $appRoleId,
+		string $applicationId,
+		string $userId
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/appRoleAssignments');
+		$payload['principalId'] = $userId;
+		$payload['appRoleId'] = $appRoleId;
+		$payload['resourceId'] = $applicationId;
+		return HttpRequestHelper::sendRequest(
+			$url,
+			$xRequestId,
+			"POST",
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			\json_encode($payload)
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $userId
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function getAssignedRole(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $userId
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/appRoleAssignments');
+		return HttpRequestHelper::get(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders()
+		);
+	}
 }

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -48,6 +48,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 ### [Settings service user can list other peoples assignments](https://github.com/owncloud/ocis/issues/5032)
 - [apiAccountsHashDifficulty/assignRole.feature:27](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAccountsHashDifficulty/assignRole.feature#L27)
 - [apiAccountsHashDifficulty/assignRole.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiAccountsHashDifficulty/assignRole.feature#L28)
+- [apiGraph/assignRole.feature:31](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/assignRole.feature#L31)
+- [apiGraph/assignRole.feature:32](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/assignRole.feature#L32)
+- [apiGraph/assignRole.feature:33](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/assignRole.feature#L33)
 
 ### [Group having percentage (%) can be created but cannot be GET](https://github.com/owncloud/ocis/issues/5083)
 - [apiGraph/deleteGroup.feature:49](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L49)

--- a/tests/acceptance/features/apiGraph/assignRole.feature
+++ b/tests/acceptance/features/apiGraph/assignRole.feature
@@ -1,0 +1,33 @@
+@api
+Feature: assign role
+  As an admin,
+  I want to assign roles to users.
+  So that users without an admin role cannot get the list of roles, assignments list and assign roles to users
+
+
+  Scenario Outline: assign role to the user using graph api
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
+    When the administrator retrieves the assigned role of user "Alice" using the Graph API
+    Then the HTTP status code should be "200"
+    And the Graph API response should have the role "<userRole>"
+    Examples:
+      | userRole    |
+      | Admin       |
+      | Space Admin |
+      | User        |
+      | Guest       |
+
+  @issue-5032
+  Scenario Outline: assign role to the user with graph api and list role with setting api
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
+    When user "Alice" tries to get list of assignment
+    Then the HTTP status code should be "<statusCode>"
+    And the setting API response should have the role "<userRole>"
+    Examples:
+      | userRole    | statusCode |
+      | Admin       | 201        |
+      | Space Admin | 401        |
+      | User        | 401        |
+      | Guest       | 401        |

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -29,6 +29,13 @@ class GraphContext implements Context {
 	private FeatureContext $featureContext;
 
 	/**
+	 * application Entity
+	 *
+	 * @var array
+	 */
+	private $appEntity = [];
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *
@@ -1630,5 +1637,93 @@ class GraphContext implements Context {
 			$this->featureContext->getGroupIdByGroupName($group)
 		);
 		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @Given /^the administrator has assigned the role "([^"]*)" to user "([^"]*)" using the Graph API$/
+	 *
+	 * @param string $role
+	 * @param string $user
+	 *
+	 * @return void
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theAdministratorHasGivenTheRoleUsingTheGraphApi(string $role, string $user): void {
+		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id') ?? $user;
+
+		if (empty($this->appEntity)) {
+			$applicationEntity = (
+				$this->featureContext->getJsonDecodedResponse(
+					GraphHelper::getApplications(
+						$this->featureContext->getBaseUrl(),
+						$this->featureContext->getStepLineRef(),
+						$this->featureContext->getAdminUsername(),
+						$this->featureContext->getAdminPassword(),
+					)
+				)
+			)['value'][0];
+			$this->appEntity["id"] = $applicationEntity["id"];
+			foreach ($applicationEntity["appRoles"] as $value) {
+				$this->appEntity["appRoles"][$value['displayName']] = $value['id'];
+			}
+		}
+
+		$response = GraphHelper::assignRole(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->appEntity["appRoles"][$role],
+			$this->appEntity["id"],
+			$userId
+		);
+		Assert::assertEquals(
+			201,
+			$response->getStatusCode(),
+			__METHOD__
+			. "\nExpected status code '200' but got '" . $response->getStatusCode() . "'"
+		);
+	}
+
+	/**
+	 * @When /^the administrator retrieves the assigned role of user "([^"]*)" using the Graph API$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userRetrievesAssignedRoleUsingTheGraphApi(string $user): void {
+		$admin = $this->featureContext->getAdminUserName();
+		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id') ?? $user;
+		$this->featureContext->setResponse(
+			GraphHelper::getAssignedRole(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getStepLineRef(),
+				$admin,
+				$this->featureContext->getPasswordForUser($admin),
+				$userId
+			)
+		);
+	}
+
+	/**
+	 * @Then /^the Graph API response should have the role "([^"]*)"$/
+	 *
+	 * @param string $role
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theGraphApiResponseShouldHaveTheRole(string $role): void {
+		$response = $this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())['value'][0];
+		Assert::assertEquals(
+			$this->appEntity["appRoles"][$role],
+			$response['appRoleId'],
+			__METHOD__
+			. "\nExpected rolId for role '$role'' to be '" . $this->appEntity["appRoles"][$role] . "' but got '" . $response['appRoleId'] . "'"
+		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/RoleAssignmentContext.php
+++ b/tests/acceptance/features/bootstrap/RoleAssignmentContext.php
@@ -127,8 +127,7 @@ class RoleAssignmentContext implements Context {
 	public function theAdministratorHasGivenUserTheRole(string $user, string $role): void {
 		$admin = $this->featureContext->getAdminUserName();
 		$roleId = $this->userGetRoleIdByRoleName($admin, $role);
-		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id');
-		$userId = $userId ?? $user;
+		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id') ?? $user;
 		$this->setRoleToUser($admin, $userId, $roleId);
 	}
 
@@ -239,7 +238,7 @@ class RoleAssignmentContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" should have the role "([^"]*)"$/
+	 * @Then /^user "([^"]*)" should have the role "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $role
@@ -255,5 +254,19 @@ class RoleAssignmentContext implements Context {
 		$rawBody =  $this->featureContext->getResponse()->getBody()->getContents();
 		$assignmentRoleId = \json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR)["assignments"][0]["roleId"];
 		Assert::assertEquals($this->userGetRoleIdByRoleName($this->featureContext->getAdminUserName(), $role), $assignmentRoleId, "user $user has no role $role");
+	}
+
+	/**
+	 * @Then /^the setting API response should have the role "([^"]*)"$/
+	 *
+	 * @param string $role
+	 *
+	 * @return void
+	 *
+	 * @throws Exception
+	 */
+	public function theSettingApiResponseShouldHaveTheRole(string $role): void {
+		$assignmentRoleId = $this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())["assignments"][0]["roleId"];
+		Assert::assertEquals($this->userGetRoleIdByRoleName($this->featureContext->getAdminUserName(), $role), $assignmentRoleId, "user has no role $role");
 	}
 }


### PR DESCRIPTION
## Description
This scenario adds scenario assign a role to a user using the graph API and check if its correctly listed by the graph API and and by the settings API

## Related Issue
- https://github.com/owncloud/ocis/issues/5565#

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
