### PR TITLE
[tests-only][full-ci] Add test coverage for file preview using space dav version

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -946,7 +946,7 @@ def wopiValidatorTests(ctx, storage, accounts_hash_difficulty = 4):
     }
 
 def coreApiTests(ctx, part_number = 1, number_of_parts = 1, storage = "ocis", accounts_hash_difficulty = 4):
-    filterTags = "~@skipOnGraph&&~@skipOnOcis-%s-Storage" % ("OC" if storage == "owncloud" else "OCIS")
+    filterTags = "~@skipOnGraph&&~@skipOnOcis-%s-Storage&&~@skipOnStable3.0" % ("OC" if storage == "owncloud" else "OCIS")
     expectedFailuresFile = "%s/tests/acceptance/expected-failures-API-on-%s-storage.md" % (dirs["base"], storage.upper())
 
     return {

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -209,14 +209,6 @@ cannot share a folder with create permission
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 - [coreApiSharePublicLink1/createPublicLinkShare.feature:327](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L327)
 
-#### [download previews of other users file](https://github.com/owncloud/ocis/issues/2071)
-
-- [coreApiWebdavPreviews/previews.feature:94](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L94)
-
-#### [different error message detail for previews of folder](https://github.com/owncloud/ocis/issues/2064)
-
-- [coreApiWebdavPreviews/previews.feature:103](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L103)
-
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
 - [coreApiSharePublicLink2/copyFromPublicLink.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L65)

--- a/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
@@ -1,84 +1,142 @@
 Feature: previews of files downloaded through the webdav API
+  As a user
+  I want to be able to download the preview of the files
+  So that I can view the contents of the files
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
 
   Scenario Outline: download previews with invalid width
-    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Alice" downloads the preview of "/parent.txt" with width "<width>" and height "32" using the WebDAV API
     Then the HTTP status code should be "400"
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "Cannot set width of 0 or smaller!"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\BadRequest"
     Examples:
-      | width |
-      | 0     |
-      | 0.5   |
-      | -1    |
-      | false |
-      | true  |
-      | A     |
-      | %2F   |
+      | dav-path-version | width |
+      | old              | 0     |
+      | old              | 0.5   |
+      | old              | -1    |
+      | old              | false |
+      | old              | true  |
+      | old              | A     |
+      | old              | %2F   |
+      | new              | 0     |
+      | new              | 0.5   |
+      | new              | -1    |
+      | new              | false |
+      | new              | true  |
+      | new              | A     |
+      | new              | %2F   |
+      | spaces           | 0     |
+      | spaces           | 0.5   |
+      | spaces           | -1    |
+      | spaces           | false |
+      | spaces           | true  |
+      | spaces           | A     |
+      | spaces           | %2F   |
 
 
   Scenario Outline: download previews with invalid height
-    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Alice" downloads the preview of "/parent.txt" with width "32" and height "<height>" using the WebDAV API
     Then the HTTP status code should be "400"
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "Cannot set height of 0 or smaller!"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\BadRequest"
     Examples:
-      | height |
-      | 0      |
-      | 0.5    |
-      | -1     |
-      | false  |
-      | true   |
-      | A      |
-      | %2F    |
+      | dav-path-version | height |
+      | old              | 0      |
+      | old              | 0.5    |
+      | old              | -1     |
+      | old              | false  |
+      | old              | true   |
+      | old              | A      |
+      | old              | %2F    |
+      | new              | 0      |
+      | new              | 0.5    |
+      | new              | -1     |
+      | new              | false  |
+      | new              | true   |
+      | new              | A      |
+      | new              | %2F    |
+      | spaces           | 0      |
+      | spaces           | 0.5    |
+      | spaces           | -1     |
+      | spaces           | false  |
+      | spaces           | true   |
+      | spaces           | A      |
+      | spaces           | %2F    |
 
 
-  Scenario: download previews of files inside sub-folders
-    Given user "Alice" has created folder "subfolder"
-    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/subfolder/parent.txt"
-    When user "Alice" downloads the preview of "/subfolder/parent.txt" with width "32" and height "32" using the WebDAV API
+  Scenario Outline: download previews of files inside sub-folders
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created folder "subfolder"
+    And user "Alice" has uploaded file "filesForUpload/example.gif" to "example.gif"
+    When user "Alice" downloads the preview of "example.gif" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
   Scenario Outline: download previews of file types that don't support preview
-    Given user "Alice" has uploaded file "filesForUpload/<filename>" to "/<newfilename>"
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/<filename>" to "/<newfilename>"
     When user "Alice" downloads the preview of "/<newfilename>" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
     Examples:
-      | filename     | newfilename |
-      | simple.pdf   | test.pdf    |
-      | simple.odt   | test.odt    |
-      | new-data.zip | test.zip    |
+      | dav-path-version | filename     |
+      | old              | simple.pdf   |
+      | old              | simple.odt   |
+      | old              | new-data.zip |
+      | new              | simple.pdf   |
+      | new              | simple.odt   |
+      | new              | new-data.zip |
+      | spaces           | simple.pdf   |
+      | spaces           | simple.odt   |
+      | spaces           | new-data.zip |
 
 
   Scenario Outline: download previews of different image file types
-    Given user "Alice" has uploaded file "filesForUpload/<imageName>" to "/<newImageName>"
-    When user "Alice" downloads the preview of "/<newImageName>" with width "32" and height "32" using the WebDAV API
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/<imageName>" to "/<imageName>"
+    When user "Alice" downloads the preview of "/<imageName>" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
     Examples:
-      | imageName      | newImageName  |
-      | testavatar.jpg | testimage.jpg |
-      | testavatar.png | testimage.png |
+      | dav-path-version | imageName      |
+      | old              | testavatar.jpg |
+      | old              | testavatar.png |
+      | new              | testavatar.jpg |
+      | new              | testavatar.png |
+      | spaces           | testavatar.jpg |
+      | spaces           | testavatar.png |
 
 
-  Scenario: download previews of image after renaming it
-    Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+  Scenario Outline: download previews of image after renaming it
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
     And user "Alice" has moved file "/testimage.jpg" to "/testimage.txt"
     When user "Alice" downloads the preview of "/testimage.txt" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
   Scenario Outline: download previews of shared files (to shares folder)
-    Given user "Brian" has been created with default attributes and without skeleton files
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/<resource>" to "/<resource>"
     And user "Alice" has shared file "/<resource>" with user "Brian"
     And user "Brian" has accepted share "/<resource>" offered by user "Alice"
@@ -86,45 +144,71 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
     Examples:
-      | resource    |
-      | lorem.txt   |
-      | example.gif |
+      | dav-path-version | resource    |
+      | old              | lorem.txt   |
+      | old              | example.gif |
+      | new              | lorem.txt   |
+      | new              | example.gif |
 
 
-  Scenario: download previews of other users files
-    Given user "Brian" has been created with default attributes and without skeleton files
+  Scenario Outline: user tries to download previews of other users files
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Brian" downloads the preview of "/parent.txt" of "Alice" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "404"
-    And the value of the item "/d:error/s:message" in the response about user "Alice" should be "File not found: parent.txt in '%username%'"
+    And the value of the item "/d:error/s:message" in the response about user "Alice" should be "File with name parent.txt could not be located"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
+    Examples:
+      | dav-path-version |
+      | new              |
+      | spaces           |
 
-
-  Scenario: download previews of folders
-    Given user "Alice" has created folder "subfolder"
+  @issue-2064 @skipOnStable3.0
+  Scenario Outline: download previews of folders
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created folder "subfolder"
     When user "Alice" downloads the preview of "/subfolder/" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "400"
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "Unsupported file type"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\BadRequest"
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: download previews of not-existing files
-    When user "Alice" downloads the preview of "/parent.txt" with width "32" and height "32" using the WebDAV API
+  Scenario Outline: download previews of nonexistent files
+    Given using <dav-path-version> DAV path
+    When user "Alice" tries to download the preview of nonexistent file "/parent.txt" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "File with name parent.txt could not be located"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
-
-  Scenario: preview content changes with the change in file content
-    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+  @issue-2570
+  Scenario Outline: preview content changes with the change in file content
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And user "Alice" has downloaded the preview of "/parent.txt" with width "32" and height "32"
     When user "Alice" uploads file with content "this is a file to upload" to "/parent.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/parent.txt" with width "32" and height "32" should have been changed
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
   @issue-2538
-  Scenario: when owner updates a shared file, previews for sharee are also updated (to shared folder)
-    Given user "Brian" has been created with default attributes and without skeleton files
+  Scenario Outline: when owner updates a shared file, previews for sharee are also updated (to shared folder)
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And user "Alice" has shared file "/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
@@ -132,19 +216,30 @@ Feature: previews of files downloaded through the webdav API
     When user "Alice" uploads file with content "this is a file to upload" to "/parent.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as user "Brian" the preview of "/Shares/parent.txt" with width "32" and height "32" should have been changed
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
 
-
-  Scenario: it should update the preview content if the file content is updated (content with UTF chars)
-    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+  @issue-2570
+  Scenario Outline: it should update the preview content if the file content is updated (content with UTF chars)
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "Alice" has uploaded file with content "ओनक्लाउड फाएल शेरिङ्ग एन्ड सिन्किङ" to "/lorem.txt"
     When user "Alice" downloads the preview of "/lorem.txt" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
     And the downloaded preview content should match with "unicode-fixture.png" fixtures preview content
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: updates to a file should change the preview for both sharees and sharers
-    Given user "Brian" has been created with default attributes and without skeleton files
+  Scenario Outline: updates to a file should change the preview for both sharees and sharers
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file with content "file to upload" to "/FOLDER/lorem.txt"
     And user "Alice" has shared folder "FOLDER" with user "Brian"
@@ -159,10 +254,15 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
 
 
-  Scenario: updates to a group shared file should change the preview for both sharees and sharers
-    Given group "grp1" has been created
+  Scenario Outline: updates to a group shared file should change the preview for both sharees and sharers
+    Given using <dav-path-version> DAV path
+    And group "grp1" has been created
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
@@ -185,3 +285,7 @@ Feature: previews of files downloaded through the webdav API
     And as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Carol" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |


### PR DESCRIPTION
## Description
Previously there was test coverage for previewing resources using new wed-dav only. This PR has added tests coverage of preview using old and spaces wed-dav version in personal spaces.
- https://github.com/owncloud/ocis/issues/2071
 decision let error different in ocis and oc10 : https://github.com/owncloud/ocis/issues/2071#issuecomment-1655370760
- https://github.com/owncloud/ocis/issues/2064 (Fixed in master branch so skipped on stable branch)


Open task:
- [ ] add tests coverage for previewing shared resource in spaces webdav

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/6752

## How Has This Been Tested?
- Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
