### PR TITLE
fix: make error message compatible with oc10 while trying to preview other user's file via webdav

### DIFF
--- a/changelog/unreleased/fix-error-message-downloading-others-file-preview.md
+++ b/changelog/unreleased/fix-error-message-downloading-others-file-preview.md
@@ -1,0 +1,7 @@
+Bugfix: Fix error message while downloading preview of other user's file
+
+Fix error message while downloading preview of other user's file via new dav endpoint and
+make it compatible with the oc10 behavior
+
+https://github.com/owncloud/ocis/issues/2071
+https://github.com/owncloud/ocis/pull/6897

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -346,7 +346,11 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		switch e.Code {
 		case http.StatusNotFound:
 			// StatusNotFound is expected for unsupported files
-			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
+			message := notFoundMsg(tr.Filename)
+			if strings.Contains(e.Detail, "could not find space") {
+				message = spaceNotFoundMsg(tr.Filename, user.Username)
+			}
+			renderError(w, r, errNotFound(message))
 			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(err.Error()))
@@ -540,4 +544,8 @@ func renderError(w http.ResponseWriter, r *http.Request, err *errResponse) {
 
 func notFoundMsg(name string) string {
 	return "File with name " + name + " could not be located"
+}
+
+func spaceNotFoundMsg(name string, space string) string {
+	return "File not found: " + name + " in '" + space + "'"
 }

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -208,10 +208,6 @@ cannot share a folder with create permission
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 - [coreApiSharePublicLink1/createPublicLinkShare.feature:327](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L327)
 
-#### [download previews of other users file](https://github.com/owncloud/ocis/issues/2071)
-
-- [coreApiWebdavPreviews/previews.feature:98](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L98)
-
 #### [different error message detail for previews of folder](https://github.com/owncloud/ocis/issues/2064)
 
 - [coreApiWebdavPreviews/previews.feature:107](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L107)


### PR DESCRIPTION
## Description
This PR just tries to fix https://github.com/owncloud/ocis/issues/2071. I don't know if we can/should do this (set message based on the error message). But I couldn't find any other way to determine if the `404 fail` was due to space or resource not being found.

**oC10 behavior:**
1. non-existing file: `/remote.php/dav/files/user1/nonexisting.txt?x=32&y=32&forceIcon=0&preview=1`
    > File with name nonexisting.txt could not be located
2. :bulb: other user: `/remote.php/dav/files/user2/lorem.txt?x=32&y=32&forceIcon=0&preview=1`
    > File not found: lorem.txt in 'user2'
3. non-existing user: `/remote.php/dav/files/unknown/lorem.txt?x=32&y=32&forceIcon=0&preview=1`
    > Principal with name unknown not found

**oCIS behavior (old):**
1. non-existing file: `/remote.php/dav/files/user1/nonexisting.txt?x=32&y=32&forceIcon=0&preview=1`
    > File with name nonexisting.txt could not be located
2. :bulb: other user: `/remote.php/dav/files/user2/lorem.txt?x=32&y=32&forceIcon=0&preview=1`
    > File with name lorem.txt could not be located
3. non-existing user: `/remote.php/dav/files/unknown/lorem.txt?x=32&y=32&forceIcon=0&preview=1`
    > could not get user

**oCIS behavior (this PR):**
1. non-existing file: `/remote.php/dav/files/user1/nonexisting.txt?x=32&y=32&forceIcon=0&preview=1`
    > File with name nonexisting.txt could not be located
2. :bulb: other user: `/remote.php/dav/files/user2/lorem.txt?x=32&y=32&forceIcon=0&preview=1`
    > File not found: lorem.txt in 'user2'
3. non-existing user: `/remote.php/dav/files/unknown/lorem.txt?x=32&y=32&forceIcon=0&preview=1`
    > could not get user

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/2071

## Motivation
https://github.com/owncloud/ocis/issues/2071#issuecomment-847621421

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
