### PR TITLE
[tests-only] fix not optional parameter after optional

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3700,15 +3700,15 @@ class FeatureContext extends BehatVariablesContext {
 	/**
 	 * Verify that the tableNode contains expected headers
 	 *
-	 * @param TableNode $table
+	 * @param TableNode|null $table
 	 * @param array|null $requiredHeader
 	 * @param array|null $allowedHeader
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function verifyTableNodeColumns(TableNode $table, ?array $requiredHeader = [], ?array $allowedHeader = []): void {
-		if (\count($table->getHash()) < 1) {
+	public function verifyTableNodeColumns(?TableNode $table, ?array $requiredHeader = [], ?array $allowedHeader = []): void {
+		if (is_null($table) || \count($table->getHash()) < 1) {
 			throw new Exception("Table should have at least one row.");
 		}
 		$tableHeaders = $table->getRows()[0];

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3708,7 +3708,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws Exception
 	 */
 	public function verifyTableNodeColumns(?TableNode $table, ?array $requiredHeader = [], ?array $allowedHeader = []): void {
-		if (is_null($table) || \count($table->getHash()) < 1) {
+		if ($table === null || \count($table->getHash()) < 1) {
 			throw new Exception("Table should have at least one row.");
 		}
 		$tableHeaders = $table->getRows()[0];

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1042,17 +1042,17 @@ class SpacesContext implements Context {
 	 * @param string $spaceName
 	 * @param string|null $userName
 	 * @param string|null $fileName
-	 * @param string|PyStringNode $schemaString
+	 * @param PyStringNode|null $schemaString
 	 *
 	 * @return void
-	 * @throws Exception
 	 */
 	public function theJsonDataFromLastResponseShouldMatch(
 		string $spaceName,
 		?string $userName = null,
 		?string $fileName = null,
-		PyStringNode|string $schemaString = ""
+		?PyStringNode $schemaString = null
 	): void {
+		Assert::assertNotNull($schemaString, 'schema is not valid JSON');
 		if (isset($this->featureContext->getJsonDecodedResponseBodyContent()->value)) {
 			$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->value;
 			foreach ($responseBody as $value) {
@@ -1110,7 +1110,7 @@ class SpacesContext implements Context {
 	 * @param string|null $spaceName
 	 * @param string|null $grantedUser
 	 * @param string|null $fileName
-	 * @param PyStringNode|string $schemaString
+	 * @param PyStringNode|null $schemaString
 	 *
 	 * @return void
 	 * @throws GuzzleException
@@ -1120,7 +1120,7 @@ class SpacesContext implements Context {
 		?string $spaceName = null,
 		?string $grantedUser = null,
 		?string $fileName = null,
-		PyStringNode|string $schemaString = ""
+		?PyStringNode $schemaString = null
 	): void {
 		$this->theUserListsAllHisAvailableSpacesUsingTheGraphApi($user);
 		$this->theJsonDataFromLastResponseShouldMatch($spaceName, $grantedUser, $fileName, $schemaString);

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -921,7 +921,7 @@ class SpacesContext implements Context {
 	 * @param string|null $userName
 	 * @param string|null $fileName
 	 * @param string|null $groupName
-	 * @param TableNode $table
+	 * @param TableNode|null $table
 	 *
 	 * @return void
 	 * @throws Exception
@@ -931,7 +931,7 @@ class SpacesContext implements Context {
 		?string $userName = null,
 		?string $fileName = null,
 		?string $groupName = null,
-		TableNode $table
+		?TableNode $table = null
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
 		Assert::assertIsArray($spaceAsArray = $this->getSpaceByNameFromResponse($spaceName), "No space with name $spaceName found");
@@ -991,17 +991,17 @@ class SpacesContext implements Context {
 	 * @param string $spaceName
 	 * @param string|null $grantedUser
 	 * @param string|null $fileName
-	 * @param TableNode $table
+	 * @param TableNode|null $table
 	 *
 	 * @return void
-	 * @throws Exception|GuzzleException
+	 * @throws GuzzleException
 	 */
 	public function userHasSpaceWith(
 		string $user,
 		string $spaceName,
 		?string $grantedUser = null,
 		?string $fileName = null,
-		TableNode $table
+		?TableNode $table = null
 	): void {
 		$this->theUserListsAllHisAvailableSpacesUsingTheGraphApi($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
@@ -1042,7 +1042,7 @@ class SpacesContext implements Context {
 	 * @param string $spaceName
 	 * @param string|null $userName
 	 * @param string|null $fileName
-	 * @param PyStringNode $schemaString
+	 * @param string|PyStringNode $schemaString
 	 *
 	 * @return void
 	 * @throws Exception
@@ -1051,7 +1051,7 @@ class SpacesContext implements Context {
 		string $spaceName,
 		?string $userName = null,
 		?string $fileName = null,
-		PyStringNode $schemaString
+		PyStringNode|string $schemaString = ""
 	): void {
 		if (isset($this->featureContext->getJsonDecodedResponseBodyContent()->value)) {
 			$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->value;
@@ -1066,7 +1066,9 @@ class SpacesContext implements Context {
 		}
 
 		// substitute the value here
-		$schemaString = $schemaString->getRaw();
+		if (\gettype($schemaString) !== 'string') {
+			$schemaString = $schemaString->getRaw();
+		}
 		$schemaString = $this->featureContext->substituteInLineCodes(
 			$schemaString,
 			$this->featureContext->getCurrentUser(),
@@ -1104,22 +1106,21 @@ class SpacesContext implements Context {
 	 * @Then /^for user "([^"]*)" the JSON response of space project should match$/
 	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" and match$/
 	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" (?:with description file|with space image) "([^"]*)" and match$/
-
 	 * @param string $user
-	 * @param string $spaceName
+	 * @param string|null $spaceName
 	 * @param string|null $grantedUser
 	 * @param string|null $fileName
-	 * @param PyStringNode $schemaString
+	 * @param PyStringNode|string $schemaString
 	 *
 	 * @return void
-	 * @throws Exception|GuzzleException
+	 * @throws GuzzleException
 	 */
 	public function forUserTheJSONDataOfTheResponseShouldMatch(
 		string $user,
 		?string $spaceName = null,
 		?string $grantedUser = null,
 		?string $fileName = null,
-		PyStringNode $schemaString
+		PyStringNode|string $schemaString = ""
 	): void {
 		$this->theUserListsAllHisAvailableSpacesUsingTheGraphApi($user);
 		$this->theJsonDataFromLastResponseShouldMatch($spaceName, $grantedUser, $fileName, $schemaString);

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1106,6 +1106,7 @@ class SpacesContext implements Context {
 	 * @Then /^for user "([^"]*)" the JSON response of space project should match$/
 	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" and match$/
 	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" (?:with description file|with space image) "([^"]*)" and match$/
+	 *
 	 * @param string $user
 	 * @param string|null $spaceName
 	 * @param string|null $grantedUser


### PR DESCRIPTION
## Description
The tests fail when ran with PHP 8.1 like described in the issue.
In PHP a non optional parameter cannot be after an optional one. PHP 7.4 and 8.0 seem not to care too much, but these functions break with PHP 8.1
With this PR the last parameter of the affected functions are made nullable and by that optional and checked later for correct content.

~~PLEASE NOTE: This PR breaks compatibility with PHP 7.4 because of `PyStringNode|string $schemaString = "`, if we want to keep compatibility with PHP7.4 I can change that~~

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #5914

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
