### PR TITLE
[full-ci] chore: bump web to v7.1.0-alpha.2

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=69ab5c83e6eba00ec99d1c8c5dcb62927722e9e7
-WEB_BRANCH=stable-7.0
+WEB_COMMITID=acd9fa2872134b79491096d35c7d577186397aac
+WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.0.1
+WEB_ASSETS_VERSION = v7.1.0-alpha.2
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
This includes the latest work on the cloud importer.