### PR TITLE
[tests-only][full-ci]Retry listing notifications

### DIFF
--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -318,6 +318,15 @@ class NotificationContext implements Context {
 	 */
 	public function userShouldGetANotificationWithMessage(string $user, string $subject, TableNode $table):void {
 		$this->userListAllNotifications($user);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200);
+		// sometimes the test might try to get notification before the notification is created by the server
+		// in order to prevent test from failing because of that list the notifications again
+		if (!isset($this->filterResponseAccordingToNotificationSubject($subject)->message)) {
+			\sleep(1);
+			$this->featureContext->setResponse(null);
+			$this->userListAllNotifications($user);
+			$this->featureContext->theHTTPStatusCodeShouldBe(200);
+		}
 		$actualMessage = str_replace(["\r", "\n"], " ", $this->filterResponseAccordingToNotificationSubject($subject)->message);
 		$expectedMessage = $table->getColumnsHash()[0]['message'];
 		Assert::assertSame(

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -319,11 +319,9 @@ class NotificationContext implements Context {
 	 */
 	public function userShouldGetANotificationWithMessage(string $user, string $subject, TableNode $table):void {
 		$count = 0;
-		$this->userListAllNotifications($user);
-		$this->featureContext->theHTTPStatusCodeShouldBe(200);
 		// sometimes the test might try to get notification before the notification is created by the server
 		// in order to prevent test from failing because of that try to list the notifications again
-		while (!isset($this->filterResponseAccordingToNotificationSubject($subject)->message) && $count <= 5) {
+		do {
 			if ($count > 0) {
 				\sleep(1);
 			}
@@ -331,7 +329,7 @@ class NotificationContext implements Context {
 			$this->userListAllNotifications($user);
 			$this->featureContext->theHTTPStatusCodeShouldBe(200);
 			++$count;
-		}
+		} while (!isset($this->filterResponseAccordingToNotificationSubject($subject)->message) && $count <= 5);
 		if (isset($this->filterResponseAccordingToNotificationSubject($subject)->message)) {
 			$actualMessage = str_replace(["\r", "\n"], " ", $this->filterResponseAccordingToNotificationSubject($subject)->message);
 		} else {

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -317,15 +317,15 @@ class NotificationContext implements Context {
 	 * @return void
 	 */
 	public function userShouldGetANotificationWithMessage(string $user, string $subject, TableNode $table):void {
-		$this->userListAllNotifications($user);
-		$this->featureContext->theHTTPStatusCodeShouldBe(200);
+		$count = 0;
 		// sometimes the test might try to get notification before the notification is created by the server
 		// in order to prevent test from failing because of that list the notifications again
-		if (!isset($this->filterResponseAccordingToNotificationSubject($subject)->message)) {
+		while (!isset($this->filterResponseAccordingToNotificationSubject($subject)->message) && $count <= 5) {
 			\sleep(1);
 			$this->featureContext->setResponse(null);
 			$this->userListAllNotifications($user);
 			$this->featureContext->theHTTPStatusCodeShouldBe(200);
+			++$count;
 		}
 		$actualMessage = str_replace(["\r", "\n"], " ", $this->filterResponseAccordingToNotificationSubject($subject)->message);
 		$expectedMessage = $table->getColumnsHash()[0]['message'];

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -315,25 +315,28 @@ class NotificationContext implements Context {
 	 * @param TableNode $table
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function userShouldGetANotificationWithMessage(string $user, string $subject, TableNode $table):void {
 		$count = 0;
-        $this->userListAllNotifications($user);
-        $this->featureContext->theHTTPStatusCodeShouldBe(200);
+		$this->userListAllNotifications($user);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200);
 		// sometimes the test might try to get notification before the notification is created by the server
-		// in order to prevent test from failing because of that list the notifications again
+		// in order to prevent test from failing because of that try to list the notifications again
 		while (!isset($this->filterResponseAccordingToNotificationSubject($subject)->message) && $count <= 5) {
-            if ($count > 0)\sleep(1);
+			if ($count > 0) {
+				\sleep(1);
+			}
 			$this->featureContext->setResponse(null);
 			$this->userListAllNotifications($user);
 			$this->featureContext->theHTTPStatusCodeShouldBe(200);
 			++$count;
 		}
-        if (isset($this->filterResponseAccordingToNotificationSubject($subject)->message)){
-            $actualMessage = str_replace(["\r", "\n"], " ", $this->filterResponseAccordingToNotificationSubject($subject)->message);
-        } else {
-            throw new \Exception("Notification was not found even after retrying for 5 seconds");
-        }
+		if (isset($this->filterResponseAccordingToNotificationSubject($subject)->message)) {
+			$actualMessage = str_replace(["\r", "\n"], " ", $this->filterResponseAccordingToNotificationSubject($subject)->message);
+		} else {
+			throw new \Exception("Notification was not found even after retrying for 5 seconds.");
+		}
 		$expectedMessage = $table->getColumnsHash()[0]['message'];
 		Assert::assertSame(
 			$expectedMessage,


### PR DESCRIPTION
Part of: https://github.com/owncloud/QA/issues/817

Sometimes tests try to get the notification before the server sends it, so the in this PR if the `message` is not set, then try to get the notification again. This will hopefully prevent error's like https://github.com/owncloud/QA/issues/817#issuecomment-1632153289

## Related error
`apiAntivirus/antivirus.feature:294`
`apiAntivirus/antivirus.feature:296`: https://drone.owncloud.com/owncloud/ocis/24228/56/7
```feature
  Scenario Outline: upload a file with virus smaller than the upload threshold                                             # /drone/src/tests/acceptance/features/apiAntivirus/antivirus.feature:283
    Given the config "ANTIVIRUS_MAX_SCAN_SIZE" has been set to "100"                                                       # OcisConfigContext::theConfigHasBeenSetTo()
    And using <dav-path-version> DAV path                                                                                  # FeatureContext::usingOldOrNewDavPath()
    When user "Alice" uploads file "filesForUpload/filesWithVirus/eicar.com" to "/aFileWithVirus.txt" using the WebDAV API # FeatureContext::userUploadsAFileTo()
    Then the HTTP status code should be "201"                                                                              # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And user "Alice" should get a notification with subject "Virus found" and message:                                     # NotificationContext::userShouldGetANotificationWithMessage()
      | message                                                                             |
      | Virus found in aFileWithVirus.txt. Upload not possible. Virus: Win.Test.EICAR_HDB-1 |
    And as "Alice" file "/aFileWithVirus.txt" should not exist                                                             # FeatureContext::asFileOrFolderShouldNotExist()

    Examples:
      | dav-path-version |
      | old              |
        Failed step: And user "Alice" should get a notification with subject "Virus found" and message:
        Notice: Undefined property: stdClass::$message in /drone/src/tests/acceptance/features/bootstrap/NotificationContext.php line 205
      | new              |
      | spaces           |
        Failed step: And user "Alice" should get a notification with subject "Virus found" and message:
        Notice: Undefined property: stdClass::$message in /drone/src/tests/acceptance/features/bootstrap/NotificationContext.php line 205
```

