### PR TITLE
thumbnails: Add portrait resolutions to default config

### DIFF
--- a/changelog/unreleased/portrait-thumbnails.md
+++ b/changelog/unreleased/portrait-thumbnails.md
@@ -2,4 +2,4 @@ Bugfix: Add portrait thumbnail resolutions
 
 Add portrait-orientation resolutions to the thumbnail service's default configuration. This prevents portrait photos from being heavily cropped into landscape resolutions in the web viewer.
 
-#5656
+https://github.com/owncloud/ocis/pull/5656

--- a/changelog/unreleased/portrait-thumbnails.md
+++ b/changelog/unreleased/portrait-thumbnails.md
@@ -1,0 +1,5 @@
+Bugfix: Add portrait thumbnail resolutions
+
+Add portrait-orientation resolutions to the thumbnail service's default configuration. This prevents portrait photos from being heavily cropped into landscape resolutions in the web viewer.
+
+#5656

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -37,7 +37,7 @@ func DefaultConfig() *config.Config {
 			Name: "thumbnails",
 		},
 		Thumbnail: config.Thumbnail{
-			Resolutions: []string{"16x16", "32x32", "64x64", "128x128", "1920x1080", "3840x2160", "7680x4320"},
+			Resolutions: []string{"16x16", "32x32", "64x64", "128x128", "1080x1920", "1920x1080", "2160x3840", "3840x2160", "4320x7680", "7680x4320"},
 			FileSystemStorage: config.FileSystemStorage{
 				RootDirectory: path.Join(defaults.BaseDataPath(), "thumbnails"),
 			},


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This adds corresponding portrait-orientation resolutions for each existing landscape-orientation resolution to the thumbnailer service's default config.

## Related Issue
This improves, but does not actually fix, the following bug (affecting web):
- https://github.com/owncloud/ocis/issues/5179 
- https://github.com/owncloud/web/issues/7728 

## Motivation and Context
Cropping portrait-orientation photos to landscape greatly reduces the usefulness of the resulting thumbnails (see the screenshots section below.)

## How Has This Been Tested?
I added these three portrait-orientation resolutions to the config on my own server, and it improved the behavior by allowing a portrait-orientation photo to have a portrait-orientation preview. (The behavior is still not ideal because the preview should not be cropped at all, but this at least allows me to see most of the image in the preview, instead of a small fraction of it.)

## Screenshots (if appropriate):
I have been uploading scanned documents to my OCIS server, some of which are in image format. Below is what a document looked like with the current default config (left), and what it looks like after adding the portrait orientations (right):

![image](https://user-images.githubusercontent.com/7199422/221432146-a106cce7-e4a2-4c65-92ac-8831e74e1bf4.png)

Much more of the image is now visible in the web view.

Although this isn't a proper fix for the web view bug, it seems to make sense that anyone with a portrait-orientation photo and using it in a cropped/thumbnailed context would prefer to have more of their photo appear in the thumbnail. Adding the portrait orientations to the default config was suggested by an ownCloud developer [here](https://github.com/owncloud/ocis/issues/5179#issuecomment-1337496949).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
