### PR TITLE
storage-users:  cleanups and preparation for allowing cleaner shutdown

### DIFF
--- a/ocis-pkg/registry/register.go
+++ b/ocis-pkg/registry/register.go
@@ -39,6 +39,7 @@ func RegisterService(ctx context.Context, service *mRegistry.Service, logger log
 				if err != nil {
 					logger.Err(err).Msgf("Error unregistering external service %v", service.Name)
 				}
+				return
 			}
 		}
 	}()

--- a/ocis-pkg/service/debug/option.go
+++ b/ocis-pkg/service/debug/option.go
@@ -1,6 +1,7 @@
 package debug
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
@@ -12,6 +13,7 @@ type Option func(o *Options)
 // Options defines the available options for this package.
 type Options struct {
 	Logger               log.Logger
+	Context              context.Context
 	Name                 string
 	Version              string
 	Address              string
@@ -42,6 +44,13 @@ func newOptions(opts ...Option) Options {
 func Logger(l log.Logger) Option {
 	return func(o *Options) {
 		o.Logger = l
+	}
+}
+
+// Context provides a function to set the context option.
+func Context(ctx context.Context) Option {
+	return func(o *Options) {
+		o.Context = ctx
 	}
 }
 

--- a/ocis-pkg/service/debug/service.go
+++ b/ocis-pkg/service/debug/service.go
@@ -1,6 +1,8 @@
 package debug
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"net/http/pprof"
 
@@ -46,8 +48,16 @@ func NewService(opts ...Option) *http.Server {
 		mux.Handle("/debug", h)
 	}
 
+	baseCtx := dopts.Context
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+
 	return &http.Server{
 		Addr: dopts.Address,
+		BaseContext: func(_ net.Listener) context.Context {
+			return baseCtx
+		},
 		Handler: alice.New(
 			chimiddleware.RealIP,
 			chimiddleware.RequestID,

--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -75,7 +75,16 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			gr.Add(debugServer.ListenAndServe, func(_ error) {
+			gr.Add(debugServer.ListenAndServe, func(err error) {
+				logger.Error().Err(err).Str("server", cfg.Service.Name).
+					Msg("Shutting down debug server")
+				if err := debugServer.Shutdown(context.Background()); err != nil {
+					logger.Error().
+						Err(err).
+						Str("server", cfg.Service.Name).
+						Msg("Error during debug server shutdown")
+				}
+
 				cancel()
 			})
 

--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -108,12 +108,17 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				eventSVC, err := event.NewService(selector, stream, logger, *cfg)
+				eventSVC, err := event.NewService(ctx, selector, stream, logger, *cfg)
 				if err != nil {
-					logger.Fatal().Err(err).Msg("can't create event service")
+					logger.Fatal().Err(err).Msg("can't create event handler")
 				}
 
 				gr.Add(eventSVC.Run, func(_ error) {
+					logger.Error().
+						Err(err).
+						Str("server", cfg.Service.Name).
+						Msg("Shutting down event handler")
+
 					cancel()
 				})
 			}

--- a/services/storage-users/pkg/event/service.go
+++ b/services/storage-users/pkg/event/service.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"time"
 
 	apiGateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -21,15 +22,17 @@ type Service struct {
 	eventStream     events.Stream
 	logger          log.Logger
 	config          config.Config
+	ctx             context.Context
 }
 
 // NewService prepares and returns a Service implementation.
-func NewService(gatewaySelector pool.Selectable[apiGateway.GatewayAPIClient], eventStream events.Stream, logger log.Logger, conf config.Config) (Service, error) {
+func NewService(ctx context.Context, gatewaySelector pool.Selectable[apiGateway.GatewayAPIClient], eventStream events.Stream, logger log.Logger, conf config.Config) (Service, error) {
 	svc := Service{
 		gatewaySelector: gatewaySelector,
 		eventStream:     eventStream,
 		logger:          logger,
 		config:          conf,
+		ctx:             ctx,
 	}
 
 	return svc, nil
@@ -42,39 +45,52 @@ func (s Service) Run() error {
 		return err
 	}
 
-	for e := range ch {
-		var errs []error
-
-		switch ev := e.Event.(type) {
-		case PurgeTrashBin:
-			executionTime := ev.ExecutionTime
-			if executionTime.IsZero() {
-				executionTime = time.Now()
+	for {
+		select {
+		case <-s.ctx.Done():
+			s.logger.Info().Str("service", s.config.Service.Name).Msg("Context canceled. Shutting down event handler")
+			return nil
+		case e, more := <-ch:
+			if !more {
+				s.logger.Info().Str("service", s.config.Service.Name).Msg("Event channel closed. Shutting down event handler")
+				// the channel was closed we can stop here
+				return nil
 			}
-
-			tasks := map[task.SpaceType]time.Time{
-				task.Project:  executionTime.Add(-s.config.Tasks.PurgeTrashBin.ProjectDeleteBefore),
-				task.Personal: executionTime.Add(-s.config.Tasks.PurgeTrashBin.PersonalDeleteBefore),
-			}
-
-			for spaceType, deleteBefore := range tasks {
-				// skip task execution if the deleteBefore time is the same as the now time,
-				// which indicates that the duration configuration for this space type is set to 0 which is the equivalent to disabled.
-				if deleteBefore.Equal(executionTime) {
-					continue
-				}
-
-				if err = task.PurgeTrashBin(s.config.ServiceAccount.ServiceAccountID, deleteBefore, spaceType, s.gatewaySelector, s.config.ServiceAccount.ServiceAccountSecret); err != nil {
-					errs = append(errs, err)
-				}
-			}
-
-		}
-
-		for _, err := range errs {
-			s.logger.Error().Err(err).Interface("event", e)
+			s.handleEvent(e)
 		}
 	}
+}
 
-	return nil
+func (s Service) handleEvent(e events.Event) {
+	var errs []error
+
+	switch ev := e.Event.(type) {
+	case PurgeTrashBin:
+		executionTime := ev.ExecutionTime
+		if executionTime.IsZero() {
+			executionTime = time.Now()
+		}
+
+		tasks := map[task.SpaceType]time.Time{
+			task.Project:  executionTime.Add(-s.config.Tasks.PurgeTrashBin.ProjectDeleteBefore),
+			task.Personal: executionTime.Add(-s.config.Tasks.PurgeTrashBin.PersonalDeleteBefore),
+		}
+
+		for spaceType, deleteBefore := range tasks {
+			// skip task execution if the deleteBefore time is the same as the now time,
+			// which indicates that the duration configuration for this space type is set to 0 which is the equivalent to disabled.
+			if deleteBefore.Equal(executionTime) {
+				continue
+			}
+
+			if err := task.PurgeTrashBin(s.config.ServiceAccount.ServiceAccountID, deleteBefore, spaceType, s.gatewaySelector, s.config.ServiceAccount.ServiceAccountSecret); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+	}
+
+	for _, err := range errs {
+		s.logger.Error().Err(err).Interface("event", e).Msg("Error running PurgeTrashBin task")
+	}
 }

--- a/services/storage-users/pkg/server/debug/server.go
+++ b/services/storage-users/pkg/server/debug/server.go
@@ -15,6 +15,7 @@ func Server(opts ...Option) (*http.Server, error) {
 
 	return debug.NewService(
 		debug.Logger(options.Logger),
+		debug.Context(options.Context),
 		debug.Name(options.Config.Service.Name),
 		debug.Version(version.GetString()),
 		debug.Address(options.Config.Debug.Addr),


### PR DESCRIPTION
This contains some smaller cleanups to prepare for a more graceful shutdown of the storage-users service. The main context is now passed to all members of the run.Group so that e.g. the event handler's service runner and the debugServer are properly be stopped.

This also fixes a bug when de-registering a service which could keep the ServerRegister go-routine running in a tight loop when the context was canceled.

This does not provide a complete fix for a proper shutdown of storage-users.  More changes are coming via the reva repo.
