### PR TITLE
[tests-only] [full-ci] Refactoring example table dav-version text

### DIFF
--- a/tests/acceptance/features/apiAccountsHashDifficulty/uploadFile.feature
+++ b/tests/acceptance/features/apiAccountsHashDifficulty/uploadFile.feature
@@ -11,12 +11,12 @@ Feature: upload file
   Scenario Outline: upload a file and check download content
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "/upload.txt" using the WebDAV API
     Then the content of file "/upload.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | ocs_api_version | dav_version |
-      | 1               | old         |
-      | 1               | new         |
-      | 2               | old         |
-      | 2               | new         |
+      | ocs_api_version | dav-path-version |
+      | 1               | old              |
+      | 1               | new              |
+      | 2               | old              |
+      | 2               | new              |

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -16,7 +16,7 @@ Feature: REPORT request to Shares space
 
 
   Scenario Outline: check the REPORT response of the found folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -29,13 +29,13 @@ Feature: REPORT request to Shares space
       | d:getcontenttype | httpd/unix-directory |
       | oc:permissions   | S                    |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check the REPORT response of the found file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     And user "Alice" has uploaded file with content "Not all those who wander are lost." to "/folderMain/SubFolder1/subFOLDER2/frodo.txt"
     When user "Brian" searches for "frodo.txt" using the WebDAV API
@@ -50,17 +50,17 @@ Feature: REPORT request to Shares space
       | oc:permissions     | S                                      |
       | d:getcontentlength | 34                                     |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: search for the shared folder when share is not accepted
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Brian" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiFavorites/favorites.feature
+++ b/tests/acceptance/features/coreApiFavorites/favorites.feature
@@ -18,7 +18,7 @@ Feature: favorite
 
   @issue-1263
   Scenario Outline: favorite a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" favorites element "/FOLDER" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Alice" folder "/FOLDER" should be favorited
@@ -28,18 +28,18 @@ Feature: favorite
     Then the HTTP status code should be "207"
     And the single response should contain a property "oc:favorite" with value "1"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1263
   Scenario Outline: unfavorite a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has favorited element "/FOLDER"
     When user "Alice" unfavorites element "/FOLDER" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -50,18 +50,18 @@ Feature: favorite
     Then the HTTP status code should be "207"
     And the single response should contain a property "oc:favorite" with value "0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest @issue-1263
   Scenario Outline: favorite a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" favorites element "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Alice" file "/textfile0.txt" should be favorited
@@ -71,18 +71,18 @@ Feature: favorite
     Then the HTTP status code should be "207"
     And the single response should contain a property "oc:favorite" with value "1"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest @issue-1263
   Scenario Outline: unfavorite a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has favorited element "/textfile0.txt"
     When user "Alice" unfavorites element "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -93,18 +93,18 @@ Feature: favorite
     Then the HTTP status code should be "207"
     And the single response should contain a property "oc:favorite" with value "0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: get favorited elements of a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" favorites element "/FOLDER" using the WebDAV API
     And user "Alice" favorites element "/textfile0.txt" using the WebDAV API
     And user "Alice" favorites element "/textfile1.txt" using the WebDAV API
@@ -114,18 +114,18 @@ Feature: favorite
       | /textfile0.txt |
       | /textfile1.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get favorited elements of a subfolder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/subfolder"
     And user "Alice" has uploaded file with content "some data" to "/subfolder/textfile0.txt"
     And user "Alice" has uploaded file with content "some data" to "/subfolder/textfile1.txt"
@@ -141,18 +141,18 @@ Feature: favorite
     And user "Alice" should not have favorited the following elements
       | /subfolder/textfile1.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get favorited elements and limit count of entries
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has favorited element "/textfile0.txt"
     And user "Alice" has favorited element "/textfile1.txt"
     And user "Alice" has favorited element "/textfile2.txt"
@@ -166,18 +166,18 @@ Feature: favorite
       | /textfile3.txt |
       | /textfile4.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get favorited elements paginated in subfolder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/subfolder"
     And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile0.txt"
     And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile1.txt"
@@ -199,18 +199,18 @@ Feature: favorite
       | /subfolder/textfile3.txt |
       | /subfolder/textfile4.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" favorites element "/PARENT/parent.txt" using the WebDAV API
     And user "Alice" favorites element "/PARENT" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -218,11 +218,11 @@ Feature: favorite
       | /PARENT            |
       | /PARENT/parent.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature
+++ b/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature
@@ -11,7 +11,7 @@ Feature: favorite
 
 
   Scenario Outline: favorite a file inside of a received share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared folder "/PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -19,13 +19,13 @@ Feature: favorite
     Then the HTTP status code should be "207"
     And as user "Brian" file "/Shares/PARENT/parent.txt" should be favorited
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: favorite a folder inside of a received share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT/sub-folder"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -34,13 +34,13 @@ Feature: favorite
     Then the HTTP status code should be "207"
     And as user "Brian" folder "/Shares/PARENT/sub-folder" should be favorited
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: favorite a received share itself
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared folder "/PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -48,13 +48,13 @@ Feature: favorite
     Then the HTTP status code should be "207"
     And as user "Brian" folder "/Shares/PARENT" should be favorited
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: moving a favorite file out of a share keeps favorite state
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared folder "/PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -64,13 +64,13 @@ Feature: favorite
     And as "Brian" file "/taken_out.txt" should exist
     And as user "Brian" file "/taken_out.txt" should be favorited
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared file "/PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
@@ -79,6 +79,6 @@ Feature: favorite
     And as user "Brian" file "/Shares/parent.txt" should be favorited
     And as user "Alice" file "/PARENT/parent.txt" should not be favorited
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiMain/checksums.feature
+++ b/tests/acceptance/features/coreApiMain/checksums.feature
@@ -8,90 +8,90 @@ Feature: checksums
     Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: uploading a file with checksum should work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
     Then the HTTP status code should be "201"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest @issue-1291
   Scenario Outline: uploading a file with checksum should return the checksum in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" requests the checksum of "/myChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest @issue-1316
   Scenario Outline: uploading a file with checksum should return the checksum in the download header
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" downloads file "/myChecksumFile.txt" using the WebDAV API
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1291
   Scenario Outline: moving a file with checksum should return the checksum in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as user "Alice" the webdav checksum of "/myMovedChecksumFile.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1316
   Scenario Outline: downloading a file with checksum should return the checksum in the download header
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     And user "Alice" has moved file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt"
     When user "Alice" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1291
   Scenario Outline: uploading a chunked file with checksum should return the checksum in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "Alice" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "Alice" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
@@ -99,17 +99,17 @@ Feature: checksums
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
     Examples:
-      | dav_version |
-      | old         |
+      | dav-path-version |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1343
   Scenario Outline: uploading a chunked file with checksum should return the checksum in the download header
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "Alice" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "Alice" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
@@ -117,63 +117,63 @@ Feature: checksums
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
     Examples:
-      | dav_version |
-      | old         |
+      | dav-path-version |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: moving file with checksum should return the checksum in the download header
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
     And user "Alice" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1291
   Scenario Outline: copying a file with checksum should return the checksum in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as user "Alice" the webdav checksum of "/myChecksumFileCopy.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
-      | dav_version |
-      | new         |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1316
   Scenario Outline: copying file with checksum should return the checksum in the download header
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the header checksum when user "Alice" downloads file "/myChecksumFileCopy.txt" using the WebDAV API should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
-      | dav_version |
-      | new         |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1291
   Scenario: sharing a file with checksum should return the checksum in the propfind using new DAV path
@@ -199,39 +199,39 @@ Feature: checksums
 
   @issue-1315
   Scenario Outline: upload a file where checksum does not match
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "Alice" should not see the following elements
       | /chksumtst.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file where checksum does match
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1315
   Scenario Outline: uploaded file should have the same checksum when downloaded
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
     When user "Alice" downloads file "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "200"
@@ -239,36 +239,36 @@ Feature: checksums
       | header      | value                                         |
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   ## Validation Plugin or Old Endpoint Specific
   @issue-1343
   Scenario Outline: uploading an old method chunked file with checksum should fail using new DAV path
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the WebDAV API
     Then the HTTP status code should be "503"
     And user "Alice" should not see the following elements
       | /myChecksumFile.txt |
     Examples:
-      | dav_version |
-      | new         |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   ## upload overwriting
   @issue-1291
   Scenario Outline: uploading a file with MD5 checksum overwriting an existing file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -280,18 +280,18 @@ Feature: checksums
       Cheers.
       """
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1291
   Scenario Outline: uploading a file with SHA1 checksum overwriting an existing file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -303,36 +303,36 @@ Feature: checksums
       Cheers.
       """
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @skipOnStorage:ceph @skipOnStorage:scality @issue-1291
   Scenario Outline: uploading a file with invalid SHA1 checksum overwriting an existing file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:f005ba11f005ba11f005ba11f005ba11f005ba11" using the WebDAV API
     Then the HTTP status code should be "400"
     And as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:2052377dec0724bda0d57aeab67fa819278b7f74 MD5:096e350e9ff1339a997a14145f9fc4b9 ADLER32:7d5a0921"
     And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1296
   Scenario Outline: uploading a file with checksum should work for file with special characters
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to <renamed_file> with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file <renamed_file> for user "Alice" should be:
@@ -342,14 +342,14 @@ Feature: checksums
       Cheers.
       """
     Examples:
-      | dav_version | renamed_file      |
-      | old         | " oc?test=ab&cd " |
-      | old         | "# %ab ab?=ed"    |
-      | new         | " oc?test=ab&cd " |
-      | new         | "# %ab ab?=ed"    |
+      | dav-path-version | renamed_file      |
+      | old              | " oc?test=ab&cd " |
+      | old              | "# %ab ab?=ed"    |
+      | new              | " oc?test=ab&cd " |
+      | new              | "# %ab ab?=ed"    |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | renamed_file      |
-      | spaces      | " oc?test=ab&cd " |
-      | spaces      | "# %ab ab?=ed"    |
+      | dav-path-version | renamed_file      |
+      | spaces           | " oc?test=ab&cd " |
+      | spaces           | "# %ab ab?=ed"    |

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
@@ -12,7 +12,7 @@ Feature: sharing
 
   @smokeTest
   Scenario Outline: moving a file into a share as recipient
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/shared"
     And user "Alice" has shared folder "/shared" with user "Brian"
     And user "Brian" has accepted share "/shared" offered by user "Alice"
@@ -22,13 +22,13 @@ Feature: sharing
     And as "Brian" file "/Shares/shared/shared_file.txt" should exist
     And as "Alice" file "/shared/shared_file.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: move files between shares by same user
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
@@ -44,13 +44,13 @@ Feature: sharing
     And as "Alice" file "share1/textfile0.txt" should not exist
     But as "Alice" file "share2/textfile0.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: move files between shares by same user added by sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
     And user "Brian" has uploaded file with content "some data" to "/textfile0.txt"
@@ -66,13 +66,13 @@ Feature: sharing
     But as "Brian" file "/Shares/share2/shared_file.txt" should exist
     And as "Alice" file "share2/shared_file.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: move files between shares by different users
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has created folder "/PARENT"
@@ -88,13 +88,13 @@ Feature: sharing
     And as "Brian" file "PARENT/shared_file.txt" should exist
     But as "Alice" file "PARENT/shared_file.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: overwrite a received file share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "this is the old content" to "/textfile1.txt"
     And user "Alice" has shared file "/textfile1.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile1.txt" offered by user "Alice"
@@ -104,7 +104,7 @@ Feature: sharing
     And the content of file "Shares/textfile1.txt" for user "Brian" should be "this is a new content"
     And the content of file "textfile1.txt" for user "Alice" should be "this is a new content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -13,7 +13,7 @@ Feature: sharing
 
   @smokeTest
   Scenario Outline: check webdav share-permissions for owned file
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
     When user "Alice" gets the following properties of file "/tmp.txt" using the WebDAV API
       | propertyName          |
@@ -21,18 +21,18 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: check webdav share-permissions for received file with edit and reshare permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
     And user "Alice" has shared file "/tmp.txt" with user "Brian"
     And user "Brian" has accepted share "/tmp.txt" offered by user "Alice"
@@ -42,13 +42,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received group shared file with edit and reshare permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -64,13 +64,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-2213
   Scenario Outline: check webdav share-permissions for received file with edit permissions but no reshare permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
     And user "Alice" has shared file "tmp.txt" with user "Brian"
     And user "Brian" has accepted share "/tmp.txt" offered by user "Alice"
@@ -79,13 +79,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And as user "Brian" file "/Shares/tmp.txt" should contain a property "ocs:share-permissions" with value "3"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-2213
   Scenario Outline: check webdav share-permissions for received group shared file with edit permissions but no reshare permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -101,13 +101,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "3"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-2213
   Scenario Outline: check webdav share-permissions for received file with reshare permissions but no edit permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
     And user "Alice" has shared file "tmp.txt" with user "Brian"
     And user "Brian" has accepted share "/tmp.txt" offered by user "Alice"
@@ -116,13 +116,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And as user "Brian" file "/Shares/tmp.txt" should contain a property "ocs:share-permissions" with value "17"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received group shared file with reshare permissions but no edit permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -138,13 +138,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "17"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for owned folder
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
     When user "Alice" gets the following properties of folder "/" using the WebDAV API
       | propertyName          |
@@ -152,18 +152,18 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: check webdav share-permissions for received folder with all permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
     And user "Alice" has shared file "/tmp" with user "Brian"
     And user "Brian" has accepted share "/tmp" offered by user "Alice"
@@ -173,13 +173,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received group shared folder with all permissions
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/tmp"
@@ -194,13 +194,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-2213
   Scenario Outline: check webdav share-permissions for received folder with all permissions but edit
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
     And user "Alice" has shared file "/tmp" with user "Brian"
     And user "Brian" has accepted share "/tmp" offered by user "Alice"
@@ -209,13 +209,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And as user "Brian" folder "/Shares/tmp" should contain a property "ocs:share-permissions" with value "29"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received group shared folder with all permissions but edit
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/tmp"
@@ -231,13 +231,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "29"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received folder with all permissions but create
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
     And user "Alice" has shared file "/tmp" with user "Brian"
     And user "Brian" has accepted share "/tmp" offered by user "Alice"
@@ -246,13 +246,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And as user "Brian" folder "/Shares/tmp" should contain a property "ocs:share-permissions" with value "27"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received group shared folder with all permissions but create
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/tmp"
@@ -268,13 +268,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "27"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received folder with all permissions but delete
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
     And user "Alice" has shared file "/tmp" with user "Brian"
     And user "Brian" has accepted share "/tmp" offered by user "Alice"
@@ -283,13 +283,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And as user "Brian" folder "/Shares/tmp" should contain a property "ocs:share-permissions" with value "23"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received group shared folder with all permissions but delete
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/tmp"
@@ -305,13 +305,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "23"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received folder with all permissions but share
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
     And user "Alice" has shared file "/tmp" with user "Brian"
     And user "Brian" has accepted share "/tmp" offered by user "Alice"
@@ -320,13 +320,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And as user "Brian" folder "/Shares/tmp" should contain a property "ocs:share-permissions" with value "15"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: check webdav share-permissions for received group shared folder with all permissions but share
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/tmp"
@@ -342,6 +342,6 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the single response should contain a property "ocs:share-permissions" with value "15"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
@@ -23,7 +23,7 @@ Feature: sharing
 
 
   Scenario Outline: uploading file to a group read-only share folder does not work
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -38,13 +38,13 @@ Feature: sharing
     Then the HTTP status code should be "403"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: uploading file to a user upload-only share folder works
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
@@ -64,13 +64,13 @@ Feature: sharing
     Cheers.
     """
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: uploading file to a group upload-only share folder works
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -92,13 +92,13 @@ Feature: sharing
     Cheers.
     """
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @smokeTest
   Scenario Outline: uploading file to a user read/write share folder works
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
@@ -116,13 +116,13 @@ Feature: sharing
     Cheers.
     """
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: uploading file to a group read/write share folder works
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -142,13 +142,13 @@ Feature: sharing
     Cheers.
     """
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @smokeTest @skipOnGraph
   Scenario Outline: check quota of owners parent directory of a shared file
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And the quota of user "Brian" has been set to "0"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/myfile.txt"
@@ -165,13 +165,13 @@ Feature: sharing
     Cheers.
     """
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @skipOnGraph
   Scenario Outline: uploading to a user shared folder with read/write permission when the sharer has insufficient quota does not work
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
@@ -185,13 +185,13 @@ Feature: sharing
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: uploading to a group shared folder with read/write permission when the sharer has insufficient quota does not work
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -207,13 +207,13 @@ Feature: sharing
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @skipOnGraph
   Scenario Outline: uploading to a user shared folder with upload-only permission when the sharer has insufficient quota does not work
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
@@ -227,13 +227,13 @@ Feature: sharing
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @skipOnGraph
   Scenario Outline: uploading to a group shared folder with upload-only permission when the sharer has insufficient quota does not work
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -249,13 +249,13 @@ Feature: sharing
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer can download file uploaded with different permission by sharee to a shared folder
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
@@ -269,13 +269,13 @@ Feature: sharing
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     Examples:
-      | dav-path | permissions |
-      | old      | change      |
-      | new      | create      |
+      | dav-path-version | permissions |
+      | old              | change      |
+      | new              | create      |
 
 
   Scenario Outline: upload an empty file (size zero byte) to a shared folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/folder-to-share"
     And user "Brian" has shared folder "/folder-to-share" with user "Alice"
@@ -285,6 +285,6 @@ Feature: sharing
     And as "Alice" file "/Shares/folder-to-share/zerobyte.txt" should exist
     And the content of file "/Shares/folder-to-share/zerobyte.txt" for user "Alice" should be ""
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -346,7 +346,7 @@ Feature: create a public link share
 
 
   Scenario Outline: get the mtime of a file shared by public link
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | file.txt |
@@ -354,13 +354,13 @@ Feature: create a public link share
     Then the HTTP status code should be "200"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
+      | dav-path-version |
       | old         |
       | new         |
 
 
   Scenario Outline: get the mtime of a file inside a folder shared by public link
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "testFolder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" creates a public link share using the sharing API with settings
@@ -369,7 +369,7 @@ Feature: create a public link share
     Then the HTTP status code should be "200"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
+      | dav-path-version |
       | old         |
       | new         |
 

--- a/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
@@ -116,7 +116,7 @@ Feature: multi-link sharing
 
   Scenario Outline: deleting a file also deletes its public links
     Given using OCS API version "1"
-    And using <dav-path> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | textfile0.txt |
@@ -136,14 +136,14 @@ Feature: multi-link sharing
     Then the HTTP status code should be "201"
     And as user "Alice" the file "/textfile0.txt" should not have any shares
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting one public link share of a file doesn't affect the rest
@@ -182,7 +182,7 @@ Feature: multi-link sharing
 
   Scenario Outline: overwriting a file doesn't remove its public shares
     Given using OCS API version "1"
-    And using <dav-path> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | textfile0.txt |
@@ -203,19 +203,19 @@ Feature: multi-link sharing
       | /textfile0.txt | 1           | sharedlink1 |
       | /textfile0.txt | 1           | sharedlink2 |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1251
   Scenario Outline: renaming a folder doesn't remove its public shares
     Given using OCS API version "1"
-    And using <dav-path> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path         | FOLDER      |
@@ -238,11 +238,11 @@ Feature: multi-link sharing
       | /FOLDER_RENAMED | 15          | sharedlink1 |
       | /FOLDER_RENAMED | 15          | sharedlink2 |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
-  @skipOnRevaMaster
+    @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
@@ -375,7 +375,7 @@ Feature: update a public link share
 
   Scenario Outline: rename a folder with public link and get its info
     Given using OCS API version "<ocs_api_version>"
-    And using <dav-path> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
@@ -406,22 +406,22 @@ Feature: update a public link share
       | mail_send              | 0                    |
       | name                   |                      |
     Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | old      | 1               | 100             |
-      | old      | 2               | 200             |
-      | new      | 1               | 100             |
-      | new      | 2               | 200             |
+      | dav-path-version | ocs_api_version | ocs_status_code |
+      | old              | 1               | 100             |
+      | old              | 2               | 200             |
+      | new              | 1               | 100             |
+      | new              | 2               | 200             |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | spaces   | 1               | 100             |
-      | spaces   | 2               | 200             |
+      | dav-path-version | ocs_api_version | ocs_status_code |
+      | spaces           | 1               | 100             |
+      | spaces           | 2               | 200             |
 
 
   Scenario Outline: rename a file with public link and get its info
     Given using OCS API version "<ocs_api_version>"
-    And using <dav-path> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "some content" to "/lorem.txt"
     And user "Alice" has created a public link share with settings
       | path | lorem.txt |
@@ -452,22 +452,22 @@ Feature: update a public link share
       | mail_send              | 0              |
       | name                   |                |
     Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | old      | 1               | 100             |
-      | old      | 2               | 200             |
-      | new      | 1               | 100             |
-      | new      | 2               | 200             |
+      | dav-path-version | ocs_api_version | ocs_status_code |
+      | old              | 1               | 100             |
+      | old              | 2               | 200             |
+      | new              | 1               | 100             |
+      | new              | 2               | 200             |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | spaces   | 1               | 100             |
-      | spaces   | 2               | 200             |
+      | dav-path-version | ocs_api_version | ocs_status_code |
+      | spaces           | 1               | 100             |
+      | spaces           | 2               | 200             |
 
 
   Scenario Outline: update the role of a public link to internal
     Given using OCS API version "<ocs_api_version>"
-    And using <dav-path> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile.txt"
     And user "Alice" has created a public link share with settings
       | path        | /textfile.txt |
@@ -477,14 +477,14 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | old      | 1               | 100             |
-      | old      | 2               | 200             |
-      | new      | 1               | 100             |
-      | new      | 2               | 200             |
+      | dav-path-version | ocs_api_version | ocs_status_code |
+      | old              | 1               | 100             |
+      | old              | 2               | 200             |
+      | new              | 1               | 100             |
+      | new              | 2               | 200             |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | spaces   | 1               | 100             |
-      | spaces   | 2               | 200             |
+      | dav-path-version | ocs_api_version | ocs_status_code |
+      | spaces           | 1               | 100             |
+      | spaces           | 2               | 200             |

--- a/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -25,7 +25,7 @@ Feature: upload to a public link share
 
 
   Scenario Outline: uploading file to a public upload-only share using public API that was deleted does not work
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
@@ -35,14 +35,14 @@ Feature: upload to a public link share
 
     @issue-1268
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1269
   Scenario: uploading file to a public read-only share folder with public API does not work

--- a/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
@@ -261,7 +261,7 @@ Feature: sharing
 
 
   Scenario Outline: sharer deletes file uploaded with upload-only permission by sharee to a shared folder
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has created a share with settings
@@ -276,6 +276,6 @@ Feature: sharing
     And as "Brian" file "/Shares/FOLDER/textFile.txt" should not exist
     And as "Alice" file "/textFile.txt" should not exist
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinDelete.feature
@@ -15,7 +15,7 @@ Feature: files and folders can be deleted from the trashbin
 
   @smokeTest
   Scenario Outline: trashbin can be emptied
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "file with comma" to "sample,0.txt"
     And user "Alice" has uploaded file with content "file with comma" to "sample,1.txt"
     And user "Alice" has deleted file "<filename1>"
@@ -25,19 +25,19 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "<filename1>" should not exist in the trashbin
     And as "Alice" the file with original path "<filename2>" should not exist in the trashbin
     Examples:
-      | dav-path | filename1     | filename2     |
-      | new      | textfile0.txt | textfile1.txt |
-      | new      | sample,0.txt  | sample,1.txt  |
+      | dav-path-version | filename1     | filename2     |
+      | new              | textfile0.txt | textfile1.txt |
+      | new              | sample,0.txt  | sample,1.txt  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | filename1     | filename2     |
-      | spaces   | textfile0.txt | textfile1.txt |
-      | spaces   | sample,0.txt  | sample,1.txt  |
+      | dav-path-version | filename1     | filename2     |
+      | spaces           | textfile0.txt | textfile1.txt |
+      | spaces           | sample,0.txt  | sample,1.txt  |
 
   @smokeTest
   Scenario Outline: delete a single file from the trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
     And user "Alice" has deleted file "/PARENT/parent.txt"
@@ -49,17 +49,17 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: delete multiple files from the trashbin and make sure the correct ones are gone
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/child.txt"
     And user "Alice" has deleted file "/textfile0.txt"
@@ -76,17 +76,17 @@ Feature: files and folders can be deleted from the trashbin
     But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/child.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to delete another user's trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
@@ -100,13 +100,13 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | new      |
-      | spaces   |
+      | dav-path-version |
+      | new              |
+      | spaces           |
 
 
   Scenario Outline: user tries to delete trashbin file using invalid password
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
@@ -119,17 +119,17 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to delete trashbin file using no password
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
@@ -142,17 +142,17 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete a folder that contains a file from the trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created folder "FOLDER/CHILD"
     And user "Alice" has uploaded file with content "to delete" to "/FOLDER/parent.txt"
@@ -167,17 +167,17 @@ Feature: files and folders can be deleted from the trashbin
     But as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete a subfolder from a deleted folder from the trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created folder "FOLDER/CHILD"
     And user "Alice" has uploaded file with content "to delete" to "/FOLDER/parent.txt"
@@ -192,17 +192,17 @@ Feature: files and folders can be deleted from the trashbin
     But as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete files with special characters from the trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded the following files with content "special character file"
       | path             |
       | qa&dev.txt       |
@@ -229,17 +229,17 @@ Feature: files and folders can be deleted from the trashbin
       | %file *?2.txt    |
       | # %ab ab?=ed.txt |
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete folders with special characters from the trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created the following folders
       | path         |
       | qa&dev       |
@@ -266,17 +266,17 @@ Feature: files and folders can be deleted from the trashbin
       | %file *?2    |
       | # %ab ab?=ed |
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete folders with dot in the name from the trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created the following folders
       | path      |
       | /fo.      |
@@ -315,10 +315,10 @@ Feature: files and folders can be deleted from the trashbin
       | /fo.xyz   |
       | /fo.exe   |
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
@@ -10,39 +10,39 @@ Feature: files and folders exist in the trashbin after being deleted
 
   @smokeTest
   Scenario Outline: deleting a file moves it to trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "/textfile0.txt" should exist in the trashbin
     But as "Alice" file "/textfile0.txt" should not exist
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: deleting a folder moves it to trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
     When user "Alice" deletes folder "/tmp" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/tmp" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting a file in a folder moves it to the trashbin root
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "Alice" deletes file "/new-folder/new-file.txt" using the WebDAV API
@@ -51,17 +51,17 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" file "/new-file.txt" should exist in the trashbin
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting a file in a shared folder moves it to the trashbin root
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -72,17 +72,17 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" file "/shared_file.txt" should exist in the trashbin
     But as "Alice" file "/shared/shared_file.txt" should not exist
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting a shared folder moves it to trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -91,13 +91,13 @@ Feature: files and folders exist in the trashbin after being deleted
     Then the HTTP status code should be "204"
     And as "Alice" the folder with original path "/shared" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   # This scenario deletes many files as close together in time as the test can run.
@@ -105,7 +105,7 @@ Feature: files and folders exist in the trashbin after being deleted
   # But on "reasonable" systems, some of the files will be deleted in the same second,
   # thus testing the required behavior.
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/folderA"
     And user "Alice" has created folder "/folderB"
     And user "Alice" has created folder "/folderC"
@@ -127,17 +127,17 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   # Note: the underlying acceptance test code ensures that each delete step is separated by a least 1 second
   Scenario Outline: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/folderA"
     And user "Alice" has created folder "/folderB"
     And user "Alice" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
@@ -150,17 +150,17 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @issue-3561
   Scenario Outline: listing other user's trashbin is prohibited
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "testtrashbin100" has been created with default attributes and without skeleton files
     And user "testtrashbin100" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -172,13 +172,13 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile1.txt | testtrashbin100 |
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | new      |
-      | spaces   |
+      | dav-path-version |
+      | new              |
+      | spaces           |
 
   @issue-3561 @smokeTest
   Scenario Outline: listing other user's trashbin is prohibited with multiple files on trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "testtrashbin101" has been created with default attributes and without skeleton files
     And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile2.txt"
@@ -193,13 +193,13 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile2.txt | testtrashbin101 |
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | new      |
-      | spaces   |
+      | dav-path-version |
+      | new              |
+      | spaces           |
 
   @issue-3561  @provisioning_api-app-required
   Scenario Outline: listing other user's trashbin is prohibited for newly recreated user with same name
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "testtrashbin102" has been created with default attributes and without skeleton files
     And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile2.txt"
@@ -219,43 +219,43 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile3.txt | testtrashbin102 |
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | new      |
-      | spaces   |
+      | dav-path-version |
+      | new              |
+      | spaces           |
 
   @issue-3561
   Scenario Outline: listing other user's empty unused trashbin is prohibited
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "testtrashbinempty" has been created with default attributes and without skeleton files
     And user "testtrashbinempty" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     When user "Alice" tries to list the trashbin content for user "testtrashbinempty"
     Then the HTTP status code should be "404"
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @issue-3561
   Scenario Outline: listing non-existent user's trashbin is prohibited
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" tries to list the trashbin content for user "testtrashbinnotauser"
     Then the HTTP status code should be "404"
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: get trashbin content with wrong password
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" tries to list the trashbin content for user "Alice" using password "invalid"
@@ -264,17 +264,17 @@ Feature: files and folders exist in the trashbin after being deleted
       | path           | user  |
       | /textfile0.txt | Alice |
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: get trashbin content without password
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" tries to list the trashbin content for user "Alice" using password ""
@@ -283,17 +283,17 @@ Feature: files and folders exist in the trashbin after being deleted
       | path           | user  |
       | /textfile0.txt | Alice |
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user with unusual username deletes a file
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "<username>" has been created with default attributes and without skeleton files
     And user "<username>" has uploaded file with content "to delete" to "/textfile0.txt"
     When user "<username>" deletes file "/textfile0.txt" using the WebDAV API
@@ -301,38 +301,38 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "<username>" file "/textfile0.txt" should exist in the trashbin
     But as "<username>" file "/textfile0.txt" should not exist
     Examples:
-      | dav-path | username |
-      | new      | dash-123 |
-      | new      | null     |
-      | new      | nil      |
+      | dav-path-version | username |
+      | new              | dash-123 |
+      | new              | null     |
+      | new              | nil      |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | username |
-      | spaces   | dash-123 |
-      | spaces   | null     |
-      | spaces   | nil      |
+      | dav-path-version | username |
+      | spaces           | dash-123 |
+      | spaces           | null     |
+      | spaces           | nil      |
 
 
   Scenario Outline: deleting a file with comma in the filename moves it to trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "file with comma in filename" to "sample,1.txt"
     When user "Alice" deletes file "sample,1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "sample,1.txt" should exist in the trashbin
     But as "Alice" file "sample,1.txt" should not exist
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting a folder moves all its content to the trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/new-folder/new-file.txt"
     When user "Alice" deletes folder "/new-folder" using the WebDAV API
@@ -342,34 +342,34 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" file "/new-folder/new-file.txt" should exist in the trashbin
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @issue-541
   Scenario Outline: deleted file has appropriate deletion time information
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2018 04:18:13 GMT" using the WebDAV API
     And user "Alice" has deleted file "file.txt"
     When user "Alice" tries to list the trashbin content for user "Alice"
     Then the HTTP status code should be "207"
     And the deleted file "file.txt" should have the correct deletion mtime in the response
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1547
   Scenario Outline: deleting files with special characters moves it to trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded the following files with content "special character file"
       | path             |
       | qa&dev.txt       |
@@ -396,17 +396,17 @@ Feature: files and folders exist in the trashbin after being deleted
       | %file *?2.txt    |
       | # %ab ab?=ed.txt |
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1547
   Scenario Outline: deleting folders with special characters moves it to trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created the following folders
       | path         |
       | qa&dev       |
@@ -433,10 +433,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | %file *?2    |
       | # %ab ab?=ed |
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
@@ -10,7 +10,7 @@ Feature: using trashbin together with sharing
 
   @smokeTest
   Scenario Outline: deleting a received folder doesn't move it to trashbin
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -21,17 +21,17 @@ Feature: using trashbin together with sharing
     Then the HTTP status code should be "204"
     And as "Brian" the folder with original path "/Shares/renamed_shared" should not exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting a file in a received folder moves it to trashbin of both users
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -43,17 +43,17 @@ Feature: using trashbin together with sharing
     And as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should exist in the trashbin
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: sharee deleting a file in a group-shared folder moves it to the trashbin of sharee and sharer only
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -70,17 +70,17 @@ Feature: using trashbin together with sharing
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: sharer deleting a file in a group-shared folder moves it to the trashbin of sharer only
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -97,17 +97,17 @@ Feature: using trashbin together with sharing
     And as "Brian" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: sharee deleting a folder in a group-shared folder moves it to the trashbin of sharee and sharer only
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -125,17 +125,17 @@ Feature: using trashbin together with sharing
     And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
     And as "Carol" the file with original path "/Shares/sub/shared/shared_file.txt" should not exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: sharer deleting a folder in a group-shared folder moves it to the trashbin of sharer only
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -153,17 +153,17 @@ Feature: using trashbin together with sharing
     And as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
     And as "Carol" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -181,17 +181,17 @@ Feature: using trashbin together with sharing
       | /Shares/renamed_shared/shared_file.txt |
     And the content of file "/Shares/renamed_shared/shared_file.txt" for user "Brian" should be "file to delete"
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: restoring a file to a read-only folder
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "shareFolderParent"
     And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
@@ -204,17 +204,17 @@ Feature: using trashbin together with sharing
     And as "Alice" file "/Shares/shareFolderParent/textfile0.txt" should not exist
     And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: restoring a file to a read-only sub-folder
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "shareFolderParent"
     And user "Brian" has created folder "shareFolderParent/shareFolderChild"
@@ -228,10 +228,10 @@ Feature: using trashbin together with sharing
     And as "Alice" file "/Shares/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     Examples:
-      | dav-path |
-      | new      |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/coreApiTrashbinRestore/trashbinRestore.feature
@@ -10,7 +10,7 @@ Feature: restore deleted files/folders
 
   @smokeTest
   Scenario Outline: deleted file can be restored
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "parent text" to "/PARENT/parent.txt"
@@ -30,13 +30,13 @@ Feature: restore deleted files/folders
       | /textfile0.txt     |
       | /textfile1.txt     |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: file deleted from a folder can be restored to the original folder
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "Alice" has deleted file "/new-folder/new-file.txt"
@@ -46,13 +46,13 @@ Feature: restore deleted files/folders
     And as "Alice" file "/new-folder/new-file.txt" should exist
     And the content of file "/new-folder/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: file deleted from a folder is restored to the original folder if the original folder was deleted and restored
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "Alice" has deleted file "/new-folder/new-file.txt"
@@ -64,13 +64,13 @@ Feature: restore deleted files/folders
     And as "Alice" file "/new-folder/new-file.txt" should exist
     And the content of file "/new-folder/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: file is deleted and restored to a new destination
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/CHILD"
     And user "Alice" has uploaded file with content "to delete" to "<delete-path>"
@@ -84,18 +84,18 @@ Feature: restore deleted files/folders
     And as "Alice" file "<delete-path>" should not exist
     And the content of file "<restore-path>" for user "Alice" should be "to delete"
     Examples:
-      | dav-path | delete-path             | restore-path         |
-      | old      | /PARENT/parent.txt      | parent.txt           |
-      | new      | /PARENT/parent.txt      | parent.txt           |
-      | old      | /PARENT/CHILD/child.txt | child.txt            |
-      | new      | /PARENT/CHILD/child.txt | child.txt            |
-      | old      | /textfile0.txt          | PARENT/textfile0.txt |
-      | new      | /textfile0.txt          | PARENT/textfile0.txt |
+      | dav-path-version | delete-path             | restore-path         |
+      | old              | /PARENT/parent.txt      | parent.txt           |
+      | new              | /PARENT/parent.txt      | parent.txt           |
+      | old              | /PARENT/CHILD/child.txt | child.txt            |
+      | new              | /PARENT/CHILD/child.txt | child.txt            |
+      | old              | /textfile0.txt          | PARENT/textfile0.txt |
+      | new              | /textfile0.txt          | PARENT/textfile0.txt |
 
 
   Scenario Outline: restoring a file to an already existing path overrides the file
     Given user "Alice" has uploaded file with content "file to delete" to "/.hiddenfile0.txt"
-    And using <dav-path> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "PARENT file content" to <upload-path>
     And user "Alice" has deleted file <delete-path>
@@ -104,15 +104,15 @@ Feature: restore deleted files/folders
     And as "Alice" file <upload-path> should exist
     And the content of file <upload-path> for user "Alice" should be "file to delete"
     Examples:
-      | dav-path | upload-path                | delete-path        |
-      | old      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
-      | new      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
-      | old      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
-      | new      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
+      | dav-path-version | upload-path                | delete-path        |
+      | old              | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
+      | new              | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
+      | old              | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
+      | new              | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
 
 
   Scenario Outline: file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "Alice" has deleted file "/new-folder/new-file.txt"
@@ -126,13 +126,13 @@ Feature: restore deleted files/folders
     And as "Alice" file "/new-folder/new-file.txt" should exist
     And the content of file "/new-folder/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @smokeTest
   Scenario Outline: deleted file cannot be restored by a different user
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Brian" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the trashbin API
@@ -141,13 +141,13 @@ Feature: restore deleted files/folders
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @smokeTest
   Scenario Outline: deleted file cannot be restored with invalid password
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the password "invalid" and the trashbin API
@@ -156,13 +156,13 @@ Feature: restore deleted files/folders
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @smokeTest
   Scenario Outline: deleted file cannot be restored without using a password
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the password "" and the trashbin API
@@ -171,13 +171,13 @@ Feature: restore deleted files/folders
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: files with strange names can be restored
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "file original content" to "<file-to-upload>"
     And user "Alice" has deleted file "<file-to-upload>"
     And user "Alice" restores the file with original path "<file-to-upload>" using the trashbin API
@@ -186,17 +186,17 @@ Feature: restore deleted files/folders
     And as "Alice" file "<file-to-upload>" should exist
     And the content of file "<file-to-upload>" for user "Alice" should be "file original content"
     Examples:
-      | dav-path | file-to-upload          |
-      | old      | 😛 😜 🐱 🐭 ⌚️ ♀️ 🚴‍♂️ |
-      | new      | 😛 😜 🐱 🐭 ⌚️ ♀️ 🚴‍♂️ |
-      | old      | strängé नेपाली file     |
-      | new      | strängé नेपाली file     |
-      | old      | sample,1.txt            |
-      | new      | sample,1.txt            |
+      | dav-path-version | file-to-upload          |
+      | old              | 😛 😜 🐱 🐭 ⌚️ ♀️ 🚴‍♂️ |
+      | new              | 😛 😜 🐱 🐭 ⌚️ ♀️ 🚴‍♂️ |
+      | old              | strängé नेपाली file     |
+      | new              | strängé नेपाली file     |
+      | old              | sample,1.txt            |
+      | new              | sample,1.txt            |
 
 
   Scenario Outline: file deleted from a multi level sub-folder can be restored to the original folder
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has created folder "/new-folder/folder1/"
     And user "Alice" has created folder "/new-folder/folder1/folder2/"
@@ -208,13 +208,13 @@ Feature: restore deleted files/folders
     And as "Alice" file "/new-folder/folder1/folder2/new-file.txt" should exist
     And the content of file "/new-folder/folder1/folder2/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: deleted multi level folder can be restored including the content
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has created folder "/new-folder/folder1/"
     And user "Alice" has created folder "/new-folder/folder1/folder2/"
@@ -226,13 +226,13 @@ Feature: restore deleted files/folders
     And as "Alice" file "/new-folder/folder1/folder2/new-file.txt" should exist
     And the content of file "/new-folder/folder1/folder2/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: subfolder from a deleted multi level folder can be restored including the content
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has created folder "/new-folder/folder1"
     And user "Alice" has created folder "/new-folder/folder1/folder2"
@@ -246,13 +246,13 @@ Feature: restore deleted files/folders
     And the content of file "/folder1/folder2/new-file.txt" for user "Alice" should be "file to delete"
     But as "Alice" the folder with original path "/new-folder" should exist in the trashbin
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: file from a deleted multi level sub-folder can be restored
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has created folder "/new-folder/folder1/"
     And user "Alice" has created folder "/new-folder/folder1/folder2/"
@@ -266,13 +266,13 @@ Feature: restore deleted files/folders
     And the content of file "/new-file.txt" for user "Alice" should be "file to delete"
     But as "Alice" the file with original path "/new-folder/folder1/folder2/not-restored.txt" should exist in the trashbin
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: deleted hidden file can be restored
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded the following files with content "hidden file"
       | path                 |
@@ -300,13 +300,13 @@ Feature: restore deleted files/folders
       | .hidden_file         |
       | /FOLDER/.hidden_file |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: restoring files with special characters
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded the following files with content "special character file"
       | path             |
       | qa&dev.txt       |
@@ -339,13 +339,13 @@ Feature: restore deleted files/folders
       | %file *?2.txt    |
       | # %ab ab?=ed.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: restoring folders with special characters
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created the following folders
       | path         |
       | qa&dev       |
@@ -378,13 +378,13 @@ Feature: restore deleted files/folders
       | %file *?2    |
       | # %ab ab?=ed |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: deleted file inside a nested folder can be restored to a different location
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/parent_folder"
     And user "Alice" has created folder "/parent_folder/sub"
     And user "Alice" has uploaded file with content "parent text" to "/parent_folder/sub/parent.txt"
@@ -396,13 +396,13 @@ Feature: restore deleted files/folders
     And as "Alice" the file with original path "/parent_folder/sub/parent.txt" should not exist in the trashbin
     And the content of file "parent.txt" for user "Alice" should be "parent text"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: deleted file inside a nested folder cannot be restored to the original location if the location doesn't exist
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/parent_folder"
     And user "Alice" has created folder "/parent_folder/sub"
     And user "Alice" has uploaded file with content "parent text" to "/parent_folder/sub/parent.txt"
@@ -415,13 +415,13 @@ Feature: restore deleted files/folders
       | /parent_folder/sub/           |
       | /parent_folder/sub/parent.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: deleted file inside a nested folder can be restored to the original location if the location exists
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/parent_folder"
     And user "Alice" has created folder "/parent_folder/sub"
     And user "Alice" has uploaded file with content "parent text" to "/parent_folder/sub/parent.txt"
@@ -439,13 +439,13 @@ Feature: restore deleted files/folders
       | /parent_folder/sub/           |
       | /parent_folder/sub/parent.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: deleted file inside a nested folder cannot be restored without the destination
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/parent_folder"
     And user "Alice" has created folder "/parent_folder/sub"
     And user "Alice" has uploaded file with content "parent text" to "/parent_folder/sub/parent.txt"
@@ -458,13 +458,13 @@ Feature: restore deleted files/folders
       | /parent_folder/sub/           |
       | /parent_folder/sub/parent.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: deleted file cannot be restored without the destination
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "parent text" to "/parent.txt"
     And user "Alice" has deleted file "parent.txt"
     When user "Alice" restores the folder with original path "parent.txt" without specifying the destination using the trashbin API
@@ -473,13 +473,13 @@ Feature: restore deleted files/folders
     And user "Alice" should not see the following elements
       | /parent.txt |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: restoring folders with dot in the name
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created the following folders
       | path      |
       | /fo.      |
@@ -527,6 +527,6 @@ Feature: restore deleted files/folders
       | /fo.xyz   |
       | /fo.exe   |
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -369,7 +369,7 @@ Feature: dav-versions
 
 
   Scenario Outline: moving a file (with versions) into a shared folder as the sharee and as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
@@ -388,13 +388,13 @@ Feature: dav-versions
     And as "Brian" file "/testfile.txt" should not exist
     And the version folder of file "/Shares/testshare/testfile.txt" for user "Alice" should contain "2" elements
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: moving a file (with versions) out of a shared folder as the sharee and as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data 1" to "/testshare/testfile.txt"
@@ -413,9 +413,9 @@ Feature: dav-versions
     And as "Brian" file "/testshare/testfile.txt" should not exist
     And the version folder of file "/testfile.txt" for user "Brian" should contain "2" elements
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario: sharee tries to get file versions of file not shared by the sharer

--- a/tests/acceptance/features/coreApiWebdavDelete/deleteFile.feature
+++ b/tests/acceptance/features/coreApiWebdavDelete/deleteFile.feature
@@ -9,24 +9,24 @@ Feature: delete file
 
   @smokeTest
   Scenario Outline: delete a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
     When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "/textfile0.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete a file when 2 files exist with different case
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "to delete" to "/textfile1.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/TextFile1.txt"
     When user "Alice" deletes file "/textfile1.txt" using the WebDAV API
@@ -35,77 +35,77 @@ Feature: delete file
     And as "Alice" file "/TextFile1.txt" should exist
     And the content of file "/TextFile1.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete file from folder with dots in the path
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content for file name with dots" to "<folder_name>/<file_name>"
     When user "Alice" deletes file "<folder_name>/<file_name>" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "<folder_name>/<file_name>" should not exist
     Examples:
-      | dav_version | folder_name   | file_name   |
-      | old         | /upload.      | abc.        |
-      | old         | /upload.      | abc .       |
-      | old         | /upload.1     | abc.txt     |
-      | old         | /upload...1.. | abc...txt.. |
-      | old         | /...          | ...         |
-      | old         | /..upload     | abc         |
-      | old         | /..upload     | ..abc       |
-      | new         | /upload.      | abc.        |
-      | new         | /upload.      | abc .       |
-      | new         | /upload.1     | abc.txt     |
-      | new         | /upload...1.. | abc...txt.. |
-      | new         | /...          | ...         |
-      | new         | /..upload     | abc         |
-      | new         | /..upload     | ..abc       |
+      | dav-path-version | folder_name   | file_name   |
+      | old              | /upload.      | abc.        |
+      | old              | /upload.      | abc .       |
+      | old              | /upload.1     | abc.txt     |
+      | old              | /upload...1.. | abc...txt.. |
+      | old              | /...          | ...         |
+      | old              | /..upload     | abc         |
+      | old              | /..upload     | ..abc       |
+      | new              | /upload.      | abc.        |
+      | new              | /upload.      | abc .       |
+      | new              | /upload.1     | abc.txt     |
+      | new              | /upload...1.. | abc...txt.. |
+      | new              | /...          | ...         |
+      | new              | /..upload     | abc         |
+      | new              | /..upload     | ..abc       |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version    | folder_name   | file_name   |
-      | spaces         | /upload.      | abc.        |
-      | spaces         | /upload...1.. | abc...txt.. |
-      | spaces         | /upload.1     | abc.txt     |
-      | spaces         | /upload.      | abc .       |
-      | spaces         | /...          | ...         |
-      | spaces         | /..upload     | abc         |
-      | spaces         | /..upload     | ...abc      |
+      | dav-path-version | folder_name   | file_name   |
+      | spaces           | /upload.      | abc.        |
+      | spaces           | /upload...1.. | abc...txt.. |
+      | spaces           | /upload.1     | abc.txt     |
+      | spaces           | /upload.      | abc .       |
+      | spaces           | /...          | ...         |
+      | spaces           | /..upload     | abc         |
+      | spaces           | /..upload     | ...abc      |
 
 
   Scenario Outline: delete a file with comma in the filename
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "file with comma in filename" to <filename>
     When user "Alice" deletes file <filename> using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file <filename> should not exist
     Examples:
-      | dav_version | filename       |
-      | old         | "sample,1.txt" |
-      | old         | ",,,.txt"      |
-      | old         | ",,,.,"        |
-      | new         | "sample,1.txt" |
-      | new         | ",,,.txt"      |
-      | new         | ",,,.,"        |
+      | dav-path-version | filename       |
+      | old              | "sample,1.txt" |
+      | old              | ",,,.txt"      |
+      | old              | ",,,.,"        |
+      | new              | "sample,1.txt" |
+      | new              | ",,,.txt"      |
+      | new              | ",,,.,"        |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version    | filename       |
-      | spaces         | "sample,1.txt" |
-      | spaces         | ",,,.txt"      |
-      | spaces         | ",,,.,"        |
+      | dav-path-version | filename       |
+      | spaces           | "sample,1.txt" |
+      | spaces           | ",,,.txt"      |
+      | spaces           | ",,,.,"        |
 
 
   Scenario Outline: delete a hidden file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded the following files with content "hidden file"
       | path                 |
@@ -121,14 +121,14 @@ Feature: delete file
       | .hidden_file         |
       | /FOLDER/.hidden_file |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version    |
-      | spaces         |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario: delete a file of size zero byte

--- a/tests/acceptance/features/coreApiWebdavDelete/deleteFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavDelete/deleteFolder.feature
@@ -10,41 +10,41 @@ Feature: delete folder
 
   @smokeTest
   Scenario Outline: delete a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/PARENT" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete a folder when 2 folder exist with different case
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/parent"
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/PARENT" should not exist
     But as "Alice" folder "/parent" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: delete a sub-folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/PARENT/parent.txt"
     When user "Alice" deletes folder "/PARENT/CHILD" using the WebDAV API
@@ -53,46 +53,46 @@ Feature: delete folder
     But as "Alice" folder "/PARENT" should exist
     And as "Alice" file "/PARENT/parent.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting folder with dot in the name
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     When user "Alice" deletes folder "<folder_name>" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "<folder_name>" should not exist
     Examples:
-      | dav_version | folder_name |
-      | old         | /fo.        |
-      | old         | /fo.1       |
-      | old         | /fo...1..   |
-      | old         | /...        |
-      | old         | /..fo       |
-      | old         | /fo.xyz     |
-      | old         | /fo.exe     |
-      | new         | /fo.        |
-      | new         | /fo.1       |
-      | new         | /fo...1..   |
-      | new         | /...        |
-      | new         | /..fo       |
-      | new         | /fo.xyz     |
-      | new         | /fo.exe     |
+      | dav-path-version | folder_name |
+      | old              | /fo.        |
+      | old              | /fo.1       |
+      | old              | /fo...1..   |
+      | old              | /...        |
+      | old              | /..fo       |
+      | old              | /fo.xyz     |
+      | old              | /fo.exe     |
+      | new              | /fo.        |
+      | new              | /fo.1       |
+      | new              | /fo...1..   |
+      | new              | /...        |
+      | new              | /..fo       |
+      | new              | /fo.xyz     |
+      | new              | /fo.exe     |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name |
-      | spaces      | /fo.        |
-      | spaces      | /fo.1       |
-      | spaces      | /fo...1..   |
-      | spaces      | /...        |
-      | spaces      | /..fo       |
-      | spaces      | /fo.xyz     |
-      | spaces      | /fo.exe     |
+      | dav-path-version | folder_name |
+      | spaces           | /fo.        |
+      | spaces           | /fo.1       |
+      | spaces           | /fo...1..   |
+      | spaces           | /...        |
+      | spaces           | /..fo       |
+      | spaces           | /fo.xyz     |
+      | spaces           | /fo.exe     |

--- a/tests/acceptance/features/coreApiWebdavDelete/deleteFolderContents.feature
+++ b/tests/acceptance/features/coreApiWebdavDelete/deleteFolderContents.feature
@@ -9,7 +9,7 @@ Feature: delete folder contents
 
 
   Scenario Outline: removing everything from a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/PARENT/"
     And user "Alice" has created folder "/FOLDER/"
     And user "Alice" has created folder "/FOLDER/SUBFOLDER"
@@ -29,11 +29,11 @@ Feature: delete folder contents
       | /FOLDER/fileToDelete.txt        |
       | /FOLDER/SUBFOLDER/testfile0.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -10,7 +10,7 @@ Feature: propagation of etags when deleting a file or folder
 
 
   Scenario Outline: deleting a file changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has stored etag of element "/"
@@ -24,18 +24,18 @@ Feature: propagation of etags when deleting a file or folder
       | Alice | /upload     |
       | Alice | /upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: deleting a folder changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has stored etag of element "/"
@@ -49,18 +49,18 @@ Feature: propagation of etags when deleting a file or folder
       | Alice | /upload     |
       | Alice | /upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: deleting a folder with content changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/toDelete/file.txt"
@@ -75,19 +75,19 @@ Feature: propagation of etags when deleting a file or folder
       | Alice | /upload     |
       | Alice | /upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: sharee deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -111,14 +111,14 @@ Feature: propagation of etags when deleting a file or folder
       | Brian | /Shares/upload     |
       | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -142,14 +142,14 @@ Feature: propagation of etags when deleting a file or folder
       | Brian | /Shares/upload     |
       | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: sharee deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -173,14 +173,14 @@ Feature: propagation of etags when deleting a file or folder
       | Brian | /Shares/upload     |
       | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -204,13 +204,13 @@ Feature: propagation of etags when deleting a file or folder
       | Brian | /Shares/upload     |
       | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: deleting a file in a publicly shared folder changes its etag for the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
       | path        | upload |
@@ -224,18 +224,18 @@ Feature: propagation of etags when deleting a file or folder
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
-  @skipOnRevaMaster
+    @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: deleting a folder in a publicly shared folder changes its etag for the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
       | path        | upload |
@@ -249,11 +249,11 @@ Feature: propagation of etags when deleting a file or folder
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
@@ -9,7 +9,7 @@ Feature: propagation of etags when moving files or folders
 
 
   Scenario Outline: renaming a file inside a folder changes its etag
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has stored etag of element "/"
@@ -21,18 +21,18 @@ Feature: propagation of etags when moving files or folders
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: moving a file from one folder to an other changes the etags of both folders
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/dst"
     And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
@@ -47,18 +47,18 @@ Feature: propagation of etags when moving files or folders
       | Alice | /src |
       | Alice | /dst |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: moving a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
@@ -73,18 +73,18 @@ Feature: propagation of etags when moving files or folders
       | Alice | /upload     |
       | Alice | /upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: renaming a folder inside a folder changes its etag
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/src"
     And user "Alice" has stored etag of element "/"
@@ -96,18 +96,18 @@ Feature: propagation of etags when moving files or folders
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: moving a folder from one folder to an other changes the etags of both folders
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/src/folder"
     And user "Alice" has created folder "/dst"
@@ -122,18 +122,18 @@ Feature: propagation of etags when moving files or folders
       | Alice | /src |
       | Alice | /dst |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: moving a folder into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/folder"
     And user "Alice" has created folder "/upload/sub"
@@ -148,19 +148,19 @@ Feature: propagation of etags when moving files or folders
       | Alice | /upload     |
       | Alice | /upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: sharee renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -180,14 +180,14 @@ Feature: propagation of etags when moving files or folders
       | Brian | /Shares        |
       | Brian | /Shares/upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -207,14 +207,14 @@ Feature: propagation of etags when moving files or folders
       | Brian | /Shares        |
       | Brian | /Shares/upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/dst"
     And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
@@ -241,14 +241,14 @@ Feature: propagation of etags when moving files or folders
       | Brian | /Shares/src |
       | Brian | /Shares/dst |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharee moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/dst"
     And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
@@ -275,14 +275,14 @@ Feature: propagation of etags when moving files or folders
       | Brian | /Shares/src |
       | Brian | /Shares/dst |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/dst"
     And user "Alice" has created folder "/src/toMove"
@@ -309,14 +309,14 @@ Feature: propagation of etags when moving files or folders
       | Brian | /Shares/src |
       | Brian | /Shares/dst |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharee moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/dst"
     And user "Alice" has created folder "/src/toMove"
@@ -343,13 +343,13 @@ Feature: propagation of etags when moving files or folders
       | Brian | /Shares/src |
       | Brian | /Shares/dst |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: renaming a file in a publicly shared folder changes its etag for the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
@@ -364,18 +364,18 @@ Feature: propagation of etags when moving files or folders
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: renaming a folder in a publicly shared folder changes its etag for the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
@@ -390,11 +390,11 @@ Feature: propagation of etags when moving files or folders
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
@@ -9,7 +9,7 @@ Feature: propagation of etags when copying files or folders
 
   @issue-4251
   Scenario Outline: copying a file does not change its etag
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/file.txt"
@@ -24,18 +24,18 @@ Feature: propagation of etags when copying files or folders
       | Alice | /                |
       | Alice | /renamedFile.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: copying a file inside a folder changes its etag
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     And user "Alice" has stored etag of element "/file.txt"
@@ -51,18 +51,18 @@ Feature: propagation of etags when copying files or folders
       | Alice | /folder/renamedFile.txt |
       | Alice | /folder                 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: copying a file from one folder to an other changes the etags of destination
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
     And user "Alice" has created folder "/dst"
@@ -79,18 +79,18 @@ Feature: propagation of etags when copying files or folders
       | user  | path |
       | Alice | /src |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
@@ -112,18 +112,18 @@ Feature: propagation of etags when copying files or folders
       | Alice | /upload/file.txt |
     @issue-4091
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
@@ -145,19 +145,19 @@ Feature: propagation of etags when copying files or folders
       | Alice | /upload/file.txt |
     @issue-4091
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: sharee copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -187,14 +187,14 @@ Feature: propagation of etags when copying files or folders
       | Alice | /upload/file.txt        |
       | Brian | /Shares/upload/file.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
@@ -224,6 +224,6 @@ Feature: propagation of etags when copying files or folders
       | Alice | /upload/file.txt        |
       | Brian | /Shares/upload/file.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
@@ -9,7 +9,7 @@ Feature: propagation of etags when creating folders
 
   @issue-4251
   Scenario Outline: creating a folder inside a folder changes its etag
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/folder"
@@ -20,18 +20,18 @@ Feature: propagation of etags when creating folders
       | Alice | /       |
       | Alice | /folder |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: creating an invalid folder inside a folder should not change any etags
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has created folder "/folder/sub"
     And user "Alice" has stored etag of element "/"
@@ -45,19 +45,19 @@ Feature: propagation of etags when creating folders
       | Alice | /folder     |
       | Alice | /folder/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: sharee creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has shared folder "/folder" with user "Brian"
     And user "Brian" has accepted share "/folder" offered by user "Alice"
@@ -76,14 +76,14 @@ Feature: propagation of etags when creating folders
       | Brian | /Shares        |
       | Brian | /Shares/folder |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: sharer creating a folder inside a shared folder changes etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has shared folder "/folder" with user "Brian"
     And user "Brian" has accepted share "/folder" offered by user "Alice"
@@ -102,13 +102,13 @@ Feature: propagation of etags when creating folders
       | Brian | /Shares        |
       | Brian | /Shares/folder |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: creating a folder in a publicly shared folder changes its etag for the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has created a public link share with settings
       | path        | folder |
@@ -122,11 +122,11 @@ Feature: propagation of etags when creating folders
       | Alice | /       |
       | Alice | /folder |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
-  @skipOnRevaMaster
+    @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature
@@ -10,7 +10,7 @@ Feature: propagation of etags when restoring a file or folder from trash
 
 
   Scenario Outline: restoring a file to its original location changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has deleted file "/upload/sub/file.txt"
@@ -25,13 +25,13 @@ Feature: propagation of etags when restoring a file or folder from trash
       | Alice | /upload     |
       | Alice | /upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: restoring a file to an other location changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/restore"
     And user "Alice" has created folder "/restore/sub"
@@ -48,13 +48,13 @@ Feature: propagation of etags when restoring a file or folder from trash
       | Alice | /restore     |
       | Alice | /restore/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: restoring a folder to its original location changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has deleted folder "/upload/sub/toDelete"
@@ -69,13 +69,13 @@ Feature: propagation of etags when restoring a file or folder from trash
       | Alice | /upload     |
       | Alice | /upload/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: restoring a folder to an other location changes the etags of all parents
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has deleted folder "/upload/sub/toDelete"
@@ -92,6 +92,6 @@ Feature: propagation of etags when restoring a file or folder from trash
       | Alice | /restore     |
       | Alice | /restore/sub |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
@@ -10,7 +10,7 @@ Feature: propagation of etags when uploading data
 
   @issue-4251
   Scenario Outline: uploading a file inside a folder changes its etag
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     When user "Alice" uploads file with content "uploaded content" to "/upload/file.txt" using the WebDAV API
@@ -20,18 +20,18 @@ Feature: propagation of etags when uploading data
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: overwriting a file inside a folder changes its etag
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
@@ -44,19 +44,19 @@ Feature: propagation of etags when uploading data
       | Alice | /upload          |
       | Alice | /upload/file.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4251
   Scenario Outline: sharee uploading a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
@@ -74,14 +74,14 @@ Feature: propagation of etags when uploading data
       | Brian | /Shares        |
       | Brian | /Shares/upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
@@ -99,14 +99,14 @@ Feature: propagation of etags when uploading data
       | Brian | /Shares        |
       | Brian | /Shares/upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharee overwriting a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
@@ -125,14 +125,14 @@ Feature: propagation of etags when uploading data
       | Brian | /Shares        |
       | Brian | /Shares/upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
@@ -151,13 +151,13 @@ Feature: propagation of etags when uploading data
       | Brian | /Shares        |
       | Brian | /Shares/upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-4251
   Scenario Outline: uploading a file into a publicly shared folder changes its etag for the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a public link share with settings
       | path        | upload |
       | permissions | create |
@@ -170,11 +170,11 @@ Feature: propagation of etags when uploading data
       | Alice | /       |
       | Alice | /upload |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/coreApiWebdavLocks/exclusiveLocks.feature
@@ -9,7 +9,7 @@ Feature: there can be only one exclusive lock on a resource
 
 
   Scenario Outline: second lock cannot be set on a folder when its exclusively locked
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | exclusive |
@@ -18,21 +18,21 @@ Feature: there can be only one exclusive lock on a resource
     Then the HTTP status code should be "423"
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: sharee cannot lock a resource exclusively locked by itself
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -45,21 +45,21 @@ Feature: there can be only one exclusive lock on a resource
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "textfile0 (2).txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: sharee cannot lock a resource exclusively locked by the owner
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -72,21 +72,21 @@ Feature: there can be only one exclusive lock on a resource
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "textfile0 (2).txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: sharer cannot lock a resource exclusively locked by a sharee
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -99,14 +99,14 @@ Feature: there can be only one exclusive lock on a resource
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "textfile0 (2).txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |

--- a/tests/acceptance/features/coreApiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/coreApiWebdavLocks/requestsWithToken.feature
@@ -9,7 +9,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
 
 
   Scenario Outline: two users having both a shared lock can use the resource
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
     And user "Brian" has uploaded file with content "some data" to "textfile0.txt"
@@ -28,11 +28,11 @@ Feature: actions on a locked item are possible if the token is sent with the req
     And the content of file "textfile0.txt" for user "Alice" should be "from user 1"
     And the content of file "Shares/textfile0.txt" for user "Brian" should be "from user 1"
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavLocks2/independentLocks.feature
+++ b/tests/acceptance/features/coreApiWebdavLocks2/independentLocks.feature
@@ -9,7 +9,7 @@ Feature: independent locks - make sure all locks are independent and don't inter
 
 
   Scenario Outline: locking a file does not lock other items with the same name in other parts of the file system
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "locked"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
     And user "Alice" has created folder "notlocked"
@@ -21,21 +21,21 @@ Feature: independent locks - make sure all locks are independent and don't inter
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/textfile0.txt"
     But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/textfile0.txt"
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: locking a file/folder with git specific names does not lock other items with the same name in other parts of the file system
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "locked/"
     And user "Alice" has created folder "locked/.git"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/.git/config"
@@ -49,20 +49,20 @@ Feature: independent locks - make sure all locks are independent and don't inter
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/.git/config"
     But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/.git/config"
     Examples:
-      | dav-path | lock-scope | to-lock     |
-      | old      | shared     | .git        |
-      | old      | shared     | .git/config |
-      | old      | exclusive  | .git        |
-      | old      | exclusive  | .git/config |
-      | new      | shared     | .git        |
-      | new      | shared     | .git/config |
-      | new      | exclusive  | .git        |
-      | new      | exclusive  | .git/config |
+      | dav-path-version | lock-scope | to-lock     |
+      | old              | shared     | .git        |
+      | old              | shared     | .git/config |
+      | old              | exclusive  | .git        |
+      | old              | exclusive  | .git/config |
+      | new              | shared     | .git        |
+      | new              | shared     | .git/config |
+      | new              | exclusive  | .git        |
+      | new              | exclusive  | .git/config |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope | to-lock     |
-      | spaces   | shared     | .git        |
-      | spaces   | shared     | .git/config |
-      | spaces   | exclusive  | .git        |
-      | spaces   | exclusive  | .git/config |
+      | dav-path-version | lock-scope | to-lock     |
+      | spaces           | shared     | .git        |
+      | spaces           | shared     | .git/config |
+      | spaces           | exclusive  | .git        |
+      | spaces           | exclusive  | .git/config |

--- a/tests/acceptance/features/coreApiWebdavLocks2/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/coreApiWebdavLocks2/independentLocksShareToShares.feature
@@ -10,7 +10,7 @@ Feature: independent locks - make sure all locks are independent and don't inter
 
 
   Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares (shares from different users)
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FromAlice"
     And user "Brian" has created folder "FromBrian"
@@ -26,21 +26,21 @@ Feature: independent locks - make sure all locks are independent and don't inter
     And user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/FromAlice/textfile0.txt"
     But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/FromBrian/textfile0.txt"
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares (shares from same user)
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "locked/"
     And user "Alice" has created folder "notlocked/"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
@@ -55,14 +55,14 @@ Feature: independent locks - make sure all locks are independent and don't inter
     And user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/notlocked/textfile0.txt"
     But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/locked/textfile0.txt"
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |

--- a/tests/acceptance/features/coreApiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/coreApiWebdavLocksUnlock/unlock.feature
@@ -9,7 +9,7 @@ Feature: Unlock locked items
 
 
   Scenario Outline: unlock one of multiple locks set by the user itself
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |
@@ -19,14 +19,14 @@ Feature: Unlock locked items
     Then the HTTP status code should be "204"
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
@@ -45,7 +45,7 @@ Feature: Unlock locked items
 
 
   Scenario Outline: unlocking a file or folder does not unlock another file with the same name in another part of the file system
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "locked"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
     And user "Alice" has created folder "notlocked"
@@ -62,14 +62,14 @@ Feature: Unlock locked items
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/textfile0.txt"
     But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/textfile0.txt"
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |

--- a/tests/acceptance/features/coreApiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/coreApiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -14,7 +14,7 @@ Feature: UNLOCK locked items (sharing)
 
 
   Scenario Outline: unlocking a shared file that has been locked by the file owner is not feasible unless the owner lock tocken is used
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
@@ -24,21 +24,21 @@ Feature: UNLOCK locked items (sharing)
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "Shares/parent.txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: sharee cannot unlock a file within a shared folder when it is locked by the file owner unless the owner lock token is used
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -48,21 +48,21 @@ Feature: UNLOCK locked items (sharing)
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "Shares/PARENT/parent.txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: sharee unlock a shared file
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
     And user "Brian" has locked file "Shares/parent.txt" setting the following properties
@@ -72,21 +72,21 @@ Feature: UNLOCK locked items (sharing)
     And 0 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 0 locks should be reported for file "Shares/parent.txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: as owner unlocking a shared file locked by the receiver is not possible. To unlock use the receivers locktoken
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
     And user "Brian" has locked file "Shares/parent.txt" setting the following properties
@@ -96,21 +96,21 @@ Feature: UNLOCK locked items (sharing)
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "Shares/parent.txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |
 
 
   Scenario Outline: unlocking a file in a shared folder, which was locked by the sharee is not possible for the owner unless the receiver's locktoken is used
-    Given using <dav-path> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has locked file "Shares/PARENT/parent.txt" setting the following properties
@@ -120,14 +120,14 @@ Feature: UNLOCK locked items (sharing)
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "Shares/PARENT/parent.txt" of user "Brian" by the WebDAV API
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path-version | lock-scope |
+      | old              | shared     |
+      | old              | exclusive  |
+      | new              | shared     |
+      | new              | exclusive  |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
+      | dav-path-version | lock-scope |
+      | spaces           | shared     |
+      | spaces           | exclusive  |

--- a/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature
@@ -10,61 +10,61 @@ Feature: move (rename) folder
 
 
   Scenario Outline: renaming a folder to a backslash should return an error
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     When user "Alice" moves folder "/testshare" to "\" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "Alice" should see the following elements
       | /testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: renaming a folder beginning with a backslash should return an error
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     When user "Alice" moves folder "/testshare" to "\testshare" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "Alice" should see the following elements
       | /testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: renaming a folder including a backslash encoded should return an error
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     When user "Alice" moves folder "/testshare" to "/hola\hola" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "Alice" should see the following elements
       | /testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: move a folder into an other folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     And user "Alice" has created folder "/an-other-folder"
     When user "Alice" moves folder "/testshare" to "/an-other-folder/testshare" using the WebDAV API
@@ -74,66 +74,66 @@ Feature: move (rename) folder
     And user "Alice" should see the following elements
       | /an-other-folder/testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: move a folder into a nonexistent folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     When user "Alice" moves folder "/testshare" to "/not-existing/testshare" using the WebDAV API
     Then the HTTP status code should be "409"
     And user "Alice" should see the following elements
       | /testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: renaming folder with dots in the path
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content for file name ending with a dot" to "<folder_name>/abc.txt"
     When user "Alice" moves folder "<folder_name>" to "/uploadFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/uploadFolder/abc.txt" for user "Alice" should be "uploaded content for file name ending with a dot"
     Examples:
-      | dav_version | folder_name   |
-      | old         | /upload.      |
-      | old         | /upload.1     |
-      | old         | /upload...1.. |
-      | old         | /...          |
-      | old         | /..upload     |
-      | new         | /upload.      |
-      | new         | /upload.1     |
-      | new         | /upload...1.. |
-      | new         | /...          |
-      | new         | /..upload     |
+      | dav-path-version | folder_name   |
+      | old              | /upload.      |
+      | old              | /upload.1     |
+      | old              | /upload...1.. |
+      | old              | /...          |
+      | old              | /..upload     |
+      | new              | /upload.      |
+      | new              | /upload.1     |
+      | new              | /upload...1.. |
+      | new              | /...          |
+      | new              | /..upload     |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name   |
-      | spaces      | /upload.      |
-      | spaces      | /upload.1     |
-      | spaces      | /upload...1.. |
-      | spaces      | /...          |
-      | spaces      | /..upload     |
+      | dav-path-version | folder_name   |
+      | spaces           | /upload.      |
+      | spaces           | /upload.1     |
+      | spaces           | /upload...1.. |
+      | spaces           | /...          |
+      | spaces           | /..upload     |
 
   @skipOnRevaMaster @issue-3023
   Scenario Outline: moving a folder into a sub-folder of itself
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file with content "parent text" to "/PARENT/parent.txt"
@@ -143,7 +143,7 @@ Feature: move (rename) folder
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "parent text"
     And the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be "child text"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
-      | spaces      |
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavMove1/moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/coreApiWebdavMove1/moveFolderToBlacklistedName.feature
@@ -10,18 +10,18 @@ Feature: users cannot move (rename) a folder to a blacklisted name
 
 
   Scenario Outline: rename a folder to a name that is banned by default
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     When user "Alice" moves folder "/testshare" to "/.htaccess" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "Alice" should see the following elements
       | /testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature
@@ -10,7 +10,7 @@ Feature: move (rename) file
 
   @smokeTest
   Scenario Outline: moving a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
@@ -19,18 +19,18 @@ Feature: move (rename) file
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And the content of file "/FOLDER/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: moving and overwriting a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     When user "Alice" moves file "/textfile0.txt" to "/textfile1.txt" using the WebDAV API
@@ -39,36 +39,36 @@ Feature: move (rename) file
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: moving (renaming) a file to be only different case
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/TextFile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/textfile0.txt" should not exist
     And the content of file "/TextFile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: moving (renaming) a file to a file with only different case to an existing file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     When user "Alice" moves file "/textfile1.txt" to "/TextFile0.txt" using the WebDAV API
@@ -76,18 +76,18 @@ Feature: move (rename) file
     And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     And the content of file "/TextFile0.txt" for user "Alice" should be "ownCloud test text file 1"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: moving (renaming) a file to a file in a folder with only different case to an existing file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
@@ -96,50 +96,50 @@ Feature: move (rename) file
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
     And the content of file "/PARENT/Parent.txt" for user "Alice" should be "ownCloud test text file 1"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: move file into a not-existing folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToMove.txt"
     When user "Alice" moves file "/fileToMove.txt" to "/not-existing/fileToMove.txt" using the WebDAV API
     Then the HTTP status code should be "409"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1295
   Scenario Outline: rename a file into an invalid filename
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToRename.txt"
     When user "Alice" moves file "/fileToRename.txt" to "/a\\a" using the WebDAV API
     Then the HTTP status code should be "400"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: checking file id after a move
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has stored id of file "/textfile0.txt"
@@ -149,18 +149,18 @@ Feature: move (rename) file
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1295
   Scenario Outline: renaming a file to a path with extension .part should not be possible
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToRename.txt"
     When user "Alice" moves file "/fileToRename.txt" to "/welcome.part" using the WebDAV API
     Then the HTTP status code should be "400"
@@ -172,18 +172,18 @@ Feature: move (rename) file
     But user "Alice" should not see the following elements
       | /fileToRename.part |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @sqliteDB
   Scenario Outline: renaming to a file with special characters
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 2" to "textfile2.txt"
@@ -200,102 +200,102 @@ Feature: move (rename) file
     And the content of file "file[2]" for user "Alice" should be "ownCloud test text file 2"
     And the content of file "file [ 3 ]" for user "Alice" should be "ownCloud test text file 3"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1259
   #after fixing the issues merge this Scenario into the one above
   Scenario Outline: renaming to a file with question mark in its name
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/#oc ab?cd=ef#" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/#oc ab?cd=ef#" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: renaming file with dots in the path
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content for file name ending with a dot" to "<folder_name>/<file_name>"
     When user "Alice" moves file "<folder_name>/<file_name>" to "<folder_name>/abc.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "<folder_name>/abc.txt" should exist
     Examples:
-      | dav_version | folder_name   | file_name   |
-      | old         | /upload.      | abc.        |
-      | old         | /upload.      | abc .       |
-      | old         | /upload.1     | abc         |
-      | old         | /upload...1.. | abc...txt.. |
-      | old         | /...          | abcd.txt    |
-      | old         | /..upload     | ..abc       |
-      | new         | /upload.      | abc.        |
-      | new         | /upload.      | abc .       |
-      | new         | /upload.1     | ..abc.txt   |
-      | new         | /upload...1.. | abc...txt.. |
-      | new         | /...          | ...         |
-      | new         | /..upload     | ..abc       |
+      | dav-path-version | folder_name   | file_name   |
+      | old              | /upload.      | abc.        |
+      | old              | /upload.      | abc .       |
+      | old              | /upload.1     | abc         |
+      | old              | /upload...1.. | abc...txt.. |
+      | old              | /...          | abcd.txt    |
+      | old              | /..upload     | ..abc       |
+      | new              | /upload.      | abc.        |
+      | new              | /upload.      | abc .       |
+      | new              | /upload.1     | ..abc.txt   |
+      | new              | /upload...1.. | abc...txt.. |
+      | new              | /...          | ...         |
+      | new              | /..upload     | ..abc       |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name   | file_name   |
-      | spaces      | /upload.      | abc.        |
-      | spaces      | /upload.      | abc .       |
-      | spaces      | /upload.1     | abc         |
-      | spaces      | /upload...1.. | abc...txt.. |
-      | spaces      | /...          | abcd.txt    |
-      | spaces      | /...          | ...         |
+      | dav-path-version | folder_name   | file_name   |
+      | spaces           | /upload.      | abc.        |
+      | spaces           | /upload.      | abc .       |
+      | spaces           | /upload.1     | abc         |
+      | spaces           | /upload...1.. | abc...txt.. |
+      | spaces           | /...          | abcd.txt    |
+      | spaces           | /...          | ...         |
 
   @smokeTest
   Scenario Outline: user tries to move a file that doesnt exist into a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     When user "Alice" moves file "/doesNotExist.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     And as "Alice" file "/FOLDER/textfile0.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: user tries to rename a file that doesn't exist
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" moves file "/doesNotExist.txt" to "/exist.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     And as "Alice" file "/exist.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: moving a hidden file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded the following files with content "hidden file"
       | path                    |
@@ -315,18 +315,18 @@ Feature: move (rename) file
       | .hidden_file102         |
       | /FOLDER/.hidden_file101 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: renaming to/from a hidden file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded the following files with content "hidden file"
       | path               |
       | .hidden_file101    |
@@ -345,18 +345,18 @@ Feature: move (rename) file
       | .hidden_file102    |
       | hidden_file102.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: moving a file (deep moves with various folder and file names)
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<source_folder>"
     And user "Alice" has created folder "<target_folder>"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/<source_folder>/<source_file>"
@@ -366,39 +366,39 @@ Feature: move (rename) file
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And the content of file "/<target_folder>/<target_file>" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version | source_folder | source_file | target_folder | target_file |
-      | old         | text          | file.txt    | 0             | file.txt    |
-      | old         | text          | file.txt    | 1             | file.txt    |
-      | old         | 0             | file.txt    | text          | file.txt    |
-      | old         | 1             | file.txt    | text          | file.txt    |
-      | old         | texta         | 0           | textb         | file.txt    |
-      | old         | texta         | 1           | textb         | file.txt    |
-      | old         | texta         | file.txt    | textb         | 0           |
-      | old         | texta         | file.txt    | textb         | 1           |
-      | new         | text          | file.txt    | 0             | file.txt    |
-      | new         | text          | file.txt    | 1             | file.txt    |
-      | new         | 0             | file.txt    | text          | file.txt    |
-      | new         | 1             | file.txt    | text          | file.txt    |
-      | new         | texta         | 0           | textb         | file.txt    |
-      | new         | texta         | 1           | textb         | file.txt    |
-      | new         | texta         | file.txt    | textb         | 0           |
-      | new         | texta         | file.txt    | textb         | 1           |
+      | dav-path-version | source_folder | source_file | target_folder | target_file |
+      | old              | text          | file.txt    | 0             | file.txt    |
+      | old              | text          | file.txt    | 1             | file.txt    |
+      | old              | 0             | file.txt    | text          | file.txt    |
+      | old              | 1             | file.txt    | text          | file.txt    |
+      | old              | texta         | 0           | textb         | file.txt    |
+      | old              | texta         | 1           | textb         | file.txt    |
+      | old              | texta         | file.txt    | textb         | 0           |
+      | old              | texta         | file.txt    | textb         | 1           |
+      | new              | text          | file.txt    | 0             | file.txt    |
+      | new              | text          | file.txt    | 1             | file.txt    |
+      | new              | 0             | file.txt    | text          | file.txt    |
+      | new              | 1             | file.txt    | text          | file.txt    |
+      | new              | texta         | 0           | textb         | file.txt    |
+      | new              | texta         | 1           | textb         | file.txt    |
+      | new              | texta         | file.txt    | textb         | 0           |
+      | new              | texta         | file.txt    | textb         | 1           |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | source_folder | source_file | target_folder | target_file |
-      | spaces      | text          | file.txt    | 0             | file.txt    |
-      | spaces      | text          | file.txt    | 1             | file.txt    |
-      | spaces      | 0             | file.txt    | text          | file.txt    |
-      | spaces      | 1             | file.txt    | text          | file.txt    |
-      | spaces      | texta         | 0           | textb         | file.txt    |
-      | spaces      | texta         | 1           | textb         | file.txt    |
-      | spaces      | texta         | file.txt    | textb         | 0           |
-      | spaces      | texta         | file.txt    | textb         | 1           |
+      | dav-path-version | source_folder | source_file | target_folder | target_file |
+      | spaces           | text          | file.txt    | 0             | file.txt    |
+      | spaces           | text          | file.txt    | 1             | file.txt    |
+      | spaces           | 0             | file.txt    | text          | file.txt    |
+      | spaces           | 1             | file.txt    | text          | file.txt    |
+      | spaces           | texta         | 0           | textb         | file.txt    |
+      | spaces           | texta         | 1           | textb         | file.txt    |
+      | spaces           | texta         | file.txt    | textb         | 0           |
+      | spaces           | texta         | file.txt    | textb         | 1           |
 
 
   Scenario Outline: moving a file from a folder to the root
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<source_folder>"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/<source_folder>/<source_file>"
     When user "Alice" moves file "/<source_folder>/<source_file>" to "/<target_file>" using the WebDAV API
@@ -407,33 +407,33 @@ Feature: move (rename) file
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And the content of file "/<target_file>" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version | source_folder | source_file | target_file |
-      | old         | 0             | file.txt    | file.txt    |
-      | old         | 1             | file.txt    | file.txt    |
-      | old         | texta         | 0           | file.txt    |
-      | old         | texta         | 1           | file.txt    |
-      | old         | texta         | file.txt    | 0           |
-      | old         | texta         | file.txt    | 1           |
-      | new         | 0             | file.txt    | file.txt    |
-      | new         | 1             | file.txt    | file.txt    |
-      | new         | texta         | 0           | file.txt    |
-      | new         | texta         | 1           | file.txt    |
-      | new         | texta         | file.txt    | 0           |
-      | new         | texta         | file.txt    | 1           |
+      | dav-path-version | source_folder | source_file | target_file |
+      | old              | 0             | file.txt    | file.txt    |
+      | old              | 1             | file.txt    | file.txt    |
+      | old              | texta         | 0           | file.txt    |
+      | old              | texta         | 1           | file.txt    |
+      | old              | texta         | file.txt    | 0           |
+      | old              | texta         | file.txt    | 1           |
+      | new              | 0             | file.txt    | file.txt    |
+      | new              | 1             | file.txt    | file.txt    |
+      | new              | texta         | 0           | file.txt    |
+      | new              | texta         | 1           | file.txt    |
+      | new              | texta         | file.txt    | 0           |
+      | new              | texta         | file.txt    | 1           |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | source_folder | source_file | target_file |
-      | spaces      | 0             | file.txt    | file.txt    |
-      | spaces      | 1             | file.txt    | file.txt    |
-      | spaces      | texta         | 0           | file.txt    |
-      | spaces      | texta         | 1           | file.txt    |
-      | spaces      | texta         | file.txt    | 0           |
-      | spaces      | texta         | file.txt    | 1           |
+      | dav-path-version | source_folder | source_file | target_file |
+      | spaces           | 0             | file.txt    | file.txt    |
+      | spaces           | 1             | file.txt    | file.txt    |
+      | spaces           | texta         | 0           | file.txt    |
+      | spaces           | texta         | 1           | file.txt    |
+      | spaces           | texta         | file.txt    | 0           |
+      | spaces           | texta         | file.txt    | 1           |
 
 
   Scenario Outline: move a file of size zero byte
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/zerobyte.txt" to "/zerobyte.txt"
     And user "Alice" has created folder "/testZeroByte"
     When user "Alice" moves file "/zerobyte.txt" to "/testZeroByte/zerobyte.txt" using the WebDAV API
@@ -441,29 +441,29 @@ Feature: move (rename) file
     And as "Alice" file "/testZeroByte/zerobyte.txt" should exist
     And as "Alice" file "/zerobyte.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: rename a file of size zero byte
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/zerobyte.txt" to "/zerobyte.txt"
     When user "Alice" moves file "/zerobyte.txt" to "/rename_zerobyte.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/rename_zerobyte.txt" should exist
     And as "Alice" file "/zerobyte.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature
@@ -11,15 +11,15 @@ Feature: users cannot move (rename) a file to a blacklisted name
 
   @issue-1295
   Scenario Outline: rename a file to a filename that is banned by default
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" moves file "/textfile0.txt" to "/.htaccess" using the WebDAV API
     Then the HTTP status code should be "403"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
@@ -10,7 +10,7 @@ Feature: move (rename) file
 
 
   Scenario Outline: moving a file into a shared folder as the sharee and as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
@@ -26,15 +26,15 @@ Feature: move (rename) file
     And the content of file "/testshare/testfile.txt" for user "Brian" should be "test data"
     And as "<mover>" file "/testfile.txt" should not exist
     Examples:
-      | dav_version | mover | destination_folder |
-      | old         | Alice | /Shares/testshare  |
-      | old         | Brian | /testshare         |
-      | new         | Alice | /Shares/testshare  |
-      | new         | Brian | /testshare         |
+      | dav-path-version | mover | destination_folder |
+      | old              | Alice | /Shares/testshare  |
+      | old              | Brian | /testshare         |
+      | new              | Alice | /Shares/testshare  |
+      | new              | Brian | /testshare         |
 
 
   Scenario Outline: moving a file out of a shared folder as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
@@ -50,13 +50,13 @@ Feature: move (rename) file
     And as "Alice" file "/Shares/testshare/testfile.txt" should not exist
     And as "Brian" file "/testshare/testfile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: moving a file out of a shared folder as the sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
@@ -71,13 +71,13 @@ Feature: move (rename) file
     And as "Alice" file "/Shares/testshare/testfile.txt" should exist
     And as "Brian" file "/testshare/testfile.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: moving a folder into a shared folder as the sharee and as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
@@ -94,15 +94,15 @@ Feature: move (rename) file
     And the content of file "/testshare/testsubfolder/testfile.txt" for user "Brian" should be "test data"
     And as "<mover>" file "/testsubfolder" should not exist
     Examples:
-      | dav_version | mover | destination_folder |
-      | old         | Alice | /Shares/testshare  |
-      | old         | Brian | /testshare         |
-      | new         | Alice | /Shares/testshare  |
-      | new         | Brian | /testshare         |
+      | dav-path-version | mover | destination_folder |
+      | old              | Alice | /Shares/testshare  |
+      | old              | Brian | /testshare         |
+      | new              | Alice | /Shares/testshare  |
+      | new              | Brian | /testshare         |
 
 
   Scenario Outline: moving a folder out of a shared folder as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created the following folders
       | path                     |
@@ -121,13 +121,13 @@ Feature: move (rename) file
     And as "Alice" folder "/testshare/testsubfolder" should not exist
     And as "Brian" folder "/testshare/testsubfolder" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: moving a folder out of a shared folder as the sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created the following folders
       | path                     |
@@ -145,13 +145,13 @@ Feature: move (rename) file
     And as "Alice" folder "/Shares/testshare/testsubfolder" should exist
     And as "Brian" folder "/testshare/testsubfolder" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: moving a file to a shared folder with no permissions
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
@@ -165,13 +165,13 @@ Feature: move (rename) file
     Then the HTTP status code should be "403"
     And user "Alice" should not be able to download file "/Shares/testshare/textfile0.txt"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: moving a file to overwrite a file in a shared folder with no permissions
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
@@ -187,13 +187,13 @@ Feature: move (rename) file
     Then the HTTP status code should be "403"
     And the content of file "/Shares/testshare/overwritethis.txt" for user "Alice" should be "Welcome to ownCloud"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: checking file id after a move between received shares
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created the following folders
       | path     |
@@ -217,6 +217,6 @@ Feature: move (rename) file
     And as "Brian" folder "/Shares/folderB/ONE/TWO" should exist
     And user "Brian" folder "/Shares/folderB/ONE" should have the previously stored id
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature
@@ -11,75 +11,75 @@ Feature: download file
 
   @smokeTest
   Scenario Outline: download a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1346
   Scenario Outline: download a file with range
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/welcome.txt" with range "bytes=24-50" using the WebDAV API
     Then the HTTP status code should be "206"
     And the downloaded content should be "example file for developers"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: download a file larger than 4MB (ref: https://github.com/sabre-io/http/pull/119 )
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "/file9000000.txt" ending with "text at end of file" of size 9000000 bytes
     When user "Alice" downloads file "/file9000000.txt" using the WebDAV API
     Then the HTTP status code should be "200"
     And the size of the downloaded file should be 9000000 bytes
     And the downloaded content should end with "text at end of file"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get the size of a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     When user "Alice" gets the size of file "test-file.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the size of the file should be "19"
 
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1316
   Scenario Outline: get the content-length response header of a pdf file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/simple.pdf" to "/simple.pdf"
     When user "Alice" downloads file "/simple.pdf" using the WebDAV API
     Then the HTTP status code should be "200"
@@ -87,18 +87,18 @@ Feature: download file
       | header         | value |
       | Content-Length | 9622  |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1316
   Scenario Outline: get the content-length response header of an image file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/testavatar.png" to "/testavatar.png"
     When user "Alice" downloads file "/testavatar.png" using the WebDAV API
     Then the HTTP status code should be "200"
@@ -106,41 +106,41 @@ Feature: download file
       | header         | value |
       | Content-Length | 35323 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: download a file with comma in the filename
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "file with comma in filename" to <filename>
     When user "Alice" downloads file <filename> using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "file with comma in filename"
     Examples:
-      | dav_version | filename       |
-      | old         | "sample,1.txt" |
-      | old         | ",,,.txt"      |
-      | old         | ",,,.,"        |
-      | new         | "sample,1.txt" |
-      | new         | ",,,.txt"      |
-      | new         | ",,,.,"        |
+      | dav-path-version | filename       |
+      | old              | "sample,1.txt" |
+      | old              | ",,,.txt"      |
+      | old              | ",,,.,"        |
+      | new              | "sample,1.txt" |
+      | new              | ",,,.txt"      |
+      | new              | ",,,.,"        |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | filename          |
-      | spaces         | "sample,1.txt" |
-      | spaces         | ",,,.txt"      |
-      | spaces         | ",,,.,"        |
+      | dav-path-version | filename       |
+      | spaces           | "sample,1.txt" |
+      | spaces           | ",,,.txt"      |
+      | spaces           | ",,,.,"        |
 
 
   Scenario Outline: download a file with single part ranges
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/welcome.txt" with range "bytes=0-51" using the WebDAV API
     Then the HTTP status code should be "206"
     And the following headers should be set
@@ -149,18 +149,18 @@ Feature: download file
       | Content-Range  | bytes 0-51/52 |
     And the downloaded content should be "Welcome this is just an example file for developers."
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: download a file with multipart ranges
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/welcome.txt" with range "bytes=0-6, 40-51" using the WebDAV API
     Then the HTTP status code should be "206" or "200"
     And if the HTTP status code was "206" then the following headers should match these regular expressions
@@ -180,65 +180,65 @@ Feature: download file
       """
     But if the HTTP status code was "200" then the downloaded content should be "Welcome this is just an example file for developers."
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: download a file with last byte range out of bounds
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/welcome.txt" with range "bytes=0-55" using the WebDAV API
     Then the HTTP status code should be "206"
     And the downloaded content should be "Welcome this is just an example file for developers."
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: download a range at the end of a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/welcome.txt" with range "bytes=-11" using the WebDAV API
     Then the HTTP status code should be "206"
     And the downloaded content should be "developers."
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: download a file with range out of bounds
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/welcome.txt" with range "bytes=55-60" using the WebDAV API
     Then the HTTP status code should be "416"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: download hidden files
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded the following files with content "hidden file"
       | path                 |
@@ -254,18 +254,18 @@ Feature: download file
       | .hidden_file         |
       | /FOLDER/.hidden_file |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: downloading a file should serve security headers
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" downloads file "/welcome.txt" using the WebDAV API
     Then the HTTP status code should be "200"
     And the following headers should be set
@@ -280,14 +280,14 @@ Feature: download file
       | X-XSS-Protection                  | 1; mode=block                                                    |
     And the downloaded content should start with "Welcome"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario: download a zero byte size file

--- a/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
@@ -25,7 +25,7 @@ Feature: list files
 
 
   Scenario Outline: get the list of resources in the root folder with depth 0
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" lists the resources in "/" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should not contain these nodes
@@ -38,18 +38,18 @@ Feature: list files
       | simple-folder/simple-empty-folder |
       | simple-folder/simple-folder1      |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get the list of resources in the root folder with depth 1
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" lists the resources in "/" with depth "1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -64,18 +64,18 @@ Feature: list files
       | simple-folder/simple-empty-folder |
       | simple-folder/simple-folder1      |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @depthInfinityPropfindEnabled
   Scenario Outline: get the list of resources in the root folder with depth infinity
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -93,18 +93,18 @@ Feature: list files
       | simple-folder/simple-folder1/simple-folder2/textfile0.txt |
       | simple-folder/simple-folder1/simple-folder2/welcome.txt   |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get the list of resources in a folder with depth 0
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" lists the resources in "/simple-folder" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -117,18 +117,18 @@ Feature: list files
       | simple-folder/simple-empty-folder |
       | simple-folder/simple-folder1      |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get the list of resources in a folder with depth 1
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" lists the resources in "/simple-folder" with depth "1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -145,18 +145,18 @@ Feature: list files
       | simple-folder/simple-folder1/simple-folder2/textfile0.txt |
       | simple-folder/simple-folder1/simple-folder2/welcome.txt   |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @depthInfinityPropfindEnabled
   Scenario Outline: get the list of resources in a folder with depth infinity
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" lists the resources in "/simple-folder" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -170,14 +170,14 @@ Feature: list files
       | simple-folder/simple-folder1/simple-folder2/textfile0.txt |
       | simple-folder/simple-folder1/simple-folder2/welcome.txt   |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario: get the list of resources in a folder shared through public link with depth 0
@@ -252,7 +252,7 @@ Feature: list files
 
 
   Scenario Outline: get the list of files in the trashbin with depth 0
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |
@@ -272,18 +272,18 @@ Feature: list files
       | simple-folder/simple-folder1/simple-folder2/textfile0.txt |
       | simple-folder/simple-folder1/simple-folder2/welcome.txt   |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get the list of files in the trashbin with depth 1
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |
@@ -305,18 +305,18 @@ Feature: list files
       | simple-folder/simple-folder1/simple-folder2/textfile0.txt |
       | simple-folder/simple-folder1/simple-folder2/welcome.txt   |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @depthInfinityPropfindEnabled
   Scenario Outline: get the list of files in the trashbin with depth infinity
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |
@@ -336,33 +336,33 @@ Feature: list files
       | simple-folder/simple-folder1/simple-folder2/textfile0.txt |
       | simple-folder/simple-folder1/simple-folder2/welcome.txt   |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @depthInfinityPropfindDisabled
   Scenario Outline: get the list of resources in the root folder with depth infinity when depth infinity is not allowed
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "412"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @depthInfinityPropfindDisabled
   Scenario Outline: get the list of resources in a folder shared through public link with depth infinity when depth infinity is not allowed
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created the following folders
       | path                                                                       |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |
@@ -371,17 +371,17 @@ Feature: list files
     When the public lists the resources in the last created public link with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "412"
     Examples:
-      | dav_version |
-      | new         |
+      | dav-path-version |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @depthInfinityPropfindDisabled
   Scenario Outline: get the list of files in the trashbin with depth infinity when depth infinity is not allowed
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |
@@ -390,11 +390,11 @@ Feature: list files
     When user "Alice" lists the resources in the trashbin with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "412"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
@@ -10,13 +10,13 @@ Feature: PROPFIND
     When user "Alice" requests "<dav_path>" with "PROPFIND" using basic auth
     Then the HTTP status code should be "405"
     Examples:
-      | dav_path                      |
-      | /remote.php/dav/files         |
+      | dav_path              |
+      | /remote.php/dav/files |
 
     @skipOnRevaMaster
     Examples:
-      | dav_path                      |
-      | /remote.php/dav/spaces        |
+      | dav_path               |
+      | /remote.php/dav/spaces |
 
 
   Scenario Outline: send PROPFIND request to "/remote.php/dav/(files|spaces)" with depth header
@@ -29,6 +29,7 @@ Feature: PROPFIND
       | dav_path                    | depth    |
       | /remote.php/dav/files/alice | 0        |
       | /remote.php/dav/files/alice | infinity |
+
     @skipOnRevaMaster
     Examples:
       | dav_path                         | depth    |

--- a/tests/acceptance/features/coreApiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/refuseAccess.feature
@@ -10,7 +10,7 @@ Feature: refuse access
   @smokeTest
   Scenario Outline: unauthenticated call
     # cannot perform with spaces WebDAV due to the absence of user
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When an unauthenticated client connects to the DAV endpoint using the WebDAV API
     Then the HTTP status code should be "401"
     And there should be no duplicate headers
@@ -18,24 +18,24 @@ Feature: refuse access
       | header           | value                                        |
       | WWW-Authenticate | Basic realm="%productname%", charset="UTF-8" |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: disabled user cannot use webdav
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has been disabled
     When user "Alice" downloads file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version    |
-      | spaces         |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavOperations/search.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/search.feature
@@ -23,7 +23,7 @@ Feature: Search
 
   @smokeTest
   Scenario Outline: search for entry by pattern
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "upload" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these entries:
@@ -38,18 +38,18 @@ Feature: Search
     But the search result of user "Alice" should not contain these entries:
       | /a-image.png |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: search for entries by only some letters from the middle of the entry name
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     When user "Alice" searches for "ol" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -60,18 +60,18 @@ Feature: Search
       | /FOLDER                  |
       | /just-a-folder/lolol.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: search for files by extension
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "png" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these entries:
@@ -83,33 +83,33 @@ Feature: Search
       | /just-a-folder/upload.txt     |
       | /just-a-folder/uploadÜठिF.txt |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: search with empty field
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "" using the WebDAV API
     Then the HTTP status code should be "400"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: limit returned search entries
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "upload" and limits the results to "3" items using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain any "3" of these entries:
@@ -122,18 +122,18 @@ Feature: Search
       | /upload😀 😁/upload😀 😁.txt  |
       | /upload😀 😁/upload,1.txt     |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: limit returned search entries to only 1 entry
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "upload" and limits the results to "1" items using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain any "1" of these entries:
@@ -146,18 +146,18 @@ Feature: Search
       | /upload😀 😁/upload😀 😁.txt  |
       | /upload😀 😁/upload,1.txt     |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: limit returned search entries to more entries than there are
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "upload" and limits the results to "100" items using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "8" entries
@@ -171,18 +171,18 @@ Feature: Search
       | /upload😀 😁/upload😀 😁.txt  |
       | /upload😀 😁/upload,1.txt     |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4712
   Scenario Outline: report extra properties in search entries for a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "upload" using the WebDAV API requesting these properties:
       | oc:fileid             |
       | oc:permissions        |
@@ -204,18 +204,18 @@ Feature: Search
       | {http://owncloud.org/ns}owner-id           | %username%                                                                                        |
       | {http://owncloud.org/ns}owner-display-name | %displayname%                                                                                     |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-4712
   Scenario Outline: report extra properties in search entries for a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "upload" using the WebDAV API requesting these properties:
       | oc:fileid             |
       | oc:permissions        |
@@ -236,18 +236,18 @@ Feature: Search
       | {http://owncloud.org/ns}owner-id           | %username%                                                                                        |
       | {http://owncloud.org/ns}owner-display-name | %displayname%                                                                                     |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: search for entry with emoji by pattern
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "😀 😁" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these entries:
@@ -261,11 +261,11 @@ Feature: Search
       | /just-a-folder/uploadÜठिF.txt |
       | /फनी näme/upload.txt          |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
@@ -13,57 +13,57 @@ Feature: copy file
 
   @smokeTest
   Scenario Outline: copying a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" copies file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: copying and overwriting a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" copies file "/textfile0.txt" to "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: copying a file when 2 files exist with different case
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     # "/textfile1.txt" already exists in the skeleton, make another with only case differences in the file name
     When user "Alice" copies file "/textfile0.txt" to "/TextFile1.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 1"
     And the content of file "/TextFile1.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: copying a file to a folder with no permissions
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
@@ -76,13 +76,13 @@ Feature: copy file
     Then the HTTP status code should be "403"
     And user "Alice" should not be able to download file "/Shares/testshare/textfile0.txt"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copying a file to overwrite a file into a folder with no permissions
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
@@ -97,13 +97,13 @@ Feature: copy file
     Then the HTTP status code should be "403"
     And the content of file "/Shares/testshare/overwritethis.txt" for user "Alice" should be "ownCloud test text file 1"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1345
   Scenario Outline: copying file to a path with extension .part should not be possible
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" copies file "/textfile1.txt" to "/textfile1.part" using the WebDAV API
     Then the HTTP status code should be "400"
     And the DAV exception should be "OCA\DAV\Connector\Sabre\Exception\InvalidPath"
@@ -114,18 +114,18 @@ Feature: copy file
     But user "Alice" should not see the following elements
       | /textfile1.part |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a file over the top of an existing folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER/sample-folder"
     When user "Alice" copies file "/textfile1.txt" to "/FOLDER" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -133,36 +133,36 @@ Feature: copy file
     And as "Alice" folder "/FOLDER/sample-folder" should not exist
     And as "Alice" file "/textfile1.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a folder over the top of an existing file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER/sample-folder"
     When user "Alice" copies folder "/FOLDER" to "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/FOLDER/sample-folder" should exist
     And as "Alice" folder "/textfile1.txt/sample-folder" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a folder into another folder at different level
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER/second-level-folder"
     And user "Alice" has created folder "FOLDER/second-level-folder/third-level-folder"
     And user "Alice" has created folder "Sample-Folder-A"
@@ -173,18 +173,18 @@ Feature: copy file
     And as "Alice" folder "/Sample-Folder-A/sample-folder-b/sample-folder-c" should exist
     And as "Alice" folder "/FOLDER/second-level-folder/third-level-folder/sample-folder-c" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a file into a folder at different level
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER/second-level-folder"
     And user "Alice" has created folder "FOLDER/second-level-folder/third-level-folder"
     And user "Alice" has created folder "Sample-Folder-A"
@@ -197,18 +197,18 @@ Feature: copy file
     And as "Alice" file "FOLDER/second-level-folder" should exist
     And the content of file "FOLDER/second-level-folder" for user "Alice" should be "sample file-c"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a file into a file at different level
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "file at second level" to "FOLDER/second-level-file.txt"
     And user "Alice" has created folder "Sample-Folder-A"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
@@ -220,18 +220,18 @@ Feature: copy file
     And as "Alice" file "FOLDER/textfile-c.txt" should not exist
     And the content of file "FOLDER/second-level-file.txt" for user "Alice" should be "sample file-c"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a folder into a file at different level
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER/second-level-folder"
     And user "Alice" has created folder "FOLDER/second-level-folder/third-level-folder"
     And user "Alice" has created folder "Sample-Folder-A"
@@ -244,18 +244,18 @@ Feature: copy file
     And as "Alice" folder "Sample-Folder-A/sample-folder-b/textfile-c.txt/third-level-folder" should exist
     And as "Alice" folder "Sample-Folder-A/sample-folder-b/second-level-folder" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a file over the top of an existing folder received as a user share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/BRIAN-Folder"
     And user "Brian" has created folder "BRIAN-Folder/sample-folder"
@@ -268,13 +268,13 @@ Feature: copy file
     And as "Alice" file "/textfile1.txt" should exist
     And user "Alice" should not have any received shares
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a folder over the top of an existing file received as a user share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has uploaded file with content "file to share" to "/sharedfile1.txt"
     And user "Brian" has shared file "/sharedfile1.txt" with user "Alice"
@@ -286,13 +286,13 @@ Feature: copy file
     And as "Alice" folder "/Shares/sharedfile1.txt/sample-folder" should exist
     And user "Alice" should not have any received shares
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "BRIAN-FOLDER"
     And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
@@ -309,13 +309,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a file into a folder at different level received as a user share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "BRIAN-FOLDER"
     And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
@@ -334,13 +334,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a file into a file at different level received as a user share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "BRIAN-FOLDER"
     And user "Brian" has uploaded file with content "file at second level" to "BRIAN-FOLDER/second-level-file.txt"
@@ -358,13 +358,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a folder into a file at different level received as a user share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "BRIAN-FOLDER"
     And user "Brian" has created folder "BRIAN-FOLDER/second-level-folder"
@@ -382,13 +382,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a file over the top of an existing folder received as a group share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -404,18 +404,18 @@ Feature: copy file
     And as "Alice" file "/textfile1.txt" should exist
     And user "Alice" should not have any received shares
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a folder over the top of an existing file received as a group share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -430,18 +430,18 @@ Feature: copy file
     And as "Alice" folder "/Shares/sharedfile1.txt/sample-folder" should exist
     And user "Alice" should not have any received shares
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1239
   Scenario Outline: copy a folder into another folder at different level which is received as a group share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -461,13 +461,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a file into a folder at different level received as a group share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -489,13 +489,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a file into a file at different level received as a group share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -516,13 +516,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
   @issue-1239
   Scenario Outline: copy a folder into a file at different level received as a group share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -543,13 +543,13 @@ Feature: copy file
     And the response when user "Alice" gets the info of the last share should include
       | file_target | /Shares/BRIAN-FOLDER |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copy a file of size zero byte
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/zerobyte.txt" to "/zerobyte.txt"
     And user "Alice" has created folder "/testZeroByte"
     When user "Alice" copies file "/zerobyte.txt" to "/testZeroByte/zerobyte.txt" using the WebDAV API
@@ -557,69 +557,69 @@ Feature: copy file
     And as "Alice" file "/testZeroByte/zerobyte.txt" should exist
     And as "Alice" file "/zerobyte.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
-  @skipOnRevaMaster
+    @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: copy file into a nonexistent folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToCopy.txt"
     When user "Alice" copies file "/fileToCopy.txt" to "/not-existing-folder/fileToCopy.txt" using the WebDAV API
     Then the HTTP status code should be "409"
     And as "Alice" file "/fileToCopy.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: copy a nonexistent file into a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" copies file "/doesNotExist.txt" to "/FOLDER/doesNotExist.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     And as "Alice" file "/FOLDER/doesNotExist.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: copy a folder into a nonexistent one
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     When user "Alice" copies folder "/testshare" to "/not-existing/testshare" using the WebDAV API
     Then the HTTP status code should be "409"
     And user "Alice" should see the following elements
       | /testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: copying a file into a shared folder as the sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
@@ -633,13 +633,13 @@ Feature: copy file
     And the content of file "/Shares/testshare/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     And the content of file "/testshare/textfile0.txt" for user "Brian" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copying a file into a shared folder as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
@@ -654,13 +654,13 @@ Feature: copy file
     And the content of file "/Shares/testshare/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     And the content of file "/testshare/textfile0.txt" for user "Brian" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copying a file out of a shared folder as the sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
@@ -676,13 +676,13 @@ Feature: copy file
     And the content of file "/fileInsideShare.txt" for user "Alice" should be "ownCloud test text file inside share"
     And the content of file "/testshare/fileInsideShare.txt" for user "Brian" should be "ownCloud test text file inside share"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copying a file out of a shared folder as the sharer
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "ownCloud test text file inside share" to "/testshare/fileInsideShare.txt"
@@ -698,13 +698,13 @@ Feature: copy file
     And the content of file "/Shares/testshare/fileInsideShare.txt" for user "Alice" should be "ownCloud test text file inside share"
     And the content of file "/fileInsideShare.txt" for user "Brian" should be "ownCloud test text file inside share"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copying a hidden file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded the following files with content "hidden file"
       | path                    |
       | .hidden_file101         |
@@ -720,18 +720,18 @@ Feature: copy file
       | .hidden_file102         |
       | /FOLDER/.hidden_file101 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: copying a file between shares received from different users
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare0"
@@ -756,13 +756,13 @@ Feature: copy file
     And the content of file "/testshare1/testshare0.txt" for user "Carol" should be "content inside testshare0"
     And the content of file "/Shares/testshare1/testshare0.txt" for user "Alice" should be "content inside testshare0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copying a folder between shares received from different users
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare0"
@@ -788,13 +788,13 @@ Feature: copy file
     And the content of file "testshare1/folder_to_copy/testshare0.txt" for user "Carol" should be "content inside testshare0"
     And the content of file "/Shares/testshare1/folder_to_copy/testshare0.txt" for user "Alice" should be "content inside testshare0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copying a file to a folder that is shared with multiple users
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testshare"
@@ -817,13 +817,13 @@ Feature: copy file
     And the content of file "/Shares/testshare/textfile0.txt" for user "Brian" should be "ownCloud test text file 0"
     And the content of file "/Shares/testshare/textfile0.txt" for user "Carol" should be "ownCloud test text file 0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: copy a folder into another one
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/testshare"
     And user "Alice" has created folder "/an-other-folder"
     When user "Alice" copies folder "/testshare" to "/an-other-folder/testshare" using the WebDAV API
@@ -833,18 +833,18 @@ Feature: copy file
     And user "Alice" should see the following elements
       | /an-other-folder/testshare/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @skipOnRevaMaster @issue-3023
   Scenario Outline: copying a folder into a sub-folder of itself
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/CHILD"
     And user "Alice" has uploaded file with content "parent text" to "/PARENT/parent.txt"
@@ -854,14 +854,14 @@ Feature: copy file
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "parent text"
     And the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be "child text"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
-      | spaces      |
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
   Scenario Outline: copying a folder with a file into another folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER1"
     And user "Alice" has created folder "/FOLDER2"
     And user "Alice" has uploaded file with content "Folder 1 text" to "/FOLDER1/textfile.txt"
@@ -871,11 +871,11 @@ Feature: copy file
     And as "Alice" file "/FOLDER2/FOLDER1/textfile.txt" should exist
     And as "Alice" folder "/FOLDER1" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavProperties1/createFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/createFileFolder.feature
@@ -10,44 +10,44 @@ Feature: create files and folder
 
 
   Scenario Outline: create a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" creates folder "<folder_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" folder "<folder_name>" should exist
     Examples:
-      | dav_version | folder_name     |
-      | old         | /upload         |
-      | old         | /strängé folder |
-      | old         | /C++ folder.cpp |
-      | old         | /नेपाली           |
-      | old         | /folder #2      |
-      | old         | /folder ?2      |
-      | old         | /😀 🤖          |
-      | old         | /new&folder     |
-      | new         | /upload         |
-      | new         | /strängé folder |
-      | new         | /C++ folder.cpp |
-      | new         | /नेपाली           |
-      | new         | /folder #2      |
-      | new         | /folder ?2      |
-      | new         | /😀 🤖          |
-      | new         | /new&folder     |
+      | dav-path-version | folder_name     |
+      | old              | /upload         |
+      | old              | /strängé folder |
+      | old              | /C++ folder.cpp |
+      | old              | /नेपाली         |
+      | old              | /folder #2      |
+      | old              | /folder ?2      |
+      | old              | /😀 🤖          |
+      | old              | /new&folder     |
+      | new              | /upload         |
+      | new              | /strängé folder |
+      | new              | /C++ folder.cpp |
+      | new              | /नेपाली         |
+      | new              | /folder #2      |
+      | new              | /folder ?2      |
+      | new              | /😀 🤖          |
+      | new              | /new&folder     |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name |
-      | spaces      | /upload         |
-      | spaces      | /strängé folder |
-      | spaces      | /C++ folder.cpp |
-      | spaces      | /नेपाली           |
-      | spaces      | /folder #2      |
-      | spaces      | /folder ?2      |
-      | spaces      | /😀 🤖          |
-      | spaces      | /new&folder     |
+      | dav-path-version | folder_name     |
+      | spaces           | /upload         |
+      | spaces           | /strängé folder |
+      | spaces           | /C++ folder.cpp |
+      | spaces           | /नेपाली         |
+      | spaces           | /folder #2      |
+      | spaces           | /folder ?2      |
+      | spaces           | /😀 🤖          |
+      | spaces           | /new&folder     |
 
   @smokeTest
   Scenario Outline: get resourcetype property of a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test_folder"
     When user "Alice" gets the following properties of folder "/test_folder" using the WebDAV API
       | propertyName   |
@@ -55,18 +55,18 @@ Feature: create files and folder
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: get resourcetype property of a folder with special chars
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test_folder:5"
     When user "Alice" gets the following properties of folder "/test_folder:5" using the WebDAV API
       | propertyName   |
@@ -74,18 +74,18 @@ Feature: create files and folder
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1345
   Scenario Outline: creating a directory which contains .part should not be possible
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" creates folder "/folder.with.ext.part" using the WebDAV API
     Then the HTTP status code should be "400"
     And the DAV exception should be "OCA\DAV\Connector\Sabre\Exception\InvalidPath"
@@ -94,18 +94,18 @@ Feature: create files and folder
     And user "Alice" should not see the following elements
       | /folder.with.ext.part |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1283
   Scenario Outline: try to create a folder that already exists
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "my-data"
     When user "Alice" creates folder "my-data" using the WebDAV API
     Then the HTTP status code should be "405"
@@ -113,18 +113,18 @@ Feature: create files and folder
     And the DAV exception should be "Sabre\DAV\Exception\MethodNotAllowed"
     And the DAV message should be "The resource you tried to create already exists"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1283
   Scenario Outline: try to create a folder with a name of an existing file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded data" to "/my-data.txt"
     When user "Alice" creates folder "my-data.txt" using the WebDAV API
     Then the HTTP status code should be "405"
@@ -132,49 +132,49 @@ Feature: create files and folder
     And the DAV message should be "The resource you tried to create already exists"
     And the content of file "/my-data.txt" for user "Alice" should be "uploaded data"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: create a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "some text" to "<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "<file_name>" should exist
     And the content of file "<file_name>" for user "Alice" should be "some text"
     Examples:
-      | dav_version | file_name        |
-      | old         | /upload.txt      |
-      | old         | /strängéfile.txt |
-      | old         | /C++ file.cpp    |
-      | old         | /नेपाली            |
-      | old         | /file #2.txt     |
-      | old         | /file ?2.pdf     |
-      | old         | /😀 🤖.txt       |
-      | old         | /new&file.txt    |
-      | new         | /upload.txt      |
-      | new         | /strängéfile.txt |
-      | new         | /C++ file.cpp    |
-      | new         | /नेपाली            |
-      | new         | /file #2.txt     |
-      | new         | /file ?2.pdf     |
-      | new         | /😀 🤖.txt       |
-      | new         | /new&file.txt    |
+      | dav-path-version | file_name        |
+      | old              | /upload.txt      |
+      | old              | /strängéfile.txt |
+      | old              | /C++ file.cpp    |
+      | old              | /नेपाली          |
+      | old              | /file #2.txt     |
+      | old              | /file ?2.pdf     |
+      | old              | /😀 🤖.txt       |
+      | old              | /new&file.txt    |
+      | new              | /upload.txt      |
+      | new              | /strängéfile.txt |
+      | new              | /C++ file.cpp    |
+      | new              | /नेपाली          |
+      | new              | /file #2.txt     |
+      | new              | /file ?2.pdf     |
+      | new              | /😀 🤖.txt       |
+      | new              | /new&file.txt    |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name        |
-      | spaces      | /upload.txt      |
-      | spaces      | /strängéfile.txt |
-      | spaces      | /C++ file.cpp    |
-      | spaces      | /नेपाली            |
-      | spaces      | /file #2.txt     |
-      | spaces      | /file ?2.pdf     |
-      | spaces      | /😀 🤖.txt       |
-      | spaces      | /new&file.txt    |
+      | dav-path-version | file_name        |
+      | spaces           | /upload.txt      |
+      | spaces           | /strängéfile.txt |
+      | spaces           | /C++ file.cpp    |
+      | spaces           | /नेपाली          |
+      | spaces           | /file #2.txt     |
+      | spaces           | /file ?2.pdf     |
+      | spaces           | /😀 🤖.txt       |
+      | spaces           | /new&file.txt    |

--- a/tests/acceptance/features/coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature
@@ -15,56 +15,56 @@ Feature: create file or folder named similar to Shares folder
 
 
   Scenario Outline: create a folder with a name similar to Shares
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Brian" creates folder "<folder_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "<folder_name>" should exist
     And as "Brian" folder "/Shares" should exist
     Examples:
-      | dav_version | folder_name |
-      | old         | /Share      |
-      | old         | /shares     |
-      | old         | /Shares1    |
-      | new         | /Share      |
-      | new         | /shares     |
-      | new         | /Shares1    |
+      | dav-path-version | folder_name |
+      | old              | /Share      |
+      | old              | /shares     |
+      | old              | /Shares1    |
+      | new              | /Share      |
+      | new              | /shares     |
+      | new              | /Shares1    |
 
 
   Scenario Outline: create a file with a name similar to Shares
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Brian" uploads file with content "some text" to "<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "<file_name>" for user "Brian" should be "some text"
     And as "Brian" folder "/Shares" should exist
     Examples:
-      | dav_version | file_name |
-      | old         | /Share    |
-      | old         | /shares   |
-      | old         | /Shares1  |
-      | new         | /Share    |
-      | new         | /shares   |
-      | new         | /Shares1  |
+      | dav-path-version | file_name |
+      | old              | /Share    |
+      | old              | /shares   |
+      | old              | /Shares1  |
+      | new              | /Share    |
+      | new              | /shares   |
+      | new              | /Shares1  |
 
 
   Scenario Outline: try to create a folder named Shares
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Brian" creates folder "/Shares" using the WebDAV API
     Then the HTTP status code should be "405"
     And as "Brian" folder "/Shares" should exist
     And as "Brian" folder "/Shares/FOLDER" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: try to create a file named Shares
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Brian" uploads file with content "some text" to "/Shares" using the WebDAV API
     Then the HTTP status code should be "409"
     And as "Brian" folder "/Shares" should exist
     And as "Brian" folder "/Shares/FOLDER" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiWebdavProperties1/getQuota.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/getQuota.feature
@@ -10,31 +10,31 @@ Feature: get quota
 
 
   Scenario Outline: retrieving folder quota when no quota is set
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When the administrator gives unlimited quota to user "Alice" using the provisioning API
     Then the HTTP status code should be "200"
     And as user "Alice" folder "/" should contain a property "d:quota-available-bytes" with value "-3"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
-      | spaces      |
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
   @smokeTest
   Scenario Outline: retrieving folder quota when quota is set
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When the administrator sets the quota of user "Alice" to "10 MB" using the provisioning API
     Then the HTTP status code should be "200"
     And as user "Alice" folder "/" should contain a property "d:quota-available-bytes" with value "10485406"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
-      | spaces      |
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
   Scenario Outline: retrieving folder quota of shared folder with quota when no quota is set for recipient
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has been given unlimited quota
     And the quota of user "Brian" has been set to "10 MB"
@@ -50,14 +50,14 @@ Feature: get quota
     Then the HTTP status code should be "200"
     And the single response should contain a property "d:quota-available-bytes" with value "10485406"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
-      | spaces      |
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
   Scenario Outline: retrieving folder quota when quota is set and a file was uploaded
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And the quota of user "Alice" has been set to "1 KB"
     And user "Alice" has uploaded file "/prueba.txt" of size 93 bytes
     When user "Alice" gets the following properties of folder "/" using the WebDAV API
@@ -66,14 +66,14 @@ Feature: get quota
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:quota-available-bytes" with value "577"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
-      | spaces      |
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
   Scenario Outline: retrieving folder quota when quota is set and a file was received
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and small skeleton files
     And the quota of user "Brian" has been set to "1 KB"
     And user "Alice" has uploaded file "/Alice.txt" of size 93 bytes
@@ -84,7 +84,7 @@ Feature: get quota
     Then the HTTP status code should be "200"
     And the single response should contain a property "d:quota-available-bytes" with value "670"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
-      | spaces      |
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/setFileProperties.feature
@@ -10,59 +10,59 @@ Feature: set file properties
 
   @smokeTest @issue-1263
   Scenario Outline: setting custom DAV property and reading it
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"
     And user "Alice" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustomprop.txt" to "veryCustomPropValue"
     When user "Alice" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustomprop.txt"
     Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and value "veryCustomPropValue"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1297
   Scenario Outline: setting custom complex DAV property and reading it
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"
     And user "Alice" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustomprop.txt" to "<foo xmlns='http://bar'/>"
     When user "Alice" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustomprop.txt"
     Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and complex value "<x2:foo xmlns:x2=\"http://bar\"/>"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1263
   Scenario Outline: setting custom DAV property and reading it after the file is renamed
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustompropwithmove.txt"
     And user "Alice" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustompropwithmove.txt" to "valueForMovetest"
     And user "Alice" has moved file "/testcustompropwithmove.txt" to "/catchmeifyoucan.txt"
     When user "Alice" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/catchmeifyoucan.txt"
     Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and value "valueForMovetest"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1297
   Scenario Outline: setting custom DAV property on a shared file as an owner and reading as a recipient
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustompropshared.txt"
     And user "Alice" has created a share with settings
@@ -74,32 +74,32 @@ Feature: set file properties
     When user "Brian" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustompropshared.txt"
     Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and value "valueForSharetest"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1263
   Scenario Outline: setting custom DAV property using one endpoint and reading it with other endpoint
-    Given using <action_dav_version> DAV path
+    Given using <action-dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testnewold.txt"
     And user "Alice" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testnewold.txt" to "lucky"
-    And using <other_dav_version> DAV path
+    And using <other-dav-path-version> DAV path
     When user "Alice" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testnewold.txt"
     Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and value "lucky"
     Examples:
-      | action_dav_version | other_dav_version |
-      | old                | new               |
-      | new                | old               |
+      | action-dav-path-version | other-dav-path-version |
+      | old                     | new                    |
+      | new                     | old                    |
 
     @skipOnRevaMaster
     Examples:
-      | action_dav_version | other_dav_version |
-      | spaces             | new               |
-      | spaces             | old               |
-      | new                | spaces            |
-      | old                | spaces            |
+      | action-dav-path-version | other-dav-path-version |
+      | spaces                  | new                    |
+      | spaces                  | old                    |
+      | new                     | spaces                 |
+      | old                     | spaces                 |

--- a/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
@@ -10,60 +10,60 @@ Feature: get file properties
 
   @smokeTest
   Scenario Outline: user sends a PROPFIND request on various file names
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "<file_name>"
     When user "Alice" gets the properties of file "<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the properties response should contain an etag
     Examples:
-      | dav_version | file_name         |
-      | old         | /upload.txt       |
-      | old         | /strängé file.txt |
-      | old         | /नेपाली.txt         |
-      | old         | s,a,m,p,l,e.txt   |
-      | new         | /upload.txt       |
-      | new         | /strängé file.txt |
-      | new         | /नेपाली.txt         |
-      | new         | s,a,m,p,l,e.txt   |
+      | dav-path-version | file_name         |
+      | old              | /upload.txt       |
+      | old              | /strängé file.txt |
+      | old              | /नेपाली.txt       |
+      | old              | s,a,m,p,l,e.txt   |
+      | new              | /upload.txt       |
+      | new              | /strängé file.txt |
+      | new              | /नेपाली.txt       |
+      | new              | s,a,m,p,l,e.txt   |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name         |
-      | spaces      | /upload.txt       |
-      | spaces      | /strängé file.txt |
-      | spaces      | /नेपाली.txt         |
-      | spaces      | s,a,m,p,l,e.txt   |
+      | dav-path-version | file_name         |
+      | spaces           | /upload.txt       |
+      | spaces           | /strängé file.txt |
+      | spaces           | /नेपाली.txt       |
+      | spaces           | s,a,m,p,l,e.txt   |
 
   @issue-1296
   Scenario Outline: user sends a PROPFIND request on various file with '?, #, &, +' in its name
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "<file_name>"
     When user "Alice" gets the properties of file "<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the properties response should contain an etag
     And there should be an entry with href containing "<expected_href>" in the response to user "Alice"
     Examples:
-      | dav_version | file_name     | expected_href                                 |
-      | old         | /C++ file.cpp | remote.php/webdav/C++ file.cpp                |
-      | old         | /file #2.txt  | remote.php/webdav/file #2.txt                 |
-      | old         | /file ?2.txt  | remote.php/webdav/file ?2.txt                 |
-      | old         | /file &2.txt  | remote.php/webdav/file &2.txt                 |
-      | new         | /C++ file.cpp | remote.php/dav/files/%username%/C++ file.cpp  |
-      | new         | /file #2.txt  | remote.php/dav/files/%username%/file #2.txt   |
-      | new         | /file ?2.txt  | remote.php/dav/files/%username%/file ?2.txt   |
-      | new         | /file &2.txt  | remote.php/dav/files/%username%/file &2.txt   |
+      | dav-path-version | file_name     | expected_href                                |
+      | old              | /C++ file.cpp | remote.php/webdav/C++ file.cpp               |
+      | old              | /file #2.txt  | remote.php/webdav/file #2.txt                |
+      | old              | /file ?2.txt  | remote.php/webdav/file ?2.txt                |
+      | old              | /file &2.txt  | remote.php/webdav/file &2.txt                |
+      | new              | /C++ file.cpp | remote.php/dav/files/%username%/C++ file.cpp |
+      | new              | /file #2.txt  | remote.php/dav/files/%username%/file #2.txt  |
+      | new              | /file ?2.txt  | remote.php/dav/files/%username%/file ?2.txt  |
+      | new              | /file &2.txt  | remote.php/dav/files/%username%/file &2.txt  |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name     | expected_href                     |
-      | spaces      | /C++ file.cpp | dav/spaces/%spaceid%/C++ file.cpp |
-      | spaces      | /file #2.txt  | dav/spaces/%spaceid%/file #2.txt  |
-      | spaces      | /file ?2.txt  | dav/spaces/%spaceid%/file ?2.txt  |
-      | spaces      | /file &2.txt  | dav/spaces/%spaceid%/file &2.txt  |
+      | dav-path-version | file_name     | expected_href                     |
+      | spaces           | /C++ file.cpp | dav/spaces/%spaceid%/C++ file.cpp |
+      | spaces           | /file #2.txt  | dav/spaces/%spaceid%/file #2.txt  |
+      | spaces           | /file ?2.txt  | dav/spaces/%spaceid%/file ?2.txt  |
+      | spaces           | /file &2.txt  | dav/spaces/%spaceid%/file &2.txt  |
 
   @issue-1296
   Scenario Outline: user sends a PROPFIND request on various folder names
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file1.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file2.txt"
@@ -73,85 +73,85 @@ Feature: get file properties
     And there should be an entry with href containing "<expected_href>/file1.txt" in the response to user "Alice"
     And there should be an entry with href containing "<expected_href>/file2.txt" in the response to user "Alice"
     Examples:
-      | dav_version | folder_name     | expected_href                                  |
-      | old         | /upload         | remote.php/webdav/upload                       |
-      | old         | /strängé folder | remote.php/webdav/strängé folder              |
-      | old         | /C++ folder     | remote.php/webdav/C++ folder                   |
-      | old         | /नेपाली           | remote.php/webdav/नेपाली                        |
-      | old         | /folder #2.txt  | remote.php/webdav/folder #2.txt                |
-      | old         | /folder ?2.txt  | remote.php/webdav/folder ?2.txt                |
-      | old         | /folder &2.txt  | remote.php/webdav/folder &2.txt                |
-      | new         | /upload         | remote.php/dav/files/%username%/upload         |
-      | new         | /strängé folder | remote.php/dav/files/%username%/strängé folder |
-      | new         | /C++ folder     | remote.php/dav/files/%username%/C++ folder     |
-      | new         | /नेपाली           | remote.php/dav/files/%username%/नेपाली          |
-      | new         | /folder #2.txt  | remote.php/dav/files/%username%/folder #2.txt  |
-      | new         | /folder ?2.txt  | remote.php/dav/files/%username%/folder ?2.txt  |
-      | new         | /folder &2.txt  | remote.php/dav/files/%username%/folder &2.txt  |
+      | dav-path-version | folder_name     | expected_href                                  |
+      | old              | /upload         | remote.php/webdav/upload                       |
+      | old              | /strängé folder | remote.php/webdav/strängé folder               |
+      | old              | /C++ folder     | remote.php/webdav/C++ folder                   |
+      | old              | /नेपाली         | remote.php/webdav/नेपाली                       |
+      | old              | /folder #2.txt  | remote.php/webdav/folder #2.txt                |
+      | old              | /folder ?2.txt  | remote.php/webdav/folder ?2.txt                |
+      | old              | /folder &2.txt  | remote.php/webdav/folder &2.txt                |
+      | new              | /upload         | remote.php/dav/files/%username%/upload         |
+      | new              | /strängé folder | remote.php/dav/files/%username%/strängé folder |
+      | new              | /C++ folder     | remote.php/dav/files/%username%/C++ folder     |
+      | new              | /नेपाली         | remote.php/dav/files/%username%/नेपाली         |
+      | new              | /folder #2.txt  | remote.php/dav/files/%username%/folder #2.txt  |
+      | new              | /folder ?2.txt  | remote.php/dav/files/%username%/folder ?2.txt  |
+      | new              | /folder &2.txt  | remote.php/dav/files/%username%/folder &2.txt  |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name     | expected_href                       |
-      | spaces      | /upload         | dav/spaces/%spaceid%/upload         |
-      | spaces      | /strängé folder | dav/spaces/%spaceid%/strängé folder |
-      | spaces      | /C++ folder     | dav/spaces/%spaceid%/C++ folder     |
-      | spaces      | /नेपाली           | dav/spaces/%spaceid%/नेपाली          |
-      | spaces      | /folder #2.txt  | dav/spaces/%spaceid%/folder #2.txt  |
-      | spaces      | /folder ?2.txt  | dav/spaces/%spaceid%/folder ?2.txt  |
-      | spaces      | /folder &2.txt  | dav/spaces/%spaceid%/folder &2.txt  |
+      | dav-path-version | folder_name     | expected_href                       |
+      | spaces           | /upload         | dav/spaces/%spaceid%/upload         |
+      | spaces           | /strängé folder | dav/spaces/%spaceid%/strängé folder |
+      | spaces           | /C++ folder     | dav/spaces/%spaceid%/C++ folder     |
+      | spaces           | /नेपाली         | dav/spaces/%spaceid%/नेपाली         |
+      | spaces           | /folder #2.txt  | dav/spaces/%spaceid%/folder #2.txt  |
+      | spaces           | /folder ?2.txt  | dav/spaces/%spaceid%/folder ?2.txt  |
+      | spaces           | /folder &2.txt  | dav/spaces/%spaceid%/folder &2.txt  |
 
 
   Scenario Outline: user sends a PROPFIND request on various files inside various folders
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/<file_name>"
     When user "Alice" gets the properties of file "<folder_name>/<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the properties response should contain an etag
     Examples:
-      | dav_version | folder_name                      | file_name                     |
-      | old         | /upload                          | abc.txt                       |
-      | old         | /strängé folder                  | strängé file.txt              |
-      | old         | /C++ folder                      | C++ file.cpp                  |
-      | old         | /नेपाली                          | नेपाली                        |
-      | old         | /folder #2.txt                   | file #2.txt                   |
-      | new         | /upload                          | abc.txt                       |
-      | new         | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
-      | new         | /C++ folder                      | C++ file.cpp                  |
-      | new         | /नेपाली                          | नेपाली                        |
-      | new         | /folder #2.txt                   | file #2.txt                   |
+      | dav-path-version | folder_name                      | file_name                     |
+      | old              | /upload                          | abc.txt                       |
+      | old              | /strängé folder                  | strängé file.txt              |
+      | old              | /C++ folder                      | C++ file.cpp                  |
+      | old              | /नेपाली                          | नेपाली                        |
+      | old              | /folder #2.txt                   | file #2.txt                   |
+      | new              | /upload                          | abc.txt                       |
+      | new              | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
+      | new              | /C++ folder                      | C++ file.cpp                  |
+      | new              | /नेपाली                          | नेपाली                        |
+      | new              | /folder #2.txt                   | file #2.txt                   |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name     | file_name        |
-      | spaces      | /upload         | abc.txt          |
-      | spaces      | /strängé folder | strängé file.txt |
-      | spaces      | /C++ folder     | C++ file.cpp     |
-      | spaces      | /नेपाली         | नेपाली           |
-      | spaces      | /folder #2.txt  | file #2.txt      |
+      | dav-path-version | folder_name     | file_name        |
+      | spaces           | /upload         | abc.txt          |
+      | spaces           | /strängé folder | strängé file.txt |
+      | spaces           | /C++ folder     | C++ file.cpp     |
+      | spaces           | /नेपाली         | नेपाली           |
+      | spaces           | /folder #2.txt  | file #2.txt      |
 
   @issue-1259
   #after fixing all issues delete this Scenario and merge with the one above
   Scenario Outline: user sends a PROPFIND request on various files inside various folders with '?' character in its name
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder ?2.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/folder ?2.txt/file ?2.txt"
     When user "Alice" gets the properties of file "/folder ?2.txt/file ?2.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the properties response should contain an etag
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: file that is not shared does not have a share-types property
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
@@ -159,18 +159,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the response should contain an empty property "oc:share-types"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: file that is shared to a user has a share-types property
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has created a share with settings
@@ -185,18 +185,18 @@ Feature: get file properties
     And the response should contain a share-types property with
       | 0 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: file that is shared to a group has a share-types property
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Alice" has created folder "/test"
     And user "Alice" has created a share with settings
@@ -211,18 +211,18 @@ Feature: get file properties
     And the response should contain a share-types property with
       | 1 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: file that is shared by link has a share-types property
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     And user "Alice" has created a public link share with settings
       | path        | test |
@@ -234,18 +234,18 @@ Feature: get file properties
     And the response should contain a share-types property with
       | 3 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: file that is shared by user,group and link has a share-types property
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has created folder "/test"
@@ -271,18 +271,18 @@ Feature: get file properties
       | 1 |
       | 3 |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest @issue-2809
   Scenario Outline: retrieving a private link
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     When user "Alice" gets the following properties of file "/somefile.txt" using the WebDAV API
       | propertyName   |
@@ -290,14 +290,14 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user sends a PROPFIND request on a nonexistent URL
@@ -319,7 +319,7 @@ Feature: get file properties
 
   @issue-1297
   Scenario Outline: add, receive multiple custom meta properties to a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/TestFolder"
     And user "Alice" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
     And user "Alice" has set the following properties of file "/TestFolder/test1.txt" using the WebDav API
@@ -337,18 +337,18 @@ Feature: get file properties
       | /TestFolder/test1.txt | testprop2    | BBBBB           |
       | /TestFolder/test1.txt | status       | HTTP/1.1 200 OK |
     Examples:
-      | dav_version |
-      | new         |
-      | old         |
+      | dav-path-version |
+      | new              |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1297
   Scenario Outline: add multiple properties to files inside a folder and do a propfind of the parent folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/TestFolder"
     And user "Alice" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
     And user "Alice" has uploaded file with content "test data two" to "/TestFolder/test2.txt"
@@ -373,18 +373,18 @@ Feature: get file properties
       | /TestFolder/test2.txt | testprop2    | DDDDD                  |
       | /TestFolder/          | status       | HTTP/1.1 404 Not Found |
     Examples:
-      | dav_version |
-      | new         |
-      | old         |
+      | dav-path-version |
+      | new              |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the last modified date of a folder using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName      |
@@ -392,18 +392,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:getlastmodified" with value like "/^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$/"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the content type of a folder using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName     |
@@ -411,18 +411,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:getcontenttype" with value ""
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the content type of a file using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName     |
@@ -430,18 +430,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:getcontenttype" with value "text/plain.*"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the etag of a file using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName |
@@ -449,18 +449,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:getetag" with value like '%\"[a-z0-9:]{1,32}\"%'
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the resource type of a file using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName   |
@@ -468,18 +468,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "d:resourcetype" with value ""
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the size of a file using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName |
@@ -487,18 +487,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:size" with value "16"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the size of a folder using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName |
@@ -506,18 +506,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:size" with value "0"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the file id of a file using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName |
@@ -525,18 +525,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:fileid" with value like '/[a-zA-Z0-9]+/'
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the file id of a folder using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName |
@@ -544,18 +544,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:fileid" with value like '/[a-zA-Z0-9]+/'
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the owner display name of a file using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of file "file.txt" using the WebDAV API
       | propertyName          |
@@ -563,18 +563,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response about the file owned by "Alice" should contain a property "oc:owner-display-name" with value "%displayname%"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the owner display name of a folder using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName          |
@@ -582,18 +582,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response about the file owned by "Alice" should contain a property "oc:owner-display-name" with value "%displayname%"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the permissions on a file using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName   |
@@ -601,18 +601,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:permissions" with value like '/RM{0,1}DNVW/'
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the permissions on a folder using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
@@ -620,18 +620,18 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:permissions" with value like '/RM{0,1}DNVCK/'
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: user tries to get the size of a folder with files using webdav api
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file with content "a" to "/test/file.txt"
     And user "Alice" has uploaded file with content "b" to "/test/file1.txt"
@@ -644,11 +644,11 @@ Feature: get file properties
     Then the HTTP status code should be "201"
     And the single response should contain a property "oc:size" with value "5"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUpload1/uploadFile.feature
@@ -10,165 +10,165 @@ Feature: upload file
 
   @smokeTest
   Scenario Outline: upload a file and check etag and download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And the content of file "<file_name>" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version | file_name         |
-      | old         | /upload.txt       |
-      | old         | /नेपाली.txt       |
-      | old         | /strängé file.txt |
-      | old         | /s,a,m,p,l,e.txt  |
-      | new         | /upload.txt       |
-      | new         | /नेपाली.txt       |
-      | new         | /strängé file.txt |
-      | new         | /s,a,m,p,l,e.txt  |
+      | dav-path-version | file_name         |
+      | old              | /upload.txt       |
+      | old              | /नेपाली.txt       |
+      | old              | /strängé file.txt |
+      | old              | /s,a,m,p,l,e.txt  |
+      | new              | /upload.txt       |
+      | new              | /नेपाली.txt       |
+      | new              | /strängé file.txt |
+      | new              | /s,a,m,p,l,e.txt  |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name         |
-      | spaces      | /upload.txt       |
-      | spaces      | /नेपाली.txt       |
-      | spaces      | /strängé file.txt |
-      | spaces      | /s,a,m,p,l,e.txt  |
+      | dav-path-version | file_name         |
+      | spaces           | /upload.txt       |
+      | spaces           | /नेपाली.txt       |
+      | spaces           | /strängé file.txt |
+      | spaces           | /s,a,m,p,l,e.txt  |
 
 
   Scenario Outline: upload a file and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to <file_name> using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file <file_name> for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version | file_name      |
-      | old         | "C++ file.cpp" |
-      | old         | "file #2.txt"  |
-      | new         | "C++ file.cpp" |
-      | new         | "file #2.txt"  |
+      | dav-path-version | file_name      |
+      | old              | "C++ file.cpp" |
+      | old              | "file #2.txt"  |
+      | new              | "C++ file.cpp" |
+      | new              | "file #2.txt"  |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name      |
-      | spaces      | "C++ file.cpp" |
-      | spaces      | "file #2.txt"  |
+      | dav-path-version | file_name      |
+      | spaces           | "C++ file.cpp" |
+      | spaces           | "file #2.txt"  |
 
   @issue-1259
   #after fixing all issues delete this Scenario and merge with the one above
   Scenario Outline: upload a file with character '?' in its name and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to <file_name> using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file <file_name> for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version | file_name           |
-      | old         | "file ?2.txt"       |
-      | old         | " ?fi=le&%#2 . txt" |
-      | old         | " # %ab ab?=ed "    |
-      | new         | "file ?2.txt"       |
-      | new         | " ?fi=le&%#2 . txt" |
-      | new         | " # %ab ab?=ed "    |
+      | dav-path-version | file_name           |
+      | old              | "file ?2.txt"       |
+      | old              | " ?fi=le&%#2 . txt" |
+      | old              | " # %ab ab?=ed "    |
+      | new              | "file ?2.txt"       |
+      | new              | " ?fi=le&%#2 . txt" |
+      | new              | " # %ab ab?=ed "    |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name           |
-      | spaces      | "file ?2.txt"       |
-      | spaces      | " ?fi=le&%#2 . txt" |
-      | spaces      | " # %ab ab?=ed "    |
+      | dav-path-version | file_name           |
+      | spaces           | "file ?2.txt"       |
+      | spaces           | " ?fi=le&%#2 . txt" |
+      | spaces           | " # %ab ab?=ed "    |
 
 
   Scenario Outline: upload a file with comma in the filename and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "file with comma" to <file_name> using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file <file_name> for user "Alice" should be "file with comma"
     Examples:
-      | dav_version | file_name      |
-      | old         | "sample,1.txt" |
-      | old         | ",,,.txt"      |
-      | old         | ",,,.,"        |
-      | new         | "sample,1.txt" |
-      | new         | ",,,.txt"      |
-      | new         | ",,,.,"        |
+      | dav-path-version | file_name      |
+      | old              | "sample,1.txt" |
+      | old              | ",,,.txt"      |
+      | old              | ",,,.,"        |
+      | new              | "sample,1.txt" |
+      | new              | ",,,.txt"      |
+      | new              | ",,,.,"        |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name      |
-      | spaces      | "sample,1.txt" |
-      | spaces      | ",,,.txt"      |
-      | spaces      | ",,,.,"        |
+      | dav-path-version | file_name      |
+      | spaces           | "sample,1.txt" |
+      | spaces           | ",,,.txt"      |
+      | spaces           | ",,,.,"        |
 
 
   Scenario Outline: upload a file into a folder and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     When user "Alice" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "<folder_name>/<file_name>" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version | folder_name                      | file_name                     |
-      | old         | /upload                          | abc.txt                       |
-      | old         | /strängé folder                  | strängé file.txt              |
-      | old         | /C++ folder                      | C++ file.cpp                  |
-      | old         | /नेपाली                          | नेपाली                        |
-      | old         | /folder #2.txt                   | file #2.txt                   |
-      | new         | /upload                          | abc.txt                       |
-      | new         | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
-      | new         | /C++ folder                      | C++ file.cpp                  |
-      | new         | /नेपाली                          | नेपाली                        |
-      | new         | /folder #2.txt                   | file #2.txt                   |
+      | dav-path-version | folder_name                      | file_name                     |
+      | old              | /upload                          | abc.txt                       |
+      | old              | /strängé folder                  | strängé file.txt              |
+      | old              | /C++ folder                      | C++ file.cpp                  |
+      | old              | /नेपाली                          | नेपाली                        |
+      | old              | /folder #2.txt                   | file #2.txt                   |
+      | new              | /upload                          | abc.txt                       |
+      | new              | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
+      | new              | /C++ folder                      | C++ file.cpp                  |
+      | new              | /नेपाली                          | नेपाली                        |
+      | new              | /folder #2.txt                   | file #2.txt                   |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name     | file_name        |
-      | spaces      | /strängé folder | strängé file.txt |
-      | spaces      | /upload         | abc.txt          |
-      | spaces      | /C++ folder     | C++ file.cpp     |
-      | spaces      | /नेपाली         | नेपाली           |
-      | spaces      | /folder #2.txt  | file #2.txt      |
+      | dav-path-version | folder_name     | file_name        |
+      | spaces           | /strängé folder | strängé file.txt |
+      | spaces           | /upload         | abc.txt          |
+      | spaces           | /C++ folder     | C++ file.cpp     |
+      | spaces           | /नेपाली         | नेपाली           |
+      | spaces           | /folder #2.txt  | file #2.txt      |
 
   @issue-1259
     #after fixing all issues delete this Scenario and merge with the one above
   Scenario Outline: upload a file into a folder with character '?' in its name and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     When user "Alice" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "<folder_name>/<file_name>" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version | folder_name       | file_name    |
-      | old         | /folder ?2.txt    | file ?2.txt  |
-      | old         | /?fi=le&%#2 . txt | # %ab ab?=ed |
-      | new         | /folder ?2.txt    | file ?2.txt  |
-      | new         | /?fi=le&%#2 . txt | # %ab ab?=ed |
+      | dav-path-version | folder_name       | file_name    |
+      | old              | /folder ?2.txt    | file ?2.txt  |
+      | old              | /?fi=le&%#2 . txt | # %ab ab?=ed |
+      | new              | /folder ?2.txt    | file ?2.txt  |
+      | new              | /?fi=le&%#2 . txt | # %ab ab?=ed |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name       | file_name    |
-      | spaces      | /folder ?2.txt    | file ?2.txt  |
-      | spaces      | /?fi=le&%#2 . txt | # %ab ab?=ed |
+      | dav-path-version | folder_name       | file_name    |
+      | spaces           | /folder ?2.txt    | file ?2.txt  |
+      | spaces           | /?fi=le&%#2 . txt | # %ab ab?=ed |
 
 
   Scenario Outline: attempt to upload a file into a nonexistent folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "nonexistent-folder/new-file.txt" using the WebDAV API
     Then the HTTP status code should be "409"
     And as "Alice" folder "nonexistent-folder" should not exist
     And as "Alice" file "nonexistent-folder/new-file.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @issue-1345
   Scenario Outline: uploading file to path with extension .part should not be possible
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile.part" using the WebDAV API
     Then the HTTP status code should be "400"
     And the DAV exception should be "OCA\DAV\Connector\Sabre\Exception\InvalidPath"
@@ -177,84 +177,84 @@ Feature: upload file
     And user "Alice" should not see the following elements
       | /textfile.part |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file into a folder with dots in the path and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     When user "Alice" uploads file with content "uploaded content for file name ending with a dot" to "<folder_name>/<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/<folder_name>/<file_name>" should exist
     And the content of file "<folder_name>/<file_name>" for user "Alice" should be "uploaded content for file name ending with a dot"
     Examples:
-      | dav_version | folder_name   | file_name   |
-      | old         | /upload.      | abc.        |
-      | old         | /upload.      | abc .       |
-      | old         | /upload.1     | abc.txt     |
-      | old         | /upload...1.. | abc...txt.. |
-      | old         | /...          | ...         |
-      | new         | /..upload     | ..abc       |
-      | new         | /upload.      | abc.        |
-      | new         | /upload.      | abc .       |
-      | new         | /upload.1     | abc.txt     |
-      | new         | /upload...1.. | abc...txt.. |
-      | new         | /...          | ...         |
+      | dav-path-version | folder_name   | file_name   |
+      | old              | /upload.      | abc.        |
+      | old              | /upload.      | abc .       |
+      | old              | /upload.1     | abc.txt     |
+      | old              | /upload...1.. | abc...txt.. |
+      | old              | /...          | ...         |
+      | new              | /..upload     | ..abc       |
+      | new              | /upload.      | abc.        |
+      | new              | /upload.      | abc .       |
+      | new              | /upload.1     | abc.txt     |
+      | new              | /upload...1.. | abc...txt.. |
+      | new              | /...          | ...         |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name   | file_name   |
-      | spaces      | /upload.      | abc.        |
-      | spaces      | /upload.      | abc .       |
-      | spaces      | /upload.1     | abc.txt     |
-      | spaces      | /upload...1.. | abc...txt.. |
-      | spaces      | /...          | ...         |
+      | dav-path-version | folder_name   | file_name   |
+      | spaces           | /upload.      | abc.        |
+      | spaces           | /upload.      | abc .       |
+      | spaces           | /upload.1     | abc.txt     |
+      | spaces           | /upload...1.. | abc...txt.. |
+      | spaces           | /...          | ...         |
 
 
   Scenario Outline: upload file with mtime
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "file.txt" should exist
     And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file with mtime in a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "testFolder"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "/testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: moving a file does not change its mtime
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "testFolder"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     And user "Alice" moves file "file.txt" to "/testFolder/file.txt" using the WebDAV API
@@ -262,18 +262,18 @@ Feature: upload file
     And as "Alice" file "/testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "/testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: overwriting a file changes its mtime
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "first time upload content" to "file.txt"
     When user "Alice" uploads a file with content "Overwrite file" and mtime "Thu, 08 Aug 2019 04:18:13 GMT" to "file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -281,18 +281,18 @@ Feature: upload file
     And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the content of file "file.txt" for user "Alice" should be "Overwrite file"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a hidden file and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     When user "Alice" uploads the following files with content "hidden file"
       | path                 |
@@ -308,27 +308,27 @@ Feature: upload file
       | .hidden_file         |
       | /FOLDER/.hidden_file |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file of size zero byte
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/zerobyte.txt" to "/zerobyte.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "zerobyte.txt" should exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/coreApiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -10,7 +10,7 @@ Feature: upload file using old chunking
 
 
   Scenario Outline: upload chunked file in ascending order
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |
@@ -22,17 +22,17 @@ Feature: upload file using old chunking
     And as "Alice" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
     Examples:
-      | dav_version |
-      | old         |
+      | dav-path-version |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload chunked file in descending order
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
       | number | content |
       | 3      | CCCCC   |
@@ -42,17 +42,17 @@ Feature: upload file using old chunking
     And as "Alice" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
     Examples:
-      | dav_version |
-      | old         |
+      | dav-path-version |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload chunked file in random order
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
       | number | content |
       | 2      | BBBBB   |
@@ -62,17 +62,17 @@ Feature: upload file using old chunking
     And as "Alice" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
     Examples:
-      | dav_version |
-      | old         |
+      | dav-path-version |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: checking file id after a move overwrite using old chunking endpoint
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has copied file "/textfile0.txt" to "/existingFile.txt"
     And user "Alice" has stored id of file "/existingFile.txt"
@@ -86,20 +86,20 @@ Feature: upload file using old chunking
       Cheers.
       """
     Examples:
-      | dav_version |
-      | old         |
+      | dav-path-version |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
   @smokeTest
   # This smokeTest scenario does ordinary checks for chunked upload,
   # without adjusting the log level. This allows it to run in test environments
   # where the log level has been fixed and cannot be changed.
   Scenario Outline: chunked upload files with difficult name
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/<file-name>" in 3 chunks using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/<file-name>" should exist
@@ -110,19 +110,19 @@ Feature: upload file using old chunking
       Cheers.
       """
     Examples:
-      | dav_version | file-name                       |
-      | old         | &#? TIÄFÜ @a#8a=b?c=d ?abc=oc # |
-      | old         | 0                               |
+      | dav-path-version | file-name                       |
+      | old              | &#? TIÄFÜ @a#8a=b?c=d ?abc=oc # |
+      | old              | 0                               |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file-name                       |
-      | spaces      | &#? TIÄFÜ @a#8a=b?c=d ?abc=oc # |
-      | spaces      | 0                               |
+      | dav-path-version | file-name                       |
+      | spaces           | &#? TIÄFÜ @a#8a=b?c=d ?abc=oc # |
+      | spaces           | 0                               |
 
 
   Scenario Outline: upload chunked file with old chunking with lengthy filenames
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads the following chunks to "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" with old chunking and using the WebDAV API
       | number | content                   |
       | 1      | AAAAAAAAAAAAAAAAAAAAAAAAA |
@@ -134,10 +134,10 @@ Feature: upload file using old chunking
     And as "Alice" file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" should exist
     And the content of file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" for user "Alice" should be "AAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCCCCCC"
     Examples:
-      | dav_version |
-      | old         |
+      | dav-path-version |
+      | old              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/checksums.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/checksums.feature
@@ -9,7 +9,7 @@ Feature: checksums
 
 
   Scenario Outline: uploading a file with checksum should work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -18,21 +18,21 @@ Feature: checksums
     Then the HTTP status code should be "204"
     And the content of file "/textFile.txt" for user "Alice" should be "12345"
     Examples:
-      | dav_version | checksum                                      |
-      | old         | MD5 827ccb0eea8a706c4c34a16891f84e7b          |
-      | new         | MD5 827ccb0eea8a706c4c34a16891f84e7b          |
-      | old         | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
-      | new         | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
+      | dav-path-version | checksum                                      |
+      | old              | MD5 827ccb0eea8a706c4c34a16891f84e7b          |
+      | new              | MD5 827ccb0eea8a706c4c34a16891f84e7b          |
+      | old              | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
+      | new              | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | checksum                                      |
-      | spaces      | MD5 827ccb0eea8a706c4c34a16891f84e7b          |
-      | spaces      | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
+      | dav-path-version | checksum                                      |
+      | spaces           | MD5 827ccb0eea8a706c4c34a16891f84e7b          |
+      | spaces           | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
 
 
   Scenario Outline: uploading a file with checksum should return the checksum in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -42,18 +42,18 @@ Feature: checksums
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964 MD5:827ccb0eea8a706c4c34a16891f84e7b ADLER32:02f80100"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: uploading a file with checksum should return the checksum in the download header
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -63,18 +63,18 @@ Feature: checksums
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: uploading a file with incorrect checksum should not work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -83,21 +83,21 @@ Feature: checksums
     Then the HTTP status code should be "406"
     And as "Alice" file "textFile.txt" should not exist
     Examples:
-      | dav_version | incorrect_checksum                            |
-      | old         | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
-      | new         | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
-      | old         | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
-      | new         | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
+      | dav-path-version | incorrect_checksum                            |
+      | old              | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
+      | new              | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
+      | old              | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
+      | new              | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | incorrect_checksum                            |
-      | spaces      | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
-      | spaces      | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
+      | dav-path-version | incorrect_checksum                            |
+      | spaces           | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
+      | spaces           | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
 
 
   Scenario Outline: uploading a chunked file with correct checksum should work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -107,18 +107,18 @@ Feature: checksums
     Then the HTTP status code should be "204"
     And the content of file "/textFile.txt" for user "Alice" should be "0123456789"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: uploading a chunked file with correct checksum should return the checksum in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -129,18 +129,18 @@ Feature: checksums
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:87acec17cd9dcd20a716cc2cf67417b71c8a7016 MD5:781e5e245d69b566979b86e28d23f2c7 ADLER32:0aff020e"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: uploading a chunked file with checksum should return the checksum in the download header
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -151,18 +151,18 @@ Feature: checksums
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:87acec17cd9dcd20a716cc2cf67417b71c8a7016"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: uploading second chunk of file with incorrect checksum should not work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -172,18 +172,18 @@ Feature: checksums
     Then the HTTP status code should be "409"
     And as "Alice" file "textFile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: uploading a file with correct checksum and overwriting an existing file should return the checksum for new data in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -198,21 +198,21 @@ Feature: checksums
     And the webdav checksum should match "SHA1:aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d MD5:5d41402abc4b2a76b9719d911017c592 ADLER32:062c0215"
     And the content of file "/textFile.txt" for user "Alice" should be "hello"
     Examples:
-      | dav_version | overwriteChecksum                             |
-      | old         | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | new         | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
-      | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
+      | dav-path-version | overwriteChecksum                             |
+      | old              | MD5 5d41402abc4b2a76b9719d911017c592          |
+      | new              | MD5 5d41402abc4b2a76b9719d911017c592          |
+      | old              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
+      | new              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | overwriteChecksum                             |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
+      | dav-path-version | overwriteChecksum                             |
+      | spaces           | MD5 5d41402abc4b2a76b9719d911017c592          |
+      | spaces           | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
 
 
   Scenario Outline: uploading a file with correct checksum and overwriting an existing file with invalid checksum should not work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -225,21 +225,21 @@ Feature: checksums
     Then the HTTP status code should be "406"
     And the content of file "/textFile.txt" for user "Alice" should be "0123456789"
     Examples:
-      | dav_version | overwriteInvalidChecksum                      |
-      | old         | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | new         | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
-      | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
+      | dav-path-version | overwriteInvalidChecksum                      |
+      | old              | MD5 5d41402abc4b2a76b9719d911017c593          |
+      | new              | MD5 5d41402abc4b2a76b9719d911017c593          |
+      | old              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
+      | new              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | overwriteInvalidChecksum                      |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
+      | dav-path-version | overwriteInvalidChecksum                      |
+      | spaces           | MD5 5d41402abc4b2a76b9719d911017c593          |
+      | spaces           | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
 
 
   Scenario Outline: overwriting an existing file with new data and checksum should return the checksum of new data in the propfind
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -254,21 +254,21 @@ Feature: checksums
     And the webdav checksum should match "SHA1:aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d MD5:5d41402abc4b2a76b9719d911017c592 ADLER32:062c0215"
     And the content of file "/textFile.txt" for user "Alice" should be "hello"
     Examples:
-      | dav_version | overwriteChecksum                             |
-      | old         | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | new         | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
-      | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
+      | dav-path-version | overwriteChecksum                             |
+      | old              | MD5 5d41402abc4b2a76b9719d911017c592          |
+      | new              | MD5 5d41402abc4b2a76b9719d911017c592          |
+      | old              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
+      | new              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | overwriteChecksum                             |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
+      | dav-path-version | overwriteChecksum                             |
+      | spaces           | MD5 5d41402abc4b2a76b9719d911017c592          |
+      | spaces           | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
 
 
   Scenario Outline: overwriting an existing file with new data and invalid checksum should not work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -281,14 +281,14 @@ Feature: checksums
     Then the HTTP status code should be "406"
     And the content of file "/textFile.txt" for user "Alice" should be "12345"
     Examples:
-      | dav_version | overwriteChecksum                             |
-      | old         | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | new         | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
-      | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
+      | dav-path-version | overwriteChecksum                             |
+      | old              | MD5 5d41402abc4b2a76b9719d911017c593          |
+      | new              | MD5 5d41402abc4b2a76b9719d911017c593          |
+      | old              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
+      | new              | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | overwriteChecksum                             |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
+      | dav-path-version | overwriteChecksum                             |
+      | spaces           | MD5 5d41402abc4b2a76b9719d911017c593          |
+      | spaces           | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/creationWithUploadExtension.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/creationWithUploadExtension.feature
@@ -9,7 +9,7 @@ Feature: tests of the creation extension see https://tus.io/protocols/resumable-
 
 
   Scenario Outline: creating a new upload resource using creation with upload extension
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" creates a new TUS resource with content "uploaded content" on the WebDAV API with these headers:
       | Upload-Length   | 16                              |
       | Tus-Resumable   | 1.0.0                           |
@@ -24,26 +24,26 @@ Feature: tests of the creation extension see https://tus.io/protocols/resumable-
       | Upload-Offset | /\d+/                           |
     And the content of file "/test.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: creating a new resource and upload data in multiple bytes using creation with upload extension
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" creates file "textFile.txt" and uploads content "12345" in the same request using the TUS protocol on the WebDAV API
     Then the content of file "/textFile.txt" for user "Alice" should be "12345"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelCreationExtension.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelCreationExtension.feature
@@ -9,7 +9,7 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
 
 
   Scenario Outline: creating a new upload resource
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" creates a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 100                                           |
       #    d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg== is the base64 encode of world_domination_plan.pdf
@@ -20,18 +20,18 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
       | Tus-Resumable | /1\.0\.0/                       |
       | Location      | /http[s]?:\/\/.*:\d+\/data\/.*/ |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: creating a new upload resource without upload length
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
       #    d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg== is the base64 encode of world_domination_plan.pdf
@@ -41,11 +41,11 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
       | header   |
       | Location |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelUpload.feature
@@ -9,7 +9,7 @@ Feature: low level tests for upload of chunks
 
 
   Scenario Outline: upload a chunk twice
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
       #    ZmlsZS50eHQ= is the base64 encode of file.txt
@@ -19,18 +19,18 @@ Feature: low level tests for upload of chunks
     Then the HTTP status code should be "409"
     And as "Alice" file "file.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: finalize file upload after uploading a chunk twice
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
       #    ZmlsZS50eHQ= is the base64 encode of file.txt
@@ -41,18 +41,18 @@ Feature: low level tests for upload of chunks
     Then the HTTP status code should be "204"
     And the content of file "/file.txt" for user "Alice" should be "1234567890"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: send last chunk twice
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
       #    ZmlsZS50eHQ= is the base64 encode of file.txt
@@ -63,18 +63,18 @@ Feature: low level tests for upload of chunks
     Then the HTTP status code should be "404"
     And the content of file "/file.txt" for user "Alice" should be "1234567890"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: start with uploading not at the beginning of the file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
       #    ZmlsZS50eHQ= is the base64 encode of file.txt
@@ -83,11 +83,11 @@ Feature: low level tests for upload of chunks
     Then the HTTP status code should be "409"
     And as "Alice" file "file.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature
@@ -9,179 +9,179 @@ Feature: upload file
 
 
   Scenario Outline: upload a file and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "<file_name>" using the TUS protocol on the WebDAV API
     Then the content of file "<file_name>" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version | file_name         |
-      | old         | /upload.txt       |
-      | old         | /नेपाली.txt       |
-      | old         | /strängé file.txt |
-      | old         | /s,a,m,p,l,e.txt  |
-      | old         | /C++ file.cpp     |
-      | old         | /?fi=le&%#2 . txt |
-      | old         | /# %ab ab?=ed     |
-      | new         | /upload.txt       |
-      | new         | /strängé file.txt |
-      | new         | /नेपाली.txt       |
-      | new         | /s,a,m,p,l,e.txt  |
-      | new         | /C++ file.cpp     |
-      | new         | /?fi=le&%#2 . txt |
-      | new         | /# %ab ab?=ed     |
+      | dav-path-version | file_name         |
+      | old              | /upload.txt       |
+      | old              | /नेपाली.txt       |
+      | old              | /strängé file.txt |
+      | old              | /s,a,m,p,l,e.txt  |
+      | old              | /C++ file.cpp     |
+      | old              | /?fi=le&%#2 . txt |
+      | old              | /# %ab ab?=ed     |
+      | new              | /upload.txt       |
+      | new              | /strängé file.txt |
+      | new              | /नेपाली.txt       |
+      | new              | /s,a,m,p,l,e.txt  |
+      | new              | /C++ file.cpp     |
+      | new              | /?fi=le&%#2 . txt |
+      | new              | /# %ab ab?=ed     |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | file_name         |
-      | spaces      | /upload.txt       |
-      | spaces      | /strängé file.txt |
-      | spaces      | /नेपाली.txt       |
-      | spaces      | /s,a,m,p,l,e.txt  |
-      | spaces      | /C++ file.cpp     |
-      | spaces      | /?fi=le&%#2 . txt |
-      | spaces      | /# %ab ab?=ed     |
+      | dav-path-version | file_name         |
+      | spaces           | /upload.txt       |
+      | spaces           | /strängé file.txt |
+      | spaces           | /नेपाली.txt       |
+      | spaces           | /s,a,m,p,l,e.txt  |
+      | spaces           | /C++ file.cpp     |
+      | spaces           | /?fi=le&%#2 . txt |
+      | spaces           | /# %ab ab?=ed     |
 
 
   Scenario Outline: upload a file into a folder and check download content
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "<folder_name>"
     When user "Alice" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the TUS protocol on the WebDAV API
     Then the content of file "<folder_name>/<file_name>" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version | folder_name                      | file_name                     |
-      | old         | /upload                          | abc.txt                       |
-      | old         | /strängé folder                  | strängé file.txt              |
-      | old         | /C++ folder                      | C++ file.cpp                  |
-      | old         | /नेपाली                          | नेपाली                        |
-      | old         | /folder #2.txt                   | file #2.txt                   |
-      | old         | /folder ?2.txt                   | file ?2.txt                   |
-      | old         | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
-      | new         | /upload                          | abc.txt                       |
-      | new         | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
-      | new         | /C++ folder                      | C++ file.cpp                  |
-      | new         | /नेपाली                          | नेपाली                        |
-      | new         | /folder #2.txt                   | file #2.txt                   |
-      | new         | /folder ?2.txt                   | file ?2.txt                   |
-      | new         | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
+      | dav-path-version | folder_name                      | file_name                     |
+      | old              | /upload                          | abc.txt                       |
+      | old              | /strängé folder                  | strängé file.txt              |
+      | old              | /C++ folder                      | C++ file.cpp                  |
+      | old              | /नेपाली                          | नेपाली                        |
+      | old              | /folder #2.txt                   | file #2.txt                   |
+      | old              | /folder ?2.txt                   | file ?2.txt                   |
+      | old              | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
+      | new              | /upload                          | abc.txt                       |
+      | new              | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
+      | new              | /C++ folder                      | C++ file.cpp                  |
+      | new              | /नेपाली                          | नेपाली                        |
+      | new              | /folder #2.txt                   | file #2.txt                   |
+      | new              | /folder ?2.txt                   | file ?2.txt                   |
+      | new              | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version | folder_name                      | file_name                     |
-      | spaces      | /upload                          | abc.txt                       |
-      | spaces      | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
-      | spaces      | /C++ folder                      | C++ file.cpp                  |
-      | spaces      | /नेपाली                          | नेपाली                        |
-      | spaces      | /folder #2.txt                   | file #2.txt                   |
-      | spaces      | /folder ?2.txt                   | file ?2.txt                   |
-      | spaces      | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
+      | dav-path-version | folder_name                      | file_name                     |
+      | spaces           | /upload                          | abc.txt                       |
+      | spaces           | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
+      | spaces           | /C++ folder                      | C++ file.cpp                  |
+      | spaces           | /नेपाली                          | नेपाली                        |
+      | spaces           | /folder #2.txt                   | file #2.txt                   |
+      | spaces           | /folder ?2.txt                   | file ?2.txt                   |
+      | spaces           | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
 
 
   Scenario Outline: upload chunked file with TUS
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" in 3 chunks to "/myChunkedFile.txt" using the TUS protocol on the WebDAV API
     Then the content of file "/myChunkedFile.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload 1 byte chunks with TUS
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "0123456789" in 10 chunks to "/myChunkedFile.txt" using the TUS protocol on the WebDAV API
     Then the content of file "/myChunkedFile.txt" for user "Alice" should be "0123456789"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload to overwriting a file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "original content" to "textfile.txt"
     When user "Alice" uploads file with content "overwritten content" to "textfile.txt" using the TUS protocol on the WebDAV API
     Then the content of file "textfile.txt" for user "Alice" should be "overwritten content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file and no version is available
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "/upload.txt" using the TUS protocol on the WebDAV API
     Then the version folder of file "/upload.txt" for user "Alice" should contain "0" elements
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file twice and versions are available
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "/upload.txt" using the TUS protocol on the WebDAV API
     And user "Alice" uploads file with content "re-uploaded content" to "/upload.txt" using the TUS protocol on the WebDAV API
     Then the version folder of file "/upload.txt" for user "Alice" should contain "1" element
     And the content of file "/upload.txt" for user "Alice" should be "re-uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file in chunks with TUS and no version is available
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "0123456789" in 10 chunks to "/myChunkedFile.txt" using the TUS protocol on the WebDAV API
     Then the version folder of file "/myChunkedFile.txt" for user "Alice" should contain "0" elements
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: upload a twice file in chunks with TUS and versions are available
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "0123456789" in 10 chunks to "/myChunkedFile.txt" using the TUS protocol on the WebDAV API
     And user "Alice" uploads file with content "01234" in 5 chunks to "/myChunkedFile.txt" using the TUS protocol on the WebDAV API
     Then the version folder of file "/myChunkedFile.txt" for user "Alice" should contain "1" elements
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "01234"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file with invalid-name
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" creates a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 100                 |
       | Upload-Metadata | filename <metadata> |
@@ -192,20 +192,20 @@ Feature: upload file
       | Location |
     And as "Alice" file <file_name> should not exist
     Examples:
-      | dav_version | file_name               | metadata                     |
-      | old         | " "                     | IA==                         |
-      | old         | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
-      | old         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
-      | old         | "my\\file"              | bXkMaWxl                     |
-      | new         | " "                     | IA==                         |
-      | new         | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
-      | new         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
-      | new         | "my\\file"              | bXkMaWxl                     |
+      | dav-path-version | file_name               | metadata                     |
+      | old              | " "                     | IA==                         |
+      | old              | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
+      | old              | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
+      | old              | "my\\file"              | bXkMaWxl                     |
+      | new              | " "                     | IA==                         |
+      | new              | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
+      | new              | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
+      | new              | "my\\file"              | bXkMaWxl                     |
 
-  @skipOnRevaMaster
-  Examples:
-    | dav_version | file_name               | metadata                     |
-    | spaces      | " "                     | IA==                         |
-    | spaces      | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
-    | spaces      | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
-    | spaces      | "my\\file"              | bXkMaWxl                     |
+    @skipOnRevaMaster
+    Examples:
+      | dav-path-version | file_name               | metadata                     |
+      | spaces           | " "                     | IA==                         |
+      | spaces           | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
+      | spaces           | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
+      | spaces           | "my\\file"              | bXkMaWxl                     |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature
@@ -9,62 +9,62 @@ Feature: upload file
 
 
   Scenario Outline: upload file with mtime
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload file with future mtime
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2129 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2129 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: upload a file with mtime in a folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "testFolder"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "/testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: overwriting a file changes its mtime
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "first time upload content" to "file.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtimeShares.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtimeShares.feature
@@ -1,4 +1,4 @@
-@api 
+@api
 Feature: upload file
   As a user
   I want the mtime of an uploaded file to be the creation date on upload source not the upload date
@@ -12,7 +12,7 @@ Feature: upload file
 
 
   Scenario Outline: upload file with mtime to a received share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/toShare"
     And user "Alice" has shared folder "/toShare" with user "Brian"
     And user "Brian" has accepted share "/toShare" offered by user "Alice"
@@ -20,13 +20,13 @@ Feature: upload file
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: upload file with mtime to a send share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/toShare"
     And user "Alice" has shared folder "/toShare" with user "Brian"
     And user "Brian" has accepted share "/toShare" offered by user "Alice"
@@ -34,13 +34,13 @@ Feature: upload file
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: overwriting a file with mtime in a received share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/toShare"
     And user "Alice" has shared folder "/toShare" with user "Brian"
     And user "Brian" has accepted share "/toShare" offered by user "Alice"
@@ -49,13 +49,13 @@ Feature: upload file
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: overwriting a file with mtime in a send share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/toShare"
     And user "Alice" has shared folder "/toShare" with user "Brian"
     And user "Brian" has accepted share "/toShare" offered by user "Alice"
@@ -64,6 +64,6 @@ Feature: upload file
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToMoveFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToMoveFolder.feature
@@ -9,7 +9,7 @@ Feature: move folders
 
 
   Scenario Outline: uploading file into a moved folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     And user "Alice" has created folder "/test-moved"
     And user "Alice" has moved folder "/test-moved" to "/test/test-moved"
@@ -17,12 +17,12 @@ Feature: move folders
     Then as "Alice" file "/test/test-moved/textfile.txt" should exist
     And the content of file "/test/test-moved/textfile.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToNonExistingFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToNonExistingFolder.feature
@@ -10,34 +10,34 @@ Feature: upload file
 
 
   Scenario Outline: attempt to upload a file into a nonexistent folder inside shares
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Alice" folder "/Shares/FOLDER/" should not exist
     And as "Alice" file "/Shares/FOLDER/textfile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: attempt to upload a file into a nonexistent folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "/nonExistentFolder/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Alice" folder "/nonExistentFolder" should not exist
     And as "Alice" file "/nonExistentFolder/textfile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
     @skipOnRevaMaster
     Examples:
-      | dav_version |
-      | spaces      |
+      | dav-path-version |
+      | spaces           |
 
 
   Scenario Outline: attempt to upload a file into a nonexistent folder within correctly received share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
@@ -46,13 +46,13 @@ Feature: upload file
     Then as "Brian" folder "/Shares/FOLDER/nonExistentFolder" should not exist
     And as "Brian" file "/Shares/FOLDER/nonExistentFolder/textfile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: attempt to upload a file into a nonexistent folder within correctly received read only share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read"
@@ -61,6 +61,6 @@ Feature: upload file
     Then as "Brian" folder "/Shares/FOLDER/nonExistentFolder" should not exist
     And as "Brian" file "/Shares/FOLDER/nonExistentFolder/textfile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature
@@ -12,7 +12,7 @@ Feature: upload file to shared folder
 
 
   Scenario Outline: uploading file to a received share folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -20,13 +20,13 @@ Feature: upload file to shared folder
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: uploading file to a user read/write share folder works
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "change"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -34,13 +34,13 @@ Feature: upload file to shared folder
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: uploading a file into a group share as share receiver
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/FOLDER"
@@ -50,13 +50,13 @@ Feature: upload file to shared folder
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: overwrite file to a received share folder
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "original content" to "/FOLDER/textfile.txt"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
@@ -65,26 +65,26 @@ Feature: upload file to shared folder
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "overwritten content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: attempt to upload a file into a folder within correctly received read only share
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Brian" file "/Shares/FOLDER/textfile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: upload a file to shared folder with checksum should return the checksum in the propfind for sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -97,13 +97,13 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964 MD5:827ccb0eea8a706c4c34a16891f84e7b ADLER32:02f80100"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: upload a file to shared folder with checksum should return the checksum in the download header for sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -116,13 +116,13 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer shares a file with correct checksum should return the checksum in the propfind for sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -134,13 +134,13 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964 MD5:827ccb0eea8a706c4c34a16891f84e7b ADLER32:02f80100"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer shares a file with correct checksum should return the checksum in the download header for sharee
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -152,13 +152,13 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharee uploads a file to a received share folder with correct checksum
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -172,13 +172,13 @@ Feature: upload file to shared folder
     And as "Alice" file "/FOLDER/textFile.txt" should exist
     And the content of file "/FOLDER/textFile.txt" for user "Alice" should be "uploaded content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharee uploads a file to a received share folder with wrong checksum should not work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -191,13 +191,13 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "406"
     And as "Alice" file "/FOLDER/textFile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer uploads a file to shared folder with wrong correct checksum should not work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -210,13 +210,13 @@ Feature: upload file to shared folder
     And as "Alice" file "/FOLDER/textFile.txt" should not exist
     And as "Brian" file "/Shares/FOLDER/textFile.txt" should not exist
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer uploads a chunked file with correct checksum and share it with sharee should work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -228,13 +228,13 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "200"
     And the content of file "/Shares/textFile.txt" for user "Brian" should be "0123456789"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharee uploads a chunked file with correct checksum to a received share folder should work
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
@@ -249,13 +249,13 @@ Feature: upload file to shared folder
     And as "Alice" file "/FOLDER/textFile.txt" should exist
     And the content of file "/FOLDER/textFile.txt" for user "Alice" should be "0123456789"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer uploads a file with checksum and as a sharee overwrites the shared file with new data and correct checksum
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 16                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -270,13 +270,13 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "204"
     And the content of file "/textFile.txt" for user "Alice" should be "overwritten content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: sharer uploads a file with checksum and as a sharee overwrites the shared file with new data and invalid checksum
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 16                        |
       #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
@@ -291,6 +291,6 @@ Feature: upload file to shared folder
     Then the HTTP status code should be "406"
     And the content of file "/textFile.txt" for user "Alice" should be "original content"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |

--- a/tests/parallelDeployAcceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/parallelDeployAcceptance/features/apiWebdavOperations/downloadFile.feature
@@ -12,24 +12,24 @@ Feature: download file
 
   Scenario Outline: download a file
     Given using "ocis" as owncloud selector
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" downloads file "textfile.txt" using the WebDAV API
     Then the downloaded content should be "ownCloud test text file"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: download a file with range
     Given using "ocis" as owncloud selector
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" downloads file "textfile.txt" with range "bytes=0-7" using the WebDAV API
     Then the downloaded content should be "ownCloud"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario: Get the size of a file
@@ -40,74 +40,74 @@ Feature: download file
 
 
   Scenario Outline: Download a file with comma in the filename
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "file with comma in filename" to <filename>
     And using "ocis" as owncloud selector
     When user "Alice" downloads file <filename> using the WebDAV API
     Then the downloaded content should be "file with comma in filename"
     Examples:
-      | dav_version | filename       |
-      | old         | "sample,1.txt" |
-      | old         | ",,,.txt"      |
-      | old         | ",,,.,"        |
-      | new         | "sample,1.txt" |
-      | new         | ",,,.txt"      |
-      | new         | ",,,.,"        |
+      | dav-path-version | filename       |
+      | old              | "sample,1.txt" |
+      | old              | ",,,.txt"      |
+      | old              | ",,,.,"        |
+      | new              | "sample,1.txt" |
+      | new              | ",,,.txt"      |
+      | new              | ",,,.,"        |
 
 
   Scenario Outline: download a file with single part ranges
     Given using "ocis" as owncloud selector
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" downloads file "textfile.txt" with range "bytes=0-7" using the WebDAV API
     Then the HTTP status code should be "206"
     And the following headers should be set
-      | header         | value         |
-      | Content-Length | 8             |
-      | Content-Range  | bytes 0-7/23  |
+      | header         | value        |
+      | Content-Length | 8            |
+      | Content-Range  | bytes 0-7/23 |
     And the downloaded content should be "ownCloud"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: download a file with last byte range out of bounds
     Given using "ocis" as owncloud selector
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" downloads file "textfile.txt" with range "bytes=0-24" using the WebDAV API
     Then the HTTP status code should be "206"
     And the downloaded content should be "ownCloud test text file"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: download a range at the end of a file
     Given using "ocis" as owncloud selector
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" downloads file "textfile.txt" with range "bytes=-4" using the WebDAV API
     Then the HTTP status code should be "206"
     And the downloaded content should be "file"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: download a file with range out of bounds
     Given using "ocis" as owncloud selector
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" downloads file "textfile.txt" with range "bytes=24-30" using the WebDAV API
     Then the HTTP status code should be "416"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: download a hidden file
-    Given using <dav_version> DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded the following files with content "hidden file"
       | path                |
@@ -121,17 +121,17 @@ Feature: download file
     Then the HTTP status code should be "200"
     And the downloaded content should be "hidden file"
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
   Scenario Outline: Downloading a file should serve security headers
     Given using "ocis" as owncloud selector
-    And using <dav_version> DAV path
+    And using <dav-path-version> DAV path
     When user "Alice" downloads file "textfile.txt" using the WebDAV API
     Then the following headers should be set
-      | header                            | value                                                              | 
+      | header                            | value                                                              |
       | Content-Disposition               | attachment; filename*=UTF-8''textfile.txt; filename="textfile.txt" |
       | Content-Security-Policy           | default-src 'none';                                                |
       | X-Content-Type-Options            | nosniff                                                            |
@@ -141,6 +141,6 @@ Feature: download file
       | X-Robots-Tag                      | none                                                               |
       | X-XSS-Protection                  | 1; mode=block                                                      |
     Examples:
-      | dav_version |
-      | old         |
-      | new         |
+      | dav-path-version |
+      | old              |
+      | new              |


### PR DESCRIPTION

## Description
This PR refactors the feature files text so that everywhere the word "dav-path-version" is coherent rather than using different variations of that phrase. 

## Related Issue
- Part of <https://github.com/owncloud/ocis/issues/5337>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally:
- ci:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
