### PR TITLE
[full-ci] chore: bump web to v7.0.0-rc.14

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=5f66ccb84634586a34a058cd104ff61f31e46004
+WEB_COMMITID=617940b0685bb7d1f18ec331dc7fc9db7a5d4b27
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.13
+WEB_ASSETS_VERSION = v7.0.0-rc.14
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
bump web to v7.0.0-rc.14

includes permission checks, so this should unblock further work on defining roles via config. cc @micbar 