### PR TITLE
Add Permission to change project space quota

### DIFF
--- a/changelog/unreleased/set-project-space-quota-permission.md
+++ b/changelog/unreleased/set-project-space-quota-permission.md
@@ -1,0 +1,5 @@
+Enhancement: Add new SetProjectSpaceQuota permission
+
+Additionally to `set-space-quota` for setting quota on personal spaces we now have `Drive.ReadWriteQuota.Project` for setting project spaces quota
+
+https://github.com/owncloud/ocis/pull/5660

--- a/go.mod
+++ b/go.mod
@@ -291,3 +291,5 @@ require (
 )
 
 replace github.com/cs3org/go-cs3apis => github.com/c0rby/go-cs3apis v0.0.0-20230110100311-5b424f1baa35
+
+replace github.com/cs3org/reva/v2 => github.com/kobergj/reva/v2 v2.0.0-20230227101854-eed3cfa1324f

--- a/go.sum
+++ b/go.sum
@@ -343,8 +343,6 @@ github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3p
 github.com/crewjam/saml v0.4.6/go.mod h1:ZBOXnNPFzB3CgOkRm7Nd6IVdkG+l/wF+0ZXLqD96t1A=
 github.com/crewjam/saml v0.4.9 h1:X2jDv4dv3IvfT9t+RhADavzNFAcq3fVxzTCIH3G605U=
 github.com/crewjam/saml v0.4.9/go.mod h1:9Zh6dWPtB3MSzTRt8fIFH60Z351QQ+s7hCU3J/tTlA4=
-github.com/cs3org/reva/v2 v2.12.1-0.20230222151731-83c7b4d26b2b h1:wIwnuSyH8tM4dbr16UYEoYF7ESlfxah2q99oz/FscU0=
-github.com/cs3org/reva/v2 v2.12.1-0.20230222151731-83c7b4d26b2b/go.mod h1:dbaNP2U3nGQA5BHLc5w/hqviq7b0F4eygNwC38jeaiU=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -872,6 +870,8 @@ github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0 h1:eyi1Ad2aNJMW95zcSbmGg7Cg6cq3ADwLpMAP96d8rF0=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/kobergj/reva/v2 v2.0.0-20230227101854-eed3cfa1324f h1:ntyscpHQqymhGH6AmT9FA4ThSPoVF2wkFWhKRE90Ep8=
+github.com/kobergj/reva/v2 v2.0.0-20230227101854-eed3cfa1324f/go.mod h1:dbaNP2U3nGQA5BHLc5w/hqviq7b0F4eygNwC38jeaiU=
 github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b/go.mod h1:o03bZfuBwAXHetKXuInt4S7omeXUu62/A845kiycsSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -33,10 +33,15 @@ const (
 	// LanguageReadWriteName is the hardcoded setting name for the language read write permission
 	LanguageReadWriteName string = "language-readwrite"
 
-	// SetSpaceQuotaPermissionID is the hardcoded setting UUID for the set space quota permission
-	SetSpaceQuotaPermissionID string = "4e6f9709-f9e7-44f1-95d4-b762d27b7896"
-	// SetSpaceQuotaPermissionName is the hardcoded setting name for the set space quota permission
-	SetSpaceQuotaPermissionName string = "set-space-quota"
+	// SetPersonalSpaceQuotaPermissionID is the hardcoded setting UUID for the set personal space quota permission
+	SetPersonalSpaceQuotaPermissionID string = "4e6f9709-f9e7-44f1-95d4-b762d27b7896"
+	// SetPersonalSpaceQuotaPermissionName is the hardcoded setting name for the set personal space quota permission
+	SetPersonalSpaceQuotaPermissionName string = "set-space-quota"
+
+	// SetProjectSpaceQuotaPermissionID is the hardcoded setting UUID for the set project space quota permission
+	SetProjectSpaceQuotaPermissionID string = "977f0ae6-0da2-4856-93f3-22e0a8482489"
+	// SetProjectSpaceQuotaPermissionName is the hardcoded setting name for the set project space quota permission
+	SetProjectSpaceQuotaPermissionName string = "Drive.ReadWriteQuota.Project"
 
 	// ListAllSpacesPermissionID is the hardcoded setting UUID for the list all spaces permission
 	ListAllSpacesPermissionID string = "016f6ddd-9501-4a0a-8ebe-64a20ee8ec82"
@@ -191,10 +196,25 @@ func generateBundleAdminRole() *settingsmsg.Bundle {
 				},
 			},
 			{
-				Id:          SetSpaceQuotaPermissionID,
-				Name:        SetSpaceQuotaPermissionName,
-				DisplayName: "Set Space Quota",
-				Description: "This permission allows to manage space quotas.",
+				Id:          SetPersonalSpaceQuotaPermissionID,
+				Name:        SetPersonalSpaceQuotaPermissionName,
+				DisplayName: "Set Personal Space Quota",
+				Description: "This permission allows to manage personal space quotas.",
+				Resource: &settingsmsg.Resource{
+					Type: settingsmsg.Resource_TYPE_SYSTEM,
+				},
+				Value: &settingsmsg.Setting_PermissionValue{
+					PermissionValue: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+						Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+					},
+				},
+			},
+			{
+				Id:          SetProjectSpaceQuotaPermissionID,
+				Name:        SetProjectSpaceQuotaPermissionName,
+				DisplayName: "Set Project Space Quota",
+				Description: "This permission allows to manage project space quotas.",
 				Resource: &settingsmsg.Resource{
 					Type: settingsmsg.Resource_TYPE_SYSTEM,
 				},
@@ -326,10 +346,10 @@ func generateBundleSpaceAdminRole() *settingsmsg.Bundle {
 				},
 			},
 			{
-				Id:          SetSpaceQuotaPermissionID,
-				Name:        SetSpaceQuotaPermissionName,
-				DisplayName: "Set Space Quota",
-				Description: "This permission allows to manage space quotas.",
+				Id:          SetProjectSpaceQuotaPermissionID,
+				Name:        SetProjectSpaceQuotaPermissionName,
+				DisplayName: "Set Project Space Quota",
+				Description: "This permission allows to manage project space quotas.",
 				Resource: &settingsmsg.Resource{
 					Type: settingsmsg.Resource_TYPE_SYSTEM,
 				},

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -38,4 +38,4 @@ sonar.go.golangci-lint.reportPaths=cache/checkstyle/app-provider_checkstyle.xml,
 # Exclude files
 sonar.exclusions=**/third_party,docs/**,changelog/**,*/pkg/assets/embed.go,idp/assets/identifier/**,**/package.json,**/rollup.config.js,CHANGELOG.md,**/pkg/proto/**/*.pb.*,deployments/**,tests/**,vendor-bin/**,README.md,**/mocks/
 sonar.coverage.exclusions=**/*_test.go,**mocks/**,/protogen/**
-sonar.cpd.exclusions=**/*_test.go,**/revaconfig/**
+sonar.cpd.exclusions=**/*_test.go,**/revaconfig/**,services/settings/pkg/store/defaults/defaults.go


### PR DESCRIPTION
Adds a new permission `Drive.ReadWriteQuota.Project` (following new naming scheme) which allows to change the space quota for a project space. `set-space-quota` (old naming scheme) will still be needed when changing personal space quota.

The new permission is assigned to both, the `admin` and the `spaceadmin`
