### PR TITLE
graph: Add strict json decoding to return errors when receiving unknown parameters

### DIFF
--- a/services/graph/pkg/service/v0/approleassignments.go
+++ b/services/graph/pkg/service/v0/approleassignments.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -46,7 +45,7 @@ func (g Graph) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 	logger.Info().Interface("query", r.URL.Query()).Msg("calling create appRoleAssignment")
 
 	appRoleAssignment := libregraph.NewAppRoleAssignmentWithDefaults()
-	err := json.NewDecoder(r.Body).Decode(appRoleAssignment)
+	err := StrictJSONUnmarshal(r.Body, appRoleAssignment)
 	if err != nil {
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err.Error()))
 		return

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -246,7 +246,7 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 
 	client := g.GetGatewayClient()
 	drive := libregraph.Drive{}
-	if err := json.NewDecoder(r.Body).Decode(&drive); err != nil {
+	if err := StrictJSONUnmarshal(r.Body, &drive); err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create drive: invalid body schema definition")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
@@ -342,7 +342,7 @@ func (g Graph) UpdateDrive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	drive := libregraph.Drive{}
-	if err = json.NewDecoder(r.Body).Decode(&drive); err != nil {
+	if err = StrictJSONUnmarshal(r.Body, &drive); err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update drive, invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: error: %v", err.Error()))
 		return

--- a/services/graph/pkg/service/v0/educationclasses.go
+++ b/services/graph/pkg/service/v0/educationclasses.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -59,7 +58,7 @@ func (g Graph) PostEducationClass(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("calling post EducationClass")
 	class := libregraph.NewEducationClassWithDefaults()
-	err := json.NewDecoder(r.Body).Decode(class)
+	err := StrictJSONUnmarshal(r.Body, class)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create education class: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
@@ -120,7 +119,7 @@ func (g Graph) PatchEducationClass(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	changes := libregraph.NewEducationClassWithDefaults()
-	err = json.NewDecoder(r.Body).Decode(changes)
+	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not change class: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
@@ -344,7 +343,7 @@ func (g Graph) PostEducationClassMember(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	memberRef := libregraph.NewMemberReference()
-	err = json.NewDecoder(r.Body).Decode(memberRef)
+	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
 		logger.Debug().
 			Err(err).
@@ -505,7 +504,7 @@ func (g Graph) PostEducationClassTeacher(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	memberRef := libregraph.NewMemberReference()
-	err = json.NewDecoder(r.Body).Decode(memberRef)
+	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
 		logger.Debug().
 			Err(err).

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -57,7 +56,7 @@ func (g Graph) PostEducationSchool(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("calling post school")
 	school := libregraph.NewEducationSchool()
-	err := json.NewDecoder(r.Body).Decode(school)
+	err := StrictJSONUnmarshal(r.Body, school)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create school: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
@@ -129,7 +128,7 @@ func (g Graph) PatchEducationSchool(w http.ResponseWriter, r *http.Request) {
 	}
 
 	school := libregraph.NewEducationSchool()
-	err = json.NewDecoder(r.Body).Decode(school)
+	err = StrictJSONUnmarshal(r.Body, school)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update school: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
@@ -315,7 +314,7 @@ func (g Graph) PostEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	memberRef := libregraph.NewMemberReference()
-	err = json.NewDecoder(r.Body).Decode(memberRef)
+	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
 		logger.Debug().
 			Err(err).
@@ -485,7 +484,7 @@ func (g Graph) PostEducationSchoolClass(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	memberRef := libregraph.NewMemberReference()
-	err = json.NewDecoder(r.Body).Decode(memberRef)
+	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
 		logger.Debug().
 			Err(err).

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -60,7 +59,7 @@ func (g Graph) PostEducationUser(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Interface("body", r.Body).Msg("calling create education user")
 	u := libregraph.NewEducationUser()
-	err := json.NewDecoder(r.Body).Decode(u)
+	err := StrictJSONUnmarshal(r.Body, u)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create education user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err.Error()))
@@ -334,7 +333,7 @@ func (g Graph) PatchEducationUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	changes := libregraph.NewEducationUser()
-	err = json.NewDecoder(r.Body).Decode(changes)
+	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update education user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -60,7 +59,7 @@ func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Msg("calling post group")
 	grp := libregraph.NewGroup()
-	err := json.NewDecoder(r.Body).Decode(grp)
+	err := StrictJSONUnmarshal(r.Body, grp)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create group: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
@@ -119,7 +118,7 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	changes := libregraph.NewGroup()
-	err = json.NewDecoder(r.Body).Decode(changes)
+	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not change group: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
@@ -325,7 +324,7 @@ func (g Graph) PostGroupMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	memberRef := libregraph.NewMemberReference()
-	err = json.NewDecoder(r.Body).Decode(memberRef)
+	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
 		logger.Debug().
 			Err(err).

--- a/services/graph/pkg/service/v0/password.go
+++ b/services/graph/pkg/service/v0/password.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -34,7 +33,7 @@ func (g Graph) ChangeOwnPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cpw := libregraph.NewPasswordChangeWithDefaults()
-	err = json.NewDecoder(r.Body).Decode(cpw)
+	err = StrictJSONUnmarshal(r.Body, cpw)
 	if err != nil {
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
 		return

--- a/services/graph/pkg/service/v0/tags.go
+++ b/services/graph/pkg/service/v0/tags.go
@@ -1,7 +1,6 @@
 package svc
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -54,7 +53,7 @@ func (g Graph) AssignTags(w http.ResponseWriter, r *http.Request) {
 		ctx        = r.Context()
 	)
 
-	if err := json.NewDecoder(r.Body).Decode(&assignment); err != nil {
+	if err := StrictJSONUnmarshal(r.Body, &assignment); err != nil {
 		g.logger.Debug().Err(err).Interface("body", r.Body).Msg("could not decode tag assignment request")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
@@ -143,7 +142,7 @@ func (g Graph) UnassignTags(w http.ResponseWriter, r *http.Request) {
 		ctx          = r.Context()
 	)
 
-	if err := json.NewDecoder(r.Body).Decode(&unassignment); err != nil {
+	if err := StrictJSONUnmarshal(r.Body, &unassignment); err != nil {
 		g.logger.Debug().Err(err).Interface("body", r.Body).Msg("could not decode tag assignment request")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -2,7 +2,6 @@ package svc
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -264,7 +263,7 @@ func (g Graph) PostUser(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
 	logger.Info().Interface("body", r.Body).Msg("calling create user")
 	u := libregraph.NewUser()
-	err := json.NewDecoder(r.Body).Decode(u)
+	err := StrictJSONUnmarshal(r.Body, u)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err.Error()))
@@ -639,7 +638,7 @@ func (g Graph) PatchUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	changes := libregraph.NewUser()
-	err = json.NewDecoder(r.Body).Decode(changes)
+	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,

--- a/services/graph/pkg/service/v0/utils.go
+++ b/services/graph/pkg/service/v0/utils.go
@@ -1,0 +1,13 @@
+package svc
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// StrictJSONUnmarshal is a wrapper around json.Unmarshal that returns an error if the json contains unknown fields.
+func StrictJSONUnmarshal(r io.Reader, v interface{}) error {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
+}

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -127,9 +127,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 #### [Same users can be added in a group multiple time](https://github.com/owncloud/ocis/issues/5702)
 - [apiGraph/addUserToGroup.feature:246](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L246)
 
-#### [Try to add group to a group return 204](https://github.com/owncloud/ocis/issues/5793)
-- [apiGraph/addUserToGroup.feature:268](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L268)
-
 #### [API requests from an unauthorized user should return 403](https://github.com/owncloud/ocis/issues/5938)
 - [apiGraph/addUserToGroup.feature:131](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L131)
 - [apiGraph/addUserToGroup.feature:132](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L132)


### PR DESCRIPTION
## Description
Adding strict json decoding so that receiving unknown parameters (or with typos) will return an error.

## Related Issue
- Fixes #5888 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with curl and current unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
