### PR TITLE
Always make Name and Tags queries case-insensitive

### DIFF
--- a/services/search/pkg/engine/bleve.go
+++ b/services/search/pkg/engine/bleve.go
@@ -368,6 +368,7 @@ func formatQuery(q string) string {
 
 	fieldRe := regexp.MustCompile(`\w+:[^ ]+`)
 	if fieldRe.MatchString(cq) {
+		nameTagesRe := regexp.MustCompile(`\+?(Name|Tags)`) // detect "Name", "+Name, "Tags" and "+Tags"
 		parts := strings.Split(cq, " ")
 
 		cq = ""
@@ -376,7 +377,7 @@ func formatQuery(q string) string {
 			if len(fieldParts) > 1 {
 				key := fieldParts[0]
 				value := fieldParts[1]
-				if key == "Name" || key == "Tags" {
+				if nameTagesRe.MatchString(key) {
 					value = strings.ToLower(value) // do a lowercase query on the lowercased fields
 				}
 				cq += key + ":" + value + " "


### PR DESCRIPTION
This PR fixes a problem were `Name` and `Tags` field queries were case-sensitive in some cases.