### PR TITLE
OIDC authentication using authelia fails with no roles

### DIFF
--- a/services/proxy/pkg/userroles/oidcroles.go
+++ b/services/proxy/pkg/userroles/oidcroles.go
@@ -43,7 +43,8 @@ func (ra oidcRoleAssigner) UpdateUserRoleAssignment(ctx context.Context, user *c
 	claimRolesRaw, ok := claims[ra.rolesClaim].([]interface{})
 	if !ok {
 		logger.Error().Str("rolesClaim", ra.rolesClaim).Msg("No roles in user claims")
-		return nil, errors.New("no roles in user claims")
+		user.Opaque = utils.AppendJSONToOpaque(user.Opaque, "roles", []string{""})
+		return user, nil
 	}
 
 	logger.Debug().Str("rolesClaim", ra.rolesClaim).Interface("rolesInClaim", claims[ra.rolesClaim]).Msg("got roles in claim")


### PR DESCRIPTION
## Description

Using Authelia for OIDC Authentication, Version 2.0.0 allows the users to authenticate, though as authelia's OIDC implementation is not complete, there are no roles in the claim.

Version 3.0.0, has a failure point when there are no roles for the user. This means that upgrading from 2.0.0 to 3.0.0
will break existing systems.

Its not ideal that there are no roles, but i was able to get my user to be "admin" by disabling OIDC, logging in
as the auto created admin user and then making my user from authelia "admin", then re-enabling OIDC.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [<issue_link>](https://github.com/owncloud/ocis/issues/6474)

## Motivation and Context
Being able to use authelia to authenticate. Otherwise would require adding an extra authentication handler
like keycloak which is not ideal.

## How Has This Been Tested?
Installed on my test container, built with the web ui included, was able to successfully authenticate and be presented with
the user interface.
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
