### PR TITLE
[tests-only][full-ci]Add test for search restored files using content

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -189,6 +189,7 @@ default:
         - CapabilitiesContext:
         - FilesVersionsContext:
         - OCSContext:
+        - TrashbinContext:
 
   extensions:
     rdx\behatvars\BehatVariablesExtension: ~

--- a/tests/acceptance/features/apiFullTextSearch/search.feature
+++ b/tests/acceptance/features/apiFullTextSearch/search.feature
@@ -66,3 +66,20 @@ Feature: full text search
       | old              |
       | new              |
       | spaces           |
+
+
+  Scenario Outline: search restored files by content
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created folder "uploadFolder"
+    And user "Alice" has uploaded file with content "hello world from nepal" to "keywordAtStart.txt"
+    And user "Alice" has deleted file "keywordAtStart.txt"
+    And user "Alice" has restored the file with original path "keywordAtStart.txt"
+    When user "Alice" searches for "Content:hello" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these files:
+      | keywordAtStart.txt  |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |


### PR DESCRIPTION
## Description
This PR adds the API tests for search restored files through a tag. The scenarios added in this PR are
- search restored files using a content

## Related Issue
- https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
- there was no test coverage for api test for search restored files through a content. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
