### PR TITLE
add common part, make the logic theme name agnostic

### DIFF
--- a/changelog/unreleased/branding-api.md
+++ b/changelog/unreleased/branding-api.md
@@ -3,4 +3,5 @@ Enhancement: Add endpoints to upload a custom logo
 Added endpoints to upload and reset custom logos. The files are stored under the `WEB_ASSET_PATH`
 which defaults to `$OCIS_BASE_DATA_PATH/web/assets`.
 
+https://github.com/owncloud/ocis/pull/5735
 https://github.com/owncloud/ocis/pull/5559

--- a/services/web/pkg/service/v0/branding.go
+++ b/services/web/pkg/service/v0/branding.go
@@ -167,36 +167,33 @@ func (p Web) updateLogoThemeConfig(logoPath string) error {
 	var m map[string]interface{}
 	_ = json.NewDecoder(f).Decode(&m)
 
+	// change logo in common part
+	commonCfg, ok := m["common"].(map[string]interface{})
+	if !ok {
+		return errInvalidThemeConfig
+	}
+	commonCfg["logo"] = logoPath
+
 	webCfg, ok := m["web"].(map[string]interface{})
 	if !ok {
 		return errInvalidThemeConfig
 	}
 
-	defaultCfg, ok := webCfg["default"].(map[string]interface{})
-	if !ok {
-		return errInvalidThemeConfig
+	// iterate over all possible themes and replace logo
+	for theme := range webCfg {
+		themeCfg, ok := webCfg[theme].(map[string]interface{})
+		if !ok {
+			return errInvalidThemeConfig
+		}
+
+		logoCfg, ok := themeCfg["logo"].(map[string]interface{})
+		if !ok {
+			return errInvalidThemeConfig
+		}
+
+		logoCfg["login"] = logoPath
+		logoCfg["topbar"] = logoPath
 	}
-
-	logoCfg, ok := defaultCfg["logo"].(map[string]interface{})
-	if !ok {
-		return errInvalidThemeConfig
-	}
-
-	logoCfg["login"] = logoPath
-	logoCfg["topbar"] = logoPath
-
-	defaultDarkCfg, ok := webCfg["default-dark"].(map[string]interface{})
-	if !ok {
-		return errInvalidThemeConfig
-	}
-
-	logoDarkCfg, ok := defaultDarkCfg["logo"].(map[string]interface{})
-	if !ok {
-		return errInvalidThemeConfig
-	}
-
-	logoDarkCfg["login"] = logoPath
-	logoDarkCfg["topbar"] = logoPath
 
 	dst, err := p.fs.Create(_themesConfigPath)
 	if err != nil {


### PR DESCRIPTION
## Description

- Make `common` logo key also replacable
- Make the logic theme name agnostic

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
