### PR TITLE
Fix 'decomposedfs meta set' value handling

### DIFF
--- a/ocis/pkg/command/decomposedfs.go
+++ b/ocis/pkg/command/decomposedfs.go
@@ -135,15 +135,19 @@ func setCmd(cfg *config.Config) *cli.Command {
 				b64, err := base64.StdEncoding.DecodeString(v[2:])
 				if err == nil {
 					v = string(b64)
+				} else {
+					fmt.Printf("Error decoding base64 string: '%s'. Using as raw string.\n", err)
 				}
 			} else if strings.HasPrefix(v, "0x") {
-				h, err := hex.DecodeString(v)
+				h, err := hex.DecodeString(v[2:])
 				if err == nil {
 					v = string(h)
+				} else {
+					fmt.Printf("Error decoding base64 string: '%s'. Using as raw string.\n", err)
 				}
 			}
 
-			err = backend.Set(path, c.String("attribute"), []byte(v[2:]))
+			err = backend.Set(path, c.String("attribute"), []byte(v))
 			if err != nil {
 				fmt.Println("Error setting attribute")
 				return err


### PR DESCRIPTION
Don't strip off the first two characters of the target value to set unconditionally. Also print an error if decoding hex/base64 values fails (falling back to treating the values as strings).
