### PR TITLE
cache special drive items until space root changes

### DIFF
--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -54,6 +54,8 @@ func DefaultConfig() *config.Config {
 			WebDavPath:   "/dav/spaces/",
 			DefaultQuota: "1000000000",
 			// 30 minutes
+			ExtendedSpacePropertiesCacheTTL: 1800,
+			// 30 minutes
 			GroupsCacheTTL: 1800,
 			// 30 minutes
 			UsersCacheTTL: 1800,

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -278,11 +278,11 @@ func spaceRootStatKey(id *storageprovider.ResourceId, imagenode, readmeNode stri
 		return ""
 	}
 	sha3 := sha3.NewShake256()
-	sha3.Write([]byte(id.GetStorageId()))
-	sha3.Write([]byte(id.GetSpaceId()))
-	sha3.Write([]byte(id.GetOpaqueId()))
-	sha3.Write([]byte(imagenode))
-	sha3.Write([]byte(readmeNode))
+	_, _ = sha3.Write([]byte(id.GetStorageId()))
+	_, _ = sha3.Write([]byte(id.GetSpaceId()))
+	_, _ = sha3.Write([]byte(id.GetOpaqueId()))
+	_, _ = sha3.Write([]byte(imagenode))
+	_, _ = sha3.Write([]byte(readmeNode))
 	h := make([]byte, 64)
 	sha3.Read(h)
 	return fmt.Sprintf("%x", h)

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -237,12 +237,9 @@ func (g Graph) getSpecialDriveItems(ctx context.Context, baseURL *url.URL, space
 		return nil
 	}
 	metadata := space.Opaque.Map
-	names := map[string]string{
-		SpaceImageSpecialFolderName: "/.space/logo.png",
-		ReadmeSpecialFolderName:     "/.space/readme.md",
-	}
+	names := [2]string{SpaceImageSpecialFolderName, ReadmeSpecialFolderName}
 
-	for itemName, itemPath := range names {
+	for _, itemName := range names {
 		// The default is a path relative to the space root
 		var ref storageprovider.Reference
 		if itemID, ok := metadata[itemName]; ok {
@@ -252,15 +249,10 @@ func (g Graph) getSpecialDriveItems(ctx context.Context, baseURL *url.URL, space
 			ref = storageprovider.Reference{
 				ResourceId: &rid,
 			}
-		} else {
-			ref = storageprovider.Reference{
-				ResourceId: space.GetRoot(),
-				Path:       itemPath,
+			spaceItem := g.getSpecialDriveItem(ctx, ref, itemName, baseURL, space)
+			if spaceItem != nil {
+				spaceItems = append(spaceItems, *spaceItem)
 			}
-		}
-		spaceItem := g.getSpecialDriveItem(ctx, ref, itemName, baseURL, space)
-		if spaceItem != nil {
-			spaceItems = append(spaceItems, *spaceItem)
 		}
 	}
 

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -536,7 +536,7 @@ func (g Graph) formatDrives(ctx context.Context, baseURL *url.URL, storageSpaces
 
 				// can't access disabled space
 				if utils.ReadPlainFromOpaque(storageSpace.Opaque, "trashed") != "trashed" {
-					res.Special = g.getExtendedSpaceProperties(ctx, baseURL, storageSpace)
+					res.Special = g.getSpecialDriveItems(ctx, baseURL, storageSpace)
 					quota, err := g.getDriveQuota(ctx, storageSpace)
 					res.Quota = &quota
 					if err != nil {

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -65,7 +65,7 @@ type Graph struct {
 	gatewayClient            gateway.GatewayAPIClient
 	roleService              RoleService
 	permissionsService       Permissions
-	spacePropertiesCache     *ttlcache.Cache[string, interface{}]
+	specialDriveItemsCache   *ttlcache.Cache[string, interface{}]
 	usersCache               *ttlcache.Cache[string, libregraph.User]
 	groupsCache              *ttlcache.Cache[string, libregraph.Group]
 	eventsPublisher          events.Publisher

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -136,7 +136,7 @@ func NewService(opts ...Option) (Graph, error) {
 		config:                   options.Config,
 		mux:                      m,
 		logger:                   &options.Logger,
-		spacePropertiesCache:     spacePropertiesCache,
+		specialDriveItemsCache:   spacePropertiesCache,
 		usersCache:               usersCache,
 		groupsCache:              groupsCache,
 		eventsPublisher:          options.EventsPublisher,


### PR DESCRIPTION
When listing drives we now cach special drive items until the space root changes again or the TTL is reached.

brings back the cache that was dropped in https://github.com/owncloud/ocis/pull/3141