### PR TITLE
[tests-only]Added GDPR export. check events when user is created

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1360,4 +1360,37 @@ class GraphHelper {
 			self::getRequestHeaders()
 		);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $userId
+	 * @param string $path
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function generateGDPRReport(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $userId,
+		string $path
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/exportPersonalData');
+		// this payload is the storage location of the report generated
+		$payload['storageLocation'] = $path;
+		return HttpRequestHelper::sendRequest(
+			$url,
+			$xRequestId,
+			"POST",
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			\json_encode($payload)
+		);
+	}
 }

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -1,8 +1,8 @@
-@api @skipOnOcV10
+@api
 Feature: user GDPR (General Data Protection Regulation) report
   As a user
-  I want to get or generate GDPR report of my own data
-  So that i can see the report of my own data at any time
+  I want to generate my GDPR report
+  So that I can review what events are stored by the server
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -10,10 +10,10 @@ Feature: user GDPR (General Data Protection Regulation) report
 
 
   Scenario: generate a GDPR report and check user data in the downloaded report
-    When user "Alice" generates GDPR reports of his own data to "/.personal_data_export.json"
-    And user "Alice" downloads the content of generated GDPR report of file ".personal_data_export.json" using password "123456"
+    When user "Alice" exports her GDPR report to "/.personal_data_export.json" using the Graph API
+    And user "Alice" downloads the content of GDPR report ".personal_data_export.json"
     Then the HTTP status code of responses on each endpoint should be "201, 200" respectively
-    And the downloaded JSON should contain key "user" and match
+    And the downloaded JSON content should contain key 'user' and match
     """
     {
       "type": "object",
@@ -73,8 +73,8 @@ Feature: user GDPR (General Data Protection Regulation) report
     """
 
   Scenario: generate a GDPR report and check events when a user is created
-    When user "Alice" generates GDPR reports of his own data to "/.personal_data_export.json"
-    And user "Alice" downloads the content of generated GDPR report of file ".personal_data_export.json" using password "123456"
+    When user "Alice" exports her GDPR report to "/.personal_data_export.json" using the Graph API
+    And user "Alice" downloads the content of GDPR report ".personal_data_export.json"
     Then the HTTP status code of responses on each endpoint should be "201, 200" respectively
     And the downloaded JSON content should contain event type "events.UserCreated" in item 'events' and should match
     """
@@ -135,7 +135,8 @@ Feature: user GDPR (General Data Protection Regulation) report
           "required": [
             "Executant",
             "Name",
-            "Type"
+            "Type",
+            "Quota"
           ],
           "properties": {
             "Executant": {
@@ -167,6 +168,10 @@ Feature: user GDPR (General Data Protection Regulation) report
             "Type": {
               "type": "string",
               "enum": ["personal"]
+            },
+            "Quota": {
+              "type": ["number", "null"],
+              "enum": [null]
             }
           }
         }

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -1,0 +1,49 @@
+@api @skipOnOcV10
+Feature: user GDPR (General Data Protection Regulation) report
+  As a user
+  I want to get or generate GDPR report of my own data
+  So that i can see the report of my own data at any time
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And using spaces DAV path
+
+  Scenario: request and check a GDPR report when user upload a file
+    Given user "Alice" has uploaded file with content "sample text" to "lorem.txt"
+    When user "Alice" generates GDPR reports of his own data to "/.personal_data_export.json"
+    And user "Alice" downloads the content of generated GDPR report of file "personal_data_export.json" using password "123456"
+    Then the HTTP status code of responses on each endpoint should be "201, 200" respectively
+    And the downloaded JSON content should contain event type "events.FileUploaded" in item 'events' and should match
+    """
+    {
+      "type": "object",
+      "required": [
+        "event"
+      ],
+      "properties": {
+        "event" : {
+          "type": "object",
+          "required": [
+            "Executant",
+            "Owner",
+            "Ref",
+            "SpaceOwner"
+          ],
+          "properties": {
+            "Ref": {
+              "type": "object",
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path" : {
+                  "type": "string",
+                  "enum": ["./lorem.txt"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -8,12 +8,11 @@ Feature: user GDPR (General Data Protection Regulation) report
     Given user "Alice" has been created with default attributes and without skeleton files
     And using spaces DAV path
 
-  Scenario: request and check a GDPR report when user upload a file
-    Given user "Alice" has uploaded file with content "sample text" to "lorem.txt"
+  Scenario: generate a GDPR report and check when a user is created
     When user "Alice" generates GDPR reports of his own data to "/.personal_data_export.json"
-    And user "Alice" downloads the content of generated GDPR report of file "personal_data_export.json" using password "123456"
+    And user "Alice" downloads the content of generated GDPR report of file ".personal_data_export.json" using password "123456"
     Then the HTTP status code of responses on each endpoint should be "201, 200" respectively
-    And the downloaded JSON content should contain event type "events.FileUploaded" in item 'events' and should match
+    And the downloaded JSON content should contain event type "events.UserCreated" in item 'events' and should match
     """
     {
       "type": "object",
@@ -25,22 +24,85 @@ Feature: user GDPR (General Data Protection Regulation) report
           "type": "object",
           "required": [
             "Executant",
-            "Owner",
-            "Ref",
-            "SpaceOwner"
+            "UserID"
           ],
           "properties": {
-            "Ref": {
+            "Executant": {
               "type": "object",
               "required": [
-                "path"
+                "idp",
+                "opaque_id",
+                "type"
               ],
               "properties": {
-                "path" : {
+                "idp": {
                   "type": "string",
-                  "enum": ["./lorem.txt"]
+                  "pattern": "^%base_url%$"
+                },
+                "opaque_id": {
+                  "type": "string",
+                  "pattern": "^%user_id_pattern%$"
+                },
+                "type": {
+                  "type": "number",
+                  "enum": [1]
                 }
               }
+            },
+            "UserID": {
+              "type": "string",
+              "pattern": "^%user_id_pattern%$"
+            }
+          }
+        }
+      }
+    }
+    """
+    And the downloaded JSON content should contain event type "events.SpaceCreated" in item 'events' and should match
+    """
+    {
+      "type": "object",
+      "required": [
+        "event"
+      ],
+      "properties": {
+        "event" : {
+          "type": "object",
+          "required": [
+            "Executant",
+            "Name",
+            "Type"
+          ],
+          "properties": {
+            "Executant": {
+              "type": "object",
+              "required": [
+                "idp",
+                "opaque_id",
+                "type"
+              ],
+              "properties": {
+                "idp": {
+                  "type": "string",
+                  "pattern": "^%base_url%$"
+                },
+                "opaque_id": {
+                  "type": "string",
+                  "pattern": "^%user_id_pattern%$"
+                },
+                "type": {
+                  "type": "number",
+                  "enum": [1]
+                }
+              }
+            },
+            "Name": {
+              "type": "string",
+              "enum": ["Alice Hansen"]
+            },
+            "Type": {
+              "type": "string",
+              "enum": ["personal"]
             }
           }
         }

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -8,7 +8,71 @@ Feature: user GDPR (General Data Protection Regulation) report
     Given user "Alice" has been created with default attributes and without skeleton files
     And using spaces DAV path
 
-  Scenario: generate a GDPR report and check when a user is created
+
+  Scenario: generate a GDPR report and check user data in the downloaded report
+    When user "Alice" generates GDPR reports of his own data to "/.personal_data_export.json"
+    And user "Alice" downloads the content of generated GDPR report of file ".personal_data_export.json" using password "123456"
+    Then the HTTP status code of responses on each endpoint should be "201, 200" respectively
+    And the downloaded JSON should contain key "user" and match
+    """
+    {
+      "type": "object",
+      "required": [
+        "id",
+        "username",
+        "mail",
+        "display_name",
+        "uid_number",
+        "gid_number"
+      ],
+      "properties": {
+        "id": {
+          "type": "object",
+          "required": [
+            "idp",
+            "opaque_id",
+            "type"
+          ],
+          "properties": {
+            "idp": {
+              "type": "string",
+              "pattern": "^%base_url%$"
+            },
+            "opaque_id": {
+              "type": "string",
+              "pattern": "^%user_id_pattern%$"
+            },
+            "type": {
+              "type": "number",
+              "enum": [1]
+            }
+          }
+        },
+        "username": {
+          "type": "string",
+          "enum": ["Alice"]
+        },
+        "mail": {
+          "type": "string",
+          "enum": ["alice@example.org"]
+        },
+        "display_name": {
+          "type": "string",
+          "enum": ["Alice Hansen"]
+        },
+        "uid_number": {
+          "type": "number",
+          "enum": [99]
+        },
+        "gid_number": {
+          "type": "number",
+          "enum": [99]
+        }
+      }
+    }
+    """
+
+  Scenario: generate a GDPR report and check events when a user is created
     When user "Alice" generates GDPR reports of his own data to "/.personal_data_export.json"
     And user "Alice" downloads the content of generated GDPR report of file ".personal_data_export.json" using password "123456"
     Then the HTTP status code of responses on each endpoint should be "201, 200" respectively

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2344,28 +2344,34 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @Then the downloaded JSON content should contain event type :arg1 in item 'events' and should match
+	 * @Then the downloaded JSON content should contain event type :key in item 'events' and should match
+	 * @Then the downloaded JSON should contain key :key and match
 	 *
-	 * @param string $eventType
+	 * @param string $key
 	 * @param PyStringNode $schemaString
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 *
 	 */
-	public function downloadedJsonContentShouldContainEventTypeInItemAndShouldMatch(string $eventType, PyStringNode $schemaString): void {
-		$events = $this->featureContext->getJsonDecodedResponseBodyContent()->events;
-		// search for the event type and assert
+	public function downloadedJsonContentShouldContainEventTypeInItemAndShouldMatch(string $key, PyStringNode $schemaString): void {
 		$actualResponseToAssert = null;
-		foreach ($events as $event) {
-			if ($event->type === $eventType) {
-				$actualResponseToAssert = $event;
-				break;
+		// the response contains only 2 key either events or user
+		if ($key === "user") {
+			$actualResponseToAssert = $this->featureContext->getJsonDecodedResponseBodyContent()->user;
+		} else {
+			$events = $this->featureContext->getJsonDecodedResponseBodyContent()->events;
+			foreach ($events as $event) {
+				if ($event->type === $key) {
+					$actualResponseToAssert = $event;
+					break;
+				}
 			}
 		}
+		// search for the event type and assert
 		if ($actualResponseToAssert === null) {
 			throw new Error(
-				"Response does not contain event type '" . $eventType . "'."
+				"Response does not contain key '" . $key . "'."
 			);
 		}
 		JsonAssertions::assertJsonDocumentMatchesSchema(

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5387,17 +5387,16 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the content of generated GDPR report of file :pathToFile using password :password
+	 * @When user :user downloads the content of GDPR report :pathToFile
 	 *
 	 * @param string $user
 	 * @param string $pathToFile
-	 * @param string $password
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userGetsTheContentOfGeneratedJsonReport(string $user, string $pathToFile, string $password): void {
-		$password = $this->getActualPassword($password);
+	public function userGetsTheContentOfGeneratedJsonReport(string $user, string $pathToFile): void {
+		$password = $this->getPasswordForUser($user);
 		$this->downloadFileAsUserUsingPassword($user, $pathToFile, $password);
 		$this->pushToLastStatusCodesArrays();
 	}

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -24,6 +24,7 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Ring\Exception\ConnectException;
+use Helmich\JsonAssert\JsonAssertions;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Stream\StreamInterface;
@@ -5383,5 +5384,21 @@ trait WebDav {
 			$actualUserDisplayName,
 			"Expected display name of version with index $index in response to user '$this->responseUser' was '$expectedUserDisplayName', but got '$actualUserDisplayName'"
 		);
+	}
+
+	/**
+	 * @When user :user downloads the content of generated GDPR report of file :pathToFile using password :password
+	 *
+	 * @param string $user
+	 * @param string $pathToFile
+	 * @param string $password
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsTheContentOfGeneratedJsonReport(string $user, string $pathToFile, string $password): void {
+		$password = $this->getActualPassword($password);
+		$this->downloadFileAsUserUsingPassword($user, $pathToFile, $password);
+		$this->pushToLastStatusCodesArrays();
 	}
 }


### PR DESCRIPTION
### Description
This PR adds the scenario for a user to generate a GDPR report for event as uploading a single file.
For now this PR adds just a single scenario.

```feature
Scenario: generate a GDPR report and check user data in the downloaded report
Scenario: generate a GDPR report and check when a user is created
````

### Related issue:
https://github.com/owncloud/ocis/issues/6059