### PR TITLE
[tests-only] [full-ci] ApiTest. added option. stop running tests after first failure

### DIFF
--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -255,6 +255,12 @@ A specific scenario from a feature can be run by adding `:<line-number>` at the 
 >
 > STORAGE_DRIVER=owncloudsql
 
+`STOP_ON_FAILURE`: to stop running tests after the first failure
+
+> Example:
+>
+> STOP_ON_FAILURE=true
+
 ### Use Existing Tests for BDD
 
 As a lot of scenarios from `test-acceptance-from-core-api` are written for oC10, we can use those tests for Behaviour driven development in oCIS.

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -22,6 +22,11 @@ then
 	STEP_THROUGH_OPTION="--step-through"
 fi
 
+if [ -n "${STOP_ON_FAILURE}" ]
+then
+	STOP_OPTION="--stop-on-failure"
+fi
+
 if [ -n "${PLAIN_OUTPUT}" ]
 then
 	# explicitly tell Behat to not do colored output
@@ -180,6 +185,7 @@ fi
 # ---------------
 # $UNEXPECTED_FAILED_SCENARIOS array of scenarios that failed unexpectedly
 # $UNEXPECTED_PASSED_SCENARIOS array of scenarios that passed unexpectedly (while running with expected-failures.txt)
+# $STOP_ON_FAILURE - aborts the test run after the first failure
 
 declare -a UNEXPECTED_FAILED_SCENARIOS
 declare -a UNEXPECTED_PASSED_SCENARIOS
@@ -195,7 +201,7 @@ function run_behat_tests() {
 	fi
 
 	echo "Using behat config '${BEHAT_YML}'"
-	${BEHAT} ${COLORS_OPTION} --strict ${STEP_THROUGH_OPTION} -c ${BEHAT_YML} -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${BEHAT_FEATURE} -v 2>&1 | tee -a ${TEST_LOG_FILE}
+	${BEHAT} ${COLORS_OPTION} ${STOP_OPTION} --strict ${STEP_THROUGH_OPTION} -c ${BEHAT_YML} -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${BEHAT_FEATURE} -v 2>&1 | tee -a ${TEST_LOG_FILE}
 
 	BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
 


### PR DESCRIPTION
Sometimes when running tests locally, it is necessary to have an option to "abort the test after the first failure". 

@aduffeck please use `STOP_ON_FAILURE=true` in the script to enable it. 

CI does not need this option because it must compare failed tests with the expected failures file 