### PR TITLE
[tests-only]Add configuration for antivirus in docker compose for tests

### DIFF
--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -70,11 +70,25 @@ But some test suites that are tagged with `@env-config` require the oCIS server 
 {{< /hint >}}
 
 {{< hint info >}}
-To run the tests that require an email server (tests tagged with `@email`), you need to provide `START_EMAIL=true` while running the tests.
+To run the tests that requires an email server (tests tagged with `@email`), you need to provide `START_EMAIL=true` while running the tests.
 
 ```bash
 START_EMAIL=true \
-BEHAT_FEATURE='tests/acceptance/features/apiEmailNotification/emailNotification.feature' \
+BEHAT_FEATURE='tests/acceptance/features/apiNotification/emailNotification.feature' \
+make -C tests/acceptance/docker test-ocis-feature-ocis-storage
+```
+
+{{< /hint >}}
+
+{{< hint info >}}
+To run the tests that requires an antivirus service (tests tagged with `@antivirus`), you need to provide following environment variables while running the tests.
+
+```bash
+START_ANTIVIRUS=true \
+OCIS_ASYNC_UPLOADS=true \
+OCIS_ADD_RUN_SERVICES=antivirus \
+POSTPROCESSING_STEPS=virusscan \
+BEHAT_FEATURE='tests/acceptance/features/apiAntivirus/antivirus.feature' \
 make -C tests/acceptance/docker test-ocis-feature-ocis-storage
 ```
 
@@ -428,7 +442,7 @@ The commands are ubuntu specific and may differ according to your system. You ca
 
 #### 2. Setup clamAV With Docker
 ##### a. Create a Volume
-For `clamAV` only local sockets can currently be configured we need to create a volume in order to share the socket with `oCIS server`. Run the following command to do so:
+For `clamAV` only local sockets can currently be configured, we need to create a volume in order to share the socket with `oCIS server`. Run the following command to do so:
 ```bash
  docker volume create -d local -o device=/your/local/filesystem/path/ -o o=bind -o type=none clamav_vol
 ```
@@ -442,7 +456,7 @@ The path to the socket i.e. `/var/run/clamav/` may differ as per the image you a
 {{< /hint>}}
 
 ##### b. Change Ownership
-Change the ownership of the path of your local filesystem that the volume `clamav_vol` is mounted on. After running `clamav` through docker the ownership of the bound path gets changed. As we need to provide this path to ocis server the ownership should be changed back to $USER or whatever ownership that your server requires.
+Change the ownership of the path of your local filesystem that the volume `clamav_vol` is mounted on. After running `clamav` through docker the ownership of the bound path gets changed. As we need to provide this path to ocis server, the ownership should be changed back to $USER or whatever ownership that your server requires.
 ```bash
  sudo chown -R $USER:$USER /your/local/filesystem/path/
 ```
@@ -451,7 +465,7 @@ Make sure that `clamAV` is fully up before running this command. The command is 
 {{< /hint>}}
 
 {{< hint info >}}
-If you want to use the same volume after the container is down. Before running the container once again you need to either remove all the data inside `/your/local/filesystem/path/` or give the ownership back. For instance, it ubuntu it might be `sudo chown -R systemd-network:systemd-journal /your/local/filesystem/path/`  and repeat step 2 and 3`
+If you want to use the same volume after the container is down. Before running the container once again, you either need to remove all the data inside `/your/local/filesystem/path/` or give the ownership back. For instance, on ubuntu it might be `sudo chown -R systemd-network:systemd-journal /your/local/filesystem/path/`  and repeat `step 2 and 3`
 {{< /hint>}}
 
 ### Run oCIS

--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -70,7 +70,7 @@ But some test suites that are tagged with `@env-config` require the oCIS server 
 {{< /hint >}}
 
 {{< hint info >}}
-To run the tests that requires an email server (tests tagged with `@email`), you need to provide `START_EMAIL=true` while running the tests.
+To run the tests that require an email server (tests tagged with `@email`), you need to provide `START_EMAIL=true` while running the tests.
 
 ```bash
 START_EMAIL=true \
@@ -81,7 +81,7 @@ make -C tests/acceptance/docker test-ocis-feature-ocis-storage
 {{< /hint >}}
 
 {{< hint info >}}
-To run the tests that requires an antivirus service (tests tagged with `@antivirus`), you need to provide following environment variables while running the tests.
+To run the tests that require an antivirus service (tests tagged with `@antivirus`), you need to provide the following environment variables while running the tests.
 
 ```bash
 START_ANTIVIRUS=true \
@@ -465,7 +465,7 @@ Make sure that `clamAV` is fully up before running this command. The command is 
 {{< /hint>}}
 
 {{< hint info >}}
-If you want to use the same volume after the container is down. Before running the container once again, you either need to remove all the data inside `/your/local/filesystem/path/` or give the ownership back. For instance, on ubuntu it might be `sudo chown -R systemd-network:systemd-journal /your/local/filesystem/path/`  and repeat `step 2 and 3`
+If you want to use the same volume after the container is down then before running the container once again, you either need to remove all the data inside `/your/local/filesystem/path/` or give the ownership back. For instance, on Ubuntu it might be `sudo chown -R systemd-network:systemd-journal /your/local/filesystem/path/`  and repeat `step 2 and 3`
 {{< /hint>}}
 
 ### Run oCIS

--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -186,11 +186,19 @@ testSuite: $(OCIS_WRAPPER) build-dev-image clean-docker-container
 		COMPOSE_FILE=src/email.yml \
 		docker-compose run start_email; \
 	fi; \
+	if [ "${START_ANTIVIRUS}" == "true" ]; then \
+    		COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+    		COMPOSE_FILE=src/antivirus.yml \
+    		docker-compose run start_antivirus; \
+    fi; \
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 	COMPOSE_FILE=$(COMPOSE_FILE) \
 	STORAGE_DRIVER=$(STORAGE_DRIVER) \
 	TEST_SOURCE=$(TEST_SOURCE) \
 	WITH_WRAPPER=$(WITH_WRAPPER) \
+	OCIS_ASYNC_UPLOADS=$(OCIS_ASYNC_UPLOADS) \
+	OCIS_ADD_RUN_SERVICES=$(OCIS_ADD_RUN_SERVICES) \
+	POSTPROCESSING_STEPS=$(POSTPROCESSING_STEPS) \
 	OCIS_IMAGE_TAG=$(OCIS_IMAGE_TAG) \
 	BEHAT_SUITE=$(BEHAT_SUITE) \
 	BEHAT_FEATURE=$(BEHAT_FEATURE) \

--- a/tests/acceptance/docker/src/antivirus.yml
+++ b/tests/acceptance/docker/src/antivirus.yml
@@ -1,0 +1,14 @@
+services:
+  start_antivirus:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - clamav
+    command: clamav:3310
+  clamav:
+    image: owncloudci/clamavd
+    volumes:
+      - clamavSocket:/var/run/clamav/
+
+volumes:
+  clamavSocket:
+

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -22,6 +22,9 @@ services:
       IDM_CREATE_DEMO_USERS: "true"
       IDM_ADMIN_PASSWORD: "admin"
       FRONTEND_SEARCH_MIN_LENGTH: "2"
+      OCIS_ASYNC_UPLOADS: $OCIS_ASYNC_UPLOADS
+      OCIS_ADD_RUN_SERVICES: $OCIS_ADD_RUN_SERVICES
+
       # s3ng specific settings
       STORAGE_USERS_S3NG_ENDPOINT: http://ceph:8080
       STORAGE_USERS_S3NG_REGION: default
@@ -32,6 +35,19 @@ services:
       NOTIFICATIONS_SMTP_HOST: email
       NOTIFICATIONS_SMTP_PORT: 2500
       NOTIFICATIONS_SMTP_INSECURE: "true"
+
+      # antivirus
+      ANTIVIRUS_SCANNER_TYPE: "clamav"
+      ANTIVIRUS_CLAMAV_SOCKET: "/var/run/clamav/clamd.sock"
+
+      # postprocessing step
+      POSTPROCESSING_STEPS: $POSTPROCESSING_STEPS
     volumes:
       - ../../../config:/drone/src/tests/config
       - ../../../ociswrapper/bin/ociswrapper:/usr/bin/ociswrapper
+      - clamavSocket:/var/run/clamav/
+
+volumes:
+  clamavSocket:
+    external:
+      name: ocis-acceptance-tests_clamavSocket


### PR DESCRIPTION
## Description
This PR changes the compose file to add the flexibility to run tests using `antivirus` service.
Also changes some wording in the docs.

Part of: https://github.com/owncloud/ocis/issues/6255
