### PR TITLE
[tests-only][full-ci] api test to set quota by users with different roles

### DIFF
--- a/tests/acceptance/features/apiSpaces/setQuota.feature
+++ b/tests/acceptance/features/apiSpaces/setQuota.feature
@@ -1,0 +1,178 @@
+@api
+Feature: Set quota
+  As a user
+  I want to set quota to different users
+  So that users can only take up a certain amount of storage space
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+
+  Scenario Outline: admin sets personal space quota of user with different role
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    When user "Alice" changes the quota of the "Brian Murphy" space to "100" owned by user "Brian"
+    Then the HTTP status code should be "200"
+    And for user "Brian" the JSON response should contain space called "Brian Murphy" and match
+    """
+    {
+      "type": "object",
+      "required": [
+        "quota"
+      ],
+      "properties": {
+        "quota": {
+          "type": "object",
+          "required": [
+            "total"
+          ],
+          "properties": {
+            "total" : {
+              "type": "number",
+              "enum": [100]
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | userRole    |
+      | Admin       |
+      | Space Admin |
+      | User        |
+      | Guest       |
+
+
+  Scenario Outline: non-admin user tries to set the personal space quota of other users
+    Given the administrator has given "Alice" the role "<role>" using the settings api
+    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    When user "Alice" changes the quota of the "Brian Murphy" space to "100" owned by user "Brian"
+    Then the HTTP status code should be "401"
+    And for user "Brian" the JSON response should contain space called "Brian Murphy" and match
+    """
+    {
+      "type": "object",
+      "required": [
+        "quota"
+      ],
+      "properties": {
+        "quota": {
+          "type": "object",
+          "required": [
+            "total"
+          ],
+          "properties": {
+            "total" : {
+              "type": "number",
+              "enum": [0]
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | role        | userRole    |
+      | Space Admin | Admin       |
+      | Space Admin | Space Admin |
+      | Space Admin | User        |
+      | Space Admin | Guest       |
+      | User        | Admin       |
+      | User        | Space Admin |
+      | User        | User        |
+      | User        | Guest       |
+      | Guest       | Admin       |
+      | Guest       | Space Admin |
+      | Guest       | User        |
+      | Guest       | Guest       |
+
+
+  Scenario Outline: admin or space admin user sets a quota of a project space
+    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
+    When user "Brian" changes the quota of the "Project Jupiter" space to "100" owned by user "Alice"
+    Then the HTTP status code should be "200"
+    And for user "Alice" the JSON response should contain space called "Project Jupiter" and match
+    """
+    {
+      "type": "object",
+      "required": [
+        "name",
+        "quota"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["Project Jupiter"]
+        },
+        "quota": {
+          "type": "object",
+          "required": [
+            "total"
+          ],
+          "properties": {
+            "total" : {
+              "type": "number",
+              "enum": [100]
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | userRole    |
+      | Admin       |
+      | Space Admin |
+
+
+  Scenario Outline: normal or guest user tries to set quota of a space
+    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
+    And user "Alice" has shared a space "Project Jupiter" with settings:
+      | shareWith | Brian       |
+      | role      | <spaceRole> |
+    When user "Brian" changes the quota of the "Project Jupiter" space to "100"
+    Then the HTTP status code should be "401"
+    And for user "Alice" the JSON response should contain space called "Project Jupiter" and match
+    """
+    {
+      "type": "object",
+      "required": [
+        "name",
+        "quota"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["Project Jupiter"]
+        },
+        "quota": {
+          "type": "object",
+          "required": [
+            "total"
+          ],
+          "properties": {
+            "total" : {
+              "type": "number",
+              "enum": [20]
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | userRole | spaceRole |
+      | User     | viewer    |
+      | User     | editor    |
+      | User     | manager   |
+      | Guest    | viewer    |
+      | Guest    | editor    |
+      | Guest    | manager   |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds API test to set quota by users with different roles

## Related Issue
Related to issue: https://github.com/owncloud/ocis/issues/5565

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
