### PR TITLE
Fix Search reindexing performance regression

### DIFF
--- a/changelog/unreleased/fix-search-reindexing-performance-regression.md
+++ b/changelog/unreleased/fix-search-reindexing-performance-regression.md
@@ -1,0 +1,6 @@
+Bugfix: Fix Search reindexing performance regression
+
+We've fixed a regression in the search service reindexing step, causing the
+whole space to be reindexed instead of just the changed resources.
+
+https://github.com/owncloud/ocis/pull/6085

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,6 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
-github.com/cs3org/reva/v2 v2.12.1-0.20230404090709-bb973fae26ae h1:APfYubzIYqCTXtmX6cAm4c8wBYS3R/cZwomX8IlXLaI=
-github.com/cs3org/reva/v2 v2.12.1-0.20230404090709-bb973fae26ae/go.mod h1:FNAYs5H3xs8v0OFmNgZtiMAzIMXd/6TJmO0uZuNn8pQ=
 github.com/cs3org/reva/v2 v2.12.1-0.20230417084429-b3d96f9db80c h1:H6OjKTaRowZfAU/Hwvv4W0pLFFH/KNbHaNVNw3ANoHU=
 github.com/cs3org/reva/v2 v2.12.1-0.20230417084429-b3d96f9db80c/go.mod h1:FNAYs5H3xs8v0OFmNgZtiMAzIMXd/6TJmO0uZuNn8pQ=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=

--- a/services/search/pkg/content/basic.go
+++ b/services/search/pkg/content/basic.go
@@ -6,6 +6,7 @@ import (
 
 	storageProvider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/tags"
+	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 )
 
@@ -34,7 +35,7 @@ func (b Basic) Extract(_ context.Context, ri *storageProvider.ResourceInfo) (Doc
 	}
 
 	if ri.Mtime != nil {
-		doc.Mtime = time.Unix(int64(ri.Mtime.Seconds), int64(ri.Mtime.Nanos)).UTC().Format(time.RFC3339)
+		doc.Mtime = utils.TSToTime(ri.Mtime).Format(time.RFC3339Nano)
 	}
 
 	return doc, nil


### PR DESCRIPTION
We've fixed a regression in the search service reindexing step, causing the whole space to be reindexed instead of just the changed resources.

Stats from testing (this was with a really small space, the effects for larger spaces will be more dramatic):
```
Upload file into the space root with 24 files and 2 subdirs (warm cache):
Before:                                             After:
+-----------+------------------+-------+            +-----------+------------------+-------+
| Function  | last 5 second(s) | total |            | Function  | last 5 second(s) | total |
+-----------+------------------+-------+            +-----------+------------------+-------+
| Chtimes   |                1 |    11 |            | Chtimes   |                1 |    14 |
| Create    |                0 |     5 |            | Create    |                0 |     5 |
| Open      |               13 |    46 |            | Open      |               12 |   100 |
| OpenFile  |                0 |     0 |            | OpenFile  |                0 |     0 |
| Lstat     |              117 |   229 |            | Lstat     |               59 |   476 |
| MkdirAll  |                3 |    26 |            | MkdirAll  |                3 |    43 |
| ReadFile  |                2 |     7 |            | ReadFile  |                2 |    13 |
| Readlink  |               99 |   255 |            | Readlink  |                8 |   206 |
| Rename    |                0 |     0 |            | Rename    |                0 |     8 |
| Remove    |                2 |    22 |            | Remove    |                2 |    36 |
| RemoveAll |                0 |     0 |            | RemoveAll |                0 |     0 |
| Stat      |              110 |   187 |            | Stat      |               12 |   104 |
| Symlink   |                4 |    19 |            | Symlink   |                4 |    35 |
| WriteFile |                0 |     0 |            | WriteFile |                0 |     0 |
+-----------+------------------+-------+            +-----------+------------------+-------+
```