### PR TITLE
[tests-only][full-ci]Add skip on reva instead

### DIFF
--- a/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature
@@ -131,7 +131,7 @@ Feature: move (rename) folder
       | spaces      | /...          |
       | spaces      | /..upload     |
 
-  @issue-3023
+  @skipOnReva @issue-3023
   Scenario Outline: Moving a folder into a sub-folder of itself
     Given using <dav_version> DAV path
     And user "Alice" has created folder "PARENT"

--- a/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature
@@ -131,7 +131,7 @@ Feature: move (rename) folder
       | spaces      | /...          |
       | spaces      | /..upload     |
 
-  @skipOnReva @issue-3023
+  @skipOnRevaMaster @issue-3023
   Scenario Outline: Moving a folder into a sub-folder of itself
     Given using <dav_version> DAV path
     And user "Alice" has created folder "PARENT"

--- a/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
@@ -843,7 +843,7 @@ Feature: copy file
       | dav_version |
       | spaces      |
 
-  @issue-3023
+  @skipOnReva @issue-3023
   Scenario Outline: Copying a folder into a sub-folder of itself
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/PARENT"

--- a/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
@@ -843,7 +843,7 @@ Feature: copy file
       | dav_version |
       | spaces      |
 
-  @skipOnReva @issue-3023
+  @skipOnRevaMaster @issue-3023
   Scenario Outline: Copying a folder into a sub-folder of itself
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/PARENT"


### PR DESCRIPTION
### Description
This PR adds tag `skipOnReva` to the 2 scenarios. Those 2 scenarios were explicitly skipped with this tag in drone `issue-ocis-3023`. This is the issue https://github.com/owncloud/ocis/issues/3023 that occurs only in `reva-master`. But is fixed in `reva-edge` -> https://github.com/owncloud/ocis/issues/3023#issuecomment-1175180108.
since the refactor PR https://github.com/cs3org/reva/pull/3776#issuecomment-1515818527 the issue tag, the scenarios were running which hung the drone.

### Related Issue:
Fixes https://github.com/cs3org/reva/pull/3776 this bump