### PR TITLE
[test-only] Api test. Checking X-Request-Id in response header

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -202,7 +202,7 @@ class WebDavHelper {
 			throw new InvalidArgumentException('Invalid depth value ' . $folderDepth);
 		}
 		$headers['Depth'] = $folderDepth;
-    $headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
+		$headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		return self::makeDavRequest(
 			$baseUrl,
 			$user,

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -201,7 +201,8 @@ class WebDavHelper {
 		if ($folderDepth !== '0' && $folderDepth !== '1' && $folderDepth !== 'infinity') {
 			throw new InvalidArgumentException('Invalid depth value ' . $folderDepth);
 		}
-		$headers = ['Depth' => $folderDepth];
+		$headers['Depth'] = $folderDepth;
+    $headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		return self::makeDavRequest(
 			$baseUrl,
 			$user,

--- a/tests/acceptance/features/apiContract/copy.feature
+++ b/tests/acceptance/features/apiContract/copy.feature
@@ -1,9 +1,9 @@
-@api 
+@api
 Feature: Copy test
   As a user
   I want to check the PROPFIND response
   So that I can make sure that the response contains all the relevant values
-  
+
 
   Background:
     Given these users have been created with default attributes and without skeleton files:
@@ -22,3 +22,5 @@ Feature: Copy test
     And the following headers should match these regular expressions
       | Oc-Fileid                   | /^[a-f0-9!\$\-]{110}$/ |
       | Access-Control-Allow-Origin | /^[*]{1}$/             |
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -18,6 +18,8 @@ Feature: Propfind test
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
     When user "Alice" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
       | key            | value            |
       | oc:fileid      | UUIDof:new-space |
@@ -34,6 +36,8 @@ Feature: Propfind test
       | role      | <role> |
     When user "Brian" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
       | key            | value            |
       | oc:fileid      | UUIDof:new-space |

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -20,6 +20,8 @@ Feature: REPORT request to Shares space
     And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:SubFolder1    |
@@ -40,6 +42,8 @@ Feature: REPORT request to Shares space
     And user "Alice" has uploaded file with content "Not all those who wander are lost." to "/folderMain/SubFolder1/subFOLDER2/frodo.txt"
     When user "Brian" searches for "frodo.txt" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key                | value                                  |
       | oc:fileid          | UUIDof:SubFolder1/subFOLDER2/frodo.txt |
@@ -59,6 +63,8 @@ Feature: REPORT request to Shares space
     Given using <dav_version> DAV path
     When user "Brian" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the search result should contain "0" entries
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiContract/spacesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesReport.feature
@@ -19,6 +19,8 @@ Feature: REPORT request to project space
     And using new DAV path
     When user "Alice" searches for "testFile.txt" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key                | value               |
       | oc:fileid          | UUIDof:testFile.txt |
@@ -35,6 +37,8 @@ Feature: REPORT request to project space
     And using new DAV path
     When user "Alice" searches for "insideTheFolder.txt" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key                | value                                                       |
       | oc:fileid          | UUIDof:folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
@@ -50,6 +54,8 @@ Feature: REPORT request to project space
     And using new DAV path
     When user "Alice" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:folderMain    |
@@ -64,6 +70,8 @@ Feature: REPORT request to project space
     Given user "Alice" has created a folder "folderMain/sub-folder" in space "findData"
     And using new DAV path
     When user "Alice" searches for "sub" using the WebDAV API
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     Then the HTTP status code should be "207"
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key              | value                        |

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -28,6 +28,8 @@ Feature: Report test
     And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:SubFolder1    |
@@ -47,6 +49,8 @@ Feature: Report test
     And user "Brian" has accepted share "/folderMain" offered by user "Alice"
     When user "Brian" searches for "insideTheFolder.txt" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key                | value                                            |
       | oc:fileid          | UUIDof:SubFolder1/subFOLDER2/insideTheFolder.txt |
@@ -65,4 +69,6 @@ Feature: Report test
       | role      | viewer     |
     When user "Brian" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the following headers should match these regular expressions
+      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     And the search result should contain "0" entries

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -58,6 +58,7 @@ class SearchContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$password = $this->featureContext->getPasswordForUser($user);
+    $headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		$body
 			= "<?xml version='1.0' encoding='utf-8' ?>\n" .
 			"	<oc:search-files xmlns:a='DAV:' xmlns:oc='http://owncloud.org/ns' >\n" .
@@ -83,7 +84,7 @@ class SearchContext implements Context {
 			$password,
 			"REPORT",
 			"/",
-			null,
+			$headers,
 			$this->featureContext->getStepLineRef(),
 			$body,
 			$this->featureContext->getDavPathVersion()

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -58,7 +58,7 @@ class SearchContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$password = $this->featureContext->getPasswordForUser($user);
-    $headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
+		$headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		$body
 			= "<?xml version='1.0' encoding='utf-8' ?>\n" .
 			"	<oc:search-files xmlns:a='DAV:' xmlns:oc='http://owncloud.org/ns' >\n" .

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1655,6 +1655,7 @@ class SpacesContext implements Context {
 	):void {
 		$space = $this->getSpaceByName($user, $fromSpaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName);
+    $headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($fileSource, "/");
 		$this->featureContext->setResponse($this->copyFilesAndFoldersRequest($user, $fullUrl, $headers));
 	}

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1655,7 +1655,7 @@ class SpacesContext implements Context {
 	):void {
 		$space = $this->getSpaceByName($user, $fromSpaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName);
-    $headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
+		$headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($fileSource, "/");
 		$this->featureContext->setResponse($this->copyFilesAndFoldersRequest($user, $fullUrl, $headers));
 	}


### PR DESCRIPTION
related https://github.com/owncloud/ocis/pull/6715

I added checking `X-Request-Id` in response header to the existing contract tests