### PR TITLE
[tests-only]add tika service to s3 docker compose example

### DIFF
--- a/deployments/examples/ocis_s3/.env
+++ b/deployments/examples/ocis_s3/.env
@@ -22,6 +22,8 @@ ADMIN_PASSWORD=
 # The demo users should not be created on a production instance
 # because their passwords are public. Defaults to "false".
 DEMO_USERS=
+# Enable basic auth. Defaults to "false"
+PROXY_ENABLE_BASIC_AUTH=
 
 ### MINIO / S3 settings ###
 # Domain of MinIO where the Web UI is accessible. Defaults to "minio.owncloud.test".

--- a/deployments/examples/ocis_s3/docker-compose.yml
+++ b/deployments/examples/ocis_s3/docker-compose.yml
@@ -78,6 +78,16 @@ services:
       IDM_ADMIN_PASSWORD: "${ADMIN_PASSWORD:-admin}" # this overrides the admin password from the configuration file
       # demo users
       IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
+
+      #FRONTEND
+      FRONTEND_SEARCH_MIN_LENGTH: "2"
+      FRONTEND_OCS_ENABLE_DENIALS: "true"
+      FRONTEND_FULL_TEXT_SEARCH_ENABLED: "true"
+
+      # TIKA
+      SEARCH_EXTRACTOR_TYPE: "tika"
+      SEARCH_EXTRACTOR_TIKA_TIKA_URL: "http://tika:9998"
+      SEARCH_EXTRACTOR_CS3SOURCE_INSECURE: "true"
     volumes:
       - ocis-config:/etc/ocis
       - ocis-data:/var/lib/ocis
@@ -117,6 +127,12 @@ services:
       - "traefik.http.services.minio.loadbalancer.server.port=9001"
     logging:
       driver: "local"
+    restart: always
+
+  tika:
+    image: ${TIKA_IMAGE:-apache/tika:latest-full}
+    networks:
+      ocis-net:
     restart: always
 
 volumes:


### PR DESCRIPTION
We don't have a tika service setup in the docker-compose example for S3, so I added it along with other environment variables.
These changes can be helpful especially during the QA phase as we run e2e tests that require these services and envs