### PR TITLE
[tests-only] [full-ci] Add examples of more username combinations

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -23,8 +23,8 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/createGroupCaseSensitive.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L24)
 - [apiGraph/createGroupCaseSensitive.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L25)
 - [apiGraph/createGroup.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroup.feature#L28)
-- [apiGraph/createUser.feature:37](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createUser.feature#L37)
-- [apiGraph/createUser.feature:68](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createUser.feature#L68)
+- [apiGraph/createUser.feature:41](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createUser.feature#L41)
+- [apiGraph/createUser.feature:72](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createUser.feature#L72)
 
 ### [PROPFIND on accepted shares with identical names containing brackets exit with 404](https://github.com/owncloud/ocis/issues/4421)
 - [apiSpacesShares/changingFilesShare.feature:15](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature#L15)

--- a/tests/acceptance/features/apiGraph/createUser.feature
+++ b/tests/acceptance/features/apiGraph/createUser.feature
@@ -1,4 +1,4 @@
-@api 
+@api
 Feature: create user
   As a admin
   I want to create a user
@@ -22,13 +22,17 @@ Feature: create user
     Then the HTTP status code should be "<code>"
     And user "<userName>" <shouldOrNot> exist
     Examples:
-      | userName                     | displayName     | email               | password                     | code | enable | shouldOrNot |
-      | SameDisplayName              | Alice Hansen    | new@example.org     | containsCharacters(*:!;_+-&) | 200  | true   | should      |
-      | withoutPassSameEmail         | without pass    | alice@example.org   |                              | 200  | true   | should      |
-      | name                         | pass with space | example@example.org | my pass                      | 200  | true   | should      |
-      | nameWithCharacters(*:!;_+-&) | user            | new@example.org     | 123                          | 400  | true   | should not  |
-      | name with space              | name with space | example@example.org | 123                          | 400  | true   | should not  |
-      | createDisabledUser           | disabled user   | example@example.org | 123                          | 200  | false  | should      |
+      | userName                     | displayName     | email                   | password                     | code | enable | shouldOrNot |
+      | SameDisplayName              | Alice Hansen    | new@example.org         | containsCharacters(*:!;_+-&) | 200  | true   | should      |
+      | withoutPassSameEmail         | without pass    | alice@example.org       |                              | 200  | true   | should      |
+      | name                         | pass with space | example@example.org     | my pass                      | 200  | true   | should      |
+      | nameWithCharacters(*:!;_+-&) | user            | new@example.org         | 123                          | 400  | true   | should not  |
+      | name with space              | name with space | example@example.org     | 123                          | 400  | true   | should not  |
+      | createDisabledUser           | disabled user   | example@example.org     | 123                          | 200  | false  | should      |
+      | nameWithNumbers0123456       | user            | name0123456@example.org | 123                          | 200  | true   | should      |
+      | name.with.dots               | user            | name.w.dots@example.org | 123                          | 200  | true   | should      |
+      | 123456789                    | user            | 123456789@example.org   | 123                          | 400  | true   | should not  |
+      | 0.0                          | user            | float@example.org       | 123                          | 400  | true   | should not  |
 
     @skipOnStable2.0
     Examples:


### PR DESCRIPTION
## Description
Some test scenario examples in coreApiTrashbin/trashbinFilesFolders.feature used usernames that are just numbers: 123, -123, 0.0
Those examples were failing because a username like that cannot be created. So as part of PR #6270 those examples are being removed.

This PR adds some examples to `createUser.feature` for:
- username with letters and numbers (works)
- username with letters and dots (works)
- username is only digits (cannot be created)
- username is 0.0 (looks like a float) (cannot be created)

This will help "document" which usernames can and cannot be created in a default installation.

See doc issue https://github.com/owncloud/docs-ocis/issues/495 - it seems that this is configurable with `GRAPH_USERNAME_MATCH=none` so the default behavior here is expected.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
