### PR TITLE
[tests-only][full-ci] Bump Web to 7.0.0-rc39

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=e8bdc25468e9a68e58cffd778209e039dd4beaf1
+WEB_COMMITID=9957bbec919671f21523b92a9bee6b512d332bc1
 WEB_BRANCH=stable-7.0

--- a/.drone.star
+++ b/.drone.star
@@ -148,7 +148,7 @@ config = {
         "earlyFail": True,
     },
     "e2eTests": {
-        "skip": True,
+        "skip": False,
         "earlyFail": True,
     },
     "rocketchat": {

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0-rc.38
+WEB_ASSETS_VERSION = v7.0.0-rc.39
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bumps web and reenables e2e tests