### PR TITLE
[tests-only] added scenarios for overwrite file with virus content in user share

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -409,38 +409,58 @@ Feature: antivirus
     And for user "Brian" the content of the file "/test.txt" of the space "Shares" should be "hello"
     And the content of file "/test.txt" for user "Alice" should be "hello"
 
-
-    Scenario Outline: try to overwrite a file with the virus content in user share
-      Given using <dav-path-version> DAV path
-      And user "Brian" has been created with default attributes and without skeleton files
-      And user "Alice" has created folder "uploadFolder"
-      And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
-      And user "Alice" has uploaded file with content "hello" to "uploadFolder/test.txt"
-      And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
-      When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "Shares/uploadFolder/test.txt" using the WebDAV API
-      Then the HTTP status code should be "204"
-      And user "Brian" should get a notification with subject "Virus found" and message:
-        | message                                                                   |
-        | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-      And the content of file "Shares/uploadFolder/test.txt" for user "Brian" should be "hello"
-      And the content of file "uploadFolder/test.txt" for user "Alice" should be "hello"
-      Examples:
-        | dav-path-version |
-        | old              |
-        | new              |
+    
+  Scenario Outline: try to overwrite a file with the virus content in user share
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "uploadFolder"
+    And user "Alice" has uploaded file with content "this is a test file." to "uploadFolder/test.txt"
+    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Alice" has uploaded file with content "this is a test file." to "/test.txt"
+    And user "Alice" has shared file "/test.txt" with user "Brian"
+    And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+    And user "Brian" has accepted share "/test.txt" offered by user "Alice"
+    When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "Shares/uploadFolder/test.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                   |
+      | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And the content of file "Shares/uploadFolder/test.txt" for user "Brian" should be "this is a test file."
+    And the content of file "uploadFolder/test.txt" for user "Alice" should be "this is a test file."
+    When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "Shares/test.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                       |
+      | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And the content of file "Shares/test.txt" for user "Brian" should be "this is a test file."
+    And the content of file "/test.txt" for user "Alice" should be "this is a test file."
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario: try to overwrite a file with the virus content in user share using spaces dav endpoint
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has uploaded file with content "hello" to "uploadFolder/test.txt"
+    And user "Alice" has uploaded file with content "this is a test file." to "uploadFolder/test.txt"
     And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Alice" has uploaded file with content "this is a test file." to "/test.txt"
+    And user "Alice" has shared file "/test.txt" with user "Brian"
     And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+    And user "Brian" has accepted share "/test.txt" offered by user "Alice"
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "/uploadFolder/test.txt" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "204"
     And user "Brian" should get a notification with subject "Virus found" and message:
       | message                                                                   |
       | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
-    And for user "Brian" the content of the file "/uploadFolder/test.txt" of the space "Shares" should be "hello"
-    And the content of file "uploadFolder/test.txt" for user "Alice" should be "hello"
+    And for user "Brian" the content of the file "/uploadFolder/test.txt" of the space "Shares" should be "this is a test file."
+    And the content of file "uploadFolder/test.txt" for user "Alice" should be "this is a test file."
+    When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "/test.txt" in space "Shares" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                   |
+      | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And for user "Brian" the content of the file "/test.txt" of the space "Shares" should be "this is a test file."
+    And the content of file "/test.txt" for user "Alice" should be "this is a test file."

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -408,3 +408,39 @@ Feature: antivirus
       | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And for user "Brian" the content of the file "/test.txt" of the space "Shares" should be "hello"
     And the content of file "/test.txt" for user "Alice" should be "hello"
+
+
+    Scenario Outline: try to overwrite a file with the virus content in user share
+      Given using <dav-path-version> DAV path
+      And user "Brian" has been created with default attributes and without skeleton files
+      And user "Alice" has created folder "uploadFolder"
+      And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+      And user "Alice" has uploaded file with content "hello" to "uploadFolder/test.txt"
+      And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+      When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "Shares/uploadFolder/test.txt" using the WebDAV API
+      Then the HTTP status code should be "204"
+      And user "Brian" should get a notification with subject "Virus found" and message:
+        | message                                                                   |
+        | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+      And the content of file "Shares/uploadFolder/test.txt" for user "Brian" should be "hello"
+      And the content of file "uploadFolder/test.txt" for user "Alice" should be "hello"
+      Examples:
+        | dav-path-version |
+        | old              |
+        | new              |
+
+
+  Scenario: try to overwrite a file with the virus content in user share using spaces dav endpoint
+    Given using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "uploadFolder"
+    And user "Alice" has uploaded file with content "hello" to "uploadFolder/test.txt"
+    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Brian" has accepted share "/uploadFolder" offered by user "Alice"
+    When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "/uploadFolder/test.txt" in space "Shares" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "Brian" should get a notification with subject "Virus found" and message:
+      | message                                                                   |
+      | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
+    And for user "Brian" the content of the file "/uploadFolder/test.txt" of the space "Shares" should be "hello"
+    And the content of file "uploadFolder/test.txt" for user "Alice" should be "hello"


### PR DESCRIPTION
## Description
This PR adds the API test scenarios for overwrite file with virus content in user share:
- Scenario for trying to overwrite a file with the virus content in user share
- Scenario for trying to overwrite a file with the virus content in user share using spaces dav endpoint
## Related Issue
- Part of: https://github.com/owncloud/ocis/issues/6255

## Motivation and Context
- There was no test coverage for overwrite file with virus content in user share. So, this PR coves the required scenario test case.

## How Has This Been Tested?
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
