### PR TITLE
use a proxy for the golangci-lint step

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -477,6 +477,14 @@ def testOcisModule(ctx, module):
                 "make -C %s ci-golangci-lint" % (module),
                 "mv %s/checkstyle.xml cache/checkstyle/$(basename %s)_checkstyle.xml" % (module, module),
             ],
+            "environment": {
+                "HTTP_PROXY": {
+                    "from_secret": "drone_http_proxy",
+                },
+                "HTTPS_PROXY": {
+                    "from_secret": "drone_http_proxy",
+                },
+            },
             "volumes": [stepVolumeGo],
         },
         {

--- a/.drone.star
+++ b/.drone.star
@@ -2007,6 +2007,14 @@ def makeGoGenerate(module):
             "commands": [
                 "retry -t 3 '%s ci-go-generate'" % (make),
             ],
+            "environment": {
+                "HTTP_PROXY": {
+                    "from_secret": "drone_http_proxy",
+                },
+                "HTTPS_PROXY": {
+                    "from_secret": "drone_http_proxy",
+                },
+            },
             "volumes": [stepVolumeGo],
         },
     ]


### PR DESCRIPTION
# Description

Use a proxy to avoid 403 responses when trying to load go modules.

## Steps

- [x] golangci-lint
- [x] go-generate