### PR TITLE
[tests-only][full-ci] Retry ocis startup with ociswrapper

### DIFF
--- a/tests/ociswrapper/cmd/cmd.go
+++ b/tests/ociswrapper/cmd/cmd.go
@@ -31,6 +31,7 @@ func serveCmd() *cobra.Command {
 			// set configs
 			ocisConfig.Set("bin", cmd.Flag("bin").Value.String())
 			ocisConfig.Set("url", cmd.Flag("url").Value.String())
+			ocisConfig.Set("retry", cmd.Flag("retry").Value.String())
 		},
 	}
 
@@ -38,6 +39,7 @@ func serveCmd() *cobra.Command {
 	serveCmd.Flags().SortFlags = false
 	serveCmd.Flags().StringP("bin", "", ocisConfig.Get("bin"), "Full oCIS binary path")
 	serveCmd.Flags().StringP("url", "", ocisConfig.Get("url"), "oCIS server url")
+	serveCmd.Flags().StringP("retry", "", ocisConfig.Get("retry"), "Number of retries to start oCIS server")
 	serveCmd.Flags().StringP("port", "p", wrapperConfig.Get("port"), "Wrapper API server port")
 
 	return serveCmd

--- a/tests/ociswrapper/ocis/config/config.go
+++ b/tests/ociswrapper/ocis/config/config.go
@@ -1,8 +1,9 @@
 package config
 
 var config = map[string]string{
-	"bin": "/usr/bin/ocis",
-	"url": "https://localhost:9200",
+	"bin":   "/usr/bin/ocis",
+	"url":   "https://localhost:9200",
+	"retry": "5",
 }
 
 func Set(key string, value string) {

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"ociswrapper/common"
@@ -16,7 +17,6 @@ import (
 
 var cmd *exec.Cmd
 var retryCount = 0
-var maxRetry = 5
 
 func Start(envMap map[string]any) {
 	if retryCount == 0 {
@@ -57,6 +57,8 @@ func Start(envMap map[string]any) {
 		m := stdoutScanner.Text()
 		fmt.Println(m)
 		retryCount++
+
+		maxRetry, _ := strconv.Atoi(config.Get("retry"))
 		if retryCount <= maxRetry {
 			fmt.Println(fmt.Sprintf("Retry starting oCIS server... (retry %v)", retryCount))
 			// Stop and start again
@@ -71,6 +73,7 @@ func Stop() {
 	if err != nil {
 		log.Panic("Cannot kill oCIS server")
 	}
+	cmd.Wait()
 }
 
 func WaitForConnection() bool {

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -59,6 +59,8 @@ func Start(envMap map[string]any) {
 		retryCount++
 		if retryCount <= maxRetry {
 			fmt.Println(fmt.Sprintf("Retry starting oCIS server... (retry %v)", retryCount))
+			// Stop and start again
+			Stop()
 			Start(envMap)
 		}
 	}
@@ -88,7 +90,7 @@ func WaitForConnection() bool {
 	for {
 		select {
 		case <-timeout:
-			fmt.Println(fmt.Sprintf("Timeout waiting for oCIS server [%f] seconds", timeoutValue.Seconds()))
+			fmt.Println(fmt.Sprintf("%v seconds timeout waiting for oCIS server", int64(timeoutValue.Seconds())))
 			return false
 		default:
 			_, err := client.Get(config.Get("url"))


### PR DESCRIPTION
## Description
While restarting ocis server with ociswrapper during the tests, sometimes the ocis server is not started properly. In order to heal the restarting of ocis server, this PR has implemented starting ocis server with a certain number of retries (current default is `5`). The retries can be configured at the time of running ociswrapper command with `--retry` option.
```bash
ociswrapper serve --bin=/bin/ocis --retry=2
```

## Related Issue
Fixes https://github.com/owncloud/ocis/issues/6751

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
