### PR TITLE
fix: make ldap example use share for certs

### DIFF
--- a/deployments/examples/ocis_ldap/config/ldap/docker-entrypoint-override.sh
+++ b/deployments/examples/ocis_ldap/config/ldap/docker-entrypoint-override.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 printenv
 
-if [ ! -f /opt/bitnami/openldap/certs/openldap.key ]
+if [ ! -f /opt/bitnami/openldap/share/openldap.key ]
 then	
-	openssl req -x509 -newkey rsa:4096 -keyout /opt/bitnami/openldap/certs/openldap.key -out /opt/bitnami/openldap/certs/openldap.crt -sha256 -days 365 -batch -nodes
+	openssl req -x509 -newkey rsa:4096 -keyout /opt/bitnami/openldap/share/openldap.key -out /opt/bitnami/openldap/share/openldap.crt -sha256 -days 365 -batch -nodes
 fi
 # run original docker-entrypoint
 /opt/bitnami/scripts/openldap/entrypoint.sh "$@"

--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -112,9 +112,9 @@ services:
       BITNAMI_DEBUG: true
       LDAP_TLS_VERIFY_CLIENT: never
       LDAP_ENABLE_TLS: "yes"
-      LDAP_TLS_CA_FILE: /opt/bitnami/openldap/certs/openldap.crt
-      LDAP_TLS_CERT_FILE: /opt/bitnami/openldap/certs/openldap.crt
-      LDAP_TLS_KEY_FILE: /opt/bitnami/openldap/certs/openldap.key
+      LDAP_TLS_CA_FILE: /opt/bitnami/openldap/share/openldap.crt
+      LDAP_TLS_CERT_FILE: /opt/bitnami/openldap/share/openldap.crt
+      LDAP_TLS_KEY_FILE: /opt/bitnami/openldap/share/openldap.key
       LDAP_ROOT: "dc=owncloud,dc=com"
       LDAP_ADMIN_PASSWORD: ${LDAP_ADMIN_PASSWORD:-admin}
     ports:
@@ -124,7 +124,7 @@ services:
       - ./config/ldap/ldif:/ldifs
       - ./config/ldap/schemas:/schemas
       - ./config/ldap/docker-entrypoint-override.sh:/opt/bitnami/scripts/openldap/docker-entrypoint-override.sh
-      - ldap-certs:/opt/bitnami/openldap/certs
+      - ldap-certs:/opt/bitnami/openldap/share
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always


### PR DESCRIPTION
## Description
In the current docker-compose example the ldap server fails to start with

```
ocis_ldap-ldap-server-1  | writing new private key to '/opt/bitnami/openldap/certs/openldap.key'
ocis_ldap-ldap-server-1  | req: Can't open "/opt/bitnami/openldap/certs/openldap.key" for writing, Permission denied
```

This is due to `/opt/bitnami/openldap/certs/` being only writeable by root not the 1001 user used in the container. Possible directories to use are listen in https://github.com/bitnami/containers/blob/ca697710be7e425fbf07aa04649209e4279bf29e/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/openldap/postunpack.sh#L18. @wkloucek and myself decided to use  `/opt/bitnami/openldap/share`

## Motivation and Context
Non-starting ldap container in example

## How Has This Been Tested?
Tested by myself

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
