### PR TITLE
Do not include full-text and tag data in the composite field

### DIFF
--- a/services/search/pkg/engine/bleve.go
+++ b/services/search/pkg/engine/bleve.go
@@ -63,14 +63,19 @@ func NewBleveEngine(index bleve.Index) *Bleve {
 
 // BuildBleveMapping builds a bleve index mapping which can be used for indexing
 func BuildBleveMapping() (mapping.IndexMapping, error) {
+	nameMapping := bleve.NewTextFieldMapping()
+	nameMapping.Analyzer = "lowercaseKeyword"
+
 	lowercaseMapping := bleve.NewTextFieldMapping()
+	lowercaseMapping.IncludeInAll = false
 	lowercaseMapping.Analyzer = "lowercaseKeyword"
 
 	fulltextFieldMapping := bleve.NewTextFieldMapping()
 	fulltextFieldMapping.Analyzer = "fulltext"
+	fulltextFieldMapping.IncludeInAll = false
 
 	docMapping := bleve.NewDocumentMapping()
-	docMapping.AddFieldMappingsAt("Name", lowercaseMapping)
+	docMapping.AddFieldMappingsAt("Name", nameMapping)
 	docMapping.AddFieldMappingsAt("Tags", lowercaseMapping)
 	docMapping.AddFieldMappingsAt("Content", fulltextFieldMapping)
 


### PR DESCRIPTION
This commit removes the full-text and tag data from the composite field ("_all") which can be used for default term queries which we don't do anyways.

As a result the search index shrinks considerably in size,  my test index went from 13MB down to 7,6MB, for example.

/cc @fschade 