### PR TITLE
Provide Search filter for locations

### DIFF
--- a/changelog/unreleased/enhancement-add-search-filter-for-location.md
+++ b/changelog/unreleased/enhancement-add-search-filter-for-location.md
@@ -1,0 +1,8 @@
+Enhancement: Provide Search filter for locations
+
+The search result REPORT response now can be restricted the by the current folder via api (recursive)
+The scope needed for "current folder" (default is to search all available spaces) - part of the oc:pattern:"scope:<uuid>
+/Test"
+
+https://github.com/owncloud/ocis/pull/6713
+OCIS-3705

--- a/services/search/pkg/engine/bleve.go
+++ b/services/search/pkg/engine/bleve.go
@@ -162,8 +162,10 @@ func (b *Bleve) Search(_ context.Context, sir *searchService.SearchIndexRequest)
 	}
 
 	matches := make([]*searchMessage.Match, 0, len(res.Hits))
+	totalMatches := res.Total
 	for _, hit := range res.Hits {
 		if sir.Ref != nil && !strings.HasPrefix(getFieldValue[string](hit.Fields, "Path"), utils.MakeRelativePath(path.Join(sir.Ref.Path, "/"))) {
+			totalMatches--
 			continue
 		}
 
@@ -206,7 +208,7 @@ func (b *Bleve) Search(_ context.Context, sir *searchService.SearchIndexRequest)
 
 	return &searchService.SearchIndexResponse{
 		Matches:      matches,
-		TotalMatches: int32(res.Total),
+		TotalMatches: int32(totalMatches),
 	}, nil
 }
 

--- a/services/search/pkg/search/search.go
+++ b/services/search/pkg/search/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -13,12 +14,15 @@ import (
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	searchmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/search/v0"
 	"github.com/owncloud/ocis/v2/services/search/pkg/engine"
 	"google.golang.org/grpc/metadata"
 )
+
+var scopeRegex = regexp.MustCompile(`scope:\s*([^" "\n\r]*)`)
 
 // ResolveReference makes sure the path is relative to the space root
 func ResolveReference(ctx context.Context, ref *provider.Reference, ri *provider.ResourceInfo, gatewaySelector pool.Selectable[gateway.GatewayAPIClient]) (*provider.Reference, error) {
@@ -154,4 +158,29 @@ func convertToWebDAVPermissions(isShared, isMountpoint, isDir bool, p *provider.
 		fmt.Fprintf(&b, "CK")
 	}
 	return b.String()
+}
+
+func extractScope(path string) (*searchmsg.Reference, error) {
+	ref, err := storagespace.ParseReference(path)
+	if err != nil {
+		return nil, err
+	}
+	return &searchmsg.Reference{
+		ResourceId: &searchmsg.ResourceID{
+			StorageId: ref.ResourceId.StorageId,
+			SpaceId:   ref.ResourceId.SpaceId,
+			OpaqueId:  ref.ResourceId.OpaqueId,
+		},
+		Path: ref.GetPath(),
+	}, nil
+}
+
+// ParseScope extract a scope value from the query string and returns search, scope strings
+func ParseScope(query string) (string, string) {
+	match := scopeRegex.FindStringSubmatch(query)
+	if len(match) >= 2 {
+		cut := match[0]
+		return strings.TrimSpace(strings.ReplaceAll(query, cut, "")), strings.TrimSpace(match[1])
+	}
+	return query, ""
 }

--- a/services/search/pkg/search/search.go
+++ b/services/search/pkg/search/search.go
@@ -160,13 +160,13 @@ func convertToWebDAVPermissions(isShared, isMountpoint, isDir bool, p *provider.
 	return b.String()
 }
 
-func extractScope(path string) (*searchmsg.Reference, error) {
+func extractScope(path string) (*provider.Reference, error) {
 	ref, err := storagespace.ParseReference(path)
 	if err != nil {
 		return nil, err
 	}
-	return &searchmsg.Reference{
-		ResourceId: &searchmsg.ResourceID{
+	return &provider.Reference{
+		ResourceId: &provider.ResourceId{
 			StorageId: ref.ResourceId.StorageId,
 			SpaceId:   ref.ResourceId.SpaceId,
 			OpaqueId:  ref.ResourceId.OpaqueId,

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -72,10 +72,31 @@ func NewService(gatewaySelector pool.Selectable[gateway.GatewayAPIClient], eng e
 
 // Search processes a search request and passes it down to the engine.
 func (s *Service) Search(ctx context.Context, req *searchsvc.SearchRequest) (*searchsvc.SearchResponse, error) {
-	if req.Query == "" {
+	s.logger.Debug().Str("query", req.Query).Msg("performing a search")
+	query, scope := ParseScope(req.Query)
+	if query == "" {
 		return nil, errtypes.BadRequest("empty query provided")
 	}
-	s.logger.Debug().Str("query", req.Query).Msg("performing a search")
+	req.Query = query
+	var filters []*provider.ListStorageSpacesRequest_Filter
+	if len(scope) > 0 {
+		scopeRef, err := extractScope(scope)
+		if err != nil {
+			return nil, err
+		}
+		if req.Ref == nil {
+			req.Ref = scopeRef
+		}
+		req.Ref.Path = scopeRef.GetPath()
+		if scopeRef.GetResourceId().OpaqueId != "" {
+			filters = []*provider.ListStorageSpacesRequest_Filter{
+				{
+					Type: provider.ListStorageSpacesRequest_Filter_TYPE_ID,
+					Term: &provider.ListStorageSpacesRequest_Filter_Id{Id: &provider.StorageSpaceId{OpaqueId: scopeRef.GetResourceId().OpaqueId}},
+				},
+			}
+		}
+	}
 
 	gatewayClient, err := s.gatewaySelector.Next()
 	if err != nil {
@@ -84,18 +105,17 @@ func (s *Service) Search(ctx context.Context, req *searchsvc.SearchRequest) (*se
 
 	currentUser := revactx.ContextMustGetUser(ctx)
 
-	listSpacesRes, err := gatewayClient.ListStorageSpaces(ctx, &provider.ListStorageSpacesRequest{
-		Filters: []*provider.ListStorageSpacesRequest_Filter{
-			{
-				Type: provider.ListStorageSpacesRequest_Filter_TYPE_USER,
-				Term: &provider.ListStorageSpacesRequest_Filter_User{User: currentUser.GetId()},
-			},
-			{
-				Type: provider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE,
-				Term: &provider.ListStorageSpacesRequest_Filter_SpaceType{SpaceType: "+grant"},
-			},
+	filters = append(filters, []*provider.ListStorageSpacesRequest_Filter{
+		{
+			Type: provider.ListStorageSpacesRequest_Filter_TYPE_USER,
+			Term: &provider.ListStorageSpacesRequest_Filter_User{User: currentUser.GetId()},
 		},
-	})
+		{
+			Type: provider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE,
+			Term: &provider.ListStorageSpacesRequest_Filter_SpaceType{SpaceType: "+grant"},
+		},
+	}...)
+	listSpacesRes, err := gatewayClient.ListStorageSpaces(ctx, &provider.ListStorageSpacesRequest{Filters: filters})
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to list the user's storage spaces")
 		return nil, err
@@ -229,7 +249,7 @@ func (s *Service) searchIndex(ctx context.Context, req *searchsvc.SearchRequest,
 		rootName         string
 		permissions      *provider.ResourcePermissions
 	)
-	mountpointPrefix := ""
+	mountpointPrefix := req.GetRef().GetPath()
 	switch space.SpaceType {
 	case "mountpoint":
 		return nil, errSkipSpace // mountpoint spaces are only "links" to the shared spaces. we have to search the shared "grant" space instead

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -88,9 +88,9 @@ func (s *Service) Search(ctx context.Context, req *searchsvc.SearchRequest) (*se
 	}
 	req.Query = query
 	if len(scope) > 0 {
-		if req.Ref != nil {
-			return nil, errtypes.BadRequest("cannot scope a search that is limited to a resource")
-		}
+		// if req.Ref != nil {
+		// 	return nil, errtypes.BadRequest("cannot scope a search that is limited to a resource")
+		// }
 		scopeRef, err := extractScope(scope)
 		if err != nil {
 			return nil, err

--- a/services/search/pkg/search/service_test.go
+++ b/services/search/pkg/search/service_test.go
@@ -391,3 +391,51 @@ var _ = Describe("Searchprovider", func() {
 		})
 	})
 })
+
+var _ = DescribeTable("Parse Scope",
+	func(pattern, wantSearch, wantScope string) {
+		gotSearch, gotScope := search.ParseScope(pattern)
+		Expect(gotSearch).To(Equal(wantSearch))
+		Expect(gotScope).To(Equal(wantScope))
+	},
+	Entry("When scope is at the end of the line",
+		`+Name:*file* +Tags:&quot;foo&quot; scope:<uuid>/folder/subfolder`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the end of the line 2",
+		`+Name:*file* +Tags:&quot;foo&quot; scope:<uuid>/folder`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`<uuid>/folder`,
+	),
+	Entry("When scope is at the end of the line 3",
+		`file scope:<uuid>/folder/subfolder`,
+		`file`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the end of the line with a space",
+		`+Name:*file* +Tags:&quot;foo&quot; scope: <uuid>/folder/subfolder`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is in the middle of the line",
+		`+Name:*file* scope:<uuid>/folder/subfolder +Tags:&quot;foo&quot;`,
+		`+Name:*file*  +Tags:&quot;foo&quot;`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the end of the line",
+		`scope:<uuid>/folder/subfolder +Name:*file*`,
+		`+Name:*file*`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When scope is at the begging of the line",
+		`scope:<uuid>/folder/subfolder file`,
+		`file`,
+		`<uuid>/folder/subfolder`,
+	),
+	Entry("When no scope",
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		`+Name:*file* +Tags:&quot;foo&quot;`,
+		``,
+	),
+)

--- a/services/search/pkg/search/service_test.go
+++ b/services/search/pkg/search/service_test.go
@@ -53,9 +53,10 @@ var _ = Describe("Searchprovider", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: "storageid$personalspace!personalspace"},
-			Root: &sprovider.ResourceId{StorageId: "storageid", SpaceId: "personalspace", OpaqueId: "personalspace"},
-			Name: "personalspace",
+			Id:        &sprovider.StorageSpaceId{OpaqueId: "storageid$personalspace!personalspace"},
+			Root:      &sprovider.ResourceId{StorageId: "storageid", SpaceId: "personalspace", OpaqueId: "personalspace"},
+			Name:      "personalspace",
+			SpaceType: "personal",
 		}
 
 		ri = &sprovider.ResourceInfo{
@@ -94,10 +95,6 @@ var _ = Describe("Searchprovider", func() {
 			Status: status.NewOK(ctx),
 			Token:  "authtoken",
 		}, nil)
-		gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
-			Status: status.NewOK(context.Background()),
-			Info:   ri,
-		}, nil)
 		gatewayClient.On("GetPath", mock.Anything, mock.MatchedBy(func(req *sprovider.GetPathRequest) bool {
 			return req.ResourceId.OpaqueId == ri.Id.OpaqueId
 		})).Return(&sprovider.GetPathResponse{
@@ -123,7 +120,10 @@ var _ = Describe("Searchprovider", func() {
 			extractor.On("Extract", mock.Anything, mock.Anything, mock.Anything).Return(content.Document{}, nil)
 			indexClient.On("Upsert", mock.Anything, mock.Anything).Return(nil)
 			indexClient.On("Search", mock.Anything, mock.Anything).Return(&searchsvc.SearchIndexResponse{}, nil)
-
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
+				Status: status.NewOK(context.Background()),
+				Info:   ri,
+			}, nil)
 			err := s.IndexSpace(&sprovider.StorageSpaceId{OpaqueId: "storageid$spaceid!spaceid"}, user.Id)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -167,6 +167,10 @@ var _ = Describe("Searchprovider", func() {
 						},
 					},
 				}, nil)
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
+					Status: status.NewOK(context.Background()),
+					Info:   ri,
+				}, nil)
 			})
 
 			It("does not mess with field-based searches", func() {
@@ -183,6 +187,75 @@ var _ = Describe("Searchprovider", func() {
 				res, err := s.Search(ctx, &searchsvc.SearchRequest{
 					Query: "foo",
 				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).ToNot(BeNil())
+				Expect(res.TotalMatches).To(Equal(int32(1)))
+				Expect(len(res.Matches)).To(Equal(1))
+				match := res.Matches[0]
+				Expect(match.Entity.Id.OpaqueId).To(Equal("foo-id"))
+				Expect(match.Entity.Name).To(Equal("Foo.pdf"))
+				Expect(match.Entity.Ref.ResourceId.OpaqueId).To(Equal(personalSpace.Root.OpaqueId))
+				Expect(match.Entity.Ref.Path).To(Equal("./path/to/Foo.pdf"))
+			})
+		})
+
+		Context("with a personal space with a filter", func() {
+			BeforeEach(func() {
+				gatewayClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(&sprovider.ListStorageSpacesResponse{
+					Status:        status.NewOK(ctx),
+					StorageSpaces: []*sprovider.StorageSpace{personalSpace},
+				}, nil)
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
+					Status: status.NewOK(context.Background()),
+					Info: &sprovider.ResourceInfo{
+						Space: &sprovider.StorageSpace{Root: &sprovider.ResourceId{
+							StorageId: "storageid",
+							SpaceId:   "personalspace",
+							OpaqueId:  "personalspace",
+						}},
+					},
+				}, nil)
+				gatewayClient.On("GetPath", mock.Anything, mock.Anything).Return(&sprovider.GetPathResponse{
+					Status: status.NewOK(ctx),
+					Path:   "/path",
+				}, nil)
+				indexClient.On("Search", mock.Anything, mock.Anything).Return(&searchsvc.SearchIndexResponse{
+					TotalMatches: 1,
+					Matches: []*searchmsg.Match{
+						{
+							Score: 1,
+							Entity: &searchmsg.Entity{
+								Ref: &searchmsg.Reference{
+									ResourceId: &searchmsg.ResourceID{
+										StorageId: personalSpace.Root.StorageId,
+										SpaceId:   personalSpace.Root.SpaceId,
+										OpaqueId:  personalSpace.Root.OpaqueId,
+									},
+									Path: "./path/to/Foo.pdf",
+								},
+								Id: &searchmsg.ResourceID{
+									StorageId: personalSpace.Root.StorageId,
+									OpaqueId:  "foo-id",
+								},
+								Name: "Foo.pdf",
+							},
+						},
+					},
+				}, nil)
+			})
+
+			It("searches the personal user space", func() {
+				res, err := s.Search(ctx, &searchsvc.SearchRequest{
+					Query: "foo scope:storageid$personalspace!personalspace/path",
+					Ref: &searchmsg.Reference{
+						ResourceId: &searchmsg.ResourceID{
+							StorageId: "storageid",
+							SpaceId:   "personalspace",
+							OpaqueId:  "personalspace",
+						},
+					},
+				})
+
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
 				Expect(res.TotalMatches).To(Equal(int32(1)))
@@ -223,6 +296,10 @@ var _ = Describe("Searchprovider", func() {
 						},
 					},
 				}
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
+					Status: status.NewOK(context.Background()),
+					Info:   ri,
+				}, nil)
 				gatewayClient.On("GetPath", mock.Anything, mock.Anything).Return(&sprovider.GetPathResponse{
 					Status: status.NewOK(ctx),
 					Path:   "/grant/path",


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Enhancement: [ocis] Provide Search filter for locations OCIS-3705

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 Acceptance Criteria
- provide possibility for the client to restrict the search to the current folder via api (recursive)
- scope needed for "current folder" (default is to search all available spaces) - part of the `oc-pattern:"scope:<uuid>/Test"`
- search service only retruns results in the given scope
- API call is documented in dev docs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Local
- test case 1:  
1.1 Login as admin; go to the Personal; create the file 'testfile.txt'; create the folder 'nfolder' and create inside the file 'newfile.txt'.
1.2 Call the API by name and location `<oc:pattern>file scope:storage-users-1$some-admin-user-id-0000-000000000000!some-admin-user-id-0000-000000000000/nfolder</oc:pattern>` have to return only the 'newfile.txt' as a search result.
Request:
```bash
curl 'https://localhost:9200/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000' \
  -X 'REPORT' \
  --data-raw $'<?xml version="1.0"?>\n<oc:search-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n  <d:prop>\n    <oc:permissions />\n    <oc:favorite />\n    <oc:fileid />\n    <oc:file-parent />\n    <oc:name />\n    <oc:owner-id />\n    <oc:owner-display-name />\n    <oc:shareid />\n    <oc:shareroot />\n    <oc:share-types />\n    <oc:privatelink />\n    <d:getcontentlength />\n    <oc:size />\n    <d:getlastmodified />\n    <d:getetag />\n    <d:getcontenttype />\n    <d:resourcetype />\n    <oc:downloadURL />\n    <oc:tags />\n  </d:prop>\n  <oc:search>\n    <oc:pattern>file scope:storage-users-1$some-admin-user-id-0000-000000000000/nfolder</oc:pattern>\n    <oc:limit>8</oc:limit>\n  </oc:search>\n</oc:search-files>' \
  -ik \
  -uadmin:admin
```
Response:
```bash
HTTP/1.1 207 Multi-Status
Cache-Control: no-cache, no-store, max-age=0, must-revalidate, value
Content-Length: 916
Content-Range: rows 0-0/7
Content-Security-Policy: frame-ancestors 'none'
Content-Type: application/xml; charset=utf-8
Date: Fri, 07 Jul 2023 09:24:15 GMT
Dav: 1, 3, extended-mkcol
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Last-Modified: Fri, 07 Jul 2023 09:24:15 GMT
Vary: Origin
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Webdav-Version: 3.1.0-next.2+dev

<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:response><d:href>/remote.php/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000/newfile.txt</d:href><d:propstat><d:prop><oc:fileid>storage-users-1$some-admin-user-id-0000-000000000000!6531b70d-fe7d-45d2-85ed-c9f70bd553e8</oc:fileid><oc:file-parent>storage-users-1$some-admin-user-id-0000-000000000000!80fcf9f6-2ed2-40cc-b12a-db170576d3c4</oc:file-parent><oc:name>newfile.txt</oc:name><d:getlastmodified>2023-06-27T09:38:14Z</d:getlastmodified><d:getcontenttype>text/plain</d:getcontenttype><oc:permissions>RDNVW</oc:permissions><oc:highlights></oc:highlights><oc:tags></oc:tags><d:getetag></d:getetag><d:resourcetype></d:resourcetype><d:getcontentlength>3</d:getcontentlength><oc:score>0.19501826167106628</oc:score></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>%
```
2. Search in the Shares
2.1 Admin shared the folder with Einstein and this folder contains a subfolder.
The search request will be:
`curl 'https://localhost:9200/dav/spaces/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!storage-users-1:some-admin-user-id-0000-000000000000:7abb7cb0-8dc8-4011-b485-3e5b816a136b/' \
  -X 'REPORT' \
  --data-raw $'<?xml version="1.0"?>\n<oc:search-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n  <d:prop>\n    <oc:permissions />\n    <oc:favorite />\n    <oc:fileid />\n    <oc:file-parent />\n    <oc:name />\n    <oc:owner-id />\n    <oc:owner-display-name />\n    <oc:shareid />\n    <oc:shareroot />\n    <oc:share-types />\n    <oc:privatelink />\n    <d:getcontentlength />\n    <oc:size />\n    <d:getlastmodified />\n    <d:getetag />\n    <d:getcontenttype />\n    <d:resourcetype />\n    <oc:downloadURL />\n    <oc:tags />\n  </d:prop>\n  <oc:search>\n    <oc:pattern>file scope:a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!storage-users-1:some-admin-user-id-0000-000000000000:7abb7cb0-8dc8-4011-b485-3e5b816a136b/subfolder</oc:pattern>\n    <oc:limit>8</oc:limit>\n  </oc:search>\n</oc:search-files>' \
  -ik \
  -ueinstein:relativity`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
