### PR TITLE
Replacing implicit grpc client initialization with explicit package local variables

### DIFF
--- a/ocis-pkg/service/grpc/service.go
+++ b/ocis-pkg/service/grpc/service.go
@@ -21,11 +21,6 @@ type Service struct {
 	micro.Service
 }
 
-// NewService initializes a new grpc service.
-func NewService(opts ...Option) (Service, error) {
-	return NewServiceWithClient(DefaultClient(), opts...)
-}
-
 // NewServiceWithClient initializes a new grpc service with explicit client.
 func NewServiceWithClient(client client.Client, opts ...Option) (Service, error) {
 	var mServer server.Server

--- a/ocis/pkg/command/server.go
+++ b/ocis/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
-	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/owncloud/ocis/v2/ocis/pkg/runtime"
 	"github.com/urfave/cli/v2"
@@ -23,10 +22,6 @@ func Server(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			// Prefer the in-memory registry as the default when running in single-binary mode
 			registry.Configure("memory")
-			err := grpc.Configure(grpc.GetClientOptions(cfg.GRPCClientTLS)...)
-			if err != nil {
-				return err
-			}
 			r := runtime.New(cfg)
 			return r.Start()
 		},

--- a/services/eventhistory/pkg/command/server.go
+++ b/services/eventhistory/pkg/command/server.go
@@ -37,7 +37,8 @@ func Server(cfg *config.Config) *cli.Command {
 			if err != nil {
 				return err
 			}
-			err = ogrpc.Configure(
+
+			cfg.GrpcClient, err = ogrpc.NewClient(
 				append(ogrpc.GetClientOptions(cfg.GRPCClientTLS), ogrpc.WithTraceProvider(traceProvider))...,
 			)
 			if err != nil {

--- a/services/eventhistory/pkg/config/config.go
+++ b/services/eventhistory/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"go-micro.dev/v4/client"
 )
 
 // Config combines all available configuration parts.
@@ -19,6 +20,7 @@ type Config struct {
 
 	GRPC          GRPCConfig            `yaml:"grpc"`
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	GrpcClient    client.Client         `yaml:"-"`
 
 	Events Events `yaml:"events"`
 	Store  Store  `yaml:"store"`

--- a/services/eventhistory/pkg/server/grpc/server.go
+++ b/services/eventhistory/pkg/server/grpc/server.go
@@ -11,7 +11,8 @@ import (
 func NewService(opts ...Option) grpc.Service {
 	options := newOptions(opts...)
 
-	service, err := grpc.NewService(
+	service, err := grpc.NewServiceWithClient(
+		options.Config.GrpcClient,
 		grpc.TLSEnabled(options.Config.GRPC.TLS.Enabled),
 		grpc.TLSCert(
 			options.Config.GRPC.TLS.Cert,
@@ -25,7 +26,6 @@ func NewService(opts ...Option) grpc.Service {
 		grpc.Context(options.Context),
 		grpc.Flags(options.Flags...),
 		grpc.Version(version.GetString()),
-		grpc.TraceProvider(options.TraceProvider),
 	)
 	if err != nil {
 		options.Logger.Fatal().Err(err).Msg("Error creating event history service")

--- a/services/graph/pkg/command/server.go
+++ b/services/graph/pkg/command/server.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
-	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config/parser"
@@ -29,18 +27,6 @@ func Server(cfg *config.Config) *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			logger := logging.Configure(cfg.Service.Name, cfg.Log)
-			traceProvider, err := tracing.GetServiceTraceProvider(cfg.Tracing, cfg.Service.Name)
-			if err != nil {
-				return err
-			}
-			err = ogrpc.Configure(
-				append(
-					ogrpc.GetClientOptions(cfg.GRPCClientTLS),
-					ogrpc.WithTraceProvider(traceProvider),
-				)...)
-			if err != nil {
-				return err
-			}
 
 			gr := run.Group{}
 			ctx, cancel := func() (context.Context, context.CancelFunc) {

--- a/services/graph/pkg/service/v0/application_test.go
+++ b/services/graph/pkg/service/v0/application_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
 	settings "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
@@ -71,7 +70,6 @@ var _ = Describe("Applications", func() {
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 		cfg.Application.ID = "some-application-ID"
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),

--- a/services/graph/pkg/service/v0/approleassignments_test.go
+++ b/services/graph/pkg/service/v0/approleassignments_test.go
@@ -18,7 +18,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
 	settings "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
@@ -81,7 +80,6 @@ var _ = Describe("AppRoleAssignments", func() {
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 		cfg.Application.ID = "some-application-ID"
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),

--- a/services/graph/pkg/service/v0/driveitems_test.go
+++ b/services/graph/pkg/service/v0/driveitems_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/graph/mocks"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
@@ -76,7 +75,6 @@ var _ = Describe("Driveitems", func() {
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),

--- a/services/graph/pkg/service/v0/educationclasses_test.go
+++ b/services/graph/pkg/service/v0/educationclasses_test.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/graph/mocks"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
@@ -80,7 +79,6 @@ var _ = Describe("EducationClass", func() {
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),

--- a/services/graph/pkg/service/v0/educationschools_test.go
+++ b/services/graph/pkg/service/v0/educationschools_test.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/grpc"
 
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config/defaults"
@@ -79,7 +78,6 @@ var _ = Describe("Schools", func() {
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),

--- a/services/graph/pkg/service/v0/educationuser_test.go
+++ b/services/graph/pkg/service/v0/educationuser_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/mocks"
@@ -81,7 +80,6 @@ var _ = Describe("EducationUsers", func() {
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),

--- a/services/graph/pkg/service/v0/groups_test.go
+++ b/services/graph/pkg/service/v0/groups_test.go
@@ -18,7 +18,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/graph/mocks"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
@@ -81,7 +80,6 @@ var _ = Describe("Groups", func() {
 		cfg.Commons = &shared.Commons{}
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
 	settings "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
@@ -85,7 +84,6 @@ var _ = Describe("Users", func() {
 		cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 		cfg.Application.ID = "some-application-ID"
 
-		_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 		svc, _ = service.NewService(
 			service.Config(cfg),
 			service.WithGatewaySelector(gatewaySelector),
@@ -690,7 +688,6 @@ var _ = Describe("Users", func() {
 
 					localCfg.API.UsernameMatch = usernameMatch
 
-					_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 					localSvc, _ := service.NewService(
 						service.Config(localCfg),
 						service.WithGatewaySelector(gatewaySelector),

--- a/services/notifications/pkg/service/service_test.go
+++ b/services/notifications/pkg/service/service_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config/defaults"
@@ -77,7 +76,6 @@ var _ = Describe("Notifications", func() {
 		func(tc testChannel, ev events.Event) {
 			cfg := defaults.FullDefaultConfig()
 			cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-			_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 			ch := make(chan events.Event)
 			evts := service.NewEventsNotifier(ch, tc, log.NewLogger(), gatewaySelector, vs, "", "", "")
 			go evts.Run()
@@ -276,7 +274,6 @@ var _ = Describe("Notifications X-Site Scripting", func() {
 		func(tc testChannel, ev events.Event) {
 			cfg := defaults.FullDefaultConfig()
 			cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
-			_ = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
 			ch := make(chan events.Event)
 			evts := service.NewEventsNotifier(ch, tc, log.NewLogger(), gatewaySelector, vs, "", "", "")
 			go evts.Run()

--- a/services/policies/pkg/command/server.go
+++ b/services/policies/pkg/command/server.go
@@ -61,12 +61,13 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			{
-				err = grpc.Configure(grpc.GetClientOptions(cfg.GRPCClientTLS)...)
+				grpcClient, err := grpc.NewClient(grpc.GetClientOptions(cfg.GRPCClientTLS)...)
 				if err != nil {
 					return err
 				}
 
-				svc, err := grpc.NewService(
+				svc, err := grpc.NewServiceWithClient(
+					grpcClient,
 					grpc.Logger(logger),
 					grpc.TLSEnabled(cfg.GRPC.TLS.Enabled),
 					grpc.TLSCert(

--- a/services/search/pkg/command/server.go
+++ b/services/search/pkg/command/server.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"github.com/owncloud/ocis/v2/services/search/pkg/config"
@@ -33,6 +34,12 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
+			cfg.GrpcClient, err = ogrpc.NewClient(
+				append(ogrpc.GetClientOptions(cfg.GRPCClientTLS), ogrpc.WithTraceProvider(traceProvider))...,
+			)
+			if err != nil {
+				return err
+			}
 			gr := run.Group{}
 			ctx, cancel := func() (context.Context, context.CancelFunc) {
 				if cfg.Context == nil {

--- a/services/search/pkg/config/config.go
+++ b/services/search/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"go-micro.dev/v4/client"
 )
 
 // Config combines all available configuration parts.
@@ -16,7 +17,8 @@ type Config struct {
 	Log     *Log     `yaml:"log"`
 	Debug   Debug    `yaml:"debug"`
 
-	GRPC GRPCConfig `yaml:"grpc"`
+	GRPC       GRPCConfig    `yaml:"grpc"`
+	GrpcClient client.Client `yaml:"-"`
 
 	TokenManager *TokenManager `yaml:"token_manager"`
 

--- a/services/search/pkg/server/grpc/server.go
+++ b/services/search/pkg/server/grpc/server.go
@@ -11,7 +11,8 @@ import (
 func Server(opts ...Option) (grpc.Service, func(), error) {
 	options := newOptions(opts...)
 
-	service, err := grpc.NewService(
+	service, err := grpc.NewServiceWithClient(
+		options.Config.GrpcClient,
 		grpc.TLSEnabled(options.Config.GRPC.TLS.Enabled),
 		grpc.TLSCert(
 			options.Config.GRPC.TLS.Cert,

--- a/services/settings/pkg/command/server.go
+++ b/services/settings/pkg/command/server.go
@@ -35,7 +35,7 @@ func Server(cfg *config.Config) *cli.Command {
 			if err != nil {
 				return err
 			}
-			err = ogrpc.Configure(
+			cfg.GrpcClient, err = ogrpc.NewClient(
 				append(ogrpc.GetClientOptions(cfg.GRPCClientTLS), ogrpc.WithTraceProvider(tracingProvider))...,
 			)
 			if err != nil {

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
+	"go-micro.dev/v4/client"
 )
 
 // Config combines all available configuration parts.
@@ -22,6 +23,7 @@ type Config struct {
 	GRPC GRPCConfig `yaml:"grpc"`
 
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	GrpcClient    client.Client         `yaml:"-"`
 
 	StoreType   string                `yaml:"store_type" env:"SETTINGS_STORE_TYPE" desc:"Store type configures the persistency driver. Supported values are 'metadata' and 'filesystem'. Note that the value 'filesystem' is considered deprecated."`
 	DataPath    string                `yaml:"data_path" env:"SETTINGS_DATA_PATH" desc:"The directory where the filesystem storage will store ocis settings. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/settings."`

--- a/services/settings/pkg/server/grpc/server.go
+++ b/services/settings/pkg/server/grpc/server.go
@@ -15,7 +15,8 @@ import (
 func Server(opts ...Option) grpc.Service {
 	options := newOptions(opts...)
 
-	service, err := grpc.NewService(
+	service, err := grpc.NewServiceWithClient(
+		options.Config.GrpcClient,
 		grpc.TLSEnabled(options.Config.GRPC.TLS.Enabled),
 		grpc.TLSCert(
 			options.Config.GRPC.TLS.Cert,

--- a/services/store/pkg/command/server.go
+++ b/services/store/pkg/command/server.go
@@ -34,7 +34,9 @@ func Server(cfg *config.Config) *cli.Command {
 			if err != nil {
 				return err
 			}
-			err = ogrpc.Configure(ogrpc.GetClientOptions(cfg.GRPCClientTLS)...)
+			cfg.GrpcClient, err = ogrpc.NewClient(
+				ogrpc.GetClientOptions(cfg.GRPCClientTLS)...,
+			)
 			if err != nil {
 				return err
 			}

--- a/services/store/pkg/config/config.go
+++ b/services/store/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
+	"go-micro.dev/v4/client"
 )
 
 // Config combines all available configuration parts.
@@ -19,6 +20,7 @@ type Config struct {
 	GRPC GRPCConfig `yaml:"grpc"`
 
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
+	GrpcClient    client.Client         `yaml:"-"`
 
 	Datapath string `yaml:"data_path" env:"STORE_DATA_PATH" desc:"The directory where the filesystem storage will store ocis settings. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/store."`
 

--- a/services/store/pkg/server/grpc/server.go
+++ b/services/store/pkg/server/grpc/server.go
@@ -11,7 +11,8 @@ import (
 func Server(opts ...Option) grpc.Service {
 	options := newOptions(opts...)
 
-	service, err := grpc.NewService(
+	service, err := grpc.NewServiceWithClient(
+		options.Config.GrpcClient,
 		grpc.TLSEnabled(options.Config.GRPC.TLS.Enabled),
 		grpc.TLSCert(
 			options.Config.GRPC.TLS.Cert,


### PR DESCRIPTION
Removing the remaining references to grpc.DefaultClient() and the related methods.