### PR TITLE
[full-ci] chore: bump web to v7.0.1

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=13a10f5a86dea81e48e01f2644280877b64492cb
+WEB_COMMITID=0759adba28e0fb230b47646b07509471d3ce5a4f
 WEB_BRANCH=stable-7.0

--- a/changelog/unreleased/update-web-7.0.1.md
+++ b/changelog/unreleased/update-web-7.0.1.md
@@ -1,0 +1,11 @@
+Enhancement: Update web to v7.0.1
+
+Tags: web
+
+We updated ownCloud Web to v7.0.1. Please refer to the changelog (linked) for details on the web release.
+
+## Summary
+* Bugfix [owncloud/web#9153](https://github.com/owncloud/web/pull/9153): Reduce space preloading
+
+https://github.com/owncloud/ocis/pull/6470
+https://github.com/owncloud/web/releases/tag/v7.0.1

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.0
+WEB_ASSETS_VERSION = v7.0.1
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bumps web to v7.0.1 to bring in a performance improvement for initial space preloading