### PR TITLE
feat: additional web config for css, scripts and translations

### DIFF
--- a/changelog/unreleased/enhancement-web-config-additions.md
+++ b/changelog/unreleased/enhancement-web-config-additions.md
@@ -1,0 +1,5 @@
+Enhancement: Web config additions
+
+We've added config keys for defining additional css, scripts and translations for ownCloud Web.
+
+https://github.com/owncloud/ocis/pull/6032

--- a/services/web/pkg/config/config.go
+++ b/services/web/pkg/config/config.go
@@ -33,6 +33,22 @@ type Asset struct {
 	Path string `yaml:"path" env:"WEB_ASSET_PATH" desc:"Serve ownCloud Web assets from a path on the filesystem instead of the builtin assets."`
 }
 
+// CustomStyle references additional css to be loaded into ownCloud Web.
+type CustomStyle struct {
+	Href string `json:"href" yaml:"href"`
+}
+
+// CustomScript references an additional script to be loaded into ownCloud Web.
+type CustomScript struct {
+	Src   string `json:"src" yaml:"src"`
+	Async bool   `json:"async,omitempty" yaml:"async"`
+}
+
+// CustomTranslation references a json file for overwriting translations in ownCloud Web.
+type CustomTranslation struct {
+	Url string `json:"url" yaml:"url"`
+}
+
 // WebConfig defines the available web configuration for a dynamically rendered config.json.
 type WebConfig struct {
 	Server        string                 `json:"server,omitempty" yaml:"server" env:"OCIS_URL;WEB_UI_CONFIG_SERVER" desc:"URL, where the oCIS APIs are reachable for ownCloud Web."`
@@ -42,6 +58,9 @@ type WebConfig struct {
 	Applications  []Application          `json:"applications,omitempty" yaml:"applications"`
 	ExternalApps  []ExternalApp          `json:"external_apps,omitempty" yaml:"external_apps"`
 	Options       map[string]interface{} `json:"options,omitempty" yaml:"options"`
+	Styles        []CustomStyle          `json:"styles,omitempty" yaml:"styles"`
+	Scripts       []CustomScript         `json:"scripts,omitempty" yaml:"scripts"`
+	Translations  []CustomTranslation    `json:"customTranslations,omitempty" yaml:"custom_translations"`
 }
 
 // OIDC defines the available oidc configuration


### PR DESCRIPTION
## Description
This PR adds three key/value pairs to the config struct of the `web` service that reflect the status quo of config.json options:
- `styles` for loading additional css
- `scripts` for loading additional scripts
- `customTranslations` for overwriting translations as needed

## Related Issue
- Relates to https://github.com/owncloud/web/issues/8791
- Relates to https://github.com/owncloud/web/issues/4735

## Motivation and Context
- Make it possible to define styles/scripts/customTranslations via config/env vars
- Stop kicking out the three key/value pairs when parsing a dedicated config.json file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
