### PR TITLE
[docs-only] Fix missed default metadata backend

### DIFF
--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -73,7 +73,7 @@ func DefaultConfig() *config.Config {
 				LockCycleDurationFactor:    30,
 			},
 			OCIS: config.OCISDriver{
-				MetadataBackend:            "xattrs",
+				MetadataBackend:            "messagepack",
 				Root:                       filepath.Join(defaults.BaseDataPath(), "storage", "users"),
 				ShareFolder:                "/Shares",
 				UserLayout:                 "{{.Id.OpaqueId}}",


### PR DESCRIPTION
References: #6213 ([docs-only] Set messagepack as default metadata backend)

The `storage-users` service has two locations for defining the default metadata backend. One was missed to fix in the referenced PR.

Many thanks @d7oc for catching this.