### PR TITLE
remove references to oc.ios://ios.owncloud.com since it is no longer used

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/config/keycloak/clients/ios_app.json
+++ b/deployments/examples/oc10_ocis_parallel/config/keycloak/clients/ios_app.json
@@ -7,8 +7,7 @@
     "clientAuthenticatorType": "client-secret",
     "secret" : "KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx",
     "redirectUris": [
-        "oc://ios.owncloud.com",
-        "oc.ios://ios.owncloud.com"
+        "oc://ios.owncloud.com"
     ],
     "webOrigins": [],
     "notBefore": 0,

--- a/deployments/examples/oc10_ocis_parallel/config/keycloak/owncloud-realm.dist.json
+++ b/deployments/examples/oc10_ocis_parallel/config/keycloak/owncloud-realm.dist.json
@@ -579,7 +579,7 @@
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
     "secret" : "KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx",
-    "redirectUris" : [ "oc://ios.owncloud.com", "oc.ios://ios.owncloud.com" ],
+    "redirectUris" : [ "oc://ios.owncloud.com" ],
     "webOrigins" : [ ],
     "notBefore" : 0,
     "bearerOnly" : false,

--- a/deployments/examples/ocis_keycloak/config/keycloak/clients/ios_app.json
+++ b/deployments/examples/ocis_keycloak/config/keycloak/clients/ios_app.json
@@ -7,8 +7,7 @@
     "clientAuthenticatorType": "client-secret",
     "secret" : "KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx",
     "redirectUris": [
-        "oc://ios.owncloud.com",
-        "oc.ios://ios.owncloud.com"
+        "oc://ios.owncloud.com"
     ],
     "webOrigins": [],
     "notBefore": 0,

--- a/deployments/examples/ocis_keycloak/config/keycloak/ocis-realm.dist.json
+++ b/deployments/examples/ocis_keycloak/config/keycloak/ocis-realm.dist.json
@@ -980,8 +980,7 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx",
       "redirectUris": [
-        "oc://ios.owncloud.com",
-        "oc.ios://ios.owncloud.com"
+        "oc://ios.owncloud.com"
       ],
       "webOrigins": [],
       "notBefore": 0,

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -109,7 +109,6 @@ func DefaultConfig() *config.Config {
 				ApplicationType: "native",
 				RedirectURIs: []string{
 					"oc://ios.owncloud.com",
-					"oc.ios://ios.owncloud.com",
 				},
 			},
 		},

--- a/services/invitations/md-sources/example-realm.json
+++ b/services/invitations/md-sources/example-realm.json
@@ -543,8 +543,7 @@
             "clientAuthenticatorType": "client-secret",
             "secret": "**********",
             "redirectUris": [
-                "oc://ios.owncloud.com",
-                "oc.ios://ios.owncloud.com"
+                "oc://ios.owncloud.com"
             ],
             "webOrigins": [],
             "notBefore": 0,


### PR DESCRIPTION
## Description
According to @michaelstingl oc.ios://ios.owncloud.com is no longer used

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- not beeing tested

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
