### PR TITLE
[tests-only][full-ci]Added test to search when share is no accepted yet

### DIFF
--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -11,11 +11,11 @@ Feature: REPORT request to Shares space
     And user "Alice" has created folder "/folderMain/SubFolder1"
     And user "Alice" has created folder "/folderMain/SubFolder1/subFOLDER2"
     And user "Alice" has shared entry "/folderMain" with user "Brian" with permissions "17"
-    And user "Brian" has accepted share "/folderMain" offered by user "Alice"
 
 
   Scenario Outline: Check the REPORT response of the found folder
     Given using <dav_version> DAV path
+    And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
@@ -34,6 +34,7 @@ Feature: REPORT request to Shares space
 
   Scenario Outline: Check the REPORT response of the found file
     Given using <dav_version> DAV path
+    And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     And user "Alice" has uploaded file with content "Not all those who wander are lost." to "/folderMain/SubFolder1/subFOLDER2/frodo.txt"
     When user "Brian" searches for "frodo.txt" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -46,6 +47,17 @@ Feature: REPORT request to Shares space
       | d:getcontenttype   | text/plain                             |
       | oc:permissions     | S                                      |
       | d:getcontentlength | 34                                     |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: search for the shared folder when share is not accepted
+    Given using <dav_version> DAV path
+    When user "Brian" searches for "folderMain" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "0" entries
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -54,3 +54,13 @@ Feature: Report test
       | d:getcontenttype   | text/plain                                       |
       | oc:permissions     | SD                                               |
       | d:getcontentlength | 12                                               |
+
+    
+  Scenario: search for the shared folder when the share is not accepted
+    Given user "Alice" has created a share inside of space "find data" with settings:
+      | path      | folderMain |
+      | shareWith | Brian      |
+      | role      | viewer     |
+    When user "Brian" searches for "folderMain" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "0" entries


### PR DESCRIPTION
### Description
Add API test scenarios to search when user tries to search the shared folder which is not accepted yet.

### Related Issue:
https://github.com/owncloud/ocis/issues/4489#issuecomment-1505094923