### PR TITLE
[full-ci] ci: bump web commit id for updated tests (to stable-3.0)

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=13a10f5a86dea81e48e01f2644280877b64492cb
+WEB_COMMITID=69ab5c83e6eba00ec99d1c8c5dcb62927722e9e7
 WEB_BRANCH=stable-7.0


### PR DESCRIPTION
bumping web commit id to bring in the adjusted tests, fixing https://github.com/owncloud/ocis/issues/6431