### PR TITLE
Add session export to keycloak PII report.

### DIFF
--- a/ocis-pkg/keycloak/client.go
+++ b/ocis-pkg/keycloak/client.go
@@ -137,9 +137,15 @@ func (c *ConcreteClient) GetPIIReport(ctx context.Context, realm string, email s
 		return nil, err
 	}
 
+	sessions, err := c.keycloak.GetUserSessions(ctx, token.AccessToken, realm, keycloakID)
+	if err != nil {
+		return nil, err
+	}
+
 	return &PIIReport{
 		UserData:    u,
 		Credentials: creds,
+		Sessions:    sessions,
 	}, nil
 }
 

--- a/ocis-pkg/keycloak/gocloak.go
+++ b/ocis-pkg/keycloak/gocloak.go
@@ -16,4 +16,5 @@ type GoCloak interface {
 	LoginClient(ctx context.Context, clientID, clientSecret, realm string) (*gocloak.JWT, error)
 	RetrospectToken(ctx context.Context, accessToken, clientID, clientSecret, realm string) (*gocloak.IntroSpectTokenResult, error)
 	GetCredentials(ctx context.Context, accessToken, realm, userID string) ([]*gocloak.CredentialRepresentation, error)
+	GetUserSessions(ctx context.Context, token, realm, userID string) ([]*gocloak.UserSessionRepresentation, error)
 }

--- a/ocis-pkg/keycloak/types.go
+++ b/ocis-pkg/keycloak/types.go
@@ -26,8 +26,9 @@ var userActionsToString = map[UserAction]string{
 
 // PIIReport is a structure of all the PersonalIdentifiableInformation contained in keycloak.
 type PIIReport struct {
-	UserData    *libregraph.User                    `json:"user_data,omitempty"`
-	Credentials []*gocloak.CredentialRepresentation `json:"credentials,omitempty"`
+	UserData    *libregraph.User                     `json:"user_data,omitempty"`
+	Credentials []*gocloak.CredentialRepresentation  `json:"credentials,omitempty"`
+	Sessions    []*gocloak.UserSessionRepresentation `json:"sessions,omitempty"`
 }
 
 // Client represents a keycloak client.


### PR DESCRIPTION
This adds the user sessions to the PII report. This was data missing
from it before and is needed for the GDPR export.