### PR TITLE
[full-ci] chore: bump web to v7.1.0-rc.2

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=4925a1bd117f31530f6ebdf5af2a9215ad3c6796
+WEB_COMMITID=373eac416486791123912f13c6b9f6efb7511ae3
 WEB_BRANCH=stable-7.1

--- a/changelog/3.1.0_2023-07-18/update-web-7.1.0-rc.1.md
+++ b/changelog/3.1.0_2023-07-18/update-web-7.1.0-rc.1.md
@@ -1,8 +1,8 @@
-Enhancement: Update web to v7.1.0-rc.1
+Enhancement: Update web to v7.1.0-rc.2
 
 Tags: web
 
-We updated ownCloud Web to v7.1.0-rc.1. Please refer to the changelog (linked) for details on the web release.
+We updated ownCloud Web to v7.1.0-rc.2. Please refer to the changelog (linked) for details on the web release.
 
 ## Summary
 * Bugfix [owncloud/web#9078](https://github.com/owncloud/web/pull/9078): Favorites list update on removal
@@ -14,6 +14,7 @@ We updated ownCloud Web to v7.1.0-rc.1. Please refer to the changelog (linked) f
 * Bugfix [owncloud/web#9315](https://github.com/owncloud/web/issues/9315): Switch columns displayed on small screens in "Shared with me" view
 * Bugfix [owncloud/web#9351](https://github.com/owncloud/web/pull/9351): Media controls overflow on mobile screens
 * Bugfix [owncloud/web#9389](https://github.com/owncloud/web/pull/9389): Space editors see empty trashbin and delete actions in space trashbin
+* Bugfix [owncloud/web#9461](https://github.com/owncloud/web/pull/9461): Merging folders
 * Enhancement [owncloud/web#7967](https://github.com/owncloud/web/pull/7967): Add hasPriority property for editors per extension
 * Enhancement [owncloud/web#8422](https://github.com/owncloud/web/issues/8422): Improve extension app topbar
 * Enhancement [owncloud/web#8445](https://github.com/owncloud/web/issues/8445): Open individually shared file in dedicated view
@@ -51,5 +52,5 @@ We updated ownCloud Web to v7.1.0-rc.1. Please refer to the changelog (linked) f
 * Enhancement [owncloud/web#9386](https://github.com/owncloud/web/pull/9386): Allow local storage for auth token
 * Enhancement [owncloud/web#9394](https://github.com/owncloud/web/pull/9394): Button styling
 
-https://github.com/owncloud/ocis/pull/6828
-https://github.com/owncloud/web/releases/tag/v7.1.0-rc.1
+https://github.com/owncloud/ocis/pull/6894
+https://github.com/owncloud/web/releases/tag/v7.1.0-rc.2

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.1.0-rc.1
+WEB_ASSETS_VERSION = v7.1.0-rc.2
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
The following issues have been fixed since the last RC:

- fix: add missing translations: [owncloud/web#9443](https://github.com/owncloud/web/pull/9443)
- fix: access token renewal during cloud imports: [owncloud/web#9460](https://github.com/owncloud/web/pull/9460)
- fix: broken cloud import dashboard when upload failed before: [owncloud/web#9471](https://github.com/owncloud/web/pull/9471)
- fix: prevent uploads when a cloud import is running: [owncloud/web#9470](https://github.com/owncloud/web/pull/9470)
- fix: concurrent uploads: [owncloud/web#9463](https://github.com/owncloud/web/pull/9463)
- fix: generate unique request ids for tus upload requests: [owncloud/web#9418](https://github.com/owncloud/web/pull/9418)
- fix: merging folders: [owncloud/web#9477](https://github.com/owncloud/web/pull/9477)
- fix: various search location filter issues: [owncloud/web#9432](https://github.com/owncloud/web/pull/9432)
- fix: location filter seach with shares: [owncloud/web#9456](https://github.com/owncloud/web/pull/9456)
