### PR TITLE
feat: add uppy companion url config

### DIFF
--- a/changelog/unreleased/enhancement-add-companion-url-config.md
+++ b/changelog/unreleased/enhancement-add-companion-url-config.md
@@ -1,0 +1,5 @@
+Enhancement: Add companion URL config
+
+Introduce a config to set the Uppy Companion URL via `WEB_OPTION_UPLOAD_COMPANION_URL`.
+
+https://github.com/owncloud/ocis/pull/6453

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -194,7 +194,7 @@ func Sanitize(cfg *config.Config) {
 		cfg.Web.Config.Options.FeedbackLink = nil
 	}
 	// remove Upload parent if no value is set
-	if cfg.Web.Config.Options.Upload.XHR.Timeout == 0 {
+	if cfg.Web.Config.Options.Upload.XHR.Timeout == 0 && cfg.Web.Config.Options.Upload.CompanionURL == "" {
 		cfg.Web.Config.Options.Upload = nil
 	}
 }

--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -51,7 +51,8 @@ type Routing struct {
 
 // Upload are the upload options
 type Upload struct {
-	XHR XHR `json:"xhr,omitempty" yaml:"xhr"`
+	XHR          XHR    `json:"xhr,omitempty" yaml:"xhr"`
+	CompanionURL string `json:"companionUrl,omitempty" yaml:"companionUrl" env:"WEB_OPTION_UPLOAD_COMPANION_URL" desc:"Sets the URL of Companion which is a service provided by Uppy to import files from external cloud providers. See https://uppy.io/docs/companion/ for instructions on how to set up Companion. This feature is disabled as long as no URL is given."`
 }
 
 // XHR are the XHR options


### PR DESCRIPTION
## Description
The config can be set via env var `WEB_OPTION_UPLOAD_COMPANION_URL`. This is needed for https://github.com/owncloud/web/pull/9150.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

