### PR TITLE
[test-only] apiTest. check parentId in the Propfind response

### DIFF
--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -48,8 +48,8 @@ Feature: Propfind test
       | viewer  |               |
 
 
-  Scenario Outline: space member with a different role checks the PROPFIND request of folders in the space
-    Given user "Alice" has created a folder "folderMain/subFolder1/subFolder2" in space "new-space"
+  Scenario Outline: space member with a different role checks the PROPFIND request of the folder in the space
+    Given user "Alice" has created a folder "folderMain" in space "new-space"
     And user "Alice" has shared a space "new-space" with settings:
       | shareWith | Brian  |
       | role      | <role> |
@@ -62,6 +62,18 @@ Feature: Propfind test
       | oc:name        | folderMain        |
       | oc:permissions | <oc_permission>   |
       | oc:size        | 0                 |
+    Examples:
+      | role    | oc_permission |
+      | manager | RDNVCKZP      |
+      | editor  | DNVCK         |
+      | viewer  |               |
+
+
+  Scenario Outline: space member with a different role checks the PROPFIND request of the sub-folder in the space
+    Given user "Alice" has created a folder "folderMain/subFolder1/subFolder2" in space "new-space"
+    And user "Alice" has shared a space "new-space" with settings:
+      | shareWith | Brian  |
+      | role      | <role> |
     When user "Brian" sends PROPFIND request from the space "new-space" to the resource "folderMain/subFolder1/subFolder2" using the WebDAV API
     Then the HTTP status code should be "207"
     And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -46,3 +46,54 @@ Feature: Propfind test
       | manager | RDNVCKZP      |
       | editor  | DNVCK         |
       | viewer  |               |
+
+
+  Scenario Outline: space member with a different role checks the PROPFIND request of folders in the space
+    Given user "Alice" has created a folder "folderMain/subFolder1/subFolder2" in space "new-space"
+    And user "Alice" has shared a space "new-space" with settings:
+      | shareWith | Brian  |
+      | role      | <role> |
+    When user "Brian" sends PROPFIND request from the space "new-space" to the resource "folderMain" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+      | key            | value             |
+      | oc:fileid      | UUIDof:folderMain |
+      | oc:file-parent | UUIDof:new-space  |
+      | oc:name        | folderMain        |
+      | oc:permissions | <oc_permission>   |
+      | oc:size        | 0                 |
+    When user "Brian" sends PROPFIND request from the space "new-space" to the resource "folderMain/subFolder1/subFolder2" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+      | key            | value                                   |
+      | oc:fileid      | UUIDof:folderMain/subFolder1/subFolder2 |
+      | oc:file-parent | UUIDof:folderMain/subFolder1            |
+      | oc:name        | subFolder2                              |
+      | oc:permissions | <oc_permission>                         |
+      | oc:size        | 0                                       |
+    Examples:
+      | role    | oc_permission |
+      | manager | RDNVCKZP      |
+      | editor  | DNVCK         |
+      | viewer  |               |
+
+
+  Scenario Outline: space member with a different role checks the PROPFIND request of the file in the space
+    Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
+    And user "Alice" has shared a space "new-space" with settings:
+      | shareWith | Brian  |
+      | role      | <role> |
+    When user "Brian" sends PROPFIND request from the space "new-space" to the resource "testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+      | key            | value               |
+      | oc:fileid      | UUIDof:testfile.txt |
+      | oc:file-parent | UUIDof:new-space    |
+      | oc:name        | testfile.txt        |
+      | oc:permissions | <oc_permission>     |
+      | oc:size        | 12                  |
+    Examples:
+      | role    | oc_permission |
+      | manager | RDNVWZP       |
+      | editor  | DNVW          |
+      | viewer  |               |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3117,7 +3117,7 @@ class SpacesContext implements Context {
 	 */
 	public function userSendsPropfindRequestToSpace(string $user, string $spaceName, ?string $resource = ""): void {
 		$this->setSpaceIDByName($user, $spaceName);
-		$properties = ['oc:permissions','oc:fileid','oc:share-types','oc:privatelink','d:resourcetype','oc:size','oc:name','d:getcontenttype', 'oc:tags'];
+		$properties = ['oc:permissions','oc:file-parent','oc:fileid','oc:share-types','oc:privatelink','d:resourcetype','oc:size','oc:name','d:getcontenttype', 'oc:tags'];
 		$this->featureContext->setResponse(
 			WebDavHelper::propfind(
 				$this->featureContext->getBaseUrl(),


### PR DESCRIPTION
Related #4727 
- added test to check `parentId` in Propfind response
- tests for checking `parentId` in Report response have already been implemented