### PR TITLE
[full-ci] chore: bump web to v7.0.0-rc.27

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=8f9dd94303af308b9f2e3a56779b254811c3c01a
+WEB_COMMITID=a3bb344aeab7fbb42c53815502abef7311e948fe
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.26
+WEB_ASSETS_VERSION = v7.0.0-rc.27
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
bump web to v7.0.0-rc.27

This includes fixes to the token renewal behaviour in web.