### PR TITLE
dig into http2 support

### DIFF
--- a/ocis-pkg/config/helpers.go
+++ b/ocis-pkg/config/helpers.go
@@ -1,11 +1,15 @@
 package config
 
 import (
+	"crypto/tls"
+	"fmt"
 	"path"
 
 	gofig "github.com/gookit/config/v2"
 	gooyaml "github.com/gookit/config/v2/yaml"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
+	ociscrypto "github.com/owncloud/ocis/v2/ocis-pkg/crypto"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 )
 
 var (
@@ -33,4 +37,36 @@ func BindSourcesToStructs(service string, dst interface{}) (*gofig.Config, error
 	}
 
 	return cnf, nil
+}
+
+// BuildTLSConfig returns a tls.Config struct for the given configuration.
+// When tls is enabled it will try to load the given certificate or generate a self signed certificate
+func BuildTLSConfig(l log.Logger, enabled bool, certPath, keyPath, address string) (*tls.Config, error) {
+	if enabled {
+		var cert tls.Certificate
+		var err error
+		if certPath != "" {
+			// Generate a self-signing cert if no certificate is present
+			if err := ociscrypto.GenCert(certPath, keyPath, l); err != nil {
+				return nil, err
+			}
+			cert, err = tls.LoadX509KeyPair(certPath, keyPath)
+			if err != nil {
+				return nil, fmt.Errorf("error loading server certificate and key: %w", err)
+			}
+		} else {
+			cert, err = ociscrypto.GenTempCertForAddr(address)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return &tls.Config{
+			NextProtos: []string{"h2", "http/1.1"},
+			//MinVersion:   tls.VersionTLS12,
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{cert},
+		}, nil
+	}
+	return nil, nil
+
 }

--- a/ocis-pkg/service/grpc/client.go
+++ b/ocis-pkg/service/grpc/client.go
@@ -64,6 +64,7 @@ func Configure(opts ...ClientOption) error {
 			}
 			cOpts = append(cOpts, mgrpcc.AuthTLS(tlsConfig))
 		case "on":
+			// TODO use function to add cert to cert pool?
 			tlsConfig = &tls.Config{}
 			// Note: If caCert is empty we use the system's default set of trusted CAs
 			if options.caCert != "" {

--- a/ocis-pkg/service/grpc/service.go
+++ b/ocis-pkg/service/grpc/service.go
@@ -26,6 +26,7 @@ func NewService(opts ...Option) (Service, error) {
 	sopts := newOptions(opts...)
 	tlsConfig := &tls.Config{}
 	if sopts.TLSEnabled {
+		// TODO reuse ocis-pkg/config and pass a real tls.Config
 		var cert tls.Certificate
 		var err error
 		if sopts.TLSCert != "" {

--- a/ocis-pkg/service/http/option.go
+++ b/ocis-pkg/service/http/option.go
@@ -2,10 +2,10 @@ package http
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/urfave/cli/v2"
 )
 
@@ -15,7 +15,7 @@ type Option func(o *Options)
 // Options defines the available options for this package.
 type Options struct {
 	Logger    log.Logger
-	TLSConfig shared.HTTPServiceTLS
+	TLSConfig *tls.Config
 	Namespace string
 	Name      string
 	Version   string
@@ -88,7 +88,7 @@ func Flags(flags ...cli.Flag) Option {
 }
 
 // TLSConfig provides a function to set the TLSConfig option.
-func TLSConfig(config shared.HTTPServiceTLS) Option {
+func TLSConfig(config *tls.Config) Option {
 	return func(o *Options) {
 		o.TLSConfig = config
 	}

--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -76,11 +76,12 @@ type Debug struct {
 }
 
 type HTTPConfig struct {
-	Addr      string `yaml:"addr" env:"FRONTEND_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Namespace string `yaml:"-"`
-	Protocol  string `yaml:"protocol" env:"FRONTEND_HTTP_PROTOCOL" desc:"The transport protocol of the HTTP service."`
-	Prefix    string `yaml:"prefix" env:"FRONTEND_HTTP_PREFIX" desc:"The Path prefix where the frontend can be accessed (defaults to /)."`
-	CORS      CORS   `yaml:"cors"`
+	Addr      string                `yaml:"addr" env:"FRONTEND_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	Namespace string                `yaml:"-"`
+	Protocol  string                `yaml:"protocol" env:"FRONTEND_HTTP_PROTOCOL" desc:"The transport protocol of the HTTP service."`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
+	Prefix    string                `yaml:"prefix" env:"FRONTEND_HTTP_PREFIX" desc:"The Path prefix where the frontend can be accessed (defaults to /)."`
+	CORS      CORS                  `yaml:"cors"`
 }
 
 // CORS defines the available cors configuration.

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -27,7 +27,12 @@ func DefaultConfig() *config.Config {
 			Addr:      "127.0.0.1:9140",
 			Namespace: "com.owncloud.web",
 			Protocol:  "tcp",
-			Prefix:    "",
+			TLS: shared.HTTPServiceTLS{
+				Enabled: true,
+				Cert:    "/etc/ssl/certs/test.cert.pem",
+				Key:     "/etc/ssl/certs/test.key.pem",
+			},
+			Prefix: "",
 			CORS: config.CORS{
 				AllowedOrigins: []string{"*"},
 				AllowedMethods: []string{

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -284,6 +284,8 @@ func FrontendConfigFromStruct(cfg *config.Config) (map[string]interface{}, error
 					},
 				},
 			},
+			"certfile": cfg.HTTP.TLS.Cert,
+			"keyfile":  cfg.HTTP.TLS.Key,
 		},
 	}, nil
 }

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -30,7 +30,7 @@ func DefaultConfig() *config.Config {
 			Namespace: "com.owncloud.web",
 			TLSCert:   filepath.Join(defaults.BaseDataPath(), "idp", "server.crt"),
 			TLSKey:    filepath.Join(defaults.BaseDataPath(), "idp", "server.key"),
-			TLS:       false,
+			TLS:       true,
 		},
 		Reva: shared.DefaultRevaConfig(),
 		Service: config.Service{

--- a/services/idp/pkg/server/http/server.go
+++ b/services/idp/pkg/server/http/server.go
@@ -2,13 +2,11 @@ package http
 
 import (
 	"fmt"
-	"os"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	pkgcrypto "github.com/owncloud/ocis/v2/ocis-pkg/crypto"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	svc "github.com/owncloud/ocis/v2/services/idp/pkg/service/v0"
 	"go-micro.dev/v4"
@@ -18,17 +16,18 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
-	if options.Config.HTTP.TLS {
-		_, certErr := os.Stat(options.Config.HTTP.TLSCert)
-		_, keyErr := os.Stat(options.Config.HTTP.TLSKey)
-
-		if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
-			options.Logger.Info().Msgf("Generating certs")
-			if err := pkgcrypto.GenCert(options.Config.HTTP.TLSCert, options.Config.HTTP.TLSKey, options.Logger); err != nil {
-				options.Logger.Fatal().Err(err).Msg("Could not setup TLS")
-				os.Exit(1)
-			}
-		}
+	tlsConfig, err := config.BuildTLSConfig(
+		options.Logger,
+		options.Config.HTTP.TLS,
+		options.Config.HTTP.TLSCert,
+		options.Config.HTTP.TLSKey,
+		options.Config.HTTP.Addr,
+	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("could not build certificate")
+		return http.Service{}, fmt.Errorf("could not build certificate: %w", err)
 	}
 
 	service, err := http.NewService(
@@ -39,11 +38,7 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Address(options.Config.HTTP.Addr),
 		http.Context(options.Context),
 		http.Flags(options.Flags...),
-		http.TLSConfig(shared.HTTPServiceTLS{
-			Enabled: options.Config.HTTP.TLS,
-			Cert:    options.Config.HTTP.TLSCert,
-			Key:     options.Config.HTTP.TLSKey,
-		}),
+		http.TLSConfig(tlsConfig),
 	)
 	if err != nil {
 		options.Logger.Error().

--- a/services/ocdav/pkg/config/config.go
+++ b/services/ocdav/pkg/config/config.go
@@ -62,10 +62,11 @@ type Debug struct {
 }
 
 type HTTPConfig struct {
-	Addr      string `yaml:"addr" env:"OCDAV_HTTP_ADDR" desc:"The bind address of the HTTP service."`
-	Namespace string `yaml:"-"`
-	Protocol  string `yaml:"protocol" env:"OCDAV_HTTP_PROTOCOL" desc:"The transport protocol of the HTTP service."`
-	Prefix    string `yaml:"prefix" env:"OCDAV_HTTP_PREFIX" desc:"A URL path prefix for the handler."`
+	Addr      string                `yaml:"addr" env:"OCDAV_HTTP_ADDR" desc:"The bind address of the HTTP service."`
+	Namespace string                `yaml:"-"`
+	Protocol  string                `yaml:"protocol" env:"OCDAV_HTTP_PROTOCOL" desc:"The transport protocol of the HTTP service."`
+	TLS       shared.HTTPServiceTLS `yaml:"tls"`
+	Prefix    string                `yaml:"prefix" env:"OCDAV_HTTP_PREFIX" desc:"A URL path prefix for the handler."`
 }
 
 // Status holds the configurable values for the status.php

--- a/services/ocs/pkg/server/http/server.go
+++ b/services/ocs/pkg/server/http/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/cors"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
@@ -17,8 +18,22 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
+	tlsConfig, err := config.BuildTLSConfig(
+		options.Logger,
+		options.Config.HTTP.TLS.Enabled,
+		options.Config.HTTP.TLS.Cert,
+		options.Config.HTTP.TLS.Key,
+		options.Config.HTTP.Addr,
+	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("could not build certificate")
+		return http.Service{}, fmt.Errorf("could not build certificate: %w", err)
+	}
+
 	service, err := http.NewService(
-		http.TLSConfig(options.Config.HTTP.TLS),
+		http.TLSConfig(tlsConfig),
 		http.Logger(options.Logger),
 		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
@@ -32,6 +31,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/tracing"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/user/backend"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/net/http2"
 	"golang.org/x/oauth2"
 )
 
@@ -160,14 +160,14 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config)
 	}
 
 	var oidcHTTPClient = &http.Client{
-		Transport: &http.Transport{
+		Transport: &http2.Transport{
 			TLSClientConfig: &tls.Config{
 				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
 			},
-			DisableKeepAlives: true,
+			//DisableKeepAlives: true,
 		},
-		Timeout: time.Second * 10,
+		//Timeout: time.Second * 10,
 	}
 
 	var authenticators []middleware.Authenticator

--- a/services/proxy/pkg/server/http/server.go
+++ b/services/proxy/pkg/server/http/server.go
@@ -2,11 +2,9 @@ package http
 
 import (
 	"fmt"
-	"os"
 
-	pkgcrypto "github.com/owncloud/ocis/v2/ocis-pkg/crypto"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"go-micro.dev/v4"
 )
@@ -14,32 +12,27 @@ import (
 // Server initializes the http service and server.
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
-	l := options.Logger
-	httpCfg := options.Config.HTTP
 
-	if options.Config.HTTP.TLS {
-		l.Warn().Msgf("No tls certificate provided, using a generated one")
-		_, certErr := os.Stat(httpCfg.TLSCert)
-		_, keyErr := os.Stat(httpCfg.TLSKey)
-
-		if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
-			// GenCert has side effects as it writes 2 files to the binary running location
-			if err := pkgcrypto.GenCert(httpCfg.TLSCert, httpCfg.TLSKey, l); err != nil {
-				l.Fatal().Err(err).Msgf("Could not generate test-certificate")
-				os.Exit(1)
-			}
-		}
-	}
 	chain := options.Middlewares.Then(options.Handler)
+
+	tlsConfig, err := config.BuildTLSConfig(
+		options.Logger,
+		options.Config.HTTP.TLS,
+		options.Config.HTTP.TLSCert,
+		options.Config.HTTP.TLSKey,
+		options.Config.HTTP.Addr,
+	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("could not build certificate")
+		return http.Service{}, fmt.Errorf("could not build certificate: %w", err)
+	}
 
 	service, err := http.NewService(
 		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),
-		http.TLSConfig(shared.HTTPServiceTLS{
-			Enabled: options.Config.HTTP.TLS,
-			Cert:    options.Config.HTTP.TLSCert,
-			Key:     options.Config.HTTP.TLSKey,
-		}),
+		http.TLSConfig(tlsConfig),
 		http.Logger(options.Logger),
 		http.Address(options.Config.HTTP.Addr),
 		http.Namespace(options.Config.HTTP.Namespace),

--- a/services/thumbnails/pkg/server/http/server.go
+++ b/services/thumbnails/pkg/server/http/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	ocismiddleware "github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -16,8 +17,22 @@ import (
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
+	tlsConfig, err := config.BuildTLSConfig(
+		options.Logger,
+		options.Config.HTTP.TLS.Enabled,
+		options.Config.HTTP.TLS.Cert,
+		options.Config.HTTP.TLS.Key,
+		options.Config.HTTP.Addr,
+	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("could not build certificate")
+		return http.Service{}, fmt.Errorf("could not build certificate: %w", err)
+	}
+
 	service, err := http.NewService(
-		http.TLSConfig(options.Config.HTTP.TLS),
+		http.TLSConfig(tlsConfig),
 		http.Logger(options.Logger),
 		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),

--- a/services/userlog/pkg/server/http/server.go
+++ b/services/userlog/pkg/server/http/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/account"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/http"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -15,16 +16,26 @@ import (
 	"go-micro.dev/v4"
 )
 
-// Service is the service interface
-type Service interface {
-}
-
 // Server initializes the http service and server.
 func Server(opts ...Option) (http.Service, error) {
 	options := newOptions(opts...)
 
+	tlsConfig, err := config.BuildTLSConfig(
+		options.Logger,
+		options.Config.HTTP.TLS.Enabled,
+		options.Config.HTTP.TLS.Cert,
+		options.Config.HTTP.TLS.Key,
+		options.Config.HTTP.Addr,
+	)
+	if err != nil {
+		options.Logger.Error().
+			Err(err).
+			Msg("could not build certificate")
+		return http.Service{}, fmt.Errorf("could not build certificate: %w", err)
+	}
+
 	service, err := http.NewService(
-		http.TLSConfig(options.Config.HTTP.TLS),
+		http.TLSConfig(tlsConfig),
 		http.Logger(options.Logger),
 		http.Namespace(options.Config.HTTP.Namespace),
 		http.Name("userlog"),


### PR DESCRIPTION
I was digging into https://github.com/owncloud/ocis/issues/5116 out of curiosity.

AFAICT just instanting tls.Config or even setting some params will break http2 support. I got http2 working (partially) by manually setting `NextProtos: []string{"h2", "http/1.1"},` ... but things are a little more complicated as we also need to tell the go micro servers and clients to use a Transport with http2 support: `micro.Transport(transport.NewHTTPTransport(transport.TLSConfig(sopts.TLSConfig)))`

We are also manually adding a `use_tls` flag to the micro metadata, which the proxy evaluates to either send http or http2 requests ... IMO that should be handled by the micro registry ...

Furthermore, reva also needs some changes: https://github.com/cs3org/reva/pull/3736

In any case this needs more digging