### PR TITLE
allow adding group by name or id

### DIFF
--- a/services/graph/pkg/identity/ldap_group.go
+++ b/services/graph/pkg/identity/ldap_group.go
@@ -220,7 +220,7 @@ func (i *LDAP) DeleteGroup(ctx context.Context, id string) error {
 func (i *LDAP) AddMembersToGroup(ctx context.Context, groupID string, memberIDs []string) error {
 	logger := i.logger.SubloggerWithRequestID(ctx)
 	logger.Debug().Str("backend", "ldap").Msg("AddMembersToGroup")
-	ge, err := i.getLDAPGroupByID(groupID, true)
+	ge, err := i.getLDAPGroupByNameOrID(groupID, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows using the group name when adding users to groups. @micbar That is not exactly what you wanted, as this is not the externalid. 

@rhafer ... AFAICT we would have to add another filter to allow adding by external id ...