### PR TITLE
[full-ci] Add support for running/rolling back decomposedfs migrations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/cs3org/go-cs3apis v0.0.0-20230516150832-730ac860c71d
-	github.com/cs3org/reva/v2 v2.15.1-0.20230726135727-c444e4c5a24f
+	github.com/cs3org/reva/v2 v2.15.1-0.20230731061316-db79e9b61738
 	github.com/disintegration/imaging v1.6.2
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e
 	github.com/egirna/icap-client v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
-github.com/cs3org/reva/v2 v2.15.1-0.20230726135727-c444e4c5a24f h1:u1otcEA1Otgv7rxS4y/nHU/7zkc1kU/KdCX1YNGSzsE=
-github.com/cs3org/reva/v2 v2.15.1-0.20230726135727-c444e4c5a24f/go.mod h1:4z5EQghS2LhSWZWocH51Dw9VAs16No1zSFvFgQtgS7w=
+github.com/cs3org/reva/v2 v2.15.1-0.20230731061316-db79e9b61738 h1:EILZCEJMYRla6cktKLpi1c3KwISyoYMGTX0AKCuUTZA=
+github.com/cs3org/reva/v2 v2.15.1-0.20230731061316-db79e9b61738/go.mod h1:4z5EQghS2LhSWZWocH51Dw9VAs16No1zSFvFgQtgS7w=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -352,7 +352,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.15.1-0.20230726135727-c444e4c5a24f
+# github.com/cs3org/reva/v2 v2.15.1-0.20230731061316-db79e9b61738
 ## explicit; go 1.20
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
This pr adds a command for listing and rolling back decomposedfs migrations, e.g. before downgrading to an older release.

Example output:
```
$ ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -h
NAME:
   ocis migrate decomposedfs - run a decomposedfs migration

USAGE:
   ocis migrate decomposedfs [command options] [arguments...]

OPTIONS:
   --direction value, -d value  direction of the migration to run ('up' or 'down') (default: "up")
   --migration value, -m value  ID of the migration to run
   --root value, -r value       Path to the root directory of the decomposedfs
   --list, -l                   Print a list of migrations incl. their state (default: false)
   --help, -h                   show help
$ ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -l
+-----------+-----------+---------+
| Migration |   State   | Message |
+-----------+-----------+---------+
|      0001 | succeeded |         |
|      0002 | succeeded |         |
|      0003 | runagain  |         |
|      0004 | succeeded |         |
|      0005 | succeeded |         |
+-----------+-----------+---------+
$ ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -d down -m 0005
2023-07-27T09:23:38+02:00 INF Running migration 0005... (down) line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/migrator.go:119 service=migrate
2023-07-27T09:23:38+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/personal.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:78 root=/home/andre/.ocis/storage/users/ service=migrate
2023-07-27T09:23:38+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/project.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:78 root=/home/andre/.ocis/storage/users/ service=migrate
2023-07-27T09:23:38+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-user-id/some-admin-user-id-0000-000000000000.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:78 root=/home/andre/.ocis/storage/users/ service=migrate
2023-07-27T09:23:38+02:00 INF done. line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:105 service=migrate
2023-07-27T09:23:38+02:00 INF done line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/migrator.go:139 service=migrate
$ ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -l
+-----------+-----------+---------+
| Migration |   State   | Message |
+-----------+-----------+---------+
|      0001 | succeeded |         |
|      0002 | succeeded |         |
|      0003 | runagain  |         |
|      0004 | succeeded |         |
|      0005 | down      |         |
+-----------+-----------+---------+
$ ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -d up -m 0005
2023-07-27T09:24:12+02:00 INF Running migration 0005... line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/migrator.go:119 service=migrate
2023-07-27T09:24:12+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/personal.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:37 root=/home/andre/.ocis/storage/users/ service=migrate
2023-07-27T09:24:12+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/project.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:37 root=/home/andre/.ocis/storage/users/ service=migrate
2023-07-27T09:24:12+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-user-id/some-admin-user-id-0000-000000000000.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:37 root=/home/andre/.ocis/storage/users/ service=migrate
2023-07-27T09:24:12+02:00 INF done. line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:66 service=migrate
2023-07-27T09:24:12+02:00 INF done line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/migrator.go:139 service=migrate
```

Depends on https://github.com/cs3org/reva/pull/4083