### PR TITLE
[tests-only] Avoid Metadata Functionality in Eventhistory

### DIFF
--- a/services/userlog/pkg/service/service.go
+++ b/services/userlog/pkg/service/service.go
@@ -166,7 +166,7 @@ func (ul *UserlogService) MemorizeEvents(ch <-chan events.Event) {
 func (ul *UserlogService) GetEvents(ctx context.Context, userid string) ([]*ehmsg.Event, error) {
 	rec, err := ul.store.Read(userid)
 	if err != nil && err != store.ErrNotFound {
-		ul.log.Fatal().Err(err).Str("userid", userid).Msg("failed to read record from database")
+		ul.log.Error().Err(err).Str("userid", userid).Msg("failed to read record from database")
 		return nil, err
 	}
 
@@ -177,7 +177,7 @@ func (ul *UserlogService) GetEvents(ctx context.Context, userid string) ([]*ehms
 
 	var eventIDs []string
 	if err := json.Unmarshal(rec[0].Value, &eventIDs); err != nil {
-		ul.log.Fatal().Err(err).Str("userid", userid).Msg("failed to umarshal record from database")
+		ul.log.Error().Err(err).Str("userid", userid).Msg("failed to umarshal record from database")
 		return nil, err
 	}
 

--- a/services/userlog/pkg/service/service.go
+++ b/services/userlog/pkg/service/service.go
@@ -166,7 +166,7 @@ func (ul *UserlogService) MemorizeEvents(ch <-chan events.Event) {
 func (ul *UserlogService) GetEvents(ctx context.Context, userid string) ([]*ehmsg.Event, error) {
 	rec, err := ul.store.Read(userid)
 	if err != nil && err != store.ErrNotFound {
-		ul.log.Error().Err(err).Str("userid", userid).Msg("failed to read record from database")
+		ul.log.Error().Err(err).Str("userid", userid).Msg("failed to read record from store")
 		return nil, err
 	}
 
@@ -177,7 +177,7 @@ func (ul *UserlogService) GetEvents(ctx context.Context, userid string) ([]*ehms
 
 	var eventIDs []string
 	if err := json.Unmarshal(rec[0].Value, &eventIDs); err != nil {
-		ul.log.Error().Err(err).Str("userid", userid).Msg("failed to umarshal record from database")
+		ul.log.Error().Err(err).Str("userid", userid).Msg("failed to umarshal record from store")
 		return nil, err
 	}
 


### PR DESCRIPTION
Using `Metadata` is not supported by some stores. This would lead to a panic as it would convert incorrectly.

We now save the event type as part of the event body

NOTE: Might lead to lost events after update as data structure changed