### PR TITLE
Separate out grpc client to package local for ocs service.

### DIFF
--- a/services/ocs/pkg/command/server.go
+++ b/services/ocs/pkg/command/server.go
@@ -35,7 +35,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			err = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
+			cfg.GrpcClient, err = ogrpc.NewClient(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 			if err != nil {
 				return err
 			}

--- a/services/ocs/pkg/config/config.go
+++ b/services/ocs/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"go-micro.dev/v4/client"
 )
 
 // Config combines all available configuration parts.
@@ -19,6 +20,7 @@ type Config struct {
 	HTTP HTTP `yaml:"http"`
 
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	GrpcClient    client.Client         `yaml:"-"`
 
 	TokenManager *TokenManager `yaml:"token_manager"`
 

--- a/services/ocs/pkg/service/v0/users.go
+++ b/services/ocs/pkg/service/v0/users.go
@@ -9,7 +9,6 @@ import (
 	storesvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/store/v0"
 
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
-	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/services/ocs/pkg/service/v0/data"
 	"github.com/owncloud/ocis/v2/services/ocs/pkg/service/v0/response"
 	merrors "go-micro.dev/v4/errors"
@@ -29,7 +28,7 @@ func (o Ocs) GetSigningKey(w http.ResponseWriter, r *http.Request) {
 	// use the user's UUID
 	userID := u.Id.OpaqueId
 
-	c := storesvc.NewStoreService("com.owncloud.api.store", grpc.DefaultClient())
+	c := storesvc.NewStoreService("com.owncloud.api.store", o.config.GrpcClient)
 	res, err := c.Read(r.Context(), &storesvc.ReadRequest{
 		Options: &storemsg.ReadOptions{
 			Database: "proxy",


### PR DESCRIPTION
This removes reference to grpc.DefaultClient().
