### PR TITLE
Deprovisioning Notification

### DIFF
--- a/services/userlog/README.md
+++ b/services/userlog/README.md
@@ -34,9 +34,19 @@ The `userlog` service provides an API to retrieve configured events. For now, th
 
 Additionally to the oc10 API, the `userlog` service also provides an `/sse` (Server-Sent Events) endpoint to be informed by the server when an event happens. See [What is Server-Sent Events](https://medium.com/yemeksepeti-teknoloji/what-is-server-sent-events-sse-and-how-to-implement-it-904938bffd73) for a simple introduction and examples of server sent events. The `sse` endpoint will respect language changes of the user without needing to reconnect. Note that SSE has a limitation of six open connections per browser which can be reached if one has opened various tabs of the Web UI pointing to the same Infinite Scale instance.
 
+## Posting
+
+The userlog service is able to store global messages that will be displayed in the Web UI to all users. These messages can only be activated and deleted by users with the `admin` role but not by ordinary users. If a user deletes the message in the Web UI, it reappears on reload. Global messages use the endpoint `/ocs/v2.php/apps/notifications/api/v1/notifications/global` and are activated by sending a `POST` request. Note that sending another `POST` request of the same type overwrites the previous one. For the time being, only the type `deprovision` is supported.
+
+### Deprovisioning
+
+Deprovision messages announce a deprovision text including a deprovision date of the instance to all users. With this message, users get informed that the instance will be shut down and deprovisioned and no further access to their data is possible past the given date. This implies that users must download their data before the given date. The text shown to users refers to this information. Note that the task to deprovision the instance does not depend on the message. The text of the message can be translated according to the translation settings, see section [Translations](#translations). The endpoint only expects a `deprovision_date` parameter in the `POST` request body as the final text is assembled automatically. The string hast to be in `RFC3339` format, however, this format can be changed by using `deprovision_date_format`. See the [go time formating](https://pkg.go.dev/time#pkg-constants) for more details.
+
 ## Deleting
 
 To delete events for an user, use a `DELETE` request to `ocs/v2.php/apps/notifications/api/v1/notifications` containing the IDs to delete.
+
+Only users with the `admin` role can send a `DELETE` request to the `ocs/v2.php/apps/notifications/api/v1/notifications/global` endpoint to remove a global message, see the [Posting](#posting) section for more details.)
 
 ## Translations
 

--- a/services/userlog/pkg/command/server.go
+++ b/services/userlog/pkg/command/server.go
@@ -104,6 +104,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			hClient := ehsvc.NewEventHistoryService("com.owncloud.api.eventhistory", ogrpc.DefaultClient())
 			vClient := settingssvc.NewValueService("com.owncloud.api.settings", ogrpc.DefaultClient())
+			rClient := settingssvc.NewRoleService("com.owncloud.api.settings", ogrpc.DefaultClient())
 
 			{
 				server, err := http.Server(
@@ -116,6 +117,7 @@ func Server(cfg *config.Config) *cli.Command {
 					http.GatewaySelector(gatewaySelector),
 					http.History(hClient),
 					http.Value(vClient),
+					http.Role(rClient),
 					http.RegisteredEvents(_registeredEvents),
 				)
 

--- a/services/userlog/pkg/server/http/option.go
+++ b/services/userlog/pkg/server/http/option.go
@@ -31,6 +31,7 @@ type Options struct {
 	GatewaySelector  pool.Selectable[gateway.GatewayAPIClient]
 	HistoryClient    ehsvc.EventHistoryService
 	ValueClient      settingssvc.ValueService
+	RoleClient       settingssvc.RoleService
 	RegisteredEvents []events.Unmarshaller
 }
 
@@ -126,5 +127,12 @@ func RegisteredEvents(evs []events.Unmarshaller) Option {
 func Value(vs settingssvc.ValueService) Option {
 	return func(o *Options) {
 		o.ValueClient = vs
+	}
+}
+
+// Roles provides a function to configure the roles service client
+func Role(rs settingssvc.RoleService) Option {
+	return func(o *Options) {
+		o.RoleClient = rs
 	}
 }

--- a/services/userlog/pkg/server/http/server.go
+++ b/services/userlog/pkg/server/http/server.go
@@ -77,6 +77,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.HistoryClient(options.HistoryClient),
 		svc.GatewaySelector(options.GatewaySelector),
 		svc.ValueClient(options.ValueClient),
+		svc.RoleClient(options.RoleClient),
 		svc.RegisteredEvents(options.RegisteredEvents),
 	)
 	if err != nil {

--- a/services/userlog/pkg/service/conversion.go
+++ b/services/userlog/pkg/service/conversion.go
@@ -129,7 +129,7 @@ func (c *Converter) ConvertGlobalEvent(typ string, data json.RawMessage) (OC10No
 			return OC10Notification{}, err
 		}
 
-		return c.deprovisionMessage(PlatformDeprovision, dd.DeprovisionDate)
+		return c.deprovisionMessage(PlatformDeprovision, dd.DeprovisionDate.Format(dd.DeprovisionFormat))
 	}
 
 }
@@ -305,7 +305,7 @@ func (c *Converter) policiesMessage(eventid string, nt NotificationTemplate, exe
 	}, nil
 }
 
-func (c *Converter) deprovisionMessage(nt NotificationTemplate, deproDate time.Time) (OC10Notification, error) {
+func (c *Converter) deprovisionMessage(nt NotificationTemplate, deproDate string) (OC10Notification, error) {
 	subj, subjraw, msg, msgraw, err := composeMessage(nt, c.locale, c.translationPath, map[string]interface{}{
 		"date": deproDate,
 	})

--- a/services/userlog/pkg/service/conversion.go
+++ b/services/userlog/pkg/service/conversion.go
@@ -305,7 +305,7 @@ func (c *Converter) policiesMessage(eventid string, nt NotificationTemplate, exe
 	}, nil
 }
 
-func (c *Converter) deprovisionMessage(nt NotificationTemplate, deproDate string) (OC10Notification, error) {
+func (c *Converter) deprovisionMessage(nt NotificationTemplate, deproDate time.Time) (OC10Notification, error) {
 	subj, subjraw, msg, msgraw, err := composeMessage(nt, c.locale, c.translationPath, map[string]interface{}{
 		"date": deproDate,
 	})

--- a/services/userlog/pkg/service/globalevents.go
+++ b/services/userlog/pkg/service/globalevents.go
@@ -10,6 +10,8 @@ var (
 type DeprovisionData struct {
 	// The deprovision date
 	DeprovisionDate time.Time `json:"deprovision_date"`
+	// The Format of the deprvision date
+	DeprovisionFormat string
 	// The user who stored the deprovision message
 	Deprovisioner string
 }

--- a/services/userlog/pkg/service/globalevents.go
+++ b/services/userlog/pkg/service/globalevents.go
@@ -1,0 +1,15 @@
+package service
+
+import "time"
+
+var (
+	_globalEventsKey = "global-events"
+)
+
+// DeprovisionData is the data needed for the deprovision global event
+type DeprovisionData struct {
+	// The deprovision date
+	DeprovisionDate time.Time `json:"deprovision_date"`
+	// The user who stored the deprovision message
+	Deprovisioner string
+}

--- a/services/userlog/pkg/service/http.go
+++ b/services/userlog/pkg/service/http.go
@@ -6,6 +6,10 @@ import (
 
 	"github.com/cs3org/reva/v2/pkg/ctx"
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/roles"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
+	settings "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
 )
 
 // HeaderAcceptLanguage is the header where the client can set the locale
@@ -122,8 +126,6 @@ func (ul *UserlogService) HandlePostEvent(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// TODO: Check user is allowed to do this
-
 	var req PostEventsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		ul.log.Error().Err(err).Int("returned statuscode", http.StatusBadRequest).Msg("request body is malformed")
@@ -191,4 +193,45 @@ type PostEventsRequest struct {
 // DeprovisionData is the expected `data` for the PostEventsRequest when deprovisioning
 type DeprovisionData struct {
 	DeprovisionDate string `json:"date"`
+}
+
+// RequireAdmin middleware is used to require the user in context to be an admin / have account management permissions
+func RequireAdmin(rm *roles.Manager, logger log.Logger) func(next http.HandlerFunc) http.HandlerFunc {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			u, ok := revactx.ContextGetUser(r.Context())
+			if !ok {
+				errorcode.AccessDenied.Render(w, r, http.StatusUnauthorized, "Unauthorized")
+				return
+			}
+			if u.Id == nil || u.Id.OpaqueId == "" {
+				errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "user is missing an id")
+				return
+			}
+			// get roles from context
+			roleIDs, ok := roles.ReadRoleIDsFromContext(r.Context())
+			if !ok {
+				logger.Debug().Str("userid", u.Id.OpaqueId).Msg("No roles in context, contacting settings service")
+				var err error
+				roleIDs, err = rm.FindRoleIDsForUser(r.Context(), u.Id.OpaqueId)
+				if err != nil {
+					logger.Err(err).Str("userid", u.Id.OpaqueId).Msg("failed to get roles for user")
+					errorcode.AccessDenied.Render(w, r, http.StatusUnauthorized, "Unauthorized")
+					return
+				}
+				if len(roleIDs) == 0 {
+					errorcode.AccessDenied.Render(w, r, http.StatusUnauthorized, "Unauthorized")
+					return
+				}
+			}
+
+			// check if permission is present in roles of the authenticated account
+			if rm.FindPermissionByID(r.Context(), roleIDs, settings.AccountManagementPermissionID) != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			errorcode.AccessDenied.Render(w, r, http.StatusForbidden, "Forbidden")
+		}
+	}
 }

--- a/services/userlog/pkg/service/http.go
+++ b/services/userlog/pkg/service/http.go
@@ -186,13 +186,10 @@ type DeleteEventsRequest struct {
 
 // PostEventsRequest is the expected body for the post request
 type PostEventsRequest struct {
-	Type string          `json:"type"`
-	Data json.RawMessage `json:"data"`
-}
-
-// DeprovisionData is the expected `data` for the PostEventsRequest when deprovisioning
-type DeprovisionData struct {
-	DeprovisionDate string `json:"date"`
+	// the event type, e.g. "deprovision"
+	Type string `json:"type"`
+	// arbitray data for the event
+	Data map[string]string `json:"data"`
 }
 
 // RequireAdmin middleware is used to require the user in context to be an admin / have account management permissions

--- a/services/userlog/pkg/service/options.go
+++ b/services/userlog/pkg/service/options.go
@@ -25,6 +25,7 @@ type Options struct {
 	HistoryClient    ehsvc.EventHistoryService
 	GatewaySelector  pool.Selectable[gateway.GatewayAPIClient]
 	ValueClient      settingssvc.ValueService
+	RoleClient       settingssvc.RoleService
 	RegisteredEvents []events.Unmarshaller
 }
 
@@ -84,8 +85,16 @@ func RegisteredEvents(e []events.Unmarshaller) Option {
 	}
 }
 
+// ValueClient adds a grpc client for the value service
 func ValueClient(vs settingssvc.ValueService) Option {
 	return func(o *Options) {
 		o.ValueClient = vs
+	}
+}
+
+// RoleClient adds a grpc client for the role service
+func RoleClient(rs settingssvc.RoleService) Option {
+	return func(o *Options) {
+		o.RoleClient = rs
 	}
 }

--- a/services/userlog/pkg/service/templates.go
+++ b/services/userlog/pkg/service/templates.go
@@ -56,8 +56,8 @@ var (
 	}
 
 	PlatformDeprovision = NotificationTemplate{
-		Subject: Template("Platform will be deprovisioned"),
-		Message: Template("Attention! The platform will be deprovisioned at {date}"),
+		Subject: Template("Instance will be shut down and deprovisioned"),
+		Message: Template("Attention! The instance will be shut down and deprovisioned on {date}. Download all your data before that date as no access past that date is possible."),
 	}
 )
 

--- a/services/userlog/pkg/service/templates.go
+++ b/services/userlog/pkg/service/templates.go
@@ -54,6 +54,11 @@ var (
 		Subject: Template("Share expired"),
 		Message: Template("Access to {resource} expired"),
 	}
+
+	PlatformDeprovision = NotificationTemplate{
+		Subject: Template("Platform will be deprovisioned"),
+		Message: Template("Attention! The platform will be deprovisioned at {date}"),
+	}
 )
 
 // holds the information to turn the raw template into a parseable go template
@@ -62,6 +67,7 @@ var _placeholders = map[string]string{
 	"{space}":    "{{ .spacename }}",
 	"{resource}": "{{ .resourcename }}",
 	"{virus}":    "{{ .virusdescription }}",
+	"{date}":     "{{ .date }}",
 }
 
 // NotificationTemplate is the data structure for the notifications


### PR DESCRIPTION
Adds global notifications to userlog service

To store a deprovision notification `POST` on `/global` endpoint:
```bash
curl --insecure -X POST -v -u admin:admin -d '{"type":"deprovision", "data":{"deprovision_date": "2023-07-04T12:23:12Z"}}' https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/global
```

You can define the format of the date with the `deprovision_date_format` parameter
```bash
curl --insecure -X POST -v -u admin:admin -d '{"type":"deprovision", "data":{"deprovision_date": "2023-07-04 15:17", "deprovision_date_format":"2006-01-02 15:04"}}' https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/global 
```
See [go time formating](https://pkg.go.dev/time#pkg-constants) for format details

To delete a deprovision notification `DELETE` on `/global` endpoint
```bash
curl --insecure -X DELETE -v -u admin:admin -d '{"ids":["deprovision"]}' https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/global 
```

NOTE: non admin users will only get a `404 NOT FOUND` on both endpoints