### PR TITLE
Update APP_PROVIDER_SERVICE_NAME description

### DIFF
--- a/services/app-provider/pkg/config/config.go
+++ b/services/app-provider/pkg/config/config.go
@@ -40,15 +40,15 @@ type Log struct {
 	File   string `yaml:"file" env:"OCIS_LOG_FILE;APP_PROVIDER_LOG_FILE" desc:"The path to the log file. Activates logging to this file if set."`
 }
 
-type Service struct {
-	Name string `yaml:"name" env:"APP_PROVIDER_SERVICE_NAME" desc:"The name of the service. This needs to be changed when using more than one app provider. Each of them needs be found by a unique service name. Possible examples are: \"app-provider-collabora\", \"app-provider-onlyoffice\", \"app-provider-office365\"."`
-}
-
 type Debug struct {
 	Addr   string `yaml:"addr" env:"APP_PROVIDER_DEBUG_ADDR" desc:"Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed."`
 	Token  string `yaml:"token" env:"APP_PROVIDER_DEBUG_TOKEN" desc:"Token to secure the metrics endpoint"`
 	Pprof  bool   `yaml:"pprof" env:"APP_PROVIDER_DEBUG_PPROF" desc:"Enables pprof, which can be used for profiling"`
 	Zpages bool   `yaml:"zpages" env:"APP_PROVIDER_DEBUG_ZPAGES" desc:"Enables zpages, which can  be used for collecting and viewing traces in-memory."`
+}
+
+type Service struct {
+	Name string `yaml:"name" env:"APP_PROVIDER_SERVICE_NAME" desc:"The name of the service. This needs to be changed when using more than one app provider. Each app provider configured needs to be identified by a unique service name. Possible examples are: 'app-provider-collabora', 'app-provider-onlyoffice', 'app-provider-office365'."`
 }
 
 type GRPCConfig struct {


### PR DESCRIPTION
References: #4682

This PR does the following:

* Move the item below the `_DEBUG_ZPAGES` entry so it appears in docs in alignment as all other have this (on top we always have logging, debugging, tracing...)
* Fix the description 