### PR TITLE
[full-ci] chore: bump web to v7.0.0-rc.26

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=a61e19a94f5247304ed8f2c4bc9209a9ab66c38e
+WEB_COMMITID=005b2c667105bca61f6d28e5c129e5076f3fd642
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.25
+WEB_ASSETS_VERSION = v7.0.0-rc.26
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
bump web to v7.0.0-rc.26

includes a fix for password enforcement on single file public links with editor role.