### PR TITLE
[test-only][full-ci] using graph method instead of setting in api tests

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -221,7 +221,7 @@ Feature: antivirus
 
   Scenario Outline: upload a file with virus to a project space
     Given using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
     And user "Alice" has created a folder "uploadFolder" in space "new-space"
     When user "Alice" uploads a file "filesForUpload/filesWithVirus/<filename>" to "/uploadFolder/<newfilename>" in space "new-space" using the WebDAV API
@@ -247,7 +247,7 @@ Feature: antivirus
   Scenario Outline: upload a file with virus to a shared project space
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
     And user "Alice" has shared a space "new-space" with settings:
       | shareWith | Brian  |

--- a/tests/acceptance/features/apiContract/copy.feature
+++ b/tests/acceptance/features/apiContract/copy.feature
@@ -10,7 +10,7 @@ Feature: Copy test
       | username |
       | Alice    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
 
 

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -10,7 +10,7 @@ Feature: Propfind test
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
 
 

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -13,7 +13,7 @@ Feature: Report test
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "find data" with the default quota using the GraphApi
     And user "Alice" has created a folder "folderMain/SubFolder1/subFOLDER2" in space "find data"
     And user "Alice" has uploaded a file inside space "find data" with content "some content" to "folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt"

--- a/tests/acceptance/features/apiGraph/addUserToGroup.feature
+++ b/tests/acceptance/features/apiGraph/addUserToGroup.feature
@@ -121,7 +121,7 @@ Feature: add users to group
 
   @issue-5938
   Scenario Outline: user other than the admin tries to add herself to a group
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     And group "groupA" has been created
     When user "Alice" tries to add herself to group "groupA" using the Graph API
     Then the HTTP status code should be "403"
@@ -155,7 +155,7 @@ Feature: add users to group
   @issue-5938
   Scenario Outline: user other than the admin tries to add other user to a group
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "groupA" has been created
     When user "Alice" tries to add user "Brian" to group "groupA" using the Graph API
     Then the HTTP status code should be "403"
@@ -194,7 +194,7 @@ Feature: add users to group
   @issue-5939
   Scenario Outline: user other than the admin tries to add user to a nonexistent group
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When the user "Alice" tries to add user "Brian" to a nonexistent group using the Graph API
     Then the HTTP status code should be "404"
     Examples:
@@ -216,7 +216,7 @@ Feature: add users to group
 
 
   Scenario: add multiple users to a group at once
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -234,7 +234,7 @@ Feature: add users to group
 
 
   Scenario: admin tries to add users to a nonexistent group at once
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -247,7 +247,7 @@ Feature: add users to group
 
 
   Scenario: admin tries to add multiple nonexistent users to a group at once
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has created a group "grp1" using the Graph API
     When the administrator "Alice" tries to add the following nonexistent users to a group "grp1" at once using the Graph API
       | username |
@@ -257,7 +257,7 @@ Feature: add users to group
 
 
   Scenario: admin tries to add nonexistent and existing users to a group at once
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -284,7 +284,7 @@ Feature: add users to group
 
   @issue-5702
   Scenario: try to add users to a group twice
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -306,7 +306,7 @@ Feature: add users to group
 
   @issue-5793
   Scenario: try to add a group to another group with PATCH request
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -320,7 +320,7 @@ Feature: add users to group
 
   @issue-5793
   Scenario: try to add a group to another group with POST request
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -334,7 +334,7 @@ Feature: add users to group
 
 
   Scenario Outline: admin tries to add a user to a group with invalid JSON
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -349,7 +349,7 @@ Feature: add users to group
 
 
   Scenario Outline: admin tries to add multiple users to a group at once with invalid JSON
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -368,7 +368,7 @@ Feature: add users to group
 
   @issue-5871
   Scenario: admin tries to add multiple users with wrong host
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -382,7 +382,7 @@ Feature: add users to group
 
   @issue-5871
   Scenario: admin tries to add single user with wrong host
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -392,7 +392,7 @@ Feature: add users to group
 
 
   Scenario Outline: try to add invalid user id to a group
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has created a group "grp1" using the Graph API
     When the administrator "Alice" tries to add an invalid user id "<invalid-uuidv4>" to a group "grp1" using the Graph API
     Then the HTTP status code should be "404"
@@ -404,7 +404,7 @@ Feature: add users to group
 
 
   Scenario Outline: try to add invalid user ids to a group at once
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has created a group "grp1" using the Graph API
     When the administrator "Alice" tries to add the following invalid user ids to a group "grp1" at once using the Graph API
       | user-id          |
@@ -419,7 +419,7 @@ Feature: add users to group
 
   @issue-5855
   Scenario: add same user twice to a group at once
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |

--- a/tests/acceptance/features/apiGraph/assignRole.feature
+++ b/tests/acceptance/features/apiGraph/assignRole.feature
@@ -35,7 +35,7 @@ Feature: assign role
 
   Scenario Outline: assign role to the user with setting api and list role with graph api
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "<userRole>" using the settings api
+    And the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
     When the administrator retrieves the assigned role of user "Alice" using the Graph API
     Then the HTTP status code should be "200"
     And the Graph API response should have the role "<userRole>"

--- a/tests/acceptance/features/apiGraph/createGroup.feature
+++ b/tests/acceptance/features/apiGraph/createGroup.feature
@@ -6,7 +6,7 @@ Feature: create group
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
 
 
   Scenario Outline: admin user creates a group
@@ -34,7 +34,7 @@ Feature: create group
   @issue-5938
   Scenario Outline: user other than the admin can't create a group
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    And the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     When user "Brian" tries to create a group "mygroup" using the Graph API
     Then the HTTP status code should be "403"
     And group "mygroup" should not exist

--- a/tests/acceptance/features/apiGraph/createUser.feature
+++ b/tests/acceptance/features/apiGraph/createUser.feature
@@ -12,7 +12,7 @@ Feature: create user
 
   @issue-3516
   Scenario Outline: admin creates a user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When the user "Alice" creates a new user using GraphAPI with the following settings:
       | userName       | <userName>    |
       | displayName    | <displayName> |
@@ -42,7 +42,7 @@ Feature: create user
 
 
   Scenario: user cannot be created with empty name
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When the user "Alice" creates a new user using GraphAPI with the following settings:
       | userName       |              |
       | displayName    | emptyName    |
@@ -53,7 +53,7 @@ Feature: create user
 
 
   Scenario Outline: user without admin right cannot create a user
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When the user "Alice" creates a new user using GraphAPI with the following settings:
       | userName       | user         |
       | displayName    | user         |
@@ -71,7 +71,7 @@ Feature: create user
 
   Scenario: user cannot be created with the name of the disabled user
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And the user "Alice" has disabled user "Brian" using the Graph API
     When the user "Alice" creates a new user using GraphAPI with the following settings:
       | userName       | Brian                 |
@@ -84,7 +84,7 @@ Feature: create user
   @skipOnStable2.0
   Scenario: user can be created with the name of the deleted user
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And the user "Alice" has deleted a user "Brian" using the Graph API
     When the user "Alice" creates a new user using GraphAPI with the following settings:
       | userName       | Brian                 |

--- a/tests/acceptance/features/apiGraph/deleteGroup.feature
+++ b/tests/acceptance/features/apiGraph/deleteGroup.feature
@@ -6,7 +6,7 @@ Feature: delete groups
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
 
 
   Scenario Outline: admin user deletes a group
@@ -53,7 +53,7 @@ Feature: delete groups
   @issue-5938
   Scenario Outline: user other than the admin can't delete a group
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "new-group" has been created
     When user "Brian" tries to delete group "new-group" using the Graph API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiGraph/deleteUser.feature
+++ b/tests/acceptance/features/apiGraph/deleteUser.feature
@@ -12,7 +12,7 @@ Feature: delete user
 
 
   Scenario Outline: admin user deletes a user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | <userName>    |
       | displayName | <displayName> |
@@ -30,7 +30,7 @@ Feature: delete user
 
   Scenario: delete a user and specify the user name in different case
     Given user "brand-new-user" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When the user "Alice" deletes a user "Brand-New-User" using the Graph API
     Then the HTTP status code should be "204"
     And user "brand-new-user" should not exist
@@ -38,8 +38,8 @@ Feature: delete user
 
   Scenario Outline: admin user deletes another user with different role
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     When the user "Alice" deletes a user "Brian" using the Graph API
     Then the HTTP status code should be "204"
     And user "Brian" should not exist
@@ -52,14 +52,14 @@ Feature: delete user
 
 
   Scenario: admin user tries to delete his/her own account
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When the user "Alice" deletes a user "Alice" using the Graph API
     Then the HTTP status code should be "403"
     And user "Alice" should exist
 
 
   Scenario Outline: non-admin user tries to delete his/her own account
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When the user "Alice" deletes a user "Alice" using the Graph API
     Then the HTTP status code should be "401"
     And user "Alice" should exist
@@ -71,13 +71,13 @@ Feature: delete user
 
 
   Scenario: admin user tries to delete a nonexistent user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When the user "Alice" tries to delete a nonexistent user using the Graph API
     Then the HTTP status code should be "404"
 
 
   Scenario Outline: non-admin user tries to delete a nonexistent user
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When the user "Alice" tries to delete a nonexistent user using the Graph API
     Then the HTTP status code should be "401"
     Examples:
@@ -89,8 +89,8 @@ Feature: delete user
 
   Scenario Outline: non-admin user tries to delete another user with different role
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
-    And the administrator has given "Alice" the role "<userRole>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
+    And the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
     When the user "Alice" deletes a user "Brian" using the Graph API
     Then the HTTP status code should be "401"
     And user "Brian" should exist
@@ -111,7 +111,7 @@ Feature: delete user
 
 
   Scenario: admin user deletes a disabled user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Brian" has been created with default attributes and without skeleton files
     And the user "Alice" has disabled user "Brian" using the Graph API
     When the user "Alice" deletes a user "Brian" using the Graph API
@@ -120,11 +120,11 @@ Feature: delete user
 
 
   Scenario Outline: normal user tries to delete a disabled user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
-    And the administrator has given "Carol" the role "<userRole>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
+    And the administrator has assigned the role "<userRole>" to user "Carol" using the Graph API
     And the user "Alice" has disabled user "Brian" using the Graph API
     When the user "Carol" deletes a user "Brian" using the Graph API
     Then the HTTP status code should be "401"

--- a/tests/acceptance/features/apiGraph/editGroup.feature
+++ b/tests/acceptance/features/apiGraph/editGroup.feature
@@ -6,7 +6,7 @@ Feature: edit group name
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
 
   @issue-5977
   Scenario Outline: admin user renames a group
@@ -26,7 +26,7 @@ Feature: edit group name
 
   @issue-5938
   Scenario Outline: user other than the admin can't rename a group
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     And group "grp1" has been created
     When user "Alice" tries to rename group "grp1" to "grp101" using the Graph API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiGraph/editUser.feature
+++ b/tests/acceptance/features/apiGraph/editUser.feature
@@ -9,7 +9,7 @@ Feature: edit user
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | Brian             |
       | displayName | Brian Murphy      |
@@ -124,7 +124,7 @@ Feature: edit user
 
 
   Scenario Outline: normal user should not be able to change their email address
-    Given the administrator has given "Brian" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     When the user "Brian" tries to change the email of user "Brian" to "newemail@example.com" using the Graph API
     Then the HTTP status code should be "401"
     And the user information of "Brian" should match this JSON schema
@@ -150,13 +150,13 @@ Feature: edit user
 
 
   Scenario Outline: normal user should not be able to edit another user's email
-    Given the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     And the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | Carol             |
       | displayName | Carol King        |
       | email       | carol@example.com |
       | password    | 1234              |
-    And the administrator has given "Carol" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Carol" using the Graph API
     When the user "Brian" tries to change the email of user "Carol" to "newemail@example.com" using the Graph API
     Then the HTTP status code should be "401"
     And the user information of "Carol" should match this JSON schema
@@ -217,7 +217,7 @@ Feature: edit user
 
 
   Scenario Outline: normal user should not be able to change his/her own display name
-    Given the administrator has given "Brian" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     When the user "Brian" tries to change the display name of user "Brian" to "Brian Murphy" using the Graph API
     Then the HTTP status code should be "401"
     And the user information of "Alice" should match this JSON schema
@@ -243,13 +243,13 @@ Feature: edit user
 
 
   Scenario Outline: normal user should not be able to edit another user's display name
-    Given the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     And the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | Carol             |
       | displayName | Carol King        |
       | email       | carol@example.com |
       | password    | 1234              |
-    And the administrator has given "Carol" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Carol" using the Graph API
     When the user "Brian" tries to change the display name of user "Carol" to "Alice Hansen" using the Graph API
     Then the HTTP status code should be "401"
     And the user information of "Carol" should match this JSON schema
@@ -291,13 +291,13 @@ Feature: edit user
 
 
   Scenario Outline: normal user should not be able to reset the password of another user
-    Given the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     And the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | Carol             |
       | displayName | Carol King        |
       | email       | carol@example.com |
       | password    | 1234              |
-    And the administrator has given "Carol" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Carol" using the Graph API
     And user "Carol" has uploaded file with content "test file for reset password" to "/resetpassword.txt"
     When the user "Brian" resets the password of user "Carol" to "newpassword" using the Graph API
     Then the HTTP status code should be "401"
@@ -363,7 +363,7 @@ Feature: edit user
   @skipOnStable2.0
   Scenario Outline: normal user should not be able to disable another user
     Given user "Carol" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     When the user "Brian" tries to disable user "Carol" using the Graph API
     Then the HTTP status code should be "401"
     When user "Alice" gets information of user "Carol" using Graph API
@@ -456,7 +456,7 @@ Feature: edit user
   Scenario Outline: normal user should not be able to enable another user
     Given user "Carol" has been created with default attributes and without skeleton files
     And the user "Alice" has disabled user "Carol" using the Graph API
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     When the user "Brian" tries to enable user "Carol" using the Graph API
     Then the HTTP status code should be "401"
     When user "Alice" gets information of user "Carol" using Graph API

--- a/tests/acceptance/features/apiGraph/getApplications.feature
+++ b/tests/acceptance/features/apiGraph/getApplications.feature
@@ -9,7 +9,7 @@ Feature: get applications
 
 
   Scenario Outline: admin user lists all the groups
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When user "Alice" gets all applications using the Graph API
     Then the HTTP status code should be "200"
     And the user API response should contain the following application information:

--- a/tests/acceptance/features/apiGraph/getGroup.feature
+++ b/tests/acceptance/features/apiGraph/getGroup.feature
@@ -6,9 +6,9 @@ Feature: get groups and their members
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Admin" using the settings api
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
 
-
+  
   Scenario: admin user lists all the groups
     Given group "tea-lover" has been created
     And group "coffee-lover" has been created
@@ -23,7 +23,7 @@ Feature: get groups and their members
   @issue-5938
   Scenario Outline: user other than the admin shouldn't get the groups list
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "tea-lover" has been created
     And group "coffee-lover" has been created
     And group "h2o-lover" has been created
@@ -74,7 +74,7 @@ Feature: get groups and their members
   @issue-5938
   Scenario Outline: user other than the admin shouldn't get users of a group
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "tea-lover" has been created
     When user "Brian" gets all the members of group "tea-lover" using the Graph API
     Then the HTTP status code should be "403"
@@ -235,7 +235,7 @@ Feature: get groups and their members
   @issue-5938
   Scenario Outline: user other than the admin shouldn't get all groups along with its member's information
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "tea-lover" has been created
     And group "coffee-lover" has been created
     And user "Alice" has been added to group "tea-lover"
@@ -350,7 +350,7 @@ Feature: get groups and their members
   @issue-5604
   Scenario Outline: user other than the admin gets a group along with its member's information
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "tea-lover" has been created
     And user "Alice" has been added to group "tea-lover"
     And user "Brian" has been added to group "tea-lover"

--- a/tests/acceptance/features/apiGraph/getUser.feature
+++ b/tests/acceptance/features/apiGraph/getUser.feature
@@ -12,7 +12,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets the information of a user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When user "Alice" gets information of user "Brian" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -53,8 +53,8 @@ Feature: get users
 
   @issue-5125
   Scenario Outline: non-admin user tries to get the information of a user
-    Given the administrator has given "Alice" the role "<role>" using the settings api
-    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     When user "Brian" tries to get information of user "Alice" using Graph API
     Then the HTTP status code should be "401"
     And the JSON data of the response should match
@@ -95,7 +95,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets all users
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When user "Alice" gets all users using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should contain the user "Alice Hansen" in the item 'value', the user-details should match
@@ -161,7 +161,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets all users include disabled users
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And the user "Alice" has disabled user "Brian" using the Graph API
     When user "Alice" gets all users using the Graph API
     Then the HTTP status code should be "200"
@@ -228,7 +228,7 @@ Feature: get users
 
 
   Scenario Outline: non-admin user tries to get all users
-    Given the administrator has given "Alice" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
     When user "Brian" tries to get all users using the Graph API
     Then the HTTP status code should be "401"
     And the JSON data of the response should match
@@ -260,7 +260,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets the drive information of a user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When the user "Alice" gets user "Brian" along with his drive information using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -383,7 +383,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario Outline: non-admin user gets his/her own drive information
-    Given the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     When the user "Brian" gets his drive information using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -511,7 +511,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets the group information of a user
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And group "tea-lover" has been created
     And group "coffee-lover" has been created
     And user "Brian" has been added to group "tea-lover"
@@ -575,8 +575,8 @@ Feature: get users
 
   @issue-5125
   Scenario Outline: non-admin user tries to get the group information of a user
-    Given the administrator has given "Alice" the role "<userRole>" using the settings api
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "coffee-lover" has been created
     And user "Brian" has been added to group "coffee-lover"
     When the user "Alice" gets user "Brian" along with his group information using Graph API
@@ -619,7 +619,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets all users of certain groups
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Carol" has been created with default attributes and without skeleton files
     And the user "Alice" has disabled user "Carol" using the Graph API
     And group "tea-lover" has been created
@@ -753,7 +753,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets all users of two groups
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Carol" has been created with default attributes and without skeleton files
     And group "tea-lover" has been created
     And group "coffee-lover" has been created
@@ -827,8 +827,8 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario Outline: non admin user tries to get users of certain groups
-    Given the administrator has given "Alice" the role "Admin" using the settings api
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "tea-lover" has been created
     And user "Alice" has been added to group "tea-lover"
     When the user "Brian" gets all users of the group "tea-lover" using the Graph API
@@ -862,10 +862,10 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario: admin user gets all users with certain roles and members of a certain group
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Carol" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "Space Admin" using the settings api
-    And the administrator has given "Carol" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Carol" using the Graph API
     And group "tea-lover" has been created
     And user "Brian" has been added to group "tea-lover"
     When the user "Alice" gets all users with role "Space Admin" using the Graph API
@@ -967,7 +967,7 @@ Feature: get users
 
   @skipOnStable2.0
   Scenario Outline: non-admin user tries to get users with a certain role
-    Given the administrator has given "Alice" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
     When the user "Alice" gets all users with role "<role>" using the Graph API
     Then the HTTP status code should be "401"
     And the JSON data of the response should match

--- a/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
+++ b/tests/acceptance/features/apiGraph/removeUserFromGroup.feature
@@ -159,7 +159,7 @@ Feature: remove a user from a group
   @issue-5938
   Scenario Outline: user other than the admin can't remove a user from their group
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -496,8 +496,8 @@ Feature: user GDPR (General Data Protection Regulation) report
 
   Scenario Outline: user tries to generate GDPR report of other users
     Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "<userRole>" using the settings api
-    And the administrator has given "Brian" the role "<role>" using the settings api
+    And the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     When user "Alice" tries to export GDPR report of user "Brian" to "/.personal_data_export.json" using Graph API
     Then the HTTP status code should be "400"
     Examples:

--- a/tests/acceptance/features/apiNotification/emailNotification.feature
+++ b/tests/acceptance/features/apiNotification/emailNotification.feature
@@ -12,7 +12,7 @@ Feature: Email notification
 
 
   Scenario: user gets an email notification when someone shares a project space
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
     When user "Alice" shares a space "new-space" with settings:
       | shareWith | Brian  |

--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -10,7 +10,7 @@ Feature: Notification
       | Alice    |
       | Brian    |
       | Carol    |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "notification checking" with the default quota using the GraphApi
 
 

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -13,7 +13,7 @@ Feature: Change data of space
       | Alice    |
       | Brian    |
       | Bob      |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
     And user "Alice" has shared a space "Project Jupiter" with settings:
       | shareWith | Brian  |
@@ -509,7 +509,7 @@ Feature: Change data of space
 
 
   Scenario Outline: user can't upload resource greater than set quota
-    Given the administrator has given "Alice" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
     And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "15"
     When user "Alice" uploads a file inside space "Alice Hansen" with content "file is more than 15 bytes" to "file.txt" using the WebDAV API
     Then the HTTP status code should be "507"

--- a/tests/acceptance/features/apiSpaces/createSpace.feature
+++ b/tests/acceptance/features/apiSpaces/createSpace.feature
@@ -9,7 +9,7 @@ Feature: create space
 
   @issue-5938
   Scenario Outline: user with role user and user light can't create space via Graph API
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When user "Alice" tries to create a space "Project Mars" of type "project" with the default quota using the Graph API
     Then the HTTP status code should be "403"
     And the user "Alice" should not have a space called "share space"
@@ -20,7 +20,7 @@ Feature: create space
 
 
   Scenario Outline: admin or space admin user can create a space via the Graph API with a default quota
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When user "Alice" creates a space "Project Mars" of type "project" with the default quota using the Graph API
     Then the HTTP status code should be "201"
     And the JSON response should contain space called "Project Mars" and match
@@ -91,7 +91,7 @@ Feature: create space
 
 
   Scenario Outline: admin or space admin user can create a space via the Graph API with certain quota
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When user "Alice" creates a space "Project Venus" of type "project" with quota "2000" using the Graph API
     Then the HTTP status code should be "201"
     And the JSON response should contain space called "Project Venus" and match

--- a/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
@@ -14,7 +14,7 @@ Feature: Disabling and deleting space
       | Brian    |
       | Bob      |
       | Carol    |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project Moon" with the default quota using the GraphApi
     And user "Alice" has shared a space "Project Moon" with settings:
       | shareWith | Brian  |
@@ -25,7 +25,7 @@ Feature: Disabling and deleting space
 
 
   Scenario Outline: user can disable their own space via the Graph API
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When user "Alice" disables a space "Project Moon"
     Then the HTTP status code should be "204"
     And the user "Brian" should not have a space called "Project Moon"
@@ -39,7 +39,7 @@ Feature: Disabling and deleting space
 
 
   Scenario Outline: user with role user and user light cannot disable other space via the Graph API
-    Given the administrator has given "Carol" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Carol" using the Graph API
     When user "Carol" tries to disable a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "404"
     And the user "Brian" should have a space called "Project Moon"
@@ -61,7 +61,7 @@ Feature: Disabling and deleting space
 
 
   Scenario Outline: user cannot delete their own space without first disabling it
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When user "Alice" deletes a space "Project Moon"
     Then the HTTP status code should be "400"
     And the user "Alice" should have a space called "Project Moon"
@@ -74,7 +74,7 @@ Feature: Disabling and deleting space
 
 
   Scenario Outline: user can delete their own disabled space via the Graph API
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     And user "Alice" has disabled a space "Project Moon"
     When user "Alice" deletes a space "Project Moon"
     Then the HTTP status code should be "204"
@@ -88,7 +88,7 @@ Feature: Disabling and deleting space
 
 
   Scenario Outline: an admin and space manager can disable other space via the Graph API
-    Given the administrator has given "Carol" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Carol" using the Graph API
     When user "Carol" disables a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "204"
     And the user "Carol" should not have a space called "Project Moon"
@@ -99,7 +99,7 @@ Feature: Disabling and deleting space
 
 
   Scenario Outline: an admin and space manager can delete other disabled Space
-    Given the administrator has given "Carol" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Carol" using the Graph API
     And user "Alice" has disabled a space "Project Moon"
     When user "Carol" deletes a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "204"
@@ -112,7 +112,7 @@ Feature: Disabling and deleting space
 
 
   Scenario Outline: user with role user and user light cannot delete others disabled space via the Graph API
-    Given the administrator has given "Carol" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Carol" using the Graph API
     And user "Alice" has disabled a space "Project Moon"
     When user "Carol" tries to delete a space "Project Moon" owned by user "Alice"
     Then the HTTP status code should be "404"

--- a/tests/acceptance/features/apiSpaces/download.feature
+++ b/tests/acceptance/features/apiSpaces/download.feature
@@ -14,7 +14,7 @@ Feature: Download file in project space
       | Brian    |
       | Bob      |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "download file" with the default quota using the GraphApi
     And user "Alice" has uploaded a file inside space "download file" with content "some content" to "file.txt"
     And user "Alice" has shared a space "download file" with settings:

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -15,7 +15,7 @@ Feature: A manager of the space can edit public link
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "edit space" with the default quota using the GraphApi
     And user "Alice" has created a public link share of the space "edit space" with settings:
       | permissions | 1                        |

--- a/tests/acceptance/features/apiSpaces/filePreviews.feature
+++ b/tests/acceptance/features/apiSpaces/filePreviews.feature
@@ -11,7 +11,7 @@ Feature: Preview file in project space
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "previews of the files" with the default quota using the GraphApi
     And using spaces DAV path
 

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -150,7 +150,7 @@ Feature: List and create spaces
 
 
   Scenario: ordinary user will not see any space when using a filter for project
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "my project" of type "project" with quota "20"
     When user "Alice" lists all available spaces via the GraphApi with query "$filter=driveType eq 'project'"
     Then the HTTP status code should be "200"
@@ -289,7 +289,7 @@ Feature: List and create spaces
 
 
   Scenario Outline: user can list his created spaces via multiple endpoints
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     When user "Alice" creates a space "Project Venus" of type "project" with quota "2000" using the Graph API
     Then the HTTP status code should be "201"
     And the JSON response should contain space called "Project Venus" and match
@@ -419,7 +419,7 @@ Feature: List and create spaces
 
 
   Scenario Outline: user cannot list space by id if he is not member of the space
-    Given the administrator has given "Alice" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
     And user "Admin" has created a space "Project Venus" with the default quota using the GraphApi
     When user "Alice" tries to look up the single space "Project Venus" owned by the user "Admin" by using its id
     Then the HTTP status code should be "404"

--- a/tests/acceptance/features/apiSpaces/publicLink.feature
+++ b/tests/acceptance/features/apiSpaces/publicLink.feature
@@ -6,7 +6,7 @@ Feature: public link for a space
       | username |
       | Alice    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "public space" with the default quota using the GraphApi
     And user "Alice" has created a public link share of the space "public space" with settings:
       | permissions | 1 |

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -16,7 +16,7 @@ Feature: State of the quota
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And using spaces DAV path
 
 
@@ -135,7 +135,7 @@ Feature: State of the quota
   Scenario: try to create a space with quota greater than OCIS spaces max quota
     Given the config "OCIS_SPACES_MAX_QUOTA" has been set to "50"
     And user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has given "Brian" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     When user "Brian" tries to create a space "new space" of type "project" with quota "51" using the Graph API
     Then the HTTP status code should be "400"
     And the user "Brian" should not have a space called "new space"

--- a/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
@@ -13,7 +13,7 @@ Feature: Remove files, folder
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "delete objects" with the default quota using the GraphApi
     And user "Alice" has created a folder "folderForDeleting/sub1/sub2" in space "delete objects"
     And user "Alice" has uploaded a file inside space "delete objects" with content "some content" to "text.txt"

--- a/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaceObjects.feature
@@ -15,7 +15,7 @@ Feature: Restore files, folder
       | Bob      |
       | Carol    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "restore objects" with the default quota using the GraphApi
     And user "Alice" has created a folder "newFolder" in space "restore objects"
     And user "Alice" has uploaded a file inside space "restore objects" with content "test" to "newFolder/file.txt"

--- a/tests/acceptance/features/apiSpaces/restoreSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaces.feature
@@ -13,7 +13,7 @@ Feature: Restoring space
       | Alice    |
       | Brian    |
       | Bob      |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "restore a space" of type "project" with quota "10"
     And using spaces DAV path
 
@@ -73,7 +73,7 @@ Feature: Restoring space
 
 
   Scenario Outline: user with role user and user light cannot restore space
-    Given the administrator has given "Brian" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And user "Alice" has disabled a space "restore a space"
     When user "Brian" tries to restore a disabled space "restore a space" owned by user "Alice"
     Then the HTTP status code should be "404"
@@ -84,7 +84,7 @@ Feature: Restoring space
 
   @issue-5872
   Scenario Outline: admin and space admin can restore other space
-    Given the administrator has given "Brian" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And user "Alice" has disabled a space "restore a space"
     When user "Brian" restores a disabled space "restore a space" owned by user "Alice"
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSpaces/search.feature
+++ b/tests/acceptance/features/apiSpaces/search.feature
@@ -13,7 +13,7 @@ Feature: Search
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "find data" with the default quota using the GraphApi
     And user "Alice" has created a folder "folderMain/SubFolder1/subFOLDER2" in space "find data"
     And user "Alice" has uploaded a file inside space "find data" with content "some content" to "folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt"

--- a/tests/acceptance/features/apiSpaces/setQuota.feature
+++ b/tests/acceptance/features/apiSpaces/setQuota.feature
@@ -12,8 +12,8 @@ Feature: Set quota
 
 
   Scenario Outline: admin sets personal space quota of user with different role
-    Given the administrator has given "Alice" the role "Admin" using the settings api
-    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     When user "Alice" changes the quota of the "Brian Murphy" space to "100" owned by user "Brian"
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -48,8 +48,8 @@ Feature: Set quota
 
 
   Scenario Outline: non-admin user tries to set the personal space quota of other users
-    Given the administrator has given "Alice" the role "<role>" using the settings api
-    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     When user "Alice" changes the quota of the "Brian Murphy" space to "100" owned by user "Brian"
     Then the HTTP status code should be "403"
     Examples:
@@ -69,8 +69,8 @@ Feature: Set quota
 
 
   Scenario Outline: admin or space admin user sets a quota of a project space
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
-    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
     When user "Brian" changes the quota of the "Project Jupiter" space to "100" owned by user "Alice"
     Then the HTTP status code should be "200"
@@ -109,8 +109,8 @@ Feature: Set quota
 
 
   Scenario Outline: normal or user light user tries to set quota of a space
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
-    And the administrator has given "Brian" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
     And user "Alice" has shared a space "Project Jupiter" with settings:
       | shareWith | Brian       |
@@ -128,7 +128,7 @@ Feature: Set quota
 
 
   Scenario: admin user can set their own personal space quota
-    Given the administrator has given "Alice" the role "Admin" using the settings api
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When user "Alice" changes the quota of the "Alice Hansen" space to "100" owned by user "Alice"
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -157,7 +157,7 @@ Feature: Set quota
 
 
   Scenario Outline: non-admin user tries to set their own personal space quota
-    Given the administrator has given "Alice" the role "<userRole>" using the settings api
+    Given the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
     When user "Alice" changes the quota of the "Alice Hansen" space to "100" owned by user "Alice"
     Then the HTTP status code should be "403"
     Examples:

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -17,8 +17,8 @@ Feature: Space management
       | Brian    |
       | Carol    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
-    And the administrator has given "Brian" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Alice" has created a space "Project" of type "project" with quota "10"
 
 

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -13,7 +13,7 @@ Feature: Tag
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "use-tag" with the default quota using the GraphApi
     And user "Alice" has created a folder "folderMain" in space "use-tag"
     And user "Alice" has uploaded a file inside space "use-tag" with content "some content" to "folderMain/insideTheFolder.txt"

--- a/tests/acceptance/features/apiSpaces/tusUpload.feature
+++ b/tests/acceptance/features/apiSpaces/tusUpload.feature
@@ -8,7 +8,7 @@ Feature: upload resources using TUS protocol
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And using spaces DAV path
 
 

--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -13,7 +13,7 @@ Feature: Upload files into a space
       | Alice    |
       | Brian    |
       | Bob      |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project Ceres" of type "project" with quota "2000"
     And using spaces DAV path
 

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -13,7 +13,7 @@ Feature: copy file
 
 
   Scenario Outline: copying a file within a same project space with role manager and editor
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/insideSpace.txt"
@@ -32,7 +32,7 @@ Feature: copy file
 
 
   Scenario: copying a file within a same project space with role viewer
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
@@ -46,7 +46,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from a project space with a different role to a project space with the manager role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi
     And user "Brian" has created a space "Project2" with the default quota using the GraphApi
     And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "/project1.txt"
@@ -70,7 +70,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from a project space with a different role to a project space with a viewer role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi
     And user "Brian" has created a space "Project2" with the default quota using the GraphApi
     And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "/project1.txt"
@@ -91,7 +91,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from project space with different role to personal space
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
     And user "Brian" has shared a space "Project" with settings:
@@ -110,7 +110,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from project space with different role to share space with editor role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
@@ -132,7 +132,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from project space with different role to Shares with viewer role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
@@ -153,7 +153,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from personal space to project space with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -171,7 +171,7 @@ Feature: copy file
 
 
   Scenario: user copies a file from personal space to project space with role viewer
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -207,7 +207,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from share space with different role to personal space
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
@@ -224,7 +224,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from share space with different role to project space with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -247,7 +247,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a file from share space with different role to project space with role viewer
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -309,7 +309,7 @@ Feature: copy file
 
 
   Scenario Outline: copying a folder within the same project space with different role
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
     And user "Alice" has created a folder "/folder1" in space "Project"
     And user "Alice" has created a folder "/folder2" in space "Project"
@@ -329,7 +329,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a folder from a project space with different role to a project space with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi
     And user "Brian" has created a space "Project2" with the default quota using the GraphApi
     And user "Brian" has created a folder "/folder1" in space "Project1"
@@ -356,7 +356,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a folder from project space with different role to personal space
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created a folder "/folder1" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "/folder1/demo.txt"
@@ -375,7 +375,7 @@ Feature: copy file
 
 
   Scenario Outline: Uuer copies a folder from project space with different role to share space with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a folder "/folder1" in space "Project"
@@ -400,7 +400,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a folder from personal space to project space with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -435,7 +435,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a folder from share space with different role to personal space
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
     And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
@@ -452,7 +452,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a folder from share space with different role to project space with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -475,7 +475,7 @@ Feature: copy file
 
 
   Scenario Outline: user copies a folder from share space with different role to project space with role viewer
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -736,7 +736,7 @@ Feature: copy file
 
 
   Scenario: copying a file with an option "keep both" inside of the project space
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/newfolder/insideSpace.txt"
@@ -750,7 +750,7 @@ Feature: copy file
 
   @issue-4797
   Scenario: copying a file with an option "replace" inside of the project space
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "old content version 1" to "/newfolder/insideSpace.txt"
@@ -769,7 +769,7 @@ Feature: copy file
 
 
   Scenario: copying a file from Personal to Shares with an option "keep both"
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/newfolder/personal.txt"
@@ -791,7 +791,7 @@ Feature: copy file
 
 
   Scenario: copying a file from Personal to Shares with an option "replace"
-    Given the administrator has given "Alice" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project" with the default quota using the GraphApi
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "old content version 1" to "/newfolder/personal.txt"

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -13,7 +13,7 @@ Feature: move (rename) file
 
 
   Scenario Outline: moving a file within same space project with role manager and editor
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created a folder "newfolder" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
@@ -33,7 +33,7 @@ Feature: move (rename) file
 
 
   Scenario: moving a file within same space project with role viewer
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created a folder "newfolder" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
@@ -49,7 +49,7 @@ Feature: move (rename) file
 
 
   Scenario Outline: user moves a file from a space project with different a role to a space project with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project1" with the default quota using the GraphApi
     And user "Brian" has created a space "Project2" with the default quota using the GraphApi
     And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "project1.txt"
@@ -79,7 +79,7 @@ Feature: move (rename) file
 
 
   Scenario Outline: user moves a file from a space project with different role to a space personal
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "project.txt"
     And user "Brian" has shared a space "Project" with settings:
@@ -99,7 +99,7 @@ Feature: move (rename) file
 
 
   Scenario Outline: user moves a file from space project with different role to space Shares with different role (permission)
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "project.txt"
@@ -125,7 +125,7 @@ Feature: move (rename) file
 
 
   Scenario Outline: user moves a file from space personal to space project with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |
@@ -181,7 +181,7 @@ Feature: move (rename) file
 
 
   Scenario Outline: user moves a file from space Shares with different role (permissions) to space project with different role
-    Given the administrator has given "Brian" the role "Space Admin" using the settings api
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the GraphApi
     And user "Brian" has shared a space "Project" with settings:
       | shareWith | Alice  |

--- a/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
+++ b/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
@@ -10,7 +10,7 @@ Feature: Public can download folders from project space public link
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API 
     And user "Alice" has created a space "new-space" with the default quota using the GraphApi
 
 

--- a/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
@@ -13,7 +13,7 @@ Feature: Share spaces
       | Alice    |
       | Brian    |
       | Bob      |
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "share space" with the default quota using the GraphApi
     And using spaces DAV path
 
@@ -438,7 +438,7 @@ Feature: Share spaces
 
 
   Scenario Outline: user cannot share the personal space to an other user
-    Given the administrator has given "Brian" the role "<role>" using the settings api
+    Given the administrator has assigned the role "<role>" to user "Brian" using the Graph API
     And user "Brian" shares a space "Brian Murphy" with settings:
       | shareWith | Bob    |
       | role      | viewer |

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -13,7 +13,7 @@ Feature: Share spaces via link
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "share space" with the default quota using the GraphApi
     And user "Alice" has uploaded a file inside space "share space" with content "some content" to "test.txt"
 

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
@@ -14,7 +14,7 @@ Feature: Share a file or folder that is inside a space
       | Brian    |
       | Bob      |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "share sub-item" with the default quota using the GraphApi
     And user "Alice" has created a folder "folder" in space "share sub-item"
     And user "Alice" has uploaded a file inside space "share sub-item" with content "some content" to "file.txt"

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
@@ -27,7 +27,7 @@ Feature: Share a file or folder that is inside a space via public link
       | Alice    |
       | Brian    |
     And using spaces DAV path
-    And the administrator has given "Alice" the role "Space Admin" using the settings api
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "share sub-item" with the default quota using the GraphApi
     And user "Alice" has created a folder "folder" in space "share sub-item"
     And user "Alice" has uploaded a file inside space "share sub-item" with content "some content" to "folder/file.txt"


### PR DESCRIPTION
related https://github.com/owncloud/ocis/issues/6524 
I switched api test to using `And the administrator has assigned the role "Admin" to user "Alice" using the Graph API` instead of `And the administrator has given "Alice" the role "Admin" using the settings api`

I left steps `And the administrator has given "Alice" the role "Admin" using the settings api` only in the `apiAccountsHashDifficulty` suite