### PR TITLE
[tests-only] [full-ci] API test for enforce password config and update the public share to edit permission

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -138,6 +138,7 @@ default:
         - WebDavPropertiesContext:
         - TUSContext:
         - SpacesTUSContext:
+        - OcisConfigContext:
 
     apiCors:
       paths:

--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -12,7 +12,21 @@ Feature: enforce password on public link
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
 
 
-  Scenario Outline: user tries to update a public link to edit permission without a password
+  Scenario Outline: create a public link with edit permission without a password when enforce-password is enabled
+    Given using OCS API version "<ocs-api-version>"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | /testfile.txt |
+      | permissions | 3             |
+    Then the HTTP status code should be "<http-code>"
+    Then the OCS status code should be "400"
+    And the OCS status message should be "missing required password"
+    Examples:
+      | ocs-api-version | http-code |
+      | 1               | 200       |
+      | 2               | 400       |
+
+
+  Scenario Outline: update a public link to edit permission without a password
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has created a public link share with settings
       | path        | /testfile.txt |
@@ -28,7 +42,7 @@ Feature: enforce password on public link
       | 2               | 400       |
 
 
-  Scenario Outline: user updates a public link to edit permission with a password
+  Scenario Outline: updates a public link to edit permission with a password
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has created a public link share with settings
       | path        | /testfile.txt |

--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -1,0 +1,48 @@
+@api @env-config
+Feature: enforce password on public link
+  As a user
+  I want to enforce passwords on public links shared with upload, edit, or contribute permission
+  So that the password is required to access the contents of the link
+
+  Background:
+    Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
+
+
+  Scenario Outline: user tries to update a public link to edit permission without a password
+    Given using OCS API version "<ocs-api-version>"
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 1             |
+    When user "Alice" updates the last public link share using the sharing API with
+      | permissions | 3 |
+    Then the HTTP status code should be "<http-code>"
+    Then the OCS status code should be "400"
+    And the OCS status message should be "missing required password"
+    Examples:
+      | ocs-api-version | http-code |
+      | 1               | 200       |
+      | 2               | 400       |
+
+
+  Scenario Outline: user updates a public link to edit permission with a password
+    Given using OCS API version "<ocs-api-version>"
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 1             |
+    When user "Alice" updates the last public link share using the sharing API with
+      | permissions | 3            |
+      | password    | testpassword |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-code>"
+    And the OCS status message should be "OK"
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API without a password
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
+    But the public should be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "testpassword"
+    Examples:
+      | ocs-api-version | ocs-code |
+      | 1               | 100      |
+      | 2               | 200      |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds API test for setting the config `OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD` to true and update the public share to edit permission.

## Related Issue
- Related to issue: https://github.com/owncloud/ocis/issues/6231

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
