### PR TITLE
[ci] Cache the go/bin content as a single archive file

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -420,7 +420,7 @@ def cacheGoBin():
             "name": "archive-go-bin",
             "image": OC_UBUNTU,
             "commands": [
-                "tar -czvf %s -C /go/bin ." % dirs["gobinTarPath"],
+                "tar -czvf %s /go/bin" % dirs["gobinTarPath"],
             ],
             "volumes": [stepVolumeGo],
         },
@@ -457,9 +457,7 @@ def restoreGoBinCache():
             "name": "extract-go-bin-cache",
             "image": OC_UBUNTU,
             "commands": [
-                "mkdir -p /go/bin",
-                "tar -xvf %s -C /go/bin" % dirs["gobinTarPath"],
-                "chmod +x /go/bin/*",
+                "tar -xvmf %s -C /" % dirs["gobinTarPath"],
             ],
             "volumes": [stepVolumeGo],
         },

--- a/tests/config/drone/check_go_bin_cache.sh
+++ b/tests/config/drone/check_go_bin_cache.sh
@@ -2,6 +2,7 @@
 
 #
 # $1 - root path where .bingo resides
+# $2 - name of the cache item
 #
 
 ROOT_PATH="$1"
@@ -13,7 +14,7 @@ BINGO_DIR="$ROOT_PATH/.bingo"
 # generate hash of a .bingo folder
 BINGO_HASH=$(cat "$BINGO_DIR"/* | sha256sum | cut -d ' ' -f 1)
 
-URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/bin/golangci-lint"
+URL="$CACHE_ENDPOINT/$CACHE_BUCKET/ocis/go-bin/$BINGO_HASH/$2"
 if curl --output /dev/null --silent --head --fail "$URL"; then
     echo "[INFO] Go bin cache with has '$BINGO_HASH' exists."
     # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951


### PR DESCRIPTION
## Description
Archive `/go/bin` and push the archive to the cache bucket. Then restore the archive, extract it to the `/go/bin` path in the linting pipelines.

This reduces the requests to get go bin caches to a single request.

## Related Issue
Fixes https://github.com/owncloud/ocis/issues/5704

## Motivation and Context
- Reduce the requests to the cache bucket server

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
