### PR TITLE
[docs-only] Fix caching and envvar use in caching

### DIFF
--- a/services/graph/README.md
+++ b/services/graph/README.md
@@ -17,7 +17,7 @@ The following image gives an overview of the scenario when a client requests to 
 
 ## Caching
 
-The `graph` service can use a configured store via `GRAPH_STORE_TYPE`. Possible stores are:
+The `graph` service can use a configured store via `GRAPH_CACHE_STORE`. Possible stores are:
   -   `memory`: Basic in-memory store and the default.
   -   `ocmem`: Advanced in-memory store allowing max size.
   -   `redis`: Stores data in a configured Redis cluster.

--- a/services/ocs/README.md
+++ b/services/ocs/README.md
@@ -1,19 +1,3 @@
 # OCS
 
 The ocs service is an ...
-
-## Caching
-
-The `ocs` service can use a configured store via `OCS_STORE_TYPE`. Possible stores are:
-  -   `memory`: Basic in-memory store and the default.
-  -   `ocmem`: Advanced in-memory store allowing max size.
-  -   `redis`: Stores data in a configured Redis cluster.
-  -   `redis-sentinel`: Stores data in a configured Redis Sentinel cluster.
-  -   `etcd`: Stores data in a configured etcd cluster.
-  -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
-  -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
-
-1.  Note that in-memory stores are by nature not reboot-persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3.  The ocs service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `OCS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -95,7 +95,7 @@ In a production deployment, you want to have basic authentication (`PROXY_ENABLE
 
 ## Caching
 
-The `proxy` service can use a configured store via `PROXY_STORE_TYPE`. Possible stores are:
+The `proxy` service can use a configured store via `PROXY_OIDC_USERINFO_CACHE_STORE`. Possible stores are:
   -   `memory`: Basic in-memory store and the default.
   -   `ocmem`: Advanced in-memory store allowing max size.
   -   `redis`: Stores data in a configured Redis cluster.


### PR DESCRIPTION
References: https://github.com/owncloud/docs-ocis/pull/493 (Fix Caching Setup)

During fixing some stuff in the admin docs, I identified that some envvars were not correctly used and the ocs service does not have caching anymore - removing it from the description.