### PR TITLE
[tests-only][full-ci]Expand tests coverage for adding multiple members to a group at single request

### DIFF
--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -311,3 +311,44 @@ Feature: add users to group
     And user "Alice" has created a group "grp1" using the Graph API
     When user "Alice" tries to add user "Brian" to group "grp1" with an invalid host using the Graph API
     Then the HTTP status code should be "400"
+
+
+  Scenario Outline: try to add invalid user id to a group
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    And user "Alice" has created a group "grp1" using the Graph API
+    When the administrator "Alice" tries to add an invalid user id "<invalid-uuidv4>" to a group "grp1" using the Graph API
+    Then the HTTP status code should be "404"
+    Examples:
+      | invalid-uuidv4                        | comment                                                |
+      | �ϰ�Ϧ-@$@^-¶Ëøœ-ɧɸɱʨΌϖЁϿ               | UTF characters                                         |
+      | 4c510ada-c86b-4815-8820-42cdf82c3d511 | adding an extra character at end of valid UUID pattern |
+      | 4c510adac8-6b-4815-882042cdf-82c3d51  | invalid UUID pattern                                   |
+
+
+  Scenario Outline: try to add invalid user ids to a group at once
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    And user "Alice" has created a group "grp1" using the Graph API
+    When the administrator "Alice" tries to add the following invalid user ids to a group "grp1" at once using the Graph API
+      | user-id          |
+      | <invalid-uuidv4> |
+      | <invalid-uuidv4> |
+    Then the HTTP status code should be "404"
+    Examples:
+      | invalid-uuidv4                        | comment                                                |
+      | �ϰ�Ϧ-@$@^-¶Ëøœ-ɧɸɱʨΌϖЁϿ               | UTF characters                                         |
+      | 4c510ada-c86b-4815-8820-42cdf82c3d511 | adding an extra character at end of valid UUID pattern |
+      | 4c510adac8-6b-4815-882042cdf-82c3d51  | invalid UUID pattern                                   |
+
+  @skipOnStable2.0
+  Scenario: add same user twice to a group at once
+    Given the administrator has given "Alice" the role "Admin" using the settings api
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+    And user "Alice" has created a group "grp1" using the Graph API
+    When the administrator "Alice" adds the following users to a group "grp1" at once using the Graph API
+      | username |
+      | Brian    |
+      | Brian    |
+    Then the HTTP status code should be "204"
+    And the user "Brian" should be listed once in the group "grp1"

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -1740,7 +1740,7 @@ class GraphContext implements Context {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$this->featureContext->verifyTableNodeColumns($table, ['username']);
-		
+
 		foreach ($table->getHash() as $row) {
 			$userIds[] = $this->featureContext->getAttributeOfCreatedUser($row['username'], "id");
 		}
@@ -2280,6 +2280,88 @@ class GraphContext implements Context {
 				['Content-Type' => 'application/json'],
 				\json_encode($invalidJSON)
 			)
+		);
+	}
+
+	/**
+	 * @When /^the administrator "([^"]*)" tries to add the following invalid user ids to a group "([^"]*)" at once using the Graph API$/
+	 *
+	 * @param string $user
+	 * @param string $group
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theAdministratorTriesToAddTheFollowingUserIdWithInvalidCharacterToAGroup(string $user, string $group, TableNode $table) {
+		$userIds = [];
+		$credentials = $this->getAdminOrUserCredentials($user);
+		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
+		foreach ($table->getHash() as $row) {
+			$userIds[] = \implode(" ", $row);
+		}
+		$this->featureContext->setResponse(
+			GraphHelper::addUsersToGroup(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getStepLineRef(),
+				$credentials["username"],
+				$credentials["password"],
+				$groupId,
+				$userIds
+			)
+		);
+	}
+
+	/**
+	 * @When /^the administrator "([^"]*)" tries to add an invalid user id "([^"]*)" to a group "([^"]*)" using the Graph API$/
+	 *
+	 * @param string $user
+	 * @param string $userId
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theAdministratorTriesToAddUserIdWithInvalidCharactersToAGroup(string $user, string $userId, string $group): void {
+		$credentials = $this->getAdminOrUserCredentials($user);
+		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
+		$this->featureContext->setResponse(
+			GraphHelper::addUserToGroup(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getStepLineRef(),
+				$credentials['username'],
+				$credentials['password'],
+				$userId,
+				$groupId
+			)
+		);
+	}
+
+	/**
+	 * @Then the user :user should be listed once in the group :group
+	 *
+	 * @param string $user
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theUsersShouldBeListedOnceToAGroup(string $user, string $group): void {
+		$count = 0;
+		$members = $this->listGroupMembers($group);
+		$members = $this->featureContext->getJsonDecodedResponse($members);
+
+		foreach ($members as $member) {
+			if ($member['onPremisesSamAccountName'] === $user) {
+				$count++;
+			}
+		}
+		Assert::assertEquals(
+			1,
+			$count,
+			"Expected user '" . $user . "' to be added once to group '" . $group . "' but the user is listed '" . $count . "' times"
 		);
 	}
 }


### PR DESCRIPTION
## Description
This PR adds tests coverage 
- Scenario Outline: try to a user-id with invalid characters to a group
- Scenario Outline: try to add user-ids with invalid characters to a group at once
- Scenario: add the same user to a group at once

## Related Issue
- [Fixes <issue_link>](https://github.com/owncloud/ocis/issues/5569)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
