### PR TITLE
Separate out grpc client to package local for thumbnails service.

### DIFF
--- a/ocis-pkg/service/grpc/service.go
+++ b/ocis-pkg/service/grpc/service.go
@@ -12,6 +12,7 @@ import (
 	ociscrypto "github.com/owncloud/ocis/v2/ocis-pkg/crypto"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"go-micro.dev/v4"
+	"go-micro.dev/v4/client"
 	"go-micro.dev/v4/server"
 )
 
@@ -22,6 +23,11 @@ type Service struct {
 
 // NewService initializes a new grpc service.
 func NewService(opts ...Option) (Service, error) {
+	return NewServiceWithClient(DefaultClient(), opts...)
+}
+
+// NewServiceWithClient initializes a new grpc service with explicit client.
+func NewServiceWithClient(client client.Client, opts ...Option) (Service, error) {
 	var mServer server.Server
 	sopts := newOptions(opts...)
 	tlsConfig := &tls.Config{}
@@ -52,7 +58,7 @@ func NewService(opts ...Option) (Service, error) {
 		// first add a server because it will reset any options
 		micro.Server(mServer),
 		// also add a client that can be used after initializing the service
-		micro.Client(DefaultClient()),
+		micro.Client(client),
 		micro.Address(sopts.Address),
 		micro.Name(strings.Join([]string{sopts.Namespace, sopts.Name}, ".")),
 		micro.Version(sopts.Version),

--- a/services/thumbnails/pkg/command/server.go
+++ b/services/thumbnails/pkg/command/server.go
@@ -34,7 +34,7 @@ func Server(cfg *config.Config) *cli.Command {
 			if err != nil {
 				return err
 			}
-			err = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
+			cfg.GrpcClient, err = ogrpc.NewClient(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 			if err != nil {
 				return err
 			}

--- a/services/thumbnails/pkg/config/config.go
+++ b/services/thumbnails/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"go-micro.dev/v4/client"
 )
 
 // Config combines all available configuration parts.
@@ -21,6 +22,7 @@ type Config struct {
 	HTTP HTTP       `yaml:"http"`
 
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	GrpcClient    client.Client         `yaml:"-"`
 
 	Thumbnail Thumbnail `yaml:"thumbnail"`
 

--- a/services/thumbnails/pkg/server/grpc/server.go
+++ b/services/thumbnails/pkg/server/grpc/server.go
@@ -16,7 +16,8 @@ import (
 func NewService(opts ...Option) grpc.Service {
 	options := newOptions(opts...)
 
-	service, err := grpc.NewService(
+	service, err := grpc.NewServiceWithClient(
+		options.Config.GrpcClient,
 		grpc.TLSEnabled(options.Config.GRPC.TLS.Enabled),
 		grpc.TLSCert(
 			options.Config.GRPC.TLS.Cert,


### PR DESCRIPTION
This removes reference to grpc.DefaultClient().