### PR TITLE
Trigger a space reindex when the space has been renamed

### DIFF
--- a/services/search/pkg/search/events.go
+++ b/services/search/pkg/search/events.go
@@ -23,6 +23,7 @@ func HandleEvents(s Searcher, bus events.Consumer, logger log.Logger, cfg *confi
 		events.FileVersionRestored{},
 		events.TagsAdded{},
 		events.TagsRemoved{},
+		events.SpaceRenamed{},
 	}
 
 	if cfg.Events.AsyncUploads {
@@ -103,6 +104,8 @@ func HandleEvents(s Searcher, bus events.Consumer, logger log.Logger, cfg *confi
 					indexSpaceDebouncer.Debounce(getSpaceID(ev.Ref), getUser(ev.SpaceOwner, ev.Executant))
 				case events.UploadReady:
 					indexSpaceDebouncer.Debounce(getSpaceID(ev.FileRef), getUser(ev.SpaceOwner, ev.ExecutingUser.Id))
+				case events.SpaceRenamed:
+					indexSpaceDebouncer.Debounce(ev.ID, getUser(ev.Executant))
 				}
 
 				if err != nil {


### PR DESCRIPTION
Trigger a space reindex when the space has been renamed.

Fixes #6289 (in combination with https://github.com/cs3org/reva/pull/3889)
