### PR TITLE
[test-only] Fix code expectation

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -155,9 +155,9 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 File and sync features in a shared scenario
 
-#### Contain the remotes list in response to getting sharees while searching
+#### [federation share is not implement in ocis] (https://github.com/owncloud/ocis/issues/1329)
 
-- [coreApiSharees/sharees.feature:180](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharees/sharees.feature#L180)
+- [coreApiSharees/sharees.feature:180](https://github.com/owncloud/ocis/blob/master/test-acceptance-apr/tests/acceptance/features/coreApiSharees/sharees.feature#L180)
 - [coreApiSharees/sharees.feature:181](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharees/sharees.feature#L181)
 
 #### [accepting matching name shared resources from different users/groups sets no serial identifiers on the resource name for the receiver](https://github.com/owncloud/ocis/issues/4289)

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -157,7 +157,7 @@ File and sync features in a shared scenario
 
 #### [federation share is not implement in ocis] (https://github.com/owncloud/ocis/issues/1329)
 
-- [coreApiSharees/sharees.feature:180](https://github.com/owncloud/ocis/blob/master/test-acceptance-apr/tests/acceptance/features/coreApiSharees/sharees.feature#L180)
+- [coreApiSharees/sharees.feature:180](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharees/sharees.feature#L180)
 - [coreApiSharees/sharees.feature:181](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharees/sharees.feature#L181)
 
 #### [accepting matching name shared resources from different users/groups sets no serial identifiers on the resource name for the receiver](https://github.com/owncloud/ocis/issues/4289)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -18,7 +18,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiArchiver/downloadById.feature:134](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadById.feature#L134)
 - [apiArchiver/downloadById.feature:135](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadById.feature#L135)
 
-### [create request for already existing user exits with status code 500 ](https://github.com/owncloud/ocis/issues/3516)
+### [create request for already existing group exits with status code 500 ](https://github.com/owncloud/ocis/issues/3516)
 
 - [apiGraph/createGroupCaseSensitive.feature:20](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L20)
 - [apiGraph/createGroupCaseSensitive.feature:21](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L21)
@@ -27,8 +27,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraph/createGroupCaseSensitive.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L24)
 - [apiGraph/createGroupCaseSensitive.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroupCaseSensitive.feature#L25)
 - [apiGraph/createGroup.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createGroup.feature#L28)
-- [apiGraph/createUser.feature:41](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createUser.feature#L41)
-- [apiGraph/createUser.feature:72](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraph/createUser.feature#L72)
 
 ### [PROPFIND on accepted shares with identical names containing brackets exit with 404](https://github.com/owncloud/ocis/issues/4421)
 

--- a/tests/acceptance/features/apiGraph/createUser.feature
+++ b/tests/acceptance/features/apiGraph/createUser.feature
@@ -38,7 +38,7 @@ Feature: create user
     Examples:
       | userName                     | displayName     | email               | password                     | code | enable | shouldOrNot |
       | withoutEmail                 | without email   |                     | 123                          | 200  | true   | should      |
-      | Alice                        | same userName   | new@example.org     | 123                          | 400  | true   | should      |
+      | Alice                        | same userName   | new@example.org     | 123                          | 409  | true   | should      |
 
 
   Scenario: user cannot be created with empty name
@@ -68,7 +68,7 @@ Feature: create user
       | User        |
       | User Light  |
 
-  @issue-3516 @skipOnStable2.0
+
   Scenario: user cannot be created with the name of the disabled user
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has given "Alice" the role "Admin" using the settings api
@@ -79,7 +79,7 @@ Feature: create user
       | email          | brian@example.com     |
       | password       | 123                   |
       | accountEnabled | true                  |
-    Then the HTTP status code should be "400"
+    Then the HTTP status code should be "409"
 
   @skipOnStable2.0
   Scenario: user can be created with the name of the deleted user


### PR DESCRIPTION
I reopened https://github.com/owncloud/ocis/issues/3516
- changed createUser tests and delete tests from expected failures
- `federated sharee` is not implement in OCIS (will be near in the feature) so I linked tests with existing issue https://github.com/owncloud/ocis/issues/1329

@2403905 we should have failed tests with a link to the issue in the expected failures file, and the issue should not be closed. (if the issue is closed -> that means no tests in the list)
 

