### PR TITLE
[tests-only][full-ci](ociswrapper): separate ociswrapper logs from ocis logs

### DIFF
--- a/tests/ociswrapper/log/log.go
+++ b/tests/ociswrapper/log/log.go
@@ -1,0 +1,11 @@
+package log
+
+import "log"
+
+func Println(message string) {
+	log.Println("[ociswrapper]", message)
+}
+
+func Panic(err error) {
+	log.Panic("[ociswrapper] ", err.Error())
+}

--- a/tests/ociswrapper/wrapper/wrapper.go
+++ b/tests/ociswrapper/wrapper/wrapper.go
@@ -1,9 +1,10 @@
 package wrapper
 
 import (
-	"log"
+	"fmt"
 	"net/http"
 	"ociswrapper/common"
+	"ociswrapper/log"
 	"ociswrapper/ocis/config"
 	"ociswrapper/wrapper/handlers"
 )
@@ -26,7 +27,7 @@ func Start(port string) {
 
 	httpServer.Handler = mux
 
-	log.Printf("Starting server on port %s...", port)
+	log.Println(fmt.Sprintf("Starting ociswrapper on port %s...", port))
 
 	err := httpServer.ListenAndServe()
 	if err != nil {


### PR DESCRIPTION
## Description
Separate ocis server logs and ociswrapper logs. wrapper logs have `[ociswrapper]` scope prepended.

```bash
2023/07/12 09:54:54 [ociswrapper] some log message here
```

## Related Issue


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
