### PR TITLE
[tests-only]Backport/use different clamav image docker compose

### DIFF
--- a/tests/acceptance/docker/src/antivirus.yml
+++ b/tests/acceptance/docker/src/antivirus.yml
@@ -5,5 +5,5 @@ services:
       - clamav
     command: clamav:3310
   clamav:
-    image: owncloudci/clamavd
+    image: mkodockx/docker-clamav:alpine
 


### PR DESCRIPTION
Backport: https://github.com/owncloud/ocis/pull/6588

Use `mkodockx/docker-clamav` image  https://hub.docker.com/r/mkodockx/docker-clamav in docker-compose file instead of `owncloudci/clamavd:latest` https://hub.docker.com/r/owncloudci/clamavd/tags

The owncloud image is built only for `amd` which might not be suitable for developers with `arm`. This PR changes the image so that it can provide support for all the OS 

Part of: https://github.com/owncloud/ocis/issues/6255