### PR TITLE
Remove faulty enties in extended_vars.yaml

### DIFF
--- a/helpers/extended_vars.yaml
+++ b/helpers/extended_vars.yaml
@@ -32,22 +32,6 @@ variables:
   default_value: ""
   description: ""
   do_ignore: true
-- rawname: MICRO_LOG_LEVEL
-  path: ocis-pkg/log/log.go:31
-  foundincode: true
-  name: MICRO_LOG_LEVEL
-  type: ""
-  default_value: ""
-  description: ""
-  do_ignore: false
-- rawname: MICRO_LOG_LEVEL
-  path: ocis-pkg/log/log.go:35
-  foundincode: true
-  name: MICRO_LOG_LEVEL
-  type: ""
-  default_value: ""
-  description: ""
-  do_ignore: false
 - rawname: registryEnv
   path: ocis-pkg/registry/registry.go:44
   foundincode: true


### PR DESCRIPTION
These entries are not present in the source `master/helpers/extended_envvars.yaml`. They seem to be a leftover from some tuning at the beginnig but create 2 entries in the admin docs that should not show up. Of course they could be marked as `do_ignore: true`, but deleting them will now make the file identical to that what we have in master and fixes things on a long term. Remember that this PR is in the docs branch and not in master.
