### PR TITLE
[full-ci] DisableWopiChat envvar

### DIFF
--- a/changelog/unreleased/wopi-disable-chat.md
+++ b/changelog/unreleased/wopi-disable-chat.md
@@ -1,0 +1,5 @@
+Enhancement: Allow disabling wopi chat
+
+Add a configreva for the new reva disable-chat feature
+
+https://github.com/owncloud/ocis/pull/6544

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/cs3org/go-cs3apis v0.0.0-20230516150832-730ac860c71d
-	github.com/cs3org/reva/v2 v2.14.1-0.20230615141102-1906a729ee5a
+	github.com/cs3org/reva/v2 v2.14.1-0.20230616125400-b30fdde17262
 	github.com/disintegration/imaging v1.6.2
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e
 	github.com/egirna/icap-client v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
-github.com/cs3org/reva/v2 v2.14.1-0.20230615141102-1906a729ee5a h1:T+504loI0dvksiutkzF4ciLfIJD/LJtJFdFJ6d7I7dA=
-github.com/cs3org/reva/v2 v2.14.1-0.20230615141102-1906a729ee5a/go.mod h1:E32krZG159YflDSjDWfx/QGIC2529PS5LiPnGNHu3d0=
+github.com/cs3org/reva/v2 v2.14.1-0.20230616125400-b30fdde17262 h1:qtK30bpLgJsUha9XbJseTksGXaNQtTteynVZEobL1fw=
+github.com/cs3org/reva/v2 v2.14.1-0.20230616125400-b30fdde17262/go.mod h1:E32krZG159YflDSjDWfx/QGIC2529PS5LiPnGNHu3d0=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/services/app-provider/pkg/config/config.go
+++ b/services/app-provider/pkg/config/config.go
@@ -69,6 +69,7 @@ type WOPIDriver struct {
 	AppInternalURL            string `yaml:"app_internal_url" env:"APP_PROVIDER_WOPI_APP_INTERNAL_URL" desc:"Internal URL to the app, like in your DMZ."`
 	AppName                   string `yaml:"app_name" env:"APP_PROVIDER_WOPI_APP_NAME" desc:"Human readable app name."`
 	AppURL                    string `yaml:"app_url" env:"APP_PROVIDER_WOPI_APP_URL" desc:"URL for end users to access the app."`
+	AppDisableChat            bool   `yaml:"app_disable_chat" env:"APP_PROVIDER_WOPI_DISABLE_CHAT" desc:"Disable the chat functionality of the office app."`
 	Insecure                  bool   `yaml:"insecure" env:"APP_PROVIDER_WOPI_INSECURE" desc:"Disable TLS certificate validation for requests to the WOPI server and the web office application. Do not set this in production environments."`
 	IopSecret                 string `yaml:"wopi_server_iop_secret" env:"APP_PROVIDER_WOPI_WOPI_SERVER_IOP_SECRET" desc:"Shared secret of the CS3org WOPI server."`
 	WopiURL                   string `yaml:"wopi_server_external_url" env:"APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL" desc:"External url of the CS3org WOPI server."`

--- a/services/app-provider/pkg/revaconfig/config.go
+++ b/services/app-provider/pkg/revaconfig/config.go
@@ -40,6 +40,7 @@ func AppProviderConfigFromStruct(cfg *config.Config) map[string]interface{} {
 							"app_int_url":                   cfg.Drivers.WOPI.AppInternalURL,
 							"app_name":                      cfg.Drivers.WOPI.AppName,
 							"app_url":                       cfg.Drivers.WOPI.AppURL,
+							"app_disable_chat":              cfg.Drivers.WOPI.AppDisableChat,
 							"insecure_connections":          cfg.Drivers.WOPI.Insecure,
 							"iop_secret":                    cfg.Drivers.WOPI.IopSecret,
 							"jwt_secret":                    cfg.TokenManager.JWTSecret,

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/node.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/node.go
@@ -294,37 +294,6 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canLis
 		}
 		return nil, errtypes.InternalError("Missing parent ID on node")
 	}
-	// TODO why do we stat the parent? to determine if the current node is in the trash we would need to traverse all parents...
-	// we need to traverse all parents for permissions anyway ...
-	// - we can compare to space root owner with the current user
-	// - we can compare the share permissions on the root for spaces, which would work for managers
-	// - for non managers / owners we need to traverse all path segments because an intermediate node might have been shared
-	// - if we want to support negative acls we need to traverse the path for all users (but the owner)
-	// for trashed items we need to check all parents
-	// - one of them might have the trash suffix ...
-	// - options:
-	//   - move deleted nodes in a trash folder that is still part of the tree (aka freedesktop org trash spec)
-	//     - shares should still be removed, which requires traversing all trashed children ... and it should be undoable ...
-	//     - what if a trashed file is restored? will child items be accessible by a share?
-	//   - compare paths of trash root items and the trashed file?
-	//     - to determine the relative path of a file we would need to traverse all intermediate nodes anyway
-	//   - recursively mark all children as trashed ... async ... it is ok when that is not synchronous
-	//     - how do we pick up if an error occurs? write a journal somewhere? activity log / delta?
-	//     - stat requests will not pick up trashed items at all
-	//   - recursively move all children into the trash folder?
-	//     - no need to write an additional trash entry
-	//     - can be made more robust with a journal
-	//     - same recursion mechanism can be used to purge items? sth we still need to do
-	//   - flag the two above options with dtime
-	if !skipParentCheck {
-		_, err = os.Stat(n.ParentPath())
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil, errtypes.NotFound(err.Error())
-			}
-			return nil, err
-		}
-	}
 
 	if revisionSuffix == "" {
 		n.BlobID = attrs.String(prefixes.BlobIDAttr)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -352,7 +352,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.14.1-0.20230615141102-1906a729ee5a
+# github.com/cs3org/reva/v2 v2.14.1-0.20230616125400-b30fdde17262
 ## explicit; go 1.20
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
Adds the envvar to disable wopi chat. 

Needs https://github.com/cs3org/reva/pull/3986

Fixes https://github.com/owncloud/ocis/issues/6540

## Reva Update included

*   Bugfix [cs3org/reva#3978](https://github.com/cs3org/reva/pull/3978): Decomposedfs no longer os.Stats when reading node metadata
*   Bugfix [cs3org/reva#3948](https://github.com/cs3org/reva/pull/3948): Handle the bad request status
*   Bugfix [cs3org/reva#3977](https://github.com/cs3org/reva/pull/3977): Prevent direct access to trash items
*   Bugfix [cs3org/reva#3975](https://github.com/cs3org/reva/pull/3975): Decomposedfs now resolves the parent without an os.Stat
*   Change [cs3org/reva#3947](https://github.com/cs3org/reva/pull/3947): Bump golangci-lint to 1.51.2
*   Change [cs3org/reva#3945](https://github.com/cs3org/reva/pull/3945): Revert golangci-lint back to 1.50.1
*   Enhancement [cs3org/reva#3965](https://github.com/cs3org/reva/pull/3965): ResumePostprocessing Event
*   Enhancement [cs3org/reva#3981](https://github.com/cs3org/reva/pull/3981): We have updated the UserFeatureChangedEvent to reflect value changes
*   Enhancement [cs3org/reva#3986](https://github.com/cs3org/reva/pull/3986): Allow disabling wopi chat