### PR TITLE
add debug to eventhistory

### DIFF
--- a/changelog/unreleased/add-eventhistory-debug.md
+++ b/changelog/unreleased/add-eventhistory-debug.md
@@ -1,0 +1,6 @@
+Enhancement: Add debug server to eventhistory
+
+We added a debug server to eventhistory.
+
+https://github.com/owncloud/ocis/pull/6204
+https://github.com/owncloud/ocis/issues/5002

--- a/docs/services/general-info/port-ranges.md
+++ b/docs/services/general-info/port-ranges.md
@@ -64,7 +64,7 @@ We also suggest to use the last port in your extensions' range as a debug/metric
 | 9255-9259  | FREE                                                                                   |
 | 9260-9264  | FREE                                                                                   |
 | 9265-9269  | FREE                                                                                   |
-| 9270-9274  | FREE                                                                                   |
+| 9270-9274  | [eventhistory]({{< ref "../eventhistory/_index.md" >}})                                |
 | 9275-9279  | FREE                                                                                   |
 | 9280-9284  | FREE                                                                                   |
 | 9285-9289  | FREE                                                                                   |

--- a/services/eventhistory/pkg/config/config.go
+++ b/services/eventhistory/pkg/config/config.go
@@ -13,8 +13,9 @@ type Config struct {
 
 	Service Service `yaml:"-"`
 
-	Log   *Log  `yaml:"log"`
-	Debug Debug `yaml:"debug"`
+	Tracing *Tracing `yaml:"tracing"`
+	Log     *Log     `yaml:"log"`
+	Debug   Debug    `yaml:"debug"`
 
 	GRPC          GRPCConfig            `yaml:"grpc"`
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
@@ -49,4 +50,12 @@ type Events struct {
 	TLSInsecure          bool   `yaml:"tls_insecure" env:"OCIS_INSECURE;EVENTHISTORY_EVENTS_TLS_INSECURE" desc:"Whether to verify the server TLS certificates."`
 	TLSRootCACertificate string `yaml:"tls_root_ca_certificate" env:"EVENTHISTORY_EVENTS_TLS_ROOT_CA_CERTIFICATE" desc:"The root CA certificate used to validate the server's TLS certificate. If provided NOTIFICATIONS_EVENTS_TLS_INSECURE will be seen as false."`
 	EnableTLS            bool   `yaml:"enable_tls" env:"OCIS_EVENTS_ENABLE_TLS;EVENTHISTORY_EVENTS_ENABLE_TLS" desc:"Enable TLS for the connection to the events broker. The events broker is the ocis service which receives and delivers events between the services.."`
+}
+
+// Tracing defines the available tracing configuration.
+type Tracing struct {
+	Enabled   bool   `yaml:"enabled" env:"OCIS_TRACING_ENABLED;EVENTHISTORY_TRACING_ENABLED" desc:"Activates tracing."`
+	Type      string `yaml:"type" env:"OCIS_TRACING_TYPE;EVENTHISTORY_TRACING_TYPE" desc:"The type of tracing. Defaults to \"\", which is the same as \"jaeger\". Allowed tracing types are \"jaeger\" and \"\" as of now."`
+	Endpoint  string `yaml:"endpoint" env:"OCIS_TRACING_ENDPOINT;EVENTHISTORY_TRACING_ENDPOINT" desc:"The endpoint of the tracing agent."`
+	Collector string `yaml:"collector" env:"OCIS_TRACING_COLLECTOR;EVENTHISTORY_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset."`
 }

--- a/services/eventhistory/pkg/config/defaults/defaultconfig.go
+++ b/services/eventhistory/pkg/config/defaults/defaultconfig.go
@@ -18,6 +18,12 @@ func FullDefaultConfig() *config.Config {
 // DefaultConfig return the default configuration
 func DefaultConfig() *config.Config {
 	return &config.Config{
+		Debug: config.Debug{
+			Addr:   "127.0.0.1:9270",
+			Token:  "",
+			Pprof:  false,
+			Zpages: false,
+		},
 		Service: config.Service{
 			Name: "eventhistory",
 		},


### PR DESCRIPTION
this PR adds a debug server to the eventhistory

refs #5002 
refs #5712 
refs https://github.com/owncloud/ocis-charts/issues/111