### PR TITLE
Don't connect to ldap on startup

### DIFF
--- a/changelog/unreleased/dont-connect-ldap-on-startup.md
+++ b/changelog/unreleased/dont-connect-ldap-on-startup.md
@@ -1,0 +1,5 @@
+Bugfix: Don't connect to ldap on startup
+
+This leads to misleading error messages. Instead we connect on first request
+
+https://github.com/owncloud/ocis/pull/6565

--- a/services/graph/pkg/identity/ldap/reconnect.go
+++ b/services/graph/pkg/identity/ldap/reconnect.go
@@ -205,10 +205,10 @@ func (c ConnWithReconnect) GetConnection() (*ldap.Conn, error) {
 }
 
 func (c ConnWithReconnect) ldapAutoConnect(config Config) {
-	l, err := c.ldapConnect(config)
-	if err != nil {
-		c.logger.Error().Err(err).Msg("autoconnect could not get ldap Connection")
-	}
+	var (
+		l   *ldap.Conn
+		err error
+	)
 
 	for {
 		select {


### PR DESCRIPTION
~Reducing log level of the ldap connect error messages to debug. Corresponding reva code already logs on debug. See here: https://github.com/cs3org/reva/blob/edge/pkg/utils/ldap/reconnect.go#L206~

We removed the call to connect to ldap instead. It will connect on the first request now. This should remove the misleading error messages on startup

Fixes https://github.com/owncloud/ocis/issues/4520