### PR TITLE
[docs-only] Clarify the license of ownCloud Infinite Scale binary packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Please always refer to our [Contribution Guidelines](https://github.com/owncloud
 
 ## End User License Agreement
 
-Stable versions of ownCloud Infinite Scale are subject to the [End User License Agreement](https://github.com/owncloud/ocis/blob/master/assets/End-User-License-Agreement-for-ownCloud-Infinite-Scale.pdf).
+Some builds of stable ownCloud Infinite Scale releases provided by ownCloud GmbH are subject to an [End User License Agreement](https://owncloud.com/license-owncloud-infinite-scale/).
 
 ## Copyright
 

--- a/changelog/unreleased/clarify_license.md
+++ b/changelog/unreleased/clarify_license.md
@@ -1,0 +1,5 @@
+Enhancement: Clarify license text in the dev docs 
+
+Explain the usage of the EULA for binary builds.
+
+https://github.com/owncloud/ocis/pull/6755

--- a/docs/ocis/license.md
+++ b/docs/ocis/license.md
@@ -9,6 +9,6 @@ geekdocFilePath: license.md
 
 The source code of the project is licensed under the [Apache 2.0](https://github.com/owncloud/ocis/blob/master/LICENSE) license. For the license of the used libraries you have to check the respective sources.
 
-Stable, supported binary builds of ownCloud Infinte Scale that will be distributed by ownCloud GmbH are covered by a non OSS Freemium License [EULA](https://owncloud.com/license-owncloud-infinite-scale/). This protects additional efforts that ownCloud GmbH is putting into these builds.
+Stable, supported binary builds of ownCloud Infinite Scale that will be distributed by ownCloud GmbH are covered by a non OSS Freemium License [EULA](https://owncloud.com/license-owncloud-infinite-scale/). This protects additional efforts that ownCloud GmbH is putting into these builds.
 
 Since the source code of Infinite Scale is available under free licenses, the free usage can, should and will not be limited in general.

--- a/docs/ocis/license.md
+++ b/docs/ocis/license.md
@@ -7,4 +7,8 @@ geekdocEditPath: edit/master/docs/ocis
 geekdocFilePath: license.md
 ---
 
-This project is licensed under the [Apache 2.0](https://github.com/owncloud/ocis/blob/master/LICENSE) license. For the license of the used libraries you have to check the respective sources.
+The source code of the project is licensed under the [Apache 2.0](https://github.com/owncloud/ocis/blob/master/LICENSE) license. For the license of the used libraries you have to check the respective sources.
+
+Stable, supported binary builds of ownCloud Infinte Scale that will be distributed by ownCloud GmbH are covered by a non OSS Freemium License [EULA](https://owncloud.com/license-owncloud-infinite-scale/). This protects additional efforts that ownCloud GmbH is putting into these builds.
+
+Since the source code of Infinite Scale is available under free licenses, the free usage can, should and will not be limited in general.


### PR DESCRIPTION
Clarification of the license of Infinite Scale, especially the stable binary builds under EULA