### PR TITLE
Update IDM config.go

### DIFF
--- a/services/idp/pkg/config/config.go
+++ b/services/idp/pkg/config/config.go
@@ -83,7 +83,7 @@ type Settings struct {
 	AuthorizationEndpointURI string `yaml:"authorization_endpoint_uri" env:"IDP_ENDPOINT_URI" desc:"URL of the IDP endpoint."`
 	EndsessionEndpointURI    string `yaml:"-"` // unused, not supported by lico-idp
 
-	Insecure bool `yaml:"insecure" env:"OCIS_LDAP_INSECURE;LDAP_INSECURE;IDP_INSECURE" desc:"Disable TLS certificate validation for the LDAP connections. Do not set this in production environments." deprecationVersion:"3.0" removalVersion:"3.1" deprecationInfo:"LDAP_INSECURE changing name for consistency" deprecationReplacement:"OCIS_LDAP_INSECURE"`
+	Insecure bool `yaml:"ldap_insecure" env:"OCIS_LDAP_INSECURE;LDAP_INSECURE;IDP_INSECURE" desc:"Disable TLS certificate validation for the LDAP connections. Do not set this in production environments." deprecationVersion:"3.0" removalVersion:"3.1" deprecationInfo:"LDAP_INSECURE changing name for consistency" deprecationReplacement:"OCIS_LDAP_INSECURE"`
 
 	TrustedProxy []string `yaml:"trusted_proxy"` //TODO: how to configure this via env?
 


### PR DESCRIPTION
Fixes: #5906

After clarification and renaming the envvar via #6008 and post a discussion with @rhafer, we should align the yaml name to the envvar name. Note that the backend name (`Insecure`) is not changed.
* In the deployment examples, we use ennvars and no yaml - no issue
* ocis init does not use it - no issue

The only issue that could raise is, if one used the old yaml name. This is possible but quite unlikely.


