### PR TITLE
Handle the bad request status for the CreateStorageSpace function

### DIFF
--- a/changelog/unreleased/fix-drive-response.md
+++ b/changelog/unreleased/fix-drive-response.md
@@ -1,0 +1,7 @@
+Bugfix: Handle the bad request status
+
+Handle the bad request status for the CreateStorageSpace function
+
+https://github.com/owncloud/ocis/pull/6469
+https://github.com/cs3org/reva/pull/3948
+https://github.com/owncloud/ocis/issues/6414

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -319,6 +319,11 @@ func (g Graph) CreateDrive(w http.ResponseWriter, r *http.Request) {
 			errorcode.NotAllowed.Render(w, r, http.StatusForbidden, "permission denied")
 			return
 		}
+		if resp.GetStatus().GetCode() == cs3rpc.Code_CODE_INVALID_ARGUMENT {
+			logger.Debug().Str("grpcmessage", resp.GetStatus().GetMessage()).Msg("could not create drive: bad request")
+			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, resp.GetStatus().GetMessage())
+			return
+		}
 		logger.Debug().Interface("grpcmessage", csr).Str("grpc", resp.GetStatus().GetMessage()).Msg("could not create drive: grpc error")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, resp.GetStatus().GetMessage())
 		return


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [https://github.com/owncloud/ocis/issues/6414](https://github.com/owncloud/ocis/issues/6414)
- Related [https://github.com/cs3org/reva/pull/3948](https://github.com/cs3org/reva/pull/3948)



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local
- test case 1:
```text 
set OCIS_SPACES_MAX_QUOTA=50

curl -XPOST -k -uadmin:admin https://localhost:9200/graph/v1.0/drives -H 'Content-Type: application/json' --data-raw '{"Name": "testQuota", "description": "This is a test quota", "quota": {"total": 51}}' -ik
HTTP/1.1 400 Bad Request
Content-Length: 223
Content-Security-Policy: frame-ancestors 'none'
Content-Type: application/json; charset=utf-8
Date: Wed, 07 Jun 2023 11:49:18 GMT
Vary: Origin
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Graph-Version: 3.0.0+dev

{"error":{"code":"invalidRequest","innererror":{"date":"2023-06-07T11:49:18Z","request-id":"Julias-MacBook-Pro.local/LulWJzXL2k-000166"},"message":"error: bad request: decompsedFS: requested quota is higher than allowed"}}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
