### PR TITLE
do not send www-authenticate basic for Api requests

### DIFF
--- a/changelog/unreleased/www-authenticate-header.md
+++ b/changelog/unreleased/www-authenticate-header.md
@@ -1,0 +1,6 @@
+Bugfix: Fix authenticate headers for API requests
+
+We changed the www-authenticate header which should not be sent when the `XMLHttpRequest` header is set.
+
+https://github.com/owncloud/ocis/pull/5992
+https://github.com/owncloud/ocis/issues/5986

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -147,7 +147,9 @@ func configureSupportedChallenges(options Options) {
 func writeSupportedAuthenticateHeader(w http.ResponseWriter, r *http.Request) {
 	caser := cases.Title(language.Und)
 	for _, s := range SupportedAuthStrategies {
-		w.Header().Add(WwwAuthenticate, fmt.Sprintf("%v realm=\"%s\", charset=\"UTF-8\"", caser.String(s), r.Host))
+		if r.Header.Get("X-Requested-With") != "XMLHttpRequest" {
+			w.Header().Add(WwwAuthenticate, fmt.Sprintf("%v realm=\"%s\", charset=\"UTF-8\"", caser.String(s), r.Host))
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Bugfix: Fix authenticate headers for API requests

We changed the www-authenticate header which should not be sent for "basic-auth" when the `XMLHttpRequest` header is set.

## Related Issue

Fixes #5986 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
