### PR TITLE
[tests-only][full-ci] Refactor share related scenerio

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3520,6 +3520,40 @@ trait Sharing {
 		$this->emptyLastOCSStatusCodesArray();
 	}
 
+    /**
+     * @When /^user "([^"]*)" unshares (?:folder|file|entity) "([^"]*)" shared to "([^"]*)"$/
+     *
+     * @param string $sharer
+     * @param string $path
+     * @param string $sharee
+     *
+     * @return void
+     * @throws JsonException
+     */
+    public function userUnsharesSharedTo(string $sharer, string $path, string $sharee): void {
+        $sharer = $this->getActualUsername($sharer);
+        $sharee = $this->getActualUsername($sharee);
+
+        $response = $this->getShares($sharer, "$path&share_types=0");
+        $shareId = null;
+        foreach ($response as $shareElement) {
+            if ((string)$shareElement->share_with[0] === $sharee) {
+                $shareId = (string) $shareElement->id;
+                break;
+            }
+        }
+        Assert::assertNotNull(
+            $shareId,
+            __METHOD__ . " could not find share, offered by $sharer to $sharee"
+        );
+
+        $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+            $sharer,
+            'DELETE',
+            '/apps/files_sharing/api/v' . $this->sharingApiVersion . '/shares/' . $shareId
+        );
+    }
+
 	/**
 	 * @Then the sharing API should report that no shares are shared with user :user
 	 *

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3491,6 +3491,25 @@ trait Sharing {
 	 * @throws JsonException
 	 */
 	public function userHasUnsharedResourceSharedTo(string $sharer, string $path, string $sharee): void {
+		$this->userUnsharesSharedTo($sharer, $path, $sharee);
+		$this->ocsContext->assertOCSResponseIndicatesSuccess(
+			'The ocs share response does not indicate success.',
+		);
+		$this->emptyLastHTTPStatusCodesArray();
+		$this->emptyLastOCSStatusCodesArray();
+	}
+
+	/**
+	 * @When /^user "([^"]*)" unshares (?:folder|file|entity) "([^"]*)" shared to "([^"]*)"$/
+	 *
+	 * @param string $sharer
+	 * @param string $path
+	 * @param string $sharee
+	 *
+	 * @return void
+	 * @throws JsonException
+	 */
+	public function userUnsharesSharedTo(string $sharer, string $path, string $sharee): void {
 		$sharer = $this->getActualUsername($sharer);
 		$sharee = $this->getActualUsername($sharee);
 
@@ -3512,47 +3531,7 @@ trait Sharing {
 			'DELETE',
 			'/apps/files_sharing/api/v' . $this->sharingApiVersion . '/shares/' . $shareId
 		);
-
-		$this->ocsContext->assertOCSResponseIndicatesSuccess(
-			'The ocs share response does not indicate success.',
-		);
-		$this->emptyLastHTTPStatusCodesArray();
-		$this->emptyLastOCSStatusCodesArray();
 	}
-
-    /**
-     * @When /^user "([^"]*)" unshares (?:folder|file|entity) "([^"]*)" shared to "([^"]*)"$/
-     *
-     * @param string $sharer
-     * @param string $path
-     * @param string $sharee
-     *
-     * @return void
-     * @throws JsonException
-     */
-    public function userUnsharesSharedTo(string $sharer, string $path, string $sharee): void {
-        $sharer = $this->getActualUsername($sharer);
-        $sharee = $this->getActualUsername($sharee);
-
-        $response = $this->getShares($sharer, "$path&share_types=0");
-        $shareId = null;
-        foreach ($response as $shareElement) {
-            if ((string)$shareElement->share_with[0] === $sharee) {
-                $shareId = (string) $shareElement->id;
-                break;
-            }
-        }
-        Assert::assertNotNull(
-            $shareId,
-            __METHOD__ . " could not find share, offered by $sharer to $sharee"
-        );
-
-        $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
-            $sharer,
-            'DELETE',
-            '/apps/files_sharing/api/v' . $this->sharingApiVersion . '/shares/' . $shareId
-        );
-    }
 
 	/**
 	 * @Then the sharing API should report that no shares are shared with user :user

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3338,7 +3338,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:deletes|unshares) (?:file|folder) "([^"]*)" using the WebDAV API$/
+	 * @When /^user "([^"]*)" deletes (?:file|folder) "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $file

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -74,7 +74,7 @@ Feature: sharing
     And as "Alice" file "/shared_file.txt" should exist in the trashbin
     And as "Brian" file "/shared_file.txt" should exist in the trashbin
 
- 
+
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
     And user "Alice" has created folder "/shared"
@@ -226,3 +226,15 @@ Feature: sharing
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 404             | 200              |
       | 2               | 404             | 404              |
+
+
+   Scenario: unshare a shared resources
+     Given using OCS API version "1"
+     And user "Alice" has shared file "textfile0.txt" with user "Brian"
+     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+     When user "Alice" unshares file "textfile0.txt" shared to "Brian"
+#     Then the OCS status code should be "200"
+     Then the HTTP status code should be "204"
+     And as "Brian" file "/Shares/shared/textfile0.txt" should not exist
+
+

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -233,8 +233,8 @@ Feature: sharing
      And user "Alice" has shared file "textfile0.txt" with user "Brian"
      And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
      When user "Alice" unshares file "textfile0.txt" shared to "Brian"
-#     Then the OCS status code should be "200"
-     Then the HTTP status code should be "204"
+     Then the OCS status code should be "100"
+     And the HTTP status code should be "200"
      And as "Brian" file "/Shares/shared/textfile0.txt" should not exist
 
 

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -421,7 +421,7 @@ Feature: dav-versions
       | new         | Brian | /testshare |
 
 
-  Scenario: receiver tries to get file versions of unshared file from the sharer
+  Scenario: receiver tries to get file versions of file not shared by the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
     And user "Alice" has uploaded file with content "textfile1" to "textfile1.txt"


### PR DESCRIPTION

## Description
Previously when the sharer unshares the file to sharee, sharer actually deletes the resources rather than removing sharee from the shares. There is no actual scenario that tests for the unshare feature. 
This PR adds a new missing test scenario and refactors the shares related step definition codes 
## Related Issue
- part of  <https://github.com/owncloud/ocis/issues/6325#issuecomment-1590750636>

## How Has This Been Tested?
- test environment:
- locally
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
