### PR TITLE
[tests-only][full-ci]Remove GitHub comment from ci stable 3.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -757,7 +757,7 @@ def localApiTestPipeline(ctx):
                                      ocisServer(storage, params["accounts_hash_difficulty"], extra_server_environment = params["extraServerEnvironment"], with_wrapper = True) +
                                      (waitForClamavService() if params["antivirusNeeded"] else []) +
                                      (waitForEmailService() if params["emailNeeded"] else []) +
-                                     localApiTests(suite, storage, params["extraEnvironment"])
+                                     localApiTests(suite, storage, params["extraEnvironment"]),
                             "services": emailService() if params["emailNeeded"] else [] + clamavService() if params["antivirusNeeded"] else [],
                             "depends_on": getPipelineNames([buildOcisBinaryForTesting(ctx)]),
                             "trigger": {
@@ -820,7 +820,7 @@ def cs3ApiTests(ctx, storage, accounts_hash_difficulty = 4):
                              "/usr/bin/cs3api-validator /var/lib/cs3api-validator --endpoint=ocis-server:9142",
                          ],
                      },
-                 ]
+                 ],
         "depends_on": getPipelineNames([buildOcisBinaryForTesting(ctx)]),
         "trigger": {
             "ref": [
@@ -920,7 +920,7 @@ def wopiValidatorTests(ctx, storage, accounts_hash_difficulty = 4):
                          ],
                      },
                  ] +
-                 validatorTests
+                 validatorTests,
         "depends_on": getPipelineNames([buildOcisBinaryForTesting(ctx)]),
         "trigger": {
             "ref": [
@@ -968,7 +968,7 @@ def coreApiTests(ctx, part_number = 1, number_of_parts = 1, storage = "ocis", ac
                              "make -C %s test-acceptance-from-core-api" % (dirs["base"]),
                          ],
                      },
-                 ]
+                 ],
         "services": redisForOCStorage(storage),
         "depends_on": getPipelineNames([buildOcisBinaryForTesting(ctx)]),
         "trigger": {
@@ -1012,7 +1012,7 @@ def uiTests(ctx):
 
         for runPart in range(1, numberOfParts + 1):
             if (not debugPartsEnabled or (debugPartsEnabled and runPart in skipExceptParts)):
-                pipelines.append(uiTestPipeline(ctx, "",runPart, numberOfParts))
+                pipelines.append(uiTestPipeline(ctx, "", runPart, numberOfParts))
 
     # For ordinary PRs, always run the "minimal" UI test pipeline
     # That has its own expected-failures file, and we always want to know that it is correct,
@@ -1080,7 +1080,7 @@ def uiTestPipeline(ctx, filterTags, runPart = 1, numberOfParts = 1, storage = "o
                              "./run.sh",
                          ],
                      },
-                 ]
+                 ],
         "services": selenium() + middlewareService(),
         "volumes": [{
             "name": "uploads",
@@ -1141,7 +1141,8 @@ def e2eTests(ctx):
         restoreWebPnpmCache() + \
         ocisServer("ocis", 4, []) + \
         e2e_test_ocis + \
-        uploadTracingResult(ctx)
+        uploadTracingResult(ctx) + \
+        logTracingResults()
 
     if ("skip-e2e" in ctx.build.title.lower()):
         return []
@@ -1184,6 +1185,26 @@ def uploadTracingResult(ctx):
                 "from_secret": "cache_public_s3_secret_key",
             },
         },
+        "when": {
+            "status": [
+                "failure",
+            ],
+            "event": [
+                "pull_request",
+                "cron",
+            ],
+        },
+    }]
+
+def logTracingResults():
+    return [{
+        "name": "log-tracing-result",
+        "image": OC_UBUNTU,
+        "commands": [
+            "cd %s/reports/e2e/playwright/tracing/" % dirs["web"],
+            'echo "To see the trace, please open the following link in the console"',
+            'for f in *.zip; do echo "npx playwright show-trace https://cache.owncloud.com/public/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/tracing/$f \n"; done',
+        ],
         "when": {
             "status": [
                 "failure",

--- a/.drone.star
+++ b/.drone.star
@@ -21,7 +21,6 @@ OC_OC_TEST_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.8.5"
 OC_UBUNTU = "owncloud/ubuntu:20.04"
 PLUGINS_CODACY = "plugins/codacy:1"
 PLUGINS_DOCKER = "plugins/docker:latest"
-PLUGINS_DOWNSTREAM = "plugins/downstream:latest"
 PLUGINS_GH_PAGES = "plugins/gh-pages:1"
 PLUGINS_GITHUB_RELEASE = "plugins/github-release:1"
 PLUGINS_GIT_ACTION = "plugins/git-action:1"
@@ -1805,26 +1804,6 @@ def docs():
                     "tree docs/hugo/public",
                     "rm -rf docs/hugo",
                 ],
-            },
-            {
-                "name": "downstream",
-                "image": PLUGINS_DOWNSTREAM,
-                "settings": {
-                    "server": "https://drone.owncloud.com/",
-                    "token": {
-                        "from_secret": "drone_token",
-                    },
-                    "repositories": [
-                        "owncloud/owncloud.github.io@main",
-                    ],
-                },
-                "when": {
-                    "ref": {
-                        "exclude": [
-                            "refs/pull/**",
-                        ],
-                    },
-                },
             },
         ],
         "trigger": {


### PR DESCRIPTION
Backport: https://github.com/owncloud/ocis/pull/6783

## Description
Last week we removed the drone code to stop previous PR builds, and to cancel a build early when a single pipeline fails.

The remaining special CI feature that we have is the drone code that posts a comment to GitHub about a failing acceptance test pipeline. That no longer works because it needs a GitHub token with too many permissions, and we do not make that available to PRs.

This PR removes the GitHub comment code from the drone CI. The `earlyFail` setting is also removed, because there is nothing that uses it any more

the link for tracing result id shown in the console instead of comments

Part of: https://github.com/owncloud/QA/issues/820