### PR TITLE
[tests-only][full-ci] refactor check notification and delete it

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -226,14 +226,14 @@ Feature: antivirus
     And user "Alice" has created a folder "uploadFolder" in space "new-space"
     When user "Alice" uploads a file "filesForUpload/filesWithVirus/<filename>" to "/uploadFolder/<newfilename>" in space "new-space" using the WebDAV API
     Then the HTTP status code should be "201"
-    And user "Alice" should get a notification with subject "Virus found" and message:
+    And user "Alice" should get a notification for resource "<newfilename>" with subject "Virus found" and message:
       | message                                                                        |
       | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And for user "Alice" the space "new-space" should not contain these entries:
       | /uploadFolder/<newfilename> |
     When user "Alice" uploads a file "filesForUpload/filesWithVirus/<filename>" to "/<newfilename>" in space "new-space" using the WebDAV API
     Then the HTTP status code should be "201"
-    And user "Alice" should get a notification with subject "Virus found" and message:
+    And user "Alice" should get a notification for resource "<newfilename>" with subject "Virus found" and message:
       | message                                                                        |
       | Virus found in <newfilename>. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And for user "Alice" the space "new-space" should not contain these entries:
@@ -422,15 +422,15 @@ Feature: antivirus
     And user "Brian" has accepted share "/test.txt" offered by user "Alice"
     When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "Shares/uploadFolder/test.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And user "Brian" should get a notification with subject "Virus found" and message:
+    And user "Brian" should get a notification for resource "test.txt" with subject "Virus found" and message:
       | message                                                                   |
       | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And the content of file "Shares/uploadFolder/test.txt" for user "Brian" should be "this is a test file."
     And the content of file "uploadFolder/test.txt" for user "Alice" should be "this is a test file."
     When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "Shares/test.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And user "Brian" should get a notification with subject "Virus found" and message:
-      | message                                                                       |
+    And user "Brian" should get a notification for resource "test.txt" with subject "Virus found" and message:
+      | message                                                                   |
       | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And the content of file "Shares/test.txt" for user "Brian" should be "this is a test file."
     And the content of file "/test.txt" for user "Alice" should be "this is a test file."
@@ -452,14 +452,14 @@ Feature: antivirus
     And user "Brian" has accepted share "/test.txt" offered by user "Alice"
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "/uploadFolder/test.txt" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "204"
-    And user "Brian" should get a notification with subject "Virus found" and message:
+    And user "Brian" should get a notification for resource "test.txt" with subject "Virus found" and message:
       | message                                                                   |
       | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And for user "Brian" the content of the file "/uploadFolder/test.txt" of the space "Shares" should be "this is a test file."
     And the content of file "uploadFolder/test.txt" for user "Alice" should be "this is a test file."
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "/test.txt" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "204"
-    And user "Brian" should get a notification with subject "Virus found" and message:
+    And user "Brian" should get a notification for resource "test.txt" with subject "Virus found" and message:
       | message                                                                   |
       | Virus found in test.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
     And for user "Brian" the content of the file "/test.txt" of the space "Shares" should be "this is a test file."

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -344,6 +344,38 @@ class NotificationContext implements Context {
 	}
 
 	/**
+	 * @Then user :user should get a notification for resource :resource with subject :subject and message:
+	 *
+	 * @param string $user
+	 * @param string $resource
+	 * @param string $subject
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userShouldGetNotificationForResourceWithMessage(string $user, string $resource, string $subject, TableNode $table):void {
+		$this->userListAllNotifications($user);
+		$notification = $this->filterResponseByNotificationSubjectAndResource($subject, $resource);
+
+		if (\count($notification) === 1) {
+			$actualMessage = str_replace(["\r", "\r"], " ", $notification[0]->message);
+			$expectedMessage = $table->getColumnsHash()[0]['message'];
+			Assert::assertSame(
+				$expectedMessage,
+				$actualMessage,
+				__METHOD__ . "expected message to be '$expectedMessage' but found'$actualMessage'"
+			);
+			$this->userDeletesNotificationOfResourceAndSubject($user, $resource, $subject);
+			$this->featureContext->theHTTPStatusCodeShouldBe(200);
+		} elseif (\count($notification) === 0) {
+			throw new \Exception("Response doesn't contain any notification with resource '$resource' and subject '$subject'.\n$notification");
+		} else {
+			throw new \Exception("Response contains more than one notification with resource '$resource' and subject '$subject'.\n$notification");
+		}
+	}
+
+	/**
 	 * @Then user :user should not have a notification related to resource :resource with subject :subject
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
This PR consist refactoring antivirus feature step where antivirus notification is checked.
- new step is added where the notification message for `resource` with `subject` is checked and then it is deleted

## Motivation and Context
Previously in some scenarios in antivirus feature which contained two when then steps and checked for their respective notifications pass only if the file containing antivirus in both steps has same name.
These tests will fail if the files have different name because previously notifications were checked with parameters `user` and `subject` only which are same for two files containing virus. So, second notification check will return the notification from previous when then. 
So, new step is added which checks notification response with `user` and `subject` of notification in this PR and then deletes the notification after reading and second when then will read its own notification.


## How Has This Been Tested?

test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
