### PR TITLE
[tests-only] [full-ci] API test to remove password of a public link with enforce password enabled

### DIFF
--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -60,3 +60,23 @@ Feature: enforce password on public link
       | ocs-api-version | ocs-code |
       | 1               | 100      |
       | 2               | 200      |
+
+
+  Scenario Outline: user tries to remove password on a public link with edit permission when enforce-password is enabled
+    Given using OCS API version "<ocs-api-version>"
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 3             |
+      | password    | testpassword  |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-code>"
+    And the OCS status message should be "OK"
+    When user "Alice" updates the last public link share using the sharing API with
+      | password | %remove% |
+    Then the HTTP status code should be "<http-code>"
+    Then the OCS status code should be "996"
+    And the OCS status message should be "Error sending update request to public link provider: the public share needs to have a password"
+    Examples:
+      | ocs-api-version | ocs-code | http-code |
+      | 1               | 100      | 200       |
+      | 2               | 200      | 500       |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds API test for setting the config `OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD=true` and trying to remove the password of a public link with edit permission.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6231

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
