### PR TITLE
Decomposedfs treesizecheck

### DIFF
--- a/changelog/unreleased/add-decomposedfs-check-treesize-command.md
+++ b/changelog/unreleased/add-decomposedfs-check-treesize-command.md
@@ -1,0 +1,6 @@
+Enhancement: add 'ocis decomposedfs check-treesize' command
+
+We added a 'ocis decomposedfs check-treesize' command for checking (and reparing)
+the treesize metadata of a storage space.
+
+https://github.com/owncloud/ocis/pull/6556

--- a/ocis/pkg/command/decomposedfs.go
+++ b/ocis/pkg/command/decomposedfs.go
@@ -4,15 +4,23 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/storage/cache"
+	"github.com/cs3org/reva/v2/pkg/storage/fs/ocis/blobstore"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/options"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
+	"github.com/cs3org/reva/v2/pkg/store"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/urfave/cli/v2"
@@ -21,15 +29,157 @@ import (
 // DecomposedfsCommand is the entrypoint for the groups command.
 func DecomposedfsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:        "decomposedfs",
-		Usage:       `cli tools to inspect and manipulate a decomposedfs storage.`,
-		Category:    "maintenance",
-		Subcommands: []*cli.Command{metadataCmd(cfg)},
+		Name:     "decomposedfs",
+		Usage:    `cli tools to inspect and manipulate a decomposedfs storage.`,
+		Category: "maintenance",
+		Subcommands: []*cli.Command{
+			metadataCmd(cfg),
+			checkCmd(cfg),
+		},
 	}
 }
 
 func init() {
 	register.AddCommand(DecomposedfsCommand)
+}
+
+func checkCmd(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "check-treesize",
+		Usage: `cli tool to check the treesize metadata of a Space`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "root",
+				Aliases:  []string{"r"},
+				Required: true,
+				Usage:    "Path to the root directory of the decomposedfs",
+			},
+			&cli.StringFlag{
+				Name:     "node",
+				Required: true,
+				Aliases:  []string{"n"},
+				Usage:    "Space ID of the Space to inspect",
+			},
+			&cli.BoolFlag{
+				Name:  "repair",
+				Usage: "Try to repair nodes with incorrect treesize metadata. IMPORTANT: Only use this while ownCloud Infinite Scale is not running.",
+			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "Do not prompt for confirmation when running in repair mode.",
+			},
+		},
+		Action: check,
+	}
+}
+
+func check(c *cli.Context) error {
+	rootFlag := c.String("root")
+	repairFlag := c.Bool("repair")
+
+	if repairFlag && !c.Bool("force") {
+		answer := strings.ToLower(stringPrompt("IMPORTANT: Only use '--repair' when ownCloud Infinite Scale is not running. Do you want to continue? [yes | no = default]"))
+		if answer != "yes" && answer != "y" {
+			return nil
+		}
+	}
+
+	lu, backend := getBackend(c)
+	o := &options.Options{
+		MetadataBackend: backend.Name(),
+		MaxConcurrency:  100,
+	}
+	bs, err := blobstore.New(rootFlag)
+	if err != nil {
+		fmt.Println("Failed to init blobstore")
+		return err
+	}
+
+	tree := tree.New(lu, bs, o, store.Create())
+
+	nId := c.String("node")
+	n, err := lu.NodeFromSpaceID(context.Background(), nId)
+	if err != nil || !n.Exists {
+		fmt.Println("Can not find node '" + nId + "'")
+		return err
+	}
+	fmt.Printf("Checking treesizes in space: %s (id: %s)\n", n.Name, n.ID)
+	ctx := revactx.ContextSetUser(context.Background(),
+		&userpb.User{
+			Id: &userpb.UserId{
+				OpaqueId: "00000000-0000-0000-0000-000000000000",
+			},
+			Username: "offline",
+		})
+
+	treeSize, err := walkTree(ctx, tree, lu, n, repairFlag)
+	treesizeFromMetadata, err := n.GetTreeSize()
+	if err != nil {
+		fmt.Printf("failed to read treesize of node: %s: %s", n.ID, err)
+	}
+	if treesizeFromMetadata != treeSize {
+		fmt.Printf("Tree sizes mismatch for space: %s\n\tNodeId: %s\n\tInternalPath: %s\n\tcalculated treesize: %d\n\ttreesize in metadata: %d\n",
+			n.Name, n.ID, n.InternalPath(), treeSize, treesizeFromMetadata)
+		if repairFlag {
+			fmt.Printf("Fixing tree size for node: %s. Calculated treesize: %d\n",
+				n.ID, treeSize)
+			n.SetTreeSize(treeSize)
+		}
+	}
+	return nil
+}
+
+func walkTree(ctx context.Context, tree *tree.Tree, lu *lookup.Lookup, root *node.Node, repair bool) (uint64, error) {
+	if root.Type() != provider.ResourceType_RESOURCE_TYPE_CONTAINER {
+		return 0, errors.New("can't travers non-container nodes")
+	}
+	children, err := tree.ListFolder(ctx, root)
+	if err != nil {
+		fmt.Println("Can not list children for space'" + root.ID + "'")
+		return 0, err
+	}
+
+	var treesize uint64
+	for _, child := range children {
+		switch child.Type() {
+		case provider.ResourceType_RESOURCE_TYPE_CONTAINER:
+			subtreesize, err := walkTree(ctx, tree, lu, child, repair)
+			if err != nil {
+				fmt.Printf("error calculating tree size of node: %s: %s", child.ID, err)
+				return 0, err
+			}
+			treesizeFromMetadata, err := child.GetTreeSize()
+			if err != nil {
+				fmt.Printf("failed to read tree size of node: %s: %s", child.ID, err)
+				return 0, err
+			}
+			if treesizeFromMetadata != subtreesize {
+				origin, err := lu.Path(ctx, child, node.NoCheck)
+				if err != nil {
+					fmt.Printf("error get path: %s\n", err)
+				}
+				fmt.Printf("Tree sizes mismatch for node: %s\n\tNodeId: %s\n\tInternalPath: %s\n\tcalculated treesize: %d\n\ttreesize in metadata: %d\n",
+					origin, child.ID, child.InternalPath(), subtreesize, treesizeFromMetadata)
+				if repair {
+					fmt.Printf("Fixing tree size for node: %s. Calculated treesize: %d\n",
+						child.ID, subtreesize)
+					child.SetTreeSize(subtreesize)
+				}
+			}
+			treesize += subtreesize
+		case provider.ResourceType_RESOURCE_TYPE_FILE:
+			blobsize, err := child.GetBlobSize()
+			if err != nil {
+				fmt.Printf("error reading blobsize of node: %s: %s", child.ID, err)
+				return 0, err
+			}
+			treesize += blobsize
+		default:
+			fmt.Printf("Ignoring type: %v, node: %s %s\n", child.Type(), child.Name, child.ID)
+		}
+	}
+
+	return treesize, nil
 }
 
 func metadataCmd(cfg *config.Config) *cli.Command {
@@ -192,7 +342,7 @@ func getPath(c *cli.Context, lu *lookup.Lookup) (string, error) {
 			fmt.Println("Invalid node id.")
 			return "", err
 		}
-		n, _ := lu.NodeFromID(context.Background(), &id)
+		n, err := lu.NodeFromID(context.Background(), &id)
 		if err != nil || !n.Exists {
 			fmt.Println("Can not find node '" + nId + "'")
 			return "", err


### PR DESCRIPTION
This adds a cli command to verify  the treesize metadata of a Space in decomposedfs

```
ocis decomposedfs check-treesize -r /root/.ocis/storage/users/ -n cc1a4ba9-75d5-43e7-853c-548e1726ef60
Checking treesizes in space: Admin (id: cc1a4ba9-75d5-43e7-853c-548e1726ef60)
treesizes mismatch for node: /test2/folder/folder/folder/folder/folder
        NodeId: 2f8d8188-8c66-4c4d-a29b-cee85e3097c3
        InternalPath: /root/.ocis/storage/users/spaces/cc/1a4ba9-75d5-43e7-853c-548e1726ef60/nodes/2f/8d/81/88/-8c66-4c4d-a29b-cee85e3097c3
        calculated treesize: 1998
        treesize in metadata: 1996
treesizes mismatch for node: /test2/folder/folder/folder/folder
        NodeId: 73ccc33f-0a8b-4513-9e2c-161a9e551279
        InternalPath: /root/.ocis/storage/users/spaces/cc/1a4ba9-75d5-43e7-853c-548e1726ef60/nodes/73/cc/c3/3f/-0a8b-4513-9e2c-161a9e551279
        calculated treesize: 1998
        treesize in metadata: 1996
treesizes mismatch for node: /test2/folder/folder/folder
        NodeId: 0b95ed50-1ff4-4e01-a23f-eb48a4bd8691
        InternalPath: /root/.ocis/storage/users/spaces/cc/1a4ba9-75d5-43e7-853c-548e1726ef60/nodes/0b/95/ed/50/-1ff4-4e01-a23f-eb48a4bd8691
        calculated treesize: 1998
        treesize in metadata: 1996
treesizes mismatch for node: /test2/folder/folder
        NodeId: fb24f75a-511a-4d60-9c09-00771e49c590
        InternalPath: /root/.ocis/storage/users/spaces/cc/1a4ba9-75d5-43e7-853c-548e1726ef60/nodes/fb/24/f7/5a/-511a-4d60-9c09-00771e49c590
        calculated treesize: 1998
        treesize in metadata: 1996
treesizes mismatch for node: /test2/folder
        NodeId: 8b4f9187-1510-400c-85e2-9f3534a9f2fb
        InternalPath: /root/.ocis/storage/users/spaces/cc/1a4ba9-75d5-43e7-853c-548e1726ef60/nodes/8b/4f/91/87/-1510-400c-85e2-9f3534a9f2fb
        calculated treesize: 1998
        treesize in metadata: 1996
treesizes mismatch for node: /test2
        NodeId: 8cb2f568-b890-480d-88a6-e356b589747a
        InternalPath: /root/.ocis/storage/users/spaces/cc/1a4ba9-75d5-43e7-853c-548e1726ef60/nodes/8c/b2/f5/68/-b890-480d-88a6-e356b589747a
        calculated treesize: 1998
        treesize in metadata: 1996
treesizes mismatch for space: Admin
        NodeId: cc1a4ba9-75d5-43e7-853c-548e1726ef60
        InternalPath: /root/.ocis/storage/users/spaces/cc/1a4ba9-75d5-43e7-853c-548e1726ef60/nodes/cc/1a/4b/a9/-75d5-43e7-853c-548e1726ef60
        calculated treesize: 93692124
        treesize in metadata: 93692118
```

It's meant for offline usage. E.g. for analyzing case like: https://github.com/owncloud/enterprise/issues/5783

Using it while the ocis server is running is possible but might produce inconsistent results, when e.g. files are being uploaded/copied/deleted while the tool is running.