### PR TITLE
[tests-only][full-ci][ci] Wait for fakeoffice to be ready

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -898,6 +898,13 @@ def wopiValidatorTests(ctx, storage, accounts_hash_difficulty = 4):
                              "sh %s/tests/config/drone/serve-hosting-discovery.sh" % (dirs["base"]),
                          ],
                      },
+                     {
+                         "name": "wait-for-fakeoffice",
+                         "image": OC_CI_ALPINE,
+                         "commands": [
+                             "curl -k --fail --retry-connrefused --retry 9 --retry-all-errors 'http://fakeoffice:8080'",
+                         ],
+                     },
                  ] +
                  ocisServer(storage, accounts_hash_difficulty, [], [], "wopi_validator") +
                  [


### PR DESCRIPTION
## Description
Sometimes the wopiValidation pipeline can fail due to the race condition between `fakeoffice` and `ocis-server` steps. This was due to running both steps parallelly. This PR adds the wait for fakeoffice service so that there won't be a race condition between fakeoffice and ocis-server steps.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes https://github.com/owncloud/ocis/issues/6750

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
