### PR TITLE
proxy: Rework oidc role mapper to allow multiple matching roles

### DIFF
--- a/changelog/unreleased/role-assignment-from-oidc.md
+++ b/changelog/unreleased/role-assignment-from-oidc.md
@@ -1,0 +1,23 @@
+Enhancement: Added possiblity to assign roles based on OIDC claims
+
+oCIS can now be configured to update a user's role assignment from the values of a claim provided
+via the IDPs userinfo endpoint. The claim name and the mapping between claim values and ocis role
+name can be configured via the configuration of the proxy service. Example:
+
+```yaml
+role_assignment:
+    driver: oidc
+    oidc_role_mapper:
+        role_claim: ocisRoles
+        role_mapping:
+            - role_name: admin
+              claim_value: myAdminRole
+            - role_name: spaceadmin
+              claim_value: mySpaceAdminRole
+            - role_name: user
+              claim_value: myUserRole
+            - role_name: guest:
+              claim_value: myGuestRole
+```
+
+https://github.com/owncloud/ocis/pull/6048

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -50,10 +50,14 @@ role_assignment:
     oidc_role_mapper:
         role_claim: ocisRoles
         role_mapping:
-            admin: myAdminRole
-            user: myUserRole
-            spaceadmin: mySpaceAdminRole
-            guest: myGuestRole
+            - role_name: admin
+              claim_value: myAdminRole
+            - role_name: spaceadmin
+              claim_value: mySpaceAdminRole
+            - role_name: user
+              claim_value: myUserRole
+            - role_name: guest:
+              claim_value: myGuestRole
 ```
 
 This would assign the role `admin` to users with the value `myAdminRole` in the claim `ocisRoles`.
@@ -62,16 +66,27 @@ The role `user` to users with the values `myUserRole` in the claims `ocisRoles` 
 Claim values that are not mapped to a specific ownCloud Infinite Scale role will be ignored.
 
 Note: An ownCloud Infinite Scale user can only have a single role assigned. If the configured
-`role_mapping` and a user's claim values result in multiple possible roles for a user, an error
-will be logged and the user will not be able to login.
+`role_mapping` and a user's claim values result in multiple possible roles for a user, the order in
+which the role mappings are defined in the configuration is important. The first role in the
+`role_mappings` where the `claim_value` matches a value from the user's roles claim will be assigned
+to the user. So if e.g. a user's `ocisRoles` claim has the values `myUserRole` and
+`mySpaceAdminRole` that user will get the ocis role `spaceadmin` assigned (because `spaceadmin`
+appears before `user` in the above sample configuration).
 
-The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The `role_mapping` is:
+If a user's claim values don't match any of the configured role mappings an error will be logged and
+the user will not be able to login.
+
+The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The default `role_mapping` is:
 
 ```yaml
-admin: ocisAdmin
-user: ocisUser
-spaceadmin: ocisSpaceAdmin
-guest: ocisGuest
+- role_name: admin
+  claim_value: ocisAdmin
+- role_name: spaceadmin
+  claim_value: ocisSpaceAdmin
+- role_name: user
+  claim_value: ocisUser
+- role_name: guest:
+  claim_value: ocisGuest
 ```
 
 ## Recommendations for Production Deployments

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -178,7 +178,7 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config)
 			userroles.WithRoleService(rolesClient),
 			userroles.WithLogger(logger),
 			userroles.WithRolesClaim(cfg.RoleAssignment.OIDCRoleMapper.RoleClaim),
-			userroles.WithRoleMapping(cfg.RoleAssignment.OIDCRoleMapper.RoleMapping),
+			userroles.WithRoleMapping(cfg.RoleAssignment.OIDCRoleMapper.RolesMap),
 			userroles.WithAutoProvisonCreator(autoProvsionCreator),
 		)
 	default:

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -135,8 +135,14 @@ type RoleAssignment struct {
 
 // OIDCRoleMapper contains the configuration for the "oidc" role assignment driber
 type OIDCRoleMapper struct {
-	RoleClaim   string            `yaml:"role_claim" env:"PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM" desc:"The OIDC claim used to create the users role assignment."`
-	RoleMapping map[string]string `yaml:"role_mapping" desc:"A mapping of ocis role names to PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM claim values. This setting can only be configured in the configuration file and not via environment variables."`
+	RoleClaim string        `yaml:"role_claim" env:"PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM" desc:"The OIDC claim used to create the users role assignment."`
+	RolesMap  []RoleMapping `yaml:"role_mapping" desc:"A list of mappings of ocis role names to PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM claim values. This setting can only be configured in the configuration file and not via environment variables."`
+}
+
+// RoleMapping defines which ocis role matches a specific claim value
+type RoleMapping struct {
+	RoleName   string `yaml:"role_name" desc:"The name of an ocis role that this mapping should apply for."`
+	ClaimValue string `yaml:"claim_value" desc:"The value of the 'PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM' that matches the role defined in 'role_name'."`
 }
 
 // PolicySelector is the toplevel-configuration for different selectors

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -60,11 +60,11 @@ func DefaultConfig() *config.Config {
 			// this default is only relevant when Driver is set to "oidc"
 			OIDCRoleMapper: config.OIDCRoleMapper{
 				RoleClaim: "roles",
-				RoleMapping: map[string]string{
-					"admin":      "ocisAdmin",
-					"spaceadmin": "ocisSpaceAdmin",
-					"user":       "ocisUser",
-					"guest":      "ocisGuest",
+				RolesMap: []config.RoleMapping{
+					config.RoleMapping{RoleName: "admin", ClaimValue: "ocisAdmin"},
+					config.RoleMapping{RoleName: "spaceadmin", ClaimValue: "ocisSpaceAdmin"},
+					config.RoleMapping{RoleName: "user", ClaimValue: "ocisUser"},
+					config.RoleMapping{RoleName: "guest", ClaimValue: "ocisGuest"},
 				},
 			},
 		},

--- a/services/proxy/pkg/userroles/userroles.go
+++ b/services/proxy/pkg/userroles/userroles.go
@@ -7,6 +7,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/autoprovision"
+	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
 )
 
 //go:generate mockery --name=UserRoleAssigner
@@ -26,7 +27,7 @@ type UserRoleAssigner interface {
 type Options struct {
 	roleService         settingssvc.RoleService
 	rolesClaim          string
-	roleMapping         map[string]string
+	roleMapping         []config.RoleMapping
 	autoProvsionCreator autoprovision.Creator
 	logger              log.Logger
 }
@@ -56,7 +57,7 @@ func WithRolesClaim(claim string) Option {
 }
 
 // WithRoleMapping configures the map of ocis role names to claims values
-func WithRoleMapping(roleMap map[string]string) Option {
+func WithRoleMapping(roleMap []config.RoleMapping) Option {
 	return func(o *Options) {
 		o.roleMapping = roleMap
 	}


### PR DESCRIPTION
If multiple claims values have a valid matching for ocis roles, we'll pick the ocis role that appears first in the mapping configuration.

