### PR TITLE
[tests-only][full-ci]add test for creating a version file with virus content

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -315,7 +315,4 @@ Feature: antivirus
       | dav-path-version |
       | old              |
       | new              |
-    @skipOnRevaMaster
-    Examples:
-      | dav-path-version |
       | spaces           |

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -265,7 +265,7 @@ Feature: antivirus
       | filename      | newfilename    |
       | eicar.com     | virusFile1.txt |
       | eicar_com.zip | virusFile2.zip |
-      
+
   @env-config
   Scenario Outline: upload a file with virus smaller than the upload threshold
     Given the config "ANTIVIRUS_MAX_SCAN_SIZE" has been set to "100"
@@ -293,4 +293,29 @@ Feature: antivirus
       | dav-path-version |
       | old              |
       | new              |
+      | spaces           |
+
+  @issue-enterprise-5709
+  Scenario Outline: try to create a version of file by uploading virus content
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "hello world" to "test.txt"
+    And user "Alice" has uploaded file with content "hello nepal" to "test.txt"
+    When user "Alice" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "test.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "Alice" should get a notification with subject "Virus found" and message:
+      | message                                                                   |
+      | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And as "Alice" file "/test.txt" should exist
+    And the version folder of file "/test.txt" for user "Alice" should contain "1" element
+    And the content of file "/test.txt" for user "Alice" should be "hello nepal"
+    When user "Alice" restores version index "1" of file "/test.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/test.txt" for user "Alice" should be "hello world"
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+    @skipOnRevaMaster
+    Examples:
+      | dav-path-version |
       | spaces           |


### PR DESCRIPTION
## Description
This PR modify the API tests for antivirus service by creating version of file and uploading virus content.
The scenarios added in this PR are
- adding test with creating a version of file by uploading virus content

## Related Issue
- Part of: https://github.com/owncloud/ocis/issues/6255

## Motivation and Context
- there was no test coverage for testing of antivirus service on  creating version of file and uploading virus content

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
