### PR TITLE
[tests-only][full-ci] Added API test to search for restored resources having tag

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -120,6 +120,7 @@ default:
         - SpacesTUSContext:
         - OcisConfigContext:
         - TagContext:
+        - TrashbinContext:
 
     apiCors:
       paths:

--- a/tests/acceptance/features/apiGraph/fullSearch.feature
+++ b/tests/acceptance/features/apiGraph/fullSearch.feature
@@ -89,3 +89,22 @@ Feature: full text search
       | old              |
       | new              |
       | spaces           |
+
+
+  Scenario Outline: search restored files using a tag
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "hello world" to "file1.txt"
+    And user "Alice" has uploaded file with content "Namaste nepal" to "file2.txt"
+    And user "Alice" has created the following tags for file "file1.txt" of the space "Personal":
+      | tag1 |
+    And user "Alice" has deleted file "/file1.txt"
+    And user "Alice" has restored the file with original path "/file1.txt"
+    When user "Alice" searches for "Tags:tag1" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /file1.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |


### PR DESCRIPTION
## Description
This PR adds the API tests for search restored files through a tag. The scenarios added in this PR are
- search restored files through a tag

## Related Issue
- https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
- there was no test coverage for api test for search restored files through a tag. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
