### PR TITLE
[full-ci] bump reva, adapt changelog

### DIFF
--- a/changelog/unreleased/bump-reva.md
+++ b/changelog/unreleased/bump-reva.md
@@ -1,7 +1,20 @@
-Enhancement: Update reva
+Enhancement: Update reva to v2.15.0
 
-Update reva to latest edge
-
+*   Bugfix [cs3org/reva#4004](https://github.com/cs3org/reva/pull/4004): Add path to public link POST
+*   Bugfix [cs3org/reva#3993](https://github.com/cs3org/reva/pull/3993): Add token to LinkAccessedEvent
+*   Bugfix [cs3org/reva#4007](https://github.com/cs3org/reva/pull/4007): Close archive writer properly
+*   Bugfix [cs3org/reva#3982](https://github.com/cs3org/reva/pull/3982): Fixed couple of smaller space lookup issues
+*   Bugfix [cs3org/reva#4003](https://github.com/cs3org/reva/pull/4003): Don't connect ldap on startup
+*   Bugfix [cs3org/reva#4032](https://github.com/cs3org/reva/pull/4032): Temporarily exclude ceph-iscsi when building revad-ceph image
+*   Bugfix [cs3org/reva#4042](https://github.com/cs3org/reva/pull/4042): Fix writing 0 byte msgpack metadata
+*   Bugfix [cs3org/reva#3970](https://github.com/cs3org/reva/pull/3970): Fix enforce-password issue
+*   Bugfix [cs3org/reva#4057](https://github.com/cs3org/reva/pull/4057): Properly handle not-found errors when getting a public share
+*   Bugfix [cs3org/reva#4048](https://github.com/cs3org/reva/pull/4048): Fix messagepack propagation
+*   Bugfix [cs3org/reva#4056](https://github.com/cs3org/reva/pull/4056): Fix destroys data destination when moving issue
+*   Bugfix [cs3org/reva#4012](https://github.com/cs3org/reva/pull/4012): Fix mtime if 0 size file uploaded
+*   Bugfix [cs3org/reva#4010](https://github.com/cs3org/reva/pull/4010): Omit spaceroot when archiving
+*   Bugfix [cs3org/reva#4047](https://github.com/cs3org/reva/pull/4047): Publish events synchrously
+*   Bugfix [cs3org/reva#4039](https://github.com/cs3org/reva/pull/4039): Restart Postprocessing
 *   Bugfix [cs3org/reva#3963](https://github.com/cs3org/reva/pull/3963): Treesize interger overflows
 *   Bugfix [cs3org/reva#3943](https://github.com/cs3org/reva/pull/3943): When removing metadata always use correct database and table
 *   Bugfix [cs3org/reva#3978](https://github.com/cs3org/reva/pull/3978): Decomposedfs no longer os.Stats when reading node metadata
@@ -23,7 +36,26 @@ Update reva to latest edge
 *   Enhancement [cs3org/reva#3965](https://github.com/cs3org/reva/pull/3965): ResumePostprocessing Event
 *   Enhancement [cs3org/reva#3981](https://github.com/cs3org/reva/pull/3981): We have updated the UserFeatureChangedEvent to reflect value changes
 *   Enhancement [cs3org/reva#3986](https://github.com/cs3org/reva/pull/3986): Allow disabling wopi chat
+*   Enhancement [cs3org/reva#4060](https://github.com/cs3org/reva/pull/4060): We added a go-micro based app-provider registry
+*   Enhancement [cs3org/reva#4013](https://github.com/cs3org/reva/pull/4013): Add new WebDAV permissions
+*   Enhancement [cs3org/reva#3987](https://github.com/cs3org/reva/pull/3987): Cache space indexes
+*   Enhancement [cs3org/reva#3973](https://github.com/cs3org/reva/pull/3973): More logging for metadata propagation
+*   Enhancement [cs3org/reva#4059](https://github.com/cs3org/reva/pull/4059): Improve space index performance
+*   Enhancement [cs3org/reva#3994](https://github.com/cs3org/reva/pull/3994): Load matching spaces concurrently
+*   Enhancement [cs3org/reva#4049](https://github.com/cs3org/reva/pull/4049): Do not invalidate filemetadata cache early
+*   Enhancement [cs3org/reva#4040](https://github.com/cs3org/reva/pull/4040): Allow to use external trace provider in micro service
+*   Enhancement [cs3org/reva#4019](https://github.com/cs3org/reva/pull/4019): Allow to use external trace provider
+*   Enhancement [cs3org/reva#4045](https://github.com/cs3org/reva/pull/4045): Log error message in grpc interceptor
+*   Enhancement [cs3org/reva#3989](https://github.com/cs3org/reva/pull/3989): Parallelization of jsoncs3 operations
+*   Enhancement [cs3org/reva#3809](https://github.com/cs3org/reva/pull/3809): Trace decomposedfs syscalls
+*   Enhancement [cs3org/reva#4067](https://github.com/cs3org/reva/pull/4067): Trace upload progress
+*   Enhancement [cs3org/reva#3887](https://github.com/cs3org/reva/pull/3887): Trace requests through datagateway
+*   Enhancement [cs3org/reva#4052](https://github.com/cs3org/reva/pull/4052): Update go-ldap to v3.4.5
+*   Enhancement [cs3org/reva#4065](https://github.com/cs3org/reva/pull/4065): Upload directly to dataprovider
+*   Enhancement [cs3org/reva#4046](https://github.com/cs3org/reva/pull/4046): Use correct tracer name
+*   Enhancement [cs3org/reva#3986](https://github.com/cs3org/reva/pull/3986): Allow disabling wopi chat writer properly
 
+https://github.com/owncloud/ocis/pull/6829
 https://github.com/owncloud/ocis/pull/6529
 https://github.com/owncloud/ocis/pull/6544
 https://github.com/owncloud/ocis/pull/6507

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/cs3org/go-cs3apis v0.0.0-20230516150832-730ac860c71d
-	github.com/cs3org/reva/v2 v2.14.1-0.20230714140226-283ecff63fe4
+	github.com/cs3org/reva/v2 v2.15.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e
 	github.com/egirna/icap-client v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
-github.com/cs3org/reva/v2 v2.14.1-0.20230714140226-283ecff63fe4 h1:9hbfPVNRrrCpHNGZQwF39ymkVEZjbp7T9KxS6vmPfgk=
-github.com/cs3org/reva/v2 v2.14.1-0.20230714140226-283ecff63fe4/go.mod h1:4z5EQghS2LhSWZWocH51Dw9VAs16No1zSFvFgQtgS7w=
+github.com/cs3org/reva/v2 v2.15.0 h1:saU2Heig/HswkNdDHh2Jttmhsn0nfTkvaYbXUspcNOM=
+github.com/cs3org/reva/v2 v2.15.0/go.mod h1:4z5EQghS2LhSWZWocH51Dw9VAs16No1zSFvFgQtgS7w=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -352,7 +352,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.14.1-0.20230714140226-283ecff63fe4
+# github.com/cs3org/reva/v2 v2.15.0
 ## explicit; go 1.20
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

Enhancement: Update reva to v2.15.0

*   Bugfix [cs3org/reva#4004](https://github.com/cs3org/reva/pull/4004): Add path to public link POST
*   Bugfix [cs3org/reva#3993](https://github.com/cs3org/reva/pull/3993): Add token to LinkAccessedEvent
*   Bugfix [cs3org/reva#4007](https://github.com/cs3org/reva/pull/4007): Close archive writer properly
*   Bugfix [cs3org/reva#3982](https://github.com/cs3org/reva/pull/3982): Fixed couple of smaller space lookup issues
*   Bugfix [cs3org/reva#4003](https://github.com/cs3org/reva/pull/4003): Don't connect ldap on startup
*   Bugfix [cs3org/reva#4032](https://github.com/cs3org/reva/pull/4032): Temporarily exclude ceph-iscsi when building revad-ceph image
*   Bugfix [cs3org/reva#4042](https://github.com/cs3org/reva/pull/4042): Fix writing 0 byte msgpack metadata
*   Bugfix [cs3org/reva#3970](https://github.com/cs3org/reva/pull/3970): Fix enforce-password issue
*   Bugfix [cs3org/reva#4057](https://github.com/cs3org/reva/pull/4057): Properly handle not-found errors when getting a public share
*   Bugfix [cs3org/reva#4048](https://github.com/cs3org/reva/pull/4048): Fix messagepack propagation
*   Bugfix [cs3org/reva#4056](https://github.com/cs3org/reva/pull/4056): Fix destroys data destination when moving issue
*   Bugfix [cs3org/reva#4012](https://github.com/cs3org/reva/pull/4012): Fix mtime if 0 size file uploaded
*   Bugfix [cs3org/reva#4010](https://github.com/cs3org/reva/pull/4010): Omit spaceroot when archiving
*   Bugfix [cs3org/reva#4047](https://github.com/cs3org/reva/pull/4047): Publish events synchrously
*   Bugfix [cs3org/reva#4039](https://github.com/cs3org/reva/pull/4039): Restart Postprocessing
*   Bugfix [cs3org/reva#3963](https://github.com/cs3org/reva/pull/3963): Treesize interger overflows
*   Bugfix [cs3org/reva#3943](https://github.com/cs3org/reva/pull/3943): When removing metadata always use correct database and table
*   Bugfix [cs3org/reva#3978](https://github.com/cs3org/reva/pull/3978): Decomposedfs no longer os.Stats when reading node metadata
*   Bugfix [cs3org/reva#3959](https://github.com/cs3org/reva/pull/3959): Drop unnecessary stat
*   Bugfix [cs3org/reva#3948](https://github.com/cs3org/reva/pull/3948): Handle the bad request status
*   Bugfix [cs3org/reva#3955](https://github.com/cs3org/reva/pull/3955): Fix panic
*   Bugfix [cs3org/reva#3977](https://github.com/cs3org/reva/pull/3977): Prevent direct access to trash items
*   Bugfix [cs3org/reva#3933](https://github.com/cs3org/reva/pull/3933): Concurrently invalidate mtime cache in jsoncs3 share manager
*   Bugfix [cs3org/reva#3985](https://github.com/cs3org/reva/pull/3985): Reduce jsoncs3 lock congestion
*   Bugfix [cs3org/reva#3960](https://github.com/cs3org/reva/pull/3960): Add trace span details
*   Bugfix [cs3org/reva#3951](https://github.com/cs3org/reva/pull/3951): Link context in metadata client
*   Bugfix [cs3org/reva#3950](https://github.com/cs3org/reva/pull/3950): Use plain otel tracing in metadata client
*   Bugfix [cs3org/reva#3975](https://github.com/cs3org/reva/pull/3975): Decomposedfs now resolves the parent without an os.Stat
*   Change [cs3org/reva#3947](https://github.com/cs3org/reva/pull/3947): Bump golangci-lint to 1.51.2
*   Change [cs3org/reva#3945](https://github.com/cs3org/reva/pull/3945): Revert golangci-lint back to 1.50.1
*   Enhancement [cs3org/reva#3966](https://github.com/cs3org/reva/pull/3966): Add space metadata to ocs shares list
*   Enhancement [cs3org/reva#3953](https://github.com/cs3org/reva/pull/3953): Client selector pool
*   Enhancement [cs3org/reva#3941](https://github.com/cs3org/reva/pull/3941): Adding tracing for jsoncs3
*   Enhancement [cs3org/reva#3965](https://github.com/cs3org/reva/pull/3965): ResumePostprocessing Event
*   Enhancement [cs3org/reva#3981](https://github.com/cs3org/reva/pull/3981): We have updated the UserFeatureChangedEvent to reflect value changes
*   Enhancement [cs3org/reva#3986](https://github.com/cs3org/reva/pull/3986): Allow disabling wopi chat
*   Enhancement [cs3org/reva#4060](https://github.com/cs3org/reva/pull/4060): We added a go-micro based app-provider registry
*   Enhancement [cs3org/reva#4013](https://github.com/cs3org/reva/pull/4013): Add new WebDAV permissions
*   Enhancement [cs3org/reva#3987](https://github.com/cs3org/reva/pull/3987): Cache space indexes
*   Enhancement [cs3org/reva#3973](https://github.com/cs3org/reva/pull/3973): More logging for metadata propagation
*   Enhancement [cs3org/reva#4059](https://github.com/cs3org/reva/pull/4059): Improve space index performance
*   Enhancement [cs3org/reva#3994](https://github.com/cs3org/reva/pull/3994): Load matching spaces concurrently
*   Enhancement [cs3org/reva#4049](https://github.com/cs3org/reva/pull/4049): Do not invalidate filemetadata cache early
*   Enhancement [cs3org/reva#4040](https://github.com/cs3org/reva/pull/4040): Allow to use external trace provider in micro service
*   Enhancement [cs3org/reva#4019](https://github.com/cs3org/reva/pull/4019): Allow to use external trace provider
*   Enhancement [cs3org/reva#4045](https://github.com/cs3org/reva/pull/4045): Log error message in grpc interceptor
*   Enhancement [cs3org/reva#3989](https://github.com/cs3org/reva/pull/3989): Parallelization of jsoncs3 operations
*   Enhancement [cs3org/reva#3809](https://github.com/cs3org/reva/pull/3809): Trace decomposedfs syscalls
*   Enhancement [cs3org/reva#4067](https://github.com/cs3org/reva/pull/4067): Trace upload progress
*   Enhancement [cs3org/reva#3887](https://github.com/cs3org/reva/pull/3887): Trace requests through datagateway
*   Enhancement [cs3org/reva#4052](https://github.com/cs3org/reva/pull/4052): Update go-ldap to v3.4.5
*   Enhancement [cs3org/reva#4065](https://github.com/cs3org/reva/pull/4065): Upload directly to dataprovider
*   Enhancement [cs3org/reva#4046](https://github.com/cs3org/reva/pull/4046): Use correct tracer name
*   Enhancement [cs3org/reva#3986](https://github.com/cs3org/reva/pull/3986): Allow disabling wopi chat writer properly


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
