### PR TITLE
[docs-only] Fix adoc global template

### DIFF
--- a/docs/templates/ADOC_global.tmpl
+++ b/docs/templates/ADOC_global.tmpl
@@ -1,5 +1,12 @@
 // collected through docs/helpers/adoc-generator.go.tmpl
 
+Note that some global environment variables have been deprecated and replaced by a new one starting with `OCIS_` for naming consistency:
+
+* All envvars starting with `LDAP_`
+* All envvars starting with `IDM_` except `IDM_CREATE_DEMO_USERS`
+* The following envvars: `REVA_GATEWAY`, `STORAGE_TRANSFER_SECRET`, `STORAGE_USERS_OCIS_ASYNC_UPLOADS`, `USERLOG_MACHINE_AUTH_API_KEY`.
+* Note that `WEB_UI_CONFIG_FILE` is not a global envar and will dropped from the list in a later release.
+
 [.landscape]
 [caption=]
 .Environment variables with global scope available in multiple services


### PR DESCRIPTION
This is just a small adoc global template fix and adds a necessary explanation text.

This text will be removed when we will refactor the code behind which will bring many improvements.

This text is already added manually in the `docs-stable-3.0` branch in the global-envvars adoc file. 