### PR TITLE
[docs-only] Update IDP README.md

### DIFF
--- a/services/idp/README.md
+++ b/services/idp/README.md
@@ -10,3 +10,5 @@ By default, it is configured to use the ocis IDM service as its LDAP backend for
 looking up and authenticating users. Other backends like an external LDAP
 server can be configured via a set of
 [enviroment variables](https://owncloud.dev/services/idp/configuration/#environment-variables).
+
+Note that translations provided by the IDP service are not maintained via ownCloud but part of the embedded vendor package: LibreGraph Connect Identifier.


### PR DESCRIPTION
References: #6163 (Transifex localisation of the IDP service is not existent)

Translations provided by the IDP service are not maintained via ownCloud but part of the embedded vendor package: LibreGraph Connect Identifier.
