### PR TITLE
[tests-only][full-ci] Remove duplication of steps and scenario name within a feature file

### DIFF
--- a/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature
@@ -419,7 +419,6 @@ Feature: move (rename) file
       | new         | texta         | 0           | file.txt    |
       | new         | texta         | 1           | file.txt    |
       | new         | texta         | file.txt    | 0           |
-      | new         | texta         | file.txt    | 0           |
 
     @personalSpace
     Examples:

--- a/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
@@ -101,7 +101,7 @@ Feature: get file properties
       | spaces      | /folder &2.txt  | dav/spaces/%spaceid%/folder &2.txt  |
 
 
-  Scenario Outline: Do a PROPFIND of various files inside various folders
+  Scenario Outline: do a PROPFIND of various files inside various folders
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/<file_name>"
@@ -132,7 +132,7 @@ Feature: get file properties
 
   @issue-1259
   #after fixing all issues delete this Scenario and merge with the one above
-  Scenario Outline: Do a PROPFIND of various files inside various folders
+  Scenario Outline: do a PROPFIND of various files inside various folders with '?' character in its name
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/<file_name>"

--- a/tests/acceptance/features/coreApiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUpload1/uploadFile.feature
@@ -9,7 +9,7 @@ Feature: upload file
     And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
-  Scenario Outline: upload a file and check download content
+  Scenario Outline: upload a file and check etag and download content
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -56,7 +56,7 @@ Feature: upload file
 
   @issue-1259
   #after fixing all issues delete this Scenario and merge with the one above
-  Scenario Outline: upload a file and check download content
+  Scenario Outline: upload a file with character '?' in its name and check download content
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to <file_name> using the WebDAV API
     Then the HTTP status code should be "201"
@@ -130,7 +130,7 @@ Feature: upload file
 
   @issue-1259
     #after fixing all issues delete this Scenario and merge with the one above
-  Scenario Outline: upload a file into a folder and check download content
+  Scenario Outline: upload a file into a folder with character '?' in its name and check download content
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<folder_name>"
     When user "Alice" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the WebDAV API


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
We have a app to automatically update the line numbers of a feature file in the expected to failure
https://github.com/JankariTech/expected-failures-updater

But currently, it doesn't work because we have the following error

```bash
-> Found Scenarios with same title on same file
	Scenario 1: coreApiWebdavMove2/moveFile.feature:421
	Scenario 2: coreApiWebdavMove2/moveFile.feature:422
-> Found Scenarios with same title on same file
	Scenario 1: coreApiWebdavProperties2/getFileProperties.feature:127
	Scenario 2: coreApiWebdavProperties2/getFileProperties.feature:150
-> Found Scenarios with same title on same file
	Scenario 1: coreApiWebdavUpload1/uploadFile.feature:33
	Scenario 2: coreApiWebdavUpload1/uploadFile.feature:54
-> Found Scenarios with same title on same file
	Scenario 1: coreApiWebdavUpload1/uploadFile.feature:33
	Scenario 2: coreApiWebdavUpload1/uploadFile.feature:76
-> Found Scenarios with same title on same file
	Scenario 1: coreApiWebdavUpload1/uploadFile.feature:125
	Scenario 2: coreApiWebdavUpload1/uploadFile.feature:149

```
Since the app scans the files and line in respect to the scenario title it is necessary that the scenario titles aren't duplicated within a feature file. 

We might still need to do other maintenance work in the app for it to be fully functional but this is the first step to remove the blocker. 
