### PR TITLE
[docs-only] Adding a Identity Provider section in owncloud.dev

### DIFF
--- a/docs/ocis/identity-provider/_index.md
+++ b/docs/ocis/identity-provider/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Identity Provider"
+date: 2023-05-03T00:00:00+00:00
+weight: 20
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/ocis/identity-provider
+geekdocFilePath: _index.md
+geekdocCollapseSection: true
+---
+
+## Overview
+
+oCIS provides an internal identity provider which can be configured via the [IDP service](../../services/idp/), or connect to an external identity provider like Keycloak or Microsoft Active Directory.

--- a/docs/ocis/identity-provider/ldap-active-directory.md
+++ b/docs/ocis/identity-provider/ldap-active-directory.md
@@ -1,0 +1,42 @@
+---
+title: "LDAP - Active Directory"
+date: 2023-05-03T00:00:00+00:00
+weight: 20
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/ocis/identity-provider
+geekdocFilePath: ldap-active-directory.md
+geekdocCollapseSection: true
+---
+
+## Overview
+
+oCIS can be configured using Active Directory as identity provider.
+
+## Configuration Example
+
+This configuration is an _example_ for using Samba4 AD as well as a Windows Server 2022 as the LDAP backend for oCIS. It is intended as guideline and first starting point.
+
+```text
+OCIS_LDAP_URI=ldaps://xxxxxxxxx
+OCIS_LDAP_INSECURE="true"
+OCIS_LDAP_BIND_DN="cn=administrator,cn=users,xxxxxxxxxx"                    
+OCIS_LDAP_BIND_PASSWORD=xxxxxxx        
+OCIS_LDAP_GROUP_BASE_DN="dc=owncloud,dc=test"
+OCIS_LDAP_GROUP_OBJECTCLASS="group"
+OCIS_LDAP_GROUP_SCHEMA_ID="objectGUID"
+OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING="true"
+OCIS_LDAP_GROUP_SCHEMA_GROUPNAME="cn"
+OCIS_LDAP_USER_BASE_DN="dc=owncloud,dc=test"
+OCIS_LDAP_USER_OBJECTCLASS="user"
+OCIS_LDAP_USER_SCHEMA_ID="objectGUID"
+OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING="true"
+OCIS_LDAP_USER_SCHEMA_USERNAME="sAMAccountName"
+OCIS_LDAP_USER_ENABLED_ATTRIBUTE=""
+OCIS_LDAP_LOGIN_ATTRIBUTES="sAMAccountName"
+IDP_LDAP_LOGIN_ATTRIBUTE="sAMAccountName"
+IDP_LDAP_UUID_ATTRIBUTE="objectGUID"
+IDP_LDAP_UUID_ATTRIBUTE_TYPE=binary
+GRAPH_LDAP_SERVER_WRITE_ENABLED="false"
+OCIS_EXCLUDE_RUN_SERVICES=idm
+OCIS_ADMIN_USER_ID="<objectGUID-value-of-the-default-admin-user>"
+```


### PR DESCRIPTION
Referencing: [graph: Allow using binary LDAP UUIDs as user ids](https://github.com/owncloud/ocis/pull/6182#top)

Adding the config example in the referenced PR into a new section in owncloud.dev.

As discussed with @micbar @rhafer 

Intended as starting point for more content.