### PR TITLE
[test-only] add api tests to editing user name

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -700,20 +700,20 @@ class GraphHelper {
 		?bool $accountEnabled
 	): string {
 		$payload = [];
-		if (!is_null($userName)) {
-      // comment on after fixing #5755 because now it crashes server
-      // if (empty($userName)) { 
-      //   $payload['onPremisesSamAccountName'] = ' ';
-      // } else $payload['onPremisesSamAccountName'] = $userName;
-      $payload['onPremisesSamAccountName'] = $userName;
+		if ($userName !== null) {
+			// comment on after fixing #5755 because now it crashes server
+			// if (empty($userName)) {
+			//   $payload['onPremisesSamAccountName'] = ' ';
+			// } else $payload['onPremisesSamAccountName'] = $userName;
+			$payload['onPremisesSamAccountName'] = $userName;
 		}
-		if (!is_null($password)) {
+		if ($password !== null) {
 			$payload['passwordProfile'] = ['password' => $password];
 		}
-		if (!is_null($displayName)) {
+		if ($displayName !== null) {
 			$payload['displayName'] = $displayName;
 		}
-		if (!is_null($email)) {
+		if ($email !== null) {
 			$payload['mail'] = $email;
 		}
 		$payload['accountEnabled'] = $accountEnabled;

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -700,20 +700,23 @@ class GraphHelper {
 		?bool $accountEnabled
 	): string {
 		$payload = [];
-		if ($userName) {
-			$payload['onPremisesSamAccountName'] = $userName;
+		if (!is_null($userName)) {
+      // comment on after fixing #5755 because now it crashes server
+      // if (empty($userName)) { 
+      //   $payload['onPremisesSamAccountName'] = ' ';
+      // } else $payload['onPremisesSamAccountName'] = $userName;
+      $payload['onPremisesSamAccountName'] = $userName;
 		}
-		if ($password) {
+		if (!is_null($password)) {
 			$payload['passwordProfile'] = ['password' => $password];
 		}
-		if ($displayName) {
+		if (!is_null($displayName)) {
 			$payload['displayName'] = $displayName;
 		}
-		if ($email) {
+		if (!is_null($email)) {
 			$payload['mail'] = $email;
 		}
 		$payload['accountEnabled'] = $accountEnabled;
-
 		return \json_encode($payload);
 	}
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -104,8 +104,12 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 #### [Normal user can get expanded members information of a group](https://github.com/owncloud/ocis/issues/5604)
 - [apiGraph/getGroup.feature:100](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/getGroup.feature#L100)
 
-#### Change editUser test where we set empty value
-- [apiGraph/editUser.feature:33](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L33)
-- [apiGraph/editUser.feature:80](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L80)
+#### [Changing user with an uppercase name gives 404 error](https://github.com/owncloud/ocis/issues/5763)
+- [apiGraph/editUser.feature:41](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L41)
+
+#### [Using # in the onPremisesSamAccountName breaks getting users](https://github.com/owncloud/ocis/issues/5755)
+- [apiGraph/editUser.feature:42](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L42)
+- [apiGraph/editUser.feature:44](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L44)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiGraph/editUser.feature
+++ b/tests/acceptance/features/apiGraph/editUser.feature
@@ -14,7 +14,7 @@ Feature: edit user
       | password    | 1234              |
 
 
-  Scenario Outline: the admin user can edit another user email
+  Scenario Outline: the admin user can edit another user's email
     When the user "Alice" changes the email of user "Brian" to "<newEmail>" using the Graph API
     Then the HTTP status code should be "<code>"
     And the user "Brian" should have information with these key and value pairs:
@@ -29,7 +29,7 @@ Feature: edit user
       | change to a invalid email | invalidEmail         | 400  | brian@example.com    |
 
 
-  Scenario Outline: the admin user can edit another user name
+  Scenario Outline: the admin user can edit another user's name
     Given user "Carol" has been created with default attributes and without skeleton files
     When the user "Alice" changes the user name of user "Carol" to "<userName>" using the Graph API
     Then the HTTP status code should be "<code>"
@@ -44,7 +44,7 @@ Feature: edit user
       | empty user name              |          | 400  | Brian            |
 
 
-  Scenario: the admin user changes the name to the disabled user name
+  Scenario: the admin user changes the name of a user to the name of an existing disabled user
     Given the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | sam             |
       | displayName | sam             |
@@ -58,7 +58,7 @@ Feature: edit user
       | onPremisesSamAccountName | sam   |
 
 
-  Scenario: the admin user changes the name to the deleted user name
+  Scenario: the admin user changes the name of a user to the name of a previously deleted user
     Given the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | sam             |
       | displayName | sam             |

--- a/tests/acceptance/features/apiGraph/editUser.feature
+++ b/tests/acceptance/features/apiGraph/editUser.feature
@@ -14,28 +14,62 @@ Feature: edit user
       | password    | 1234              |
 
 
-  Scenario: the admin user can edit another user email
-    When the user "Alice" changes the email of user "Brian" to "newemail@example.com" using the Graph API
+  Scenario Outline: the admin user can edit another user email
+    When the user "Alice" changes the email of user "Brian" to "<newEmail>" using the Graph API
+    Then the HTTP status code should be "<code>"
+    And the user "Brian" should have information with these key and value pairs:
+      | key  | value           |
+      | mail | <emailAsResult> |
+    Examples:
+      | action description        | newEmail             | code | emailAsResult        |
+      | change to a valid email   | newemail@example.com | 200  | newemail@example.com |
+      | override existing mail    | brian@example.com    | 200  | brian@example.com    |
+      | two users with same mail  | alice@example.org    | 200  | alice@example.org    |
+      | empty mail                |                      | 400  | brian@example.com    |
+      | change to a invalid email | invalidEmail         | 400  | brian@example.com    |
+
+
+  Scenario Outline: the admin user can edit another user name
+    Given user "Carol" has been created with default attributes and without skeleton files
+    When the user "Alice" changes the user name of user "Carol" to "<userName>" using the Graph API
+    Then the HTTP status code should be "<code>"
+    And the user "<userNameAsResult>" should have information with these key and value pairs:
+      | key                      | value              |
+      | onPremisesSamAccountName | <userNameAsResult> |
+    Examples:
+      | action description           | userName | code | userNameAsResult |
+      | change to a valid user name  | Lionel   | 200  | Lionel           |
+      | user name characters         | *:!;_+-& | 200  | *:!;_+-&         |
+      | change to existing user name | Brian    | 409  | Brian            |
+      | empty user name              |          | 400  | Brian            |
+
+
+  Scenario: the admin user changes the name to the disabled user name
+    Given the user "Alice" has created a new user using the Graph API with the following settings:
+      | userName    | sam             |
+      | displayName | sam             |
+      | email       | sam@example.com |
+      | password    | 1234            |
+    And the user "Alice" has disabled user "Brian" using the Graph API
+    When the user "Alice" changes the user name of user "sam" to "Brian" using the Graph API
+    Then the HTTP status code should be "409"
+    And the user "sam" should have information with these key and value pairs:
+      | key                      | value |
+      | onPremisesSamAccountName | sam   |
+
+
+  Scenario: the admin user changes the name to the deleted user name
+    Given the user "Alice" has created a new user using the Graph API with the following settings:
+      | userName    | sam             |
+      | displayName | sam             |
+      | email       | sam@example.com |
+      | password    | 1234            |
+    And the user "Alice" has deleted a user "sam" using the Graph API
+    When the user "Alice" changes the user name of user "Brian" to "sam" using the Graph API
     Then the HTTP status code should be "200"
-    And the user "Brian" should have information with these key and value pairs:
-      | key  | value                |
-      | mail | newemail@example.com |
-
-
-  Scenario: the admin user can override an existing user email of another user
-    When the user "Alice" changes the email of user "Brian" to "brian@example.com" using the Graph API
-    Then the HTTP status code should be "200"
-    And the user "Brian" should have information with these key and value pairs:
-      | key  | value             |
-      | mail | brian@example.com |
-
-
-  Scenario: the admin user cannot clear an existing user email
-    When the user "Alice" tries to change the email of user "Brian" to "" using the Graph API
-    Then the HTTP status code should be "400"
-    And the user "Brian" should have information with these key and value pairs:
-      | key  | value             |
-      | mail | brian@example.com |
+    And the user "sam" should have information with these key and value pairs:
+      | key                      | value |
+      | onPremisesSamAccountName | sam   |
 
 
   Scenario Outline: a normal user should not be able to change their email address
@@ -69,20 +103,18 @@ Feature: edit user
       | User        |
 
 
-  Scenario: the admin user can edit another user display name
-    When the user "Alice" changes the display name of user "Brian" to "Carol King" using the Graph API
+  Scenario Outline: the admin user can edit another user display name
+    When the user "Alice" changes the display name of user "Brian" to "<newDisplayName>" using the Graph API
     Then the HTTP status code should be "200"
     And the user "Brian" should have information with these key and value pairs:
-      | key         | value      |
-      | displayName | Carol King |
-
-
-  Scenario: the admin user cannot clear another user display name
-    When the user "Alice" tries to change the display name of user "Brian" to "" using the Graph API
-    Then the HTTP status code should be "400"
-    And the user "Brian" should have information with these key and value pairs:
-      | key         | value        |
-      | displayName | Brian Murphy |
+      | key         | value                 |
+      | displayName | <displayNameAsResult> |
+    Examples:
+      | action description                | newDisplayName | code | displayNameAsResult |
+      | change to a display name          | Olaf Scholz    | 200  | Olaf Scholz         |
+      | override to existing display name | Carol King     | 200  | Carol King          |
+      | change to an empty display name   |                | 400  | Brian Murphy        |
+      | displayName with characters       | *:!;_+-&#(?)   | 200  | *:!;_+-&#(?)        |
 
 
   Scenario Outline: a normal user should not be able to change his/her own display name

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -147,7 +147,6 @@ class GraphContext implements Context {
 		if (!empty($userName)) {
 			$this->featureContext->addUserToCreatedUsersList($userName, '123');
 		}
-		
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -129,6 +129,28 @@ class GraphContext implements Context {
 	}
 
 	/**
+	 * @When /^the user "([^"]*)" changes the user name of user "([^"]*)" to "([^"]*)" using the Graph API$/
+	 * @When /^the user "([^"]*)" tries to change the user name of user "([^"]*)" to "([^"]*)" using the Graph API$/
+	 *
+	 * @param string $byUser
+	 * @param string $user
+	 * @param string $userName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theUserChangesTheUserNameOfUserToUsingTheGraphApi(string $byUser, string $user, string $userName): void {
+		$response = $this->editUserUsingTheGraphApi($byUser, $user, $userName);
+		$this->featureContext->setResponse($response);
+		// need add user to list to delete him after test
+		if (!empty($userName)) {
+			$this->featureContext->addUserToCreatedUsersList($userName, '123');
+		}
+		
+	}
+
+	/**
 	 * @When /^the user "([^"]*)" disables user "([^"]*)" using the Graph API$/
 	 * @When /^the user "([^"]*)" tries to disable user "([^"]*)" using the Graph API$/
 	 *

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -145,7 +145,7 @@ class GraphContext implements Context {
 		$this->featureContext->setResponse($response);
 		// need add user to list to delete him after test
 		if (!empty($userName)) {
-			$this->featureContext->addUserToCreatedUsersList($userName, '123');
+			$this->featureContext->addUserToCreatedUsersList($userName, $this->featureContext->getUserPassword($user));
 		}
 	}
 


### PR DESCRIPTION
created tests to editing user name: 

- [x] valid name
- [x] empty name
- [x] existing name
- [x] name with characters
- [x] name of disabled user
- [x] name of deleted user

- [x] deleted tests from expected failures with empty display name and email because was an error in the test implementation
- [x] collect existing tests to Scenario Outline

created bugs:
- #5755 
- #5763 