### PR TITLE
Default `LDAP_WRITE_ENABLED` to true

### DIFF
--- a/changelog/unreleased/default-ldap-write-enabled.md
+++ b/changelog/unreleased/default-ldap-write-enabled.md
@@ -1,0 +1,5 @@
+Enhancement: Default LDAP write to true
+
+Default `OCIS_LDAP_SERVER_WRITE_ENABLED` to true
+
+https://github.com/owncloud/ocis/pull/6362

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -118,6 +118,7 @@ func DefaultConfig() *config.Config {
 				CredentialsByUserAgent: map[string]string{},
 			},
 		},
+		LDAPServerWriteEnabled: true,
 	}
 }
 


### PR DESCRIPTION
Default `{OCIS|FRONTEND|GRAPH}_LDAP_SERVER_WRITE_ENABLED` to true