### PR TITLE
[tests-only] Add commands for missing Services

### DIFF
--- a/ocis/pkg/command/eventhistory.go
+++ b/ocis/pkg/command/eventhistory.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
+	"github.com/owncloud/ocis/v2/ocis/pkg/register"
+	"github.com/owncloud/ocis/v2/services/eventhistory/pkg/command"
+	"github.com/urfave/cli/v2"
+)
+
+// EventHistoryCommand is the entrypoint for the eventhistory command.
+func EventHistoryCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:     cfg.EventHistory.Service.Name,
+		Usage:    helper.SubcommandDescription(cfg.EventHistory.Service.Name),
+		Category: "services",
+		Before: func(c *cli.Context) error {
+			configlog.Error(parser.ParseConfig(cfg, true))
+			cfg.EventHistory.Commons = cfg.Commons
+			return nil
+		},
+		Subcommands: command.GetCommands(cfg.EventHistory),
+	}
+}
+
+func init() {
+	register.AddCommand(EventHistoryCommand)
+}

--- a/ocis/pkg/command/postprocessing.go
+++ b/ocis/pkg/command/postprocessing.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
+	"github.com/owncloud/ocis/v2/ocis/pkg/register"
+	"github.com/owncloud/ocis/v2/services/postprocessing/pkg/command"
+	"github.com/urfave/cli/v2"
+)
+
+// PostprocessingCommand is the entrypoint for the postprocessing command.
+func PostprocessingCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:     cfg.Postprocessing.Service.Name,
+		Usage:    helper.SubcommandDescription(cfg.Postprocessing.Service.Name),
+		Category: "services",
+		Before: func(c *cli.Context) error {
+			configlog.Error(parser.ParseConfig(cfg, true))
+			cfg.Postprocessing.Commons = cfg.Commons
+			return nil
+		},
+		Subcommands: command.GetCommands(cfg.Postprocessing),
+	}
+}
+
+func init() {
+	register.AddCommand(PostprocessingCommand)
+}

--- a/ocis/pkg/command/userlog.go
+++ b/ocis/pkg/command/userlog.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	"github.com/owncloud/ocis/v2/ocis/pkg/command/helper"
+	"github.com/owncloud/ocis/v2/ocis/pkg/register"
+	"github.com/owncloud/ocis/v2/services/userlog/pkg/command"
+	"github.com/urfave/cli/v2"
+)
+
+// UserlogCommand is the entrypoint for the userlog command.
+func UserlogCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:     cfg.Userlog.Service.Name,
+		Usage:    helper.SubcommandDescription(cfg.Userlog.Service.Name),
+		Category: "services",
+		Before: func(c *cli.Context) error {
+			configlog.Error(parser.ParseConfig(cfg, true))
+			cfg.Userlog.Commons = cfg.Commons
+			return nil
+		},
+		Subcommands: command.GetCommands(cfg.Userlog),
+	}
+}
+
+func init() {
+	register.AddCommand(UserlogCommand)
+}


### PR DESCRIPTION
Adds commands for recently introduced services `userlog`, `eventhistory` and `postprocessing`, which were forgotten on initial implementation