### PR TITLE
unmarshal token to filter spaces for current user

### DIFF
--- a/services/search/pkg/command/server.go
+++ b/services/search/pkg/command/server.go
@@ -33,7 +33,7 @@ func Server(cfg *config.Config) *cli.Command {
 			if err != nil {
 				return err
 			}
-			err = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
+			err = ogrpc.Configure(append(ogrpc.GetClientOptions(cfg.GRPCClientTLS), ogrpc.WithTraceProvider(tracing.TraceProvider))...)
 			if err != nil {
 				return err
 			}
@@ -56,6 +56,7 @@ func Server(cfg *config.Config) *cli.Command {
 				grpc.Name(cfg.Service.Name),
 				grpc.Context(ctx),
 				grpc.Metrics(mtrcs),
+				grpc.JWTSecret(cfg.Commons.TokenManager.JWTSecret),
 			)
 			defer teardown()
 			if err != nil {

--- a/services/search/pkg/config/config.go
+++ b/services/search/pkg/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 
 	GRPC GRPCConfig `yaml:"grpc"`
 
+	TokenManager *TokenManager `yaml:"token_manager"`
+
 	Reva                       *shared.Reva          `yaml:"reva"`
 	GRPCClientTLS              *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 	Events                     Events                `yaml:"events"`

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -83,6 +83,14 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tracing = &config.Tracing{}
 	}
 
+	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
+		cfg.TokenManager = &config.TokenManager{
+			JWTSecret: cfg.Commons.TokenManager.JWTSecret,
+		}
+	} else if cfg.TokenManager == nil {
+		cfg.TokenManager = &config.TokenManager{}
+	}
+
 	if cfg.MachineAuthAPIKey == "" && cfg.Commons != nil && cfg.Commons.MachineAuthAPIKey != "" {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}

--- a/services/search/pkg/config/reva.go
+++ b/services/search/pkg/config/reva.go
@@ -4,3 +4,8 @@ package config
 type Reva struct {
 	Address string `ocisConfig:"address" env:"OCIS_REVA_GATEWAY;REVA_GATEWAY" desc:"The CS3 gateway endpoint." deprecationVersion:"3.0" removalVersion:"4.0.0" deprecationInfo:"REVA_GATEWAY changing name for consistency" deprecationReplacement:"OCIS_REVA_GATEWAY"`
 }
+
+// TokenManager is the config for using the reva token manager
+type TokenManager struct {
+	JWTSecret string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;SEARCH_JWT_SECRET" desc:"The secret to mint and validate jwt tokens."`
+}

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -12,6 +12,7 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	sdk "github.com/cs3org/reva/v2/pkg/sdk/common"
@@ -81,8 +82,14 @@ func (s *Service) Search(ctx context.Context, req *searchsvc.SearchRequest) (*se
 		return nil, err
 	}
 
+	currentUser := revactx.ContextMustGetUser(ctx)
+
 	listSpacesRes, err := gatewayClient.ListStorageSpaces(ctx, &provider.ListStorageSpacesRequest{
 		Filters: []*provider.ListStorageSpacesRequest_Filter{
+			{
+				Type: provider.ListStorageSpacesRequest_Filter_TYPE_USER,
+				Term: &provider.ListStorageSpacesRequest_Filter_User{User: currentUser.GetId()},
+			},
 			{
 				Type: provider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE,
 				Term: &provider.ListStorageSpacesRequest_Filter_SpaceType{SpaceType: "+grant"},

--- a/services/search/pkg/search/service_test.go
+++ b/services/search/pkg/search/service_test.go
@@ -7,6 +7,7 @@ import (
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	sprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	cs3mocks "github.com/cs3org/reva/v2/tests/cs3mocks/mocks"
@@ -83,7 +84,7 @@ var _ = Describe("Searchprovider", func() {
 			},
 		)
 
-		ctx = context.Background()
+		ctx = revactx.ContextSetUser(context.Background(), user)
 		indexClient = &engineMocks.Engine{}
 		extractor = &contentMocks.Extractor{}
 

--- a/services/search/pkg/server/grpc/option.go
+++ b/services/search/pkg/server/grpc/option.go
@@ -15,13 +15,14 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Name    string
-	Logger  log.Logger
-	Context context.Context
-	Config  *config.Config
-	Metrics *metrics.Metrics
-	Flags   []cli.Flag
-	Handler *svc.Service
+	Name      string
+	Logger    log.Logger
+	Context   context.Context
+	Config    *config.Config
+	Metrics   *metrics.Metrics
+	Flags     []cli.Flag
+	Handler   *svc.Service
+	JWTSecret string
 }
 
 // newOptions initializes the available default options.
@@ -81,5 +82,12 @@ func Flags(val []cli.Flag) Option {
 func Handler(val *svc.Service) Option {
 	return func(o *Options) {
 		o.Handler = val
+	}
+}
+
+// JWTSecret provides a function to set the Config option.
+func JWTSecret(val string) Option {
+	return func(o *Options) {
+		o.JWTSecret = val
 	}
 }

--- a/services/search/pkg/server/grpc/server.go
+++ b/services/search/pkg/server/grpc/server.go
@@ -33,6 +33,7 @@ func Server(opts ...Option) (grpc.Service, func(), error) {
 	handle, teardown, err := svc.NewHandler(
 		svc.Config(options.Config),
 		svc.Logger(options.Logger),
+		svc.JWTSecret(options.JWTSecret),
 	)
 	if err != nil {
 		options.Logger.Error().

--- a/services/search/pkg/service/grpc/v0/option.go
+++ b/services/search/pkg/service/grpc/v0/option.go
@@ -10,8 +10,9 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Logger log.Logger
-	Config *config.Config
+	Logger    log.Logger
+	Config    *config.Config
+	JWTSecret string
 }
 
 func newOptions(opts ...Option) Options {
@@ -35,5 +36,12 @@ func Logger(val log.Logger) Option {
 func Config(val *config.Config) Option {
 	return func(o *Options) {
 		o.Config = val
+	}
+}
+
+// JWTSecret provides a function to set the Config option.
+func JWTSecret(val string) Option {
+	return func(o *Options) {
+		o.JWTSecret = val
 	}
 }


### PR DESCRIPTION
When executing a search we were listing ALL spaces of an instance without a filter on spaces the currently logged in user has access to. That might run into the 10sec timeout for search requests when a lot of spaces are in the system.