### PR TITLE
Harmonize defaults for OCIS_LDAP_DISABLE_USER_MECHANISM envvar

### DIFF
--- a/services/auth-basic/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-basic/pkg/config/defaults/defaultconfig.go
@@ -51,7 +51,7 @@ func DefaultConfig() *config.Config {
 				UserObjectClass:          "inetOrgPerson",
 				GroupObjectClass:         "groupOfNames",
 				BindDN:                   "uid=reva,ou=sysusers,o=libregraph-idm",
-				DisableUserMechanism:     "none",
+				DisableUserMechanism:     "attribute",
 				LdapDisabledUsersGroupDN: "cn=DisabledUsersGroup,ou=groups,o=libregraph-idm",
 				IDP:                      "https://localhost:9200",
 				UserSchema: config.LDAPUserSchema{

--- a/services/users/pkg/config/defaults/defaultconfig.go
+++ b/services/users/pkg/config/defaults/defaultconfig.go
@@ -51,7 +51,7 @@ func DefaultConfig() *config.Config {
 				UserObjectClass:          "inetOrgPerson",
 				GroupObjectClass:         "groupOfNames",
 				BindDN:                   "uid=reva,ou=sysusers,o=libregraph-idm",
-				DisableUserMechanism:     "none",
+				DisableUserMechanism:     "attribute",
 				LdapDisabledUsersGroupDN: "cn=DisabledUsersGroup,ou=groups,o=libregraph-idm",
 				UserTypeAttribute:        "ownCloudUserType",
 				IDP:                      "https://localhost:9200",


### PR DESCRIPTION
Fixes: #6513 (OCIS_LDAP_DISABLE_USER_MECHANISM has no consistent defaults)

Defaults for the envvar were not used consistently, correct is `attribute`.

Changes in alignment with @rhafer, see the referenced issue.

 