### PR TITLE
[full-ci] chore: bump web to v7.0.0-rc.18

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=8ac9e04975a6572c9f1151a81abfab49f073138d
+WEB_COMMITID=c2f5d649e364bb2a52c53c3f81390726af296d7d
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.17
+WEB_ASSETS_VERSION = v7.0.0-rc.18
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bumps web to v7.0.0-rc.18.

This brings the new notifications implementation, so should unblock https://github.com/owncloud/ocis/pull/5699

cc @micbar @kobergj 