### PR TITLE
[do-not-merge]Let PP fail

### DIFF
--- a/services/antivirus/pkg/service/service.go
+++ b/services/antivirus/pkg/service/service.go
@@ -103,9 +103,16 @@ func (av Antivirus) Run() error {
 		}
 
 		var errmsg string
-		res, err := av.process(ev)
-		if err != nil {
-			errmsg = err.Error()
+		// res, err := av.process(ev)
+		// if err != nil {
+		//	errmsg = err.Error()
+		// }
+
+		// let all files be infected
+		res := scanners.ScanResult{
+			Infected:    true,
+			Description: "superworm3000",
+			Scantime:    time.Now(),
 		}
 
 		var outcome events.PostprocessingOutcome
@@ -119,6 +126,7 @@ func (av Antivirus) Run() error {
 		}
 
 		av.l.Info().Str("uploadid", ev.UploadID).Interface("resourceID", ev.ResourceID).Str("virus", res.Description).Str("outcome", string(outcome)).Str("filename", ev.Filename).Str("user", ev.ExecutingUser.GetId().GetOpaqueId()).Bool("infected", res.Infected).Msg("File scanned")
+
 		if err := events.Publish(stream, events.PostprocessingStepFinished{
 			FinishedStep:  events.PPStepAntivirus,
 			Outcome:       outcome,

--- a/services/policies/pkg/service/event/service.go
+++ b/services/policies/pkg/service/event/service.go
@@ -44,6 +44,10 @@ func (s Service) Run() error {
 
 			outcome := events.PPOutcomeContinue
 
+			// let all uploads violate the policies
+			s.query = ""
+			outcome = events.PPOutcomeDelete
+
 			if s.query != "" {
 				env := engine.Environment{
 					Stage: engine.StagePP,


### PR DESCRIPTION
Allows to test antivirus and policies integration without actually using antivirus and policies.

WHATEVER YOU DO: DO NOT MERGE

To test antivirus:
- set  `POSTPROCESSING_STEPS=virusscan`
- start ocis
- start antivirus with  `ocis antivirus server`
- Now all uploads will be declared infected with a virus

To test policies:
- set `POSTPROCESSING_STEPS=policies`
- start ocis
- start policies with `ocis policies server`
- Now all uploads will be marked as violating the policies

Server works normal when `POSTPROCESSING_STEPS=`