### PR TITLE
[tests-only][full-ci]Added scenarios for quota exceed with API

### DIFF
--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -132,9 +132,9 @@ Feature: State of the quota
     Then the HTTP status code should be "507"
 
   @env-config
-  Scenario: create a space by setting OCIS spaces max quota
+  Scenario: try to create a space with quota greater than OCIS spaces max quota
     Given the config "OCIS_SPACES_MAX_QUOTA" has been set to "50"
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "Space Admin" using the settings api
     When user "Brian" creates a space "new space" of type "project" with quota "51" using the Graph API
-    Then the HTTP status code should be "500"
+    Then the HTTP status code should be "507"

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -137,4 +137,4 @@ Feature: State of the quota
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "Space Admin" using the settings api
     When user "Brian" creates a space "new space" of type "project" with quota "51" using the Graph API
-    Then the HTTP status code should be "507"
+    Then the HTTP status code should be "400"

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -130,3 +130,11 @@ Feature: State of the quota
     And user "Brian" has been created with default attributes and without skeleton files
     When user "Brian" uploads file with content "more than 10 bytes content" to "lorem.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+
+  @env-config
+  Scenario: create a space by setting OCIS spaces max quota
+    Given the config "OCIS_SPACES_MAX_QUOTA" has been set to "50"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has given "Brian" the role "Space Admin" using the settings api
+    When user "Brian" creates a space "new space" of type "project" with quota "51" using the Graph API
+    Then the HTTP status code should be "500"

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -136,5 +136,6 @@ Feature: State of the quota
     Given the config "OCIS_SPACES_MAX_QUOTA" has been set to "50"
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Brian" the role "Space Admin" using the settings api
-    When user "Brian" creates a space "new space" of type "project" with quota "51" using the Graph API
+    When user "Brian" tries to create a space "new space" of type "project" with quota "51" using the Graph API
     Then the HTTP status code should be "400"
+    And the user "Brian" should not have a space called "new space"

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -603,6 +603,7 @@ class SpacesContext implements Context {
 
 	/**
 	 * @When /^user "([^"]*)" creates a space "([^"]*)" of type "([^"]*)" with quota "([^"]*)" using the Graph API$/
+	 * @When /^user "([^"]*)" tries to create a space "([^"]*)" of type "([^"]*)" with quota "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName


### PR DESCRIPTION
### Description
This PR adds the scenario for creation for the space when `OCIS_SPACES_MAX_QUOTA` is set and when space is created with default quota than the `OCIS_SPACES_MAX_QUOTA`.

### Related Issue:
 https://github.com/owncloud/ocis/issues/6231