### PR TITLE
[tests-only] [full-ci] Update vendor-bin dependencies

### DIFF
--- a/tests/acceptance/features/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/features/bootstrap/ArchiverContext.php
@@ -35,7 +35,6 @@ require_once 'bootstrap.php';
  * Context for Archiver specific steps
  */
 class ArchiverContext implements Context {
-
 	/**
 	 * @var FeatureContext
 	 */

--- a/tests/parallelDeployAcceptance/features/bootstrap/ParallelContext.php
+++ b/tests/parallelDeployAcceptance/features/bootstrap/ParallelContext.php
@@ -31,7 +31,6 @@ require_once 'bootstrap.php';
  * Steps related to parallel deploy setup
  */
 class ParallelContext implements Context {
-
 	/**
 	 * @var FeatureContext
 	 */

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -8,19 +8,19 @@
         }
     },
     "require": {
-      "behat/behat": "^3.9",
+      "behat/behat": "^3.13",
       "behat/gherkin": "^4.9",
       "behat/mink": "1.7.1",
-      "friends-of-behat/mink-extension": "^2.5",
+      "friends-of-behat/mink-extension": "^2.7",
       "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
       "rdx/behat-variables": "^1.2",
       "sensiolabs/behat-page-object-extension": "^2.3",
       "symfony/translation": "^4.4",
       "sabre/xml": "^2.2",
-      "guzzlehttp/guzzle": "^7.4",
-      "phpunit/phpunit": "^9.5",
-      "laminas/laminas-ldap": "^2.10",
-      "ankitpokhrel/tus-php": "^2.1",
+      "guzzlehttp/guzzle": "^7.5",
+      "phpunit/phpunit": "^9.6",
+      "laminas/laminas-ldap": "^2.15",
+      "ankitpokhrel/tus-php": "^2.3",
       "wapmorgan/unified-archive": "^1.1.3",
       "helmich/phpunit-json-assert": "^3.4"
     }

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-      "owncloud/coding-standard": "^3.0"
+      "owncloud/coding-standard": "^4.1"
     }
   }

--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,8 +1,5 @@
 {
     "require": {
-        "squizlabs/php_codesniffer": "^3.5"
-    },
-    "conflict": {
-        "squizlabs/php_codesniffer": "3.5.1"
+        "squizlabs/php_codesniffer": "^3.7"
     }
 }


### PR DESCRIPTION
## Description
I just made a new release 4.1.0 of owncloud coding-standard https://github.com/owncloud/coding-standard/releases/tag/4.1.0

That uses a newer version of php-cs-fixer, which passes locally for me.

This PR updates the version numbers of dependencies in `vendor-bin` to the current minor versions that are in use. That can be helpful when there are problems with some new release of a dependency - at least we have "documented" which minor version is currently working correctly.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)


Similar core PR is https://github.com/owncloud/core/pull/40780