### PR TITLE
[full-ci] Fix the default document language for OnlyOffice

### DIFF
--- a/changelog/unreleased/fix-onlyoffice-default-document-language.md
+++ b/changelog/unreleased/fix-onlyoffice-default-document-language.md
@@ -1,0 +1,6 @@
+Bugfix: fix the default document language for OnlyOffice
+
+Fix the default document language for OnlyOffice
+
+https://github.com/owncloud/ocis/pull/6878
+https://github.com/owncloud/enterprise/issues/5807

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/cs3org/go-cs3apis v0.0.0-20230516150832-730ac860c71d
-	github.com/cs3org/reva/v2 v2.15.1-0.20230724142905-f4507ac94bd4
+	github.com/cs3org/reva/v2 v2.15.1-0.20230725125905-676d4e05f1b7
 	github.com/disintegration/imaging v1.6.2
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e
 	github.com/egirna/icap-client v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
-github.com/cs3org/reva/v2 v2.15.1-0.20230724142905-f4507ac94bd4 h1:4o6B4JibypM0phV/GI7CcIvVvIP+hF6CSkjvJ91CYJk=
-github.com/cs3org/reva/v2 v2.15.1-0.20230724142905-f4507ac94bd4/go.mod h1:4z5EQghS2LhSWZWocH51Dw9VAs16No1zSFvFgQtgS7w=
+github.com/cs3org/reva/v2 v2.15.1-0.20230725125905-676d4e05f1b7 h1:+G17hDLzyv3tVht0UdrvWwsxiFE8MaJ09QaQvxhXRdE=
+github.com/cs3org/reva/v2 v2.15.1-0.20230725125905-676d4e05f1b7/go.mod h1:4z5EQghS2LhSWZWocH51Dw9VAs16No1zSFvFgQtgS7w=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/vendor/github.com/cs3org/reva/v2/pkg/app/provider/wopi/wopi.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/app/provider/wopi/wopi.go
@@ -254,9 +254,9 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 
 	urlQuery := url.Query()
 	if language != "" {
-		urlQuery.Set("ui", language)      // OnlyOffice
-		urlQuery.Set("lang", language)    // Collabora
-		urlQuery.Set("UI_LLCC", language) // Office365
+		urlQuery.Set("ui", language)                  // OnlyOffice
+		urlQuery.Set("lang", covertLangTag(language)) // Collabora, Impact on the default document language of OnlyOffice
+		urlQuery.Set("UI_LLCC", language)             // Office365
 	}
 	if p.conf.AppDisableChat {
 		urlQuery.Set("dchat", "1") // OnlyOffice disable chat
@@ -469,4 +469,23 @@ func getEtherpadExtensions(appURL string) map[string]map[string]string {
 		".epd": appURL,
 	}
 	return appURLs
+}
+
+// TODO Find better solution
+// This conversion was made because no other way to set the default document language to OnlyOffice was found.
+func covertLangTag(lang string) string {
+	switch lang {
+	case "cs":
+		return "cs-CZ"
+	case "de":
+		return "de-DE"
+	case "es":
+		return "es-ES"
+	case "fr":
+		return "fr-FR"
+	case "it":
+		return "it-IT"
+	default:
+		return "en"
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -352,7 +352,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.15.1-0.20230724142905-f4507ac94bd4
+# github.com/cs3org/reva/v2 v2.15.1-0.20230725125905-676d4e05f1b7
 ## explicit; go 1.20
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Fix the default document language for OnlyOffice

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [https://github.com/owncloud/enterprise/issues/5807](https://github.com/owncloud/enterprise/issues/5807)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: The local docker stack [wopi](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_wopi) setup: 
- checkout to the issue branch and build the dev image `make -C ocis dev-docker`
- go to deployments/examples/ocis_wop 
- run `export OCIS_DOCKER_TAG=dev` and `docker-compose up -d`
- test case 1: Change the language to desirable in the Account settings (Galego is not supported). Create the new Microsoft Word document.
Expected result: The UI and document language match to ocis language.



## Screenshots (if appropriate):
![Screenshot 2023-07-24 at 18 52 10](https://github.com/owncloud/ocis/assets/11679989/4228a483-9d71-4617-88d0-fb918ff21ab6)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
