### PR TITLE
[docs-only] fix envvar separation in userlog

### DIFF
--- a/services/userlog/pkg/config/config.go
+++ b/services/userlog/pkg/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 
 	MachineAuthAPIKey string      `yaml:"machine_auth_api_key" env:"OCIS_MACHINE_AUTH_API_KEY;USERLOG_MACHINE_AUTH_API_KEY" desc:"Machine auth API key used to validate internal requests necessary to access resources from other services."`
 	RevaGateway       string      `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY;REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata" deprecationVersion:"3.0" removalVersion:"4.0.0" deprecationInfo:"REVA_GATEWAY changing name for consistency" deprecationReplacement:"OCIS_REVA_GATEWAY"`
-	TranslationPath   string      `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH,USERLOG_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
+	TranslationPath   string      `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH;USERLOG_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
 	Events            Events      `yaml:"events"`
 	Persistence       Persistence `yaml:"persistence"`
 


### PR DESCRIPTION
References: #6142 (adoc table generator should separate envvars by semicolon AND comma)

The `OCIS_TRANSLATION_PATH,USERLOG_TRANSLATION_PATH` envvar needs a separation with semicolon, not comma - to be (atm) recogniced by the doc generation process.

@2403905 fyi (see the referenced issue)