### PR TITLE
[tests-only][full-ci]refactor the coreapiwebdavproprtoies1 fails

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -196,7 +196,7 @@ class HttpRequestHelper {
 		} else {
 			$debugResponses = false;
 		}
-
+var_dump($url,$method,$user,$body,$headers);
 		$sendRetryLimit = self::numRetriesOnHttpTooEarly();
 		$sendCount = 0;
 		$sendExceptionHappened = false;

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -63,6 +63,7 @@ class OcsApiHelper {
 		}
 		$fullUrl .= "ocs/v$ocsApiVersion.php" . $path;
 		$headers['OCS-APIREQUEST'] = true;
+        var_dump($fullUrl);
 		return HttpRequestHelper::sendRequest($fullUrl, $xRequestId, $method, $user, $password, $headers, $body);
 	}
 

--- a/tests/acceptance/features/apiGraph/fullSearch.feature
+++ b/tests/acceptance/features/apiGraph/fullSearch.feature
@@ -89,3 +89,20 @@ Feature: full text search
       | old              |
       | new              |
       | spaces           |
+
+
+  Scenario Outline: search files using context
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "hello world" to "file1.txt"
+    And user "Alice" has uploaded file with content "Namaste nepal" to "file2.txt"
+    And user "Alice" has uploaded file with content "hello nepal" to "file3.txt"
+    When user "Alice" searches for "Content:hello" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these files:
+      | file1.txt |
+      | file3.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature
@@ -30,20 +30,21 @@ Feature: create file or folder named similar to Shares folder
       | new              | /Shares1    |
 
 
-  Scenario Outline: create a file with a name similar to Shares
-    Given using <dav-path-version> DAV path
-    When user "Brian" uploads file with content "some text" to "<file_name>" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the content of file "<file_name>" for user "Brian" should be "some text"
-    And as "Brian" folder "/Shares" should exist
-    Examples:
-      | dav-path-version | file_name |
-      | old              | /Share    |
-      | old              | /shares   |
-      | old              | /Shares1  |
-      | new              | /Share    |
-      | new              | /shares   |
-      | new              | /Shares1  |
+  Scenario: create a file with a name similar to Shares
+    Given using old DAV path
+    And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,update"
+#    When user "Brian" uploads file with content "some text" to "/shares" using the WebDAV API
+#    Then the HTTP status code should be "201"
+#    And the content of file "/shares" for user "Brian" should be "some text"
+#    And as "Brian" folder "/Shares" should exist
+#    Examples:
+#      | dav-path-version | file_name |
+#      | old              | /Share    |
+#      | old              | /shares   |
+#      | old              | /Shares1  |
+#      | new              | /Share    |
+#      | new              | /shares   |
+#      | new              | /Shares1  |
 
 
   Scenario Outline: try to create a folder named Shares


### PR DESCRIPTION
Part of: https://github.com/owncloud/QA/issues/817

## Description

 `coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature:42`: https://drone.owncloud.com/owncloud/ocis/23905/66/5

<details>
<summary>report</summary>

```feature
    Scenario Outline: create a file with a name similar to Shares                                   # /drone/src/tests/acceptance/features/coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature:33
    Given using <dav_version> DAV path                                                            # FeatureContext::usingOldOrNewDavPath()
    When user "Brian" uploads file with content "some text" to "<file_name>" using the WebDAV API # FeatureContext::userUploadsAFileWithContentTo()
    Then the HTTP status code should be "201"                                                     # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And the content of file "<file_name>" for user "Brian" should be "some text"                  # FeatureContext::contentOfFileForUserShouldBe()
    And as "Brian" folder "/Shares" should exist                                                  # FeatureContext::asFileOrFolderShouldExist()

    Examples:
      | dav_version | file_name |
      | old         | /Share    |
      | old         | /shares   |
        Failed step: And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,update"
        Sharing::userHasSharedFileWithUserUsingTheSharingApi User Alice failed to share /FOLDER with user Brian
        Failed asserting that false is true.
      | old         | /Shares1  |
      | new         | /Share    |
      | new         | /shares   |
      | new         | /Shares1  |
```
</details>