### PR TITLE
fix: use error detail as message instead of whole error object

### DIFF
--- a/changelog/unreleased/fix-error-message-on-400-code-thumbnail.md
+++ b/changelog/unreleased/fix-error-message-on-400-code-thumbnail.md
@@ -1,0 +1,6 @@
+Bugfix: Fix error message on 400 response for thumbnail requests
+
+Fix the error message when the thumbnail request returns a '400 Bad Request' response.
+
+https://github.com/owncloud/ocis/issues/2064
+https://github.com/owncloud/ocis/pull/6911

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -260,7 +260,7 @@ func (g Webdav) SpacesThumbnail(w http.ResponseWriter, r *http.Request) {
 			renderError(w, r, errTooEarly(err.Error()))
 			return
 		case http.StatusBadRequest:
-			renderError(w, r, errBadRequest(err.Error()))
+			renderError(w, r, errBadRequest(e.Detail))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
@@ -348,7 +348,7 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
 			return
 		case http.StatusBadRequest:
-			renderError(w, r, errBadRequest(err.Error()))
+			renderError(w, r, errBadRequest(e.Detail))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
@@ -389,7 +389,7 @@ func (g Webdav) PublicThumbnail(w http.ResponseWriter, r *http.Request) {
 			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
 			return
 		case http.StatusBadRequest:
-			renderError(w, r, errBadRequest(err.Error()))
+			renderError(w, r, errBadRequest(e.Detail))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
@@ -430,7 +430,7 @@ func (g Webdav) PublicThumbnailHead(w http.ResponseWriter, r *http.Request) {
 			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
 			return
 		case http.StatusBadRequest:
-			renderError(w, r, errBadRequest(err.Error()))
+			renderError(w, r, errBadRequest(e.Detail))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -212,10 +212,6 @@ cannot share a folder with create permission
 
 - [coreApiWebdavPreviews/previews.feature:98](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L98)
 
-#### [different error message detail for previews of folder](https://github.com/owncloud/ocis/issues/2064)
-
-- [coreApiWebdavPreviews/previews.feature:107](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavPreviews/previews.feature#L107)
-
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
 - [coreApiSharePublicLink2/copyFromPublicLink.feature:66](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L66)


### PR DESCRIPTION
## Description
Whenever the file preview requests fail with `400 Bad Request`, full error object was returned as error message for the webdav response. For example (try to get folder preview);
```bash
curl "https://localhost:9200/remote.php/dav/files/admin/folder?x=32&y=32&forceIcon=0&preview=1" \
-uadmin:admin -vk
```
**_Current,_**
```xml
...
< HTTP/1.1 400 Bad Request
...

<?xml version="1.0" encoding="UTF-8"?>
<d:error
	xmlns:d="DAV"
	xmlns:s="http://sabredav.org/ns">
	<s:exception>Sabre\DAV\Exception\BadRequest</s:exception>
	<s:message>{"id":"com.owncloud.api.thumbnails","code":400,"detail":"Unsupported file type","status":"Bad Request"}</s:message>
</d:error>
```
This PR fixes the redundancy in the error message and only return detail from the error object.

**_With PR,_**
```xml
...
	<s:exception>Sabre\DAV\Exception\BadRequest</s:exception>
	<s:message>Unsupported file type</s:message>
...
``` 

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/2064

## Motivation and Context
return proper error message in the response

## How Has This Been Tested?
- local
- CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
