### PR TITLE
Provide Search filter for locations

### DIFF
--- a/changelog/unreleased/enhancement-add-search-filter-for-location.md
+++ b/changelog/unreleased/enhancement-add-search-filter-for-location.md
@@ -1,0 +1,7 @@
+Enhancement: Provide Search filter for locations
+
+The search result REPORT response now contains a content preview which highlights the search term.
+The feature is only available if content extraction (e.g. apache tika) is configured
+
+https://github.com/owncloud/ocis/pull/6634
+https://github.com/owncloud/ocis/issues/6426

--- a/services/search/pkg/search/service_test.go
+++ b/services/search/pkg/search/service_test.go
@@ -391,3 +391,51 @@ var _ = Describe("Searchprovider", func() {
 		})
 	})
 })
+
+var _ = DescribeTable("Parse Scope",
+	func(pattern, wantSearch, wantScope string) {
+		gotSearch, gotScope := search.ParseScope(pattern)
+		Expect(gotSearch).To(Equal(wantSearch))
+		Expect(gotScope).To(Equal(wantScope))
+	},
+	Entry("When scope is at the end of the line",
+		`+Name:*file* +Tags:&quot;foo&quot; scope:<uuid>/folder/subfolder`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the end of the line 2",
+		`+Name:*file* +Tags:&quot;foo&quot; scope:<uuid>/folder`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`<uuid>/folder`,
+	),
+	Entry("When scope is at the end of the line 3",
+		`file scope:<uuid>/folder/subfolder`,
+		`file`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the end of the line with a space",
+		`+Name:*file* +Tags:&quot;foo&quot; scope: <uuid>/folder/subfolder`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is in the middle of the line",
+		`+Name:*file* scope:<uuid>/folder/subfolder +Tags:&quot;foo&quot;`,
+		`+Name:*file*  +Tags:&quot;foo&quot;`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the end of the line",
+		`scope:<uuid>/folder/subfolder +Name:*file*`,
+		`+Name:*file*`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the begging of the line",
+		`scope:<uuid>/folder/subfolder file`,
+		`file`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When no scope",
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		``,
+	),
+)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Enhancement: [ocis] Provide Search filter for locations OCIS-3705

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 Acceptance Criteria
- provide possibility for the client to restrict the search to the current folder via api (recursive)
- scope needed for "current folder" (default is to search all available spaces) - part of the `oc-pattern:"scope:<uuid>/Test"`
- search service only retruns results in the given scope
- API call is documented in dev docs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Local
- test case 1:  
1.1 Login as admin; go to the Personal; create the file 'testfile.txt'; create the folder 'nfolder' and create inside the file 'newfile.txt'.
1.2 Call the API by name and location `<oc:pattern>file scope:storage-users-1$some-admin-user-id-0000-000000000000!some-admin-user-id-0000-000000000000/nfolder</oc:pattern>` have to return only the 'newfile.txt' as a search result.
Request:
```bash
curl 'https://localhost:9200/remote.php/dav/files/admin/' \
  -X 'REPORT' \
  --data-raw $'<?xml version="1.0"?>\n<oc:search-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n  <d:prop>\n    <oc:permissions />\n    <oc:favorite />\n    <oc:fileid />\n    <oc:file-parent />\n    <oc:name />\n    <oc:owner-id />\n    <oc:owner-display-name />\n    <oc:shareid />\n    <oc:shareroot />\n    <oc:share-types />\n    <oc:privatelink />\n    <d:getcontentlength />\n    <oc:size />\n    <d:getlastmodified />\n    <d:getetag />\n    <d:
getcontenttype />\n    <d:resourcetype />\n    <oc:downloadURL />\n    <oc:tags />\n  </d:prop>\n  <oc:search>\n    <oc:pattern>file scope:storage-users-1$some-admin-user-id-0000-000000000000!some-admin-user-id-0000-000000000000/nfolder</oc:pattern>\n    <oc:limit>8</oc:limit>\n  </oc:search>\n</oc:search-files>' \                 
  -ik \
  -uadmin:admin
```
Response:
```bash
<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:response><d:href>/remote.php/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000/newfile.txt</d:href><d:propstat><d:prop><oc:fileid>storage-users-1$some-admin-user-id-0000-000000000000!6531b70d-fe7d-45d2-85ed-c9f70bd553e8</oc:fileid><oc:file-parent>storage-users-1$some-admin-user-id-0000-000000000000!80fcf9f6-2ed2-40cc-b12a-db170576d3c4</oc:file-parent><oc:name>newfile.txt</oc:name><d:getlastmodified>2023-06-27T09:38:14Z</d:getlastmodified><d:getcontenttype>text/plain</d:getcontenttype><oc:permissions>RDNVW</oc:permissions><oc:highlights></oc:highlights><oc:tags></oc:tags><d:getetag></d:getetag><d:resourcetype></d:resourcetype><d:getcontentlength>3</d:getcontentlength><oc:score>0.31600961089134216</oc:score></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
```


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
