### PR TITLE
graph: Fix so that accountEnabled updates work for educationUser.

### DIFF
--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -274,36 +274,23 @@ func (i *LDAP) UpdateUser(ctx context.Context, nameOrID string, user libregraph.
 	}
 
 	mr := ldap.ModifyRequest{DN: e.DN}
-	if user.GetDisplayName() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.displayName) != user.GetDisplayName() {
-			mr.Replace(i.userAttributeMap.displayName, []string{user.GetDisplayName()})
-			updateNeeded = true
+	properties := map[string]string{
+		i.userAttributeMap.displayName: user.GetDisplayName(),
+		i.userAttributeMap.mail:        user.GetMail(),
+		i.userAttributeMap.surname:     user.GetSurname(),
+		i.userAttributeMap.givenName:   user.GetGivenName(),
+		i.userAttributeMap.userType:    user.GetUserType(),
+	}
+
+	for attribute, value := range properties {
+		if value != "" {
+			if e.GetEqualFoldAttributeValue(attribute) != value {
+				mr.Replace(attribute, []string{value})
+				updateNeeded = true
+			}
 		}
 	}
-	if user.GetMail() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.mail) != user.GetMail() {
-			mr.Replace(i.userAttributeMap.mail, []string{user.GetMail()})
-			updateNeeded = true
-		}
-	}
-	if user.GetSurname() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.surname) != user.GetSurname() {
-			mr.Replace(i.userAttributeMap.surname, []string{user.GetSurname()})
-			updateNeeded = true
-		}
-	}
-	if user.GetGivenName() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.givenName) != user.GetGivenName() {
-			mr.Replace(i.userAttributeMap.givenName, []string{user.GetGivenName()})
-			updateNeeded = true
-		}
-	}
-	if user.GetUserType() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.userType) != user.GetUserType() {
-			mr.Replace(i.userAttributeMap.userType, []string{user.GetUserType()})
-			updateNeeded = true
-		}
-	}
+
 	if user.PasswordProfile != nil && user.PasswordProfile.GetPassword() != "" {
 		if i.usePwModifyExOp {
 			if err := i.updateUserPassowrd(ctx, e.DN, user.PasswordProfile.GetPassword()); err != nil {

--- a/services/graph/pkg/identity/ldap_education_school_test.go
+++ b/services/graph/pkg/identity/ldap_education_school_test.go
@@ -22,6 +22,7 @@ var eduConfig = config.LDAP{
 	UserEmailAttribute:       "mail",
 	UserNameAttribute:        "uid",
 	UserEnabledAttribute:     "userEnabledAttribute",
+	DisableUserMechanism:     "attribute",
 	UserTypeAttribute:        "userTypeAttribute",
 
 	GroupBaseDN:        "ou=groups,dc=test",

--- a/services/graph/pkg/identity/ldap_education_user.go
+++ b/services/graph/pkg/identity/ldap_education_user.go
@@ -109,36 +109,24 @@ func (i *LDAP) UpdateEducationUser(ctx context.Context, nameOrID string, user li
 	}
 
 	mr := ldap.ModifyRequest{DN: e.DN}
-	if user.GetDisplayName() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.displayName) != user.GetDisplayName() {
-			mr.Replace(i.userAttributeMap.displayName, []string{user.GetDisplayName()})
-			updateNeeded = true
+	properties := map[string]string{
+		i.userAttributeMap.displayName:                 user.GetDisplayName(),
+		i.userAttributeMap.mail:                        user.GetMail(),
+		i.userAttributeMap.surname:                     user.GetSurname(),
+		i.userAttributeMap.givenName:                   user.GetGivenName(),
+		i.userAttributeMap.userType:                    user.GetUserType(),
+		i.educationConfig.userAttributeMap.primaryRole: user.GetPrimaryRole(),
+	}
+
+	for attribute, value := range properties {
+		if value != "" {
+			if e.GetEqualFoldAttributeValue(attribute) != value {
+				mr.Replace(attribute, []string{value})
+				updateNeeded = true
+			}
 		}
 	}
-	if user.GetMail() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.mail) != user.GetMail() {
-			mr.Replace(i.userAttributeMap.mail, []string{user.GetMail()})
-			updateNeeded = true
-		}
-	}
-	if user.GetSurname() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.surname) != user.GetSurname() {
-			mr.Replace(i.userAttributeMap.surname, []string{user.GetSurname()})
-			updateNeeded = true
-		}
-	}
-	if user.GetGivenName() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.givenName) != user.GetGivenName() {
-			mr.Replace(i.userAttributeMap.givenName, []string{user.GetGivenName()})
-			updateNeeded = true
-		}
-	}
-	if user.GetUserType() != "" {
-		if e.GetEqualFoldAttributeValue(i.userAttributeMap.userType) != user.GetUserType() {
-			mr.Replace(i.userAttributeMap.userType, []string{user.GetUserType()})
-			updateNeeded = true
-		}
-	}
+
 	if user.AccountEnabled != nil {
 		un, err := i.updateAccountEnabledState(logger, user.GetAccountEnabled(), e, &mr)
 
@@ -159,12 +147,6 @@ func (i *LDAP) UpdateEducationUser(ctx context.Context, nameOrID string, user li
 			// password are hashed server side there is no need to check if the new password
 			// is actually different from the old one.
 			mr.Replace("userPassword", []string{user.PasswordProfile.GetPassword()})
-			updateNeeded = true
-		}
-	}
-	if user.GetPrimaryRole() != "" {
-		if e.GetEqualFoldAttributeValue(i.educationConfig.userAttributeMap.primaryRole) != user.GetPrimaryRole() {
-			mr.Replace(i.educationConfig.userAttributeMap.primaryRole, []string{user.GetPrimaryRole()})
 			updateNeeded = true
 		}
 	}

--- a/services/graph/pkg/service/v0/educationuser_test.go
+++ b/services/graph/pkg/service/v0/educationuser_test.go
@@ -449,6 +449,7 @@ var _ = Describe("EducationUsers", func() {
 			user.SetOnPremisesSamAccountName("user")
 			user.SetMail("user@example.com")
 			user.SetId("/users/user")
+			user.SetAccountEnabled(true)
 
 			identityEducationBackend.On("GetEducationUser", mock.Anything, mock.Anything, mock.Anything).Return(&user, nil)
 		})
@@ -502,6 +503,7 @@ var _ = Describe("EducationUsers", func() {
 			identityEducationBackend.On("UpdateEducationUser", mock.Anything, user.GetId(), mock.Anything).Return(user, nil)
 
 			user.SetDisplayName("New Display Name")
+			user.SetAccountEnabled(false)
 			data, err := json.Marshal(user)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -519,6 +521,7 @@ var _ = Describe("EducationUsers", func() {
 			err = json.Unmarshal(data, &updatedUser)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedUser.GetDisplayName()).To(Equal("New Display Name"))
+			Expect(updatedUser.GetAccountEnabled()).To(Equal(false))
 		})
 	})
 })


### PR DESCRIPTION
## Description
Fix so that the accountEnabled attribute will be updated on PATCH requests for educationUser.

## Related Issue
- Fixes #5816 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using curl and updated unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
