### PR TITLE
remove quote from api response in share jails

### DIFF
--- a/changelog/unreleased/remove-quota-from-api-for-shares.md
+++ b/changelog/unreleased/remove-quota-from-api-for-shares.md
@@ -1,0 +1,7 @@
+Enhancement: Remove quota from share jails api responses
+
+We have removed the quota object from api responses for share jails, 
+which would permanently show exceeded due to restrictions in the permission system.
+
+https://github.com/owncloud/ocis/pull/6309
+https://github.com/owncloud/ocis/issues/4472

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -538,10 +538,14 @@ func (g Graph) formatDrives(ctx context.Context, baseURL *url.URL, storageSpaces
 				// can't access disabled space
 				if utils.ReadPlainFromOpaque(storageSpace.Opaque, "trashed") != _spaceStateTrashed {
 					res.Special = g.getSpecialDriveItems(ctx, baseURL, storageSpace)
-					quota, err := g.getDriveQuota(ctx, storageSpace)
-					res.Quota = &quota
-					if err != nil {
-						return err
+					if storageSpace.SpaceType != "mountpoint" && storageSpace.SpaceType != "virtual" {
+						quota, err := g.getDriveQuota(ctx, storageSpace)
+						res.Quota = &quota
+						if err != nil {
+							return err
+						}
+					} else {
+						res.Quota = nil
 					}
 				}
 				select {


### PR DESCRIPTION
We have removed the quota object from api responses for share jails, 
which would permanently show exceeded due to restrictions in the permission system.

refs #4472 