### PR TITLE
[tests-only] [full-ci] Adjust test method tryToDeleteFileFromTrashbin

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -586,7 +586,10 @@ class TrashbinContext implements Context {
 		$numItemsDeleted = 0;
 
 		foreach ($listing as $entry) {
-			if ($entry['original-location'] === $originalPath) {
+			// The entry for the trashbin root can have original-location null.
+			// That is reasonable, because the trashbin root is not something that can be restored.
+			$originalLocation = $entry['original-location'] ?? '';
+			if (\trim($originalLocation, '/') === $originalPath) {
 				$trashItemHRef = $this->convertTrashbinHref($entry['href']);
 				$response = $this->featureContext->makeDavRequest(
 					$asUser,


### PR DESCRIPTION
## Description
This was fixed in core https://github.com/owncloud/core/pull/40816/files#diff-0c858bb3764da8bd386a1833efc1ed57756c4e3e6ae854820435659e95fddf1d

Fix it here in ocis.

A request to list the contents of the trashbin could return the `original-location` of a resource with or without a `/` on the front. In oC10 core, for example, a file that was deleted from a share seems to return `original-location` like `/sharedFolder/file.txt`, but a file in the trashbin that was just a local file of the user has something like `myFolder/myFile.txt` - when we want to delete a specific file from the trashbin, we should match either in the list-trashbin response. Otherwise the test might tell us that the file does not exist in the trashbin, when actually it does exist.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
