### PR TITLE
[tests-only][full-ci]add api test for search files using tag in project spaces

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -747,7 +747,7 @@ class WebDavHelper {
 			if ($type === "trash-bin") {
 				return "/remote.php/dav/spaces/trash-bin/" . $spaceId . '/';
 			}
-			return "dav/spaces/" . $spaceId . '/';
+			return "/remote.php/dav/spaces/" . $spaceId . '/';
 		} else {
 			if ($davPathVersionToUse === self::DAV_VERSION_OLD) {
 				if ($type === "trash-bin") {

--- a/tests/acceptance/features/apiGraph/fullSearch.feature
+++ b/tests/acceptance/features/apiGraph/fullSearch.feature
@@ -8,20 +8,58 @@ Feature: full text search
     Given user "Alice" has been created with default attributes and without skeleton files
 
 
-  Scenario Outline: search files using a tag
+  Scenario Outline: search files by tag
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded file with content "hello world" to "file1.txt"
-    And user "Alice" has uploaded file with content "Namaste nepal" to "file2.txt"
-    And user "Alice" has uploaded file with content "hello nepal" to "file3.txt"
-    And user "Alice" has created the following tags for file "file1.txt" of the space "Personal":
+    And user "Alice" has created the following folders
+      | path                      |
+      | folderWithFile            |
+      | folderWithFile/subFolder/ |
+    And user "Alice" has uploaded the following files with content "some data"
+      | path                                             |
+      | fileInRootLevel.txt                                         |
+      | folderWithFile/fileInsideFolder.txt              |
+      | folderWithFile/subFolder/fileInsideSubFolder.txt |
+    And user "Alice" has created the following tags for file "fileInRootLevel.txt" of the space "Personal":
       | tag1 |
-    And user "Alice" has created the following tags for file "file2.txt" of the space "Personal":
+    And user "Alice" has created the following tags for file "folderWithFile/fileInsideFolder.txt" of the space "Personal":
+      | tag1 |
+    And user "Alice" has created the following tags for file "folderWithFile/subFolder/fileInsideSubFolder.txt" of the space "Personal":
       | tag1 |
     When user "Alice" searches for "Tags:tag1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these files:
-      | file1.txt |
-      | file2.txt |
+      | fileInRootLevel.txt     |
+      | fileInsideFolder.txt    |
+      | fileInsideSubFolder.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+
+  Scenario Outline: search project space files by tag
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "tag-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "spacesFolderWithFile/spacesSubFolder" in space "tag-space"
+    And user "Alice" has uploaded a file inside space "tag-space" with content "tagged file" to "spacesFile.txt"
+    And user "Alice" has uploaded a file inside space "tag-space" with content "untagged file" to "spacesFileWithoutTag.txt"
+    And user "Alice" has uploaded a file inside space "tag-space" with content "tagged file in folder" to "spacesFolderWithFile/spacesFileInsideFolder.txt"
+    And user "Alice" has uploaded a file inside space "tag-space" with content "tagged file in subfolder" to "spacesFolderWithFile/spacesSubFolder/spacesFileInsideSubFolder.txt"
+    And user "Alice" has created the following tags for file "spacesFile.txt" of the space "tag-space":
+      | tag1 |
+    And user "Alice" has created the following tags for file "spacesFolderWithFile/spacesFileInsideFolder.txt" of the space "tag-space":
+      | tag1 |
+    And user "Alice" has created the following tags for file "spacesFolderWithFile/spacesSubFolder/spacesFileInsideSubFolder.txt" of the space "tag-space":
+      | tag1 |
+    And using <dav-path-version> DAV path
+    When user "Alice" searches for "Tags:tag1" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these files:
+      | spacesFile.txt                |
+      | spacesFileInsideFolder.txt    |
+      | spacesFileInsideSubFolder.txt |
     Examples:
       | dav-path-version |
       | old              |
@@ -72,6 +110,7 @@ Feature: full text search
       | dav-path-version |
       | old              |
       | new              |
+      | spaces           |
 
 
   Scenario Outline: search files using a deleted tag

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -259,6 +259,7 @@ trait WebDav {
 		$this->davPath = $this->getOldDavPath();
 		$this->usingOldDavPath = true;
 		$this->customDavPath = null;
+		$this->usingSpacesDavPath = false;
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds the API tests for full search api. The scenarios added in this PR are
- search files by tag using new DAV path in Project spaces
In this PR there is refactored on:
- search files by tag

## Related Issue
- https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
- there was no test coverage for api test for search files using tag in project spaces. This PR covers the global search using tag on  personal space and global spaces. There is only search scanerio test done only by using new Dav path. There is also done refactor on `search files by tag` there are some changes like:
1. The file name is changes
2. There is also check for search for file inside folder and subfolder

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
