### PR TITLE
[tests-only][full-ci]add test for antivirus user group sharing

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -135,32 +135,41 @@ Feature: antivirus
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
     And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
-    When user "Brian" uploads file "filesForUpload/filesWithVirus/eicar.com" to "/Shares/uploadFolder/file.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/filesWithVirus/<filename>" to "/Shares/uploadFolder/<newfilename>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
       | message                                                                   |
-      | Virus found in file.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-    And as "Brian" file "/Shares/uploadFolder/file.txt" should not exist
-    And as "Alice" file "/uploadFolder/file.txt" should not exist
+      | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
+    And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | filename      | newfilename |
+      | old              | eicar.com     | file1.txt   |
+      | old              | eicar_com.zip | file2.zip   |
+      | old              | eicarcom2.zip | file3.zip   |
+      | new              | eicar.com     | file1.txt   |
+      | new              | eicar_com.zip | file2.zip   |
+      | new              | eicarcom2.zip | file3.zip   |
 
 
-  Scenario: upload a file with virus to a user share using spaces dav endpoint
+  Scenario Outline: upload a file with virus to a user share using spaces dav endpoint
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
     And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
-    When user "Brian" uploads a file inside space "Shares" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "/uploadFolder/virusFile.txt" using the WebDAV API
+    When user "Brian" uploads a file "filesForUpload/filesWithVirus/<filename>" to "/uploadFolder/<newfilename>" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
       | message                                                                   |
-      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-    And as "Brian" file "/Shares/uploadFolder/virusFile.txt" should not exist
-    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist
+      | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
+    And as "Alice" file "/uploadFolder/<newfilename>" should not exist
+    Examples:
+      | filename      | newfilename |
+      | eicar.com     | file1.txt   |
+      | eicar_com.zip | file2.zip   |
+      | eicarcom2.zip | file3.zip   |
 
 
   Scenario Outline: upload a file with virus to a group share
@@ -171,20 +180,24 @@ Feature: antivirus
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has shared folder "uploadFolder" with group "group1"
     And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
-    When user "Brian" uploads file "filesForUpload/filesWithVirus/eicar.com" to "/Shares/uploadFolder/virusFile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/filesWithVirus/<filename>" to "/Shares/uploadFolder/<newfilename>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
       | message                                                                        |
-      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-    And as "Brian" file "/Shares/uploadFolder/virusFile.txt" should not exist
-    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist
+      | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
+    And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | filename      | newfilename |
+      | old              | eicar.com     | file1.txt   |
+      | old              | eicar_com.zip | file2.zip   |
+      | old              | eicarcom2.zip | file3.zip   |
+      | new              | eicar.com     | file1.txt   |
+      | new              | eicar_com.zip | file2.zip   |
+      | new              | eicarcom2.zip | file3.zip   |
 
 
-  Scenario: upload a file with virus to a group share using spaces dav endpoint
+  Scenario Outline: upload a file with virus to a group share using spaces dav endpoint
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "group1" has been created
@@ -192,10 +205,16 @@ Feature: antivirus
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has shared folder "uploadFolder" with group "group1"
     And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
-    When user "Brian" uploads a file inside space "Shares" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "/uploadFolder/virusFile.txt" using the WebDAV API
+    When user "Brian" uploads a file "filesForUpload/filesWithVirus/<filename>" to "/uploadFolder/<newfilename>" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
       | message                                                                        |
-      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-    And as "Brian" file "/Shares/uploadFolder/virusFile.txt" should not exist
-    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist
+      | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
+    And as "Alice" file "/uploadFolder/<newfilename>" should not exist
+    Examples:
+      | filename      | newfilename |
+      | eicar.com     | file1.txt   |
+      | eicar_com.zip | file2.zip   |
+      | eicarcom2.zip | file3.zip   |
+

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -138,18 +138,16 @@ Feature: antivirus
     When user "Brian" uploads file "filesForUpload/filesWithVirus/<filename>" to "/Shares/uploadFolder/<newfilename>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
-      | message                                                                   |
+      | message                                                                        |
       | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
     And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | dav-path-version | filename      | newfilename |
-      | old              | eicar.com     | file1.txt   |
-      | old              | eicar_com.zip | file2.zip   |
-      | old              | eicarcom2.zip | file3.zip   |
-      | new              | eicar.com     | file1.txt   |
-      | new              | eicar_com.zip | file2.zip   |
-      | new              | eicarcom2.zip | file3.zip   |
+      | dav-path-version | filename      | newfilename    |
+      | old              | eicar.com     | virusFile1.txt |
+      | old              | eicar_com.zip | virusFile2.zip |
+      | new              | eicar.com     | virusFile1.txt |
+      | new              | eicar_com.zip | virusFile2.zip |
 
 
   Scenario Outline: upload a file with virus to a user share using spaces dav endpoint
@@ -161,15 +159,14 @@ Feature: antivirus
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/<filename>" to "/uploadFolder/<newfilename>" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
-      | message                                                                   |
+      | message                                                                        |
       | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
     And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | filename      | newfilename |
-      | eicar.com     | file1.txt   |
-      | eicar_com.zip | file2.zip   |
-      | eicarcom2.zip | file3.zip   |
+      | filename      | newfilename    |
+      | eicar.com     | virusFile1.txt |
+      | eicar_com.zip | virusFile2.zip |
 
 
   Scenario Outline: upload a file with virus to a group share
@@ -188,13 +185,11 @@ Feature: antivirus
     And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
     And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | dav-path-version | filename      | newfilename |
-      | old              | eicar.com     | file1.txt   |
-      | old              | eicar_com.zip | file2.zip   |
-      | old              | eicarcom2.zip | file3.zip   |
-      | new              | eicar.com     | file1.txt   |
-      | new              | eicar_com.zip | file2.zip   |
-      | new              | eicarcom2.zip | file3.zip   |
+      | dav-path-version | filename      | newfilename    |
+      | old              | eicar.com     | virusFile1.txt |
+      | old              | eicar_com.zip | virusFile2.zip |
+      | new              | eicar.com     | virusFile1.txt |
+      | new              | eicar_com.zip | virusFile2.zip |
 
 
   Scenario Outline: upload a file with virus to a group share using spaces dav endpoint
@@ -213,8 +208,7 @@ Feature: antivirus
     And as "Brian" file "/Shares/uploadFolder/<newfilename>" should not exist
     And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | filename      | newfilename |
-      | eicar.com     | file1.txt   |
-      | eicar_com.zip | file2.zip   |
-      | eicarcom2.zip | file3.zip   |
+      | filename      | newfilename    |
+      | eicar.com     | virusFile1.txt |
+      | eicar_com.zip | virusFile2.zip |
 

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -127,3 +127,75 @@ Feature: antivirus
       | old              |
       | new              |
       | spaces           |
+
+
+  Scenario Outline: upload a file with virus to a user share
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "uploadFolder"
+    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+    When user "Brian" uploads file "filesForUpload/filesWithVirus/eicar.com" to "/Shares/uploadFolder/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                   |
+      | Virus found in file.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/file.txt" should not exist
+    And as "Alice" file "/uploadFolder/file.txt" should not exist
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+
+
+  Scenario: upload a file with virus to a user share using spaces dav endpoint
+    Given using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "uploadFolder"
+    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+    When user "Brian" uploads a file inside space "Shares" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "/uploadFolder/virusFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                   |
+      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/virusFile.txt" should not exist
+    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist
+
+
+  Scenario Outline: upload a file with virus to a group share
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has created folder "uploadFolder"
+    And user "Alice" has shared folder "uploadFolder" with group "group1"
+    And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+    When user "Brian" uploads file "filesForUpload/filesWithVirus/eicar.com" to "/Shares/uploadFolder/virusFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                        |
+      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/virusFile.txt" should not exist
+    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+
+
+  Scenario: upload a file with virus to a group share using spaces dav endpoint
+    Given using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has created folder "uploadFolder"
+    And user "Alice" has shared folder "uploadFolder" with group "group1"
+    And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+    When user "Brian" uploads a file inside space "Shares" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "/uploadFolder/virusFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                        |
+      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Brian" file "/Shares/uploadFolder/virusFile.txt" should not exist
+    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1228,6 +1228,28 @@ class SpacesContext implements Context {
 		$this->featureContext->uploadFileWithContent($user, $content, $destination);
 	}
 
+    /**
+     * @When /^user "([^"]*)" uploads a file "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/
+     *
+     * @param string $user
+     * @param string $source
+     * @param string $destination
+     * @param string $spaceName
+     *
+     * @return void
+     * @throws GuzzleException
+     * @throws Exception
+     */
+    public function theUserUploadsALocalFileToSpace(
+        string $user,
+        string $source,
+        string $destination,
+        string $spaceName
+    ): void {
+        $this->setSpaceIDByName($user, $spaceName);
+        $this->featureContext->userUploadsAFileTo($user, $source, $destination);
+    }
+
 	/**
 	 * @When /^user "([^"]*)" uploads a file inside space "([^"]*)" owned by the user "([^"]*)" with content "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1228,27 +1228,27 @@ class SpacesContext implements Context {
 		$this->featureContext->uploadFileWithContent($user, $content, $destination);
 	}
 
-    /**
-     * @When /^user "([^"]*)" uploads a file "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/
-     *
-     * @param string $user
-     * @param string $source
-     * @param string $destination
-     * @param string $spaceName
-     *
-     * @return void
-     * @throws GuzzleException
-     * @throws Exception
-     */
-    public function theUserUploadsALocalFileToSpace(
-        string $user,
-        string $source,
-        string $destination,
-        string $spaceName
-    ): void {
-        $this->setSpaceIDByName($user, $spaceName);
-        $this->featureContext->userUploadsAFileTo($user, $source, $destination);
-    }
+	/**
+	 * @When /^user "([^"]*)" uploads a file "([^"]*)" to "([^"]*)" in space "([^"]*)" using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destination
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function theUserUploadsALocalFileToSpace(
+		string $user,
+		string $source,
+		string $destination,
+		string $spaceName
+	): void {
+		$this->setSpaceIDByName($user, $spaceName);
+		$this->featureContext->userUploadsAFileTo($user, $source, $destination);
+	}
 
 	/**
 	 * @When /^user "([^"]*)" uploads a file inside space "([^"]*)" owned by the user "([^"]*)" with content "([^"]*)" to "([^"]*)" using the WebDAV API$/


### PR DESCRIPTION
## Description
This PR adds the API tests for user group link share with antivirus service. The scenarios added in this PR are
- upload a file with virus from user group sharing
- upload a file with virus from password protected user group sharing

## Related Issue
- Part of: https://github.com/owncloud/ocis/issues/6255

## Motivation and Context
- there was no test coverage for user group link share with antivirus service. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
