### PR TITLE
[full-ci][tests-only] Extend tests coverage to add users in a group 

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -503,6 +503,8 @@ class GraphHelper {
 	}
 
 	/**
+	 * add multiple users to a group at once
+	 *
 	 * @param string $baseUrl
 	 * @param string $xRequestId
 	 * @param string $adminUser
@@ -526,6 +528,42 @@ class GraphHelper {
 		foreach ($userIds as $userId) {
 			$payload["members@odata.bind"][] = self::getFullUrl($baseUrl, 'users/' . $userId);
 		}
+		return HttpRequestHelper::sendRequest(
+			$url,
+			$xRequestId,
+			'PATCH',
+			$adminUser,
+			$adminPassword,
+			self::getRequestHeaders(),
+			\json_encode($payload)
+		);
+	}
+
+	/**
+	 * tries to add a group to a group
+	 *
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @param string $groupId
+	 * @param string $groupIdToAdd
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function addGroupToGroup(
+		string $baseUrl,
+		string $xRequestId,
+		string $adminUser,
+		string $adminPassword,
+		string $groupId,
+		string $groupIdToAdd
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, 'groups/' . $groupId);
+		$payload = [
+			"@odata.id" => self::getFullUrl($baseUrl, 'groups/' . $groupIdToAdd)
+		];
 		return HttpRequestHelper::sendRequest(
 			$url,
 			$xRequestId,
@@ -713,7 +751,7 @@ class GraphHelper {
 			$payload['mail'] = $email;
 		}
 		$payload['accountEnabled'] = $accountEnabled;
-		
+
 		return \json_encode($payload);
 	}
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -111,5 +111,12 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 #### Change editUser test where we set empty value
 - [apiGraph/editUser.feature:33](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L33)
 - [apiGraph/editUser.feature:80](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L80)
+
+#### [Same users can be added in a group multiple time](https://github.com/owncloud/ocis/issues/5702)
+- [apiGraph/addUserToGroup.feature:222](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L222)
+
+#### [Try to add group to a group return 204](https://github.com/owncloud/ocis/issues/5793)
+- [apiGraph/addUserToGroup.feature:244](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L244)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -217,4 +217,39 @@ Feature: add users to group
     And the following users should be listed in the following groups
       | username | groupname |
       | Alice    | sales     |
-      
+
+  @issue-5702
+  Scenario: try to add users to a group twice
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+      | Carol    |
+    And user "Alice" has created a group "grp1" using the Graph API
+    And the administrator "Alice" has added the following users to a group "grp1" at once using the Graph API
+      | username |
+      | Brian    |
+      | Carol    |
+    When the administrator "Alice" adds the following users to a group "grp1" at once using the Graph API
+      | username |
+      | Brian    |
+      | Carol    |
+    Then the HTTP status code should be "400"
+    And the following users should be listed in the following groups
+      | username | groupname |
+      | Brian    | grp1      |
+      | Carol    | grp1      |
+
+  @issue-5793
+  Scenario: try to add a group to a group
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+    And these groups have been created:
+      | groupname |
+      | student   |
+      | music     |
+    And user "Brian" has been added to group "music"
+    When the administrator "Alice" tries to add a group "music" to a group "student" using the Graph API
+    Then the HTTP status code should be "400"

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2060,4 +2060,57 @@ class GraphContext implements Context {
 			)
 		);
 	}
+
+	/**
+	 * @Given /^the administrator "([^"]*)" has added the following users to a group "([^"]*)" at once using the Graph API$/
+	 *
+	 * @param string $user
+	 * @param string $group
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theAdministratorHasAddedTheFollowingUsersToAGroupAtOnceUsingTheGraphApi(string $user, string $group, TableNode $table) {
+		$userIds = [];
+		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
+		foreach ($table->getHash() as $row) {
+			$userIds[] = $this->featureContext->getAttributeOfCreatedUser($row['username'], "id");
+		}
+		$this->addMultipleUsersToGroup($user, $userIds, $groupId, $table);
+		$response = $this->featureContext->getResponse();
+		if ($response->getStatusCode() !== 204) {
+			$$this->throwHttpException($response, "Cannot add users to group '$group'");
+		}
+		$this->featureContext->emptyLastHTTPStatusCodesArray();
+	}
+
+	/**
+	 * @When /^the administrator "([^"]*)" tries to add a group "([^"]*)" to a group "([^"]*)" using the Graph API$/
+	 *
+	 * @param string $user
+	 * @param string $groupToAdd
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theAdministratorAddGroupToAGroupAtOnceUsingTheGraphApi(string $user, string $groupToAdd, string $group) {
+		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
+		$groupIdToAdd = $this->featureContext->getAttributeOfCreatedGroup($groupToAdd, "id");
+		$credentials = $this->getAdminOrUserCredentials($user);
+
+		$this->featureContext->setResponse(
+			GraphHelper::addGroupToGroup(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getStepLineRef(),
+				$credentials["username"],
+				$credentials["password"],
+				$groupId,
+				$groupIdToAdd
+			)
+		);
+	}
 }


### PR DESCRIPTION
## Description
This PR adds difference scenario related adding users in a group at once
- try to add users to the group that are already part of the group https://github.com/owncloud/ocis/issues/5702
- try to add a group to a group https://github.com/owncloud/ocis/issues/5793

## Related Issue
- https://github.com/owncloud/ocis/issues/5569

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
