### PR TITLE
Use the owner auth to get the path of shared resources

### DIFF
--- a/changelog/unreleased/fix-searching-shares.md
+++ b/changelog/unreleased/fix-searching-shares.md
@@ -1,0 +1,5 @@
+Bugfix: Fix search shares
+
+We fixed a problem where searching shares did not yield results when the resource was not shared from the space root.
+
+https://github.com/owncloud/ocis/pull/6741

--- a/services/search/pkg/search/service.go
+++ b/services/search/pkg/search/service.go
@@ -246,7 +246,12 @@ func (s *Service) searchIndex(ctx context.Context, req *searchsvc.SearchRequest,
 			return nil, err
 		}
 
-		gpRes, err := gatewayClient.GetPath(ctx, &provider.GetPathRequest{
+		ownerCtx, err := getAuthContext(&user.User{Id: space.Owner.Id}, s.gatewaySelector, s.secret, s.logger)
+		if err != nil {
+			return nil, err
+		}
+
+		gpRes, err := gatewayClient.GetPath(ownerCtx, &provider.GetPathRequest{
 			ResourceId: space.Root,
 		})
 		if err != nil {


### PR DESCRIPTION
This fixes searching received shares that were not shared from the space root.