### PR TITLE
[test-only] using api token in e2e instead of basic auth

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1163,6 +1163,7 @@ def e2eTests(ctx):
             "WEB_UI_CONFIG": "%s/%s" % (dirs["base"], dirs["ocisConfig"]),
             "LOCAL_UPLOAD_DIR": "/uploads",
             "SLOW_MO": "50",
+            "API_TOKEN": "true",
         },
         "commands": [
             "cd %s" % dirs["web"],


### PR DESCRIPTION
bring https://github.com/owncloud/web/pull/9063 to ocis CI