### PR TITLE
[docs-only] Fix extended_envvars.yaml has wrong referenced lineno in master

### DIFF
--- a/docs/helpers/extended_vars.yaml
+++ b/docs/helpers/extended_vars.yaml
@@ -16,7 +16,7 @@ variables:
   description: ""
   do_ignore: true
 - rawname: MICRO_LOG_LEVEL
-  path: ocis-pkg/log/log.go:34
+  path: ocis-pkg/log/log.go:31
   foundincode: true
   name: MICRO_LOG_LEVEL
   type: string
@@ -25,7 +25,7 @@ variables:
     on supervision of ownCloud Support.
   do_ignore: false
 - rawname: MICRO_LOG_LEVEL
-  path: ocis-pkg/log/log.go:30
+  path: ocis-pkg/log/log.go:35
   foundincode: true
   name: MICRO_LOG_LEVEL
   type: ""


### PR DESCRIPTION
There is an issue that is threefold:

1. When file extended_envvars.yml is not present, it is generated in master.
When it is present, nothing gets deleted, but added only - all fine.
2. When a source file gets changed and line numbers change, the converter identifies items as new because changed linenumbers - items will get added and need manual maintenance - all fine too. (rare cases, but happens, standard task)
3. What is missing, that the source file in master gets transported to the docs branch automatically and _overwrites_ the file. Currently the content is merged = things get added.

What happened now is, that we have a mismatch between what is in master vs what is in the docs branch causing items appear multiple times and making it extremely hard to check for validity.

**Solution:**

* As a first step we have to fix the source in master that the referenced line numbers match with the  locations found in the code and no orphans are present - done with this PR.
* As intermediate step when merged, we can fix the docs branch version with a 1.1 copy
* Finally we must fix CI to _overwrite_ the docs branch version with the content from master automatically.
 