### PR TITLE
graph: Adjust defaults for user, group and SpaceProperties caches

### DIFF
--- a/changelog/unreleased/fix-graph-ttl-cache.md
+++ b/changelog/unreleased/fix-graph-ttl-cache.md
@@ -1,0 +1,7 @@
+Bugfix: Reduced default TTL of user and group caches in graph API
+
+We reduced the default TTL of the cache for user and group information on the
+/drives endpoints to 60 seconds. This fixes in issue where outdated information
+was show on the spaces list for a very long time.
+
+https://github.com/owncloud/ocis/issues/6320

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -53,12 +53,12 @@ func DefaultConfig() *config.Config {
 			WebDavBase:   "https://localhost:9200",
 			WebDavPath:   "/dav/spaces/",
 			DefaultQuota: "1000000000",
-			// 30 minutes
-			ExtendedSpacePropertiesCacheTTL: 1800,
-			// 30 minutes
-			GroupsCacheTTL: 1800,
-			// 30 minutes
-			UsersCacheTTL: 1800,
+			// 1 minute
+			ExtendedSpacePropertiesCacheTTL: 60,
+			// 1 minute
+			GroupsCacheTTL: 60,
+			// 1 minute
+			UsersCacheTTL: 60,
 		},
 		Identity: config.Identity{
 			Backend: "ldap",

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -115,6 +115,7 @@ func NewService(opts ...Option) (Graph, error) {
 		ttlcache.WithTTL[string, interface{}](
 			time.Duration(options.Config.Spaces.ExtendedSpacePropertiesCacheTTL),
 		),
+		ttlcache.WithDisableTouchOnHit[string, interface{}](),
 	)
 	go spacePropertiesCache.Start()
 
@@ -122,6 +123,7 @@ func NewService(opts ...Option) (Graph, error) {
 		ttlcache.WithTTL[string, libregraph.User](
 			time.Duration(options.Config.Spaces.UsersCacheTTL),
 		),
+		ttlcache.WithDisableTouchOnHit[string, libregraph.User](),
 	)
 	go usersCache.Start()
 
@@ -129,6 +131,7 @@ func NewService(opts ...Option) (Graph, error) {
 		ttlcache.WithTTL[string, libregraph.Group](
 			time.Duration(options.Config.Spaces.GroupsCacheTTL),
 		),
+		ttlcache.WithDisableTouchOnHit[string, libregraph.Group](),
 	)
 	go groupsCache.Start()
 


### PR DESCRIPTION
The old default ttl of 30 minutes for the caches seems way too long. It could cause outdated information users or groups to be returned for quite a while. Especially since the TTL was reset every time an entry was fetched from the cache. This is disabled now as well.

Fixes: #6320

