### PR TITLE
Benchmark options

### DIFF
--- a/ocis/pkg/command/benchmark.go
+++ b/ocis/pkg/command/benchmark.go
@@ -188,10 +188,14 @@ func client(o clientOptions) error {
 				return
 			}
 
+			cookies := map[string]*http.Cookie{}
 			for {
 				req.Header.Set("Authorization", strings.TrimSpace(o.auth()))
 				for k, v := range o.headers {
 					req.Header.Set(k, v)
+				}
+				for _, cookie := range cookies {
+					req.AddCookie(cookie)
 				}
 
 				start := time.Now()
@@ -205,6 +209,9 @@ func client(o clientOptions) error {
 						job:      i,
 						duration: -time.Until(start),
 						status:   res.StatusCode,
+					}
+					for _, c := range res.Cookies() {
+						cookies[c.Name] = c
 					}
 				}
 			}

--- a/ocis/pkg/command/benchmark.go
+++ b/ocis/pkg/command/benchmark.go
@@ -139,7 +139,7 @@ func BenchmarkClientCommand(cfg *config.Config) *cli.Command {
 					case "s":
 						unit = time.Second
 					case "m":
-						unit = time.Second
+						unit = time.Minute
 					case "d":
 						unit = time.Hour * 24
 					default:

--- a/ocis/pkg/command/benchmark.go
+++ b/ocis/pkg/command/benchmark.go
@@ -211,14 +211,13 @@ func client(o clientOptions) error {
 			}
 			client := &http.Client{Transport: tr}
 
-			req, err := http.NewRequest(o.request, o.url, bytes.NewReader(o.data))
-			if err != nil {
-				log.Printf("client %d: could not create request: %s\n", i, err)
-				return
-			}
-
 			cookies := map[string]*http.Cookie{}
 			for {
+				req, err := http.NewRequest(o.request, o.url, bytes.NewReader(o.data))
+				if err != nil {
+					log.Printf("client %d: could not create request: %s\n", i, err)
+					return
+				}
 				req.Header.Set("Authorization", strings.TrimSpace(o.auth()))
 				for k, v := range o.headers {
 					req.Header.Set(k, v)


### PR DESCRIPTION
benchmark clients now remember cookies the server sent (for oc10 basic auth), we added a `--rate {num}(/{unit})` option to limit the number of requests a client is allowed to make, and we fixed a bug caused by reusing the request.

These options allow setting up clients the continuously PUT a file e.g. once every second while another process starts 10 clients that continuuosly sends PROPFINDs. Also works against oc10.

Together this can be used to simulate various access patterns.