### PR TITLE
[tests-only][full-ci]Seperate test steps for positive and negative cases

### DIFF
--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -136,7 +136,7 @@ Feature: add users to group
 
 
   Scenario: admin tries to add user to a non-existing group
-    When the administrator tries to add user "Alice" to group "nonexistentgroup" using the Graph API
+    When the administrator tries to add user "Alice" to a non-existing group using the Graph API
     Then the HTTP status code should be "404"
 
 
@@ -147,7 +147,7 @@ Feature: add users to group
 
 
   Scenario: admin tries to add user to a group without sending the group
-    When the administrator tries to add user "Alice" to group "" using the Graph API
+    When the administrator tries to add user "Alice" to a non-existing group using the Graph API
     Then the HTTP status code should be "404"
 
 

--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -136,7 +136,7 @@ Feature: add users to group
 
 
   Scenario: admin tries to add user to a non-existing group
-    When the administrator tries to add user "Alice" to a non-existing group using the Graph API
+    When the administrator tries to add user "Alice" to a nonexistent group using the Graph API
     Then the HTTP status code should be "404"
 
 
@@ -147,7 +147,7 @@ Feature: add users to group
 
 
   Scenario: admin tries to add user to a group without sending the group
-    When the administrator tries to add user "Alice" to a non-existing group using the Graph API
+    When the administrator tries to add user "Alice" to a nonexistent group using the Graph API
     Then the HTTP status code should be "404"
 
 
@@ -175,7 +175,7 @@ Feature: add users to group
       | username |
       | Brian    |
       | Carol    |
-    When the administrator "Alice" tries to add the following users to a non-existing group at once using the Graph API
+    When the administrator "Alice" tries to add the following users to a nonexistent group at once using the Graph API
       | username |
       | Brian    |
       | Carol    |
@@ -185,7 +185,7 @@ Feature: add users to group
   Scenario: admin tries to add multiple non-existing users to a group at once
     Given the administrator has given "Alice" the role "Admin" using the settings api
     And user "Alice" has created a group "grp1" using the Graph API
-    When the administrator "Alice" tries to add the following non-existing users to a group "grp1" at once using the Graph API
+    When the administrator "Alice" tries to add the following nonexistent users to a group "grp1" at once using the Graph API
       | username |
       | Brian    |
       | Carol    |

--- a/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
+++ b/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
@@ -152,7 +152,7 @@ Feature: remove a user from a group
       | Alice    | var/../etc       |
 
 
-  Scenario: admin tries to remove a user from a non-existing group
+  Scenario: admin tries to remove a user from a nonexistent group
     When the administrator tries to remove user "Alice" from a nonexistent group using the Graph API
     Then the HTTP status code should be "404"
 

--- a/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
+++ b/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
@@ -153,7 +153,7 @@ Feature: remove a user from a group
 
 
   Scenario: admin tries to remove a user from a non-existing group
-    When the administrator tries to remove user "Alice" from group "nonexistentgroup" using the Graph API
+    When the administrator tries to remove user "Alice" from a nonexistent group using the Graph API
     Then the HTTP status code should be "404"
 
 

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -1264,13 +1264,12 @@ class GraphContext implements Context {
 	 * @When user :byUser tries to remove user :user from a nonexistent group using the Graph API
 	 *
 	 * @param string $user
-	 * @param string $group
 	 * @param string|null $byUser
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function theUserTriesToRemoveAnotherUserFromNonExistentGroupUsingTheGraphAPI(string $user, string $group, ?string $byUser = null): void {
+	public function theUserTriesToRemoveAnotherUserFromNonExistentGroupUsingTheGraphAPI(string $user, ?string $byUser = null): void {
 		$groupId = WebDavHelper::generateUUIDv4();
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, "id");
 		$this->featureContext->setResponse($this->removeUserFromGroup($groupId, $userId, $byUser));
@@ -1690,7 +1689,11 @@ class GraphContext implements Context {
 		$userIds = [];
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		foreach ($table->getHash() as $row) {
-			$userIds[] = $this->featureContext->getAttributeOfCreatedUser($row['username'], "id");
+			try {
+				$userIds[] = $this->featureContext->getAttributeOfCreatedUser($row['username'], "id");
+			} catch (Exception $e) {
+				$userIds[] = WebDavHelper::generateUUIDv4();
+			}
 		}
 		$this->addMultipleUsersToGroup($user, $userIds, $groupId, $table);
 	}

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -828,7 +828,9 @@ class GraphContext implements Context {
 	 * @When the administrator tries to add user :user to a non-existing group using the Graph API
 	 *
 	 * @param string $user
+	 *
 	 * @return void
+	 *
 	 * @throws GuzzleException
 	 */
 	public function theAdministratorTriesToAddUserToNonExistingGroupUsingTheGraphAPI(string $user): void {
@@ -836,8 +838,12 @@ class GraphContext implements Context {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string|null $byUser
+	 *
+	 * @return ResponseInterface
+	 *
 	 * @throws GuzzleException
-	 * @throws Exception
 	 */
 	public function addUserToNonExistingGroup(string $user, ?string $byUser = null): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($byUser);

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -821,6 +821,7 @@ class GraphContext implements Context {
 	 *
 	 * @param string $user
 	 * @param string|null $byUser
+	 *
 	 * @return void
 	 *
 	 * @throws GuzzleException | Exception
@@ -1544,27 +1545,27 @@ class GraphContext implements Context {
 			$actualKeyValue = GraphHelper::separateAndGetValueForKey($keyName, $actualDriveInformation);
 			switch ($expectedDriveInformation[$keyName]) {
 				case '%user_id%':
-                Assert::assertTrue(GraphHelper::isUUIDv4($actualKeyValue), __METHOD__ . ' Expected user_id to have UUIDv4 pattern but found: ' . $actualKeyValue);
+					Assert::assertTrue(GraphHelper::isUUIDv4($actualKeyValue), __METHOD__ . ' Expected user_id to have UUIDv4 pattern but found: ' . $actualKeyValue);
 					break;
 				case '%space_id%':
-                Assert::assertTrue(GraphHelper::isSpaceId($actualKeyValue), __METHOD__ . ' Expected space_id to have a UUIDv4:UUIDv4 pattern but found: ' . $actualKeyValue);
+					Assert::assertTrue(GraphHelper::isSpaceId($actualKeyValue), __METHOD__ . ' Expected space_id to have a UUIDv4:UUIDv4 pattern but found: ' . $actualKeyValue);
 					break;
 				default:
-                $expectedDriveInformation[$keyName] = $this->featureContext->substituteInLineCodes(
-                $expectedDriveInformation[$keyName],
-                $this->featureContext->getCurrentUser(),
-                [],
-                [
-                [
-                // the actual space_id is substituted from the actual drive information rather than making an API request and substituting
-                "code" => "%space_id%",
-                "function" =>
-                [$this, "getSpaceIdFromActualDriveinformation"],
-                "parameter" => [$actualDriveInformation]
-                ],
-                ]
-                );
-                Assert::assertEquals($expectedDriveInformation[$keyName], $actualKeyValue);
+					$expectedDriveInformation[$keyName] = $this->featureContext->substituteInLineCodes(
+						$expectedDriveInformation[$keyName],
+						$this->featureContext->getCurrentUser(),
+						[],
+						[
+							[
+								// the actual space_id is substituted from the actual drive information rather than making an API request and substituting
+								"code" => "%space_id%",
+								"function" =>
+									[$this, "getSpaceIdFromActualDriveinformation"],
+								"parameter" => [$actualDriveInformation]
+							],
+						]
+					);
+					Assert::assertEquals($expectedDriveInformation[$keyName], $actualKeyValue);
 			}
 		}
 	}

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -755,12 +755,12 @@ class GraphContext implements Context {
 		try {
 			$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		} catch (Exception $e) {
-			$groupId = WebDavHelper::generateUUIDv4();
+			// $groupId = WebDavHelper::generateUUIDv4();
 		}
 		try {
 			$userId = $this->featureContext->getAttributeOfCreatedUser($user, "id");
 		} catch (Exception $e) {
-			$userId = WebDavHelper::generateUUIDv4();
+			// $userId = WebDavHelper::generateUUIDv4();
 		}
 
 		return GraphHelper::addUserToGroup(
@@ -822,6 +822,35 @@ class GraphContext implements Context {
 	 */
 	public function theAdministratorTriesToAddUserToGroupUsingTheGraphAPI(string $user, string $group): void {
 		$this->featureContext->setResponse($this->addUserToGroup($group, $user));
+	}
+
+	/**
+	 * @When the administrator tries to add user :user to a non-existing group using the Graph API
+	 *
+	 * @param string $user
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorTriesToAddUserToNonExistingGroupUsingTheGraphAPI(string $user): void {
+		$this->featureContext->setResponse($this->addUserToNonExistingGroup($user));
+	}
+
+	/**
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function addUserToNonExistingGroup(string $user, ?string $byUser = null): ResponseInterface {
+		$credentials = $this->getAdminOrUserCredentials($byUser);
+		$groupId = WebDavHelper::generateUUIDv4();
+		$userId = $this->featureContext->getAttributeOfCreatedUser($user, "id");
+		return GraphHelper::addUserToGroup(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$credentials['username'],
+			$credentials['password'],
+			$userId,
+			$groupId
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR separates the positive and negative test steps. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/5646

## Motivation and Context
The test step that used to be 
```feature
When the administrator tries to add user "Alice" to group "nonexistentgroup" using the Graph API
```
This is now defined as
```feature
When the administrator tries to add user "Alice" to a nonexistent group using the Graph API
```
 This is because previously we followed the following logic to randomly generate the user-id of a non-existing user/group 
```php
try {
	$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
} catch (Exception $e) {
	$groupId = WebDavHelper::generateUUIDv4();
}
try {
	$userId = $this->featureContext->getAttributeOfCreatedUser($user, "id");
} catch (Exception $e) {
	$userId = WebDavHelper::generateUUIDv4();
}
```
The problem with this logic is that if the request for getting the group id somehow fails due to some legitimate reason other than the expected user not existing, the id would still be generated which is not something we want. So we separate the cases so that the fake id is created only for the expected steps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
CI
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
