### PR TITLE
[docs-only] Deprecate some web envvars

### DIFF
--- a/services/web/README.md
+++ b/services/web/README.md
@@ -9,6 +9,14 @@ The web service also provides a minimal API for branding functionality like chan
 
 If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See [ownCloud Web / Getting Started](https://owncloud.dev/clients/web/getting-started/) and [ownCloud Web / Setup with oCIS](https://owncloud.dev/clients/web/backend-ocis/) for more details.
 
-## WebUI Options
+## WebUI Configuration
 
-Beside theming, the behaviour of the embedded WebUI can be configured via options. See the environment variables `WEB_OPTION_xxx` for more details.
+Note that single configuration settings of the embedded WebUI can be defined via `WEB_OPTION_xxx` environment variables. If a json based configuration file is used via the `WEB_UI_CONFIG_FILE` environment variable, these configurations take precedence over single options set.
+
+### WebUI Options
+
+Beside theming, the behaviour of the WebUI can be configured via options. See the environment variables `WEB_OPTION_xxx` for more details.
+
+### WebUI Config File
+
+When defined via the `WEB_UI_CONFIG_FILE` environment variable, the configuration of the WebUI can be made with a [json based](https://github.com/owncloud/web/tree/master/config) file.

--- a/services/web/README.md
+++ b/services/web/README.md
@@ -9,14 +9,14 @@ The web service also provides a minimal API for branding functionality like chan
 
 If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See [ownCloud Web / Getting Started](https://owncloud.dev/clients/web/getting-started/) and [ownCloud Web / Setup with oCIS](https://owncloud.dev/clients/web/backend-ocis/) for more details.
 
-## WebUI Configuration
+## Web UI Configuration
 
-Note that single configuration settings of the embedded WebUI can be defined via `WEB_OPTION_xxx` environment variables. If a json based configuration file is used via the `WEB_UI_CONFIG_FILE` environment variable, these configurations take precedence over single options set.
+Note that single configuration settings of the embedded web UI can be defined via `WEB_OPTION_xxx` environment variables. If a json based configuration file is used via the `WEB_UI_CONFIG_FILE` environment variable, these configurations take precedence over single options set.
 
-### WebUI Options
+### Web UI Options
 
-Beside theming, the behaviour of the WebUI can be configured via options. See the environment variables `WEB_OPTION_xxx` for more details.
+Beside theming, the behavior of the web UI can be configured via options. See the environment variables `WEB_OPTION_xxx` for more details.
 
-### WebUI Config File
+### Web UI Config File
 
-When defined via the `WEB_UI_CONFIG_FILE` environment variable, the configuration of the WebUI can be made with a [json based](https://github.com/owncloud/web/tree/master/config) file.
+When defined via the `WEB_UI_CONFIG_FILE` environment variable, the configuration of the web UI can be made with a [json based](https://github.com/owncloud/web/tree/master/config) file.

--- a/services/web/pkg/config/config.go
+++ b/services/web/pkg/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	HTTP HTTP `yaml:"http"`
 
 	Asset Asset  `yaml:"asset"`
-	File  string `yaml:"file" env:"WEB_UI_CONFIG" desc:"Read the ownCloud Web configuration from this file."` // TODO: rename this to a more self explaining string
+	File  string `yaml:"file" env:"WEB_UI_CONFIG_FILE;WEB_UI_CONFIG" desc:"Read the ownCloud Web json based configuration from this path/file. The config file takes precedence over WEB_OPTION_xxx environment variables. See the text description for more details." deprecationVersion:"3.0" removalVersion:"4.0.0" deprecationInfo:"WEB_UI_CONFIG name changing to make the usecase clear" deprecationReplacement:"WEB_UI_CONFIG_FILE"`
 	Web   Web    `yaml:"web"`
 
 	TokenManager *TokenManager `yaml:"token_manager"`
@@ -104,7 +104,7 @@ type ExternalAppConfig struct {
 
 // Web defines the available web configuration.
 type Web struct {
-	Path        string    `yaml:"path" env:"WEB_UI_PATH" desc:"Read the ownCloud Web configuration from this file path."`
+	Path        string    `yaml:"path" env:"WEB_UI_CONFIG_FILE;WEB_UI_PATH" desc:"Read the ownCloud Web configuration from this file path." deprecationVersion:"3.0" removalVersion:"4.0.0" deprecationInfo:"WEB_UI_PATH will be superceded by WEB_UI_CONFIG_FILE" deprecationReplacement:"WEB_UI_CONFIG_FILE"`
 	ThemeServer string    `yaml:"theme_server" env:"OCIS_URL;WEB_UI_THEME_SERVER" desc:"Base URL to load themes from. Will be prepended to the theme path."`  // used to build Theme in WebConfig
 	ThemePath   string    `yaml:"theme_path" env:"WEB_UI_THEME_PATH" desc:"Subpath/file to load the theme. Will be appended to the URL of the theme server."` // used to build Theme in WebConfig
 	Config      WebConfig `yaml:"config"`


### PR DESCRIPTION
Fixes: #6226 (Fix WEB_UI_CONFIG und WEB_UI_PATH envvars)

* The `WEB_UI_CONFIG` and `WEB_UI_PATH` envvars need deprecations and decription rewrites to make the use clear.
* Update the `web` readme