### PR TITLE
enable e2e tests in ocis CI again

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for UI tests
 
-WEB_COMMITID=ca6eefbf300e2014a1264d11b982db8cd87cdd04
+WEB_COMMITID=5610aa9df4413d89f5517479879bb28946be2077
 WEB_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -1162,7 +1162,7 @@ def e2eTests(ctx):
         },
         "commands": [
             "cd %s" % dirs["web"],
-            "sleep 10 && pnpm test:e2e:cucumber tests/e2e/cucumber/**/*[!.oc10].feature --tags ~@skip",
+            "sleep 10 && pnpm test:e2e:cucumber tests/e2e/cucumber/**/*[!.oc10].feature",
         ],
     }]
 


### PR DESCRIPTION
after https://github.com/owncloud/ocis/pull/6135 we disabled e2e tests
example: https://drone.owncloud.com/owncloud/ocis/21802/68/10

fixed in the web repo https://github.com/owncloud/ocis/pull/6135

cc @SwikritiT looks like old style : `cucumber --tags ~@skip` doesn't work