### PR TITLE
[docs-only] Update envvar-scopes.md (owncloud.dev)

### DIFF
--- a/docs/services/general-info/envvar-scopes.md
+++ b/docs/services/general-info/envvar-scopes.md
@@ -40,4 +40,4 @@ All environment variable types that are used in a service follow the same [depre
 
 ## Separating Envvars
 
-When multiple envvars are defined for one purpose like a global and local one, use `;` (semicolons) to properly separate the envvars in go code. Though it is possible to separate with `,` (comma) according go rules, the current implementation of the docs generation process only recognizes semicolons as separator.
+When multiple envvars are defined for one purpose like a global and local one, use `;` (semicolon) to properly separate the envvars in go code. Though it is possible to separate with `,` (comma) according go rules, the current implementation of the docs generation process only recognizes semicolons as separator.

--- a/docs/services/general-info/envvar-scopes.md
+++ b/docs/services/general-info/envvar-scopes.md
@@ -30,10 +30,14 @@ A local envvar always starts with the the service name like `POSTPROCESSING_LOG_
 
 A global envvar always starts with `OCIS_` like `OCIS_LOG_FILE`.
 
-Note that this envvar is the global version of the local example above.
+Note that this envvar is the global representation of the local example from above.
 
 To get a list of global envvars used in all services, see the [Global Environment Variables](https://doc.owncloud.com/ocis/next/deployment/services/env-vars-special-scope.html#global-environment-variables) table in the ocis admin documentation.
 
 ## Deprecations
 
 All environment variable types that are used in a service follow the same [deprecation rules]({{< ref "ocis/development/deprecating-variables/_index.md" >}}) independent of their scope.
+
+## Separating Envvars
+
+When multiple envvars are defined for one purpose like a global and local one, use `;` (semicolons) to properly separate the envvars in go code. Though it is possible to separate with `,` (comma) according go rules, the current implementation of the docs generation process only recognizes semicolons as separator.


### PR DESCRIPTION
References: #6142 (adoc table generator should separate envvars by semicolon AND comma)

Note to use semicolon as correct envvar separator because of the automated documentation process.