### PR TITLE
[tests-only][full-ci]Throw proper ocis-wrapper connection error message

### DIFF
--- a/tests/TestHelpers/OcisConfigHelper.php
+++ b/tests/TestHelpers/OcisConfigHelper.php
@@ -22,6 +22,7 @@
 
 namespace TestHelpers;
 
+use GuzzleHttp\Exception\ConnectException;
 use TestHelpers\HttpRequestHelper;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
@@ -51,7 +52,12 @@ class OcisConfigHelper {
 			[],
 			$body
 		);
-		return $client->send($request);
+
+		try {
+			return $client->send($request);
+		} catch (ConnectException $e) {
+			throw new Error("Cannot connect to the ociswrapper at the moment, make sure that ociswrapper is running before proceeding with the test run.\n" . $e->getMessage());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds test code to throw better error messages when ocis-wrapper is not reachable during the test run.
Now the error will be thrown like this
![Screenshot from 2023-06-15 09-43-26](https://github.com/owncloud/ocis/assets/54478846/e7b13321-1bff-4656-8980-7b80ddd97e2c)

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/6315

## How Has This Been Tested?
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
