### PR TITLE
[docs-only]fix path in documentation

### DIFF
--- a/docs/ocis/deployment/ocis_s3.md
+++ b/docs/ocis/deployment/ocis_s3.md
@@ -45,7 +45,7 @@ See also [example server setup]({{< ref "preparing_server" >}})
 
 * Go to the deployment example
 
-  `cd ocis/deployments/examples/ocis_s3`
+  `cd deployments/examples/ocis_s3`
 
 * Open the `.env` file in a text editor.
 


### PR DESCRIPTION
The path in the docs is incorrect `deployment/` is no longer inside `ocis/` so this PR fixes the path in docs