### PR TITLE
settings: Move cache implementation go-micro/store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-micro/plugins/v4/store/nats-js v1.1.0 // indirect
-	github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230405210006-efd9191305c5 // indirect
+	github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
@@ -320,7 +320,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace (
-	github.com/cs3org/go-cs3apis => github.com/c0rby/go-cs3apis v0.0.0-20230110100311-5b424f1baa35
-	github.com/go-micro/plugins/v4/store/redis => github.com/dragonchaser/go-micro-plugins/v4/store/redis v0.0.0-20230508144354-06738dcca00f
-)
+replace github.com/cs3org/go-cs3apis => github.com/c0rby/go-cs3apis v0.0.0-20230110100311-5b424f1baa35

--- a/go.sum
+++ b/go.sum
@@ -661,8 +661,6 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/dnsimple/dnsimple-go v0.63.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dragonchaser/go-micro-plugins/v4/store/redis v0.0.0-20230508144354-06738dcca00f h1:5siFx2qvzmMSIWJvN2JhdJmU0tlqIFzgcfOnJm8sGTg=
-github.com/dragonchaser/go-micro-plugins/v4/store/redis v0.0.0-20230508144354-06738dcca00f/go.mod h1:MbCG0YiyPqETTtm7uHFmxQNCaW1o9hBoYtFwhbVjLUg=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e h1:rcHHSQqzCgvlwP0I/fQ8rQMn/MpHE5gWSLdtpxtP6KQ=
@@ -794,6 +792,8 @@ github.com/go-micro/plugins/v4/server/http v1.2.1 h1:Cia924J90rgFT/4qWWvyLvN+XqE
 github.com/go-micro/plugins/v4/server/http v1.2.1/go.mod h1:YuAjaSPxcn3LI8j2FUsqx0Rxunrj4YwDV41Ax76rLl0=
 github.com/go-micro/plugins/v4/store/nats-js v1.1.0 h1:6Fe1/eLtg8kRyaGvMILp4olYtTDGwYNBXyb1sYfAWGk=
 github.com/go-micro/plugins/v4/store/nats-js v1.1.0/go.mod h1:jJf7Gm39OafZlT3s3UE2/9NIYj6OlI2fmZ4czSA3gvo=
+github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d h1:HQoDDVyMfdkrgXNo03ZY4vzhoOXMDZVZ4SnpBDVID6E=
+github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d/go.mod h1:MbCG0YiyPqETTtm7uHFmxQNCaW1o9hBoYtFwhbVjLUg=
 github.com/go-micro/plugins/v4/transport/grpc v1.1.0 h1:mXfDYfFQLnVDzjGY3o84oe4prfux9h8txsnA19dKsj8=
 github.com/go-micro/plugins/v4/wrapper/breaker/gobreaker v1.2.0 h1:EQj4l7fuOSz8ueUYhFlpZPp9+tN4JeONL32ARRKXW/U=
 github.com/go-micro/plugins/v4/wrapper/breaker/gobreaker v1.2.0/go.mod h1:JR9Ox/iJIrcXm8nCWdAEBsyG7Q7lyMLzsTZPfXrqvwo=

--- a/services/settings/pkg/command/server.go
+++ b/services/settings/pkg/command/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/settings/pkg/server/debug"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/server/grpc"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/server/http"
+	svc "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/tracing"
 	"github.com/urfave/cli/v2"
 )
@@ -51,6 +52,8 @@ func Server(cfg *config.Config) *cli.Command {
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
+			handle := svc.NewService(cfg, logger)
+
 			// prepare an HTTP server and add it to the group run.
 			httpServer, err := http.Server(
 				http.Name(cfg.Service.Name),
@@ -58,6 +61,7 @@ func Server(cfg *config.Config) *cli.Command {
 				http.Context(ctx),
 				http.Config(cfg),
 				http.Metrics(mtrcs),
+				http.ServiceHandler(handle),
 			)
 			if err != nil {
 				logger.Error().
@@ -71,7 +75,14 @@ func Server(cfg *config.Config) *cli.Command {
 			})
 
 			// prepare a gRPC server and add it to the group run.
-			grpcServer := grpc.Server(grpc.Name(cfg.Service.Name), grpc.Logger(logger), grpc.Context(ctx), grpc.Config(cfg), grpc.Metrics(mtrcs))
+			grpcServer := grpc.Server(
+				grpc.Name(cfg.Service.Name),
+				grpc.Logger(logger),
+				grpc.Context(ctx),
+				grpc.Config(cfg),
+				grpc.Metrics(mtrcs),
+				grpc.ServiceHandler(handle),
+			)
 			servers.Add(grpcServer.Run, func(_ error) {
 				logger.Info().Str("server", "grpc").Msg("Shutting down server")
 				cancel()

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
@@ -45,4 +46,16 @@ type Metadata struct {
 	SystemUserID     string `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID;SETTINGS_SYSTEM_USER_ID" desc:"ID of the oCIS STORAGE-SYSTEM system user. Admins need to set the ID for the STORAGE-SYSTEM system user in this config option which is then used to reference the user. Any reasonable long string is possible, preferably this would be an UUIDv4 format."`
 	SystemUserIDP    string `yaml:"system_user_idp" env:"OCIS_SYSTEM_USER_IDP;SETTINGS_SYSTEM_USER_IDP" desc:"IDP of the oCIS STORAGE-SYSTEM system user."`
 	SystemUserAPIKey string `yaml:"system_user_api_key" env:"OCIS_SYSTEM_USER_API_KEY" desc:"API key for the STORAGE-SYSTEM system user."`
+	Cache            *Cache `yaml:"cache"`
+}
+
+// Cache configures the cache of the Metadata store
+type Cache struct {
+	Store          string        `yaml:"store" env:"OCIS_CACHE_STORE;SETTINGS_CACHE_STORE" desc:"The type of the cache store. Supported values are: 'memory', 'ocmem', 'etcd', 'redis', 'redis-sentinel', 'nats-js', 'noop'. See the text description for details."`
+	Nodes          []string      `yaml:"addresses" env:"OCIS_CACHE_STORE_NODES;SETTINGS_CACHE_STORE_NODES" desc:"A comma separated list of nodes to access the configured store. This has no effect when 'memory' or 'ocmem' stores are configured. Note that the behaviour how nodes are used is dependent on the library of the configured store."`
+	Database       string        `yaml:"database" env:"OCIS_CACHE_DATABASE" desc:"The database name the configured store should use."`
+	FileTable      string        `yaml:"files_table" env:"SETTINGS_FILE_CACHE_TABLE" desc:"The database table the store should use for the file cache."`
+	DirectoryTable string        `yaml:"directories_table" env:"SETTINGS_DIRECTORY_CACHE_TABLE" desc:"The database table the store should use for the directory cache."`
+	TTL            time.Duration `yaml:"ttl" env:"OCIS_CACHE_TTL;SETTINGS_CACHE_TTL" desc:"Default time to live for entries in the cache. Only applied when access tokens has no expiration. The duration can be set as number followed by a unit identifier like s, m or h. Defaults to '10m' (10 minutes)."`
+	Size           int           `yaml:"size" env:"OCIS_CACHE_SIZE;SETTINGS_CACHE_SIZE" desc:"The maximum quantity of items in the cache. Only applies when store type 'ocmem' is configured. Defaults to 512."`
 }

--- a/services/settings/pkg/config/defaults/defaultconfig.go
+++ b/services/settings/pkg/config/defaults/defaultconfig.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
@@ -55,6 +56,13 @@ func DefaultConfig() *config.Config {
 			GatewayAddress: "127.0.0.1:9215", // system storage
 			StorageAddress: "127.0.0.1:9215",
 			SystemUserIDP:  "internal",
+			Cache: &config.Cache{
+				Store:          "memory",
+				Database:       "ocis",
+				FileTable:      "settings_files",
+				DirectoryTable: "settings_dirs",
+				TTL:            time.Minute * 10,
+			},
 		},
 		BundlesPath: "",
 		Bundles:     nil,

--- a/services/settings/pkg/server/grpc/option.go
+++ b/services/settings/pkg/server/grpc/option.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/metrics"
+	svc "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 	"github.com/urfave/cli/v2"
 )
 
@@ -14,12 +15,13 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Name    string
-	Logger  log.Logger
-	Context context.Context
-	Config  *config.Config
-	Metrics *metrics.Metrics
-	Flags   []cli.Flag
+	Name           string
+	Logger         log.Logger
+	Context        context.Context
+	Config         *config.Config
+	Metrics        *metrics.Metrics
+	ServiceHandler svc.Service
+	Flags          []cli.Flag
 }
 
 // newOptions initializes the available default options.
@@ -72,5 +74,12 @@ func Metrics(val *metrics.Metrics) Option {
 func Flags(val []cli.Flag) Option {
 	return func(o *Options) {
 		o.Flags = append(o.Flags, val...)
+	}
+}
+
+// ServiceHandler provides a function to set the ServiceHandler option
+func ServiceHandler(val svc.Service) Option {
+	return func(o *Options) {
+		o.ServiceHandler = val
 	}
 }

--- a/services/settings/pkg/server/grpc/server.go
+++ b/services/settings/pkg/server/grpc/server.go
@@ -7,7 +7,6 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
-	svc "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 	"go-micro.dev/v4/api"
 	"go-micro.dev/v4/server"
 )
@@ -34,7 +33,7 @@ func Server(opts ...Option) grpc.Service {
 		options.Logger.Fatal().Err(err).Msg("Error creating settings service")
 	}
 
-	handle := svc.NewService(options.Config, options.Logger)
+	handle := options.ServiceHandler
 	if err := settingssvc.RegisterBundleServiceHandler(service.Server(), handle); err != nil {
 		options.Logger.Fatal().Err(err).Msg("could not register Bundle service handler")
 	}

--- a/services/settings/pkg/server/http/option.go
+++ b/services/settings/pkg/server/http/option.go
@@ -6,6 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/metrics"
+	svc "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 	"github.com/urfave/cli/v2"
 )
 
@@ -14,12 +15,13 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Name    string
-	Logger  log.Logger
-	Context context.Context
-	Config  *config.Config
-	Metrics *metrics.Metrics
-	Flags   []cli.Flag
+	Name           string
+	Logger         log.Logger
+	Context        context.Context
+	Config         *config.Config
+	Metrics        *metrics.Metrics
+	ServiceHandler svc.Service
+	Flags          []cli.Flag
 }
 
 // newOptions initializes the available default options.
@@ -72,5 +74,12 @@ func Metrics(val *metrics.Metrics) Option {
 func Flags(val []cli.Flag) Option {
 	return func(o *Options) {
 		o.Flags = append(o.Flags, val...)
+	}
+}
+
+// ServiceHandler provides a function to set the ServiceHandler option
+func ServiceHandler(val svc.Service) Option {
+	return func(o *Options) {
+		o.ServiceHandler = val
 	}
 }

--- a/services/settings/pkg/server/http/server.go
+++ b/services/settings/pkg/server/http/server.go
@@ -37,7 +37,7 @@ func Server(opts ...Option) (ohttp.Service, error) {
 		return ohttp.Service{}, fmt.Errorf("could not initialize http service: %w", err)
 	}
 
-	handle := svc.NewService(options.Config, options.Logger)
+	handle := options.ServiceHandler
 
 	{
 		handle = svc.NewInstrument(handle, options.Metrics)

--- a/services/settings/pkg/store/metadata/cache.go
+++ b/services/settings/pkg/store/metadata/cache.go
@@ -11,10 +11,6 @@ import (
 
 var (
 	cachettl = 0
-	// these need to be global instances for now as the `Service` (and therefore the `Store`) are instantiated twice (for grpc and http)
-	// therefore caches need to cover both instances
-	dircache   = initCache(cachettl)
-	filescache = initCache(cachettl)
 )
 
 // CachedMDC is cache for the metadataclient
@@ -99,8 +95,8 @@ func (c *CachedMDC) MakeDirIfNotExist(ctx context.Context, id string) error {
 
 // Init instantiates the caches
 func (c *CachedMDC) Init(ctx context.Context, id string) error {
-	c.dirs = dircache
-	c.files = filescache
+	c.dirs = initCache(cachettl)
+	c.files = initCache(cachettl)
 	return c.next.Init(ctx, id)
 }
 

--- a/services/settings/pkg/store/metadata/store.go
+++ b/services/settings/pkg/store/metadata/store.go
@@ -60,7 +60,11 @@ func (s *Store) Init() {
 		return
 	}
 
-	mdc := &CachedMDC{next: NewMetadataClient(s.cfg.Metadata)}
+	mdc := &CachedMDC{
+		next:   NewMetadataClient(s.cfg.Metadata),
+		cfg:    s.cfg,
+		logger: s.Logger,
+	}
 	if err := s.initMetadataClient(mdc); err != nil {
 		s.Logger.Error().Err(err).Msg("error initializing metadata client")
 	}

--- a/vendor/github.com/go-micro/plugins/v4/store/redis/redis.go
+++ b/vendor/github.com/go-micro/plugins/v4/store/redis/redis.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -177,6 +178,10 @@ func (r *rkv) List(opts ...store.ListOption) ([]string, error) {
 		keys, cursor, err = r.Client.Scan(r.ctx, cursor, key, count).Result()
 		if err != nil {
 			return nil, err
+		}
+
+		for i, key := range keys {
+			keys[i] = strings.TrimPrefix(key, options.Table)
 		}
 
 		allKeys = append(allKeys, keys...)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -909,7 +909,7 @@ github.com/go-micro/plugins/v4/server/http
 # github.com/go-micro/plugins/v4/store/nats-js v1.1.0
 ## explicit; go 1.17
 github.com/go-micro/plugins/v4/store/nats-js
-# github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230405210006-efd9191305c5 => github.com/dragonchaser/go-micro-plugins/v4/store/redis v0.0.0-20230508144354-06738dcca00f
+# github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d
 ## explicit; go 1.17
 github.com/go-micro/plugins/v4/store/redis
 # github.com/go-micro/plugins/v4/wrapper/breaker/gobreaker v1.2.0
@@ -2124,4 +2124,3 @@ stash.kopano.io/kgol/oidc-go
 ## explicit; go 1.13
 stash.kopano.io/kgol/rndm
 # github.com/cs3org/go-cs3apis => github.com/c0rby/go-cs3apis v0.0.0-20230110100311-5b424f1baa35
-# github.com/go-micro/plugins/v4/store/redis => github.com/dragonchaser/go-micro-plugins/v4/store/redis v0.0.0-20230508144354-06738dcca00f


### PR DESCRIPTION
This moves the settings cache to use a go-micro/store based caching implementation, similar to what we're using in many other services meanwhile.

This also switches to a different fork of go-micro/v4/store/redis as we need this fix: https://github.com/go-micro/plugins/pull/110 for making the cacheinvalidation (https://github.com/owncloud/ocis/pull/6264/files#diff-9426c2b35f285118038505973e5852f93b8a31c9240420ebfd2057d3a3aaa9d9R162) work.