### PR TITLE
[tests-only] [full-ci] Test comma-separated list of tags

### DIFF
--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -284,3 +284,23 @@ Feature: Tag
       | नेपाल   |
       | file    |
       | Tag     |
+
+
+  Scenario: setting a comma-separated list of tags adds to any existing tags on the resource
+    Given user "Alice" has created the following tags for folder "folderMain" of the space "use-tag":
+      | finance,hr |
+    When user "Alice" creates the following tags for folder "folderMain" of space "use-tag":
+      | engineering,finance,qa |
+    Then the HTTP status code should be "200"
+    When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+      | key     | value                     |
+      | oc:tags | engineering,finance,hr,qa |
+    When user "Alice" lists all available tags via the GraphApi
+    Then the HTTP status code should be "200"
+    And the response should contain following tags:
+      | engineering |
+      | finance     |
+      | hr          |
+      | qa          |

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -1,7 +1,7 @@
 @api @skipOnStable2.0
 Feature: Tag
-  As a user 
-  I want to tag resources 
+  As a user
+  I want to tag resources
   So that I can sort and search them quickly
 
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
@@ -255,3 +255,32 @@ Feature: Tag
     And the response should contain following tags:
       | folderTag |
       | marketing |
+
+
+  Scenario: user creates a comma-separated list of tags for resources in the project space
+    Given user "Alice" has shared a space "use-tag" with settings:
+      | shareWith | Brian  |
+      | role      | viewer |
+    When user "Alice" creates the following tags for folder "folderMain" of space "use-tag":
+      | finance,नेपाल |
+    Then the HTTP status code should be "200"
+    When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+      | key     | value         |
+      | oc:tags | finance,नेपाल |
+    When user "Alice" creates the following tags for file "folderMain/insideTheFolder.txt" of space "use-tag":
+      | file,नेपाल,Tag |
+    Then the HTTP status code should be "200"
+    When user "Brian" sends PROPFIND request from the space "use-tag" to the resource "folderMain/insideTheFolder.txt" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+      | key     | value          |
+      | oc:tags | file,नेपाल,Tag |
+    When user "Alice" lists all available tags via the GraphApi
+    Then the HTTP status code should be "200"
+    And the response should contain following tags:
+      | finance |
+      | नेपाल   |
+      | file    |
+      | Tag     |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3153,6 +3153,15 @@ class SpacesContext implements Context {
 				case "oc:privatelink":
 					Assert::assertEquals($this->getPrivateLink($user, $spaceNameOrMountPoint), $responseValue, 'cannot find private link for space or resource in the response');
 					break;
+				case "oc:tags":
+					// The value should be a comma-separated string of tag names.
+					// We do not care what order they happen to be in, so compare as sorted lists.
+					$expectedTags = \explode(",", $value);
+					$expectedTags = \sort($expectedTags);
+					$actualTags = \explode(",", $responseValue);
+					$actualTags = \sort($actualTags);
+					Assert::assertEquals($expectedTags, $actualTags, "wrong $findItem in the response");
+					break;
 				default:
 					Assert::assertEquals($value, $responseValue, "wrong $findItem in the response");
 					break;


### PR DESCRIPTION
## Description
Add API test scenarios for using a comma-separated list of tag names.
This demonstrates the current API behavior, which has been agreed in the issue. The tags can be set by passing a comma-separated list, and are reported as a comma-separated list.

## Related Issue

#6425 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
