### PR TITLE
graph: Allow to disable the default role assignment on user creation

### DIFF
--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -98,6 +98,7 @@ type Identity struct {
 type API struct {
 	GroupMembersPatchLimit int    `yaml:"group_members_patch_limit" env:"GRAPH_GROUP_MEMBERS_PATCH_LIMIT" desc:"The amount of group members allowed to be added with a single patch request."`
 	UsernameMatch          string `yaml:"graph_username_match" env:"GRAPH_USERNAME_MATCH" desc:"Option to allow legacy usernames. Supported options are 'default' and 'none'."`
+	AssignDefaultUserRole  bool   `yaml:"graph_assign_default_user_role" env:"GRAPH_ASSIGN_DEFAULT_USER_ROLE" desc:"Whether to assign newly created users the default role 'User'. Set this to 'false' if you want to assign roles manually, or if the role assignment should happen at first login. Set this to 'true' (the default) to assign the role 'User' when creating a new user."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -40,6 +40,7 @@ func DefaultConfig() *config.Config {
 		API: config.API{
 			GroupMembersPatchLimit: 20,
 			UsernameMatch:          "default",
+			AssignDefaultUserRole:  true,
 		},
 		Reva: shared.DefaultRevaConfig(),
 		Spaces: config.Spaces{

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -17,9 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	settings "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
-	settingssvc "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 )
 
 // GetEducationUsers implements the Service interface.
@@ -148,21 +146,6 @@ func (g Graph) PostEducationUser(w http.ResponseWriter, r *http.Request) {
 			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		}
 		return
-	}
-
-	// assign roles if possible
-	if g.roleService != nil {
-		// All users get the user role by default currently.
-		// to all new users for now, as create Account request does not have any role field
-		if _, err = g.roleService.AssignRoleToUser(r.Context(), &settings.AssignRoleToUserRequest{
-			AccountUuid: *u.Id,
-			RoleId:      settingssvc.BundleUUIDRoleUser,
-		}); err != nil {
-			// log as error, admin eventually needs to do something
-			logger.Error().Err(err).Str("id", *u.Id).Str("role", settingssvc.BundleUUIDRoleUser).Msg("could not create education user: role assignment failed")
-			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, "role assignment failed")
-			return
-		}
 	}
 
 	e := events.UserCreated{UserID: *u.Id}

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -318,7 +318,7 @@ func (g Graph) PostUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// assign roles if possible
-	if g.roleService != nil {
+	if g.roleService != nil && g.config.API.AssignDefaultUserRole {
 		// All users get the user role by default currently.
 		// to all new users for now, as create Account request does not have any role field
 		if _, err = g.roleService.AssignRoleToUser(r.Context(), &settings.AssignRoleToUserRequest{


### PR DESCRIPTION
Introduces a switch ('GRAPH_ASSIGN_DEFAULT_USER_ROLE') to allow to disable the assignment of the default role "User" to newly created users. This will be used for setups where the role-assignments are populated either manually or during first login (e.g. from OIDC claims)
