### PR TITLE
[tests-only] [full-ci] Retry if 409 is received when uploading in a Given step

### DIFF
--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -49,6 +49,7 @@ class UploadHelper extends Assert {
 	 * @param int|null $chunkingVersion (1|2|null)
 	 *                                  if set to null chunking will not be used
 	 * @param int|null $noOfChunks how many chunks to upload
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -63,7 +64,8 @@ class UploadHelper extends Assert {
 		?array $headers = [],
 		?int $davPathVersionToUse = 1,
 		?int $chunkingVersion = null,
-		?int $noOfChunks = 1
+		?int $noOfChunks = 1,
+		?bool $isGivenStep = false
 	): ResponseInterface {
 		//simple upload with no chunking
 		if ($chunkingVersion === null) {
@@ -77,7 +79,16 @@ class UploadHelper extends Assert {
 				$headers,
 				$xRequestId,
 				$data,
-				$davPathVersionToUse
+				$davPathVersionToUse,
+				"files",
+				null,
+				"basic",
+				false,
+				0,
+				null,
+				[],
+				null,
+				$isGivenStep
 			);
 		} else {
 			//prepare chunking
@@ -102,7 +113,15 @@ class UploadHelper extends Assert {
 				$xRequestId,
 				null,
 				$davPathVersionToUse,
-				"uploads"
+				"uploads",
+				null,
+				"basic",
+				false,
+				0,
+				null,
+				[],
+				null,
+				$isGivenStep
 			);
 			if ($result->getStatusCode() >= 400) {
 				return $result;
@@ -130,7 +149,15 @@ class UploadHelper extends Assert {
 				$xRequestId,
 				$chunk,
 				$davPathVersionToUse,
-				$davRequestType
+				$davRequestType,
+				null,
+				"basic",
+				false,
+				0,
+				null,
+				[],
+				null,
+				$isGivenStep
 			);
 			if ($result->getStatusCode() >= 400) {
 				return $result;
@@ -152,7 +179,15 @@ class UploadHelper extends Assert {
 				$xRequestId,
 				null,
 				$davPathVersionToUse,
-				"uploads"
+				"uploads",
+				null,
+				"basic",
+				false,
+				0,
+				null,
+				[],
+				null,
+				$isGivenStep
 			);
 			if ($result->getStatusCode() >= 400) {
 				return $result;

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2047,10 +2047,16 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	public function userUploadsAFileTo(string $user, string $source, string $destination):void {
+	public function userUploadsAFileTo(
+		string $user,
+		string $source,
+		string $destination,
+		?bool $isGivenStep = false
+	):void {
 		$user = $this->getActualUsername($user);
 		$file = \fopen($this->acceptanceTestsDirLocation() . $source, 'r');
 		$this->pauseUploadDelete();
@@ -2059,7 +2065,14 @@ trait WebDav {
 			"PUT",
 			$destination,
 			[],
-			$file
+			$file,
+			"files",
+			null,
+			false,
+			null,
+			[],
+			null,
+			$isGivenStep
 		);
 		$this->lastUploadDeleteTime = \time();
 		$this->setResponseXml(
@@ -2080,7 +2093,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userHasUploadedAFileTo(string $user, string $source, string $destination):void {
-		$this->userUploadsAFileTo($user, $source, $destination);
+		$this->userUploadsAFileTo($user, $source, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$source' to '$destination' for user '$user'"
@@ -2093,11 +2106,16 @@ trait WebDav {
 	 *
 	 * @param string $source
 	 * @param string $destination
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	public function theUserUploadsAFileTo(string $source, string $destination):void {
-		$this->userUploadsAFileTo($this->currentUser, $source, $destination);
+	public function theUserUploadsAFileTo(
+		string $source,
+		string $destination,
+		?bool $isGivenStep = false
+	):void {
+		$this->userUploadsAFileTo($this->currentUser, $source, $destination, $isGivenStep);
 	}
 
 	/**
@@ -2109,7 +2127,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function theUserHasUploadedFileTo(string $source, string $destination):void {
-		$this->theUserUploadsAFileTo($source, $destination);
+		$this->theUserUploadsAFileTo($source, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$source' to '$destination'"
@@ -2123,12 +2141,19 @@ trait WebDav {
 	 * @param string $server
 	 * @param string $source
 	 * @param string $destination
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	public function userOnUploadsAFileTo(string $user, string $server, string $source, string $destination):void {
+	public function userOnUploadsAFileTo(
+		string $user,
+		string $server,
+		string $source,
+		string $destination,
+		?bool $isGivenStep = false
+	):void {
 		$previousServer = $this->usingServer($server);
-		$this->userUploadsAFileTo($user, $source, $destination);
+		$this->userUploadsAFileTo($user, $source, $destination, $isGivenStep);
 		$this->usingServer($previousServer);
 	}
 
@@ -2143,7 +2168,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userOnHasUploadedAFileTo(string $user, string $server, string $source, string $destination):void {
-		$this->userOnUploadsAFileTo($user, $server, $source, $destination);
+		$this->userOnUploadsAFileTo($user, $server, $source, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$source' to '$destination' for user '$user' on server '$server'"
@@ -2807,7 +2832,7 @@ trait WebDav {
 	 */
 	public function userHasUploadedFileToOfSizeBytes(string $user, string $destination, string $bytes):void {
 		$user = $this->getActualUsername($user);
-		$this->userUploadsAFileToOfSizeBytes($user, $destination, $bytes);
+		$this->userUploadsAFileToOfSizeBytes($user, $destination, $bytes, true);
 		$expectedElements = new TableNode([["$destination"]]);
 		$this->checkElementList($user, $expectedElements);
 	}
@@ -2818,11 +2843,23 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $destination
 	 * @param string $bytes
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	public function userUploadsAFileToOfSizeBytes(string $user, string $destination, string $bytes):void {
-		$this->userUploadsAFileToEndingWithOfSizeBytes($user, $destination, 'a', $bytes);
+	public function userUploadsAFileToOfSizeBytes(
+		string $user,
+		string $destination,
+		string $bytes,
+		?bool $isGivenStep = false
+	):void {
+		$this->userUploadsAFileToEndingWithOfSizeBytes(
+			$user,
+			$destination,
+			'a',
+			$bytes,
+			$isGivenStep
+		);
 	}
 
 	/**
@@ -2837,7 +2874,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function userHasUploadedFileToEndingWithOfSizeBytes(string $user, string $destination, string $text, string $bytes):void {
-		$this->userUploadsAFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes);
+		$this->userUploadsAFileToEndingWithOfSizeBytes($user, $destination, $text, $bytes, true);
 		$expectedElements = new TableNode([["$destination"]]);
 		$this->checkElementList($user, $expectedElements);
 	}
@@ -2849,17 +2886,25 @@ trait WebDav {
 	 * @param string $destination
 	 * @param string $text
 	 * @param string $bytes
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	public function userUploadsAFileToEndingWithOfSizeBytes(string $user, string $destination, string $text, string $bytes):void {
+	public function userUploadsAFileToEndingWithOfSizeBytes(
+		string $user,
+		string $destination,
+		string $text,
+		string $bytes,
+		?bool $isGivenStep = false
+	):void {
 		$filename = "filespecificSize.txt";
 		$this->createLocalFileOfSpecificSize($filename, $bytes, $text);
 		Assert::assertFileExists($this->workStorageDirLocation() . $filename);
 		$this->userUploadsAFileTo(
 			$user,
 			$this->temporaryStorageSubfolderName() . "/$filename",
-			$destination
+			$destination,
+			$isGivenStep
 		);
 		$this->removeFile($this->workStorageDirLocation(), $filename);
 	}
@@ -2903,6 +2948,7 @@ trait WebDav {
 	 * @param string $user
 	 * @param string|null $content
 	 * @param string $destination
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return string[]
 	 * @throws JsonException
@@ -2911,7 +2957,8 @@ trait WebDav {
 	public function uploadFileWithContent(
 		string $user,
 		?string $content,
-		string $destination
+		string $destination,
+		?bool $isGivenStep = false
 	): array {
 		$user = $this->getActualUsername($user);
 		$this->pauseUploadDelete();
@@ -2920,7 +2967,14 @@ trait WebDav {
 			"PUT",
 			$destination,
 			[],
-			$content
+			$content,
+			"files",
+			null,
+			false,
+			null,
+			[],
+			null,
+			$isGivenStep
 		);
 		$this->setResponseXml(
 			HttpRequestHelper::parseResponseAsXml($this->response)
@@ -2956,7 +3010,7 @@ trait WebDav {
 		?string $content,
 		string $destination
 	):array {
-		$fileId = $this->uploadFileWithContent($this->getAdminUsername(), $content, $destination);
+		$fileId = $this->uploadFileWithContent($this->getAdminUsername(), $content, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$destination'"
@@ -3010,12 +3064,12 @@ trait WebDav {
 
 	/**
 	 * @When user :user uploads file :source to :destination with mtime :mtime using the WebDAV API
-	 * @Given user :user has uploaded file :source to :destination with mtime :mtime using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
 	 * @param string $mtime Time in human-readable format is taken as input which is converted into milliseconds that is used by API
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 * @throws Exception
@@ -3024,7 +3078,8 @@ trait WebDav {
 		string $user,
 		string $source,
 		string $destination,
-		string $mtime
+		string $mtime,
+		?bool $isGivenStep = false
 	):void {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
@@ -3037,7 +3092,36 @@ trait WebDav {
 			$destination,
 			$this->getStepLineRef(),
 			["X-OC-Mtime" => $mtime],
-			$this->getDavPathVersion()
+			$this->getDavPathVersion(),
+			null,
+			1,
+			$isGivenStep
+		);
+	}
+
+	/**
+	 * @Given user :user has uploaded file :source to :destination with mtime :mtime using the WebDAV API
+	 *
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destination
+	 * @param string $mtime Time in human-readable format is taken as input which is converted into milliseconds that is used by API
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userHasUploadedFileToWithMtimeUsingTheWebdavApi(
+		string $user,
+		string $source,
+		string $destination,
+		string $mtime
+	):void {
+		$this->userUploadsFileToWithMtimeUsingTheWebdavApi(
+			$user,
+			$source,
+			$destination,
+			$mtime,
+			true
 		);
 	}
 
@@ -3072,7 +3156,17 @@ trait WebDav {
 			$filename,
 			["X-OC-Mtime" => $mtime],
 			$this->getStepLineRef(),
-			$content
+			$content,
+			WebDavHelper::DAV_VERSION_OLD,
+			"files",
+			null,
+			"basic",
+			false,
+			0,
+			null,
+			[],
+			null,
+			true
 		);
 	}
 
@@ -3157,7 +3251,7 @@ trait WebDav {
 		string $destination
 	):array {
 		$user = $this->getActualUsername($user);
-		$fileId = $this->uploadFileWithContent($user, $content, $destination);
+		$fileId = $this->uploadFileWithContent($user, $content, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$destination' for user '$user'"
@@ -3254,6 +3348,7 @@ trait WebDav {
 	 * @param string $checksum
 	 * @param string|null $content
 	 * @param string $destination
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
@@ -3261,7 +3356,8 @@ trait WebDav {
 		string $user,
 		string $checksum,
 		?string $content,
-		string $destination
+		string $destination,
+		?bool $isGivenStep = false
 	):void {
 		$this->pauseUploadDelete();
 		$this->response = $this->makeDavRequest(
@@ -3269,7 +3365,14 @@ trait WebDav {
 			"PUT",
 			$destination,
 			['OC-Checksum' => $checksum],
-			$content
+			$content,
+			"files",
+			null,
+			false,
+			null,
+			[],
+			null,
+			$isGivenStep
 		);
 		$this->lastUploadDeleteTime = \time();
 		$this->pushToLastStatusCodesArrays();
@@ -3295,7 +3398,8 @@ trait WebDav {
 			$user,
 			$checksum,
 			$content,
-			$destination
+			$destination,
+			true
 		);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
@@ -3590,7 +3694,7 @@ trait WebDav {
 			$admin,
 			__METHOD__ . "The provided user is not admin but '" . $admin . "'"
 		);
-		$this->userCreatesFolder($admin, $destination);
+		$this->userCreatesFolder($admin, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for admin '$admin'"
@@ -3754,6 +3858,7 @@ trait WebDav {
 	 * @param int $total
 	 * @param string|null $data
 	 * @param string $destination
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
@@ -3762,7 +3867,8 @@ trait WebDav {
 		int $num,
 		int $total,
 		?string $data,
-		string $destination
+		string $destination,
+		?bool $isGivenStep = false
 	):void {
 		$user = $this->getActualUsername($user);
 		$num -= 1;
@@ -3774,7 +3880,13 @@ trait WebDav {
 			$file,
 			['OC-Chunked' => '1'],
 			$data,
-			"uploads"
+			"uploads",
+			null,
+			false,
+			null,
+			[],
+			null,
+			$isGivenStep
 		);
 		$this->lastUploadDeleteTime = \time();
 	}
@@ -3800,7 +3912,7 @@ trait WebDav {
 		string $destination
 	):void {
 		$user = $this->getActualUsername($user);
-		$this->userUploadsChunkedFile($user, $num, $total, $data, $destination);
+		$this->userUploadsChunkedFile($user, $num, $total, $data, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload chunk $num of $total to file '$destination' for user '$user'"
@@ -3882,7 +3994,7 @@ trait WebDav {
 	 *                                | 1      | first data         |
 	 *                                | 2      | second data        |
 	 *                                Chunks may be numbered out-of-order if desired.
-	 * @param bool $checkActions
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 * @throws Exception
@@ -3892,7 +4004,7 @@ trait WebDav {
 		string $type,
 		string $file,
 		TableNode $chunkDetails,
-		bool $checkActions = false
+		?bool $isGivenStep = false
 	):void {
 		$user = $this->getActualUsername($user);
 		$async = false;
@@ -3906,7 +4018,7 @@ trait WebDav {
 			'chunking-42',
 			$chunkDetails->getHash(),
 			$async,
-			$checkActions
+			$isGivenStep
 		);
 	}
 
@@ -3922,7 +4034,7 @@ trait WebDav {
 	 *                            [content] data content of the chunk
 	 *                            Chunks may be numbered out-of-order if desired.
 	 * @param bool $async use asynchronous MOVE at the end or not
-	 * @param bool $checkActions
+	 * @param bool $isGivenStep
 	 *
 	 * @return void
 	 */
@@ -3932,10 +4044,10 @@ trait WebDav {
 		string $chunkingId,
 		array $chunkDetails,
 		bool $async = false,
-		bool $checkActions = false
+		bool $isGivenStep = false
 	):void {
 		$this->pauseUploadDelete();
-		if ($checkActions) {
+		if ($isGivenStep) {
 			$this->userHasCreatedANewChunkingUploadWithId($user, $chunkingId);
 		} else {
 			$this->userCreatesANewChunkingUploadWithId($user, $chunkingId);
@@ -3943,7 +4055,7 @@ trait WebDav {
 		foreach ($chunkDetails as $chunkDetail) {
 			$chunkNumber = (int)$chunkDetail['number'];
 			$chunkContent = $chunkDetail['content'];
-			if ($checkActions) {
+			if ($isGivenStep) {
 				$this->userHasUploadedNewChunkFileOfWithToId($user, $chunkNumber, $chunkContent, $chunkingId);
 			} else {
 				$this->userUploadsNewChunkFileOfWithToId($user, $chunkNumber, $chunkContent, $chunkingId);
@@ -3953,8 +4065,8 @@ trait WebDav {
 		if ($async === true) {
 			$headers = ['OC-LazyOps' => 'true'];
 		}
-		$this->moveNewDavChunkToFinalFile($user, $chunkingId, $file, $headers);
-		if ($checkActions) {
+		$this->moveNewDavChunkToFinalFile($user, $chunkingId, $file, $headers, $isGivenStep);
+		if ($isGivenStep) {
 			$this->theHTTPStatusCodeShouldBeSuccess();
 		}
 		$this->lastUploadDeleteTime = \time();
@@ -3965,10 +4077,15 @@ trait WebDav {
 	 *
 	 * @param string $user
 	 * @param string $id
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	public function userCreatesANewChunkingUploadWithId(string $user, string $id):void {
+	public function userCreatesANewChunkingUploadWithId(
+		string $user,
+		string $id,
+		?bool $isGivenStep = false
+	):void {
 		$user = $this->getActualUsername($user);
 		$destination = "/uploads/$user/$id";
 		$this->response = $this->makeDavRequest(
@@ -3977,7 +4094,13 @@ trait WebDav {
 			$destination,
 			[],
 			null,
-			"uploads"
+			"uploads",
+			null,
+			false,
+			null,
+			[],
+			null,
+			$isGivenStep
 		);
 	}
 
@@ -3990,7 +4113,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userHasCreatedANewChunkingUploadWithId(string $user, string $id):void {
-		$this->userCreatesANewChunkingUploadWithId($user, $id);
+		$this->userCreatesANewChunkingUploadWithId($user, $id, true);
 		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
@@ -4001,10 +4124,17 @@ trait WebDav {
 	 * @param int $num
 	 * @param string|null $data
 	 * @param string $id
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	public function userUploadsNewChunkFileOfWithToId(string $user, int $num, ?string $data, string $id):void {
+	public function userUploadsNewChunkFileOfWithToId(
+		string $user,
+		int $num,
+		?string $data,
+		string $id,
+		?bool $isGivenStep = false
+	):void {
 		$user = $this->getActualUsername($user);
 		$destination = "/uploads/$user/$id/$num";
 		$this->response = $this->makeDavRequest(
@@ -4013,7 +4143,13 @@ trait WebDav {
 			$destination,
 			[],
 			$data,
-			"uploads"
+			"uploads",
+			null,
+			false,
+			null,
+			[],
+			null,
+			$isGivenStep
 		);
 		$this->pushToLastStatusCodesArrays();
 	}
@@ -4029,7 +4165,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userHasUploadedNewChunkFileOfWithToId(string $user, int $num, ?string $data, string $id):void {
-		$this->userUploadsNewChunkFileOfWithToId($user, $num, $data, $id);
+		$this->userUploadsNewChunkFileOfWithToId($user, $num, $data, $id, true);
 		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
@@ -4232,10 +4368,17 @@ trait WebDav {
 	 * @param string $id upload id
 	 * @param string $destination destination path
 	 * @param array $headers extra headers
+	 * @param bool|null $isGivenStep
 	 *
 	 * @return void
 	 */
-	private function moveNewDavChunkToFinalFile(string $user, string $id, string $destination, array $headers):void {
+	private function moveNewDavChunkToFinalFile(
+		string $user,
+		string $id,
+		string $destination,
+		array $headers,
+		?bool $isGivenStep = false
+	):void {
 		$user = $this->getActualUsername($user);
 		$source = "/uploads/$user/$id/.file";
 		$headers['Destination'] = $this->destinationHeaderValue(
@@ -4249,7 +4392,13 @@ trait WebDav {
 			$source,
 			$headers,
 			null,
-			"uploads"
+			"uploads",
+			null,
+			false,
+			null,
+			[],
+			null,
+			$isGivenStep
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR extends #6796 
Straight after creating a user, test scenarios often create a folder or file(s) in the user's personal space. There seems to be a very small chance that the folder create MKCOL request or the file upload request gets a `409` "conflict" response. That happens when the server processing doesn't quite "see" the new user yet.

PR #6796 implemented code in the HTTP Request Helper to automatically retry the request if a `409` happens on a folder-create Given step.

This PR does the same for Given steps that upload a file - steps with the pattern "Given...has uploaded..."

The functions that are called in these cases now pass `isGivenStep` through to the HTTP Request Helper so that it knows that these are "Given" steps, and that it should retry the API  request if a `409` happens. This should further reduce the chance of getting rare intermittent failures happening in the "Given" steps that set up the user's files.

Some of the functions pass a lot of parameters. PHP 8 supports named-parameters  and would reduce the need to pass long lists of parameters just to be able to specify the last parameter. But we currently use PHP 7.4, so I have written out the parameter lists in full in the calls.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
