### PR TITLE
Restart Postprocessing

### DIFF
--- a/changelog/unreleased/restart-postprocessing.md
+++ b/changelog/unreleased/restart-postprocessing.md
@@ -1,0 +1,6 @@
+Bugfix: Restart Postprocessing
+
+In case the postprocessing service cannot find the specified upload when restarting postprocessing, it will now send a
+`RestartPostprocessing` event to retrigger complete postprocessing
+
+https://github.com/owncloud/ocis/pull/6726


### PR DESCRIPTION
Fixes ocis postprocessing restart command:
Restarts complete postprocessing pipeline if there is no active postprocessing.

https://github.com/owncloud/ocis/pull/6728 refused to get green