### PR TITLE
make graph/education API errors more consistent

### DIFF
--- a/changelog/unreleased/graph-education-errors.md
+++ b/changelog/unreleased/graph-education-errors.md
@@ -1,0 +1,6 @@
+Enhancement: Make graph/education API errors more consistent
+
+Aligned the error messages when creating schools and classes fail and changed the response code from 500 to 409.
+
+https://github.com/owncloud/ocis/pull/5682
+https://github.com/owncloud/ocis/issues/5660

--- a/services/graph/pkg/identity/ldap_education_class.go
+++ b/services/graph/pkg/identity/ldap_education_class.go
@@ -80,6 +80,13 @@ func (i *LDAP) CreateEducationClass(ctx context.Context, class libregraph.Educat
 	}
 
 	if err := i.conn.Add(ar); err != nil {
+		var lerr *ldap.Error
+		logger.Debug().Err(err).Msg("error adding class")
+		if errors.As(err, &lerr) {
+			if lerr.ResultCode == ldap.LDAPResultEntryAlreadyExists {
+				err = errorcode.New(errorcode.NameAlreadyExists, lerr.Error())
+			}
+		}
 		return nil, err
 	}
 

--- a/services/graph/pkg/service/v0/educationclasses.go
+++ b/services/graph/pkg/service/v0/educationclasses.go
@@ -83,6 +83,11 @@ func (g Graph) PostEducationClass(w http.ResponseWriter, r *http.Request) {
 
 	if class, err = g.identityEducationBackend.CreateEducationClass(r.Context(), *class); err != nil {
 		logger.Debug().Interface("class", class).Msg("could not create class: backend error")
+		var eerr errorcode.Error
+		if errors.As(err, &eerr) {
+			eerr.Render(w, r)
+			return
+		}
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -87,6 +87,11 @@ func (g Graph) PostEducationSchool(w http.ResponseWriter, r *http.Request) {
 
 	if school, err = g.identityEducationBackend.CreateEducationSchool(r.Context(), *school); err != nil {
 		logger.Debug().Err(err).Interface("school", school).Msg("could not create school: backend error")
+		var eerr errorcode.Error
+		if errors.As(err, &eerr) {
+			eerr.Render(w, r)
+			return
+		}
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/services/graph/pkg/service/v0/errorcode/errorcode.go
+++ b/services/graph/pkg/service/v0/errorcode/errorcode.go
@@ -100,9 +100,14 @@ func (e ErrorCode) Render(w http.ResponseWriter, r *http.Request, status int, ms
 }
 
 func (e Error) Render(w http.ResponseWriter, r *http.Request) {
-	status := http.StatusInternalServerError
-	if e.errorCode == ItemNotFound {
+	var status int
+	switch e.errorCode {
+	case ItemNotFound:
 		status = http.StatusNotFound
+	case NameAlreadyExists:
+		status = http.StatusConflict
+	default:
+		status = http.StatusInternalServerError
 	}
 	e.errorCode.Render(w, r, status, e.msg)
 }


### PR DESCRIPTION
 Aligned the error messages when creating schools and classes fail and changed the response code from 500 to 409.
 
 Fixes: https://github.com/owncloud/ocis/issues/5660