### PR TITLE
Fix invalid type in ocis_traefik docker-compose file

### DIFF
--- a/deployments/examples/ocis_traefik/docker-compose.yml
+++ b/deployments/examples/ocis_traefik/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       NOTIFICATIONS_SMTP_PORT: 2500
       NOTIFICATIONS_SMTP_SENDER: oCIS notifications <notifications@${OCIS_DOMAIN:-ocis.owncloud.test}>
       NOTIFICATIONS_SMTP_USERNAME: notifications@${OCIS_DOMAIN:-ocis.owncloud.test}
-      NOTIFICATIONS_SMTP_INSECURE: true # the mail catcher uses self signed certificates
+      NOTIFICATIONS_SMTP_INSECURE: "true" # the mail catcher uses self signed certificates
     volumes:
       - ocis-config:/etc/ocis
       - ocis-data:/var/lib/ocis


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Fix for
`ERROR: The Compose file './docker-compose.yml' is invalid because: services.ocis.environment.NOTIFICATIONS_SMTP_INSECURE contains true, which is an invalid type, it should be a string, number, or a null`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
