### PR TITLE
chore: bump web to v7.0.0-rc.29

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=44022d389f1d44ac3765f766396e783b6b5dfbc0
+WEB_COMMITID=c7781078121ee07cc19b866713b0047a0e1c0eed
 WEB_BRANCH=master

--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=a3bb344aeab7fbb42c53815502abef7311e948fe
+WEB_COMMITID=44022d389f1d44ac3765f766396e783b6b5dfbc0
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.28
+WEB_ASSETS_VERSION = v7.0.0-rc.29
 
 include ../../.make/recursion.mk
 

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.27
+WEB_ASSETS_VERSION = v7.0.0-rc.28
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
bump web to v7.0.0-rc.29