### PR TITLE
[ci] Enable Github comment for e2e tracing results on failure

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1144,7 +1144,8 @@ def e2eTests(ctx):
         ocisServer("ocis", 4, []) + \
         e2e_test_ocis + \
         uploadTracingResult(ctx) + \
-        publishTracingResult(ctx, "e2e test")
+        buildTracingComment() + \
+        e2eGithubComment()
 
     if ("skip-e2e" in ctx.build.title.lower()):
         return []
@@ -1177,7 +1178,7 @@ def uploadTracingResult(ctx):
             "path_style": True,
             "source": "webTestRunner/reports/e2e/playwright/tracing/**/*",
             "strip_prefix": "webTestRunner/reports/e2e/playwright/tracing",
-            "target": "${DRONE_BUILD_NUMBER}/tracing",
+            "target": "/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/tracing",
         },
         "environment": {
             "AWS_ACCESS_KEY_ID": {
@@ -1198,19 +1199,18 @@ def uploadTracingResult(ctx):
         },
     }]
 
-def publishTracingResult(ctx, suite):
+def buildTracingComment():
     return [{
-        "name": "publish-tracing-result",
+        "name": "build-tracing-comment",
         "image": OC_UBUNTU,
         "commands": [
             "cd %s/reports/e2e/playwright/tracing/" % dirs["web"],
             'echo "<details><summary>:boom: To see the trace, please open the link in the console ...</summary>\\n\\n<p>\\n\\n" >>  comments.file',
-            'for f in *.zip; do echo "#### npx playwright show-trace $CACHE_ENDPOINT/$CACHE_BUCKET/${DRONE_BUILD_NUMBER}/tracing/$f \n" >>  comments.file; done',
+            'for f in *.zip; do echo "#### npx playwright show-trace $CACHE_ENDPOINT/$CACHE_BUCKET/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/tracing/$f \n" >>  comments.file; done',
             'echo "\n</p></details>" >>  comments.file',
             "more  comments.file",
         ],
         "environment": {
-            "TEST_CONTEXT": suite,
             "CACHE_ENDPOINT": {
                 "from_secret": "cache_public_s3_server",
             },
@@ -1225,6 +1225,34 @@ def publishTracingResult(ctx, suite):
             "event": [
                 "pull_request",
                 "cron",
+            ],
+        },
+    }]
+
+def e2eGithubComment():
+    prefix = "E2E tests failed: ${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1"
+    return [{
+        "name": "github-comment",
+        "image": THEGEEKLAB_DRONE_GITHUB_COMMENT,
+        "pull": "if-not-exists",
+        "settings": {
+            "message": "%s/reports/e2e/playwright/tracing/comments.file" % dirs["web"],
+            "key": "pr-${DRONE_PULL_REQUEST}",
+            "update": "true",
+            "api_key": {
+                "from_secret": "github_token",
+            },
+        },
+        "commands": [
+            "cd %s/reports/e2e/playwright/tracing/" % dirs["web"],
+            "if [ -s comments.file ]; then echo '%s' | cat - comments.file > temp && mv temp comments.file && /bin/drone-github-comment; fi" % prefix,
+        ],
+        "when": {
+            "status": [
+                "failure",
+            ],
+            "event": [
+                "pull_request",
             ],
         },
     }]


### PR DESCRIPTION
## Description
Enable Github comment for e2e tracing results on tests failure

![Screenshot from 2023-03-02 16-41-01](https://user-images.githubusercontent.com/52366632/222409158-66e7fa0c-260e-4654-ac55-760e5f8313d1.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
