### PR TITLE
[tests-only][full-ci]Test api search by deleted tag

### DIFF
--- a/tests/acceptance/features/apiGraph/fullSearch.feature
+++ b/tests/acceptance/features/apiGraph/fullSearch.feature
@@ -72,3 +72,20 @@ Feature: full text search
       | dav-path-version |
       | old              |
       | new              |
+
+
+  Scenario Outline: search files using a deleted tag
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "hello world" to "file1.txt"
+    And user "Alice" has created the following tags for file "file1.txt" of the space "Personal":
+      | tag1 |
+    And user "Alice" has removed the following tags for file "file1.txt" of space "Personal":
+      | tag1 |
+    When user "Alice" searches for "Tags:tag1" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "0" entries
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |

--- a/tests/acceptance/features/bootstrap/TagContext.php
+++ b/tests/acceptance/features/bootstrap/TagContext.php
@@ -179,4 +179,21 @@ class TagContext implements Context {
 		);
 		$this->featureContext->setResponse($response);
 	}
+
+	/**
+	 * @Given  /^user "([^"]*)" has removed the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/
+	 *
+	 * @param string $user
+	 * @param string $fileOrFolder   (file|folder)
+	 * @param string $resource
+	 * @param string $space
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userHAsRemovedTheFollowingTagsForFileOfSpace(string $user, string $fileOrFolder, string $resource, string $space, TableNode $table):void {
+		$this->userRemovesTagsFromResourceOfTheSpace($user, $fileOrFolder, $resource, $space, $table);
+		$this->featureContext->theHttpStatusCodeShouldBe(200);
+	}
 }


### PR DESCRIPTION
## Description
This PR adds the API tests for full search api. The scenarios added in this PR are
- search file using deleted tag

## Related Issue
- https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
- there was no test coverage for api test for search file using deleted tag. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
