### PR TITLE
reduce duplication in configuration code

### DIFF
--- a/ocis-pkg/structs/structs.go
+++ b/ocis-pkg/structs/structs.go
@@ -1,0 +1,11 @@
+// Package structs provides some utility functions for dealing with structs.
+package structs
+
+// CopyOrZeroValue returns a copy of s if s is not nil otherwise the zero value of T will be returned.
+func CopyOrZeroValue[T any](s *T) *T {
+	cp := new(T)
+	if s != nil {
+		*cp = *s
+	}
+	return cp
+}

--- a/ocis-pkg/structs/structs_test.go
+++ b/ocis-pkg/structs/structs_test.go
@@ -1,0 +1,38 @@
+package structs
+
+import "testing"
+
+type example struct {
+	Attribute1 string
+	Attribute2 string
+}
+
+func TestCopyOrZeroValue(t *testing.T) {
+	var e *example
+
+	zv := CopyOrZeroValue(e)
+
+	if zv == nil {
+		t.Error("CopyOrZeroValue returned nil")
+	}
+
+	if zv.Attribute1 != "" || zv.Attribute2 != "" {
+		t.Error("CopyOrZeroValue didn't return zero value")
+	}
+
+	e2 := &example{Attribute1: "One", Attribute2: "Two"}
+
+	cp := CopyOrZeroValue(e2)
+
+	if cp == nil {
+		t.Error("CopyOrZeroValue returned nil")
+	}
+
+	if cp == e2 {
+		t.Error("CopyOrZeroValue returned reference with same address")
+	}
+
+	if cp.Attribute1 != e2.Attribute1 || cp.Attribute2 != e2.Attribute2 {
+		t.Error("CopyOrZeroValue didn't correctly copy attributes")
+	}
+}

--- a/services/app-provider/pkg/config/defaults/defaultconfig.go
+++ b/services/app-provider/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/app-provider/pkg/config"
 )
 
@@ -63,13 +64,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -80,13 +76,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/app-provider/pkg/config/defaults/defaultconfig.go
+++ b/services/app-provider/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/app-provider/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -40,6 +42,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -81,10 +84,13 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }
 
+// Validate checks that all required configs are set. If a required config value
+// is missing an error will be returned.
 func Validate(cfg *config.Config) error {
 	if cfg.TokenManager.JWTSecret == "" {
 		return shared.MissingJWTTokenError(cfg.Service.Name)

--- a/services/app-registry/pkg/config/defaults/defaultconfig.go
+++ b/services/app-registry/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/app-registry/pkg/config"
 )
 
@@ -128,13 +129,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -145,13 +141,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/app-registry/pkg/config/defaults/defaultconfig.go
+++ b/services/app-registry/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/app-registry/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -105,6 +107,7 @@ func defaultMimeTypeConfig() []config.MimeTypeConfig {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {

--- a/services/auth-basic/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-basic/pkg/config/defaults/defaultconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/auth-basic/pkg/config"
 )
 
@@ -102,13 +103,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -119,13 +115,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/auth-basic/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-basic/pkg/config/defaults/defaultconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/auth-basic/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -16,6 +17,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -79,6 +81,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -120,6 +123,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/auth-bearer/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-bearer/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/auth-bearer/pkg/config"
 )
 
@@ -61,13 +62,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -78,13 +74,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/auth-bearer/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-bearer/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/auth-bearer/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -38,6 +40,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -79,6 +82,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/auth-machine/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-machine/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/auth-machine/pkg/config"
 )
 
@@ -56,13 +57,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -77,13 +73,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/auth-machine/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-machine/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/auth-machine/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -33,6 +35,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -78,6 +81,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/eventhistory/pkg/command/root.go
+++ b/services/eventhistory/pkg/command/root.go
@@ -43,7 +43,7 @@ type SutureService struct {
 
 // NewSutureService creates a new eventhistory.SutureService
 func NewSutureService(cfg *ociscfg.Config) suture.Service {
-	cfg.Notifications.Commons = cfg.Commons
+	cfg.EventHistory.Commons = cfg.Commons
 	return SutureService{
 		cfg: cfg.EventHistory,
 	}

--- a/services/eventhistory/pkg/config/defaults/defaultconfig.go
+++ b/services/eventhistory/pkg/config/defaults/defaultconfig.go
@@ -3,7 +3,7 @@ package defaults
 import (
 	"time"
 
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/eventhistory/pkg/config"
 )
 
@@ -51,20 +51,12 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Log = &config.Log{}
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS = cfg.Commons.GRPCClientTLS
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/frontend/pkg/config"
 )
 
@@ -138,13 +139,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/frontend/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -115,6 +117,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -161,6 +164,7 @@ func EnsureDefaults(cfg *config.Config) {
 
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/gateway/pkg/config/defaults/defaultconfig.go
+++ b/services/gateway/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/gateway/pkg/config"
 )
 
@@ -85,13 +86,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -106,13 +102,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TransferSecret = cfg.Commons.TransferSecret
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/gateway/pkg/config/defaults/defaultconfig.go
+++ b/services/gateway/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/gateway/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -62,6 +64,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -107,6 +110,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -11,6 +11,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -18,6 +19,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -89,6 +91,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -140,6 +143,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// sanitize config
 	if cfg.HTTP.Root != "/" {

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
 )
 
@@ -130,12 +131,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS.Mode = cfg.Commons.GRPCClientTLS.Mode
-			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
 
 	if cfg.Commons != nil {

--- a/services/groups/pkg/config/defaults/defaultconfig.go
+++ b/services/groups/pkg/config/defaults/defaultconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/groups/pkg/config"
 )
 
@@ -103,13 +104,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -120,13 +116,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/groups/pkg/config/defaults/defaultconfig.go
+++ b/services/groups/pkg/config/defaults/defaultconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/groups/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -16,6 +17,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -80,6 +82,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -121,6 +124,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/idm/pkg/config/defaults/defaultconfig.go
+++ b/services/idm/pkg/config/defaults/defaultconfig.go
@@ -7,6 +7,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/idm/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -14,6 +15,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -32,6 +34,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -61,6 +64,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here
 }

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/idp/pkg/config"
 )
 
@@ -152,13 +153,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.MachineAuthAPIKey == "" && cfg.Commons != nil && cfg.Commons.MachineAuthAPIKey != "" {

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -10,6 +10,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/idp/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -17,6 +18,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -129,6 +131,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -162,6 +165,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
 	// sanitize config
 	if cfg.HTTP.Root != "/" {

--- a/services/nats/pkg/config/defaults/defaultconfig.go
+++ b/services/nats/pkg/config/defaults/defaultconfig.go
@@ -10,6 +10,7 @@ import (
 // NOTE: Most of this configuration is not needed to keep it as simple as possible
 // TODO: Clean up unneeded configuration
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -17,6 +18,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -37,6 +39,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -51,6 +54,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/notifications/pkg/config/defaults/defaultconfig.go
+++ b/services/notifications/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
 )
 
@@ -59,11 +60,8 @@ func EnsureDefaults(cfg *config.Config) {
 	if cfg.Notifications.MachineAuthAPIKey == "" && cfg.Commons != nil && cfg.Commons.MachineAuthAPIKey != "" {
 		cfg.Notifications.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
-	if cfg.Notifications.GRPCClientTLS == nil {
-		cfg.Notifications.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.Notifications.GRPCClientTLS = cfg.Commons.GRPCClientTLS
-		}
+	if cfg.Notifications.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.Notifications.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
 }
 

--- a/services/notifications/pkg/config/defaults/defaultconfig.go
+++ b/services/notifications/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -16,6 +17,7 @@ func FullDefaultConfig() *config.Config {
 // NOTE: Most of this configuration is not needed to keep it as simple as possible
 // TODO: Clean up unneeded configuration
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -44,6 +46,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -65,6 +68,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/ocdav/pkg/config/defaults/defaultconfig.go
+++ b/services/ocdav/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"github.com/owncloud/ocis/v2/services/ocdav/pkg/config"
 )
@@ -73,13 +74,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {

--- a/services/ocdav/pkg/config/defaults/defaultconfig.go
+++ b/services/ocdav/pkg/config/defaults/defaultconfig.go
@@ -7,6 +7,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/ocdav/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -14,6 +15,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -50,6 +52,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -91,6 +94,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/ocs/pkg/config/defaults/defaultconfig.go
+++ b/services/ocs/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/ocs/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -38,6 +40,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -85,6 +88,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitizes the configuration
 func Sanitize(cfg *config.Config) {
 	// sanitize config
 	if cfg.HTTP.Root != "/" {

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
 )
 
@@ -249,21 +250,12 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS.Mode = cfg.Commons.GRPCClientTLS.Mode
-			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
 }
 

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -10,6 +10,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -17,6 +18,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -64,6 +66,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// DefaultPolicies returns the default proxy policies.
 func DefaultPolicies() []config.Policy {
 	return []config.Policy{
 		{

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/search/pkg/config"
 )
 
@@ -83,28 +84,14 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS.Mode = cfg.Commons.GRPCClientTLS.Mode
-			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/search/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 
@@ -17,6 +18,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{

--- a/services/settings/pkg/config/defaults/defaultconfig.go
+++ b/services/settings/pkg/config/defaults/defaultconfig.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
 	rdefaults "github.com/owncloud/ocis/v2/services/settings/pkg/store/defaults"
 	"github.com/pkg/errors"
@@ -104,20 +104,11 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.AdminUserID = cfg.Commons.AdminUserID
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS.Mode = cfg.Commons.GRPCClientTLS.Mode
-			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 
 	if cfg.Commons != nil {

--- a/services/settings/pkg/config/defaults/defaultconfig.go
+++ b/services/settings/pkg/config/defaults/defaultconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -60,6 +61,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -116,6 +118,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// sanitize config
 	if cfg.HTTP.Root != "/" {

--- a/services/sharing/pkg/config/defaults/defaultconfig.go
+++ b/services/sharing/pkg/config/defaults/defaultconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/sharing/pkg/config"
 )
 
@@ -99,13 +100,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -116,13 +112,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 
 	if cfg.UserSharingDrivers.CS3.SystemUserAPIKey == "" && cfg.Commons != nil && cfg.Commons.SystemUserAPIKey != "" {

--- a/services/sharing/pkg/config/defaults/defaultconfig.go
+++ b/services/sharing/pkg/config/defaults/defaultconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/sharing/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -16,6 +17,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -76,14 +78,14 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
 		cfg.Log = &config.Log{
 			Level:  cfg.Commons.Log.Level,
-			Pretty: cfg.Commons.Log.Pretty,
-			Color:  cfg.Commons.Log.Color,
-			File:   cfg.Commons.Log.File,
+			Pretty: cfg.Commons.Log.Pretty, Color: cfg.Commons.Log.Color,
+			File: cfg.Commons.Log.File,
 		}
 	} else if cfg.Log == nil {
 		cfg.Log = &config.Log{}
@@ -149,6 +151,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/storage-publiclink/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-publiclink/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/storage-publiclink/pkg/config"
 )
 
@@ -59,13 +60,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -76,13 +72,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/storage-publiclink/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-publiclink/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/storage-publiclink/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -36,6 +38,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -77,6 +80,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/storage-shares/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-shares/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/storage-shares/pkg/config"
 )
 
@@ -59,13 +60,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -76,13 +72,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/storage-shares/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-shares/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/storage-shares/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -13,6 +14,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -36,6 +38,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -77,6 +80,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/storage-system/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-system/pkg/config/defaults/defaultconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/storage-system/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -16,6 +17,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -55,6 +57,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -105,6 +108,7 @@ func EnsureDefaults(cfg *config.Config) {
 
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/storage-system/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-system/pkg/config/defaults/defaultconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/storage-system/pkg/config"
 )
 
@@ -78,13 +79,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -103,13 +99,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.SystemUserID = cfg.Commons.SystemUserID
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 
 }

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config"
 )
 
@@ -123,13 +124,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -140,13 +136,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 
 	if cfg.Tasks.PurgeTrashBin.UserID == "" && cfg.Commons != nil {

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -10,6 +10,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -17,6 +18,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -100,6 +102,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -145,6 +148,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/store/pkg/config/defaults/defaultconfig.go
+++ b/services/store/pkg/config/defaults/defaultconfig.go
@@ -4,7 +4,7 @@ import (
 	"path"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/store/pkg/config"
 )
 
@@ -58,20 +58,11 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS.Mode = cfg.Commons.GRPCClientTLS.Mode
-			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/store/pkg/config/defaults/defaultconfig.go
+++ b/services/store/pkg/config/defaults/defaultconfig.go
@@ -8,6 +8,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/store/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -15,6 +16,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -34,6 +36,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -66,6 +69,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/config"
 )
 
@@ -73,20 +74,11 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS.Mode = cfg.Commons.GRPCClientTLS.Mode
-			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 
 	if cfg.Commons != nil {

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -10,6 +10,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -17,6 +18,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -50,6 +52,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -86,6 +89,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 	if len(cfg.Thumbnail.Resolutions) == 1 && strings.Contains(cfg.Thumbnail.Resolutions[0], ",") {

--- a/services/userlog/pkg/config/defaults/defaultconfig.go
+++ b/services/userlog/pkg/config/defaults/defaultconfig.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/userlog/pkg/config"
 )
 
@@ -62,11 +63,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS = cfg.Commons.GRPCClientTLS
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {

--- a/services/users/pkg/config/defaults/defaultconfig.go
+++ b/services/users/pkg/config/defaults/defaultconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/users/pkg/config"
 )
 
@@ -104,13 +105,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
+	if cfg.Reva == nil && cfg.Commons != nil {
+		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
 	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
@@ -121,13 +117,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.GRPC.TLS == nil {
-		cfg.GRPC.TLS = &shared.GRPCServiceTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCServiceTLS != nil {
-			cfg.GRPC.TLS.Enabled = cfg.Commons.GRPCServiceTLS.Enabled
-			cfg.GRPC.TLS.Cert = cfg.Commons.GRPCServiceTLS.Cert
-			cfg.GRPC.TLS.Key = cfg.Commons.GRPCServiceTLS.Key
-		}
+	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
+		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 }
 

--- a/services/users/pkg/config/defaults/defaultconfig.go
+++ b/services/users/pkg/config/defaults/defaultconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/users/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -16,6 +17,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -81,6 +83,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -122,6 +125,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// nothing to sanitize here atm
 }

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -8,6 +8,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/web/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -15,6 +16,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -72,6 +74,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -108,6 +111,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// sanitize config
 	if cfg.HTTP.Root != "/" {

--- a/services/webdav/pkg/config/defaults/defaultconfig.go
+++ b/services/webdav/pkg/config/defaults/defaultconfig.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/webdav/pkg/config"
 )
 
@@ -66,12 +67,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
-	if cfg.GRPCClientTLS == nil {
-		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-		if cfg.Commons != nil && cfg.Commons.GRPCClientTLS != nil {
-			cfg.GRPCClientTLS.Mode = cfg.Commons.GRPCClientTLS.Mode
-			cfg.GRPCClientTLS.CACert = cfg.Commons.GRPCClientTLS.CACert
-		}
+	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
+		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}
 
 	if cfg.Commons != nil {

--- a/services/webdav/pkg/config/defaults/defaultconfig.go
+++ b/services/webdav/pkg/config/defaults/defaultconfig.go
@@ -8,6 +8,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/webdav/pkg/config"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -15,6 +16,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -43,6 +45,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -76,6 +79,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// sanitize config
 	if cfg.HTTP.Root != "/" {

--- a/services/webfinger/pkg/config/defaults/defaultconfig.go
+++ b/services/webfinger/pkg/config/defaults/defaultconfig.go
@@ -7,6 +7,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/webfinger/pkg/relations"
 )
 
+// FullDefaultConfig returns a fully initialized default configuration
 func FullDefaultConfig() *config.Config {
 	cfg := DefaultConfig()
 	EnsureDefaults(cfg)
@@ -14,6 +15,7 @@ func FullDefaultConfig() *config.Config {
 	return cfg
 }
 
+// DefaultConfig returns a basic default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
@@ -49,6 +51,7 @@ func DefaultConfig() *config.Config {
 	}
 }
 
+// EnsureDefaults adds default values to the configuration if they are not set yet
 func EnsureDefaults(cfg *config.Config) {
 	// provide with defaults for shared logging, since we need a valid destination address for "envdecode".
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
@@ -78,6 +81,7 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 }
 
+// Sanitize sanitized the configuration
 func Sanitize(cfg *config.Config) {
 	// sanitize config
 	if cfg.HTTP.Root != "/" {


### PR DESCRIPTION
Let's see if this will lower our "Bugs" and "Code Smells" scores on sonarcloud.

Todos:
- [x] Add tests for `structs.CopyOrZeroValue`
- [x] Add missing comments to the config code.