### PR TITLE
add debug switch for antivirus

### DIFF
--- a/changelog/unreleased/add-debug-result-for-av.md
+++ b/changelog/unreleased/add-debug-result-for-av.md
@@ -1,0 +1,5 @@
+Enhancement: Add specific result to antivirus for debugging
+
+We added the ability to define a specific result for the virus scanner via env-var (ANTIVIRUS_DEBUG_SCAN_OUTCOME)
+
+https://github.com/owncloud/ocis/pull/6265

--- a/services/antivirus/pkg/config/config.go
+++ b/services/antivirus/pkg/config/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	MaxScanSize          string `yaml:"max-scan-size" env:"ANTIVIRUS_MAX_SCAN_SIZE" desc:"The maximum scan size the virusscanner can handle. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB."`
 
 	Context context.Context `yaml:"-" json:"-"`
+
+	DebugScanOutcome string `yaml:"-" env:"ANTIVIRUS_DEBUG_SCAN_OUTCOME" desc:"A predefined outcome for virus scanning, FOR DEBUG PURPOSES ONLY! (example values: \"found,infected\")"`
 }
 
 // Service defines the available service configuration.

--- a/services/antivirus/pkg/scanners/scanners.go
+++ b/services/antivirus/pkg/scanners/scanners.go
@@ -21,14 +21,14 @@ type Scanner interface {
 }
 
 // New returns a new scanner from config
-func New(c config.Scanner) (Scanner, error) {
-	switch c.Type {
+func New(c *config.Config) (Scanner, error) {
+	switch c.Scanner.Type {
 	default:
-		return nil, fmt.Errorf("unknown av scanner: '%s'", c.Type)
+		return nil, fmt.Errorf("unknown av scanner: '%s'", c.Scanner.Type)
 	case "clamav":
-		return NewClamAV(c.ClamAV.Socket), nil
+		return NewClamAV(c.Scanner.ClamAV.Socket), nil
 	case "icap":
-		return NewICAP(c.ICAP.URL, c.ICAP.Service, time.Duration(c.ICAP.Timeout)*time.Second)
+		return NewICAP(c.Scanner.ICAP.URL, c.Scanner.ICAP.Service, time.Duration(c.Scanner.ICAP.Timeout)*time.Second)
 	}
 
 }


### PR DESCRIPTION
This PR adds the ability to enforce a specific scan result for antivirus for debugging.