### PR TITLE
[docs-only] Add the minimum go version needed for compiling in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See the [Quick Guide](https://doc.owncloud.com/ocis/next/quickguide/quickguide.h
 
 ### Use the ocis Repo as Source
 
-Use this method to run an instance with the latest code. This is only recommended for development purposes. To build and run a local instance with demo users:
+Use this method to run an instance with the latest code. This is only recommended for development purposes. The minimum go version required is 1.19. To build and run a local instance with demo users:
 
 ```console
 # get the source


### PR DESCRIPTION
This just adds the minim go version required for compiling in the README.md file.