### PR TITLE
Disabled revokeRefreshToken in Keycloak config

### DIFF
--- a/deployments/examples/ocis_keycloak/config/keycloak/ocis-realm.dist.json
+++ b/deployments/examples/ocis_keycloak/config/keycloak/ocis-realm.dist.json
@@ -4,7 +4,7 @@
   "displayName": "ownCloud Infinite Scale",
   "notBefore": 0,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 0,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,


### PR DESCRIPTION
## Description
The Keycloak example has `revokeRefreshToken` enabled right now, this leads to sessions being terminated with the error `Maximum allowed refresh token reuse exceeded`. This PR disables this setting.

## Related Issue
None

## Motivation and Context
No session termination in example setups.

## How Has This Been Tested?
Tested locally once with the setting turned on and once with the setting turned off.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
