### PR TITLE
[tests-only][full-ci] use tcp for antivirus service in ci 

### DIFF
--- a/tests/acceptance/docker/src/antivirus.yml
+++ b/tests/acceptance/docker/src/antivirus.yml
@@ -6,9 +6,4 @@ services:
     command: clamav:3310
   clamav:
     image: owncloudci/clamavd
-    volumes:
-      - clamavSocket:/var/run/clamav/
-
-volumes:
-  clamavSocket:
 

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -38,16 +38,10 @@ services:
 
       # antivirus
       ANTIVIRUS_SCANNER_TYPE: "clamav"
-      ANTIVIRUS_CLAMAV_SOCKET: "/var/run/clamav/clamd.sock"
+      ANTIVIRUS_CLAMAV_SOCKET: tcp://clamav:3310
 
       # postprocessing step
       POSTPROCESSING_STEPS: $POSTPROCESSING_STEPS
     volumes:
       - ../../../config:/drone/src/tests/config
       - ../../../ociswrapper/bin/ociswrapper:/usr/bin/ociswrapper
-      - clamavSocket:/var/run/clamav/
-
-volumes:
-  clamavSocket:
-    external:
-      name: ocis-acceptance-tests_clamavSocket


### PR DESCRIPTION
This PR refactors the CI and docker-compose to use TCP to communicate with antivirus. Previously we used volumes to share sockets but that's not needed any more