### PR TITLE
[tests-only][full-ci] Fix the syntax of the test step

### DIFF
--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
@@ -22,7 +22,7 @@ Feature: Share a file or folder that is inside a space
 
 
   Scenario Outline: manager of the space can share an entity inside project space to another user with role
-    And user "Alice" creates a share inside of space "share sub-item" with settings:
+    When user "Alice" creates a share inside of space "share sub-item" with settings:
       | path       | <entity>     |
       | shareWith  | Brian        |
       | role       | <role>       |


### PR DESCRIPTION
The test step started with `And` instead of `When` as this is not the convention we follow, this PR fixes that