### PR TITLE
[docs-only] Add note that uploads could be canceled when setting is too low

### DIFF
--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	MountID           string            `yaml:"mount_id" env:"STORAGE_USERS_MOUNT_ID" desc:"Mount ID of this storage."`
 	ExposeDataServer  bool              `yaml:"expose_data_server" env:"STORAGE_USERS_EXPOSE_DATA_SERVER" desc:"Exposes the data server directly to users and bypasses the data gateway. Ensure that the data server address is reachable by users."`
 	ReadOnly          bool              `yaml:"readonly" env:"STORAGE_USERS_READ_ONLY" desc:"Set this storage to be read-only."`
-	UploadExpiration  int64             `yaml:"upload_expiration" env:"STORAGE_USERS_UPLOAD_EXPIRATION" desc:"Duration in seconds after which uploads will expire."`
+	UploadExpiration  int64             `yaml:"upload_expiration" env:"STORAGE_USERS_UPLOAD_EXPIRATION" desc:"Duration in seconds after which uploads will expire. Note that when setting this to a low number, uploads could be cancelled before they are finished and return a 403 to the user."`
 	Tasks             Tasks             `yaml:"tasks"`
 
 	Supervised bool            `yaml:"-"`


### PR DESCRIPTION
References: https://github.com/owncloud/ocis-charts/pull/241 (Add a warning to the documentation for upload cleanup job to prevent cancelling unfinished uploads)

Reflecting the warning in the helm chart in the corresponding service envvar.