### PR TITLE
Enhancement: Update go-micro kubernetes registry

### DIFF
--- a/changelog/unreleased/update-go-micro-kubernetes-registry-to-a179a6b8.md
+++ b/changelog/unreleased/update-go-micro-kubernetes-registry-to-a179a6b8.md
@@ -1,4 +1,4 @@
-Enhancement: Update go-micro kubernetes registry to v1.1.2-0.20230605104008-a179a6b8f8e6
+Enhancement: Update go-micro kubernetes registry
 
 https://github.com/owncloud/ocis/pull/6457
 https://github.com/go-micro/plugins/pull/114

--- a/changelog/unreleased/update-go-micro-kubernetes-registry-to-a179a6b8.md
+++ b/changelog/unreleased/update-go-micro-kubernetes-registry-to-a179a6b8.md
@@ -1,0 +1,5 @@
+Enhancement: Update go-micro kubernetes registry to v1.1.2-0.20230605104008-a179a6b8f8e6
+
+https://github.com/owncloud/ocis/pull/6457
+https://github.com/go-micro/plugins/pull/114
+https://github.com/go-micro/plugins/pull/113

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/go-micro/plugins/v4/logger/zerolog v1.2.0
 	github.com/go-micro/plugins/v4/registry/consul v1.2.0
 	github.com/go-micro/plugins/v4/registry/etcd v1.2.0
-	github.com/go-micro/plugins/v4/registry/kubernetes v1.1.1
+	github.com/go-micro/plugins/v4/registry/kubernetes v1.1.2-0.20230605104008-a179a6b8f8e6
 	github.com/go-micro/plugins/v4/registry/mdns v1.2.0
 	github.com/go-micro/plugins/v4/registry/memory v1.2.0
 	github.com/go-micro/plugins/v4/registry/nats v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -782,8 +782,8 @@ github.com/go-micro/plugins/v4/registry/consul v1.2.0 h1:nqrTzfWUTWKAy+M+i2FazbH
 github.com/go-micro/plugins/v4/registry/consul v1.2.0/go.mod h1:wTat7/K9XQ+i64VbbcMYFcEwipYfSgJM51HcA/sgsM4=
 github.com/go-micro/plugins/v4/registry/etcd v1.2.0 h1:tcHlU1GzvX3oZa8WQH8ylMCGie5qD5g98YWTESJjeqQ=
 github.com/go-micro/plugins/v4/registry/etcd v1.2.0/go.mod h1:CQeTHkjN3xMtIQsynaTTquMz2sHEdsTfRIfFzrX7aug=
-github.com/go-micro/plugins/v4/registry/kubernetes v1.1.1 h1:nzwyyK2JKJtmJ8w0CRn9zsn4+kwJitx8CYfAWH99eiI=
-github.com/go-micro/plugins/v4/registry/kubernetes v1.1.1/go.mod h1:u78+qWLUq8jxu/CF4UW+1UUtNgBz67x27ar2kV5Dd/o=
+github.com/go-micro/plugins/v4/registry/kubernetes v1.1.2-0.20230605104008-a179a6b8f8e6 h1:ekJ70Hq3N+Enz71GCubzhzcVuA9jfd1zWuqTXZF+UlU=
+github.com/go-micro/plugins/v4/registry/kubernetes v1.1.2-0.20230605104008-a179a6b8f8e6/go.mod h1:u78+qWLUq8jxu/CF4UW+1UUtNgBz67x27ar2kV5Dd/o=
 github.com/go-micro/plugins/v4/registry/mdns v1.2.0 h1:BsGnco+PgycvSX+HS0XbeUQEPoPT3a+dDiHWV6dbVDs=
 github.com/go-micro/plugins/v4/registry/mdns v1.2.0/go.mod h1:re0JvO5F56n59WEDaAKj2jtboKa2dklAd6iWyz5xa54=
 github.com/go-micro/plugins/v4/registry/memory v1.2.0 h1:R0G2tltffuG+fQnk+/JuAdgEJX4J+LuOafZDoNd8ow0=

--- a/vendor/github.com/go-micro/plugins/v4/registry/kubernetes/watcher.go
+++ b/vendor/github.com/go-micro/plugins/v4/registry/kubernetes/watcher.go
@@ -24,6 +24,7 @@ type k8sWatcher struct {
 
 	sync.RWMutex
 	pods map[string]*client.Pod
+	sync.Once
 }
 
 // build a cache of pods when the watcher starts.
@@ -164,7 +165,9 @@ func (k *k8sWatcher) Stop() {
 	case <-k.next:
 		return
 	default:
-		close(k.next)
+		k.Do(func() {
+			close(k.next)
+		})
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -893,7 +893,7 @@ github.com/go-micro/plugins/v4/registry/consul
 # github.com/go-micro/plugins/v4/registry/etcd v1.2.0
 ## explicit; go 1.17
 github.com/go-micro/plugins/v4/registry/etcd
-# github.com/go-micro/plugins/v4/registry/kubernetes v1.1.1
+# github.com/go-micro/plugins/v4/registry/kubernetes v1.1.2-0.20230605104008-a179a6b8f8e6
 ## explicit; go 1.18
 github.com/go-micro/plugins/v4/registry/kubernetes
 github.com/go-micro/plugins/v4/registry/kubernetes/client


### PR DESCRIPTION
Update go-micro kubernetes registry to v1.1.2-0.20230605104008-a179a6b8f8e6

https://github.com/owncloud/ocis/pull/6457
https://github.com/go-micro/plugins/pull/114
https://github.com/go-micro/plugins/pull/113
