### PR TITLE
[docs-only] Add email service to the docker-compose setup for tests

### DIFF
--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -69,7 +69,7 @@ make -C tests/acceptance/docker test-ocis-feature-ocis-storage
 But some test suites that are tagged with `@env-config` require the oCIS server to be run with ociswrapper. So, running those tests require `WITH_WRAPPER=true` (default setting).
 {{< /hint >}}
 
-{{< hint ingo >}}
+{{< hint info >}}
 To run the tests that require an email server (tests tagged with `@email`), you need to provide `START_EMAIL=true` while running the tests.
 
 ```bash

--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -69,6 +69,17 @@ make -C tests/acceptance/docker test-ocis-feature-ocis-storage
 But some test suites that are tagged with `@env-config` require the oCIS server to be run with ociswrapper. So, running those tests require `WITH_WRAPPER=true` (default setting).
 {{< /hint >}}
 
+{{< hint ingo >}}
+To run the tests that require an email server (tests tagged with `@email`), you need to provide `START_EMAIL=true` while running the tests.
+
+```bash
+START_EMAIL=true \
+BEHAT_FEATURE='tests/acceptance/features/apiEmailNotification/emailNotification.feature' \
+make -C tests/acceptance/docker test-ocis-feature-ocis-storage
+```
+
+{{< /hint >}}
+
 #### Tests Transferred From ownCloud Core (prefix `coreApi`)
 
 Command `make -C tests/acceptance/docker Core-API-Tests-ocis-storage-3` runs the same tests as the `Core-API-Tests-ocis-storage-3` CI pipeline, which runs the third (out of ten) test suite groups transferred from ownCloud core against the oCIS server with ocis storage.

--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -181,6 +181,11 @@ testSuite: $(OCIS_WRAPPER) build-dev-image clean-docker-container
 		COMPOSE_FILE=src/ceph.yml \
 		docker-compose run start_ceph; \
 	fi; \
+	if [ "${START_EMAIL}" == "true" ]; then \
+		COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		COMPOSE_FILE=src/email.yml \
+		docker-compose run start_email; \
+	fi; \
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 	COMPOSE_FILE=$(COMPOSE_FILE) \
 	STORAGE_DRIVER=$(STORAGE_DRIVER) \

--- a/tests/acceptance/docker/src/acceptance.yml
+++ b/tests/acceptance/docker/src/acceptance.yml
@@ -16,6 +16,9 @@ services:
       BEHAT_FEATURE: ${BEHAT_FEATURE:-}
       DIVIDE_INTO_NUM_PARTS: $DIVIDE_INTO_NUM_PARTS
       RUN_PART: $RUN_PART
+      # email
+      EMAIL_HOST: email
+      EMAIL_PORT: 9000
     env_file:
       - ../../../../.drone.env
     volumes:

--- a/tests/acceptance/docker/src/email.yml
+++ b/tests/acceptance/docker/src/email.yml
@@ -1,0 +1,8 @@
+services:
+  start_email:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - email
+    command: email:9000
+  email:
+    image: inbucket/inbucket

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -28,6 +28,10 @@ services:
       STORAGE_USERS_S3NG_ACCESS_KEY: test
       STORAGE_USERS_S3NG_SECRET_KEY: test
       STORAGE_USERS_S3NG_BUCKET: test
+      # email
+      NOTIFICATIONS_SMTP_HOST: email
+      NOTIFICATIONS_SMTP_PORT: 2500
+      NOTIFICATIONS_SMTP_INSECURE: "true"
     volumes:
       - ../../../config:/drone/src/tests/config
       - ../../../ociswrapper/bin/ociswrapper:/usr/bin/ociswrapper


### PR DESCRIPTION
## Description
We can run tests locally using the docker-compose setup. But the tests that require email service fail because the email service is not set up.
This PR adds the email service in the setup and allows the user to start the service using `START_EMAIL=true` envvar while running the tests.
Also, the doc has been updated.
- :gear: Setup :heavy_check_mark: 
- :scroll: Documentation :heavy_check_mark: 

## Related Issue
Fixes https://github.com/owncloud/ocis/issues/6314

## Motivation and Context
able to run email tagged tests locally using docker-compose setup

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
