### PR TITLE
[tests-only] Fix command format in tests/acceptance/run.sh

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -27,14 +27,14 @@ then
 	# explicitly tell Behat to not do colored output
 	COLORS_OPTION="--no-colors"
 	# Use the Bash "null" command to do nothing, rather than use tput to set a color
-	RED_COLOR = ":"
-	GREEN_COLOR = ":"
-	YELLOW_COLOR = ":"
+	RED_COLOR=":"
+	GREEN_COLOR=":"
+	YELLOW_COLOR=":"
 else
 	COLORS_OPTION="--colors"
-	RED_COLOR = "tput setaf 1"
-	GREEN_COLOR = "tput setaf 2"
-	YELLOW_COLOR = "tput setaf 3"
+	RED_COLOR="tput setaf 1"
+	GREEN_COLOR="tput setaf 2"
+	YELLOW_COLOR="tput setaf 3"
 fi
 
 # The following environment variables can be specified:


### PR DESCRIPTION
## Description
I got the assignment format wrong in PR #5598 
When running acceptance tests, `run.sh` emits:
```
./tests/acceptance/run.sh: line 38: RED_COLOR: command not found
./tests/acceptance/run.sh: line 39: GREEN_COLOR: command not found
./tests/acceptance/run.sh: line 40: YELLOW_COLOR: command not found
```

There should not be spaces around the `=` assignment operator.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
