### PR TITLE
Remove dead and unused IDM envvar

### DIFF
--- a/services/idm/pkg/config/config.go
+++ b/services/idm/pkg/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	Debug   Debug    `yaml:"debug"`
 
 	IDM             Settings `yaml:"idm"`
-	CreateDemoUsers bool     `yaml:"create_demo_users" env:"IDM_CREATE_DEMO_USERS;OCIS_ACCOUNTS_DEMO_USERS_AND_GROUPS;ACCOUNTS_DEMO_USERS_AND_GROUPS" desc:"Flag to enable or disable the creation of the demo users." deprecationVersion:"3.0" removalVersion:"3.1" deprecationInfo:"ACCOUNTS_DEMO_USERS_AND_GROUPS changing name for consistency" deprecationReplacement:"OCIS_ACCOUNTS_DEMO_USERS_AND_GROUPS"`
+	CreateDemoUsers bool     `yaml:"create_demo_users" env:"IDM_CREATE_DEMO_USERS" desc:"Flag to enable or disable the creation of the demo users."`
 
 	ServiceUserPasswords ServiceUserPasswords `yaml:"service_user_passwords"`
 	AdminUserID          string               `yaml:"admin_user_id" env:"OCIS_ADMIN_USER_ID;IDM_ADMIN_USER_ID" desc:"ID of the user that should receive admin privileges. Consider that the UUID can be encoded in some LDAP deployment configurations like in .ldif files. These need to be decoded beforehand."`


### PR DESCRIPTION
While working on admin docs, I identified  two IDM envvars that can safely be removed:

* `ACCOUNTS_DEMO_USERS_AND_GROUPS`
This envvar was stated in https://github.com/owncloud/ocis/pull/3474 to be removed after switching to LibreIDM. I have checked the whole ocis repo for occurences of this envvar and it is only present in the IDM service as leftover.
* `OCIS_ACCOUNTS_DEMO_USERS_AND_GROUPS`
This one was "accidentially" added but there is no global use of one of the underlaying envvar.

@micbar adding you as you have written the referenced PR.