### PR TITLE
[docs-only] Add readme.md note to not use xattrs anymore

### DIFF
--- a/services/storage-system/README.md
+++ b/services/storage-system/README.md
@@ -4,7 +4,7 @@ Purpose and description to be added
 
 ## Deprecated Metadata Backend
 
-Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the settings `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` **AND** `STORAGE_USERS_OCIS_METADATA_BACKEND` have not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
 
 ## Caching
 

--- a/services/storage-system/README.md
+++ b/services/storage-system/README.md
@@ -2,6 +2,10 @@
 
 Purpose and description to be added
 
+## Deprecated Metadata Backend
+
+Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the settings `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` **AND** `STORAGE_USERS_OCIS_METADATA_BACKEND` have not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+
 ## Caching
 
 The `storage-system` service caches file metadata via the configured store in `STORAGE_SYSTEM_CACHE_STORE`. Possible stores are:

--- a/services/storage-users/README.md
+++ b/services/storage-users/README.md
@@ -2,6 +2,10 @@
 
 Purpose and description to be added
 
+## Deprecated Metadata Backend
+
+Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the settings `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` **AND** `STORAGE_USERS_OCIS_METADATA_BACKEND` have not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+
 ## CLI Commands
 
 ### Manage Unfinished Uploads

--- a/services/storage-users/README.md
+++ b/services/storage-users/README.md
@@ -4,7 +4,7 @@ Purpose and description to be added
 
 ## Deprecated Metadata Backend
 
-Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the settings `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` **AND** `STORAGE_USERS_OCIS_METADATA_BACKEND` have not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_USERS_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
 
 ## CLI Commands
 


### PR DESCRIPTION
References: #6213 [docs-only] Set messagepack as default metadata backend 

Per suggestion of @aduffeck, we should add a note that `xattrs` should not be used anymore.