### PR TITLE
Fix config name for the web logout url

### DIFF
--- a/changelog/unreleased/fix-web-config.md
+++ b/changelog/unreleased/fix-web-config.md
@@ -1,0 +1,5 @@
+Bugfix: Fix Logout Url config name
+
+We fixed the yaml and json name of the logout url option.
+
+https://github.com/owncloud/ocis/pull/6226

--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -18,7 +18,7 @@ type Options struct {
 	Upload                   *Upload          `json:"upload,omitempty" yaml:"upload"`
 	Editor                   *Editor          `json:"editor,omitempty" yaml:"editor"`
 	ContextHelpersReadMore   bool             `json:"contextHelpersReadMore,omitempty" yaml:"contextHelpersReadMore" env:"WEB_OPTION_CONTEXTHELPERS_READ_MORE" desc:"Specifies whether the 'Read more' link should be displayed or not."`
-	LogoutURL                string           `json:"logoutURL,omitempty" yaml:"logoutURL" env:"WEB_OPTION_LOGOUT_URL" desc:"Adds a link to the user's profile page to point him to an external page, where he can manage his session and devices. This is helpful when an external IdP is used. This option is disabled by default."`
+	LogoutURL                string           `json:"logoutUrl,omitempty" yaml:"logoutUrl" env:"WEB_OPTION_LOGOUT_URL" desc:"Adds a link to the user's profile page to point him to an external page, where he can manage his session and devices. This is helpful when an external IdP is used. This option is disabled by default."`
 }
 
 // AccountEditLink are the AccountEditLink options


### PR DESCRIPTION
## Description

Bugfix: Fix Logout Url config name

We fixed the yaml and json name of the logout url option.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/5716

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
