### PR TITLE
graph: New 'terminationDate' property on educationSchool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/onsi/gomega v1.27.4
 	github.com/open-policy-agent/opa v0.51.0
 	github.com/orcaman/concurrent-map v1.0.0
-	github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b
+	github.com/owncloud/libre-graph-api-go v1.0.5-0.20230710073250-9e5acb4b5838
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.9
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1384,8 +1384,8 @@ github.com/oracle/oci-go-sdk v24.3.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35uk
 github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HDbW65HOY=
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b h1:65U1jcoFlywV2ZEfkynaw4v4DuS/UJdlyHQYCHB+fYA=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b/go.mod h1:iKdVH6nYpI8RBeK9sjeLfzrPByST6r9d+NG2IJHoJmU=
+github.com/owncloud/libre-graph-api-go v1.0.5-0.20230710073250-9e5acb4b5838 h1:1pS1yRXaUO9vpC2k7X5gAIx+l2qyqX0H86WmRouC9i4=
+github.com/owncloud/libre-graph-api-go v1.0.5-0.20230710073250-9e5acb4b5838/go.mod h1:iKdVH6nYpI8RBeK9sjeLfzrPByST6r9d+NG2IJHoJmU=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -94,6 +94,8 @@ type LDAPEducationConfig struct {
 	SchoolNameAttribute   string `yaml:"school_name_attribute" env:"GRAPH_LDAP_SCHOOL_NAME_ATTRIBUTE" desc:"LDAP Attribute to use for the name of a school."`
 	SchoolNumberAttribute string `yaml:"school_number_attribute" env:"GRAPH_LDAP_SCHOOL_NUMBER_ATTRIBUTE" desc:"LDAP Attribute to use for the number of a school."`
 	SchoolIDAttribute     string `yaml:"school_id_attribute" env:"GRAPH_LDAP_SCHOOL_ID_ATTRIBUTE" desc:"LDAP Attribute to use as the unique id for schools. This should be a stable globally unique ID like a UUID."`
+
+	SchoolTerminationGraceDays int `yaml:"school_termination_min_grace_days" env:"GRAPH_LDAP_SCHOOL_TERMINATION_MIN_GRACE_DAYS" desc:"When setting a 'terminationDate' for a school, require the date to be at least this number of days in the future."`
 }
 
 type Identity struct {

--- a/vendor/github.com/owncloud/libre-graph-api-go/api_education_school.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/api_education_school.go
@@ -470,6 +470,8 @@ func (r ApiDeleteSchoolRequest) Execute() (*http.Response, error) {
 /*
 DeleteSchool Delete school
 
+Deletes a school. A school can only be delete if it has the terminationDate property set. And if that termination Date is in the past.
+
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param schoolId key: id or schoolNumber of school
  @return ApiDeleteSchoolRequest

--- a/vendor/github.com/owncloud/libre-graph-api-go/model_education_school.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/model_education_school.go
@@ -12,6 +12,7 @@ package libregraph
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // EducationSchool Represents a school
@@ -22,6 +23,8 @@ type EducationSchool struct {
 	DisplayName *string `json:"displayName,omitempty"`
 	// School number
 	SchoolNumber *string `json:"schoolNumber,omitempty"`
+	// Date and time at which the service for this organization is scheduled to be terminated
+	TerminationDate NullableTime `json:"terminationDate,omitempty"`
 }
 
 // NewEducationSchool instantiates a new EducationSchool object
@@ -137,6 +140,49 @@ func (o *EducationSchool) SetSchoolNumber(v string) {
 	o.SchoolNumber = &v
 }
 
+// GetTerminationDate returns the TerminationDate field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *EducationSchool) GetTerminationDate() time.Time {
+	if o == nil || o.TerminationDate.Get() == nil {
+		var ret time.Time
+		return ret
+	}
+	return *o.TerminationDate.Get()
+}
+
+// GetTerminationDateOk returns a tuple with the TerminationDate field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *EducationSchool) GetTerminationDateOk() (*time.Time, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.TerminationDate.Get(), o.TerminationDate.IsSet()
+}
+
+// HasTerminationDate returns a boolean if a field has been set.
+func (o *EducationSchool) HasTerminationDate() bool {
+	if o != nil && o.TerminationDate.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetTerminationDate gets a reference to the given NullableTime and assigns it to the TerminationDate field.
+func (o *EducationSchool) SetTerminationDate(v time.Time) {
+	o.TerminationDate.Set(&v)
+}
+
+// SetTerminationDateNil sets the value for TerminationDate to be an explicit nil
+func (o *EducationSchool) SetTerminationDateNil() {
+	o.TerminationDate.Set(nil)
+}
+
+// UnsetTerminationDate ensures that no value is present for TerminationDate, not even an explicit nil
+func (o *EducationSchool) UnsetTerminationDate() {
+	o.TerminationDate.Unset()
+}
+
 func (o EducationSchool) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Id != nil {
@@ -147,6 +193,9 @@ func (o EducationSchool) MarshalJSON() ([]byte, error) {
 	}
 	if o.SchoolNumber != nil {
 		toSerialize["schoolNumber"] = o.SchoolNumber
+	}
+	if o.TerminationDate.IsSet() {
+		toSerialize["terminationDate"] = o.TerminationDate.Get()
 	}
 	return json.Marshal(toSerialize)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1507,7 +1507,7 @@ github.com/opentracing/opentracing-go/log
 # github.com/orcaman/concurrent-map v1.0.0
 ## explicit
 github.com/orcaman/concurrent-map
-# github.com/owncloud/libre-graph-api-go v1.0.5-0.20230512172639-d458ad6b300b
+# github.com/owncloud/libre-graph-api-go v1.0.5-0.20230710073250-9e5acb4b5838
 ## explicit; go 1.13
 github.com/owncloud/libre-graph-api-go
 # github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c


### PR DESCRIPTION
Schools can now have a terminationDate set. Schools can only be deleted if the terminationDate is in the past. Schools without a terminationDate cannot be deleted.

The minimal period that the terminationDate needs be be in the future can be configured using the `GRAPH_LDAP_SCHOOL_TERMINATION_MIN_GRACE_DAYS` setting.

Example:
```
GRAPH_LDAP_SCHOOL_TERMINATION_MIN_GRACE_DAYS=1 ocis/bin/ocis graph server
```

To set a termination date on a school:

```
curl -kv -X 'PATCH'   'https://provisioning.owncloud.test/graph/v1.0/education/schools/1234'  \
    -H 'accept: application/json' \
    -H 'Authorization: Bearer xxxxxxx' \
    -d '{ "terminationDate": "2023-07-12T14:55:00+02:00"}'
```

If that date is before the configured `GRAPH_LDAP_SCHOOL_TERMINATION_MIN_GRACE_DAYS` (or in the past) it will trigger in error:

```
{
  "error": {
    "code": "invalidRequest",
    "innererror": {
      "date": "2023-07-10T14:03:29Z",
      "request-id": "cf85b0d81ec9/IEqeYOI1UV-000005"
    },
    "message": "termination needs to be at least 1 day(s) in the future"
  }
}
```

Trying to delete a school for which the termination date has not passed or is not set will also return an error:

```
curl -k -X 'DELETE'   'https://provisioning.owncloud.test/graph/v1.0/education/schools/1234'  \
    -H 'accept: application/json' \
    -H 'Authorization: Bearer xxxxxxxx' \
```

```
{
  "error": {
    "code": "notAllowed",
    "innererror": {
      "date": "2023-07-10T14:06:27Z",
      "request-id": "cf85b0d81ec9/IEqeYOI1UV-000008"
    },
    "message": "can't delete school before termination date"
  }
}
```