### PR TITLE
Forbid `=` in group names

### DIFF
--- a/changelog/unreleased/forbid-equal-in-groupnames.md
+++ b/changelog/unreleased/forbid-equal-in-groupnames.md
@@ -1,0 +1,6 @@
+Bugfix: Forbid `=` in group names
+
+The underlying ldap library expects the name containing key-value pairs such as `uid=122`. It panics if you send just a `=`. 
+It should not. However since we cannot rely on it we forbid using `=` in group names. A `BadRequest` will now be returned instead
+
+https://github.com/owncloud/ocis/pull/5972

--- a/services/graph/pkg/service/v0/educationclasses.go
+++ b/services/graph/pkg/service/v0/educationclasses.go
@@ -66,9 +66,13 @@ func (g Graph) PostEducationClass(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := class.GetDisplayNameOk(); !ok {
+	name, ok := class.GetDisplayNameOk()
+	if !ok {
 		logger.Debug().Err(err).Interface("class", class).Msg("could not create class: missing required attribute")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Missing Required Attribute")
+		return
+	}
+	if !nameAccepted(*name, w, r, logger) {
 		return
 	}
 
@@ -129,6 +133,9 @@ func (g Graph) PatchEducationClass(w http.ResponseWriter, r *http.Request) {
 
 	var features []events.GroupFeature
 	if displayName, ok := changes.GetDisplayNameOk(); ok {
+		if !nameAccepted(*displayName, w, r, logger) {
+			return
+		}
 		features = append(features, events.GroupFeature{Name: "displayname", Value: *displayName})
 	}
 

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -73,9 +73,13 @@ func (g Graph) PostEducationSchool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := school.GetDisplayNameOk(); !ok {
+	name, ok := school.GetDisplayNameOk()
+	if !ok {
 		logger.Debug().Interface("school", school).Msg("could not create school: missing required attribute")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Missing Required Attribute")
+		return
+	}
+	if !nameAccepted(*name, w, r, logger) {
 		return
 	}
 
@@ -133,6 +137,10 @@ func (g Graph) PatchEducationSchool(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update school: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
+		return
+	}
+
+	if !nameAccepted(*school.DisplayName, w, r, logger) {
 		return
 	}
 

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -76,9 +76,13 @@ func (g Graph) PostEducationUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := u.GetDisplayNameOk(); !ok {
+	name, ok := u.GetDisplayNameOk()
+	if !ok {
 		logger.Debug().Err(err).Interface("user", u).Msg("could not create education user: missing required Attribute: 'displayName'")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing required Attribute: 'displayName'")
+		return
+	}
+	if !nameAccepted(*name, w, r, logger) {
 		return
 	}
 
@@ -354,6 +358,9 @@ func (g Graph) PatchEducationUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if name, ok := changes.GetDisplayNameOk(); ok {
+		if !nameAccepted(*name, w, r, logger) {
+			return
+		}
 		features = append(features, events.UserFeature{Name: "displayname", Value: *name})
 	}
 

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -67,9 +67,13 @@ func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := grp.GetDisplayNameOk(); !ok {
+	groupName, ok := grp.GetDisplayNameOk()
+	if !ok {
 		logger.Debug().Err(err).Interface("group", grp).Msg("could not create group: missing required attribute")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "Missing Required Attribute")
+		return
+	}
+	if !nameAccepted(*groupName, w, r, logger) {
 		return
 	}
 
@@ -128,6 +132,9 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 
 	if changes.HasDisplayName() {
 		groupName := changes.GetDisplayName()
+		if !nameAccepted(groupName, w, r, logger) {
+			return
+		}
 		err = g.identityBackend.UpdateGroupName(r.Context(), groupID, groupName)
 	}
 

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -271,9 +271,13 @@ func (g Graph) PostUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := u.GetDisplayNameOk(); !ok {
+	name, ok := u.GetDisplayNameOk()
+	if !ok {
 		logger.Debug().Err(err).Interface("user", u).Msg("could not create user: missing required Attribute: 'displayName'")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "missing required Attribute: 'displayName'")
+		return
+	}
+	if !nameAccepted(*name, w, r, logger) {
 		return
 	}
 	if accountName, ok := u.GetOnPremisesSamAccountNameOk(); ok {
@@ -659,6 +663,9 @@ func (g Graph) PatchUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if name, ok := changes.GetDisplayNameOk(); ok {
+		if !nameAccepted(*name, w, r, logger) {
+			return
+		}
 		features = append(features, events.UserFeature{Name: "displayname", Value: *name})
 	}
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -54,6 +54,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/assignRole.feature:33](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/assignRole.feature#L33)
 
 ### [Group having percentage (%) can be created but cannot be GET](https://github.com/owncloud/ocis/issues/5083)
+- [apiGraph/deleteGroup.feature:34](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L34)
 - [apiGraph/deleteGroup.feature:49](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L49)
 - [apiGraph/deleteGroup.feature:50](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L50)
 - [apiGraph/deleteGroup.feature:51](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L51)

--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -37,7 +37,7 @@ Feature: add users to group
       | Finance (NP)        | Space and brackets |
       | Admin&Finance       | Ampersand          |
       | maint+eng           | Plus sign          |
-      | $x<=>[y*z^2]!       | Maths symbols      |
+      | $x<>[y*z^2]!        | Maths symbols      |
       | 😁 😂               | emoji              |
       | admin:Pokhara@Nepal | Colon and @        |
     When the administrator adds the following users to the following groups using the Graph API
@@ -49,7 +49,7 @@ Feature: add users to group
       | Alice    | Finance (NP)        |
       | Alice    | Admin&Finance       |
       | Alice    | maint+eng           |
-      | Alice    | $x<=>[y*z^2]!       |
+      | Alice    | $x<>[y*z^2]!        |
       | Alice    | 😁 😂               |
       | Alice    | admin:Pokhara@Nepal |
     Then the HTTP status code of responses on all endpoints should be "204"
@@ -62,7 +62,7 @@ Feature: add users to group
       | Alice    | Finance (NP)        |
       | Alice    | Admin&Finance       |
       | Alice    | maint+eng           |
-      | Alice    | $x<=>[y*z^2]!       |
+      | Alice    | $x<>[y*z^2]!        |
       | Alice    | 😁 😂               |
       | Alice    | admin:Pokhara@Nepal |
 
@@ -72,7 +72,7 @@ Feature: add users to group
       | groupname       | comment                                 |
       | maintenance#123 | Hash sign                               |
       | 50%pass         | Percent sign (special escaping happens) |
-      | 50%25=0         | %25 literal looks like an escaped "%"   |
+      | 50%250          | %25 literal looks like an escaped "%"   |
       | 50%2Eagle       | %2E literal looks like an escaped "."   |
       | 50%2Fix         | %2F literal looks like an escaped slash |
       | Mgmt\Middle     | Backslash                               |
@@ -81,7 +81,7 @@ Feature: add users to group
       | username | groupname       |
       | Alice    | maintenance#123 |
       | Alice    | 50%pass         |
-      | Alice    | 50%25=0         |
+      | Alice    | 50%250          |
       | Alice    | 50%2Eagle       |
       | Alice    | 50%2Fix         |
       | Alice    | Mgmt\Middle     |
@@ -91,7 +91,7 @@ Feature: add users to group
       | username | groupname       |
       | Alice    | maintenance#123 |
       | Alice    | 50%pass         |
-      | Alice    | 50%25=0         |
+      | Alice    | 50%250          |
       | Alice    | 50%2Eagle       |
       | Alice    | 50%2Fix         |
       | Alice    | Mgmt\Middle     |

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -16,7 +16,7 @@ Feature: create group
     | simplegroup     |
     | España§àôœ€     |
     | नेपाली            |
-    | $x<=>[y*z^2+1]! |
+    | $x<>[y*z^2+1]! |
     | 😅 😆           |
     | comma,grp1      |
     | Finance (NP)    |

--- a/tests/acceptance/features/apiGraph/deleteGroup.feature
+++ b/tests/acceptance/features/apiGraph/deleteGroup.feature
@@ -27,11 +27,11 @@ Feature: delete groups
       | Admin&Finance       | Ampersand                             |
       | admin:Pokhara@Nepal | Colon and @                           |
       | maint+eng           | Plus sign                             |
-      | $x<=>[y*z^2]!       | Maths symbols                         |
+      | $x<>[y*z^2]!        | Maths symbols                         |
       | Mgmt\Middle         | Backslash                             |
       | 😁 😂               | emoji                                 |
       | maintenance#123     | Hash sign                             |
-      | 50%25=0             | %25 literal looks like an escaped "%" |
+      | 50%250              | %25 literal looks like an escaped "%" |
       | staff?group         | Question mark                         |
       | Mgmt/Sydney         | Slash (special escaping happens)      |
       | Mgmt//NSW/Sydney    | Multiple slash                        |

--- a/tests/acceptance/features/apiGraph/getGroup.feature
+++ b/tests/acceptance/features/apiGraph/getGroup.feature
@@ -186,8 +186,8 @@ Feature: get groups and their members
       | group           |
       | España§àôœ€     |
       | नेपाली            |
-      | $x<=>[y*z^2+1]! |
-      | եòɴԪ˯ΗՐΛɔπ     |
+      | $x<>[y*z^2+1]!  |
+      | եòɴԪ˯ΗՐΛɔπ      |
 
 
   Scenario: admin user tries to get group information of non-existing group

--- a/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
+++ b/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
@@ -43,7 +43,7 @@ Feature: remove a user from a group
       | Admin&Finance       | Ampersand          |
       | admin:Pokhara@Nepal | Colon and @        |
       | maint+eng           | Plus sign          |
-      | $x<=>[y*z^2]!       | Maths symbols      |
+      | $x<>[y*z^2]!        | Maths symbols      |
       | Mgmt\Middle         | Backslash          |
       | 😁 😂               | emoji              |
     And the following users have been added to the following groups
@@ -56,7 +56,7 @@ Feature: remove a user from a group
       | Alice    | Admin&Finance       |
       | Alice    | admin:Pokhara@Nepal |
       | Alice    | maint+eng           |
-      | Alice    | $x<=>[y*z^2]!       |
+      | Alice    | $x<>[y*z^2]!        |
       | Alice    | Mgmt\Middle         |
       | Alice    | 😁 😂               |
     When the administrator removes the following users from the following groups using the Graph API
@@ -69,7 +69,7 @@ Feature: remove a user from a group
       | Alice    | Admin&Finance       |
       | Alice    | admin:Pokhara@Nepal |
       | Alice    | maint+eng           |
-      | Alice    | $x<=>[y*z^2]!       |
+      | Alice    | $x<>[y*z^2]!        |
       | Alice    | Mgmt\Middle         |
       | Alice    | 😁 😂               |
     Then the HTTP status code of responses on all endpoints should be "204"
@@ -83,7 +83,7 @@ Feature: remove a user from a group
       | Alice    | Admin&Finance       |
       | Alice    | admin:Pokhara@Nepal |
       | Alice    | maint+eng           |
-      | Alice    | $x<=>[y*z^2]!       |
+      | Alice    | $x<>[y*z^2]!        |
       | Alice    | Mgmt\Middle         |
       | Alice    | 😁 😂               |
 
@@ -92,7 +92,7 @@ Feature: remove a user from a group
     Given these groups have been created:
       | groupname       | comment                                 |
       | maintenance#123 | Hash sign                               |
-      | 50%25=0         | %25 literal looks like an escaped "%"   |
+      | 50%250          | %25 literal looks like an escaped "%"   |
       | staff?group     | Question mark                           |
       | 50%pass         | Percent sign (special escaping happens) |
       | 50%2Eagle       | %2E literal looks like an escaped "."   |
@@ -100,7 +100,7 @@ Feature: remove a user from a group
     And the following users have been added to the following groups
       | username | groupname       |
       | Alice    | maintenance#123 |
-      | Alice    | 50%25=0         |
+      | Alice    | 50%250          |
       | Alice    | staff?group     |
       | Alice    | 50%pass         |
       | Alice    | 50%2Eagle       |
@@ -108,7 +108,7 @@ Feature: remove a user from a group
     When the administrator removes the following users from the following groups using the Graph API
       | username | groupname       |
       | Alice    | maintenance#123 |
-      | Alice    | 50%25=0         |
+      | Alice    | 50%250          |
       | Alice    | staff?group     |
       | Alice    | 50%pass         |
       | Alice    | 50%2Eagle       |
@@ -117,7 +117,7 @@ Feature: remove a user from a group
     And the following users should not belong to the following groups
       | username | groupname       |
       | Alice    | maintenance#123 |
-      | Alice    | 50%25=0         |
+      | Alice    | 50%250          |
       | Alice    | staff?group     |
       | Alice    | 50%pass         |
       | Alice    | 50%2Eagle       |


### PR DESCRIPTION
Since underlying `ldap` library panics when you do so, this is the best (aka quickest) way to solve this