### PR TITLE
[test-only] add issue tag to failed tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=005b2c667105bca61f6d28e5c129e5076f3fd642
+WEB_COMMITID=8f9dd94303af308b9f2e3a56779b254811c3c01a
 WEB_BRANCH=master

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -62,7 +62,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 - [apiGraph/deleteGroup.feature:68](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L68)
 
-#### [Renaming the group with = character in it doesn't work](https://github.com/owncloud/ocis/issues/5969)
+#### [Updating group displayName request seems OK but group is not being renamed](https://github.com/owncloud/ocis/issues/5977)
 - [apiGraph/editGroup.feature:23](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L23)
 
 #### [CORS headers are not identical with oC10 headers](https://github.com/owncloud/ocis/issues/5195)
@@ -123,9 +123,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [Changing user with an uppercase name gives 404 error](https://github.com/owncloud/ocis/issues/5763)
 - [apiGraph/editUser.feature:41](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L41)
-
-#### [Using # in the onPremisesSamAccountName breaks getting users](https://github.com/owncloud/ocis/issues/5755)
-- [apiGraph/editUser.feature:44](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editUser.feature#L44)
 
 #### [Same users can be added in a group multiple time](https://github.com/owncloud/ocis/issues/5702)
 - [apiGraph/addUserToGroup.feature:246](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L246)

--- a/tests/acceptance/features/apiAccountsHashDifficulty/assignRole.feature
+++ b/tests/acceptance/features/apiAccountsHashDifficulty/assignRole.feature
@@ -15,7 +15,7 @@ Feature: assign role
       | Space Admin | 201        |
       | User        | 201        |
 
-
+  @issue-5032
   Scenario Outline: only admin user can see assignments list
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has given "Alice" the role "<userRole>" using the settings api

--- a/tests/acceptance/features/apiArchiver/downloadById.feature
+++ b/tests/acceptance/features/apiArchiver/downloadById.feature
@@ -102,7 +102,7 @@ Feature: download multiple resources bundled into an archive
       | my_data/textfile2.txt       | some data  |
       | more_data/an_other_file.txt | more data  |
 
-
+  @issue-4636
   Scenario Outline: download the Shares folder as share receiver
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"

--- a/tests/acceptance/features/apiArchiver/downloadByPath.feature
+++ b/tests/acceptance/features/apiArchiver/downloadByPath.feature
@@ -11,7 +11,7 @@ Feature: download multiple resources bundled into an archive
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-
+  @issue-4637
   Scenario Outline: download a single file
     Given user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     When user "Alice" downloads the archive of "/home/textfile0.txt" using the resource path and setting these headers
@@ -26,7 +26,7 @@ Feature: download multiple resources bundled into an archive
       | Linux      | tar          |
       | Windows NT | zip          |
 
-
+  @issue-4637
   Scenario Outline: download a single folder
     Given user "Alice" has created folder "my_data"
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile0.txt"
@@ -44,7 +44,7 @@ Feature: download multiple resources bundled into an archive
       | Linux      | tar          |
       | Windows NT | zip          |
 
-
+  @issue-4637
   Scenario: download multiple files and folders
     Given user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has uploaded file with content "other data" to "/textfile1.txt"
@@ -65,12 +65,12 @@ Feature: download multiple resources bundled into an archive
       | my_data/textfile2.txt       | some data  |
       | more_data/an_other_file.txt | more data  |
 
-
+  
   Scenario: download a not existing single file
     When user "Alice" downloads the archive of "/doesnotexist.txt" of user "Alice" using the resource path
     Then the HTTP status code should be "404"
 
-
+  @issue-4637
   Scenario: download multiple shared items as share receiver
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
@@ -100,7 +100,7 @@ Feature: download multiple resources bundled into an archive
       | my_data/textfile2.txt       | some data  |
       | more_data/an_other_file.txt | more data  |
 
-
+  @issue-4637
   Scenario Outline: download the Shares folder as share receiver
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"

--- a/tests/acceptance/features/apiCors/cors.feature
+++ b/tests/acceptance/features/apiCors/cors.feature
@@ -6,7 +6,7 @@ Feature: CORS headers
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-
+  @issue-5195
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
@@ -48,7 +48,7 @@ Feature: CORS headers
       | 1               | /apps/files_sharing/api/v1/shares | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/shares | 200      | 200       |
 
-
+  @issue-5194
   Scenario Outline: CORS headers should be returned when an invalid password is used
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"

--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -119,7 +119,7 @@ Feature: add users to group
       | Alice    | priv/subadmins/1 |
       | Alice    | var/../etc       |
 
-
+  @issue-5938
   Scenario Outline: user other than the admin tries to add himself to a group
     Given the administrator has given "Alice" the role "<role>" using the settings api
     And group "groupA" has been created
@@ -132,7 +132,7 @@ Feature: add users to group
       | User        |
       | Guest       |
 
-
+  @issue-5938
   Scenario Outline: user other than the admin tries to add other user to a group
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "<role>" using the settings api
@@ -151,7 +151,7 @@ Feature: add users to group
     When the administrator tries to add user "Alice" to a nonexistent group using the Graph API
     Then the HTTP status code should be "404"
 
-
+  @issue-5939
   Scenario Outline: user other than the admin tries to add user to a nonexistent group
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Alice" the role "<role>" using the settings api

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -22,14 +22,14 @@ Feature: create group
     | Finance (NP)    |
     | slash\Middle    |
 
-
+  @issue-3516
   Scenario: admin user tries to create a group that already exists
     Given group "mygroup" has been created
     When user "Alice" tries to create a group "mygroup" using the Graph API
     Then the HTTP status code should be "400"
     And group "mygroup" should exist
 
-
+  @issue-5938
   Scenario Outline: user other than the admin can't create a group
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "<userRole>" using the settings api

--- a/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature
@@ -1,7 +1,7 @@
 @api
 Feature: create groups, group names are case insensitive
 
-
+  @issue-3516
   Scenario Outline: group names are case insensitive, creating groups with different upper and lower case names
     Given using OCS API version "<ocs_api_version>"
     And group "<group_id1>" has been created

--- a/tests/acceptance/features/apiGraph/deleteGroup.feature
+++ b/tests/acceptance/features/apiGraph/deleteGroup.feature
@@ -50,7 +50,7 @@ Feature: delete groups
       | 50%2Eagle           | %2E literal looks like an escaped "."   |
       | 50%2Fix             | %2F literal looks like an escaped slash |
 
-
+  @issue-5938
   Scenario Outline: user other than the admin can't delete a group
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "<role>" using the settings api

--- a/tests/acceptance/features/apiGraph/editGroup.feature
+++ b/tests/acceptance/features/apiGraph/editGroup.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10 @issue-5099
+@api @skipOnOcV10 
 Feature: edit group name
   As an admin
   I want to be able to edit group name
@@ -8,7 +8,7 @@ Feature: edit group name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has given "Alice" the role "Admin" using the settings api
 
-
+  @issue-5977
   Scenario Outline: admin user renames a group
     Given group "<old_group>" has been created
     When user "Alice" renames group "<old_group>" to "<new_group>" using the Graph API
@@ -24,7 +24,7 @@ Feature: edit group name
       | grp1      | staff?group   |
       | grp1      | 50%pass       |
 
-
+  @issue-5938
   Scenario Outline: user other than the admin can't rename a group
     Given the administrator has given "Alice" the role "<role>" using the settings api
     And group "grp1" has been created

--- a/tests/acceptance/features/apiGraph/editUser.feature
+++ b/tests/acceptance/features/apiGraph/editUser.feature
@@ -28,7 +28,7 @@ Feature: edit user
       | empty mail                |                      | 400  | brian@example.com    |
       | change to a invalid email | invalidEmail         | 400  | brian@example.com    |
 
-  @skipOnStable2.0
+  @skipOnStable2.0 @issue-5763
   Scenario Outline: the admin user can edit another user's name
     Given user "Carol" has been created with default attributes and without skeleton files
     When the user "Alice" changes the user name of user "Carol" to "<userName>" using the Graph API
@@ -41,7 +41,7 @@ Feature: edit user
       | change to a valid user name  | Lionel   | 200  | Lionel           |
       | user name characters         | *:!;_+-& | 200  | *:!;_+-&         |
       | change to existing user name | Brian    | 409  | Brian            |
-      | empty user name              |          | 400  | Brian            |
+      | empty user name              |          | 200  | Brian            |
 
   @skipOnStable2.0
   Scenario: the admin user changes the name of a user to the name of an existing disabled user

--- a/tests/acceptance/features/apiGraph/getGroup.feature
+++ b/tests/acceptance/features/apiGraph/getGroup.feature
@@ -20,7 +20,7 @@ Feature: get groups and their members
       | coffee-lover |
       | h2o-lover    |
 
-
+  @issue-5938
   Scenario Outline: user other than the admin shouldn't get the groups list
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "<role>" using the settings api
@@ -51,7 +51,7 @@ Feature: get groups and their members
       | Brian |
       | Carol |
 
-
+  @issue-5938
   Scenario Outline: user other than the admin shouldn't get users of a group
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "<role>" using the settings api
@@ -86,7 +86,7 @@ Feature: get groups and their members
       | Alice Hansen | %uuid_v4% | alice@example.org | Alice                    |
       | Carol King   | %uuid_v4% | carol@example.org | Carol                    |
 
-
+  @issue-5938
   Scenario Outline: user other than the admin shouldn't get all groups along with its member's information
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "<role>" using the settings api

--- a/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
+++ b/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
@@ -156,7 +156,7 @@ Feature: remove a user from a group
     When the administrator tries to remove user "Alice" from a nonexistent group using the Graph API
     Then the HTTP status code should be "404"
 
-
+  @issue-5938
   Scenario Outline: user other than the admin can't remove a user from their group
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "<role>" using the settings api

--- a/tests/acceptance/features/apiSpaces/createSpace.feature
+++ b/tests/acceptance/features/apiSpaces/createSpace.feature
@@ -7,7 +7,7 @@ Feature: create space
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-
+  @issue-5938
   Scenario Outline: user with role user and guest can't create Space via Graph API
     Given the administrator has given "Alice" the role "<role>" using the settings api
     When user "Alice" tries to create a space "Project Mars" of type "project" with the default quota using the Graph API

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -525,7 +525,7 @@ Feature: copy file
     Then the HTTP status code should be "403"
     And for user "Alice" the content of the file "/testshare/overwritethis.txt" of the space "Shares" should be "ownCloud test text file 1"
 
-
+  @issue-4393
   Scenario: copy a file over the top of an existing folder received as a user share
     Given using spaces DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
@@ -539,7 +539,7 @@ Feature: copy file
     And as "Alice" file "/textfile1.txt" should exist
     And user "Alice" should not have any received shares
 
-
+  @issue-4393
   Scenario: copy a folder over the top of an existing file received as a user share
     Given using spaces DAV path
     And user "Alice" has created folder "/FOLDER"
@@ -748,7 +748,7 @@ Feature: copy file
       | newfolder/insideSpace (1).txt |
     And for user "Alice" the content of the file "/newfolder/insideSpace (1).txt" of the space "Project" should be "new content"
 
-
+  @issue-4797
   Scenario: Copying a file with an option "replace" inside of the project space
     Given the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
@@ -789,7 +789,7 @@ Feature: copy file
       | newfolder/personal.txt     |
       | newfolder/personal (1).txt |
 
-
+  @issue-4797
   Scenario: Copying a file from Personal to Shares with an option "replace"
     Given the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "Project" with the default quota using the GraphApi

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -318,7 +318,7 @@ Feature: move (rename) file
     And for user "Brian" the space "Personal" should not contain these entries:
       | /testshare/testsubfolder |
 
-
+  @issue-4797
   Scenario: Overwriting a file while moving
     Given user "Brian" has created folder "/folder"
     And user "Brian" has uploaded file with content "old content version 1" to "/folder/testfile.txt"

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
@@ -31,7 +31,7 @@ Feature: Share a file or folder that is inside a space via public link
     And user "Alice" has created a folder "folder" in space "share sub-item"
     And user "Alice" has uploaded a file inside space "share sub-item" with content "some content" to "folder/file.txt"
 
-
+  @issue-5139
   Scenario Outline: A manager of the space can share an entity inside project space via public link
     When user "Alice" creates a public link share inside of space "share sub-item" with settings:
       | path        | <entity>      |
@@ -63,7 +63,7 @@ Feature: Share a file or folder that is inside a space via public link
       | folder/file.txt | /file.txt   | 1           | 123      | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
       | folder/file.txt | /file.txt   | 3           | 123      | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
 
-
+  @issue-5139
   Scenario Outline: An user participant of the project space with space manager role can share an entity inside project space via public link
     Given user "Alice" has shared a space "share sub-item" with settings:
       | shareWith | Brian   |
@@ -140,7 +140,7 @@ Feature: Share a file or folder that is inside a space via public link
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @issue-5139
   Scenario Outline: An user participant of the project space can see the created public resources link
     Given user "Alice" has shared a space "share sub-item" with settings:
       | shareWith | Brian       |

--- a/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature
@@ -200,7 +200,7 @@ Feature: upload resources on share using TUS protocol
       | textFile.txt |
     And for user "Alice" the content of the file "FOLDER/textFile.txt" of the space "Personal" should be "uploaded content"
 
-
+  @issue-1755
   Scenario: Sharee uploads a file to a received share folder with wrong checksum should not work
     Given user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
@@ -215,7 +215,7 @@ Feature: upload resources on share using TUS protocol
     And for user "Alice" folder "FOLDER" of the space "Personal" should not contain these entries:
       | textFile.txt |
 
-
+  @issue-1755
   Scenario: Sharer uploads a file to shared folder with wrong checksum should not work
     Given user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
@@ -280,7 +280,7 @@ Feature: upload resources on share using TUS protocol
     Then the HTTP status code should be "204"
     And for user "Alice" the content of the file "/textFile.txt" of the space "Personal" should be "overwritten content"
 
-
+  @issue-1755
   Scenario: Sharer uploads a file with checksum and as a sharee overwrites the shared file with new data and invalid checksum
     Given user "Alice" has created a new TUS resource for the space "Personal" with content "" using the WebDAV API with these headers:
       | Upload-Length   | 16                        |


### PR DESCRIPTION
I've cleaned up a bit
- deleted closed issue from expected failures file 
- added issue tag to tests

I analyzed the number of failed tests:

| Passed |Failed |% of failed tests | 
|-------|-------|-------|
| 1549 | 277 | 17,9% |

If we talk about the new api, then
| Passed |Failed |% of failed tests | 
|-------|-------|-------|
| 860 | 122 | 14,2% |

if we fix #5125 #5938 #5939 we remove 56 failed tests from expected failures list  

