### PR TITLE
[tests-only][full-ci]Bump web commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for UI tests
 
-WEB_COMMITID=a46ab6158a7ebf8667a079f547b84d644fd1b6ec
+WEB_COMMITID=ca6eefbf300e2014a1264d11b982db8cd87cdd04
 WEB_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -1162,7 +1162,7 @@ def e2eTests(ctx):
         },
         "commands": [
             "cd %s" % dirs["web"],
-            "sleep 10 && pnpm test:e2e:cucumber tests/e2e/cucumber/**/*[!.oc10].feature",
+            "sleep 10 && pnpm test:e2e:cucumber tests/e2e/cucumber/**/*[!.oc10].feature --tags ~@skip",
         ],
     }]
 


### PR DESCRIPTION
This PR bumps the commit id of web to pull the changes made by  https://github.com/owncloud/web/pull/8905 in ocis.
This will unblock the CI