### PR TITLE
[tests-only][full-ci] added scenarios for disabling frontend_enable_resharing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -110,6 +110,7 @@ config = {
                 "apiCors",
                 "apiAsyncUpload",
                 "apiDownloads",
+                "apiReshare",
             ],
             "skip": False,
         },

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -211,6 +211,14 @@ default:
         - OCSContext:
         - TrashbinContext:
 
+    apiReshare:
+      paths:
+        - '%paths.base%/../features/apiReshare'
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - OcisConfigContext:
+
   extensions:
     rdx\behatvars\BehatVariablesExtension: ~
 

--- a/tests/acceptance/features/apiReshare/disableReshare.feature
+++ b/tests/acceptance/features/apiReshare/disableReshare.feature
@@ -1,0 +1,58 @@
+@api @env-config
+Feature: share by disabling re-share
+  As a user
+  I want to share resources
+  So that other users can have access to them but cannot re-share them
+
+  Background:
+    Given the config "FRONTEND_ENABLE_RESHARING" has been set to "false"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has created folder "test"
+
+
+  Scenario Outline: share folder with different roles
+    Given using <dav-path-version> DAV path
+    When user "Alice" creates a share inside of space "Personal" with settings:
+      | path      | test   |
+      | shareWith | Brian  |
+      | role      | <role> |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | permissions | <expectedPermissions> |
+    Examples:
+      | dav-path-version | role   | expectedPermissions |
+      | old              | editor | 15                  |
+      | old              | viewer | 1                   |
+      | new              | editor | 15                  |
+      | new              | viewer | 1                   |
+      | spaces           | editor | 15                  |
+      | spaces           | viewer | 1                   |
+
+
+  Scenario Outline: try to re-share folder
+    Given using <dav-path-version> DAV path
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created a share inside of space "Personal" with settings:
+      | path      | test   |
+      | shareWith | Brian  |
+      | role      | <role> |
+    And user "Brian" has accepted share "/test" offered by user "Alice"
+    When user "Brian" creates a share inside of space "Shares" with settings:
+      | path      | test   |
+      | shareWith | Carol  |
+      | role      | <role> |
+    Then the HTTP status code should be "403"
+    And the OCS status code should be "403"
+    And the OCS status message should be "No share permission"
+    Examples:
+      | dav-path-version | role   |
+      | old              | editor |
+      | old              | viewer |
+      | new              | editor |
+      | new              | viewer |
+      | spaces           | editor |
+      | spaces           | viewer |


### PR DESCRIPTION

## Description
This PR adds the API tests for sharing by setting FRONTEND_ENABLE_RESHARING to false. The scenarios added in this PR are:
- share folder with different roles
- try to re-share folder

## Related Issue
-  https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- there was no test coverage for api test for disabling  FRONTEND_ENABLE_RESHARING env variable. So, this PR covers the required scenarios test cases.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
