### PR TITLE
[full-ci] [tests-only] Remove depthinfinity related steps from occ context master

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -680,14 +680,14 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 
 #### [Cannot disable the dav propfind depth infinity for resources](https://github.com/owncloud/ocis/issues/3720)
 
-- [coreApiWebdavOperations/listFiles.feature:368](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L368)
-- [coreApiWebdavOperations/listFiles.feature:369](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L369)
-- [coreApiWebdavOperations/listFiles.feature:374](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L374)
-- [coreApiWebdavOperations/listFiles.feature:393](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L393)
-- [coreApiWebdavOperations/listFiles.feature:388](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L388)
-- [coreApiWebdavOperations/listFiles.feature:407](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L407)
-- [coreApiWebdavOperations/listFiles.feature:408](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L408)
-- [coreApiWebdavOperations/listFiles.feature:413](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L413)
+- [coreApiWebdavOperations/listFiles.feature:364](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L364)
+- [coreApiWebdavOperations/listFiles.feature:365](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L365)
+- [coreApiWebdavOperations/listFiles.feature:370](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L370)
+- [coreApiWebdavOperations/listFiles.feature:384](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L384)
+- [coreApiWebdavOperations/listFiles.feature:389](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L389)
+- [coreApiWebdavOperations/listFiles.feature:403](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L403)
+- [coreApiWebdavOperations/listFiles.feature:404](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L404)
+- [coreApiWebdavOperations/listFiles.feature:409](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature#L409)
 
 ### [graph/users: enable/disable users](https://github.com/owncloud/ocis/issues/3064)
 

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -868,27 +868,6 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator has set depth_infinity_allowed to :depth_infinity_allowed
-	 *
-	 * @param int $depthInfinityAllowed
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theAdministratorHasSetDepthInfinityAllowedTo($depthInfinityAllowed) {
-		$depthInfinityAllowedString = (string) $depthInfinityAllowed;
-		$this->addSystemConfigKeyUsingTheOccCommand(
-			"dav.propfind.depth_infinity",
-			$depthInfinityAllowedString
-		);
-		if ($depthInfinityAllowedString === "0") {
-			$this->featureContext->davPropfindDepthInfinityDisabled();
-		} else {
-			$this->featureContext->davPropfindDepthInfinityEnabled();
-		}
-	}
-
-	/**
 	 * @Given the administrator has set the mail smtpmode to :smtpmode
 	 *
 	 * @param string $smtpmode

--- a/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
@@ -76,7 +76,6 @@ Feature: list files
   @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of resources in the root folder with depth infinity
     Given using <dav_version> DAV path
-    And the administrator has set depth_infinity_allowed to 1
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -158,7 +157,6 @@ Feature: list files
   @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of resources in a folder with depth infinity
     Given using <dav_version> DAV path
-    And the administrator has set depth_infinity_allowed to 1
     When user "Alice" lists the resources in "/simple-folder" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -238,7 +236,6 @@ Feature: list files
   @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of resources in a folder shared through public link with depth infinity
     Given using <dav_version> DAV path
-    And the administrator has set depth_infinity_allowed to 1
     And user "Alice" has created the following folders
       | path                                                                       |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |
@@ -329,7 +326,6 @@ Feature: list files
   @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of files in the trashbin with depth infinity
     Given using <dav_version> DAV path
-    And the administrator has set depth_infinity_allowed to 1
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |

--- a/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
@@ -18,26 +18,19 @@ Feature: PROPFIND
 
   Scenario Outline: PROPFIND to "/remote.php/dav/(files|spaces)" with depth header
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has set depth_infinity_allowed to <depth_infinity_allowed>
     When user "Alice" requests "<dav_path>" with "PROPFIND" using basic auth and with headers
       | header | value   |
       | depth  | <depth> |
     Then the HTTP status code should be "<http_status>"
-    @skipOnOcV10 @depthInfinityPropfindEnabled
     Examples:
-      | dav_path                    | depth_infinity_allowed | depth    | http_status |
-      | /remote.php/dav/files/alice | 1                      | 0        | 207         |
-      | /remote.php/dav/files/alice | 1                      | infinity | 207         |
-    @skipOnOcV10 @personalSpace @depthInfinityPropfindDisabled
+      | dav_path                    | depth    | http_status |
+      | /remote.php/dav/files/alice | 0        | 207         |
+      | /remote.php/dav/files/alice | infinity | 207         |
+    @personalSpace
     Examples:
-      | dav_path                         | depth_infinity_allowed | depth    | http_status |
-      | /remote.php/dav/spaces/%spaceid% | 0                      | 0        | 207         |
-      | /remote.php/dav/spaces/%spaceid% | 0                      | infinity | 207         |
-    @skipOnOcV10 @personalSpace @depthInfinityPropfindEnabled
-    Examples:
-      | dav_path                         | depth_infinity_allowed | depth    | http_status |
-      | /remote.php/dav/spaces/%spaceid% | 1                      | 0        | 207         |
-      | /remote.php/dav/spaces/%spaceid% | 1                      | infinity | 207         |
+      | dav_path                         | depth    | http_status |
+      | /remote.php/dav/spaces/%spaceid% | 0        | 207         |
+      | /remote.php/dav/spaces/%spaceid% | infinity | 207         |
 
 
   Scenario: send PROPFIND request to a public link


### PR DESCRIPTION
Forward port of PR https://github.com/owncloud/ocis/pull/5642

Part of https://github.com/owncloud/ocis/issues/5337