### PR TITLE
[docs-only] Fixing ADOC.tmpl typo

### DIFF
--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -12,7 +12,7 @@ ifeval::[{show-deprecation} == true]
 | Deprecation Info
 | Deprecation Version
 | Removal Version
-| Deprecation Replacment
+| Deprecation Replacement
 
 {{- range .Deprecations }}
 


### PR DESCRIPTION
Fixing a typo

Backporting to `docs-stable-2.0` neccessary.
