### PR TITLE
listing drives sould use the user filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/cs3org/go-cs3apis v0.0.0-20221012090518-ef2996678965
-	github.com/cs3org/reva/v2 v2.12.1-0.20230427075231-7842414d18e1
+	github.com/cs3org/reva/v2 v2.12.1-0.20230428064036-4434df8122a5
 	github.com/disintegration/imaging v1.6.2
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e
 	github.com/egirna/icap-client v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
-github.com/cs3org/reva/v2 v2.12.1-0.20230427075231-7842414d18e1 h1:p563+4bqdVSYPtDeo6ikOEbciU/mjbYhrei2zCjzxkw=
-github.com/cs3org/reva/v2 v2.12.1-0.20230427075231-7842414d18e1/go.mod h1:VxBmpOvIKlgKLPOsHun+fABopzX+3ZELPAp3N5bQMsM=
+github.com/cs3org/reva/v2 v2.12.1-0.20230428064036-4434df8122a5 h1:wloX5LiqRxwh2ID9O+em8O5VU1h2ZN5u6tPceAdLNDI=
+github.com/cs3org/reva/v2 v2.12.1-0.20230428064036-4434df8122a5/go.mod h1:VxBmpOvIKlgKLPOsHun+fABopzX+3ZELPAp3N5bQMsM=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -254,7 +254,7 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 	if !canCreateSpace {
 		logger.Debug().Bool("cancreatespace", canCreateSpace).Msg("could not create drive: insufficient permissions")
 		// if the permission is not existing for the user in context we can assume we don't have it. Return 401.
-		errorcode.NotAllowed.Render(w, r, http.StatusUnauthorized, "insufficient permissions to create a space.")
+		errorcode.NotAllowed.Render(w, r, http.StatusForbidden, "insufficient permissions to create a space.")
 		return
 	}
 

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -91,6 +91,20 @@ func (g Graph) getDrives(w http.ResponseWriter, r *http.Request, unrestricted bo
 		errorcode.NotSupported.Render(w, r, http.StatusNotImplemented, err.Error())
 		return
 	}
+	if !unrestricted {
+		user, ok := revactx.ContextGetUser(r.Context())
+		if !ok {
+			logger.Debug().Msg("could not create drive: invalid user")
+			errorcode.NotAllowed.Render(w, r, http.StatusUnauthorized, "invalid user")
+			return
+		}
+		filters = append(filters, &storageprovider.ListStorageSpacesRequest_Filter{
+			Type: storageprovider.ListStorageSpacesRequest_Filter_TYPE_USER,
+			Term: &storageprovider.ListStorageSpacesRequest_Filter_User{
+				User: user.GetId(),
+			},
+		})
+	}
 
 	logger.Debug().
 		Interface("filters", filters).

--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -479,7 +479,7 @@ var _ = Describe("Graph", func() {
 				r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/drives", bytes.NewBuffer(jsonBody)).WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.CreateDrive(rr, r)
-				Expect(rr.Code).To(Equal(http.StatusUnauthorized))
+				Expect(rr.Code).To(Equal(http.StatusForbidden))
 
 				body, _ := io.ReadAll(rr.Body)
 				var libreError libregraph.OdataError

--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -90,6 +90,7 @@ var _ = Describe("Graph", func() {
 				}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 				Expect(rr.Code).To(Equal(http.StatusOK))
@@ -102,6 +103,7 @@ var _ = Describe("Graph", func() {
 				}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/drives", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetAllDrives(rr, r)
 				Expect(rr.Code).To(Equal(http.StatusOK))
@@ -131,6 +133,7 @@ var _ = Describe("Graph", func() {
 				}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 
@@ -201,6 +204,7 @@ var _ = Describe("Graph", func() {
 				}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives?$orderby=name%20asc", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 
@@ -281,6 +285,7 @@ var _ = Describe("Graph", func() {
 				}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 
@@ -320,6 +325,7 @@ var _ = Describe("Graph", func() {
 				}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives?$orderby=owner%20asc", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 				Expect(rr.Code).To(Equal(http.StatusBadRequest))
@@ -361,6 +367,7 @@ var _ = Describe("Graph", func() {
 				gatewayClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(nil, errors.New("transport error"))
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives)", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 				Expect(rr.Code).To(Equal(http.StatusInternalServerError))
@@ -378,6 +385,7 @@ var _ = Describe("Graph", func() {
 					StorageSpaces: []*provider.StorageSpace{}}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives)", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 				Expect(rr.Code).To(Equal(http.StatusInternalServerError))
@@ -395,6 +403,7 @@ var _ = Describe("Graph", func() {
 					StorageSpaces: []*provider.StorageSpace{}}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives)", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 				Expect(rr.Code).To(Equal(http.StatusOK))
@@ -430,6 +439,7 @@ var _ = Describe("Graph", func() {
 				}, nil)
 
 				r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/me/drives", nil)
+				r = r.WithContext(ctx)
 				rr := httptest.NewRecorder()
 				svc.GetDrives(rr, r)
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -146,8 +146,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/removeUserFromGroup.feature:192](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/removeUserFromGroup.feature#L192)
 - [apiGraph/removeUserFromGroup.feature:193](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/removeUserFromGroup.feature#L193)
 - [apiGraph/removeUserFromGroup.feature:194](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/removeUserFromGroup.feature#L194)
-- [apiSpaces/createSpace.feature:18](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/createSpace.feature#L18)
-- [apiSpaces/createSpace.feature:19](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/createSpace.feature#L19)
 
 #### [API requests for a non-existent resources should return 404](https://github.com/owncloud/ocis/issues/5939)
 - [apiGraph/addUserToGroup.feature:202](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/addUserToGroup.feature#L202)

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/templates"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
+	"github.com/jellydator/ttlcache/v2"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -95,6 +96,8 @@ type Decomposedfs struct {
 	chunkHandler *chunking.ChunkHandler
 	stream       events.Stream
 	cache        cache.StatCache
+
+	UserCache *ttlcache.Cache
 }
 
 // NewDefault returns an instance with default components
@@ -160,6 +163,7 @@ func New(o *options.Options, lu *lookup.Lookup, p Permissions, tp Tree, es event
 		chunkHandler: chunking.NewChunkHandler(filepath.Join(o.Root, "uploads")),
 		stream:       es,
 		cache:        cache.GetStatCache(o.StatCache.Store, o.StatCache.Nodes, o.StatCache.Database, "stat", time.Duration(o.StatCache.TTL)*time.Second, o.StatCache.Size),
+		UserCache:    ttlcache.NewCache(),
 	}
 
 	if o.AsyncFileUploads {

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/options/options.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/options/options.go
@@ -35,6 +35,9 @@ type Option func(o *Options)
 // Options defines the available options for this package.
 type Options struct {
 
+	// the gateway address
+	GatewayAddr string `mapstructure:"gateway_addr"`
+
 	// the metadata backend to use, currently supports `xattr` or `ini`
 	MetadataBackend string `mapstructure:"metadata_backend"`
 
@@ -98,6 +101,8 @@ func New(m map[string]interface{}) (*Options, error) {
 		err = errors.Wrap(err, "error decoding conf")
 		return nil, err
 	}
+
+	o.GatewayAddr = sharedconf.GetGatewaySVC(o.GatewayAddr)
 
 	if o.MetadataBackend == "" {
 		o.MetadataBackend = "xattrs"

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/spacepermissions.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/spacepermissions.go
@@ -3,11 +3,13 @@ package decomposedfs
 import (
 	"context"
 
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	cs3permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/cs3org/reva/v2/pkg/utils"
 	"google.golang.org/grpc"
 )
 
@@ -70,12 +72,12 @@ func (p Permissions) ListAllSpaces(ctx context.Context) bool {
 }
 
 // ListSpacesOfUser returns true when the user is allowed to list the spaces of the given user
-func (p Permissions) ListSpacesOfUser(ctx context.Context, userid string) bool {
-	switch userid {
-	case userIDAny:
+func (p Permissions) ListSpacesOfUser(ctx context.Context, userid *userv1beta1.UserId) bool {
+	switch {
+	case userid == nil:
 		// there is no filter
 		return true // TODO: is `true` actually correct here? Shouldn't we check for ListAllSpaces too?
-	case ctxpkg.ContextMustGetUser(ctx).GetId().GetOpaqueId():
+	case utils.UserIDEqual(ctxpkg.ContextMustGetUser(ctx).GetId(), userid):
 		return true
 	default:
 		return p.ListAllSpaces(ctx)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.12.1-0.20230427075231-7842414d18e1
+# github.com/cs3org/reva/v2 v2.12.1-0.20230428064036-4434df8122a5
 ## explicit; go 1.19
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
when a user lists all spaces he has access to (unrestricted==false) we should send a user filter, so decomposedfs has a chance to use an index instead of iterating over ALL spaces.

part of todays tracing session, the reva part is in https://github.com/cs3org/reva/pull/3809

~~blocked by https://github.com/cs3org/reva/pull/3826~~
blocked by https://github.com/cs3org/reva/pull/3827