### PR TITLE
[full-ci] chore: bump web to v7.0.0-rc.21

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=1cf0e65106cd8293b0dc3417bb951b7234e4a0d9
+WEB_COMMITID=185b60b07e9e39726b0ab87fc38d6445329a104c
 WEB_BRANCH=master

--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=62100dc92495cdacc7ef01db50998bd0912d40c3
+WEB_COMMITID=c7bef3b17353d70a6272dcf290badc4b3873104d
 WEB_BRANCH=master

--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=c7bef3b17353d70a6272dcf290badc4b3873104d
+WEB_COMMITID=1cf0e65106cd8293b0dc3417bb951b7234e4a0d9
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.20
+WEB_ASSETS_VERSION = v7.0.0-rc.21
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bump web to `v7.0.0-rc.21`.

This includes a bugfix regarding the password input prompt for enforced passwords on public links.