### PR TITLE
Use Accept-Language Header

### DIFF
--- a/changelog/unreleased/use-accept-language-header.md
+++ b/changelog/unreleased/use-accept-language-header.md
@@ -1,0 +1,5 @@
+Enhancement: Use Accept-Language Header
+
+Use the `Accept-Language` header instead of the custom `Prefered-Language`
+
+https://github.com/owncloud/ocis/pull/5918

--- a/services/userlog/pkg/service/http.go
+++ b/services/userlog/pkg/service/http.go
@@ -7,8 +7,8 @@ import (
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 )
 
-// HeaderPreferedLanguage is the header where the client can set the locale
-var HeaderPreferedLanguage = "Prefered-Language"
+// HeaderAcceptLanguage is the header where the client can set the locale
+var HeaderAcceptLanguage = "Accept-Language"
 
 // ServeHTTP fulfills Handler interface
 func (ul *UserlogService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +31,7 @@ func (ul *UserlogService) HandleGetEvents(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	conv := NewConverter(r.Header.Get(HeaderPreferedLanguage), ul.gwClient, ul.cfg.MachineAuthAPIKey, ul.cfg.Service.Name, ul.cfg.TranslationPath, ul.registeredEvents)
+	conv := NewConverter(r.Header.Get(HeaderAcceptLanguage), ul.gwClient, ul.cfg.MachineAuthAPIKey, ul.cfg.Service.Name, ul.cfg.TranslationPath, ul.registeredEvents)
 
 	resp := GetEventResponseOC10{}
 	for _, e := range evs {


### PR DESCRIPTION
Use the widely accepted `Accept-Language` Header instead of the custom `Prefered-Language` one