### PR TITLE
graph: Add missing patch support for education/users

### DIFF
--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -258,13 +258,13 @@ func (i *LDAP) UpdateUser(ctx context.Context, nameOrID string, user libregraph.
 	var updateNeeded bool
 
 	// Don't allow updates of the ID
-	if user.Id != nil && *user.Id != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.id) != *user.Id {
+	if user.GetId() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.id) != user.GetId() {
 			return nil, errorcode.New(errorcode.NotAllowed, "changing the UserId is not allowed")
 		}
 	}
-	if user.OnPremisesSamAccountName != nil && *user.OnPremisesSamAccountName != "" {
-		if eu := e.GetEqualFoldAttributeValue(i.userAttributeMap.userName); eu != *user.OnPremisesSamAccountName {
+	if user.GetOnPremisesSamAccountName() != "" {
+		if eu := e.GetEqualFoldAttributeValue(i.userAttributeMap.userName); eu != user.GetOnPremisesSamAccountName() {
 			e, err = i.changeUserName(ctx, e.DN, eu, user.GetOnPremisesSamAccountName())
 			if err != nil {
 				return nil, err
@@ -273,19 +273,31 @@ func (i *LDAP) UpdateUser(ctx context.Context, nameOrID string, user libregraph.
 	}
 
 	mr := ldap.ModifyRequest{DN: e.DN}
-	if user.DisplayName != nil && *user.DisplayName != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.displayName) != *user.DisplayName {
-			mr.Replace(i.userAttributeMap.displayName, []string{*user.DisplayName})
+	if user.GetDisplayName() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.displayName) != user.GetDisplayName() {
+			mr.Replace(i.userAttributeMap.displayName, []string{user.GetDisplayName()})
 			updateNeeded = true
 		}
 	}
-	if user.Mail != nil && *user.Mail != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.mail) != *user.Mail {
-			mr.Replace(i.userAttributeMap.mail, []string{*user.Mail})
+	if user.GetMail() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.mail) != user.GetMail() {
+			mr.Replace(i.userAttributeMap.mail, []string{user.GetMail()})
 			updateNeeded = true
 		}
 	}
-	if user.PasswordProfile != nil && user.PasswordProfile.Password != nil && *user.PasswordProfile.Password != "" {
+	if user.GetSurname() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.surname) != user.GetSurname() {
+			mr.Replace(i.userAttributeMap.surname, []string{user.GetSurname()})
+			updateNeeded = true
+		}
+	}
+	if user.GetGivenName() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.givenName) != user.GetGivenName() {
+			mr.Replace(i.userAttributeMap.givenName, []string{user.GetGivenName()})
+			updateNeeded = true
+		}
+	}
+	if user.PasswordProfile != nil && user.PasswordProfile.GetPassword() != "" {
 		if i.usePwModifyExOp {
 			if err := i.updateUserPassowrd(ctx, e.DN, user.PasswordProfile.GetPassword()); err != nil {
 				return nil, err
@@ -293,7 +305,7 @@ func (i *LDAP) UpdateUser(ctx context.Context, nameOrID string, user libregraph.
 		} else {
 			// password are hashed server side there is no need to check if the new password
 			// is actually different from the old one.
-			mr.Replace("userPassword", []string{*user.PasswordProfile.Password})
+			mr.Replace("userPassword", []string{user.PasswordProfile.GetPassword()})
 			updateNeeded = true
 		}
 	}

--- a/services/graph/pkg/identity/ldap_education_school_test.go
+++ b/services/graph/pkg/identity/ldap_education_school_test.go
@@ -322,7 +322,7 @@ var userByIDSearch1 *ldap.SearchRequest = &ldap.SearchRequest{
 	Scope:      2,
 	SizeLimit:  1,
 	Filter:     "(&(objectClass=ocEducationUser)(|(uid=abcd-defg)(entryUUID=abcd-defg)))",
-	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass", "ocMemberOfSchool"},
+	Attributes: eduUserAttrs,
 	Controls:   []ldap.Control(nil),
 }
 
@@ -331,7 +331,7 @@ var userByIDSearch2 *ldap.SearchRequest = &ldap.SearchRequest{
 	Scope:      2,
 	SizeLimit:  1,
 	Filter:     "(&(objectClass=ocEducationUser)(|(uid=does-not-exist)(entryUUID=does-not-exist)))",
-	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass", "ocMemberOfSchool"},
+	Attributes: eduUserAttrs,
 	Controls:   []ldap.Control(nil),
 }
 
@@ -439,7 +439,7 @@ var usersBySchoolIDSearch *ldap.SearchRequest = &ldap.SearchRequest{
 	Scope:      2,
 	SizeLimit:  0,
 	Filter:     "(&(objectClass=ocEducationUser)(ocMemberOfSchool=abcd-defg))",
-	Attributes: []string{"displayname", "entryUUID", "mail", "uid", "oCExternalIdentity", "userClass", "ocMemberOfSchool"},
+	Attributes: eduUserAttrs,
 	Controls:   []ldap.Control(nil),
 }
 

--- a/services/graph/pkg/identity/ldap_education_user.go
+++ b/services/graph/pkg/identity/ldap_education_user.go
@@ -77,7 +77,108 @@ func (i *LDAP) DeleteEducationUser(ctx context.Context, nameOrID string) error {
 
 // UpdateEducationUser applies changes to given education user, identified by username or id
 func (i *LDAP) UpdateEducationUser(ctx context.Context, nameOrID string, user libregraph.EducationUser) (*libregraph.EducationUser, error) {
-	return nil, errNotImplemented
+	logger := i.logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "ldap").Msg("UpdateEducationUser")
+	if !i.writeEnabled {
+		return nil, ErrReadOnly
+	}
+	e, err := i.getEducationUserByNameOrID(nameOrID)
+	if err != nil {
+		return nil, err
+	}
+
+	var updateNeeded bool
+
+	// Don't allow updates of the ID
+	if user.GetId() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.id) != user.GetId() {
+			return nil, errorcode.New(errorcode.NotAllowed, "changing the UserId is not allowed")
+		}
+	}
+	if user.GetOnPremisesSamAccountName() != "" {
+		if eu := e.GetEqualFoldAttributeValue(i.userAttributeMap.userName); eu != user.GetOnPremisesSamAccountName() {
+			e, err = i.changeUserName(ctx, e.DN, eu, user.GetOnPremisesSamAccountName())
+			if err != nil {
+				return nil, err
+			}
+			e, err = i.getEducationUserByDN(e.DN)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	mr := ldap.ModifyRequest{DN: e.DN}
+	if user.GetDisplayName() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.displayName) != user.GetDisplayName() {
+			mr.Replace(i.userAttributeMap.displayName, []string{user.GetDisplayName()})
+			updateNeeded = true
+		}
+	}
+	if user.GetMail() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.mail) != user.GetMail() {
+			mr.Replace(i.userAttributeMap.mail, []string{user.GetMail()})
+			updateNeeded = true
+		}
+	}
+	if user.GetSurname() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.surname) != user.GetSurname() {
+			mr.Replace(i.userAttributeMap.surname, []string{user.GetSurname()})
+			updateNeeded = true
+		}
+	}
+	if user.GetGivenName() != "" {
+		if e.GetEqualFoldAttributeValue(i.userAttributeMap.givenName) != user.GetGivenName() {
+			mr.Replace(i.userAttributeMap.givenName, []string{user.GetGivenName()})
+			updateNeeded = true
+		}
+	}
+	if user.PasswordProfile != nil && user.PasswordProfile.GetPassword() != "" {
+		if i.usePwModifyExOp {
+			if err := i.updateUserPassowrd(ctx, e.DN, user.PasswordProfile.GetPassword()); err != nil {
+				return nil, err
+			}
+		} else {
+			// password are hashed server side there is no need to check if the new password
+			// is actually different from the old one.
+			mr.Replace("userPassword", []string{user.PasswordProfile.GetPassword()})
+			updateNeeded = true
+		}
+	}
+	if user.GetPrimaryRole() != "" {
+		if e.GetEqualFoldAttributeValue(i.educationConfig.userAttributeMap.primaryRole) != user.GetPrimaryRole() {
+			mr.Replace(i.educationConfig.userAttributeMap.primaryRole, []string{user.GetPrimaryRole()})
+			updateNeeded = true
+		}
+	}
+	if identities, ok := user.GetIdentitiesOk(); ok {
+		attrValues := make([]string, 0, len(identities))
+		for _, identity := range identities {
+			identityStr, err := i.identityToLDAPAttrValue(identity)
+			if err != nil {
+				return nil, err
+			}
+			attrValues = append(attrValues, identityStr)
+		}
+		mr.Replace(i.educationConfig.userAttributeMap.identities, attrValues)
+		updateNeeded = true
+	}
+
+	if updateNeeded {
+		if err := i.conn.Modify(&mr); err != nil {
+			return nil, err
+		}
+	}
+
+	// Read	back user from LDAP to get the generated UUID
+	e, err = i.getEducationUserByDN(e.DN)
+	if err != nil {
+		return nil, err
+	}
+
+	returnUser := i.createEducationUserModelFromLDAP(e)
+
+	return returnUser, nil
 }
 
 // GetEducationUser implements the EducationBackend interface for the LDAP backend.
@@ -189,11 +290,10 @@ func (i *LDAP) educationUserToLDAPAttrValues(user libregraph.EducationUser, attr
 	}
 	if identities, ok := user.GetIdentitiesOk(); ok {
 		for _, identity := range identities {
-			// TODO add support for the "signInType" of objectIdentity
-			if identity.GetIssuer() == "" || identity.GetIssuerAssignedId() == "" {
-				return nil, fmt.Errorf("missing Attribute for objectIdentity")
+			identityStr, err := i.identityToLDAPAttrValue(identity)
+			if err != nil {
+				return nil, err
 			}
-			identityStr := fmt.Sprintf(" $ %s $ %s", identity.GetIssuer(), identity.GetIssuerAssignedId())
 			attrs[i.educationConfig.userAttributeMap.identities] = append(
 				attrs[i.educationConfig.userAttributeMap.identities],
 				identityStr,
@@ -202,6 +302,14 @@ func (i *LDAP) educationUserToLDAPAttrValues(user libregraph.EducationUser, attr
 	}
 	attrs["objectClass"] = append(attrs["objectClass"], i.educationConfig.userObjectClass)
 	return attrs, nil
+}
+func (i *LDAP) identityToLDAPAttrValue(identity libregraph.ObjectIdentity) (string, error) {
+	// TODO add support for the "signInType" of objectIdentity
+	if identity.GetIssuer() == "" || identity.GetIssuerAssignedId() == "" {
+		return "", fmt.Errorf("missing Attribute for objectIdentity")
+	}
+	identityStr := fmt.Sprintf(" $ %s $ %s", identity.GetIssuer(), identity.GetIssuerAssignedId())
+	return identityStr, nil
 }
 
 func (i *LDAP) educationUserToAddRequest(user libregraph.EducationUser) (*ldap.AddRequest, error) {
@@ -234,6 +342,9 @@ func (i *LDAP) getEducationUserAttrTypes() []string {
 		i.userAttributeMap.id,
 		i.userAttributeMap.mail,
 		i.userAttributeMap.userName,
+		i.userAttributeMap.surname,
+		i.userAttributeMap.givenName,
+		i.userAttributeMap.accountEnabled,
 		i.educationConfig.userAttributeMap.identities,
 		i.educationConfig.userAttributeMap.primaryRole,
 		i.educationConfig.memberOfSchoolAttribute,


### PR DESCRIPTION
This implements https://owncloud.dev/libre-graph-api/#/educationUser/UpdateEducationUser for the ldap education backend.

I am still wondering how this fell through the cracks :man_facepalming: 