### PR TITLE
[docs-only] Improve special envvar description

### DIFF
--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -47,8 +47,8 @@ type Runtime struct {
 	Port       string   `yaml:"port" env:"OCIS_RUNTIME_PORT"`
 	Host       string   `yaml:"host" env:"OCIS_RUNTIME_HOST"`
 	Services   []string `yaml:"services" env:"OCIS_RUN_EXTENSIONS;OCIS_RUN_SERVICES" desc:"A comma-separated list of service names. Will start only the listed services."`
-	Disabled   []string `yaml:"disabled_services" env:"OCIS_EXCLUDE_RUN_SERVICES" desc:"A comma-separated list of service names. Will start all services except of the ones listed. Has no effect when OCIS_RUN_SERVICES is set."`
-	Additional []string `yaml:"add_services" env:"OCIS_ADD_RUN_SERVICES" desc:"A comma-separated list of service names. Will add the listed services to the default configuration. Has no effect when OCIS_RUN_SERVICES is set."`
+	Disabled   []string `yaml:"disabled_services" env:"OCIS_EXCLUDE_RUN_SERVICES" desc:"A comma-separated list of service names. Will start all default services except of the ones listed. Has no effect when OCIS_RUN_SERVICES is set."`
+	Additional []string `yaml:"add_services" env:"OCIS_ADD_RUN_SERVICES" desc:"A comma-separated list of service names. Will add the listed services to the default configuration. Has no effect when OCIS_RUN_SERVICES is set. Note that one can add services not started by the default list and exclude services from the default list by using both envvars at the same time."`
 }
 
 // Config combines all available configuration parts.


### PR DESCRIPTION
Fixes: #6084 (OCIS_ADD_RUN_SERVICES description is not clear)

`OCIS_EXCLUDE_RUN_SERVICES` and `OCIS_ADD_RUN_SERVICES` description improved.

Note that I will add a text description how to get the default list in the admin docs as footnote to the table.