### PR TITLE
feat: add logged out url config

### DIFF
--- a/changelog/unreleased/enhancement-add-logged-out-url-config
+++ b/changelog/unreleased/enhancement-add-logged-out-url-config
@@ -1,3 +1,5 @@
 Enhancement: Add logged out url config
 
 Introduce a config to set the more button url on the access denied page in web via `WEB_OPTION_LOGGED_OUT_HELP`.
+
+https://github.com/owncloud/ocis/pull/6549

--- a/changelog/unreleased/enhancement-add-logged-out-url-config
+++ b/changelog/unreleased/enhancement-add-logged-out-url-config
@@ -1,0 +1,3 @@
+Enhancement: Add logged out url config
+
+Introduce a config to set the more button url on the access denied page in web via `WEB_OPTION_LOGGED_OUT_HELP`.

--- a/changelog/unreleased/enhancement-add-logged-out-url-config
+++ b/changelog/unreleased/enhancement-add-logged-out-url-config
@@ -1,5 +1,5 @@
 Enhancement: Add logged out url config
 
-Introduce a config to set the more button url on the access denied page in web via `WEB_OPTION_LOGGED_OUT_HELP`.
+Introduce a config to set the more button url on the access denied page in web via `WEB_OPTION_ACCESS_DENIED_HELP_URL`.
 
 https://github.com/owncloud/ocis/pull/6549

--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -20,9 +20,9 @@ type Options struct {
 	ContextHelpersReadMore   bool             `json:"contextHelpersReadMore,omitempty" yaml:"contextHelpersReadMore" env:"WEB_OPTION_CONTEXTHELPERS_READ_MORE" desc:"Specifies whether the 'Read more' link should be displayed or not."`
 	LogoutURL                string           `json:"logoutUrl,omitempty" yaml:"logoutUrl" env:"WEB_OPTION_LOGOUT_URL" desc:"Adds a link to the user's profile page to point him to an external page, where he can manage his session and devices. This is helpful when an external IdP is used. This option is disabled by default."`
 	OpenLinksWithDefaultApp  bool             `json:"openLinksWithDefaultApp,omitempty" yaml:"openLinksWithDefaultApp" env:"WEB_OPTION_OPEN_LINKS_WITH_DEFAULT_APP" desc:"Specifies whether single file link shares should be opened with the default app or not. If not opened by the default app, the Web UI just displays the file details. Defaults to 'true'."`
-	ImprintURL               string           `json:"imprintUrl,omitempty" yaml:"imprintUrl" env:"WEB_OPTION_IMPRINT_URL" desc:"Specifies the target URL for the imprint link in the account menu".`
-	PrivacyURL               string           `json:"privacyUrl,omitempty" yaml:"privacyUrl" env:"WEB_OPTION_PRIVACY_URL" desc:"Specifies the target URL for the privacy link in the account menu".`
-	AccessDeniedHelpURL      string           `json:"accessDeniedHelpURL,omitempty" yaml:"accessDeniedHelpURL" env:"WEB_OPTION_ACCESS_DENIED_HELP_URL" desc:"Specifies the target URL for the generic logged out / access denied page".`
+	ImprintURL               string           `json:"imprintUrl,omitempty" yaml:"imprintUrl" env:"WEB_OPTION_IMPRINT_URL" desc:"Specifies the target URL for the imprint link valid for the ocis instance in the account menu."`
+	PrivacyURL               string           `json:"privacyUrl,omitempty" yaml:"privacyUrl" env:"WEB_OPTION_PRIVACY_URL" desc:"Specifies the target URL for the privacy link valid for the ocis instance in the account menu."`
+	AccessDeniedHelpURL      string           `json:"accessDeniedHelpURL,omitempty" yaml:"accessDeniedHelpURL" env:"WEB_OPTION_ACCESS_DENIED_HELP_URL" desc:"Specifies the target URL valid for the ocis instance for the generic logged out / access denied page."`
 }
 
 // AccountEditLink are the AccountEditLink options

--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -20,9 +20,9 @@ type Options struct {
 	ContextHelpersReadMore   bool             `json:"contextHelpersReadMore,omitempty" yaml:"contextHelpersReadMore" env:"WEB_OPTION_CONTEXTHELPERS_READ_MORE" desc:"Specifies whether the 'Read more' link should be displayed or not."`
 	LogoutURL                string           `json:"logoutUrl,omitempty" yaml:"logoutUrl" env:"WEB_OPTION_LOGOUT_URL" desc:"Adds a link to the user's profile page to point him to an external page, where he can manage his session and devices. This is helpful when an external IdP is used. This option is disabled by default."`
 	OpenLinksWithDefaultApp  bool             `json:"openLinksWithDefaultApp,omitempty" yaml:"openLinksWithDefaultApp" env:"WEB_OPTION_OPEN_LINKS_WITH_DEFAULT_APP" desc:"Specifies whether single file link shares should be opened with the default app or not. If not opened by the default app, the Web UI just displays the file details. Defaults to 'true'."`
-	ImprintURL               string           `json:"imprintUrl,omitempty" yaml:"imprintUrl" env:"WEB_OPTION_IMPRINT_URL" desc:"Specifies the target url for the imprint link in the account menu"`
-	PrivacyURL               string           `json:"privacyUrl,omitempty" yaml:"privacyUrl" env:"WEB_OPTION_PRIVACY_URL" desc:"Specifies the target url for the privacy link in the account menu"`
-	LoggedOutHelpURL         string           `json:"loggedOutHelpUrl,omitempty" yaml:"loggedOutHelpUrl" env:"WEB_OPTION_LOGGED_OUT_HELP" desc:"Specifies the target url for the generic logged out / access denied page"`
+	ImprintURL               string           `json:"imprintUrl,omitempty" yaml:"imprintUrl" env:"WEB_OPTION_IMPRINT_URL" desc:"Specifies the target URL for the imprint link in the account menu".`
+	PrivacyURL               string           `json:"privacyUrl,omitempty" yaml:"privacyUrl" env:"WEB_OPTION_PRIVACY_URL" desc:"Specifies the target URL for the privacy link in the account menu".`
+	AccessDeniedHelpURL      string           `json:"accessDeniedHelpURL,omitempty" yaml:"accessDeniedHelpURL" env:"WEB_OPTION_ACCESS_DENIED_HELP_URL" desc:"Specifies the target URL for the generic logged out / access denied page".`
 }
 
 // AccountEditLink are the AccountEditLink options

--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -22,6 +22,7 @@ type Options struct {
 	OpenLinksWithDefaultApp  bool             `json:"openLinksWithDefaultApp,omitempty" yaml:"openLinksWithDefaultApp" env:"WEB_OPTION_OPEN_LINKS_WITH_DEFAULT_APP" desc:"Specifies whether single file link shares should be opened with the default app or not. If not opened by the default app, the Web UI just displays the file details. Defaults to 'true'."`
 	ImprintURL               string           `json:"imprintUrl,omitempty" yaml:"imprintUrl" env:"WEB_OPTION_IMPRINT_URL" desc:"Specifies the target url for the imprint link in the account menu"`
 	PrivacyURL               string           `json:"privacyUrl,omitempty" yaml:"privacyUrl" env:"WEB_OPTION_PRIVACY_URL" desc:"Specifies the target url for the privacy link in the account menu"`
+	LoggedOutHelpURL         string           `json:"loggedOutHelpUrl,omitempty" yaml:"loggedOutHelpUrl" env:"WEB_OPTION_LOGGED_OUT_HELP" desc:"Specifies the target url for the generic logged out / access denied page"`
 }
 
 // AccountEditLink are the AccountEditLink options


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Introduce a config to set the more button url on the access denied page in web via `WEB_OPTION_ACCESS_DENIED_HELP_URL`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
