### PR TITLE
Remove grpc.DefaultClient() reference from policies and use only one grpc client in proxy.

### DIFF
--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"go-micro.dev/v4/client"
 )
 
 // Config combines all available configuration parts.
@@ -21,6 +22,7 @@ type Config struct {
 
 	Reva          *shared.Reva          `yaml:"reva"`
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	GrpcClient    client.Client         `yaml:"-"`
 
 	RoleQuotas            map[string]uint64  `yaml:"role_quotas"`
 	Policies              []Policy           `yaml:"policies"`

--- a/services/proxy/pkg/middleware/policies.go
+++ b/services/proxy/pkg/middleware/policies.go
@@ -9,11 +9,11 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	pMessage "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/policies/v0"
 	pService "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/policies/v0"
 	"github.com/owncloud/ocis/v2/services/webdav/pkg/net"
 	tusd "github.com/tus/tusd/pkg/handler"
+	"go-micro.dev/v4/client"
 )
 
 type (
@@ -34,8 +34,8 @@ type (
 const DeniedMessage = "Operation denied due to security policies"
 
 // Policies verifies if a request is granted or not.
-func Policies(logger log.Logger, qs string) func(next http.Handler) http.Handler {
-	pClient := pService.NewPoliciesProviderService("com.owncloud.api.policies", grpc.DefaultClient())
+func Policies(logger log.Logger, qs string, grpcClient client.Client) func(next http.Handler) http.Handler {
+	pClient := pService.NewPoliciesProviderService("com.owncloud.api.policies", grpcClient)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This replaces grpc.DefaultClient() with package local variable and uses one grpc client for all parts.