### PR TITLE
[docs-only] Fix Docs Creation

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1914,7 +1914,8 @@ def docs():
                     "password": {
                         "from_secret": "github_token",
                     },
-                    "pages_directory": "docs/hugo/content",
+                    "pages_directory": "docs/hugo/content/",
+                    "copy_contents": "true",
                     "target_branch": "docs",
                 },
                 "when": {


### PR DESCRIPTION
After github plugin was updated in https://github.com/drone-plugins/drone-gh-pages/pull/34 the copy behaviour has changed. We now need to add a trailing slash to the path and set `copy_contents` to true