### PR TITLE
[test-only] fixing tests of copying and moving files with the same name. removing from expected

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -45,11 +45,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpacesShares/shareUploadTUS.feature:219](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature#L219)
 - [apiSpacesShares/shareUploadTUS.feature:284](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareUploadTUS.feature#L284)
 
-### [Copy or move on an existing resource doesn't create a new version but deletes instead](https://github.com/owncloud/ocis/issues/4797)
-
-- [apiSpacesShares/moveSpaces.feature:322](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/moveSpaces.feature#L322)
-- [apiSpacesShares/copySpaces.feature:793](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L793)
-
 ### [Creating group with empty name returns status code 200](https://github.com/owncloud/ocis/issues/5050)
 
 - [apiGraph/createGroup.feature:48](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroup.feature#L48)

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -789,7 +789,7 @@ Feature: copy file
       | newfolder/personal.txt     |
       | newfolder/personal (1).txt |
 
-  @issue-4797
+
   Scenario: copying a file from Personal to Shares with an option "replace"
     Given the administrator has given "Alice" the role "Space Admin" using the settings api
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
@@ -811,7 +811,4 @@ Feature: copy file
     Then the HTTP status code should be "200"
     And the downloaded content should be "old content version 2"
     And for user "Brian" the content of the file "/newfolder/personal.txt" of the space "Shares" should be "new content"
-    When user "Brian" downloads version of the file "/newfolder/personal.txt" with the index "2" of the space "Shares" using the WebDAV API
-    Then the HTTP status code should be "200"
-    And the downloaded content should be "old content version 1"
     And as "Brian" file "insideSpace.txt" should not exist in the trashbin of the space "Personal"

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -318,22 +318,18 @@ Feature: move (rename) file
     And for user "Brian" the space "Personal" should not contain these entries:
       | /testshare/testsubfolder |
 
-  @issue-4797
+
   Scenario: overwriting a file while moving
     Given user "Brian" has created folder "/folder"
-    And user "Brian" has uploaded file with content "old content version 1" to "/folder/testfile.txt"
-    And user "Brian" has uploaded file with content "old content version 2" to "/folder/testfile.txt"
-    And user "Brian" has uploaded file with content "new data" to "/testfile.txt"
+    And user "Brian" has uploaded file with content "some content" to "/folder/testfile.txt"
+    And user "Brian" has uploaded file with content "old data version 1" to "/testfile.txt"
+    And user "Brian" has uploaded file with content "new data version 2" to "/testfile.txt"
     When user "Brian" overwrites file "/testfile.txt" from space "Personal" to "folder/testfile.txt" inside space "Personal" while moving using the WebDAV API
     Then the HTTP status code should be "204"
-    And the content of file "/folder/testfile.txt" for user "Brian" should be "new data"
+    And the content of file "/folder/testfile.txt" for user "Brian" should be "new data version 2"
     And for user "Brian" the space "Personal" should not contain these entries:
       | /testfile.txt |
     When user "Brian" downloads version of the file "/folder/testfile.txt" with the index "1" of the space "Personal" using the WebDAV API
     Then the HTTP status code should be "200"
-    And the downloaded content should be "old content version 2"
-    When user "Brian" downloads version of the file "/folder/testfile.txt" with the index "2" of the space "Personal" using the WebDAV API
-    Then the HTTP status code should be "200"
-    And the downloaded content should be "old content version 1"
+    And the downloaded content should be "old data version 1"
     And as "Brian" file "testfile.txt" should exist in the trashbin of the space "Personal"
-


### PR DESCRIPTION
I deleted closed issue from expected failures and fixed test

- moving test: behavior here https://github.com/owncloud/ocis/issues/4797#issuecomment-1576550992
- copying test. еhe receiver could not see the version of the file. We disabled version for receivers