### PR TITLE
Avoid repeated default role assignment

### DIFF
--- a/changelog/unreleased/fix-duplicated-demouser-roles.md
+++ b/changelog/unreleased/fix-duplicated-demouser-roles.md
@@ -1,0 +1,6 @@
+Bugfix: Fix default role assignment for demo users
+
+The roles-assignments for demo users where duplicated with every
+restart of the settings service.
+
+https://github.com/owncloud/ocis/issues/3432

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 
 	TokenManager *TokenManager `yaml:"token_manager"`
 
-	SetupDefaultAssignments bool `yaml:"set_default_assignments" env:"SETTINGS_SETUP_DEFAULT_ASSIGNMENTS;ACCOUNTS_DEMO_USERS_AND_GROUPS" desc:"The default role assignments the demo users should be setup."`
+	SetupDefaultAssignments bool `yaml:"set_default_assignments" env:"SETTINGS_SETUP_DEFAULT_ASSIGNMENTS;IDM_CREATE_DEMO_USERS" desc:"The default role assignments the demo users should be setup."`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -653,30 +653,40 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 
 // DefaultRoleAssignments returns (as one might guess) the default role assignments
 func DefaultRoleAssignments(cfg *config.Config) []*settingsmsg.UserRoleAssignment {
-	return []*settingsmsg.UserRoleAssignment{
-		// default admin users
-		{
+	assignments := []*settingsmsg.UserRoleAssignment{}
+
+	if cfg.SetupDefaultAssignments {
+		assignments = []*settingsmsg.UserRoleAssignment{
+			// default users with role "user"
+			{
+				AccountUuid: "4c510ada-c86b-4815-8820-42cdf82c3d51",
+				RoleId:      BundleUUIDRoleUser,
+			}, {
+				AccountUuid: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+				RoleId:      BundleUUIDRoleUser,
+			}, {
+				AccountUuid: "932b4540-8d16-481e-8ef4-588e4b6b151c",
+				RoleId:      BundleUUIDRoleUser,
+			},
+			{
+				// additional admin user
+				AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b", // demo user "moss"
+				RoleId:      BundleUUIDRoleAdmin,
+			}, {
+				// default users with role "spaceadmin"
+				AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7",
+				RoleId:      BundleUUIDRoleSpaceAdmin,
+			},
+		}
+	}
+
+	if cfg.AdminUserID != "" {
+		// default admin user
+		assignments = append(assignments, &settingsmsg.UserRoleAssignment{
 			AccountUuid: cfg.AdminUserID,
 			RoleId:      BundleUUIDRoleAdmin,
-		},
-		// default users with role "user"
-		{
-			AccountUuid: "4c510ada-c86b-4815-8820-42cdf82c3d51",
-			RoleId:      BundleUUIDRoleUser,
-		}, {
-			AccountUuid: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
-			RoleId:      BundleUUIDRoleUser,
-		}, {
-			AccountUuid: "932b4540-8d16-481e-8ef4-588e4b6b151c",
-			RoleId:      BundleUUIDRoleUser,
-		},
-		// default users with role "spaceadmin"
-		{
-			AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b", // demo user "moss"
-			RoleId:      BundleUUIDRoleAdmin,
-		}, {
-			AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7",
-			RoleId:      BundleUUIDRoleSpaceAdmin,
-		},
+		})
 	}
+
+	return assignments
 }

--- a/services/settings/pkg/store/metadata/store.go
+++ b/services/settings/pkg/store/metadata/store.go
@@ -131,11 +131,21 @@ func (s *Store) initMetadataClient(mdc MetadataClient) error {
 			return err
 		}
 
+		assIDs, err := mdc.ReadDir(ctx, accountPath(accountUUID))
+		if err != nil {
+			return err
+		}
+		if len(assIDs) > 0 {
+			// There is already a role assignment for this ID, skip to the next
+			continue
+		}
+
 		ass := &settingsmsg.UserRoleAssignment{
 			Id:          uuid.Must(uuid.NewV4()).String(),
 			AccountUuid: accountUUID,
 			RoleId:      roleID,
 		}
+
 		b, err := json.Marshal(ass)
 		if err != nil {
 			return err


### PR DESCRIPTION
Avoid repeated default role assignments
    
When using the metadata storage (the current default) the default role
assignments were recreated at every start of the settings service. Leading to
duplicated role assignments
    
Fixes: #3432