### PR TITLE
[docs-only] Note that we only support language but not language_territory (web frontend)

### DIFF
--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -53,7 +53,7 @@ For example, for the language `de`, one needs to place the corresponding transla
 
 <!-- also see the userlog readme -->
 
-Important: For the time being, the embedded ownCloud Web frontent only supports the main language-code but does not handle any territory. When strings are available in the language-code `language_territory`, the web frontend does not see it as it only requests `language`. As impact, any translations made must exist in the requested `language` to avoid a fallback to the default.
+Important: For the time being, the embedded ownCloud Web frontend only supports the main language code but does not handle any territory. When strings are available in the language code `language_territory`, the web frontend does not see it as it only requests `language`. In consequence, any translations made must exist in the requested `language` to avoid a fallback to the default.
 
 ### Translation Rules
 

--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -51,6 +51,8 @@ The language code pattern is composed of `language[_territory]` where  `language
 
 For example, for the language `de`, one needs to place the corresponding translation files to `{NOTIFICATIONS_TRANSLATION_PATH}/de/LC_MESSAGES/translations.po`.
 
+<!-- also see the userlog readme -->
+
 Important: For the time being, the embedded ownCloud Web frontent only supports the main language-code but does not handle any territory. When strings are available in the language-code `language_territory`, the web frontend does not see it as it only requests `language`. As impact, any translations made must exist in the requested `language` to avoid a fallback to the default.
 
 ### Translation Rules

--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -49,11 +49,12 @@ the `NOTIFICATIONS_TRANSLATION_PATH` environment variable needs to point to a ba
 
 The language code pattern is composed of `language[_territory]` where  `language` is the base language and `_territory` is optional and defines a country.
 
-For example, for the language `de_DE`, one needs to place the corresponding translation files to `{NOTIFICATIONS_TRANSLATION_PATH}/de_DE/LC_MESSAGES/translations.po`.
+For example, for the language `de`, one needs to place the corresponding translation files to `{NOTIFICATIONS_TRANSLATION_PATH}/de/LC_MESSAGES/translations.po`.
+
+Important: For the time being, the embedded ownCloud Web frontent only supports the main language-code but does not handle any territory. When strings are available in the language-code `language_territory`, the web frontend does not see it as it only requests `language`. As impact, any translations made must exist in the requested `language` to avoid a fallback to the default.
 
 ### Translation Rules
 
-*   If a requested language code is not available, the service tries to fall back to the base language if available.
-For example, if `de_DE` is not available, the service tries to fall back to translations in the `de` folder.
+*   If a requested language code is not available, the service tries to fall back to the base language if available. For example, if the requested language-code `de_DE` is not available, the service tries to fall back to translations in the `de` folder.
 *   If the base language `de` is also not available, the service falls back to the system's default English (`en`),
 which is the source of the texts provided by the code.

--- a/services/userlog/README.md
+++ b/services/userlog/README.md
@@ -48,7 +48,7 @@ For example, for the language `de`, one needs to place the corresponding transla
 
 <!-- also see the notifications readme -->
 
-Important: For the time being, the embedded ownCloud Web frontent only supports the main language-code but does not handle any territory. When strings are available in the language-code `language_territory`, the web frontend does not see it as it only requests `language`. As impact, any translations made must exist in the requested `language` to avoid a fallback to the default.
+Important: For the time being, the embedded ownCloud Web frontend only supports the main language code but does not handle any territory. When strings are available in the language code `language_territory`, the web frontend does not see it as it only requests `language`. In consequence, any translations made must exist in the requested `language` to avoid a fallback to the default.
 
 ### Translation Rules
 

--- a/services/userlog/README.md
+++ b/services/userlog/README.md
@@ -44,9 +44,12 @@ The `userlog` service has embedded translations sourced via transifex to provide
 
 The language code pattern is composed of `language[_territory]` where  `language` is the base language and `_territory` is optional and defines a country.
 
-For example, for the language `de_DE`, one needs to place the corresponding translation files to `{USERLOG_TRANSLATION_PATH}/de_DE/LC_MESSAGES/userlog.po`.
+For example, for the language `de`, one needs to place the corresponding translation files to `{USERLOG_TRANSLATION_PATH}/de_DE/LC_MESSAGES/userlog.po`.
+
+Important: For the time being, the embedded ownCloud Web frontent only supports the main language-code but does not handle any territory. When strings are available in the language-code `language_territory`, the web frontend does not see it as it only requests `language`. As impact, any translations made must exist in the requested `language` to avoid a fallback to the default.
 
 ### Translation Rules
 
-*   If a requested language code is not available, the service tries to fall back to the base language if available. For example, if `de_DE` is not available, the service tries to fall back to translations in the `de` folder.
-*   If the base language `de` is also not available, the service falls back to the system's default English (`en`), which is the source of the texts provided by the code.
+*   If a requested language code is not available, the service tries to fall back to the base language if available. For example, if the requested language-code `de_DE` is not available, the service tries to fall back to translations in the `de` folder.
+*   If the base language `de` is also not available, the service falls back to the system's default English (`en`),
+which is the source of the texts provided by the code.

--- a/services/userlog/README.md
+++ b/services/userlog/README.md
@@ -46,6 +46,8 @@ The language code pattern is composed of `language[_territory]` where  `language
 
 For example, for the language `de`, one needs to place the corresponding translation files to `{USERLOG_TRANSLATION_PATH}/de_DE/LC_MESSAGES/userlog.po`.
 
+<!-- also see the notifications readme -->
+
 Important: For the time being, the embedded ownCloud Web frontent only supports the main language-code but does not handle any territory. When strings are available in the language-code `language_territory`, the web frontend does not see it as it only requests `language`. As impact, any translations made must exist in the requested `language` to avoid a fallback to the default.
 
 ### Translation Rules


### PR DESCRIPTION
Post a discussion with regards to translations, we need to clarify which language-code types are supported by ocis and which one by onwcloud web.

This PR makes this hopefully clear.
When merged, will be transported to the admin docs.

@micbar @kulmann @2403905 fyi