### PR TITLE
graph: New 'terminationDate' property on educationSchool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -337,3 +337,5 @@ require (
 replace github.com/cs3org/go-cs3apis => github.com/2403905/go-cs3apis v0.0.0-20230517122726-727045414fd1
 
 // replace github.com/cs3org/reva/v2 => github.com/micbar/reva/v2 v2.0.0-20230626125956-c381fe19a108
+
+replace github.com/owncloud/libre-graph-api-go => github.com/rhafer/libre-graph-api-go v0.13.4-0.20230629154140-fa67e25dc257

--- a/go.sum
+++ b/go.sum
@@ -1382,8 +1382,6 @@ github.com/oracle/oci-go-sdk v24.3.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35uk
 github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HDbW65HOY=
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b h1:65U1jcoFlywV2ZEfkynaw4v4DuS/UJdlyHQYCHB+fYA=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b/go.mod h1:iKdVH6nYpI8RBeK9sjeLfzrPByST6r9d+NG2IJHoJmU=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1477,6 +1475,8 @@ github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2/go.mod h1:7tZKc
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rhafer/libre-graph-api-go v0.13.4-0.20230629154140-fa67e25dc257 h1:TC0dFPmVwUXp1aMMnFfyFrAMqW64x0Q5kZTKUCPZXAo=
+github.com/rhafer/libre-graph-api-go v0.13.4-0.20230629154140-fa67e25dc257/go.mod h1:579sFrPP7aP24LZXGPopLfvE+hAka/2DYHk0+Ij+w+U=
 github.com/riandyrn/otelchi v0.5.1 h1:0/45omeqpP7f/cvdL16GddQBfAEmZvUyl2QzLSE6uYo=
 github.com/riandyrn/otelchi v0.5.1/go.mod h1:ZxVxNEl+jQ9uHseRYIxKWRb3OY8YXFEu+EkNiiSNUEA=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 )
@@ -94,6 +95,8 @@ type LDAPEducationConfig struct {
 	SchoolNameAttribute   string `yaml:"school_name_attribute" env:"GRAPH_LDAP_SCHOOL_NAME_ATTRIBUTE" desc:"LDAP Attribute to use for the name of a school."`
 	SchoolNumberAttribute string `yaml:"school_number_attribute" env:"GRAPH_LDAP_SCHOOL_NUMBER_ATTRIBUTE" desc:"LDAP Attribute to use for the number of a school."`
 	SchoolIDAttribute     string `yaml:"school_id_attribute" env:"GRAPH_LDAP_SCHOOL_ID_ATTRIBUTE" desc:"LDAP Attribute to use as the unique id for schools. This should be a stable globally unique ID like a UUID."`
+
+	SchoolTerminationGracePeriod time.Duration `yaml:"school_termination_min_grace_period" env:"GRAPH_LDAP_SCHOOL_TERMINATION_MIN_GRACE_PERIOD" desc:"The minimal time period, which the terminationDate of a School needs to be in the future, when updating it."`
 }
 
 type Identity struct {

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -80,6 +80,16 @@ func (g Graph) PostEducationSchool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// validate terminationDate attribute, needs to be "far enough" in the future, terminationDate can be nil (means
+	// termination date is to be deleted
+	if terminationDate, ok := school.GetTerminationDateOk(); ok && terminationDate != nil {
+		err = g.validateTerminationDate(*terminationDate)
+		if err != nil {
+			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		}
+		return
+	}
+
 	if school, err = g.identityEducationBackend.CreateEducationSchool(r.Context(), *school); err != nil {
 		logger.Debug().Err(err).Interface("school", school).Msg("could not create school: backend error")
 		errorcode.RenderError(w, r, err)
@@ -123,6 +133,16 @@ func (g Graph) PatchEducationSchool(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update school: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
+		return
+	}
+
+	// validate terminationDate attribute, needs to be "far enough" in the future, terminationDate can be nil (means
+	// termination date is to be deleted
+	if terminationDate, ok := school.GetTerminationDateOk(); ok && terminationDate != nil {
+		err = g.validateTerminationDate(*terminationDate)
+		if err != nil {
+			errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		}
 		return
 	}
 
@@ -564,6 +584,19 @@ func (g Graph) DeleteEducationSchoolClass(w http.ResponseWriter, r *http.Request
 
 	render.Status(r, http.StatusNoContent)
 	render.NoContent(w, r)
+}
+
+func (g Graph) validateTerminationDate(terminationDate time.Time) error {
+	if terminationDate.Before(time.Now()) {
+		return fmt.Errorf("can not set a termination date in the past")
+	}
+	graceTime := g.config.Identity.LDAP.EducationConfig.SchoolTerminationGracePeriod
+	if graceTime != 0 {
+		if terminationDate.Before(time.Now().Add(graceTime)) {
+			return fmt.Errorf("termination needs to be at least %vin the future", graceTime)
+		}
+	}
+	return nil
 }
 
 func sortEducationSchools(req *godata.GoDataRequest, schools []*libregraph.EducationSchool) ([]*libregraph.EducationSchool, error) {

--- a/services/graph/pkg/service/v0/educationschools_test.go
+++ b/services/graph/pkg/service/v0/educationschools_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Schools", func() {
 
 		cfg = defaults.FullDefaultConfig()
 		cfg.Identity.LDAP.CACert = "" // skip the startup checks, we don't use LDAP at all in this tests
+		cfg.Identity.LDAP.EducationConfig.SchoolTerminationGracePeriod = 24 * 30 * time.Hour
 		cfg.TokenManager.JWTSecret = "loremipsum"
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
@@ -294,8 +295,17 @@ var _ = Describe("Schools", func() {
 		schoolUpdate.SetDisplayName("New School Name")
 		schoolUpdateJson, _ := json.Marshal(schoolUpdate)
 
+		schoolUpdatePast := libregraph.NewEducationSchool()
+		schoolUpdatePast.SetTerminationDate(time.Now().Add(-time.Hour * 1))
+		schoolUpdatePastJson, _ := json.Marshal(schoolUpdatePast)
 
+		schoolUpdateBeforeGrace := libregraph.NewEducationSchool()
+		schoolUpdateBeforeGrace.SetTerminationDate(time.Now().Add(24 * 10 * time.Hour))
+		schoolUpdateBeforeGraceJson, _ := json.Marshal(schoolUpdateBeforeGrace)
 
+		schoolUpdatePastGrace := libregraph.NewEducationSchool()
+		schoolUpdatePastGrace.SetTerminationDate(time.Now().Add(24 * 31 * time.Hour))
+		schoolUpdatePastGraceJson, _ := json.Marshal(schoolUpdatePastGrace)
 
 		BeforeEach(func() {
 			identityEducationBackend.On("UpdateEducationSchool", mock.Anything, mock.Anything, mock.Anything).Return(schoolUpdate, nil)
@@ -315,6 +325,9 @@ var _ = Describe("Schools", func() {
 			Entry("handles missing or empty school id", "", bytes.NewBufferString(""), http.StatusBadRequest),
 			Entry("handles malformed school id", "school%id", bytes.NewBuffer(schoolUpdateJson), http.StatusBadRequest),
 			Entry("updates the school", "school-id", bytes.NewBuffer(schoolUpdateJson), http.StatusOK),
+			Entry("fails to set a termination date in the past", "school-id", bytes.NewBuffer(schoolUpdatePastJson), http.StatusBadRequest),
+			Entry("fails to set a termination date before grace period", "school-id", bytes.NewBuffer(schoolUpdateBeforeGraceJson), http.StatusBadRequest),
+			Entry("succeeds to set a termination date past the grace period", "school-id", bytes.NewBuffer(schoolUpdatePastGraceJson), http.StatusOK),
 		)
 	})
 

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_applications.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_applications.go
@@ -35,9 +35,9 @@ func (r ApiGetApplicationRequest) Execute() (*Application, *http.Response, error
 /*
 GetApplication Get application by id
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param applicationId key: id of application
- @return ApiGetApplicationRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param applicationId key: id of application
+	@return ApiGetApplicationRequest
 */
 func (a *ApplicationsApiService) GetApplication(ctx context.Context, applicationId string) ApiGetApplicationRequest {
 	return ApiGetApplicationRequest{
@@ -48,7 +48,8 @@ func (a *ApplicationsApiService) GetApplication(ctx context.Context, application
 }
 
 // Execute executes the request
-//  @return Application
+//
+//	@return Application
 func (a *ApplicationsApiService) GetApplicationExecute(r ApiGetApplicationRequest) (*Application, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -142,8 +143,8 @@ func (r ApiListApplicationsRequest) Execute() (*CollectionOfApplications, *http.
 /*
 ListApplications Get all applications
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListApplicationsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListApplicationsRequest
 */
 func (a *ApplicationsApiService) ListApplications(ctx context.Context) ApiListApplicationsRequest {
 	return ApiListApplicationsRequest{
@@ -153,7 +154,8 @@ func (a *ApplicationsApiService) ListApplications(ctx context.Context) ApiListAp
 }
 
 // Execute executes the request
-//  @return CollectionOfApplications
+//
+//	@return CollectionOfApplications
 func (a *ApplicationsApiService) ListApplicationsExecute(r ApiListApplicationsRequest) (*CollectionOfApplications, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_drives.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_drives.go
@@ -41,8 +41,8 @@ func (r ApiCreateDriveRequest) Execute() (*Drive, *http.Response, error) {
 /*
 CreateDrive Create a new drive of a specific type
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateDriveRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateDriveRequest
 */
 func (a *DrivesApiService) CreateDrive(ctx context.Context) ApiCreateDriveRequest {
 	return ApiCreateDriveRequest{
@@ -52,7 +52,8 @@ func (a *DrivesApiService) CreateDrive(ctx context.Context) ApiCreateDriveReques
 }
 
 // Execute executes the request
-//  @return Drive
+//
+//	@return Drive
 func (a *DrivesApiService) CreateDriveExecute(r ApiCreateDriveRequest) (*Drive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -158,9 +159,9 @@ func (r ApiDeleteDriveRequest) Execute() (*http.Response, error) {
 /*
 DeleteDrive Delete a specific space
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param driveId key: id of drive
- @return ApiDeleteDriveRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param driveId key: id of drive
+	@return ApiDeleteDriveRequest
 */
 func (a *DrivesApiService) DeleteDrive(ctx context.Context, driveId string) ApiDeleteDriveRequest {
 	return ApiDeleteDriveRequest{
@@ -258,9 +259,9 @@ func (r ApiGetDriveRequest) Execute() (*Drive, *http.Response, error) {
 /*
 GetDrive Get drive by id
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param driveId key: id of drive
- @return ApiGetDriveRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param driveId key: id of drive
+	@return ApiGetDriveRequest
 */
 func (a *DrivesApiService) GetDrive(ctx context.Context, driveId string) ApiGetDriveRequest {
 	return ApiGetDriveRequest{
@@ -271,7 +272,8 @@ func (a *DrivesApiService) GetDrive(ctx context.Context, driveId string) ApiGetD
 }
 
 // Execute executes the request
-//  @return Drive
+//
+//	@return Drive
 func (a *DrivesApiService) GetDriveExecute(r ApiGetDriveRequest) (*Drive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -373,9 +375,9 @@ func (r ApiUpdateDriveRequest) Execute() (*Drive, *http.Response, error) {
 /*
 UpdateDrive Update the drive
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param driveId key: id of drive
- @return ApiUpdateDriveRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param driveId key: id of drive
+	@return ApiUpdateDriveRequest
 */
 func (a *DrivesApiService) UpdateDrive(ctx context.Context, driveId string) ApiUpdateDriveRequest {
 	return ApiUpdateDriveRequest{
@@ -386,7 +388,8 @@ func (a *DrivesApiService) UpdateDrive(ctx context.Context, driveId string) ApiU
 }
 
 // Execute executes the request
-//  @return Drive
+//
+//	@return Drive
 func (a *DrivesApiService) UpdateDriveExecute(r ApiUpdateDriveRequest) (*Drive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_drives_get_drives.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_drives_get_drives.go
@@ -47,8 +47,8 @@ func (r ApiListAllDrivesRequest) Execute() (*CollectionOfDrives1, *http.Response
 /*
 ListAllDrives Get all available drives
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListAllDrivesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListAllDrivesRequest
 */
 func (a *DrivesGetDrivesApiService) ListAllDrives(ctx context.Context) ApiListAllDrivesRequest {
 	return ApiListAllDrivesRequest{
@@ -58,7 +58,8 @@ func (a *DrivesGetDrivesApiService) ListAllDrives(ctx context.Context) ApiListAl
 }
 
 // Execute executes the request
-//  @return CollectionOfDrives1
+//
+//	@return CollectionOfDrives1
 func (a *DrivesGetDrivesApiService) ListAllDrivesExecute(r ApiListAllDrivesRequest) (*CollectionOfDrives1, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_drives_root.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_drives_root.go
@@ -35,9 +35,9 @@ func (r ApiGetRootRequest) Execute() (*DriveItem, *http.Response, error) {
 /*
 GetRoot Get root from arbitrary space
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param driveId key: id of drive
- @return ApiGetRootRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param driveId key: id of drive
+	@return ApiGetRootRequest
 */
 func (a *DrivesRootApiService) GetRoot(ctx context.Context, driveId string) ApiGetRootRequest {
 	return ApiGetRootRequest{
@@ -48,7 +48,8 @@ func (a *DrivesRootApiService) GetRoot(ctx context.Context, driveId string) ApiG
 }
 
 // Execute executes the request
-//  @return DriveItem
+//
+//	@return DriveItem
 func (a *DrivesRootApiService) GetRootExecute(r ApiGetRootRequest) (*DriveItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_education_class.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_education_class.go
@@ -42,9 +42,9 @@ func (r ApiAddUserToClassRequest) Execute() (*http.Response, error) {
 /*
 AddUserToClass Assign a user to a class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @return ApiAddUserToClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@return ApiAddUserToClassRequest
 */
 func (a *EducationClassApiService) AddUserToClass(ctx context.Context, classId string) ApiAddUserToClassRequest {
 	return ApiAddUserToClassRequest{
@@ -150,8 +150,8 @@ func (r ApiCreateClassRequest) Execute() (*EducationClass, *http.Response, error
 /*
 CreateClass Add new education class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateClassRequest
 */
 func (a *EducationClassApiService) CreateClass(ctx context.Context) ApiCreateClassRequest {
 	return ApiCreateClassRequest{
@@ -161,7 +161,8 @@ func (a *EducationClassApiService) CreateClass(ctx context.Context) ApiCreateCla
 }
 
 // Execute executes the request
-//  @return EducationClass
+//
+//	@return EducationClass
 func (a *EducationClassApiService) CreateClassExecute(r ApiCreateClassRequest) (*EducationClass, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -260,9 +261,9 @@ func (r ApiDeleteClassRequest) Execute() (*http.Response, error) {
 /*
 DeleteClass Delete education class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @return ApiDeleteClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@return ApiDeleteClassRequest
 */
 func (a *EducationClassApiService) DeleteClass(ctx context.Context, classId string) ApiDeleteClassRequest {
 	return ApiDeleteClassRequest{
@@ -358,10 +359,10 @@ func (r ApiDeleteUserFromClassRequest) Execute() (*http.Response, error) {
 /*
 DeleteUserFromClass Unassign user from a class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @param userId key: id or username of the user to unassign from class
- @return ApiDeleteUserFromClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@param userId key: id or username of the user to unassign from class
+	@return ApiDeleteUserFromClassRequest
 */
 func (a *EducationClassApiService) DeleteUserFromClass(ctx context.Context, classId string, userId string) ApiDeleteUserFromClassRequest {
 	return ApiDeleteUserFromClassRequest{
@@ -458,9 +459,9 @@ func (r ApiGetClassRequest) Execute() (*EducationClass, *http.Response, error) {
 /*
 GetClass Get class by key
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @return ApiGetClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@return ApiGetClassRequest
 */
 func (a *EducationClassApiService) GetClass(ctx context.Context, classId string) ApiGetClassRequest {
 	return ApiGetClassRequest{
@@ -471,7 +472,8 @@ func (a *EducationClassApiService) GetClass(ctx context.Context, classId string)
 }
 
 // Execute executes the request
-//  @return EducationClass
+//
+//	@return EducationClass
 func (a *EducationClassApiService) GetClassExecute(r ApiGetClassRequest) (*EducationClass, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -566,9 +568,9 @@ func (r ApiListClassMembersRequest) Execute() (*CollectionOfEducationUser, *http
 /*
 ListClassMembers Get the educationClass resources owned by an educationSchool
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @return ApiListClassMembersRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@return ApiListClassMembersRequest
 */
 func (a *EducationClassApiService) ListClassMembers(ctx context.Context, classId string) ApiListClassMembersRequest {
 	return ApiListClassMembersRequest{
@@ -579,7 +581,8 @@ func (a *EducationClassApiService) ListClassMembers(ctx context.Context, classId
 }
 
 // Execute executes the request
-//  @return CollectionOfEducationUser
+//
+//	@return CollectionOfEducationUser
 func (a *EducationClassApiService) ListClassMembersExecute(r ApiListClassMembersRequest) (*CollectionOfEducationUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -673,8 +676,8 @@ func (r ApiListClassesRequest) Execute() (*CollectionOfClass, *http.Response, er
 /*
 ListClasses list education classes
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListClassesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListClassesRequest
 */
 func (a *EducationClassApiService) ListClasses(ctx context.Context) ApiListClassesRequest {
 	return ApiListClassesRequest{
@@ -684,7 +687,8 @@ func (a *EducationClassApiService) ListClasses(ctx context.Context) ApiListClass
 }
 
 // Execute executes the request
-//  @return CollectionOfClass
+//
+//	@return CollectionOfClass
 func (a *EducationClassApiService) ListClassesExecute(r ApiListClassesRequest) (*CollectionOfClass, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -785,9 +789,9 @@ func (r ApiUpdateClassRequest) Execute() (*EducationClass, *http.Response, error
 /*
 UpdateClass Update properties of a education class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @return ApiUpdateClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@return ApiUpdateClassRequest
 */
 func (a *EducationClassApiService) UpdateClass(ctx context.Context, classId string) ApiUpdateClassRequest {
 	return ApiUpdateClassRequest{
@@ -798,7 +802,8 @@ func (a *EducationClassApiService) UpdateClass(ctx context.Context, classId stri
 }
 
 // Execute executes the request
-//  @return EducationClass
+//
+//	@return EducationClass
 func (a *EducationClassApiService) UpdateClassExecute(r ApiUpdateClassRequest) (*EducationClass, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_education_class_teachers.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_education_class_teachers.go
@@ -42,9 +42,9 @@ func (r ApiAddTeacherToClassRequest) Execute() (*http.Response, error) {
 /*
 AddTeacherToClass Assign a teacher to a class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @return ApiAddTeacherToClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@return ApiAddTeacherToClassRequest
 */
 func (a *EducationClassTeachersApiService) AddTeacherToClass(ctx context.Context, classId string) ApiAddTeacherToClassRequest {
 	return ApiAddTeacherToClassRequest{
@@ -145,10 +145,10 @@ func (r ApiDeleteTeacherFromClassRequest) Execute() (*http.Response, error) {
 /*
 DeleteTeacherFromClass Unassign user as teacher of a class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @param userId key: id or username of the user to unassign as teacher
- @return ApiDeleteTeacherFromClassRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@param userId key: id or username of the user to unassign as teacher
+	@return ApiDeleteTeacherFromClassRequest
 */
 func (a *EducationClassTeachersApiService) DeleteTeacherFromClass(ctx context.Context, classId string, userId string) ApiDeleteTeacherFromClassRequest {
 	return ApiDeleteTeacherFromClassRequest{
@@ -245,9 +245,9 @@ func (r ApiGetTeachersRequest) Execute() (*CollectionOfEducationUser, *http.Resp
 /*
 GetTeachers Get the teachers for a class
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param classId key: id or externalId of class
- @return ApiGetTeachersRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param classId key: id or externalId of class
+	@return ApiGetTeachersRequest
 */
 func (a *EducationClassTeachersApiService) GetTeachers(ctx context.Context, classId string) ApiGetTeachersRequest {
 	return ApiGetTeachersRequest{
@@ -258,7 +258,8 @@ func (a *EducationClassTeachersApiService) GetTeachers(ctx context.Context, clas
 }
 
 // Execute executes the request
-//  @return CollectionOfEducationUser
+//
+//	@return CollectionOfEducationUser
 func (a *EducationClassTeachersApiService) GetTeachersExecute(r ApiGetTeachersRequest) (*CollectionOfEducationUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_education_school.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_education_school.go
@@ -42,9 +42,9 @@ func (r ApiAddClassToSchoolRequest) Execute() (*http.Response, error) {
 /*
 AddClassToSchool Assign a class to a school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @return ApiAddClassToSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@return ApiAddClassToSchoolRequest
 */
 func (a *EducationSchoolApiService) AddClassToSchool(ctx context.Context, schoolId string) ApiAddClassToSchoolRequest {
 	return ApiAddClassToSchoolRequest{
@@ -151,9 +151,9 @@ func (r ApiAddUserToSchoolRequest) Execute() (*http.Response, error) {
 /*
 AddUserToSchool Assign a user to a school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @return ApiAddUserToSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@return ApiAddUserToSchoolRequest
 */
 func (a *EducationSchoolApiService) AddUserToSchool(ctx context.Context, schoolId string) ApiAddUserToSchoolRequest {
 	return ApiAddUserToSchoolRequest{
@@ -259,8 +259,8 @@ func (r ApiCreateSchoolRequest) Execute() (*EducationSchool, *http.Response, err
 /*
 CreateSchool Add new school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateSchoolRequest
 */
 func (a *EducationSchoolApiService) CreateSchool(ctx context.Context) ApiCreateSchoolRequest {
 	return ApiCreateSchoolRequest{
@@ -270,7 +270,8 @@ func (a *EducationSchoolApiService) CreateSchool(ctx context.Context) ApiCreateS
 }
 
 // Execute executes the request
-//  @return EducationSchool
+//
+//	@return EducationSchool
 func (a *EducationSchoolApiService) CreateSchoolExecute(r ApiCreateSchoolRequest) (*EducationSchool, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -370,10 +371,10 @@ func (r ApiDeleteClassFromSchoolRequest) Execute() (*http.Response, error) {
 /*
 DeleteClassFromSchool Unassign class from a school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @param classId key: id or externalId of the class to unassign from school
- @return ApiDeleteClassFromSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@param classId key: id or externalId of the class to unassign from school
+	@return ApiDeleteClassFromSchoolRequest
 */
 func (a *EducationSchoolApiService) DeleteClassFromSchool(ctx context.Context, schoolId string, classId string) ApiDeleteClassFromSchoolRequest {
 	return ApiDeleteClassFromSchoolRequest{
@@ -470,9 +471,9 @@ func (r ApiDeleteSchoolRequest) Execute() (*http.Response, error) {
 /*
 DeleteSchool Delete school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @return ApiDeleteSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@return ApiDeleteSchoolRequest
 */
 func (a *EducationSchoolApiService) DeleteSchool(ctx context.Context, schoolId string) ApiDeleteSchoolRequest {
 	return ApiDeleteSchoolRequest{
@@ -568,10 +569,10 @@ func (r ApiDeleteUserFromSchoolRequest) Execute() (*http.Response, error) {
 /*
 DeleteUserFromSchool Unassign user from a school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @param userId key: id or username of the user to unassign from school
- @return ApiDeleteUserFromSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@param userId key: id or username of the user to unassign from school
+	@return ApiDeleteUserFromSchoolRequest
 */
 func (a *EducationSchoolApiService) DeleteUserFromSchool(ctx context.Context, schoolId string, userId string) ApiDeleteUserFromSchoolRequest {
 	return ApiDeleteUserFromSchoolRequest{
@@ -668,9 +669,9 @@ func (r ApiGetSchoolRequest) Execute() (*EducationSchool, *http.Response, error)
 /*
 GetSchool Get the properties of a specific school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @return ApiGetSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@return ApiGetSchoolRequest
 */
 func (a *EducationSchoolApiService) GetSchool(ctx context.Context, schoolId string) ApiGetSchoolRequest {
 	return ApiGetSchoolRequest{
@@ -681,7 +682,8 @@ func (a *EducationSchoolApiService) GetSchool(ctx context.Context, schoolId stri
 }
 
 // Execute executes the request
-//  @return EducationSchool
+//
+//	@return EducationSchool
 func (a *EducationSchoolApiService) GetSchoolExecute(r ApiGetSchoolRequest) (*EducationSchool, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -776,9 +778,9 @@ func (r ApiListSchoolClassesRequest) Execute() (*CollectionOfEducationClass, *ht
 /*
 ListSchoolClasses Get the educationClass resources owned by an educationSchool
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @return ApiListSchoolClassesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@return ApiListSchoolClassesRequest
 */
 func (a *EducationSchoolApiService) ListSchoolClasses(ctx context.Context, schoolId string) ApiListSchoolClassesRequest {
 	return ApiListSchoolClassesRequest{
@@ -789,7 +791,8 @@ func (a *EducationSchoolApiService) ListSchoolClasses(ctx context.Context, schoo
 }
 
 // Execute executes the request
-//  @return CollectionOfEducationClass
+//
+//	@return CollectionOfEducationClass
 func (a *EducationSchoolApiService) ListSchoolClassesExecute(r ApiListSchoolClassesRequest) (*CollectionOfEducationClass, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -884,9 +887,9 @@ func (r ApiListSchoolUsersRequest) Execute() (*CollectionOfEducationUser1, *http
 /*
 ListSchoolUsers Get the educationUser resources associated with an educationSchool
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @return ApiListSchoolUsersRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@return ApiListSchoolUsersRequest
 */
 func (a *EducationSchoolApiService) ListSchoolUsers(ctx context.Context, schoolId string) ApiListSchoolUsersRequest {
 	return ApiListSchoolUsersRequest{
@@ -897,7 +900,8 @@ func (a *EducationSchoolApiService) ListSchoolUsers(ctx context.Context, schoolI
 }
 
 // Execute executes the request
-//  @return CollectionOfEducationUser1
+//
+//	@return CollectionOfEducationUser1
 func (a *EducationSchoolApiService) ListSchoolUsersExecute(r ApiListSchoolUsersRequest) (*CollectionOfEducationUser1, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -991,8 +995,8 @@ func (r ApiListSchoolsRequest) Execute() (*CollectionOfSchools, *http.Response, 
 /*
 ListSchools Get a list of schools and their properties
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListSchoolsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListSchoolsRequest
 */
 func (a *EducationSchoolApiService) ListSchools(ctx context.Context) ApiListSchoolsRequest {
 	return ApiListSchoolsRequest{
@@ -1002,7 +1006,8 @@ func (a *EducationSchoolApiService) ListSchools(ctx context.Context) ApiListScho
 }
 
 // Execute executes the request
-//  @return CollectionOfSchools
+//
+//	@return CollectionOfSchools
 func (a *EducationSchoolApiService) ListSchoolsExecute(r ApiListSchoolsRequest) (*CollectionOfSchools, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -1103,9 +1108,9 @@ func (r ApiUpdateSchoolRequest) Execute() (*EducationSchool, *http.Response, err
 /*
 UpdateSchool Update properties of a school
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param schoolId key: id or schoolNumber of school
- @return ApiUpdateSchoolRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param schoolId key: id or schoolNumber of school
+	@return ApiUpdateSchoolRequest
 */
 func (a *EducationSchoolApiService) UpdateSchool(ctx context.Context, schoolId string) ApiUpdateSchoolRequest {
 	return ApiUpdateSchoolRequest{
@@ -1116,7 +1121,8 @@ func (a *EducationSchoolApiService) UpdateSchool(ctx context.Context, schoolId s
 }
 
 // Execute executes the request
-//  @return EducationSchool
+//
+//	@return EducationSchool
 func (a *EducationSchoolApiService) UpdateSchoolExecute(r ApiUpdateSchoolRequest) (*EducationSchool, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_education_user.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_education_user.go
@@ -41,8 +41,8 @@ func (r ApiCreateEducationUserRequest) Execute() (*EducationUser, *http.Response
 /*
 CreateEducationUser Add new education user
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateEducationUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateEducationUserRequest
 */
 func (a *EducationUserApiService) CreateEducationUser(ctx context.Context) ApiCreateEducationUserRequest {
 	return ApiCreateEducationUserRequest{
@@ -52,7 +52,8 @@ func (a *EducationUserApiService) CreateEducationUser(ctx context.Context) ApiCr
 }
 
 // Execute executes the request
-//  @return EducationUser
+//
+//	@return EducationUser
 func (a *EducationUserApiService) CreateEducationUserExecute(r ApiCreateEducationUserRequest) (*EducationUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -151,9 +152,9 @@ func (r ApiDeleteEducationUserRequest) Execute() (*http.Response, error) {
 /*
 DeleteEducationUser Delete educationUser
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id or username of user
- @return ApiDeleteEducationUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id or username of user
+	@return ApiDeleteEducationUserRequest
 */
 func (a *EducationUserApiService) DeleteEducationUser(ctx context.Context, userId string) ApiDeleteEducationUserRequest {
 	return ApiDeleteEducationUserRequest{
@@ -255,9 +256,9 @@ func (r ApiGetEducationUserRequest) Execute() (*EducationUser, *http.Response, e
 /*
 GetEducationUser Get properties of educationUser
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id or username of user
- @return ApiGetEducationUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id or username of user
+	@return ApiGetEducationUserRequest
 */
 func (a *EducationUserApiService) GetEducationUser(ctx context.Context, userId string) ApiGetEducationUserRequest {
 	return ApiGetEducationUserRequest{
@@ -268,7 +269,8 @@ func (a *EducationUserApiService) GetEducationUser(ctx context.Context, userId s
 }
 
 // Execute executes the request
-//  @return EducationUser
+//
+//	@return EducationUser
 func (a *EducationUserApiService) GetEducationUserExecute(r ApiGetEducationUserRequest) (*EducationUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -379,8 +381,8 @@ func (r ApiListEducationUsersRequest) Execute() (*CollectionOfEducationUser, *ht
 /*
 ListEducationUsers Get entities from education users
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListEducationUsersRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListEducationUsersRequest
 */
 func (a *EducationUserApiService) ListEducationUsers(ctx context.Context) ApiListEducationUsersRequest {
 	return ApiListEducationUsersRequest{
@@ -390,7 +392,8 @@ func (a *EducationUserApiService) ListEducationUsers(ctx context.Context) ApiLis
 }
 
 // Execute executes the request
-//  @return CollectionOfEducationUser
+//
+//	@return CollectionOfEducationUser
 func (a *EducationUserApiService) ListEducationUsersExecute(r ApiListEducationUsersRequest) (*CollectionOfEducationUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -497,9 +500,9 @@ func (r ApiUpdateEducationUserRequest) Execute() (*EducationUser, *http.Response
 /*
 UpdateEducationUser Update properties of educationUser
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id or username of user
- @return ApiUpdateEducationUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id or username of user
+	@return ApiUpdateEducationUserRequest
 */
 func (a *EducationUserApiService) UpdateEducationUser(ctx context.Context, userId string) ApiUpdateEducationUserRequest {
 	return ApiUpdateEducationUserRequest{
@@ -510,7 +513,8 @@ func (a *EducationUserApiService) UpdateEducationUser(ctx context.Context, userI
 }
 
 // Execute executes the request
-//  @return EducationUser
+//
+//	@return EducationUser
 func (a *EducationUserApiService) UpdateEducationUserExecute(r ApiUpdateEducationUserRequest) (*EducationUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_group.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_group.go
@@ -42,9 +42,9 @@ func (r ApiAddMemberRequest) Execute() (*http.Response, error) {
 /*
 AddMember Add a member to a group
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param groupId key: id of group
- @return ApiAddMemberRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param groupId key: id of group
+	@return ApiAddMemberRequest
 */
 func (a *GroupApiService) AddMember(ctx context.Context, groupId string) ApiAddMemberRequest {
 	return ApiAddMemberRequest{
@@ -151,9 +151,9 @@ func (r ApiDeleteGroupRequest) Execute() (*http.Response, error) {
 /*
 DeleteGroup Delete entity from groups
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param groupId key: id of group
- @return ApiDeleteGroupRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param groupId key: id of group
+	@return ApiDeleteGroupRequest
 */
 func (a *GroupApiService) DeleteGroup(ctx context.Context, groupId string) ApiDeleteGroupRequest {
 	return ApiDeleteGroupRequest{
@@ -259,10 +259,10 @@ func (r ApiDeleteMemberRequest) Execute() (*http.Response, error) {
 /*
 DeleteMember Delete member from a group
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param groupId key: id of group
- @param directoryObjectId key: id of group member to remove
- @return ApiDeleteMemberRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param groupId key: id of group
+	@param directoryObjectId key: id of group member to remove
+	@return ApiDeleteMemberRequest
 */
 func (a *GroupApiService) DeleteMember(ctx context.Context, groupId string, directoryObjectId string) ApiDeleteMemberRequest {
 	return ApiDeleteMemberRequest{
@@ -376,9 +376,9 @@ func (r ApiGetGroupRequest) Execute() (*Group, *http.Response, error) {
 /*
 GetGroup Get entity from groups by key
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param groupId key: id or name of group
- @return ApiGetGroupRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param groupId key: id or name of group
+	@return ApiGetGroupRequest
 */
 func (a *GroupApiService) GetGroup(ctx context.Context, groupId string) ApiGetGroupRequest {
 	return ApiGetGroupRequest{
@@ -389,7 +389,8 @@ func (a *GroupApiService) GetGroup(ctx context.Context, groupId string) ApiGetGr
 }
 
 // Execute executes the request
-//  @return Group
+//
+//	@return Group
 func (a *GroupApiService) GetGroupExecute(r ApiGetGroupRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -490,9 +491,9 @@ func (r ApiListMembersRequest) Execute() (*CollectionOfUsers, *http.Response, er
 /*
 ListMembers Get a list of the group's direct members
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param groupId key: id or name of group
- @return ApiListMembersRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param groupId key: id or name of group
+	@return ApiListMembersRequest
 */
 func (a *GroupApiService) ListMembers(ctx context.Context, groupId string) ApiListMembersRequest {
 	return ApiListMembersRequest{
@@ -503,7 +504,8 @@ func (a *GroupApiService) ListMembers(ctx context.Context, groupId string) ApiLi
 }
 
 // Execute executes the request
-//  @return CollectionOfUsers
+//
+//	@return CollectionOfUsers
 func (a *GroupApiService) ListMembersExecute(r ApiListMembersRequest) (*CollectionOfUsers, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -605,9 +607,9 @@ func (r ApiUpdateGroupRequest) Execute() (*http.Response, error) {
 /*
 UpdateGroup Update entity in groups
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param groupId key: id of group
- @return ApiUpdateGroupRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param groupId key: id of group
+	@return ApiUpdateGroupRequest
 */
 func (a *GroupApiService) UpdateGroup(ctx context.Context, groupId string) ApiUpdateGroupRequest {
 	return ApiUpdateGroupRequest{

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_groups.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_groups.go
@@ -40,8 +40,8 @@ func (r ApiCreateGroupRequest) Execute() (*Group, *http.Response, error) {
 /*
 CreateGroup Add new entity to groups
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateGroupRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateGroupRequest
 */
 func (a *GroupsApiService) CreateGroup(ctx context.Context) ApiCreateGroupRequest {
 	return ApiCreateGroupRequest{
@@ -51,7 +51,8 @@ func (a *GroupsApiService) CreateGroup(ctx context.Context) ApiCreateGroupReques
 }
 
 // Execute executes the request
-//  @return Group
+//
+//	@return Group
 func (a *GroupsApiService) CreateGroupExecute(r ApiCreateGroupRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -177,8 +178,8 @@ func (r ApiListGroupsRequest) Execute() (*CollectionOfGroup, *http.Response, err
 /*
 ListGroups Get entities from groups
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListGroupsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListGroupsRequest
 */
 func (a *GroupsApiService) ListGroups(ctx context.Context) ApiListGroupsRequest {
 	return ApiListGroupsRequest{
@@ -188,7 +189,8 @@ func (a *GroupsApiService) ListGroups(ctx context.Context) ApiListGroupsRequest 
 }
 
 // Execute executes the request
-//  @return CollectionOfGroup
+//
+//	@return CollectionOfGroup
 func (a *GroupsApiService) ListGroupsExecute(r ApiListGroupsRequest) (*CollectionOfGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_me_changepassword.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_me_changepassword.go
@@ -40,8 +40,8 @@ func (r ApiChangeOwnPasswordRequest) Execute() (*http.Response, error) {
 /*
 ChangeOwnPassword Chanage your own password
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiChangeOwnPasswordRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiChangeOwnPasswordRequest
 */
 func (a *MeChangepasswordApiService) ChangeOwnPassword(ctx context.Context) ApiChangeOwnPasswordRequest {
 	return ApiChangeOwnPasswordRequest{

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_me_drive.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_me_drive.go
@@ -33,8 +33,8 @@ func (r ApiGetHomeRequest) Execute() (*Drive, *http.Response, error) {
 /*
 GetHome Get personal space for user
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetHomeRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetHomeRequest
 */
 func (a *MeDriveApiService) GetHome(ctx context.Context) ApiGetHomeRequest {
 	return ApiGetHomeRequest{
@@ -44,7 +44,8 @@ func (a *MeDriveApiService) GetHome(ctx context.Context) ApiGetHomeRequest {
 }
 
 // Execute executes the request
-//  @return Drive
+//
+//	@return Drive
 func (a *MeDriveApiService) GetHomeExecute(r ApiGetHomeRequest) (*Drive, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_me_drive_root.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_me_drive_root.go
@@ -33,8 +33,8 @@ func (r ApiHomeGetRootRequest) Execute() (*DriveItem, *http.Response, error) {
 /*
 HomeGetRoot Get root from personal space
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiHomeGetRootRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiHomeGetRootRequest
 */
 func (a *MeDriveRootApiService) HomeGetRoot(ctx context.Context) ApiHomeGetRootRequest {
 	return ApiHomeGetRootRequest{
@@ -44,7 +44,8 @@ func (a *MeDriveRootApiService) HomeGetRoot(ctx context.Context) ApiHomeGetRootR
 }
 
 // Execute executes the request
-//  @return DriveItem
+//
+//	@return DriveItem
 func (a *MeDriveRootApiService) HomeGetRootExecute(r ApiHomeGetRootRequest) (*DriveItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_me_drive_root_children.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_me_drive_root_children.go
@@ -33,8 +33,8 @@ func (r ApiHomeGetChildrenRequest) Execute() (*CollectionOfDriveItems, *http.Res
 /*
 HomeGetChildren Get children from drive
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiHomeGetChildrenRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiHomeGetChildrenRequest
 */
 func (a *MeDriveRootChildrenApiService) HomeGetChildren(ctx context.Context) ApiHomeGetChildrenRequest {
 	return ApiHomeGetChildrenRequest{
@@ -44,7 +44,8 @@ func (a *MeDriveRootChildrenApiService) HomeGetChildren(ctx context.Context) Api
 }
 
 // Execute executes the request
-//  @return CollectionOfDriveItems
+//
+//	@return CollectionOfDriveItems
 func (a *MeDriveRootChildrenApiService) HomeGetChildrenExecute(r ApiHomeGetChildrenRequest) (*CollectionOfDriveItems, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_me_drives.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_me_drives.go
@@ -47,8 +47,8 @@ func (r ApiListMyDrivesRequest) Execute() (*CollectionOfDrives, *http.Response, 
 /*
 ListMyDrives Get all drives where the current user is a regular member of
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListMyDrivesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListMyDrivesRequest
 */
 func (a *MeDrivesApiService) ListMyDrives(ctx context.Context) ApiListMyDrivesRequest {
 	return ApiListMyDrivesRequest{
@@ -58,7 +58,8 @@ func (a *MeDrivesApiService) ListMyDrives(ctx context.Context) ApiListMyDrivesRe
 }
 
 // Execute executes the request
-//  @return CollectionOfDrives
+//
+//	@return CollectionOfDrives
 func (a *MeDrivesApiService) ListMyDrivesExecute(r ApiListMyDrivesRequest) (*CollectionOfDrives, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_me_user.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_me_user.go
@@ -40,8 +40,8 @@ func (r ApiGetOwnUserRequest) Execute() (*User, *http.Response, error) {
 /*
 GetOwnUser Get current user
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetOwnUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetOwnUserRequest
 */
 func (a *MeUserApiService) GetOwnUser(ctx context.Context) ApiGetOwnUserRequest {
 	return ApiGetOwnUserRequest{
@@ -51,7 +51,8 @@ func (a *MeUserApiService) GetOwnUser(ctx context.Context) ApiGetOwnUserRequest 
 }
 
 // Execute executes the request
-//  @return User
+//
+//	@return User
 func (a *MeUserApiService) GetOwnUserExecute(r ApiGetOwnUserRequest) (*User, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_tags.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_tags.go
@@ -39,8 +39,8 @@ func (r ApiAssignTagsRequest) Execute() (*http.Response, error) {
 /*
 AssignTags Assign tags to a resource
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiAssignTagsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiAssignTagsRequest
 */
 func (a *TagsApiService) AssignTags(ctx context.Context) ApiAssignTagsRequest {
 	return ApiAssignTagsRequest{
@@ -134,8 +134,8 @@ func (r ApiGetTagsRequest) Execute() (*CollectionOfTags, *http.Response, error) 
 /*
 GetTags Get all known tags
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiGetTagsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetTagsRequest
 */
 func (a *TagsApiService) GetTags(ctx context.Context) ApiGetTagsRequest {
 	return ApiGetTagsRequest{
@@ -145,7 +145,8 @@ func (a *TagsApiService) GetTags(ctx context.Context) ApiGetTagsRequest {
 }
 
 // Execute executes the request
-//  @return CollectionOfTags
+//
+//	@return CollectionOfTags
 func (a *TagsApiService) GetTagsExecute(r ApiGetTagsRequest) (*CollectionOfTags, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -244,8 +245,8 @@ func (r ApiUnassignTagsRequest) Execute() (*http.Response, error) {
 /*
 UnassignTags Unassign tags from a resource
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiUnassignTagsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiUnassignTagsRequest
 */
 func (a *TagsApiService) UnassignTags(ctx context.Context) ApiUnassignTagsRequest {
 	return ApiUnassignTagsRequest{

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_user.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_user.go
@@ -42,9 +42,9 @@ func (r ApiDeleteUserRequest) Execute() (*http.Response, error) {
 /*
 DeleteUser Delete entity from users
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id or name of user
- @return ApiDeleteUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id or name of user
+	@return ApiDeleteUserRequest
 */
 func (a *UserApiService) DeleteUser(ctx context.Context, userId string) ApiDeleteUserRequest {
 	return ApiDeleteUserRequest{
@@ -149,9 +149,9 @@ func (r ApiExportPersonalDataRequest) Execute() (*http.Response, error) {
 /*
 ExportPersonalData export personal data of a user
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id or name of user
- @return ApiExportPersonalDataRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id or name of user
+	@return ApiExportPersonalDataRequest
 */
 func (a *UserApiService) ExportPersonalData(ctx context.Context, userId string) ApiExportPersonalDataRequest {
 	return ApiExportPersonalDataRequest{
@@ -262,9 +262,9 @@ func (r ApiGetUserRequest) Execute() (*User, *http.Response, error) {
 /*
 GetUser Get entity from users by key
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id or name of user
- @return ApiGetUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id or name of user
+	@return ApiGetUserRequest
 */
 func (a *UserApiService) GetUser(ctx context.Context, userId string) ApiGetUserRequest {
 	return ApiGetUserRequest{
@@ -275,7 +275,8 @@ func (a *UserApiService) GetUser(ctx context.Context, userId string) ApiGetUserR
 }
 
 // Execute executes the request
-//  @return User
+//
+//	@return User
 func (a *UserApiService) GetUserExecute(r ApiGetUserRequest) (*User, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -383,9 +384,9 @@ func (r ApiUpdateUserRequest) Execute() (*User, *http.Response, error) {
 /*
 UpdateUser Update entity in users
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id of user
- @return ApiUpdateUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id of user
+	@return ApiUpdateUserRequest
 */
 func (a *UserApiService) UpdateUser(ctx context.Context, userId string) ApiUpdateUserRequest {
 	return ApiUpdateUserRequest{
@@ -396,7 +397,8 @@ func (a *UserApiService) UpdateUser(ctx context.Context, userId string) ApiUpdat
 }
 
 // Execute executes the request
-//  @return User
+//
+//	@return User
 func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*User, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPatch

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_user_app_role_assignment.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_user_app_role_assignment.go
@@ -47,10 +47,9 @@ Use this API to assign a global role to a user. To grant an app role assignment 
 * `resourceId`: The `id` of the resource `servicePrincipal` or `application` that has defined the app role.
 * `appRoleId`: The `id` of the `appRole` (defined on the resource service principal or application) to assign to the user.
 
-
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id of user
- @return ApiUserCreateAppRoleAssignmentsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id of user
+	@return ApiUserCreateAppRoleAssignmentsRequest
 */
 func (a *UserAppRoleAssignmentApiService) UserCreateAppRoleAssignments(ctx context.Context, userId string) ApiUserCreateAppRoleAssignmentsRequest {
 	return ApiUserCreateAppRoleAssignmentsRequest{
@@ -61,7 +60,8 @@ func (a *UserAppRoleAssignmentApiService) UserCreateAppRoleAssignments(ctx conte
 }
 
 // Execute executes the request
-//  @return AppRoleAssignment
+//
+//	@return AppRoleAssignment
 func (a *UserAppRoleAssignmentApiService) UserCreateAppRoleAssignmentsExecute(r ApiUserCreateAppRoleAssignmentsRequest) (*AppRoleAssignment, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -169,10 +169,10 @@ func (r ApiUserDeleteAppRoleAssignmentsRequest) Execute() (*http.Response, error
 /*
 UserDeleteAppRoleAssignments Delete the appRoleAssignment from a user
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id of user
- @param appRoleAssignmentId key: id of appRoleAssignment. This is the concatenated {user-id}:{appRole-id} separated by a colon.
- @return ApiUserDeleteAppRoleAssignmentsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id of user
+	@param appRoleAssignmentId key: id of appRoleAssignment. This is the concatenated {user-id}:{appRole-id} separated by a colon.
+	@return ApiUserDeleteAppRoleAssignmentsRequest
 */
 func (a *UserAppRoleAssignmentApiService) UserDeleteAppRoleAssignments(ctx context.Context, userId string, appRoleAssignmentId string) ApiUserDeleteAppRoleAssignmentsRequest {
 	return ApiUserDeleteAppRoleAssignmentsRequest{
@@ -274,9 +274,9 @@ UserListAppRoleAssignments Get appRoleAssignments from a user
 
 Represents the global roles a user has been granted for an application.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param userId key: id of user
- @return ApiUserListAppRoleAssignmentsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId key: id of user
+	@return ApiUserListAppRoleAssignmentsRequest
 */
 func (a *UserAppRoleAssignmentApiService) UserListAppRoleAssignments(ctx context.Context, userId string) ApiUserListAppRoleAssignmentsRequest {
 	return ApiUserListAppRoleAssignmentsRequest{
@@ -287,7 +287,8 @@ func (a *UserAppRoleAssignmentApiService) UserListAppRoleAssignments(ctx context
 }
 
 // Execute executes the request
-//  @return CollectionOfAppRoleAssignments
+//
+//	@return CollectionOfAppRoleAssignments
 func (a *UserAppRoleAssignmentApiService) UserListAppRoleAssignmentsExecute(r ApiUserListAppRoleAssignmentsRequest) (*CollectionOfAppRoleAssignments, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_users.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_users.go
@@ -40,8 +40,8 @@ func (r ApiCreateUserRequest) Execute() (*User, *http.Response, error) {
 /*
 CreateUser Add new entity to users
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateUserRequest
 */
 func (a *UsersApiService) CreateUser(ctx context.Context) ApiCreateUserRequest {
 	return ApiCreateUserRequest{
@@ -51,7 +51,8 @@ func (a *UsersApiService) CreateUser(ctx context.Context) ApiCreateUserRequest {
 }
 
 // Execute executes the request
-//  @return User
+//
+//	@return User
 func (a *UsersApiService) CreateUserExecute(r ApiCreateUserRequest) (*User, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -184,8 +185,8 @@ func (r ApiListUsersRequest) Execute() (*CollectionOfUser, *http.Response, error
 /*
 ListUsers Get entities from users
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListUsersRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListUsersRequest
 */
 func (a *UsersApiService) ListUsers(ctx context.Context) ApiListUsersRequest {
 	return ApiListUsersRequest{
@@ -195,7 +196,8 @@ func (a *UsersApiService) ListUsers(ctx context.Context) ApiListUsersRequest {
 }
 
 // Execute executes the request
-//  @return CollectionOfUser
+//
+//	@return CollectionOfUser
 func (a *UsersApiService) ListUsersExecute(r ApiListUsersRequest) (*CollectionOfUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet

--- a/vendor/github.com/owncloud/libre-graph-api-go/model_education_school.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/model_education_school.go
@@ -12,6 +12,7 @@ package libregraph
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // EducationSchool Represents a school
@@ -22,6 +23,8 @@ type EducationSchool struct {
 	DisplayName *string `json:"displayName,omitempty"`
 	// School number
 	SchoolNumber *string `json:"schoolNumber,omitempty"`
+	// Date and time at which the service for this organization is scheduled to be terminated
+	TerminationDate NullableTime `json:"terminationDate,omitempty"`
 }
 
 // NewEducationSchool instantiates a new EducationSchool object
@@ -137,6 +140,49 @@ func (o *EducationSchool) SetSchoolNumber(v string) {
 	o.SchoolNumber = &v
 }
 
+// GetTerminationDate returns the TerminationDate field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *EducationSchool) GetTerminationDate() time.Time {
+	if o == nil || o.TerminationDate.Get() == nil {
+		var ret time.Time
+		return ret
+	}
+	return *o.TerminationDate.Get()
+}
+
+// GetTerminationDateOk returns a tuple with the TerminationDate field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *EducationSchool) GetTerminationDateOk() (*time.Time, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.TerminationDate.Get(), o.TerminationDate.IsSet()
+}
+
+// HasTerminationDate returns a boolean if a field has been set.
+func (o *EducationSchool) HasTerminationDate() bool {
+	if o != nil && o.TerminationDate.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetTerminationDate gets a reference to the given NullableTime and assigns it to the TerminationDate field.
+func (o *EducationSchool) SetTerminationDate(v time.Time) {
+	o.TerminationDate.Set(&v)
+}
+
+// SetTerminationDateNil sets the value for TerminationDate to be an explicit nil
+func (o *EducationSchool) SetTerminationDateNil() {
+	o.TerminationDate.Set(nil)
+}
+
+// UnsetTerminationDate ensures that no value is present for TerminationDate, not even an explicit nil
+func (o *EducationSchool) UnsetTerminationDate() {
+	o.TerminationDate.Unset()
+}
+
 func (o EducationSchool) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Id != nil {
@@ -147,6 +193,9 @@ func (o EducationSchool) MarshalJSON() ([]byte, error) {
 	}
 	if o.SchoolNumber != nil {
 		toSerialize["schoolNumber"] = o.SchoolNumber
+	}
+	if o.TerminationDate.IsSet() {
+		toSerialize["terminationDate"] = o.TerminationDate.Get()
 	}
 	return json.Marshal(toSerialize)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1503,7 +1503,7 @@ github.com/opentracing/opentracing-go/log
 # github.com/orcaman/concurrent-map v1.0.0
 ## explicit
 github.com/orcaman/concurrent-map
-# github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b
+# github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b => github.com/rhafer/libre-graph-api-go v0.13.4-0.20230629154140-fa67e25dc257
 ## explicit; go 1.13
 github.com/owncloud/libre-graph-api-go
 # github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
@@ -2196,3 +2196,4 @@ stash.kopano.io/kgol/oidc-go
 ## explicit; go 1.13
 stash.kopano.io/kgol/rndm
 # github.com/cs3org/go-cs3apis => github.com/2403905/go-cs3apis v0.0.0-20230517122726-727045414fd1
+# github.com/owncloud/libre-graph-api-go => github.com/rhafer/libre-graph-api-go v0.13.4-0.20230629154140-fa67e25dc257


### PR DESCRIPTION
Schools can now have a terminationDate set. Schools can only be deleted if the terminationDate is in the past. Schools without a terminationDate cannot be deleted.

Requires: 
https://github.com/owncloud/libre-graph-api/pull/111

