### PR TITLE
[do-not-merge]fix: make error message compatible with oc10 while trying to preview other user's file via webdav

### DIFF
--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -334,7 +334,11 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		switch e.Code {
 		case http.StatusNotFound:
 			// StatusNotFound is expected for unsupported files
-			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
+			message := notFoundMsg(tr.Filename)
+			if strings.Contains(e.Detail, "could not find space") {
+				message = spaceNotFoundMsg(tr.Filename, user.Username)
+			}
+			renderError(w, r, errNotFound(message))
 			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(err.Error()))
@@ -528,4 +532,8 @@ func renderError(w http.ResponseWriter, r *http.Request, err *errResponse) {
 
 func notFoundMsg(name string) string {
 	return "File with name " + name + " could not be located"
+}
+
+func spaceNotFoundMsg(name string, space string) string {
+	return "File not found: " + name + " in '" + space + "'"
 }


### PR DESCRIPTION
## Description
This PR just tries to fix https://github.com/owncloud/ocis/issues/2071. I don't know if we can/should do this (set message based on the error message). But I couldn't find any other way to determine if the 404 fail was due to space or resource not being found.

For master: https://github.com/owncloud/ocis/pull/6897

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/2071

## How Has This Been Tested?
- test environment: local and CI

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
