### PR TITLE
[ci] Cache the go/bin content as a single archive file

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -416,7 +416,7 @@ def cacheGoBin():
             "name": "archive-go-bin",
             "image": OC_UBUNTU,
             "commands": [
-                "tar -czvf %s -C /go/bin ." % dirs["gobinTarPath"],
+                "tar -czvf %s /go/bin" % dirs["gobinTarPath"],
             ],
             "volumes": [stepVolumeGo],
         },
@@ -453,9 +453,7 @@ def restoreGoBinCache():
             "name": "extract-go-bin-cache",
             "image": OC_UBUNTU,
             "commands": [
-                "mkdir -p /go/bin",
-                "tar -xvf %s -C /go/bin" % dirs["gobinTarPath"],
-                "chmod +x /go/bin/*",
+                "tar -xvmf %s -C /" % dirs["gobinTarPath"],
             ],
             "volumes": [stepVolumeGo],
         },

--- a/.drone.star
+++ b/.drone.star
@@ -146,7 +146,7 @@ config = {
         "os": ["linux", "darwin"],
     },
     "dockerReleases": {
-        "architectures": ["arm", "arm64", "amd64"],
+        "architectures": ["arm64", "amd64"],
     },
     "litmus": True,
     "codestyle": True,

--- a/.drone.star
+++ b/.drone.star
@@ -43,6 +43,8 @@ dirs = {
     "zip": "/drone/src/zip",
     "webZip": "/drone/src/zip/web.tar.gz",
     "webPnpmZip": "/drone/src/zip/pnpm-store.tar.gz",
+    "gobinTar": "go-bin.tar.gz",
+    "gobinTarPath": "/drone/src/go-bin.tar.gz",
     "ocisConfig": "tests/config/drone/ocis-config.json",
     "ocis": "/srv/app/tmp/ocis",
     "ocisRevaDataRoot": "/srv/app/tmp/ocis/owncloud/data",
@@ -396,7 +398,7 @@ def checkGoBinCache():
             },
         },
         "commands": [
-            "bash -x %s/tests/config/drone/check_go_bin_cache.sh %s" % (dirs["base"], dirs["base"]),
+            "bash -x %s/tests/config/drone/check_go_bin_cache.sh %s %s" % (dirs["base"], dirs["base"], dirs["gobinTar"]),
         ],
     }]
 
@@ -411,6 +413,14 @@ def cacheGoBin():
             "volumes": [stepVolumeGo],
         },
         {
+            "name": "archive-go-bin",
+            "image": OC_UBUNTU,
+            "commands": [
+                "tar -czvf %s -C /go/bin ." % dirs["gobinTarPath"],
+            ],
+            "volumes": [stepVolumeGo],
+        },
+        {
             "name": "cache-go-bin",
             "image": MINIO_MC,
             "environment": MINIO_MC_ENV,
@@ -420,7 +430,7 @@ def cacheGoBin():
                 "BINGO_HASH=$(cat %s/.bingo_hash)" % dirs["base"],
                 # cache using the minio client to the public bucket (long term bucket)
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                "mc cp -r /go/bin s3/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH",
+                "mc cp -r %s s3/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH" % (dirs["gobinTarPath"]),
             ],
             "volumes": [stepVolumeGo],
         },
@@ -435,7 +445,16 @@ def restoreGoBinCache():
             "commands": [
                 "BINGO_HASH=$(cat %s/.bingo/* | sha256sum | cut -d ' ' -f 1)" % dirs["base"],
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                "mc cp -r -a s3/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/bin /go",
+                "mc cp -r -a s3/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/%s %s" % (dirs["gobinTar"], dirs["base"]),
+            ],
+            "volumes": [stepVolumeGo],
+        },
+        {
+            "name": "extract-go-bin-cache",
+            "image": OC_UBUNTU,
+            "commands": [
+                "mkdir -p /go/bin",
+                "tar -xvf %s -C /go/bin" % dirs["gobinTarPath"],
                 "chmod +x /go/bin/*",
             ],
             "volumes": [stepVolumeGo],

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -2,6 +2,7 @@
 
 #
 # $1 - root path where .bingo resides
+# $2 - name of the cache item
 #
 
 ROOT_PATH="$1"
@@ -13,7 +14,7 @@ BINGO_DIR="$ROOT_PATH/.bingo"
 # generate hash of a .bingo folder
 BINGO_HASH=$(cat "$BINGO_DIR"/* | sha256sum | cut -d ' ' -f 1)
 
-URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/bin/golangci-lint"
+URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/$2"
 if curl --output /dev/null --silent --head --fail "$URL"; then
     echo "[INFO] Go bin cache with has '$BINGO_HASH' exists."
     # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951


### PR DESCRIPTION
## Description
Archive `/go/bin` and push the archive to the cache bucket. Then restore the archive, extract it to the `/go/bin` path in the linting pipelines.

This reduces the requests to get go bin caches to a single request.

## Related Issue
Fixes https://github.com/owncloud/ocis/issues/5704

## Motivation and Context
- Reduce the requests to the cache bucket server

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
