### PR TITLE
Raised default wopiserver version to 10.1.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -914,7 +914,7 @@ def wopiValidatorTests(ctx, storage, accounts_hash_difficulty = 4):
                  [
                      {
                          "name": "wopiserver",
-                         "image": "cs3org/wopiserver:v10.0.1",
+                         "image": "cs3org/wopiserver:v10.1.0",
                          "detach": True,
                          "commands": [
                              "cp %s/tests/config/drone/wopiserver.conf /etc/wopi/wopiserver.conf" % (dirs["base"]),

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -162,7 +162,7 @@ services:
     restart: always
 
   wopiserver:
-    image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-v10.0.1}
+    image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-v10.1.0}
     networks:
       ocis-net:
     entrypoint:


### PR DESCRIPTION
## Description
The default wopiserver version in the examples should be raised to 10.1.0

## Motivation and Context
Keep version of depending services up to date

## How Has This Been Tested?
Tested by executing the example again

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
