### PR TITLE
[docs-only] Fix envvar descriptions in shared_types.go

### DIFF
--- a/ocis-pkg/shared/shared_types.go
+++ b/ocis-pkg/shared/shared_types.go
@@ -12,7 +12,7 @@ type EnvBinding struct {
 
 // Log defines the available logging configuration.
 type Log struct {
-	Level  string `yaml:"level" env:"OCIS_LOG_LEVEL" desc:"The log level. Valid values are: \"panic\", \"fatal\", \"error\", \"warn\", \"info\", \"debug\", \"trace\"."`
+	Level  string `yaml:"level" env:"OCIS_LOG_LEVEL" desc:"The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'."`
 	Pretty bool   `yaml:"pretty" env:"OCIS_LOG_PRETTY" desc:"Activates pretty log output."`
 	Color  bool   `yaml:"color" env:"OCIS_LOG_COLOR" desc:"Activates colorized log output."`
 	File   string `yaml:"file" env:"OCIS_LOG_FILE" desc:"The path to the log file. Activates logging to this file if set."`
@@ -21,7 +21,7 @@ type Log struct {
 // Tracing defines the available tracing configuration.
 type Tracing struct {
 	Enabled   bool   `yaml:"enabled" env:"OCIS_TRACING_ENABLED" desc:"Activates tracing."`
-	Type      string `yaml:"type" env:"OCIS_TRACING_TYPE" desc:"The type of tracing. Defaults to \"\", which is the same as \"jaeger\". Allowed tracing types are \"jaeger\" and \"\" as of now."`
+	Type      string `yaml:"type" env:"OCIS_TRACING_TYPE" desc:"The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now."`
 	Endpoint  string `yaml:"endpoint" env:"OCIS_TRACING_ENDPOINT" desc:"The endpoint of the tracing agent."`
 	Collector string `yaml:"collector" env:"OCIS_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset."`
 }
@@ -33,7 +33,7 @@ type TokenManager struct {
 
 // Reva defines all available REVA client configuration.
 type Reva struct {
-	Address string        `yaml:"address" env:"OCIS_REVA_GATEWAY;REVA_GATEWAY" desc:"The CS3 gateway endpoint." deprecationVersion:"3.0" removalVersion:"3.1" deprecationInfo:"REVA_GATEWAY changing name for consistency" deprecationReplacement:"OCIS_REVA_GATEWAY"`
+	Address string        `yaml:"address" env:"OCIS_REVA_GATEWAY;REVA_GATEWAY" desc:"The CS3 gateway endpoint." deprecationVersion:"3.0" removalVersion:"4.0.0" deprecationInfo:"REVA_GATEWAY changing name for consistency" deprecationReplacement:"OCIS_REVA_GATEWAY"`
 	TLS     GRPCClientTLS `yaml:"tls"`
 }
 


### PR DESCRIPTION
Fixes: [Content of owncloud.dev/admin docs does not match code (envvar in gateway service)](https://github.com/owncloud/ocis/issues/6816#top)

* Replacing `\"` --> `'` missed when doing
#6723 and
#6724
* Correct the removalVersion for `REVA_GATEWAY` from `3.1` --> `4.0.0` 