### PR TITLE
Allow ADMIN_USER_ID being empty

### DIFF
--- a/ocis-pkg/config/parser/parse.go
+++ b/ocis-pkg/config/parser/parse.go
@@ -132,9 +132,5 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingSystemUserID("ocis")
 	}
 
-	if cfg.AdminUserID == "" {
-		return shared.MissingAdminUserID("ocis")
-	}
-
 	return nil
 }

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -92,11 +92,6 @@ func bootstrap(logger log.Logger, cfg *config.Config, srvcfg server.Config) erro
 
 	serviceUsers := []svcUser{
 		{
-			Name:     "admin",
-			Password: cfg.ServiceUserPasswords.OcisAdmin,
-			ID:       cfg.AdminUserID,
-		},
-		{
 			Name:     "libregraph",
 			Password: cfg.ServiceUserPasswords.Idm,
 		},
@@ -108,6 +103,14 @@ func bootstrap(logger log.Logger, cfg *config.Config, srvcfg server.Config) erro
 			Name:     "reva",
 			Password: cfg.ServiceUserPasswords.Reva,
 		},
+	}
+
+	if cfg.AdminUserID != "" {
+		serviceUsers = append(serviceUsers, svcUser{
+			Name:     "admin",
+			Password: cfg.ServiceUserPasswords.OcisAdmin,
+			ID:       cfg.AdminUserID,
+		})
 	}
 
 	bdb := &ldbbolt.LdbBolt{}

--- a/services/idm/pkg/config/parser/parse.go
+++ b/services/idm/pkg/config/parser/parse.go
@@ -33,7 +33,7 @@ func ParseConfig(cfg *config.Config) error {
 }
 
 func Validate(cfg *config.Config) error {
-	if cfg.AdminUserID == "" {
+	if cfg.CreateDemoUsers && cfg.AdminUserID == "" {
 		return shared.MissingAdminUserID(cfg.Service.Name)
 	}
 
@@ -41,7 +41,7 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingServiceUserPassword(cfg.Service.Name, "IDM")
 	}
 
-	if cfg.ServiceUserPasswords.OcisAdmin == "" {
+	if cfg.AdminUserID != "" && cfg.ServiceUserPasswords.OcisAdmin == "" {
 		return shared.MissingServiceUserPassword(cfg.Service.Name, "admin")
 	}
 

--- a/services/settings/pkg/config/parser/parse.go
+++ b/services/settings/pkg/config/parser/parse.go
@@ -45,7 +45,7 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingSystemUserApiKeyError(cfg.Service.Name)
 	}
 
-	if cfg.AdminUserID == "" {
+	if cfg.SetupDefaultAssignments && cfg.AdminUserID == "" {
 		return shared.MissingAdminUserID(cfg.Service.Name)
 	}
 


### PR DESCRIPTION
For certain setups we don't need the ADMIN_USER_ID to be set. It is mainly needed for bootstrapping the internal idm and the initial role assignment.  If roles are assign by other means (e.g. OIDC claims) we don't need it.

This makes the ADMIN_USER_ID optional, also if ADMIN_USER_ID is unset we don't need to configure a password for the admin user. We will still generated the admin_id and password when running 'ocis init', but it is ok to run manual setups without those settings.
