### PR TITLE
[docs-only] GRAPH_APPLICATION_ID envvar text fix

### DIFF
--- a/services/graph/pkg/config/application.go
+++ b/services/graph/pkg/config/application.go
@@ -2,6 +2,6 @@ package config
 
 // Application defines the available graph application configuration.
 type Application struct {
-	ID          string `yaml:"id" env:"GRAPH_APPLICATION_ID" desc:"The ocis application id shown in the graph. All app roles are tied to this."`
+	ID          string `yaml:"id" env:"GRAPH_APPLICATION_ID" desc:"The ocis application ID shown in the graph. All app roles are tied to this."`
 	DisplayName string `yaml:"displayname" env:"GRAPH_APPLICATION_DISPLAYNAME" desc:"The oCIS application name"`
 }

--- a/services/graph/pkg/config/application.go
+++ b/services/graph/pkg/config/application.go
@@ -2,6 +2,6 @@ package config
 
 // Application defines the available graph application configuration.
 type Application struct {
-	ID          string `yaml:"id" env:"GRAPH_APPLICATION_ID" desc:"The ocis application ID shown in the graph. All app roles are tied to this."`
+	ID          string `yaml:"id" env:"GRAPH_APPLICATION_ID" desc:"The ocis application ID shown in the graph. All app roles are tied to this ID."`
 	DisplayName string `yaml:"displayname" env:"GRAPH_APPLICATION_DISPLAYNAME" desc:"The oCIS application name"`
 }


### PR DESCRIPTION
Just a small envvar text fix: `id` --> `ID`