### PR TITLE
fix: proxy policies middleware tus filename evaluation

### DIFF
--- a/deployments/examples/service_policies/policies/postprocessing.rego
+++ b/deployments/examples/service_policies/policies/postprocessing.rego
@@ -3,8 +3,8 @@ package postprocessing
 import future.keywords.if
 import data.utils
 
-default granted = true
+default granted := true
 
-granted := false if {
+granted = false if {
     not utils.collection_contains(utils.ALLOWED_FILE_EXTENSIONS, input.resource.name)
 }

--- a/deployments/examples/service_policies/policies/proxy.rego
+++ b/deployments/examples/service_policies/policies/proxy.rego
@@ -3,10 +3,16 @@ package proxy
 import future.keywords.if
 import data.utils
 
-default granted = true
+default granted := true
 
-granted := false if {
+granted = false if {
     utils.is_request_type_put
     not input.request.path == "/data"
     not utils.collection_contains(utils.ALLOWED_FILE_EXTENSIONS, input.request.path)
+}
+
+granted = false if {
+    utils.is_request_type_post
+    startswith(input.request.path, "/remote.php")
+    not utils.collection_contains(utils.ALLOWED_FILE_EXTENSIONS, input.resource.name)
 }

--- a/deployments/examples/service_policies/policies/utils.rego
+++ b/deployments/examples/service_policies/policies/utils.rego
@@ -34,9 +34,9 @@ is_request_type_put {
     input.request.method == "PUT"
 }
 
-is_request_path_file {
+is_request_type_post {
     is_stage_http
-    input.request.method == "PUT"
+    input.request.method == "POST"
 }
 
 is_request_type_mkcol {

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
-	github.com/open-policy-agent/opa v0.50.2
+	github.com/open-policy-agent/opa v0.51.0
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.2-0.20230330145712-ea267ccd404a
 	github.com/pkg/errors v0.9.1
@@ -184,7 +184,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
-github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-micro/plugins/v4/client/grpc v1.2.0 h1:Z8BB6jqslXM2aMMhjZ+QfNuzR+msCMtGd83DGlsQQG0=
@@ -1363,8 +1363,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/onsi/gomega v1.27.4/go.mod h1:riYq/GJKh8hhoM01HN6Vmuy93AarCXCBGpvFDK3q3fQ=
-github.com/open-policy-agent/opa v0.50.2 h1:iD2kKLFkflgSCTMtrC/3jLmOQ7IWyDXMg6+VQA0tSC0=
-github.com/open-policy-agent/opa v0.50.2/go.mod h1:9jKfDk0L5b9rnhH4M0nq10cGHbYOxqygxzTT3dsvhec=
+github.com/open-policy-agent/opa v0.51.0 h1:2hS5xhos8HtkN+mgpqMhNJSFtn/1n/h3wh+AeTPJg6Q=
+github.com/open-policy-agent/opa v0.51.0/go.mod h1:OjmwLfXdeR7skSxrt8Yd3ScXTqPxyJn7GeTRJrcEerU=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/services/proxy/pkg/middleware/policies.go
+++ b/services/proxy/pkg/middleware/policies.go
@@ -8,6 +8,8 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	pMessage "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/policies/v0"
 	pService "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/policies/v0"
+	"github.com/owncloud/ocis/v2/services/webdav/pkg/net"
+	tusd "github.com/tus/tusd/pkg/handler"
 )
 
 // Policies verifies if a request is granted or not.
@@ -30,6 +32,11 @@ func Policies(logger log.Logger, qs string) func(next http.Handler) http.Handler
 					},
 					Stage: pMessage.Stage_STAGE_HTTP,
 				},
+			}
+
+			meta := tusd.ParseMetadataHeader(r.Header.Get(net.HeaderUploadMetadata))
+			req.Environment.Resource = &pMessage.Resource{
+				Name: meta["filename"],
 			}
 
 			if user, ok := revactx.ContextGetUser(r.Context()); ok {


### PR DESCRIPTION
## Description
when uploading files via uppy (tus), the path does not give any information about the file, PUT contains the filename in the path, tus POST not.

this pr extracts the HeaderUploadMetadata from that POST request and enhances the policies grpc environment request with that information. 

Therefore, the policies service is now able to evaluate proxy requests for tus uploads too. 

## Open tasks

* [ ] add unit tests
* [ ] confirm that the implementation is performant