### PR TITLE
graph-ldap: Fix possible races when editing group membership in parallel

### DIFF
--- a/services/graph/pkg/identity/ldap_education_class.go
+++ b/services/graph/pkg/identity/ldap_education_class.go
@@ -460,9 +460,5 @@ func (i *LDAP) RemoveTeacherFromEducationClass(ctx context.Context, classID stri
 		return err
 	}
 
-	if mr, err := i.removeEntryByDNAndAttributeFromEntry(class, teacher.DN, i.educationConfig.classAttributeMap.teachers); err == nil {
-		return i.conn.Modify(mr)
-	}
-
-	return nil
+	return i.removeEntryByDNAndAttributeFromEntry(class, teacher.DN, i.educationConfig.classAttributeMap.teachers)
 }


### PR DESCRIPTION
As the standard LDAP groups (groupOfNames) require at least one "member" value to be present in a group, we have workarounds in place that add an empty member ("") when creating a new group or when removing the last member from the group. This can cause a race condition when e.g. multiple request to remove members from a group an running in parallel, as we need to read the group before we can construct the modification request. If some other request modified the group (e.g. deleted the 2nd last member) after we read it, we create non-working modification request.

These changes try to catch those errors and retry the modification request once.

Fixes: #6170

