### PR TITLE
[full-ci][tests-only][backport] Check id file owner in response

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -23,14 +23,10 @@ default:
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
         - CapabilitiesContext:
-        - ChecksumContext:
-        - FavoritesContext:
         - FilesVersionsContext:
         - NotificationContext:
         - OCSContext:
         - PublicWebDavContext:
-        - TrashbinContext:
-        - WebDavPropertiesContext:
 
     apiSpaces:
       paths:
@@ -41,16 +37,12 @@ default:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
-        - ChecksumContext:
-        - FavoritesContext:
         - FilesVersionsContext:
         - NotificationContext:
         - OCSContext:
         - PublicWebDavContext:
         - SearchContext:
         - TagContext:
-        - TrashbinContext:
-        - WebDavPropertiesContext:
         - TUSContext:
         - SpacesTUSContext:
         - GraphContext:
@@ -88,14 +80,10 @@ default:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
-        - ChecksumContext:
-        - FavoritesContext:
         - FilesVersionsContext:
         - OCSContext:
         - PublicWebDavContext:
         - SearchContext:
-        - TrashbinContext:
-        - WebDavPropertiesContext:
         - TUSContext:
         - SpacesTUSContext:
         - GraphContext:
@@ -110,13 +98,9 @@ default:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
-        - ChecksumContext:
         - FilesVersionsContext:
         - OCSContext:
         - PublicWebDavContext:
-        - FavoritesContext:
-        - TrashbinContext:
-        - WebDavPropertiesContext:
         - GraphContext:
 
     apiGraph:
@@ -129,14 +113,10 @@ default:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
-        - ChecksumContext:
-        - FavoritesContext:
         - FilesVersionsContext:
         - OCSContext:
         - PublicWebDavContext:
         - SearchContext:
-        - TrashbinContext:
-        - WebDavPropertiesContext:
         - TUSContext:
         - SpacesTUSContext:
         - OcisConfigContext:
@@ -150,12 +130,8 @@ default:
       contexts:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
-        - WebDavPropertiesContext:
-        - FavoritesContext:
-        - ChecksumContext:
         - FilesVersionsContext:
         - OCSContext:
-        - TrashbinContext:
         - GraphContext:
         - OcisConfigContext:
 
@@ -167,11 +143,8 @@ default:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
         - WebDavPropertiesContext:
-        - FavoritesContext:
-        - ChecksumContext:
         - FilesVersionsContext:
         - OCSContext:
-        - TrashbinContext:
         - GraphContext:
         - OcisConfigContext:
 
@@ -183,12 +156,8 @@ default:
         - NotificationContext:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
-        - WebDavPropertiesContext:
         - OCSContext:
         - GraphContext:
-        - TrashbinContext:
-        - FavoritesContext:
-        - ChecksumContext:
         - FilesVersionsContext:
         - SettingsContext:
 
@@ -200,12 +169,8 @@ default:
         - NotificationContext:
         - SpacesContext:
         - FeatureContext: *common_feature_context_params
-        - WebDavPropertiesContext:
         - OCSContext:
         - GraphContext:
-        - TrashbinContext:
-        - FavoritesContext:
-        - ChecksumContext:
         - FilesVersionsContext:
         - SettingsContext:
         - OcisConfigContext:

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -76,10 +76,10 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:63](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L63)
 - [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:64](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L64)
 - [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L65)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:93](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L93)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:167](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L167)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:168](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L168)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:169](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L169)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:97](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L97)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:172](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L172)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:173](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L173)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:174](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L174)
 
 #### [A User can get information of another user with Graph API](https://github.com/owncloud/ocis/issues/5125)
 

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -76,10 +76,10 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:63](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L63)
 - [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:64](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L64)
 - [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L65)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:97](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L97)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:172](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L172)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:173](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L173)
-- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:174](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L174)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:93](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L93)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:167](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L167)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:168](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L168)
+- [apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature:169](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature#L169)
 
 #### [A User can get information of another user with Graph API](https://github.com/owncloud/ocis/issues/5125)
 

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
@@ -1,22 +1,22 @@
-@api 
+@api
 Feature: Share a file or folder that is inside a space via public link
-  As a user with manager space role
-  I want to be able to share the data inside the space via public link
-  So that an anonymous user can have access to certain resources
+      As a user with manager space role
+      I want to be able to share the data inside the space via public link
+      So that an anonymous user can have access to certain resources
 
-  folder permissions:
-    | role        | permissions |
-    | internal    | 0           |
-    | viewer      | 1           |
-    | uploader    | 4           |
-    | contributor | 5           |
-    | editor      | 15          |
+      folder permissions:
+      | role        | permissions |
+      | internal    | 0           |
+      | viewer      | 1           |
+      | uploader    | 4           |
+      | contributor | 5           |
+      | editor      | 15          |
 
-  file permissions:
-    | role     | permissions |
-    | internal | 0           |
-    | viewer   | 1           |
-    | editor   | 3           |
+      file permissions:
+      | role     | permissions |
+      | internal | 0           |
+      | viewer   | 1           |
+      | editor   | 3           |
 
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
@@ -44,7 +44,7 @@ Feature: Share a file or folder that is inside a space via public link
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the OCS status message should be "OK"
-    And the fields of the last response to user "Alice" should include
+    And the fields of the last response to user "Alice" and space "share sub-item" should include
       | item_type         | <item_type>   |
       | mimetype          | <mimetype>    |
       | file_target       | <file_target> |
@@ -53,6 +53,8 @@ Feature: Share a file or folder that is inside a space via public link
       | share_type        | public_link   |
       | displayname_owner | %displayname% |
       | name              | <name>        |
+      | uid_file_owner    | %space_id%    |
+      | space_id          | %space_id%    |
     Examples:
       | entity          | file_target | permissions | password | name | expireDate               | item_type | mimetype             |
       | folder          | /folder     | 0           |          | link |                          | folder    | httpd/unix-directory |
@@ -79,7 +81,7 @@ Feature: Share a file or folder that is inside a space via public link
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the OCS status message should be "OK"
-    And the fields of the last response to user "Brian" should include
+    And the fields of the last response to user "Brian" and space "share sub-item" should include
       | item_type         | <item_type>   |
       | mimetype          | <mimetype>    |
       | file_target       | <file_target> |
@@ -87,6 +89,8 @@ Feature: Share a file or folder that is inside a space via public link
       | share_type        | public_link   |
       | displayname_owner | %displayname% |
       | name              | public link   |
+      | uid_file_owner    | %space_id%    |
+      | space_id          | %space_id%    |
     Examples:
       | entity          | file_target | item_type | mimetype             |
       | folder          | /folder     | folder    | httpd/unix-directory |
@@ -115,7 +119,7 @@ Feature: Share a file or folder that is inside a space via public link
       | folder/file.txt | viewer    |
 
 
-  Scenario Outline: user creates a new public link share of a file with edit permissions
+  Scenario Outline: user creates a new public link share of a file inside the personal space with edit permissions
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/file.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -150,17 +154,18 @@ Feature: Share a file or folder that is inside a space via public link
       | path        | folder/file.txt |
       | shareType   | 3               |
       | permissions | 1               |
-    Then the fields of the last response to user "Alice" should include
-      | item_type              | file            |
-      | mimetype               | text/plain      |
-      | file_target            | /file.txt       |
-      | path                   | folder/file.txt |
-      | permissions            | 1               |
-      | share_type             | public_link     |
-      | displayname_file_owner | %displayname%   |
-      | displayname_owner      | %displayname%   |
-      | uid_file_owner         | %username%      |
-      | uid_owner              | %username%      |
+    Then the fields of the last response to user "Alice" and space "share sub-item" should include
+      | item_type              | file             |
+      | mimetype               | text/plain       |
+      | file_target            | /file.txt        |
+      | path                   | /folder/file.txt |
+      | permissions            | 1                |
+      | share_type             | public_link      |
+      | displayname_file_owner |                  |
+      | displayname_owner      | %displayname%    |
+      | uid_owner              | %username%       |
+      | uid_file_owner         | %space_id%       |
+      | space_id               | %space_id%       |
     And for user "Brian" the space "share sub-item" should contain the last created public link of the file "folder/file.txt"
     Examples:
       | spaceRole |

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
@@ -1,22 +1,22 @@
 @api
 Feature: Share a file or folder that is inside a space via public link
-      As a user with manager space role
-      I want to be able to share the data inside the space via public link
-      So that an anonymous user can have access to certain resources
+  As a user with manager space role
+  I want to be able to share the data inside the space via public link
+  So that an anonymous user can have access to certain resources
 
-      folder permissions:
-      | role        | permissions |
-      | internal    | 0           |
-      | viewer      | 1           |
-      | uploader    | 4           |
-      | contributor | 5           |
-      | editor      | 15          |
+  folder permissions:
+  | role        | permissions |
+  | internal    | 0           |
+  | viewer      | 1           |
+  | uploader    | 4           |
+  | contributor | 5           |
+  | editor      | 15          |
 
-      file permissions:
-      | role     | permissions |
-      | internal | 0           |
-      | viewer   | 1           |
-      | editor   | 3           |
+  file permissions:
+  | role     | permissions |
+  | internal | 0           |
+  | viewer   | 1           |
+  | editor   | 3           |
 
   Note - this feature is run in CI with ACCOUNTS_HASH_DIFFICULTY set to the default for production
   See https://github.com/owncloud/ocis/issues/1542 and https://github.com/owncloud/ocis/pull/839
@@ -53,8 +53,6 @@ Feature: Share a file or folder that is inside a space via public link
       | share_type        | public_link   |
       | displayname_owner | %displayname% |
       | name              | <name>        |
-      | uid_file_owner    | %space_id%    |
-      | space_id          | %space_id%    |
     Examples:
       | entity          | file_target | permissions | password | name | expireDate               | item_type | mimetype             |
       | folder          | /folder     | 0           |          | link |                          | folder    | httpd/unix-directory |
@@ -89,8 +87,6 @@ Feature: Share a file or folder that is inside a space via public link
       | share_type        | public_link   |
       | displayname_owner | %displayname% |
       | name              | public link   |
-      | uid_file_owner    | %space_id%    |
-      | space_id          | %space_id%    |
     Examples:
       | entity          | file_target | item_type | mimetype             |
       | folder          | /folder     | folder    | httpd/unix-directory |
@@ -164,8 +160,7 @@ Feature: Share a file or folder that is inside a space via public link
       | displayname_file_owner |                  |
       | displayname_owner      | %displayname%    |
       | uid_owner              | %username%       |
-      | uid_file_owner         | %space_id%       |
-      | space_id               | %space_id%       |
+      | uid_file_owner         | %username%       |
     And for user "Brian" the space "share sub-item" should contain the last created public link of the file "folder/file.txt"
     Examples:
       | spaceRole |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -162,6 +162,7 @@ class FeatureContext extends BehatVariablesContext {
 	public OCSContext $ocsContext;
 	public AuthContext $authContext;
 	public GraphContext $graphContext;
+	public SpacesContext $spacesContext;
 	public AppConfigurationContext $appConfigurationContext;
 	private array $initialTrustedServer;
 
@@ -3221,12 +3222,15 @@ class FeatureContext extends BehatVariablesContext {
 		$this->ocsContext = new OCSContext();
 		$this->authContext = new AuthContext();
 		$this->appConfigurationContext = new AppConfigurationContext();
+		$this->spacesContext = new SpacesContext();
 		$this->ocsContext->before($scope);
 		$this->authContext->setUpScenario($scope);
 		$this->appConfigurationContext->setUpScenario($scope);
 		$environment->registerContext($this->ocsContext);
 		$environment->registerContext($this->authContext);
 		$environment->registerContext($this->appConfigurationContext);
+		$this->spacesContext->setUpScenario($scope);
+		$environment->registerContext($this->spacesContext);
 		$scenarioLine = $scope->getScenario()->getLine();
 		$featureFile = $scope->getFeature()->getFile();
 		$suiteName = $scope->getSuite()->getName();

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2753,6 +2753,70 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then the fields of the last response to user :user and space :space should include
+	 *
+	 * @param string $user
+	 * @param string $space
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function checkFieldsOfSpaceSharingResponse(string $user, string $space, ?TableNode $body):void {
+		$this->verifyTableNodeColumnsCount($body, 2);
+	
+		$bodyRows = $body->getRowsHash();
+		$userRelatedFieldNames = [
+			"owner",
+			"user",
+			"uid_owner",
+			"uid_file_owner",
+			"share_with",
+			"displayname_file_owner",
+			"displayname_owner",
+			"additional_info_owner",
+			"additional_info_file_owner",
+			"space_id"
+		];
+
+		$this->setLastPublicShareData($this->getResponseXml(null, __METHOD__));
+		foreach ($bodyRows as $field => $value) {
+			if (\in_array($field, $userRelatedFieldNames)) {
+				$value = $this->substituteInLineCodes($value, $user);
+				$value = $this->substituteInLineCodes(
+					$value,
+					$user,
+					[],
+					[
+						[
+							"code" => "%space_id%",
+							"function" =>
+								[$this->spacesContext, "getSpaceIdByName"],
+							"parameter" => [$user, $space]
+						],
+					],
+					null,
+					null
+				);
+				if ($field === "uid_file_owner") {
+					$value = (explode("$", $value))[1];
+				}
+				if ($field === "space_id") {
+					$exploadedSpaceId = explode("$", $value);
+					$value = $exploadedSpaceId[0] . "$" . $exploadedSpaceId[1] . "!" . $exploadedSpaceId[1];
+				}
+			}
+			$value = $this->getActualUsername($value);
+			$value = $this->replaceValuesFromTable($field, $value);
+   
+			Assert::assertTrue(
+				$this->isFieldInResponse($field, $value, true, $this->getLastPublicShareData()->data[0]),
+				"$field doesn't have value '$value'"
+			);
+		}
+	}
+
+	/**
 	 * @Then /^the fields of the last response (?:to|about) user "([^"]*)" sharing with (?:user|group) "([^"]*)" should include$/
 	 *
 	 * @param string $sharer

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2782,7 +2782,6 @@ trait Sharing {
 		$this->setLastPublicShareData($this->getResponseXml(null, __METHOD__));
 		foreach ($bodyRows as $field => $value) {
 			if (\in_array($field, $userRelatedFieldNames)) {
-				$value = $this->substituteInLineCodes($value, $user);
 				$value = $this->substituteInLineCodes(
 					$value,
 					$user,

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -205,7 +205,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * The method finds the space of a user by name and returns the space id
+	 * The method finds available spaces to the user and returns the spaceId by spaceName
 	 *
 	 * @param string $user
 	 * @param string $spaceName
@@ -215,10 +215,6 @@ class SpacesContext implements Context {
 	 */
 	public function getSpaceIdByName(string $user, string $spaceName): string {
 		$space = $this->getSpaceByName($user, $spaceName);
-		Assert::assertIsArray($space, "Space with name $spaceName not found");
-		if (!isset($space["id"])) {
-			throw new Exception(__METHOD__ . " space with name $spaceName not found in $space");
-		}
 		return $space["id"];
 	}
 
@@ -396,14 +392,20 @@ class SpacesContext implements Context {
 	public function setUpScenario(BeforeScenarioScope $scope): void {
 		// Get the environment
 		$environment = $scope->getEnvironment();
+		// register new context
+		$this->trashbinContext = new TrashbinContext();
+		$this->webDavPropertiesContext = new WebDavPropertiesContext();
+		$this->favoritesContext = new FavoritesContext();
+		$this->checksumContext = new ChecksumContext();
+		$this->filesVersionsContext = new FilesVersionsContext();
+		$environment->registerContext($this->trashbinContext);
+		$environment->registerContext($this->webDavPropertiesContext);
+		$environment->registerContext($this->favoritesContext);
+		$environment->registerContext($this->checksumContext);
+		$environment->registerContext($this->filesVersionsContext);
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
 		$this->ocsContext = $environment->getContext('OCSContext');
-		$this->trashbinContext = $environment->getContext('TrashbinContext');
-		$this->webDavPropertiesContext = $environment->getContext('WebDavPropertiesContext');
-		$this->favoritesContext = $environment->getContext('FavoritesContext');
-		$this->checksumContext = $environment->getContext('ChecksumContext');
-		$this->filesVersionsContext = $environment->getContext('FilesVersionsContext');
 		// Run the BeforeScenario function in OCSContext to set it up correctly
 		$this->ocsContext->before($scope);
 		$this->baseUrl = \trim($this->featureContext->getBaseUrl(), "/");


### PR DESCRIPTION
Backport: https://github.com/owncloud/ocis/pull/6627

the feature `uid_file_owner = spaceId for project space` was not merged to the stable branch, so this check is not done here.