### PR TITLE
[tests-only][full-ci]update public sharing test for zip virus file

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -94,17 +94,20 @@ Feature: antivirus
       | name        | sharedlink               |
       | permissions | change                   |
       | expireDate  | 2040-01-01T23:59:59+0100 |
-    When user "Alice" uploads file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/filesWithVirus/<filename>" to "/<newfilename>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                        |
-      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist
+      | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
-      | spaces           |
+      | dav-path-version | filename      | newfilename    |
+      | old              | eicar.com     | virusFile1.txt |
+      | old              | eicar_com.zip | virusFile2.zip |
+      | new              | eicar.com     | virusFile1.txt |
+      | new              | eicar_com.zip | virusFile2.zip |
+      | spaces           | eicar.com     | virusFile1.txt |
+      | spaces           | eicar_com.zip | virusFile2.zip |
 
 
   Scenario Outline: upload a file with the virus to a password-protected public share
@@ -116,17 +119,20 @@ Feature: antivirus
       | permissions | change                   |
       | password    | newpasswd                |
       | expireDate  | 2040-01-01T23:59:59+0100 |
-    When user "Alice" uploads file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/filesWithVirus/<filename>" to "/<newfilename>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                        |
-      | Virus found in virusFile.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-    And as "Alice" file "/uploadFolder/virusFile.txt" should not exist
+      | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Alice" file "/uploadFolder/<newfilename>" should not exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
-      | spaces           |
+      | dav-path-version | filename      | newfilename    |
+      | old              | eicar.com     | virusFile1.txt |
+      | old              | eicar_com.zip | virusFile2.zip |
+      | new              | eicar.com     | virusFile1.txt |
+      | new              | eicar_com.zip | virusFile2.zip |
+      | spaces           | eicar.com     | virusFile1.txt |
+      | spaces           | eicar_com.zip | virusFile2.zip |
 
 
   Scenario Outline: upload a file with virus to a user share


### PR DESCRIPTION
## Description
This PR modify the API tests for public link share with antivirus service.
The scenarios modify in public link PR are
- adding test with virus zip file in pubic sharing
- adding test with virus zip file in password protected user group sharing

## Related Issue
- Part of: https://github.com/owncloud/ocis/issues/6255
- test covergae for issue https://github.com/owncloud/enterprise/issues/5708

## Motivation and Context
- there was no test coverage for testing of antivirus service on public link sharing for virus zip file. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
