### PR TITLE
graph: user groupTypes property to indicate read-only groups

### DIFF
--- a/changelog/unreleased/enhancement-ldap-group-create-basedn.md
+++ b/changelog/unreleased/enhancement-ldap-group-create-basedn.md
@@ -1,0 +1,13 @@
+Enhancement: Make the LDAP base DN for new groups configurable
+
+The LDAP backend for the Graph service introduced a new config option for setting the
+Parent DN for new groups created via the `/groups/` endpoint. (`GRAPH_LDAP_GROUP_CREATE_BASE_DN`)
+
+It defaults to the value of `GRAPH_LDAP_GROUP_BASE_DN`. If set to a different value the
+`GRAPH_LDAP_GROUP_CREATE_BASE_DN` needs to be a subordinate DN of `GRAPH_LDAP_GROUP_BASE_DN`.
+
+All existing groups with a DN outside the `GRAPH_LDAP_GROUP_CREATE_BASE_DN` tree will be treated as
+read-only groups. So it is not possible to edit these groups.
+
+https://github.com/owncloud/ocis/pull/5974
+

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/onsi/gomega v1.27.4
 	github.com/open-policy-agent/opa v0.50.2
 	github.com/orcaman/concurrent-map v1.0.0
-	github.com/owncloud/libre-graph-api-go v1.0.2-0.20230309112802-ff71ba8c90aa
+	github.com/owncloud/libre-graph-api-go v1.0.2-0.20230330145712-ea267ccd404a
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.9
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -1373,8 +1373,8 @@ github.com/oracle/oci-go-sdk v24.3.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35uk
 github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HDbW65HOY=
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
-github.com/owncloud/libre-graph-api-go v1.0.2-0.20230309112802-ff71ba8c90aa h1:Lab1HHZ7Z8cBjojLDSfGYbGSZT08iww25uTW+EV1Sao=
-github.com/owncloud/libre-graph-api-go v1.0.2-0.20230309112802-ff71ba8c90aa/go.mod h1:iKdVH6nYpI8RBeK9sjeLfzrPByST6r9d+NG2IJHoJmU=
+github.com/owncloud/libre-graph-api-go v1.0.2-0.20230330145712-ea267ccd404a h1:C7YCoyXn/8pkapUhw2KoIxEMdgIFUx3JjZQKtsXaaLc=
+github.com/owncloud/libre-graph-api-go v1.0.2-0.20230330145712-ea267ccd404a/go.mod h1:iKdVH6nYpI8RBeK9sjeLfzrPByST6r9d+NG2IJHoJmU=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -69,6 +69,7 @@ type LDAP struct {
 	LdapDisabledUsersGroupDN string `yaml:"ldap_disabled_users_group_dn" env:"LDAP_DISABLED_USERS_GROUP_DN;GRAPH_DISABLED_USERS_GROUP_DN" desc:"The distinguished name of the group to which added users will be classified as disabled when 'disable_user_mechanism' is set to 'group'."`
 
 	GroupBaseDN        string `yaml:"group_base_dn" env:"LDAP_GROUP_BASE_DN;GRAPH_LDAP_GROUP_BASE_DN" desc:"Search base DN for looking up LDAP groups."`
+	GroupCreateBaseDN  string `yaml:"group_create_base_dn" env:"GRAPH_LDAP_GROUP_CREATE_BASE_DN" desc:"Parent DN under which new groups are created. This DN needs to be subordinate to the 'GRAPH_LDAP_GROUP_BASE_DN'. This setting is only relevant when 'GRAPH_LDAP_SERVER_WRITE_ENABLED' is 'true'. It defaults to the value of 'GRAPH_LDAP_GROUP_BASE_DN'. All groups outside of this subtree are treated as readonly groups and cannot be updated."`
 	GroupSearchScope   string `yaml:"group_search_scope" env:"LDAP_GROUP_SCOPE;GRAPH_LDAP_GROUP_SEARCH_SCOPE" desc:"LDAP search scope to use when looking up groups. Supported scopes are 'base', 'one' and 'sub'."`
 	GroupFilter        string `yaml:"group_filter" env:"LDAP_GROUP_FILTER;GRAPH_LDAP_GROUP_FILTER" desc:"LDAP filter to add to the default filters for group searches."`
 	GroupObjectClass   string `yaml:"group_objectclass" env:"LDAP_GROUP_OBJECTCLASS;GRAPH_LDAP_GROUP_OBJECTCLASS" desc:"The object class to use for groups in the default group search filter ('groupOfNames'). "`

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -153,6 +153,10 @@ func EnsureDefaults(cfg *config.Config) {
 	if cfg.MachineAuthAPIKey == "" && cfg.Commons != nil && cfg.Commons.MachineAuthAPIKey != "" {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
+
+	if cfg.Identity.LDAP.GroupCreateBaseDN == "" {
+		cfg.Identity.LDAP.GroupCreateBaseDN = cfg.Identity.LDAP.GroupBaseDN
+	}
 }
 
 // Sanitize sanitized the configuration

--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -58,6 +58,7 @@ type LDAP struct {
 	localUserDisableGroupDN string
 
 	groupBaseDN       string
+	groupCreateBaseDN string
 	groupFilter       string
 	groupObjectClass  string
 	groupScope        int
@@ -148,6 +149,7 @@ func NewLDAPBackend(lc ldap.Client, config config.LDAP, logger *log.Logger) (*LD
 		userScope:               userScope,
 		userAttributeMap:        uam,
 		groupBaseDN:             config.GroupBaseDN,
+		groupCreateBaseDN:       config.GroupCreateBaseDN,
 		groupFilter:             config.GroupFilter,
 		groupObjectClass:        config.GroupObjectClass,
 		groupScope:              groupScope,

--- a/services/graph/pkg/service/v0/errorcode/errorcode.go
+++ b/services/graph/pkg/service/v0/errorcode/errorcode.go
@@ -106,6 +106,8 @@ func (e Error) Render(w http.ResponseWriter, r *http.Request) {
 		status = http.StatusNotFound
 	case NameAlreadyExists:
 		status = http.StatusConflict
+	case NotAllowed:
+		status = http.StatusForbidden
 	default:
 		status = http.StatusInternalServerError
 	}

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -82,8 +82,13 @@ func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if grp, err = g.identityBackend.CreateGroup(r.Context(), *grp); err != nil {
-		logger.Debug().Interface("group", grp).Msg("could not create group: backend error")
-		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		var errcode errorcode.Error
+		if errors.As(err, &errcode) {
+			errcode.Render(w, r)
+		} else {
+			logger.Debug().Interface("group", grp).Msg("could not create group: backend error")
+			errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
By setting GRAPH_LDAP_GROUP_CREATE_BASE_DN a distinct subtree can be configure
where new LDAP groups are created. That subtree needs to be subordinate to
GRAPH_LDAP_GROUP_BASE_DN. All groups outside for
GRAPH_LDAP_GROUP_CREATE_BASE_DN are considered read-only and only group below
that DN can be updated and deleted.
    
This is introduced for a pretty specific usecase where most groups are managed
in an external source (e.g. a read-only replica of an LDAP tree). But we still
want to allow the local administrator to create groups in a writeable subtree
attached to that replica.

To test this you can start ocis with

```
IDM_CREATE_DEMO_USERS=true GRAPH_LDAP_GROUP_CREATE_BASE_DN=ou=users,o=libregraph-idm GRAPH_LDAP_GROUP_BASE_DN=o=libregraph-idm ocis/bin/ocis server
```

This will make all the demo groups "readonly" (indicated through "ReadOnly" value in "groupTypes":

```
~> curl -s -k -u admin:admin  'https://localhost:9200/graph/v1.0/groups/users'   -H 'accept: application/json' | jq .
{
  "displayName": "users",
  "groupTypes": [
    "ReadOnly"
  ],
  "id": "509a9dcd-bb37-4f4f-a01a-19dca27d9cfa"
}
```

Trying to update the group will end with an error (currently a 500), but I still need to fix that to return a 405 or 403.

Adding groups is still possible, but they'll endup in a seperate part of the LDAP tree:

```
~> curl -s -k -u admin:admin  'https://localhost:9200/graph/v1.0/groups'   -H 'accept: application/json' -X POST --data '{"displayName": "Lokal"}' | jq .
{
  "displayName": "Lokal",
  "groupTypes": [],
  "id": "0a0f201c-c38f-40fd-a4c4-cd87d9168ee9"
}
```

Groups without the "ReadOnly" value in the groupTypes can be updated:

```
~> curl -i -k -u admin:admin  'https://localhost:9200/graph/v1.0/groups/0a0f201c-c38f-40fd-a4c4-cd87d9168ee9'   -H 'accept: application/json' -X PATCH --data '{"displayName": "Lokale Gruppe"}' 
HTTP/1.1 204 No Content
Date: Thu, 30 Mar 2023 16:48:47 GMT
X-Graph-Version: 3.0.0-alpha.1+093d65dcd
```