### PR TITLE
[tests-only][full-ci]add tag skipOnReva

### DIFF
--- a/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnReva
 Feature: previews of files downloaded through the webdav API
   As a user
   I want to be able to download the preview of the files

--- a/tests/acceptance/features/coreApiWebdavPreviews/previewsAutoAdustedSizing.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/previewsAutoAdustedSizing.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnReva
 Feature: sizing of previews of files downloaded through the webdav API
   As a user
   I want the aspect-ratio of previews to be preserved even when I ask for an unusual preview size


### PR DESCRIPTION
Previously, the scenarios of feature files `previews.feature` and `previewsAutoAdjustedSizing.feature` were skipped using the tag `@preview-extension-required` but tag was removed in recent PR (https://github.com/owncloud/ocis/pull/6766), so the scenarios are failing in both Reva edge (https://drone.owncloud.com/cs3org/reva/2307/16/6) and master (https://drone.owncloud.com/cs3org/reva/2313/12/7).

This PR adds tag `@skipOnReva`.