### PR TITLE
add remote item metadata

### DIFF
--- a/changelog/unreleased/add-remote-item-metadata.md
+++ b/changelog/unreleased/add-remote-item-metadata.md
@@ -1,0 +1,5 @@
+Enhancement: Add more metadata to the remote item
+
+We added the drive alias, the space name and the relative path to the remote item. This is needed to resolve shared files directly on the source space.
+
+https://github.com/owncloud/ocis/pull/6300

--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -278,18 +278,28 @@ var _ = Describe("Graph", func() {
 									"grantOpaqueID":  {Decoder: "plain", Value: []byte("opaqueID")},
 								},
 							},
+							RootInfo: &provider.ResourceInfo{Path: "New Folder", Name: "Project Mars"},
 						},
 					},
 				}, nil)
+				var opaque *typesv1beta1.Opaque
+				opaque = utils.AppendPlainToOpaque(opaque, "spaceAlias", "project/project-mars")
 				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&provider.StatResponse{
 					Status: status.NewOK(ctx),
 					Info: &provider.ResourceInfo{
 						Etag:  "123456789",
 						Type:  provider.ResourceType_RESOURCE_TYPE_CONTAINER,
 						Id:    &provider.ResourceId{StorageId: "ownerStorageID", SpaceId: "spaceID", OpaqueId: "opaqueID"},
-						Path:  "New Folder",
+						Path:  "Folder/New Folder",
 						Mtime: &typesv1beta1.Timestamp{Seconds: 1648327606, Nanos: 0},
 						Size:  uint64(1234),
+						Name:  "New Folder",
+						Space: &provider.StorageSpace{
+							Name:      "Project Mars",
+							SpaceType: "project",
+							Opaque:    opaque,
+							Root:      &provider.ResourceId{StorageId: "ownerStorageID", SpaceId: "spaceID", OpaqueId: "opaqueID"},
+						},
 					},
 				}, nil)
 				gatewayClient.On("GetQuota", mock.Anything, mock.Anything).Return(&provider.GetQuotaResponse{
@@ -322,8 +332,9 @@ var _ = Describe("Graph", func() {
 				Expect(value.Root.RemoteItem.LastModifiedDateTime.UTC()).To(Equal(time.Unix(1648327606, 0).UTC()))
 				Expect(*value.Root.RemoteItem.Folder).To(Equal(libregraph.Folder{}))
 				Expect(*value.Root.RemoteItem.Name).To(Equal("New Folder"))
+				Expect(*value.Root.RemoteItem.Path).To(Equal("Folder/New Folder"))
 				Expect(*value.Root.RemoteItem.Size).To(Equal(int64(1234)))
-				Expect(*value.Root.RemoteItem.WebDavUrl).To(Equal("https://localhost:9200/dav/spaces/ownerStorageID$spaceID%21opaqueID"))
+				Expect(*value.Root.RemoteItem.WebDavUrl).To(Equal("https://localhost:9200/dav/spaces/ownerStorageID$spaceID%21opaqueID/Folder/New%20Folder"))
 			})
 			It("can not list spaces with wrong sort parameter", func() {
 				gatewayClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(&provider.ListStorageSpacesResponse{


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

This adds the needed metadata to the remote item which represents the real location of a share in the storage space of the share owner.

This is needed to access shares via the `storage-users` provider to have the same URL for all participants of a share.


## Related Issue
- Needs https://github.com/cs3org/reva/pull/3836
- Needed for https://github.com/owncloud/ocis/issues/6120

## Motivation and Context

Access shares via the original Url of the owner

## Examples

Admin shares `Test/Test2/Test3` with Einstein

### Einstein lists his drives an finds a share (`driveType=mountpoint`)

```json
{
    "driveAlias":"mountpoint/test3",
    "driveType":"mountpoint",
    "id":"a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!storage-users-1:some-admin-user-id-0000-000000000000:405575a4-6543-47f5-badf-df0012074105",
    "name":"test3",
    "owner":{
        "user":{
            "displayName":"",
            "id":"some-admin-user-id-0000-000000000000"
        }
    },
    "quota":{
        "remaining":0,
        "state":"exceeded",
        "total":0,
        "used":0
    },
    "root":{
        "id":"a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!storage-users-1:some-admin-user-id-0000-000000000000:405575a4-6543-47f5-badf-df0012074105",
        "remoteItem":{
            "driveAlias":"personal/admin",
            "eTag":"\"bb78fbc89ef8bd249c558509ce87165e\"",
            "folder":{
                
            },
            "id":"storage-users-1$some-admin-user-id-0000-000000000000!2fc98624-c510-4bef-bdac-331d790b4db9",
            "lastModifiedDateTime":"2023-05-09T10:49:55.502298122+02:00",
            "name":"test3",
            "path":"/Test/Test2/test3",
            "rootId":"storage-users-1$some-admin-user-id-0000-000000000000!some-admin-user-id-0000-000000000000",
            "size":0,
            "webDavUrl":"https://localhost:9200/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000%21some-admin-user-id-0000-000000000000/Test/Test2/test3"
        },
        "webDavUrl":"https://localhost:9200/dav/spaces/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668%21storage-users-1:some-admin-user-id-0000-000000000000:405575a4-6543-47f5-badf-df0012074105"
    },
    "webUrl":"https://localhost:9200/f/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668%21storage-users-1:some-admin-user-id-0000-000000000000:405575a4-6543-47f5-badf-df0012074105"
}
```

In the `remoteItem` we can no see 3 new properties:

1. `path` The relative path of the item in the originating space (needed for web navigation)
2. `rootId` The ID of the originating space
3. `driveAlias` the drive alias of the originating space (needed for web navigation)
4. `webDavUrl` the ready-to-use WebDAVURL to access the share

### NOTE
This moves the access to the share  away from the `sharesstorageprovider` and uses the normal `storage-users` provider of the share owner.

### Example

```sh
curl -L -X PROPFIND 'https://localhost:9200/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000%21some-admin-user-id-0000-000000000000/Test/Test2/test3' \
-H 'Authorization: Basic ZWluc3RlaW46cmVsYXRpdml0eQ=='
```

#### Response

```xml
<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
    <d:response>
        <d:href>/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000%21some-admin-user-id-0000-000000000000/Test/Test2/test3/</d:href>
        <d:propstat>
            <d:prop>
                <oc:id>storage-users-1$some-admin-user-id-0000-000000000000!2fc98624-c510-4bef-bdac-331d790b4db9</oc:id>
                <oc:fileid>storage-users-1$some-admin-user-id-0000-000000000000!2fc98624-c510-4bef-bdac-331d790b4db9</oc:fileid>
                <oc:spaceid>some-admin-user-id-0000-000000000000</oc:spaceid>
                <oc:file-parent>storage-users-1$some-admin-user-id-0000-000000000000!0cd66714-605b-4398-a1b4-755408aa7859</oc:file-parent>
                <oc:name>test3</oc:name>
                <d:getetag>"bb78fbc89ef8bd249c558509ce87165e"</d:getetag>
                <oc:permissions>SRDNVCK</oc:permissions>
                <d:resourcetype>
                    <d:collection/>
                </d:resourcetype>
                <oc:size>0</oc:size>
                <d:getlastmodified>Tue, 09 May 2023 08:49:55 GMT</d:getlastmodified>
                <oc:tags></oc:tags>
                <oc:favorite>0</oc:favorite>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
  <d:response>
        <d:href>/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000%21some-admin-user-id-0000-000000000000/Test/Test2/test3/File.md</d:href>
        <d:propstat>
            <d:prop>
                <oc:id>storage-users-1$some-admin-user-id-0000-000000000000!1fe3eb41-9950-45b1-97ad-dd6a5af40758</oc:id>
                <oc:fileid>storage-users-1$some-admin-user-id-0000-000000000000!1fe3eb41-9950-45b1-97ad-dd6a5af40758</oc:fileid>
                <oc:spaceid>some-admin-user-id-0000-000000000000</oc:spaceid>
                <oc:file-parent>storage-users-1$some-admin-user-id-0000-000000000000!2fc98624-c510-4bef-bdac-331d790b4db9</oc:file-parent>
                <oc:name>File.md</oc:name>
                <d:getetag>"06951524a15b155593fca499b77600e6"</d:getetag>
                <oc:permissions>RDNVW</oc:permissions>
                <d:resourcetype></d:resourcetype>
                <d:getcontentlength>10</d:getcontentlength>
                <d:getcontenttype>text/markdown</d:getcontenttype>
                <d:getlastmodified>Mon, 15 May 2023 20:40:49 GMT</d:getlastmodified>
                <oc:checksums>
                    <oc:checksum>SHA1:7372e8a68e32dd9f22d0365736d5d0531baa0110 MD5:7a3626e690c0df52aafe3784210f991c ADLER32:0ff1035e</oc:checksum>
                </oc:checksums>
                <oc:tags></oc:tags>
                <oc:favorite>0</oc:favorite>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```

###  Download the file

```sh
curl -L 'https://localhost:9200/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000%21some-admin-user-id-0000-000000000000/Test/Test2/test3/File.md' \
-H 'Authorization: Basic ZWluc3RlaW46cmVsYXRpdml0eQ=='
```

#### Response

`# Headline`

## How Has This Been Tested?
- Manually (see examples)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
