### PR TITLE
Add default store to postprocessing service

### DIFF
--- a/changelog/unreleased/add-default-store-to-postprocessing.md
+++ b/changelog/unreleased/add-default-store-to-postprocessing.md
@@ -1,0 +1,5 @@
+Bugfix: Add default store to postprocessing
+
+Postprocessing did not have a default store especially `database` and `table` are needed to talk to nats-js
+
+https://github.com/owncloud/ocis/pull/6578

--- a/services/postprocessing/pkg/config/defaults/defaultconfig.go
+++ b/services/postprocessing/pkg/config/defaults/defaultconfig.go
@@ -30,6 +30,11 @@ func DefaultConfig() *config.Config {
 				Cluster:  "ocis-cluster",
 			},
 		},
+		Store: config.Store{
+			Store:    "memory",
+			Database: "postprocessing",
+			Table:    "postprocessing",
+		},
 	}
 }
 


### PR DESCRIPTION
Adds a default store to postprocessing service. Especially `database` and `table` are needed.

A migration is imo not necessary as it only stores data during uploads (which might be breaking during update anyways)

Fixes https://github.com/owncloud/ocis/issues/6547
Fixes https://github.com/owncloud/ocis/issues/6514