### PR TITLE
[docs-only] Add a readme descriton to webui option envvars

### DIFF
--- a/services/web/README.md
+++ b/services/web/README.md
@@ -8,3 +8,7 @@ The web service also provides a minimal API for branding functionality like chan
 ## Custom Compiled Web Assets
 
 If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See [ownCloud Web / Getting Started](https://owncloud.dev/clients/web/getting-started/) and [ownCloud Web / Setup with oCIS](https://owncloud.dev/clients/web/backend-ocis/) for more details.
+
+## WebUI Options
+
+Beside theming, the behaviour of the embedded WebUI can be configured via options. See the environment variables `WEB_OPTIONS_xxx` for more details.


### PR DESCRIPTION
References: #6188 (Hardcoded web options)

Just a small addon to the readme to describe that we have options to configure the webui.