### PR TITLE
[full-ci] bump reva to ec27f5f8feb3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.3.5
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/cs3org/go-cs3apis v0.0.0-20221012090518-ef2996678965
-	github.com/cs3org/reva/v2 v2.12.1-0.20230208154945-81b9c3e9d310
+	github.com/cs3org/reva/v2 v2.12.1-0.20230214085134-ec27f5f8feb3
 	github.com/disintegration/imaging v1.6.2
 	github.com/ggwhite/go-masker v1.0.9
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -343,8 +343,8 @@ github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3p
 github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD96t1A=
 github.com/crewjam/saml v0.4.9 h1:X2jDv4dv3IvfT9t+RhADavzNFAcq3fVxzTCIH3G605U=
 github.com/crewjam/saml v0.4.9/go.mod h1:9Zh6dWPtB3MSzTRt8fIFH60Z351QQ+s7hCU3J/tTlA4=
-github.com/cs3org/reva/v2 v2.12.1-0.20230208154945-81b9c3e9d310 h1:UIsxP51vo9Z7OJTclC6yYetgtAPZaoLJ8d41c6WkT+o=
-github.com/cs3org/reva/v2 v2.12.1-0.20230208154945-81b9c3e9d310/go.mod h1:u73Df9JAZsDj43GIjQIb3DO1PLJuPutZXkRqQH0oGXA=
+github.com/cs3org/reva/v2 v2.12.1-0.20230214085134-ec27f5f8feb3 h1:KaFl1ZfjjKSlDsq/zvhBV9f+mXYqnLdK5IhAaZBoXDo=
+github.com/cs3org/reva/v2 v2.12.1-0.20230214085134-ec27f5f8feb3/go.mod h1:u73Df9JAZsDj43GIjQIb3DO1PLJuPutZXkRqQH0oGXA=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/services/audit/pkg/service/service.go
+++ b/services/audit/pkg/service/service.go
@@ -19,7 +19,7 @@ type Log func([]byte)
 type Marshaller func(interface{}) ([]byte, error)
 
 // AuditLoggerFromConfig will start a new AuditLogger generated from the config
-func AuditLoggerFromConfig(ctx context.Context, cfg config.Auditlog, ch <-chan interface{}, log log.Logger) {
+func AuditLoggerFromConfig(ctx context.Context, cfg config.Auditlog, ch <-chan events.Event, log log.Logger) {
 	var logs []Log
 
 	if cfg.LogToConsole {
@@ -37,14 +37,14 @@ func AuditLoggerFromConfig(ctx context.Context, cfg config.Auditlog, ch <-chan i
 // StartAuditLogger will block. run in separate go routine
 //
 //nolint:gocyclo
-func StartAuditLogger(ctx context.Context, ch <-chan interface{}, log log.Logger, marshaller Marshaller, logto ...Log) {
+func StartAuditLogger(ctx context.Context, ch <-chan events.Event, log log.Logger, marshaller Marshaller, logto ...Log) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case i := <-ch:
 			var auditEvent interface{}
-			switch ev := i.(type) {
+			switch ev := i.Event.(type) {
 			case events.ShareCreated:
 				auditEvent = types.ShareCreated(ev)
 			case events.LinkCreated:

--- a/services/audit/pkg/service/service_test.go
+++ b/services/audit/pkg/service/service_test.go
@@ -20,17 +20,19 @@ import (
 
 var testCases = []struct {
 	Alias           string
-	SystemEvent     interface{}
+	SystemEvent     events.Event
 	CheckAuditEvent func(*testing.T, []byte)
 }{
 	{
 		Alias: "ShareCreated - user",
-		SystemEvent: events.ShareCreated{
-			Sharer:         userID("sharing-userid"),
-			GranteeUserID:  userID("beshared-userid"),
-			GranteeGroupID: nil,
-			ItemID:         resourceID("provider-1", "storage-1", "itemid-1"),
-			CTime:          timestamp(0),
+		SystemEvent: events.Event{
+			Event: events.ShareCreated{
+				Sharer:         userID("sharing-userid"),
+				GranteeUserID:  userID("beshared-userid"),
+				GranteeGroupID: nil,
+				ItemID:         resourceID("provider-1", "storage-1", "itemid-1"),
+				CTime:          timestamp(0),
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventShareCreated{}
@@ -52,12 +54,14 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "ShareCreated - group",
-		SystemEvent: events.ShareCreated{
-			Sharer:         userID("sharing-userid"),
-			GranteeUserID:  nil,
-			GranteeGroupID: groupID("beshared-groupid"),
-			ItemID:         resourceID("provider-1", "storage-1", "itemid-1"),
-			CTime:          timestamp(10e8),
+		SystemEvent: events.Event{
+			Event: events.ShareCreated{
+				Sharer:         userID("sharing-userid"),
+				GranteeUserID:  nil,
+				GranteeGroupID: groupID("beshared-groupid"),
+				ItemID:         resourceID("provider-1", "storage-1", "itemid-1"),
+				CTime:          timestamp(10e8),
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventShareCreated{}
@@ -80,15 +84,17 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "ShareUpdated",
-		SystemEvent: events.ShareUpdated{
-			ShareID:        shareID("shareid"),
-			Sharer:         userID("sharing-userid"),
-			GranteeUserID:  nil,
-			GranteeGroupID: groupID("beshared-groupid"),
-			ItemID:         resourceID("provider-1", "storage-1", "itemid-1"),
-			Permissions:    sharePermissions("stat", "get_quota"),
-			MTime:          timestamp(10e8),
-			Updated:        "permissions",
+		SystemEvent: events.Event{
+			Event: events.ShareUpdated{
+				ShareID:        shareID("shareid"),
+				Sharer:         userID("sharing-userid"),
+				GranteeUserID:  nil,
+				GranteeGroupID: groupID("beshared-groupid"),
+				ItemID:         resourceID("provider-1", "storage-1", "itemid-1"),
+				Permissions:    sharePermissions("stat", "get_quota"),
+				MTime:          timestamp(10e8),
+				Updated:        "permissions",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventShareUpdated{}
@@ -110,17 +116,19 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "LinkUpdated - permissions",
-		SystemEvent: events.LinkUpdated{
-			ShareID:           linkID("shareid"),
-			Sharer:            userID("sharing-userid"),
-			ItemID:            resourceID("provider-1", "storage-1", "itemid-1"),
-			Permissions:       linkPermissions("stat"),
-			CTime:             timestamp(10e8),
-			DisplayName:       "link",
-			Expiration:        timestamp(10e8 + 10e5),
-			PasswordProtected: true,
-			Token:             "token-123",
-			FieldUpdated:      "permissions",
+		SystemEvent: events.Event{
+			Event: events.LinkUpdated{
+				ShareID:           linkID("shareid"),
+				Sharer:            userID("sharing-userid"),
+				ItemID:            resourceID("provider-1", "storage-1", "itemid-1"),
+				Permissions:       linkPermissions("stat"),
+				CTime:             timestamp(10e8),
+				DisplayName:       "link",
+				Expiration:        timestamp(10e8 + 10e5),
+				PasswordProtected: true,
+				Token:             "token-123",
+				FieldUpdated:      "permissions",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventShareUpdated{}
@@ -142,9 +150,11 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "ShareRemoved",
-		SystemEvent: events.ShareRemoved{
-			ShareID:  shareID("shareid"),
-			ShareKey: nil,
+		SystemEvent: events.Event{
+			Event: events.ShareRemoved{
+				ShareID:  shareID("shareid"),
+				ShareKey: nil,
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventShareRemoved{}
@@ -161,10 +171,12 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "LinkRemoved - id",
-		SystemEvent: events.LinkRemoved{
-			Executant:  userID("sharing-userid"),
-			ShareID:    linkID("shareid"),
-			ShareToken: "",
+		SystemEvent: events.Event{
+			Event: events.LinkRemoved{
+				Executant:  userID("sharing-userid"),
+				ShareID:    linkID("shareid"),
+				ShareToken: "",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventShareRemoved{}
@@ -181,10 +193,12 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "LinkRemoved - token",
-		SystemEvent: events.LinkRemoved{
-			Executant:  userID("sharing-userid"),
-			ShareID:    nil,
-			ShareToken: "token-123",
+		SystemEvent: events.Event{
+			Event: events.LinkRemoved{
+				Executant:  userID("sharing-userid"),
+				ShareID:    nil,
+				ShareToken: "token-123",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventShareRemoved{}
@@ -201,15 +215,17 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Share accepted",
-		SystemEvent: events.ReceivedShareUpdated{
-			ShareID:        shareID("shareid"),
-			ItemID:         resourceID("provider-1", "storageid-1", "itemid-1"),
-			Permissions:    sharePermissions("get_quota"),
-			GranteeUserID:  userID("beshared-userid"),
-			GranteeGroupID: nil,
-			Sharer:         userID("sharing-userid"),
-			MTime:          timestamp(10e8),
-			State:          "SHARE_STATE_ACCEPTED",
+		SystemEvent: events.Event{
+			Event: events.ReceivedShareUpdated{
+				ShareID:        shareID("shareid"),
+				ItemID:         resourceID("provider-1", "storageid-1", "itemid-1"),
+				Permissions:    sharePermissions("get_quota"),
+				GranteeUserID:  userID("beshared-userid"),
+				GranteeGroupID: nil,
+				Sharer:         userID("sharing-userid"),
+				MTime:          timestamp(10e8),
+				State:          "SHARE_STATE_ACCEPTED",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventReceivedShareUpdated{}
@@ -226,15 +242,17 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Share declined",
-		SystemEvent: events.ReceivedShareUpdated{
-			ShareID:        shareID("shareid"),
-			ItemID:         resourceID("provider-1", "storageid-1", "itemid-1"),
-			Permissions:    sharePermissions("get_quota"),
-			GranteeUserID:  userID("beshared-userid"),
-			GranteeGroupID: nil,
-			Sharer:         userID("sharing-userid"),
-			MTime:          timestamp(10e8),
-			State:          "SHARE_STATE_DECLINED",
+		SystemEvent: events.Event{
+			Event: events.ReceivedShareUpdated{
+				ShareID:        shareID("shareid"),
+				ItemID:         resourceID("provider-1", "storageid-1", "itemid-1"),
+				Permissions:    sharePermissions("get_quota"),
+				GranteeUserID:  userID("beshared-userid"),
+				GranteeGroupID: nil,
+				Sharer:         userID("sharing-userid"),
+				MTime:          timestamp(10e8),
+				State:          "SHARE_STATE_DECLINED",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventReceivedShareUpdated{}
@@ -251,16 +269,18 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Link accessed - success",
-		SystemEvent: events.LinkAccessed{
-			ShareID:           linkID("shareid"),
-			Sharer:            userID("sharing-userid"),
-			ItemID:            resourceID("provider-1", "storage-1", "itemid-1"),
-			Permissions:       linkPermissions("stat"),
-			DisplayName:       "link",
-			Expiration:        timestamp(10e8 + 10e5),
-			PasswordProtected: true,
-			CTime:             timestamp(10e8),
-			Token:             "token-123",
+		SystemEvent: events.Event{
+			Event: events.LinkAccessed{
+				ShareID:           linkID("shareid"),
+				Sharer:            userID("sharing-userid"),
+				ItemID:            resourceID("provider-1", "storage-1", "itemid-1"),
+				Permissions:       linkPermissions("stat"),
+				DisplayName:       "link",
+				Expiration:        timestamp(10e8 + 10e5),
+				PasswordProtected: true,
+				CTime:             timestamp(10e8),
+				Token:             "token-123",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventLinkAccessed{}
@@ -277,11 +297,13 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Link accessed - failure",
-		SystemEvent: events.LinkAccessFailed{
-			ShareID: linkID("shareid"),
-			Token:   "token-123",
-			Status:  8,
-			Message: "access denied",
+		SystemEvent: events.Event{
+			Event: events.LinkAccessFailed{
+				ShareID: linkID("shareid"),
+				Token:   "token-123",
+				Status:  8,
+				Message: "access denied",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventLinkAccessed{}
@@ -298,10 +320,12 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "File created",
-		SystemEvent: events.FileUploaded{
-			Executant: userID("uid-123"),
-			Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
-			Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+		SystemEvent: events.Event{
+			Event: events.FileUploaded{
+				Executant: userID("uid-123"),
+				Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
+				Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventFileCreated{}
@@ -314,10 +338,12 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "File read",
-		SystemEvent: events.FileDownloaded{
-			Executant: userID("uid-123"),
-			Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
-			Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+		SystemEvent: events.Event{
+			Event: events.FileDownloaded{
+				Executant: userID("uid-123"),
+				Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
+				Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventFileRead{}
@@ -330,10 +356,12 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "File trashed",
-		SystemEvent: events.ItemTrashed{
-			Executant: userID("uid-123"),
-			Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
-			Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+		SystemEvent: events.Event{
+			Event: events.ItemTrashed{
+				Executant: userID("uid-123"),
+				Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
+				Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventFileDeleted{}
@@ -346,11 +374,13 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "File renamed",
-		SystemEvent: events.ItemMoved{
-			Executant:    userID("uid-123"),
-			Ref:          reference("pro-1", "sto-123", "iid-123", "./item"),
-			OldReference: reference("pro-1", "sto-123", "iid-123", "./anotheritem"),
-			Owner:        userID("uid-123"), // NOTE: owner not yet implemented in reva
+		SystemEvent: events.Event{
+			Event: events.ItemMoved{
+				Executant:    userID("uid-123"),
+				Ref:          reference("pro-1", "sto-123", "iid-123", "./item"),
+				OldReference: reference("pro-1", "sto-123", "iid-123", "./anotheritem"),
+				Owner:        userID("uid-123"), // NOTE: owner not yet implemented in reva
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventFileRenamed{}
@@ -366,10 +396,12 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "File purged",
-		SystemEvent: events.ItemPurged{
-			Executant: userID("uid-123"),
-			Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
-			Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+		SystemEvent: events.Event{
+			Event: events.ItemPurged{
+				Executant: userID("uid-123"),
+				Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
+				Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventFilePurged{}
@@ -382,12 +414,14 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "File restored",
-		SystemEvent: events.ItemRestored{
-			Executant:    userID("uid-123"),
-			Ref:          reference("pro-1", "sto-123", "iid-123", "./item"),
-			Owner:        userID("uid-123"), // NOTE: owner not yet implemented in reva
-			OldReference: reference("pro-1", "sto-123", "sto-123!iid-123/item", "./oldpath"),
-			Key:          "",
+		SystemEvent: events.Event{
+			Event: events.ItemRestored{
+				Executant:    userID("uid-123"),
+				Ref:          reference("pro-1", "sto-123", "iid-123", "./item"),
+				Owner:        userID("uid-123"), // NOTE: owner not yet implemented in reva
+				OldReference: reference("pro-1", "sto-123", "sto-123!iid-123/item", "./oldpath"),
+				Key:          "",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventFileRestored{}
@@ -403,11 +437,13 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "File version restored",
-		SystemEvent: events.FileVersionRestored{
-			Executant: userID("uid-123"),
-			Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
-			Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
-			Key:       "v1",
+		SystemEvent: events.Event{
+			Event: events.FileVersionRestored{
+				Executant: userID("uid-123"),
+				Ref:       reference("pro-1", "sto-123", "iid-123", "./item"),
+				Owner:     userID("uid-123"), // NOTE: owner not yet implemented in reva
+				Key:       "v1",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventFileVersionRestored{}
@@ -423,15 +459,17 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Space created",
-		SystemEvent: events.SpaceCreated{
-			Executant: userID("uid-123"),
-			ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
-			Owner:     userID("uid-123"),
-			Root:      resourceID("pro-1", "sto-123", "iid-123"),
-			Name:      "test-space",
-			Type:      "project",
-			Quota:     nil, // Quota not interesting atm
-			MTime:     timestamp(10e9),
+		SystemEvent: events.Event{
+			Event: events.SpaceCreated{
+				Executant: userID("uid-123"),
+				ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+				Owner:     userID("uid-123"),
+				Root:      resourceID("pro-1", "sto-123", "iid-123"),
+				Name:      "test-space",
+				Type:      "project",
+				Quota:     nil, // Quota not interesting atm
+				MTime:     timestamp(10e9),
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventSpaceCreated{}
@@ -449,11 +487,13 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Space renamed",
-		SystemEvent: events.SpaceRenamed{
-			Executant: userID("uid-123"),
-			ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
-			Owner:     userID("uid-123"),
-			Name:      "new-name",
+		SystemEvent: events.Event{
+			Event: events.SpaceRenamed{
+				Executant: userID("uid-123"),
+				ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+				Owner:     userID("uid-123"),
+				Name:      "new-name",
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventSpaceRenamed{}
@@ -468,9 +508,11 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Space disabled",
-		SystemEvent: events.SpaceDisabled{
-			Executant: userID("uid-123"),
-			ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+		SystemEvent: events.Event{
+			Event: events.SpaceDisabled{
+				Executant: userID("uid-123"),
+				ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventSpaceDisabled{}
@@ -483,9 +525,11 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Space enabled",
-		SystemEvent: events.SpaceEnabled{
-			Executant: userID("uid-123"),
-			ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+		SystemEvent: events.Event{
+			Event: events.SpaceEnabled{
+				Executant: userID("uid-123"),
+				ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventSpaceEnabled{}
@@ -498,9 +542,11 @@ var testCases = []struct {
 		},
 	}, {
 		Alias: "Space deleted",
-		SystemEvent: events.SpaceDeleted{
-			Executant: userID("uid-123"),
-			ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+		SystemEvent: events.Event{
+			Event: events.SpaceDeleted{
+				Executant: userID("uid-123"),
+				ID:        &provider.StorageSpaceId{OpaqueId: "space-123"},
+			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {
 			ev := types.AuditEventSpaceDeleted{}
@@ -517,7 +563,7 @@ var testCases = []struct {
 func TestAuditLogging(t *testing.T) {
 	log := log.NewLogger()
 
-	inch := make(chan interface{})
+	inch := make(chan events.Event)
 	defer close(inch)
 
 	outch := make(chan []byte)

--- a/services/notifications/pkg/service/service.go
+++ b/services/notifications/pkg/service/service.go
@@ -29,7 +29,7 @@ type Service interface {
 
 // NewEventsNotifier provides a new eventsNotifier
 func NewEventsNotifier(
-	events <-chan interface{},
+	events <-chan events.Event,
 	channel channels.Channel,
 	logger log.Logger,
 	gwClient gateway.GatewayAPIClient,
@@ -49,7 +49,7 @@ func NewEventsNotifier(
 type eventsNotifier struct {
 	logger            log.Logger
 	channel           channels.Channel
-	events            <-chan interface{}
+	events            <-chan events.Event
 	signals           chan os.Signal
 	gwClient          gateway.GatewayAPIClient
 	machineAuthAPIKey string
@@ -65,7 +65,7 @@ func (s eventsNotifier) Run() error {
 		select {
 		case evt := <-s.events:
 			go func() {
-				switch e := evt.(type) {
+				switch e := evt.Event.(type) {
 				case events.SpaceShared:
 					s.handleSpaceShared(e)
 				case events.SpaceUnshared:

--- a/services/notifications/pkg/service/service_test.go
+++ b/services/notifications/pkg/service/service_test.go
@@ -49,8 +49,8 @@ var _ = Describe("Notifications", func() {
 	})
 
 	DescribeTable("Sending notifications",
-		func(tc testChannel, ev interface{}) {
-			ch := make(chan interface{})
+		func(tc testChannel, ev events.Event) {
+			ch := make(chan events.Event)
 			evts := service.NewEventsNotifier(ch, tc, log.NewLogger(), gwc, "", "", "")
 			go evts.Run()
 

--- a/services/notifications/pkg/service/service_test.go
+++ b/services/notifications/pkg/service/service_test.go
@@ -68,11 +68,13 @@ var _ = Describe("Notifications", func() {
 			expectedSubject:     "Dr. S. Harer shared 'secrets of the board' with you",
 			expectedSender:      sharer.GetDisplayName(),
 			done:                make(chan struct{}),
-		}, events.ShareCreated{
-			Sharer:        sharer.GetId(),
-			GranteeUserID: sharee.GetId(),
-			CTime:         utils.TimeToTS(time.Date(2023, 4, 17, 16, 42, 0, 0, time.UTC)),
-			ItemID:        resourceid,
+		}, events.Event{
+			Event: events.ShareCreated{
+				Sharer:        sharer.GetId(),
+				GranteeUserID: sharee.GetId(),
+				CTime:         utils.TimeToTS(time.Date(2023, 4, 17, 16, 42, 0, 0, time.UTC)),
+				ItemID:        resourceid,
+			},
 		}),
 
 		Entry("Share Expired", testChannel{
@@ -80,11 +82,13 @@ var _ = Describe("Notifications", func() {
 			expectedSubject:     "Share to 'secrets of the board' expired at 2023-04-17 16:42:00",
 			expectedSender:      sharer.GetDisplayName(),
 			done:                make(chan struct{}),
-		}, events.ShareExpired{
-			ShareOwner:    sharer.GetId(),
-			GranteeUserID: sharee.GetId(),
-			ExpiredAt:     time.Date(2023, 4, 17, 16, 42, 0, 0, time.UTC),
-			ItemID:        resourceid,
+		}, events.Event{
+			Event: events.ShareExpired{
+				ShareOwner:    sharer.GetId(),
+				GranteeUserID: sharee.GetId(),
+				ExpiredAt:     time.Date(2023, 4, 17, 16, 42, 0, 0, time.UTC),
+				ItemID:        resourceid,
+			},
 		}),
 
 		Entry("Added to Space", testChannel{
@@ -92,11 +96,13 @@ var _ = Describe("Notifications", func() {
 			expectedSubject:     "Dr. S. Harer invited you to join secret space",
 			expectedSender:      sharer.GetDisplayName(),
 			done:                make(chan struct{}),
-		}, events.SpaceShared{
-			Executant:     sharer.GetId(),
-			Creator:       sharer.GetId(),
-			GranteeUserID: sharee.GetId(),
-			ID:            &provider.StorageSpaceId{OpaqueId: "spaceid"},
+		}, events.Event{
+			Event: events.SpaceShared{
+				Executant:     sharer.GetId(),
+				Creator:       sharer.GetId(),
+				GranteeUserID: sharee.GetId(),
+				ID:            &provider.StorageSpaceId{OpaqueId: "spaceid"},
+			},
 		}),
 
 		Entry("Removed from Space", testChannel{
@@ -104,10 +110,12 @@ var _ = Describe("Notifications", func() {
 			expectedSubject:     "Dr. S. Harer removed you from secret space",
 			expectedSender:      sharer.GetDisplayName(),
 			done:                make(chan struct{}),
-		}, events.SpaceUnshared{
-			Executant:     sharer.GetId(),
-			GranteeUserID: sharee.GetId(),
-			ID:            &provider.StorageSpaceId{OpaqueId: "spaceid"},
+		}, events.Event{
+			Event: events.SpaceUnshared{
+				Executant:     sharer.GetId(),
+				GranteeUserID: sharee.GetId(),
+				ID:            &provider.StorageSpaceId{OpaqueId: "spaceid"},
+			},
 		}),
 
 		Entry("Space Expired", testChannel{
@@ -115,12 +123,14 @@ var _ = Describe("Notifications", func() {
 			expectedSubject:     "Membership of 'secret space' expired at 2023-04-17 16:42:00",
 			expectedSender:      sharer.GetDisplayName(),
 			done:                make(chan struct{}),
-		}, events.SpaceMembershipExpired{
-			SpaceOwner:    sharer.GetId(),
-			GranteeUserID: sharee.GetId(),
-			SpaceID:       &provider.StorageSpaceId{OpaqueId: "spaceid"},
-			SpaceName:     "secret space",
-			ExpiredAt:     time.Date(2023, 4, 17, 16, 42, 0, 0, time.UTC),
+		}, events.Event{
+			Event: events.SpaceMembershipExpired{
+				SpaceOwner:    sharer.GetId(),
+				GranteeUserID: sharee.GetId(),
+				SpaceID:       &provider.StorageSpaceId{OpaqueId: "spaceid"},
+				SpaceName:     "secret space",
+				ExpiredAt:     time.Date(2023, 4, 17, 16, 42, 0, 0, time.UTC),
+			},
 		}),
 	)
 })

--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -10,7 +10,7 @@ import (
 // PostprocessingService is an instance of the service handling postprocessing of files
 type PostprocessingService struct {
 	log    log.Logger
-	events <-chan interface{}
+	events <-chan events.Event
 	pub    events.Publisher
 	steps  []events.Postprocessingstep
 	c      config.Postprocessing
@@ -42,7 +42,7 @@ func (pps *PostprocessingService) Run() error {
 	current := make(map[string]*postprocessing.Postprocessing)
 	for e := range pps.events {
 		var next interface{}
-		switch ev := e.(type) {
+		switch ev := e.Event.(type) {
 		case events.BytesReceived:
 			pp := postprocessing.New(ev.UploadID, ev.URL, ev.ExecutingUser, ev.Filename, ev.Filesize, ev.ResourceID, pps.steps, pps.c.Delayprocessing)
 			current[ev.UploadID] = pp

--- a/services/search/pkg/search/events.go
+++ b/services/search/pkg/search/events.go
@@ -70,13 +70,13 @@ func HandleEvents(s Searcher, bus events.Consumer, logger log.Logger, cfg *confi
 	})
 
 	for i := 0; i < cfg.Events.NumConsumers; i++ {
-		go func(s Searcher, ch <-chan interface{}) {
+		go func(s Searcher, ch <-chan events.Event) {
 			for e := range ch {
 				logger.Debug().Interface("event", e).Msg("updating index")
 
 				var err error
 
-				switch ev := e.(type) {
+				switch ev := e.Event.(type) {
 				case events.ItemTrashed:
 					u := getUser(ev.SpaceOwner, ev.Executant)
 					s.TrashItem(ev.ID)

--- a/services/storage-users/pkg/event/service.go
+++ b/services/storage-users/pkg/event/service.go
@@ -45,7 +45,7 @@ func (s Service) Run() error {
 	for e := range ch {
 		var errs []error
 
-		switch ev := e.(type) {
+		switch ev := e.Event.(type) {
 		case PurgeTrashBin:
 			executionTime := ev.ExecutionTime
 			if executionTime.IsZero() {


### PR DESCRIPTION
This bumps reva to v2.12.1-0.20230214085134-ec27f5f8feb3, pulling in the events change from https://github.com/cs3org/reva/pull/3637 causing several changes.