### PR TITLE
[full-ci] update reva vendor files

### DIFF
--- a/vendor/github.com/cs3org/reva/v2/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/vendor/github.com/cs3org/reva/v2/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -61,8 +61,9 @@ func (h *Handler) getGrantee(ctx context.Context, name string) (provider.Grantee
 	log.Debug().Str("name", name).Msg("no user found")
 
 	groupRes, err := client.GetGroupByClaim(ctx, &groupv1beta1.GetGroupByClaimRequest{
-		Claim: "group_name",
-		Value: name,
+		Claim:               "group_name",
+		Value:               name,
+		SkipFetchingMembers: true,
 	})
 	if err == nil && groupRes.Status.Code == rpc.Code_CODE_OK {
 		return provider.Grantee{

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/cache/cache.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/cache/cache.go
@@ -211,9 +211,6 @@ func (cache cacheStore) List(opts ...microstore.ListOption) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	for i, key := range keys {
-		keys[i] = strings.TrimPrefix(key, cache.table)
-	}
 	return keys, nil
 }
 

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/node.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/node.go
@@ -405,8 +405,8 @@ func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
 	return c, nil
 }
 
-// Parent returns the parent node
-func (n *Node) Parent() (p *Node, err error) {
+// ParentWithReader returns the parent node
+func (n *Node) ParentWithReader(r io.Reader) (p *Node, err error) {
 	if n.ParentID == "" {
 		return nil, fmt.Errorf("decomposedfs: root has no parent")
 	}
@@ -417,6 +417,9 @@ func (n *Node) Parent() (p *Node, err error) {
 		SpaceRoot: n.SpaceRoot,
 	}
 
+	// fill metadata cache using the reader
+	_, _ = p.XattrsWithReader(r)
+
 	// lookup name and parent id in extended attributes
 	p.ParentID, _ = p.XattrString(prefixes.ParentidAttr)
 	p.Name, _ = p.XattrString(prefixes.NameAttr)
@@ -426,6 +429,11 @@ func (n *Node) Parent() (p *Node, err error) {
 		p.Exists = true
 	}
 	return
+}
+
+// Parent returns the parent node
+func (n *Node) Parent() (p *Node, err error) {
+	return n.ParentWithReader(nil)
 }
 
 // Owner returns the space owner

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -731,7 +731,7 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 			}
 		}()
 
-		if n, err = n.Parent(); err != nil {
+		if n, err = n.ParentWithReader(f); err != nil {
 			return err
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.13.3-0.20230510083816-98d8707dea33
+# github.com/cs3org/reva/v2 v2.13.3-0.20230515075524-e00c55c0a4d3
 ## explicit; go 1.19
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
## Description\
Reva updated in https://github.com/owncloud/ocis/commit/62878b6428e22c93e4982f2c3aa7bb3e019876ef but not the vendor files.


## Related Issue
Cannot generate/build ocis
```
...
go: inconsistent vendoring in /mnt/workspace/owncloud/ocis:
	github.com/cs3org/reva/v2@v2.13.3-0.20230515075524-e00c55c0a4d3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/cs3org/reva/v2@v2.13.3-0.20230510083816-98d8707dea33: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod

	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor
make: *** [../.make/go.mk:102: bin/ocis] Error 1
make: Leaving directory '/mnt/workspace/owncloud/ocis/ocis'
```
Failing CI https://drone.owncloud.com/owncloud/ocis/22389/6/4

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
