### PR TITLE
Try to fix problems with unescaping values.

### DIFF
--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -76,7 +76,13 @@ type Graph struct {
 
 // ServeHTTP implements the Service interface.
 func (g Graph) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// There was a number of issues with the chi router and parameters with
+	// slashes/percentage/other characters that didn't get properly escaped.
+	// This is a workaround to fix this. Also, we're not the only ones who have
+	// tried to fix this, as seen in this issue:
+	// https://github.com/go-chi/chi/issues/641#issuecomment-883156692
 	r.URL.RawPath = r.URL.EscapedPath()
+
 	g.mux.ServeHTTP(w, r)
 }
 

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -76,6 +76,7 @@ type Graph struct {
 
 // ServeHTTP implements the Service interface.
 func (g Graph) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.URL.RawPath = r.URL.EscapedPath()
 	g.mux.ServeHTTP(w, r)
 }
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -53,12 +53,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/assignRole.feature:32](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/assignRole.feature#L32)
 - [apiGraph/assignRole.feature:33](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/assignRole.feature#L33)
 
-### [Group having percentage (%) can be created but cannot be GET](https://github.com/owncloud/ocis/issues/5083)
-- [apiGraph/deleteGroup.feature:49](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L49)
-- [apiGraph/deleteGroup.feature:50](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L50)
-- [apiGraph/deleteGroup.feature:51](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L51)
-- [apiGraph/editGroup.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/editGroup.feature#L25)
-
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 - [apiGraph/deleteGroup.feature:68](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/deleteGroup.feature#L68)
 


### PR DESCRIPTION
Overwriting URL.RawPath with EscapedPath to avoid problems with unescaping values.

Fixes #5083 