### PR TITLE
[tests-only][full-ci]refactor for Intermittent test failures on coreApiTrashbin/trashbinDelete.feature

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -231,6 +231,7 @@ class TrashbinContext implements Context {
 			'trash-bin',
 			$davPathVersion
 		);
+		$this->featureContext->setResponse($response);
 		$responseXml = HttpRequestHelper::getResponseXml(
 			$response,
 			__METHOD__ . " $collectionPath"
@@ -714,10 +715,7 @@ class TrashbinContext implements Context {
 	 * @throws Exception
 	 */
 	private function isInTrash(?string $user, ?string $originalPath):bool {
-		$res = $this->featureContext->getResponse();
 		$listing = $this->listTrashbinFolder($user);
-
-		$this->featureContext->setResponse($res);
 
 		// we don't care if the test step writes a leading "/" or not
 		$originalPath = \ltrim($originalPath, '/');
@@ -981,8 +979,11 @@ class TrashbinContext implements Context {
 		?string $originalPath
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
+		$result = $this->isInTrash($user, $originalPath);
+		$actualStatus = $this->featureContext->getResponse()->getStatusCode();
+		Assert::assertEquals(207, $actualStatus, "Expected status code to be '207', but got '$actualStatus'");
 		Assert::assertTrue(
-			$this->isInTrash($user, $originalPath),
+			$result,
 			"File previously located at $originalPath wasn't found in the trashbin of user $user"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -231,10 +231,10 @@ class TrashbinContext implements Context {
 			'trash-bin',
 			$davPathVersion
 		);
-        $response->getBody()->rewind();
-        $statusCode = $response->getStatusCode();
-        $respBody = $response->getBody()->getContents();
-        Assert::assertEquals("207",$statusCode,"Expected status code to be '207' but got $statusCode \nResponse\n$respBody");
+		$response->getBody()->rewind();
+		$statusCode = $response->getStatusCode();
+		$respBody = $response->getBody()->getContents();
+		Assert::assertEquals("207", $statusCode, "Expected status code to be '207' but got $statusCode \nResponse\n$respBody");
 
 		$responseXml = HttpRequestHelper::getResponseXml(
 			$response,
@@ -243,17 +243,17 @@ class TrashbinContext implements Context {
 
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);
 
-        //set endpoint for according to dav path
-        $endpoint = "/remote.php/dav/trash-bin/$user";
-        if($this->featureContext->getDavPathVersion() === 3){
-            $space_id = (WebDavHelper::$SPACE_ID_FROM_OCIS) ?: WebDavHelper::getPersonalSpaceIdForUser(
-                $this->featureContext->getBaseUrl(),
-                $user,
-                $this->featureContext->getPasswordForUser($user),
-                $this->featureContext->getStepLineRef()
-            );
-            $endpoint = "/remote.php/dav/spaces/trash-bin/$space_id";
-        }
+		//set endpoint for according to dav path
+		$endpoint = "/remote.php/dav/trash-bin/$user";
+		if ($this->featureContext->getDavPathVersion() === 3) {
+			$space_id = (WebDavHelper::$SPACE_ID_FROM_OCIS) ?: WebDavHelper::getPersonalSpaceIdForUser(
+				$this->featureContext->getBaseUrl(),
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				$this->featureContext->getStepLineRef()
+			);
+			$endpoint = "/remote.php/dav/spaces/trash-bin/$space_id";
+		}
 
 		// filter out the collection itself, we only want to return the members
 		$files = \array_filter(
@@ -997,7 +997,7 @@ class TrashbinContext implements Context {
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
 		Assert::assertTrue(
-            $this->isInTrash($user, $originalPath),
+			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath wasn't found in the trashbin of user $user"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -243,7 +243,7 @@ class TrashbinContext implements Context {
 
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);
 
-		//set endpoint for according to dav path
+		//set endpoint according to webdav request (1 = old, 2 = new, 3 = spaces)
 		$endpoint = "/remote.php/dav/trash-bin/$user";
 		if ($this->featureContext->getDavPathVersion() === 3) {
 			$space_id = (WebDavHelper::$SPACE_ID_FROM_OCIS) ?: WebDavHelper::getPersonalSpaceIdForUser(

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -243,9 +243,9 @@ class TrashbinContext implements Context {
 
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);
 
-		//set endpoint according to webdav request (1 = old, 2 = new, 3 = spaces)
+		// set endpoint according to webdav request (2 = new, 3 = spaces)
 		$endpoint = "/remote.php/dav/trash-bin/$user";
-		if ($this->featureContext->getDavPathVersion() === 3) {
+		if ($davPathVersion === 3) {
 			$space_id = (WebDavHelper::$SPACE_ID_FROM_OCIS) ?: WebDavHelper::getPersonalSpaceIdForUser(
 				$this->featureContext->getBaseUrl(),
 				$user,


### PR DESCRIPTION
## Description
This PR  addresses this issue: https://github.com/owncloud/ocis/issues/6628
Findings:
- Passes locally (reproducing locally is not possible)
- status code is checked after when step but following steps also calls api for listing trashbin where status is not checked
So asserting is added to check the status code after listing trashbin api call which returns 207 and also returning response on failing assertion if this intermittent test failure is encountered again.
Also filtering the response according to the wevdav request (note: there is no endpoint for trashbin in old dav version)

## Related Issue
https://github.com/owncloud/ocis/issues/6628

## Motivation and Context
to solve https://github.com/owncloud/ocis/issues/6628

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
