### PR TITLE
[tests-only] [full-ci] Refactor scenario related to checking json response

### DIFF
--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -52,26 +52,6 @@ Feature: Change data of space
   Scenario Outline: user other than space manager role can't change the name of a Space via the Graph API
     When user "<user>" changes the name of the "Project Jupiter" space to "Project Jupiter"
     Then the HTTP status code should be "403"
-    And for user "<user>" the JSON response should contain space called "Project Jupiter" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Jupiter"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        }
-      }
-    }
-    """
     Examples:
       | user  |
       | Brian |
@@ -120,34 +100,6 @@ Feature: Change data of space
   Scenario Outline: user with normal space permission can't increases the quota of a Space via the Graph API
     When user "<user>" changes the quota of the "Project Jupiter" space to "100"
     Then the HTTP status code should be "403"
-    And for user "<user>" the JSON response should contain space called "Project Jupiter" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "quota"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Jupiter"]
-        },
-        "quota": {
-          "type": "object",
-          "required": [
-            "total"
-          ],
-          "properties": {
-            "total" : {
-              "type": "number",
-              "enum": [20]
-            }
-          }
-        }
-      }
-    }
-    """
     Examples:
       | user  |
       | Brian |
@@ -192,7 +144,7 @@ Feature: Change data of space
     """
     When user "Alice" uploads a file inside space "Project Jupiter" with content "some content" to "file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And for user "Alice" the JSON response should contain space called "Project Jupiter" and match
+    And for user "Alice" the JSON representation of their drive should contain space called "Project Jupiter" and match
     """
      {
       "type": "object",
@@ -236,7 +188,7 @@ Feature: Change data of space
     And user "Alice" has uploaded a file inside space "Project Jupiter" with content "space description" to ".space/readme.md"
     When user "Alice" sets the file ".space/readme.md" as a description in a special section of the "Project Jupiter" space
     Then the HTTP status code should be "200"
-    And for user "Alice" the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/readme.md" and match
+    And the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/readme.md" and match
     """
     {
       "type": "object",
@@ -319,7 +271,7 @@ Feature: Change data of space
     And user "Alice" has set the file ".space/readme.md" as a description in a special section of the "Project Jupiter" space
     When user "<user>" uploads a file inside space "Project Jupiter" with content "new description" to ".space/readme.md" using the WebDAV API
     Then the HTTP status code should be "<code>"
-    And for user "Alice" the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/readme.md" and match
+    And for user "<user>" the JSON representation of their drive should contain space called "Project Jupiter" owned by "Alice" with description file ".space/readme.md" and match
     """
     {
       "type": "object",
@@ -405,7 +357,7 @@ Feature: Change data of space
     And user "<user>" has uploaded a file inside space "Project Jupiter" with content "" to ".space/<fileName>"
     When user "<user>" sets the file ".space/<fileName>" as a space image in a special section of the "Project Jupiter" space
     Then the HTTP status code should be "200"
-    And for user "Alice" the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/<fileName>" and match
+    And the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/<fileName>" and match
     """
     {
       "type": "object",
@@ -499,7 +451,7 @@ Feature: Change data of space
     When user "<user>" uploads a file inside space "Project Jupiter" owned by the user "Alice" with content "new content" to ".space/readme.md" using the WebDAV API
     Then the HTTP status code should be "<code>"
     And for user "<user>" the content of the file ".space/readme.md" of the space "Project Jupiter" should be "<expectedContent>"
-    And for user "<user>" the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/readme.md" and match
+    And the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/readme.md" and match
     """
     {
       "type": "object",
@@ -585,7 +537,7 @@ Feature: Change data of space
     When user "<user>" has uploaded a file inside space "Project Jupiter" with content "" to ".space/newSpaceImage.png"
     And user "<user>" sets the file ".space/newSpaceImage.png" as a space image in a special section of the "Project Jupiter" space
     Then the HTTP status code should be "200"
-    And for user "<user>" the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/newSpaceImage.png" and match
+    And the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/newSpaceImage.png" and match
     """
     {
       "type": "object",
@@ -681,7 +633,7 @@ Feature: Change data of space
     Then the HTTP status code should be "200"
     When user "Brian" uploads a file inside space "Brian Murphy" with content "file is more than 15 bytes" to "file.txt" using the WebDAV API
     Then the HTTP status code should be <code>
-    And for user "Brian" the JSON response should contain space called "Brian Murphy" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "Brian Murphy" and match
     """
      {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -24,10 +24,10 @@ Feature: Change data of space
     And using spaces DAV path
 
 
-  Scenario: only space admin user can change the name of a space via the Graph API
+  Scenario: user with space manager role can change the name of a space via the Graph API
     When user "Alice" changes the name of the "Project Jupiter" space to "Project Death Star"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Project Death Star" and match
+    And the JSON data of the response should match
     """
      {
       "type": "object",
@@ -49,10 +49,10 @@ Feature: Change data of space
     """
 
 
-  Scenario Outline: other than space admin user can't change the name of a Space via the Graph API
-    When user "<user>" changes the name of the "Project Jupiter" space to "<expectedName>"
-    Then the HTTP status code should be "<code>"
-    And for user "<user>" the JSON response should contain space called "<expectedName>" and match
+  Scenario Outline: user other than space manager role can't change the name of a Space via the Graph API
+    When user "<user>" changes the name of the "Project Jupiter" space to "Project Jupiter"
+    Then the HTTP status code should be "403"
+    And for user "<user>" the JSON response should contain space called "Project Jupiter" and match
     """
      {
       "type": "object",
@@ -63,7 +63,7 @@ Feature: Change data of space
       "properties": {
         "name": {
           "type": "string",
-          "enum": ["<expectedName>"]
+          "enum": ["Project Jupiter"]
         },
         "driveType": {
           "type": "string",
@@ -73,15 +73,15 @@ Feature: Change data of space
     }
     """
     Examples:
-      | user  | code | expectedName       |
-      | Brian | 403  | Project Jupiter    |
-      | Bob   | 403  | Project Jupiter    |
+      | user  |
+      | Brian |
+      | Bob   |
 
 
-  Scenario: only space admin user can change the description(subtitle) of a space via the Graph API
+  Scenario: user with space manager role can change the description(subtitle) of a space via the Graph API
     When user "Alice" changes the description of the "Project Jupiter" space to "The Death Star is a fictional mobile space station"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Project Jupiter" and match
+    And the JSON data of the response should match
     """
      {
       "type": "object",
@@ -110,45 +110,11 @@ Feature: Change data of space
 
   Scenario Outline: viewer and editor cannot change the description(subtitle) of a space via the Graph API
     When user "<user>" changes the description of the "Project Jupiter" space to "The Death Star is a fictional mobile space station"
-    Then the HTTP status code should be "<code>"
+    Then the HTTP status code should be "403"
     Examples:
-      | user  | code |
-      | Brian | 403  |
-      | Bob   | 403  |
-
-
-  Scenario: user tries to increase the quota of a Space via the Graph API
-  Scenario: An user tries to increase the quota of a Space via the Graph API
-    When user "Alice" changes the quota of the "Project Jupiter" space to "100"
-    Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Project Jupiter" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "quota"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Jupiter"]
-        },
-        "quota": {
-          "type": "object",
-          "required": [
-            "total"
-          ],
-          "properties": {
-            "total" : {
-              "type": "number",
-              "enum": [100]
-            }
-          }
-        }
-      }
-    }
-    """
+      | user  |
+      | Brian |
+      | Bob   |
 
 
   Scenario Outline: user with normal space permission can't increases the quota of a Space via the Graph API
@@ -191,7 +157,7 @@ Feature: Change data of space
   Scenario Outline: space admin user set no restriction quota of a Space via the Graph API
     When user "Alice" changes the quota of the "Project Jupiter" space to "<quotaValue>"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Project Jupiter" and match
+    And the JSON data of the response should match
     """
      {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -97,7 +97,7 @@ Feature: Change data of space
       | Bob   |
 
 
-  Scenario Outline: user with normal space permission can't increases the quota of a Space via the Graph API
+  Scenario Outline: user with normal space permission can't increase the quota of a Space via the Graph API
     When user "<user>" changes the quota of the "Project Jupiter" space to "100"
     Then the HTTP status code should be "403"
     Examples:

--- a/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
@@ -28,42 +28,6 @@ Feature: Disabling and deleting space
     Given the administrator has given "Alice" the role "<role>" using the settings api
     When user "Alice" disables a space "Project Moon"
     Then the HTTP status code should be "204"
-    And for user "Alice" the JSON representation of their drive should contain space called "Project Moon" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "root"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Moon"]
-        },
-        "root": {
-          "type": "object",
-          "required": [
-            "deleted"
-          ],
-          "properties": {
-            "deleted": {
-              "type": "object",
-              "required": [
-                "state"
-              ],
-              "properties": {
-                "state": {
-                  "type": "string",
-                  "enum": ["trashed"]
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    """
     And the user "Brian" should not have a space called "Project Moon"
     And the user "Bob" should not have a space called "Project Moon"
     Examples:
@@ -78,6 +42,8 @@ Feature: Disabling and deleting space
     Given the administrator has given "Carol" the role "<role>" using the settings api
     When user "Carol" tries to disable a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "403"
+    And the user "Brian" should have a space called "Project Moon"
+    And the user "Bob" should have a space called "Project Moon"
     Examples:
       | role  |
       | User  |
@@ -98,6 +64,7 @@ Feature: Disabling and deleting space
     Given the administrator has given "Alice" the role "<role>" using the settings api
     When user "Alice" deletes a space "Project Moon"
     Then the HTTP status code should be "400"
+    And the user "Alice" should have a space called "Project Moon"
     Examples:
       | role        |
       | Admin       |
@@ -124,42 +91,7 @@ Feature: Disabling and deleting space
     Given the administrator has given "Carol" the role "<role>" using the settings api
     When user "Carol" disables a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "204"
-    And for user "Alice" the JSON representation of their drive should contain space called "Project Moon" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "root"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Moon"]
-        },
-        "root": {
-          "type": "object",
-          "required": [
-            "deleted"
-          ],
-          "properties": {
-            "deleted": {
-              "type": "object",
-              "required": [
-                "state"
-              ],
-              "properties": {
-                "state": {
-                  "type": "string",
-                  "enum": ["trashed"]
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    """
+    And the user "Carol" should not have a space called "Project Moon"
     Examples:
       | role        |
       | Admin       |
@@ -169,9 +101,10 @@ Feature: Disabling and deleting space
   Scenario Outline: an admin and space manager can delete other disabled Space
     Given the administrator has given "Carol" the role "<role>" using the settings api
     And user "Alice" has disabled a space "Project Moon"
-    When user "Carol" tries to delete a space "Project Moon" owned by user "Alice"
+    When user "Carol" deletes a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "204"
     And the user "Alice" should not have a space called "Project Moon"
+    And the user "Carol" should not have a space called "Project Moon"
     Examples:
       | role        |
       | Admin       |

--- a/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
@@ -28,7 +28,7 @@ Feature: Disabling and deleting space
     Given the administrator has given "Alice" the role "<role>" using the settings api
     When user "Alice" disables a space "Project Moon"
     Then the HTTP status code should be "204"
-    And for user "Alice" the JSON response should contain space called "Project Moon" and match
+    And for user "Alice" the JSON representation of their drive should contain space called "Project Moon" and match
     """
      {
       "type": "object",
@@ -78,36 +78,6 @@ Feature: Disabling and deleting space
     Given the administrator has given "Carol" the role "<role>" using the settings api
     When user "Carol" tries to disable a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "403"
-    And for user "Brian" the JSON response should contain space called "Project Moon" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Moon"]
-        }
-      }
-    }
-    """
-    And for user "Bob" the JSON response should contain space called "Project Moon" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Moon"]
-        }
-      }
-    }
-    """
     Examples:
       | role  |
       | User  |
@@ -128,21 +98,6 @@ Feature: Disabling and deleting space
     Given the administrator has given "Alice" the role "<role>" using the settings api
     When user "Alice" deletes a space "Project Moon"
     Then the HTTP status code should be "400"
-    And for user "Alice" the JSON response should contain space called "Project Moon" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Moon"]
-        }
-      }
-    }
-    """
     Examples:
       | role        |
       | Admin       |
@@ -167,9 +122,9 @@ Feature: Disabling and deleting space
 
   Scenario Outline: an admin and space manager can disable other space via the Graph API
     Given the administrator has given "Carol" the role "<role>" using the settings api
-    When user "Carol" tries to disable a space "Project Moon" owned by user "Alice"
+    When user "Carol" disables a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "204"
-    And for user "Alice" the JSON response should contain space called "Project Moon" and match
+    And for user "Alice" the JSON representation of their drive should contain space called "Project Moon" and match
     """
      {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -83,31 +83,6 @@ Feature: List and create spaces
     And user "Brian" has created folder "folder"
     And user "Brian" has shared folder "folder" with user "Alice" with permissions "31"
     And user "Alice" has accepted share "/folder" offered by user "Brian"
-    Then for user "Alice" the JSON response should contain space called "Shares" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "driveType",
-        "id",
-        "name"
-      ],
-      "properties": {
-        "driveType": {
-          "type": "string",
-          "enum": ["virtual"]
-        },
-        "id": {
-          "type": "string",
-          "enum": ["%space_id%"]
-        },
-        "name": {
-          "type": "string",
-          "enum": ["Shares"]
-        }
-      }
-    }
-    """
     When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'personal'"
     Then the HTTP status code should be "200"
     And the JSON response should contain space called "Alice Hansen" and match

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -4,7 +4,7 @@ Feature: State of the quota
   I want to be able to see the state of the quota
   So that I will not let the quota overrun
 
-  
+
   quota state indication:
   | 0 - 75%  | normal   |
   | 76 - 90% | nearing  |
@@ -23,7 +23,7 @@ Feature: State of the quota
   Scenario Outline: quota information is returned in the list of spaces returned via the Graph API
     Given user "Alice" has created a space "<spaceName>" of type "project" with quota "<total>"
     When user "Alice" uploads a file inside space "<spaceName>" with content "<fileContent>" to "test.txt" using the WebDAV API
-    Then for user "Alice" the JSON response should contain space called "<spaceName>" and match
+    Then for user "Alice" the JSON representation of their drive should contain space called "<spaceName>" and match
     """
      {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -23,7 +23,8 @@ Feature: State of the quota
   Scenario Outline: quota information is returned in the list of spaces returned via the Graph API
     Given user "Alice" has created a space "<spaceName>" of type "project" with quota "<total>"
     When user "Alice" uploads a file inside space "<spaceName>" with content "<fileContent>" to "test.txt" using the WebDAV API
-    Then for user "Alice" the JSON representation of their drive should contain space called "<spaceName>" and match
+    And user "Alice" lists all available spaces via the GraphApi
+    Then the JSON response should contain space called "<spaceName>" and match
     """
      {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
@@ -61,34 +61,6 @@ Feature: Remove files, folder
       | role      | <role> |
     When user "<user>" removes the file "text.txt" from space "delete objects"
     Then the HTTP status code should be "<code>"
-    And for user "<user>" the JSON representation of their drive should contain space called "delete objects" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "quota"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["delete objects"]
-        },
-        "quota": {
-          "type": "object",
-          "required": [
-            "used"
-          ],
-          "properties": {
-            "used": {
-              "type": "number",
-              "enum": [<quotaValue>]
-            }
-          }
-        }
-      }
-    }
-    """
     And for user "<user>" the space "delete objects" <shouldOrNotBeInSpace> contain these entries:
       | text.txt |
     And as "<user>" file "text.txt" <shouldOrNotBeInTrash> exist in the trashbin of the space "delete objects"
@@ -100,6 +72,6 @@ Feature: Remove files, folder
       | Brian | viewer  | 403  | should               | should not           | 12         |
 
 
-  Scenario: user is unable to delete a space via the webDav API
+  Scenario: try to delete an empty string folder from a space
     When user "Alice" removes the folder "" from space "delete objects"
     Then the HTTP status code should be "405"

--- a/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
@@ -61,9 +61,6 @@ Feature: Remove files, folder
       | role      | <role> |
     When user "<user>" removes the file "text.txt" from space "delete objects"
     Then the HTTP status code should be "<code>"
-    And for user "<user>" the space "delete objects" <shouldOrNotBeInSpace> contain these entries:
-      | text.txt |
-    And as "<user>" file "text.txt" <shouldOrNotBeInTrash> exist in the trashbin of the space "delete objects"
     And for user "<user>" the JSON response should contain space called "delete objects" and match
     """
      {
@@ -92,6 +89,9 @@ Feature: Remove files, folder
       }
     }
     """
+    And for user "<user>" the space "delete objects" <shouldOrNotBeInSpace> contain these entries:
+      | text.txt |
+    And as "<user>" file "text.txt" <shouldOrNotBeInTrash> exist in the trashbin of the space "delete objects"
     Examples:
       | user  | role    | code | shouldOrNotBeInSpace | shouldOrNotBeInTrash | quotaValue |
       | Alice | manager | 204  | should not           | should               | 0          |

--- a/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
@@ -61,7 +61,7 @@ Feature: Remove files, folder
       | role      | <role> |
     When user "<user>" removes the file "text.txt" from space "delete objects"
     Then the HTTP status code should be "<code>"
-    And for user "<user>" the JSON response should contain space called "delete objects" and match
+    And for user "<user>" the JSON representation of their drive should contain space called "delete objects" and match
     """
      {
       "type": "object",
@@ -103,18 +103,3 @@ Feature: Remove files, folder
   Scenario: user is unable to delete a space via the webDav API
     When user "Alice" removes the folder "" from space "delete objects"
     Then the HTTP status code should be "405"
-    And for user "Alice" the JSON response should contain space called "delete objects" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["delete objects"]
-        }
-      }
-    }
-    """

--- a/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
@@ -81,38 +81,4 @@ Feature: Restore files, folder
     And user "Brian" has uploaded file with content "some content" to "newFile.txt"
     When user "Brian" restores version index "1" of file "/file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And for user "Brian" the JSON representation of their drive should contain space called "Brian Murphy" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "quota"
-      ],
-      "properties": {
-        "quota": {
-          "type": "object",
-          "required": [
-            "state",
-            "total",
-            "remaining",
-            "used"
-          ],
-          "properties": {
-            "state" : {
-              "type": "string",
-              "enum": ["exceeded"]
-            },
-            "total" : {
-              "type": "number",
-              "enum": [30]
-            },
-            "used": {
-              "type": "number",
-              "enum": [38]
-            }
-          }
-        }
-      }
-    }
-    """
     And the content of file "/file.txt" for user "Brian" should be "file is less than 30 bytes"

--- a/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
@@ -81,7 +81,6 @@ Feature: Restore files, folder
     And user "Brian" has uploaded file with content "some content" to "newFile.txt"
     When user "Brian" restores version index "1" of file "/file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And the content of file "/file.txt" for user "Brian" should be "file is less than 30 bytes"
     And for user "Brian" the JSON response should contain space called "Brian Murphy" and match
     """
      {
@@ -116,3 +115,4 @@ Feature: Restore files, folder
       }
     }
     """
+    And the content of file "/file.txt" for user "Brian" should be "file is less than 30 bytes"

--- a/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
@@ -81,7 +81,7 @@ Feature: Restore files, folder
     And user "Brian" has uploaded file with content "some content" to "newFile.txt"
     When user "Brian" restores version index "1" of file "/file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And for user "Brian" the JSON response should contain space called "Brian Murphy" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "Brian Murphy" and match
     """
      {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/setQuota.feature
+++ b/tests/acceptance/features/apiSpaces/setQuota.feature
@@ -16,7 +16,7 @@ Feature: Set quota
     And the administrator has given "Brian" the role "<userRole>" using the settings api
     When user "Alice" changes the quota of the "Brian Murphy" space to "100" owned by user "Brian"
     Then the HTTP status code should be "200"
-    And for user "Brian" the JSON response should contain space called "Brian Murphy" and match
+    And the JSON response should contain space called "Brian Murphy" and match
     """
     {
       "type": "object",
@@ -97,7 +97,7 @@ Feature: Set quota
     And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
     When user "Brian" changes the quota of the "Project Jupiter" space to "100" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And for user "Alice" the JSON response should contain space called "Project Jupiter" and match
+    And the JSON response should contain space called "Project Jupiter" and match
     """
     {
       "type": "object",
@@ -182,7 +182,7 @@ Feature: Set quota
     Given the administrator has given "Alice" the role "Admin" using the settings api
     When user "Alice" changes the quota of the "Alice Hansen" space to "100" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And for user "Alice" the JSON response should contain space called "Alice Hansen" and match
+    And the JSON response should contain space called "Alice Hansen" and match
     """
     {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/setQuota.feature
+++ b/tests/acceptance/features/apiSpaces/setQuota.feature
@@ -16,7 +16,7 @@ Feature: Set quota
     And the administrator has given "Brian" the role "<userRole>" using the settings api
     When user "Alice" changes the quota of the "Brian Murphy" space to "100" owned by user "Brian"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Brian Murphy" and match
+    And the JSON data of the response should match
     """
     {
       "type": "object",
@@ -97,7 +97,7 @@ Feature: Set quota
     And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
     When user "Brian" changes the quota of the "Project Jupiter" space to "100" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Project Jupiter" and match
+    And the JSON data of the response should match
     """
     {
       "type": "object",
@@ -182,7 +182,7 @@ Feature: Set quota
     Given the administrator has given "Alice" the role "Admin" using the settings api
     When user "Alice" changes the quota of the "Alice Hansen" space to "100" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Alice Hansen" and match
+    And the JSON data of the response should match
     """
     {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/setQuota.feature
+++ b/tests/acceptance/features/apiSpaces/setQuota.feature
@@ -52,29 +52,6 @@ Feature: Set quota
     And the administrator has given "Brian" the role "<userRole>" using the settings api
     When user "Alice" changes the quota of the "Brian Murphy" space to "100" owned by user "Brian"
     Then the HTTP status code should be "403"
-    And for user "Brian" the JSON response should contain space called "Brian Murphy" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "quota"
-      ],
-      "properties": {
-        "quota": {
-          "type": "object",
-          "required": [
-            "total"
-          ],
-          "properties": {
-            "total" : {
-              "type": "number",
-              "enum": [0]
-            }
-          }
-        }
-      }
-    }
-    """
     Examples:
       | role        | userRole    |
       | Space Admin | Admin       |
@@ -140,34 +117,6 @@ Feature: Set quota
       | role      | <spaceRole> |
     When user "Brian" changes the quota of the "Project Jupiter" space to "100"
     Then the HTTP status code should be "403"
-    And for user "Alice" the JSON response should contain space called "Project Jupiter" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "quota"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Jupiter"]
-        },
-        "quota": {
-          "type": "object",
-          "required": [
-            "total"
-          ],
-          "properties": {
-            "total" : {
-              "type": "number",
-              "enum": [20]
-            }
-          }
-        }
-      }
-    }
-    """
     Examples:
       | userRole | spaceRole |
       | User     | viewer    |
@@ -211,29 +160,6 @@ Feature: Set quota
     Given the administrator has given "Alice" the role "<userRole>" using the settings api
     When user "Alice" changes the quota of the "Alice Hansen" space to "100" owned by user "Alice"
     Then the HTTP status code should be "403"
-    And for user "Alice" the JSON response should contain space called "Alice Hansen" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "quota"
-      ],
-      "properties": {
-        "quota": {
-          "type": "object",
-          "required": [
-            "total"
-          ],
-          "properties": {
-            "total" : {
-              "type": "number",
-              "enum": [0]
-            }
-          }
-        }
-      }
-    }
-    """
     Examples:
       | userRole    |
       | Space Admin |

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -94,7 +94,7 @@ Feature: Space management
   Scenario: space admin user changes the name of the project space
     When user "Brian" changes the name of the "Project" space to "New Name" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And for user "Alice" the JSON response should contain space called "New Name" and match
+    And the JSON response should contain space called "New Name" and match
     """
     {
       "type": "object",
@@ -134,7 +134,7 @@ Feature: Space management
   Scenario: space admin user changes the description of the project space
     When user "Brian" changes the description of the "Project" space to "New description" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And for user "Alice" the JSON response should contain space called "Project" and match
+    And the JSON response should contain space called "Project" and match
     """
     {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -94,7 +94,7 @@ Feature: Space management
   Scenario: space admin user changes the name of the project space
     When user "Brian" changes the name of the "Project" space to "New Name" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "New Name" and match
+    And the JSON data of the response should match
     """
     {
       "type": "object",
@@ -134,7 +134,7 @@ Feature: Space management
   Scenario: space admin user changes the description of the project space
     When user "Brian" changes the description of the "Project" space to "New description" owned by user "Alice"
     Then the HTTP status code should be "200"
-    And the JSON response should contain space called "Project" and match
+    And the JSON data of the response should match
     """
     {
       "type": "object",

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -114,6 +114,7 @@ Feature: Space management
   Scenario: user without space admin permission tries to change the name of the project space
     When user "Carol" tries to change the name of the "Project" space to "New Name" owned by user "Alice"
     Then the HTTP status code should be "403"
+    And the user "Alice" should have a space called "Project"
 
   @skipOnStable2.0
   Scenario: space admin user changes the description of the project space
@@ -145,42 +146,7 @@ Feature: Space management
   Scenario: space admin user disables the project space
     When user "Brian" disables a space "Project" owned by user "Alice"
     Then the HTTP status code should be "204"
-    And for user "Alice" the JSON representation of their drive should contain space called "Project" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "root"
-      ],
-      "properties": {
-        "name": {
-           "type": "string",
-           "enum": ["Project"]
-        },
-        "root": {
-          "type": "object",
-          "required": [
-            "deleted"
-          ],
-          "properties": {
-            "deleted": {
-              "type": "object",
-              "required": [
-              "state"
-              ],
-              "properties": {
-                "state": {
-                  "type": "string",
-                  "enum": ["trashed"]
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    """
+    And the user "Brian" should not have a space called "Project"
 
 
   Scenario: user without space admin permission tries to disable the project space
@@ -220,3 +186,4 @@ Feature: Space management
     Given user "Alice" has disabled a space "Project"
     When user "Carol" tries to restore a disabled space "Project" owned by user "Alice"
     Then the HTTP status code should be "404"
+    And the user "Alice" should not have a space called "Project"

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -186,4 +186,4 @@ Feature: Space management
     Given user "Alice" has disabled a space "Project"
     When user "Carol" tries to restore a disabled space "Project" owned by user "Alice"
     Then the HTTP status code should be "404"
-    And the user "Alice" should not have a space called "Project"
+    And the user "Alice" should have a space "Project" in the disable state

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -114,21 +114,6 @@ Feature: Space management
   Scenario: user without space admin permission tries to change the name of the project space
     When user "Carol" tries to change the name of the "Project" space to "New Name" owned by user "Alice"
     Then the HTTP status code should be "403"
-    And for user "Alice" the JSON response should contain space called "Project" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-           "type": "string",
-           "enum": ["Project"]
-        }
-      }
-    }
-    """
 
   @skipOnStable2.0
   Scenario: space admin user changes the description of the project space
@@ -155,27 +140,12 @@ Feature: Space management
     Given user "Alice" has changed the description of the "Project" space to "old description"
     When user "Carol" tries to change the description of the "Project" space to "New description" owned by user "Alice"
     Then the HTTP status code should be "403"
-    And for user "Alice" the JSON response should contain space called "Project" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "description"
-      ],
-      "properties": {
-        "description": {
-           "type": "string",
-           "enum": ["old description"]
-        }
-      }
-    }
-    """
 
   @skipOnStable2.0
   Scenario: space admin user disables the project space
     When user "Brian" disables a space "Project" owned by user "Alice"
     Then the HTTP status code should be "204"
-    And for user "Alice" the JSON response should contain space called "Project" and match
+    And for user "Alice" the JSON representation of their drive should contain space called "Project" and match
     """
     {
       "type": "object",
@@ -238,42 +208,6 @@ Feature: Space management
     Given user "Alice" has disabled a space "Project"
     When user "Carol" tries to delete a space "Project" owned by user "Alice"
     Then the HTTP status code should be "403"
-    And for user "Alice" the JSON response should contain space called "Project" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "root"
-      ],
-      "properties": {
-        "name": {
-           "type": "string",
-           "enum": ["Project"]
-        },
-        "root": {
-          "type": "object",
-          "required": [
-            "deleted"
-          ],
-          "properties": {
-            "deleted": {
-              "type": "object",
-              "required": [
-              "state"
-              ],
-              "properties": {
-                "state": {
-                  "type": "string",
-                  "enum": ["trashed"]
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    """
 
   @skipOnStable2.0
   Scenario: space admin user enables the project space
@@ -286,39 +220,3 @@ Feature: Space management
     Given user "Alice" has disabled a space "Project"
     When user "Carol" tries to restore a disabled space "Project" owned by user "Alice"
     Then the HTTP status code should be "404"
-    And for user "Alice" the JSON response should contain space called "Project" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "root"
-      ],
-      "properties": {
-        "name": {
-           "type": "string",
-           "enum": ["Project"]
-        },
-        "root": {
-          "type": "object",
-          "required": [
-            "deleted"
-          ],
-          "properties": {
-            "deleted": {
-              "type": "object",
-              "required": [
-              "state"
-              ],
-              "properties": {
-                "state": {
-                  "type": "string",
-                  "enum": ["trashed"]
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    """

--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -41,39 +41,11 @@ Feature: Upload files into a space
     Then the HTTP status code should be "<code>"
     And for user "Brian" the space "Project Ceres" <shouldOrNot> contain these entries:
       | test.txt |
-    And for user "Brian" the JSON representation of their drive should contain space called "Project Ceres" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "quota"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["Project Ceres"]
-        },
-        "quota": {
-          "type": "object",
-          "required": [
-            "used"
-          ],
-          "properties": {
-            "used": {
-              "type": "number",
-              "enum": [<usedQuota>]
-            }
-          }
-        }
-      }
-    }
-    """
     Examples:
-      | role    | code | shouldOrNot | usedQuota |
-      | manager | 201  | should      | 4         |
-      | editor  | 201  | should      | 4         |
-      | viewer  | 403  | should not  | 0         |
+      | role    | code | shouldOrNot |
+      | manager | 201  | should      |
+      | editor  | 201  | should      |
+      | viewer  | 403  | should not  |
 
 
   Scenario: user can create subfolders in a space via the Graph API

--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -41,7 +41,7 @@ Feature: Upload files into a space
     Then the HTTP status code should be "<code>"
     And for user "Brian" the space "Project Ceres" <shouldOrNot> contain these entries:
       | test.txt |
-    And for user "Brian" the JSON response should contain space called "Project Ceres" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "Project Ceres" and match
     """
      {
       "type": "object",

--- a/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
@@ -25,31 +25,7 @@ Feature: Share spaces
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the OCS status message should be "OK"
-    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType",
-        "id"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["share space"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        },
-        "id": {
-          "type": "string",
-          "pattern": "^%space_id_pattern%$"
-        }
-      }
-    }
-    """
+    And the user "Brian" should have a space called "share space"
     Examples:
       | role    |
       | manager |
@@ -90,31 +66,6 @@ Feature: Share spaces
     Given user "Alice" has shared a space "share space" with settings:
       | shareWith | Brian  |
       | role      | viewer |
-    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
-    """
-     {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType",
-        "id"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["share space"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        },
-        "id": {
-          "type": "string",
-          "pattern": "^%space_id_pattern%$"
-        }
-      }
-    }
-    """
     When user "Alice" unshares a space "share space" to user "Brian"
     Then the HTTP status code should be "200"
     But the user "Brian" should not have a space called "share space"
@@ -126,31 +77,6 @@ Feature: Share spaces
       | role      | manager |
     When user "<user>" unshares a space "share space" to user "Alice"
     Then the HTTP status code should be "200"
-    And for user "Brian" the JSON representation of their drive should contain space called "share space" owned by "Alice" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType",
-        "id"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["share space"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        },
-        "id": {
-          "type": "string",
-          "pattern": "^%space_id_pattern%$"
-        }
-      }
-    }
-    """
     But the user "Alice" should not have a space called "share space"
     Examples:
       | user  |
@@ -198,31 +124,7 @@ Feature: Share spaces
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the OCS status message should be "OK"
-    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType",
-        "id"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["share space"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        },
-        "id": {
-          "type": "string",
-          "pattern": "^%space_id_pattern%$"
-        }
-      }
-    }
-    """
+    And the user "Bob" should have a space called "share space"
     Examples:
       | role    |
       | manager |
@@ -301,56 +203,8 @@ Feature: Share spaces
       | shareType | 8      |
       | role      | <role> |
     Then the HTTP status code should be "200"
-    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType",
-        "id"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["share space"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        },
-        "id": {
-          "type": "string",
-          "pattern": "^%space_id_pattern%$"
-        }
-      }
-    }
-    """
-    And for user "Bob" the JSON representation of their drive should contain space called "share space" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType",
-        "id"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["share space"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        },
-        "id": {
-          "type": "string",
-          "pattern": "^%space_id_pattern%$"
-        }
-      }
-    }
-    """
+    And the user "Brian" should have a space called "share space"
+    And the user "Bob" should have a space called "share space"
     Examples:
       | role    |
       | manager |
@@ -388,31 +242,7 @@ Feature: Share spaces
       | Brian    | group2    |
     Then the HTTP status code of responses on all endpoints should be "204"
     And the user "Brian" should not have a space called "share space"
-    But for user "Bob" the JSON representation of their drive should contain space called "share space" and match
-    """
-    {
-      "type": "object",
-      "required": [
-        "name",
-        "driveType",
-        "id"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": ["share space"]
-        },
-        "driveType": {
-          "type": "string",
-          "enum": ["project"]
-        },
-        "id": {
-          "type": "string",
-          "pattern": "^%space_id_pattern%$"
-        }
-      }
-    }
-    """
+    But the user "Bob" should have a space called "share space"
 
   @skipOnStable2.0
   Scenario: users don't have access to the space if the group has been deleted

--- a/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
@@ -25,7 +25,7 @@ Feature: Share spaces
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the OCS status message should be "OK"
-    And for user "Brian" the JSON response should contain space called "share space" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
     """
     {
       "type": "object",
@@ -90,7 +90,7 @@ Feature: Share spaces
     Given user "Alice" has shared a space "share space" with settings:
       | shareWith | Brian  |
       | role      | viewer |
-    And for user "Brian" the JSON response should contain space called "share space" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
     """
      {
       "type": "object",
@@ -126,7 +126,7 @@ Feature: Share spaces
       | role      | manager |
     When user "<user>" unshares a space "share space" to user "Alice"
     Then the HTTP status code should be "200"
-    And for user "Brian" the JSON response should contain space called "share space" owned by "Alice" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "share space" owned by "Alice" and match
     """
     {
       "type": "object",
@@ -198,7 +198,7 @@ Feature: Share spaces
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the OCS status message should be "OK"
-    And for user "Brian" the JSON response should contain space called "share space" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
     """
     {
       "type": "object",
@@ -301,7 +301,7 @@ Feature: Share spaces
       | shareType | 8      |
       | role      | <role> |
     Then the HTTP status code should be "200"
-    And for user "Brian" the JSON response should contain space called "share space" and match
+    And for user "Brian" the JSON representation of their drive should contain space called "share space" and match
     """
     {
       "type": "object",
@@ -326,7 +326,7 @@ Feature: Share spaces
       }
     }
     """
-    And for user "Bob" the JSON response should contain space called "share space" and match
+    And for user "Bob" the JSON representation of their drive should contain space called "share space" and match
     """
     {
       "type": "object",
@@ -388,7 +388,7 @@ Feature: Share spaces
       | Brian    | group2    |
     Then the HTTP status code of responses on all endpoints should be "204"
     And the user "Brian" should not have a space called "share space"
-    But for user "Bob" the JSON response should contain space called "share space" and match
+    But for user "Bob" the JSON representation of their drive should contain space called "share space" and match
     """
     {
       "type": "object",

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -876,6 +876,7 @@ class SpacesContext implements Context {
 		?PyStringNode $schemaString = null
 	): void {
 		Assert::assertNotNull($schemaString, 'schema is not valid JSON');
+
 		if (isset($this->featureContext->getJsonDecodedResponseBodyContent()->value)) {
 			$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->value;
 			foreach ($responseBody as $value) {
@@ -919,6 +920,7 @@ class SpacesContext implements Context {
 			null,
 			$userName,
 		);
+
 		JsonAssertions::assertJsonDocumentMatchesSchema(
 			$responseBody,
 			$this->featureContext->getJSONSchema($schemaString)
@@ -926,9 +928,9 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" and match$/
-	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" and match$/
-	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" (?:with description file|with space image) "([^"]*)" and match$/
+	 * @Then /^for user "([^"]*)" the JSON representation of their drive should contain space called "([^"]*)" and match$/
+	 * @Then /^for user "([^"]*)" the JSON representation of their drive should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" and match$/
+	 * @Then /^for user "([^"]*)" the JSON representation of their drive should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" (?:with description file|with space image) "([^"]*)" and match$/
 	 *
 	 * @param string $user
 	 * @param string|null $spaceName

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1006,6 +1006,40 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @Then /^the user "([^"]*)" should have a space "([^"]*)" in the disable state$/
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 *
+	 * @return mixed
+	 * @throws Exception
+	 */
+	public function theUserShouldHaveASpaceInTheDisableState(
+		string $user,
+		string $spaceName
+	): void {
+		$this->theUserListsAllHisAvailableSpacesUsingTheGraphApi($user);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			200,
+			"Expected response status code should be 200"
+		);
+		$response = json_decode((string)$this->featureContext->getResponse()->getBody(), true, 512, JSON_THROW_ON_ERROR);
+		if (isset($response["value"])) {
+			foreach ($response["value"] as $spaceCandidate) {
+				if ($spaceCandidate['name'] === $spaceName) {
+					if ($spaceCandidate['root']['deleted']['state'] !== 'trashed') {
+						throw new \Exception(
+							"space $spaceName should be in disable state but it's not "
+						);
+					}
+					return;
+				}
+			}
+		}
+		throw new \Exception("space '$spaceName' should be available for a user '$user' but not found");
+	}
+
+	/**
 	 * @Then /^the json responded should (not|only|)\s?contain spaces of type "([^"]*)"$/
 	 *
 	 * @param string $onlyOrNot (not|only|)

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -928,31 +928,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" the JSON representation of their drive should contain space called "([^"]*)" and match$/
-	 * @Then /^for user "([^"]*)" the JSON representation of their drive should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" and match$/
-	 * @Then /^for user "([^"]*)" the JSON representation of their drive should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" (?:with description file|with space image) "([^"]*)" and match$/
-	 *
-	 * @param string $user
-	 * @param string|null $spaceName
-	 * @param string|null $grantedUser
-	 * @param string|null $fileName
-	 * @param PyStringNode|null $schemaString
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function forUserTheJSONDataOfTheResponseShouldMatch(
-		string $user,
-		?string $spaceName = null,
-		?string $grantedUser = null,
-		?string $fileName = null,
-		?PyStringNode $schemaString = null
-	): void {
-		$this->theUserListsAllHisAvailableSpacesUsingTheGraphApi($user);
-		$this->theJsonDataFromLastResponseShouldMatch($spaceName, $grantedUser, $fileName, $schemaString);
-	}
-
-	/**
 	 * @Then /^the user "([^"]*)" should have a space called "([^"]*)" granted to "([^"]*)" with role "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1004,9 +979,10 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should not have a space called "([^"]*)"$/
+	 * @Then /^the user "([^"]*)" should (not |)have a space called "([^"]*)"$/
 	 *
 	 * @param string $user
+	 * @param string $shouldOrNot
 	 * @param string $spaceName
 	 *
 	 * @return void
@@ -1014,6 +990,7 @@ class SpacesContext implements Context {
 	 */
 	public function userShouldNotHaveSpace(
 		string $user,
+		string $shouldOrNot,
 		string $spaceName
 	): void {
 		$this->theUserListsAllHisAvailableSpacesUsingTheGraphApi($user);
@@ -1021,7 +998,11 @@ class SpacesContext implements Context {
 			200,
 			"Expected response status code should be 200"
 		);
-		$this->jsonRespondedShouldNotContain($spaceName);
+		if (\trim($shouldOrNot) === "not") {
+			$this->jsonRespondedShouldNotContain($spaceName);
+		} else {
+			Assert::assertNotEmpty($this->getSpaceByNameFromResponse($spaceName), "space '$spaceName' should be available for a user '$user' but not found");
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -926,7 +926,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" the JSON response of space project should match$/
 	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" and match$/
 	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" and match$/
 	 * @Then /^for user "([^"]*)" the JSON response should contain space called "([^"]*)" (?:owned by|granted to) "([^"]*)" (?:with description file|with space image) "([^"]*)" and match$/


### PR DESCRIPTION
## Description
This PR 
- separate steps regarding successful JSON response and failure JSON response and remove 
`And for user "Alice" the JSON response should contain space called "Project Jupiter" and match`
steps from negative testing scenario

- `And for user "Alice" the JSON response should contain space called "Project Jupiter" and match` has been removed from the scenario where **When** scenario returns JSON response replaced with steps like
```
And the JSON data of the response should match
And the JSON response should contain space called "Project Jupiter" owned by "Alice" with description file ".space/readme.md" and match
```
which assert the expected Json with above step response

## Related Issue
-  https://github.com/owncloud/ocis/issues/5792

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
