### PR TITLE
[tests-only][full-ci] refactored acceptance test code to store response data related to public shares on single store

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2793,7 +2793,7 @@ class FeatureContext extends BehatVariablesContext {
 				"code" => "%last_public_share_token%",
 				"function" => [
 					$this,
-					"getLastPublicShareToken"
+					"getLastCreatedPublicShareToken"
 				],
 				"parameter" => []
 			],

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -51,7 +51,7 @@ class PublicWebDavContext implements Context {
 			// accessing it as a public link using the "new" public webDAV API
 			// the client needs to provide the public link share token followed
 			// by just the name of the file - not the full path.
-			$fullPath = $this->featureContext->getLastPublicSharePath();
+			$fullPath = (string) $this->featureContext->getLastCreatedPublicShare()->path;
 			$fullPathParts = \explode("/", $fullPath);
 			$path = \end($fullPathParts);
 		} else {
@@ -76,7 +76,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFileWithRangeAndPassword(string $range, string $password, string $publicWebDAVAPIVersion):void {
 		if ($publicWebDAVAPIVersion === "new") {
-			$path = $this->featureContext->getLastPublicShareData()->data->file_target;
+			$path = (string) $this->featureContext->getLastCreatedPublicShare()->file_target;
 		} else {
 			$path = "";
 		}
@@ -124,7 +124,7 @@ class PublicWebDavContext implements Context {
 		if ($publicWebDAVAPIVersion === "old") {
 			return;
 		}
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -178,7 +178,7 @@ class PublicWebDavContext implements Context {
 		if ($publicWebDAVAPIVersion === "old") {
 			return;
 		}
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -296,7 +296,7 @@ class PublicWebDavContext implements Context {
 	):void {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -401,7 +401,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicCopiesFileUsingTheWebDAVApi(string $source, string $destination, string $publicWebDAVAPIVersion):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1086,7 +1086,7 @@ class PublicWebDavContext implements Context {
 		if ($publicWebDAVAPIVersion === "old") {
 			return;
 		}
-		$filename = (string)$this->featureContext->getLastPublicShareData()->data[0]->file_target;
+		$filename = (string)$this->featureContext->getLastCreatedPublicShare()->file_target;
 
 		$this->publicUploadContent(
 			$filename,
@@ -1251,7 +1251,7 @@ class PublicWebDavContext implements Context {
 		if ($publicWebDAVAPIVersion === "old") {
 			return;
 		} elseif ($publicWebDAVAPIVersion === "new") {
-			$path = $this->featureContext->getLastPublicSharePath();
+			$path = (string) $this->featureContext->getLastCreatedPublicShare()->path;
 		} else {
 			$path = "";
 		}
@@ -1329,7 +1329,7 @@ class PublicWebDavContext implements Context {
 		string $destination,
 		string $password
 	):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1421,7 +1421,7 @@ class PublicWebDavContext implements Context {
 		string $fileName,
 		string $mtime
 	):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$mtime = \explode(" ", $mtime);
 		\array_pop($mtime);
@@ -1450,7 +1450,7 @@ class PublicWebDavContext implements Context {
 		string $fileName,
 		string $mtime
 	):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		Assert::assertNotEquals(
 			$mtime,
@@ -1487,7 +1487,7 @@ class PublicWebDavContext implements Context {
 			return;
 		}
 		$password = $this->featureContext->getActualPassword($password);
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1593,7 +1593,7 @@ class PublicWebDavContext implements Context {
 		} else {
 			$body = null;
 		}
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			null,
 			null,

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -43,21 +43,6 @@ trait Sharing {
 	 */
 	private array $createdUserGroupShares = [];
 
-	private ?string $userWhoCreatedLastPublicShare = null;
-
-	/**
-	 * Contains the API response to the last public link share that was created
-	 * by the test-runner using the Sharing API.
-	 * Shares created on the webUI do not have an entry.
-	 */
-	private ?SimpleXMLElement $lastPublicShareData = null;
-
-	/**
-	 * Contains the share id of the last public link share that was created by
-	 * the test-runner, either using the Sharing API or on the web UI.
-	 */
-	private ?string $lastPublicShareId = null;
-
 	private ?float $localLastShareTime = null;
 
 	/**
@@ -85,61 +70,32 @@ trait Sharing {
 		'attributes', 'permissions', 'share_with', 'share_with_displayname', 'share_with_additional_info'
 	];
 
-	/*
-	 * Contains information about the public links that have been created with the webUI.
-	 * Each entry in the array has a "name", "url" and "path".
-	 */
-	private array $createdPublicLinks = [];
-
 	/**
-	 * The end (last) entry will itself be an array with keys "name", "url" and "path"
-	 *
-	 * @return array
+	 * @var array
 	 */
-	public function getLastCreatedPublicLink():array {
-		return \end($this->createdPublicLinks);
-	}
+	private array $createdPublicShares = [];
 
 	/**
 	 * @return string
 	 */
-	public function getLastCreatedPublicLinkUrl():string {
-		$lastCreatedLink = $this->getLastCreatedPublicLink();
-		return $lastCreatedLink["url"];
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLastCreatedPublicLinkPath():string {
-		$lastCreatedLink = $this->getLastCreatedPublicLink();
-		return $lastCreatedLink["path"];
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLastCreatedPublicLinkToken():string {
-		$lastCreatedLinkUrl = $this->getLastCreatedPublicLinkUrl();
-		// The token is the last part of the URL, delimited by "/"
-		$urlParts = \explode("/", $lastCreatedLinkUrl);
-		return \end($urlParts);
+	public function getLastCreatedPublicShareToken():string {
+		return (string) $this->getLastCreatedPublicShare()->token;
 	}
 
 	/**
 	 * @return SimpleXMLElement|null
 	 */
-	public function getLastPublicShareData():?SimpleXMLElement {
-		return $this->lastPublicShareData;
+	public function getLastCreatedPublicShare():?SimpleXMLElement {
+		return \end($this->createdPublicShares);
 	}
 
 	/**
-	 * @param SimpleXMLElement $responseXml
+	 * @param SimpleXMLElement $shareData
 	 *
 	 * @return void
 	 */
-	public function setLastPublicShareData(SimpleXMLElement $responseXml): void {
-		$this->lastPublicShareData = $responseXml;
+	public function addToCreatedPublicShares(SimpleXMLElement $shareData): void {
+		$this->createdPublicShares[] = $shareData;
 	}
 
 	/**
@@ -169,10 +125,8 @@ trait Sharing {
 	/**
 	 * @return void
 	 */
-	public function resetLastPublicShareData():void {
-		$this->lastPublicShareData = null;
-		$this->lastPublicShareId = null;
-		$this->userWhoCreatedLastPublicShare = null;
+	public function emptyCreatedPublicShares():void {
+		$this->createdPublicShares = [];
 	}
 
 	/**
@@ -886,7 +840,7 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 
 		if ($updateLastPublicLink) {
-			$share_id = $this->getLastPublicLinkShareId();
+			$share_id = (string) $this->getLastCreatedPublicShare()->id;
 		} else {
 			if ($shareOwner === null) {
 				$share_id = $this->getLastCreatedUserGroupShareId();
@@ -1004,17 +958,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @param string $name
-	 * @param string $url
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function addToListOfCreatedPublicLinks(string $name, string $url, string $path = ""):void {
-		$this->createdPublicLinks[] = ["name" => $name, "url" => $url, "path" => $path];
-	}
-
-	/**
 	 * @param string $user
 	 * @param string|null $path
 	 * @param string|null $shareType
@@ -1074,26 +1017,19 @@ trait Sharing {
 			|| (($httpStatusCode === 200) && ($this->ocsContext->getOCSResponseStatusCode($this->response) > 299))
 		) {
 			if ($shareType === 'public_link') {
-				$this->resetLastPublicShareData();
+				$this->emptyCreatedPublicShares();
 			} else {
 				$this->emptyCreatedUserGroupShares();
 			}
 		} else {
-			if ($shareType === 'public_link') {
-				$this->setLastPublicShareData($this->getResponseXml(null, __METHOD__));
-				$this->setLastPublicLinkShareId((string) $this->lastPublicShareData->data[0]->id);
-				$this->setUserWhoCreatedLastPublicShare($user);
-				if (isset($this->lastPublicShareData->data)) {
-					$linkName = (string) $this->lastPublicShareData->data[0]->name;
-					$linkUrl = (string) $this->lastPublicShareData->data[0]->url;
-					$this->addToListOfCreatedPublicLinks($linkName, $linkUrl, $path);
-				}
-			} else {
-				$response = $this->getResponseXml(null, __METHOD__);
-				if (isset($response->data)) {
-					$shareData = $response->data;
+			$response = $this->getResponseXml(null, __METHOD__);
+			if (isset($response->data)) {
+				$shareData = $response->data;
+				if ($shareType === 'public_link') {
+					$this->addToCreatedPublicShares($shareData);
+				} else {
 					$sharer = (string) $response->data->uid_owner;
-					$this->addToCreatedUserGroupShares($sharer, $shareData);
+					$this->addToCreatedUserGroupshares($sharer, $shareData);
 				}
 			}
 		}
@@ -1933,7 +1869,7 @@ trait Sharing {
 	public function deleteLastShareUsingSharingApi(string $user, string $sharer = null, bool $deleteLastPublicLink = false):void {
 		$user = $this->getActualUsername($user);
 		if ($deleteLastPublicLink) {
-			$shareId = $this->getLastPublicLinkShareId();
+			$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		} else {
 			if ($sharer === null) {
 				$shareId = $this->getLastCreatedUserGroupShareId();
@@ -2042,7 +1978,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function theUserGetsInfoOfLastPublicLinkShareUsingTheSharingApi():void {
-		$this->userGetsInfoOfLastPublicLinkShareUsingTheSharingApi($this->getUserWhoCreatedLastPublicShare());
+		$this->userGetsInfoOfLastPublicLinkShareUsingTheSharingApi((string) $this->getLastCreatedPublicShare()->uid_owner);
 	}
 
 	/**
@@ -2056,8 +1992,8 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function userGetsInfoOfLastPublicLinkShareUsingTheSharingApi(string $user, ?string $language = null):void {
-		if ($this->lastPublicShareId !== null) {
-			$shareId = $this->lastPublicShareId;
+		if ($this->getLastCreatedPublicShare()->id !== null) {
+			$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		} else {
 			throw new Exception(
 				__METHOD__ . " last public link share data was not found"
@@ -2106,46 +2042,6 @@ trait Sharing {
 		TableNode $table
 	):void {
 		$this->asLastShareInfoAboutUserSharingWithUserShouldInclude($sharer, $sharer, $sharee, $table);
-	}
-
-	/**
-	 * Sets the id of the last public link shared file
-	 *
-	 * @param string $shareId
-	 *
-	 * @return void
-	 */
-	public function setLastPublicLinkShareId(string $shareId):void {
-		$this->lastPublicShareId = $shareId;
-	}
-
-	/**
-	 * Retrieves the id of the last public link shared file
-	 *
-	 * @return string|null
-	 */
-	public function getLastPublicLinkShareId():?string {
-		return $this->lastPublicShareId;
-	}
-
-	/**
-	 * Sets the user who created the last public link share
-	 *
-	 * @param string $user
-	 *
-	 * @return void
-	 */
-	public function setUserWhoCreatedLastPublicShare(string $user):void {
-		$this->userWhoCreatedLastPublicShare = $user;
-	}
-
-	/**
-	 * Gets the user who created the last public link share
-	 *
-	 * @return string|null
-	 */
-	public function getUserWhoCreatedLastPublicShare():?string {
-		return $this->userWhoCreatedLastPublicShare;
 	}
 
 	/**
@@ -2223,7 +2119,7 @@ trait Sharing {
 	 */
 	public function userGetsTheLastShareSharedWithHimUsingTheSharingApi(string $user, TableNode $table):void {
 		$user = $this->getActualUsername($user);
-		$shareId = $this->getLastPublicLinkShareId();
+		$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		$this->getShareData($user, $shareId);
 		$this->checkFields($user, $table);
 	}
@@ -2429,7 +2325,7 @@ trait Sharing {
 	):void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
-		$this->getShareData($user, (string)$this->getLastPublicLinkShareId());
+		$this->getShareData($user, (string) $this->getLastCreatedPublicShare()->id);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
 			"Error getting info of last public link share for user $user"
@@ -2564,7 +2460,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function checkLastPublicLinkShareIDIsNotIncluded():void {
-		$shareId = $this->getLastPublicLinkShareId();
+		$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		if ($this->isFieldInResponse('id', $shareId, false)) {
 			Assert::fail(
 				"Public link share id $shareId has been found in response"
@@ -2705,7 +2601,8 @@ trait Sharing {
 			"space_id"
 		];
 
-		$this->setLastPublicShareData($this->getResponseXml(null, __METHOD__));
+		$response = $this->getResponseXml(null, __METHOD__);
+		$this->addToCreatedPublicShares($response->data);
 		foreach ($bodyRows as $field => $value) {
 			if (\in_array($field, $userRelatedFieldNames)) {
 				$value = $this->substituteInLineCodes(
@@ -2735,7 +2632,7 @@ trait Sharing {
 			$value = $this->replaceValuesFromTable($field, $value);
 
 			Assert::assertTrue(
-				$this->isFieldInResponse($field, $value, true, $this->getLastPublicShareData()->data[0]),
+				$this->isFieldInResponse($field, $value, true, $this->getLastCreatedPublicShare()),
 				"$field doesn't have value '$value'"
 			);
 		}
@@ -3586,73 +3483,6 @@ trait Sharing {
 	}
 
 	/**
-	 * The tests can create public link shares with the API or with the webUI.
-	 * If lastPublicShareData is null, then there have not been any created with the API,
-	 * so look for details of a public link share created with the webUI.
-	 *
-	 * @return string authorization token
-	 */
-	public function getLastPublicShareToken():string {
-		if ($this->lastPublicShareData === null) {
-			return $this->getLastCreatedPublicLinkToken();
-		} else {
-			if (\count($this->lastPublicShareData->data->element) > 0) {
-				return (string)$this->lastPublicShareData->data[0]->token;
-			}
-
-			return (string)$this->lastPublicShareData->data->token;
-		}
-	}
-
-	/**
-	 * Returns the attribute values from the last public link share data
-	 *
-	 * @param $attr - attribute name to get
-	 *
-	 * @return string
-	 * @throws Exception
-	 */
-	public function getLastPublicShareAttribute(string $attr): string {
-		if ($this->lastPublicShareData === null) {
-			throw new Exception(__METHOD__ . "No public share data available.");
-		}
-		if (!\in_array($attr, $this->shareResponseFields)) {
-			throw new Exception(
-				__METHOD__ . " attribute $attr is not in the list of allowed attributes"
-			);
-		}
-		if (\count($this->lastPublicShareData->data->element) > 0) {
-			if (!isset($this->lastPublicShareData->data[0]->$attr)) {
-				throw new Exception(__METHOD__ . " No attribute $attr available in the last share data.");
-			}
-			return (string)$this->lastPublicShareData->data[0]->{$attr};
-		}
-
-		if (!isset($this->lastPublicShareData->data->$attr)) {
-			throw new Exception(__METHOD__ . " No attribute $attr available in the last share data.");
-		}
-
-		return (string)$this->lastPublicShareData->data->{$attr};
-	}
-
-	/**
-	 * @return string path of file that was shared (relevant when a single file has been shared)
-	 */
-	public function getLastPublicSharePath():string {
-		if ($this->lastPublicShareData === null) {
-			// There have not been any public links created with the API
-			// so get the path of the last public link created with the webUI
-			return $this->getLastCreatedPublicLinkPath();
-		} else {
-			if (\count($this->lastPublicShareData->data->element) > 0) {
-				return (string)$this->lastPublicShareData->data[0]->path;
-			}
-
-			return (string)$this->lastPublicShareData->data->path;
-		}
-	}
-
-	/**
 	 * Send request for preview of a file in a public link
 	 *
 	 * @param string $fileName
@@ -3678,8 +3508,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function thePublicAccessesThePreviewOfTheSharedFileUsingTheSharingApi(string $path):void {
-		$shareData = $this->getLastPublicShareData();
-		$token = (string) $shareData->data->token;
+		$token = $this->getLastCreatedPublicShareToken();
 		$this->getPublicPreviewOfFile($path, $token);
 		$this->pushToLastStatusCodesArrays();
 	}
@@ -3700,8 +3529,7 @@ trait Sharing {
 		$this->emptyLastHTTPStatusCodesArray();
 		$this->emptyLastOCSStatusCodesArray();
 		foreach ($paths as $path) {
-			$shareData = $this->getLastPublicShareData();
-			$token = (string) $shareData->data->token;
+			$token = $this->getLastCreatedPublicShareToken();
 			$this->getPublicPreviewOfFile($path["path"], $token);
 			$this->pushToLastStatusCodesArrays();
 		}
@@ -3722,12 +3550,12 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 		$userPassword = $this->getPasswordForUser($user);
 
-		$shareData = $this->getLastPublicShareData();
-		$owner = (string) $shareData->data->uid_owner;
-		$name = $this->encodePath((string) $shareData->data->file_target);
+		$shareData = $this->getLastCreatedPublicShare();
+		$owner = (string) $shareData->uid_owner;
+		$name = $this->encodePath((string) $shareData->file_target);
 		$name = \trim($name, "/");
-		$ownerDisplayName = (string) $shareData->data->displayname_owner;
-		$token = (string) $shareData->data->token;
+		$ownerDisplayName = (string) $shareData->displayname_owner;
+		$token = (string) $shareData->token;
 
 		if (\strtolower($shareServer) == "remote") {
 			$remote = $this->getRemoteBaseUrl();
@@ -3870,7 +3698,7 @@ trait Sharing {
 	 * @throws GuzzleException
 	 */
 	public function expireLastCreatedPublicLinkShare():void {
-		$shareId = $this->getLastPublicLinkShareId();
+		$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		$this->expireShare($shareId);
 	}
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -367,20 +367,6 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * using method from core to set share data
-	 *
-	 * @return void
-	 */
-	public function setLastShareData(): void {
-		// set last response as PublicShareData
-		$this->featureContext->setLastPublicShareData($this->featureContext->getResponseXml(null, __METHOD__));
-		// set last shareId if ShareData exists
-		if (isset($this->featureContext->getLastPublicShareData()->data)) {
-			$this->featureContext->setLastPublicLinkShareId((string) $this->featureContext->getLastPublicShareData()->data[0]->id);
-		}
-	}
-
-	/**
 	 * @BeforeScenario
 	 *
 	 * @param BeforeScenarioScope $scope
@@ -1927,7 +1913,8 @@ class SpacesContext implements Context {
 				$body
 			)
 		);
-		$this->setLastShareData();
+		$response = $this->featureContext->getResponseXml(null, __METHOD__);
+		$this->featureContext->addToCreatedPublicShares($response->data);
 	}
 
 	/**
@@ -1980,7 +1967,7 @@ class SpacesContext implements Context {
 	 * @throws JsonException
 	 */
 	public function updateSharedResource(string $user, array $rows):ResponseInterface {
-		$shareId = $this->featureContext->getLastPublicLinkShareId();
+		$shareId = (string) $this->featureContext->getLastCreatedPublicShare()->id;
 		$fullUrl = $this->baseUrl . $this->ocsApiUrl . '/' . $shareId;
 		return  HttpRequestHelper::sendRequest(
 			$fullUrl,
@@ -2050,7 +2037,8 @@ class SpacesContext implements Context {
 			)
 		);
 
-		$this->setLastShareData();
+		$response = $this->featureContext->getResponseXml(null, __METHOD__);
+		$this->featureContext->addToCreatedPublicShares($response->data);
 	}
 
 	/**
@@ -2882,7 +2870,8 @@ class SpacesContext implements Context {
 			)
 		);
 
-		$this->setLastShareData();
+		$response = $this->featureContext->getResponseXml(null, __METHOD__);
+		$this->featureContext->addToCreatedPublicShares($response->data);
 	}
 
 	/**
@@ -2907,7 +2896,6 @@ class SpacesContext implements Context {
 			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus"
 		);
-		$this->featureContext->setLastPublicLinkShareId((string) $this->featureContext->getLastPublicShareData()->data[0]->id);
 	}
 
 	/**
@@ -2952,7 +2940,7 @@ class SpacesContext implements Context {
 		if ($should) {
 			Assert::assertNotEmpty($responseArray, __METHOD__ . ' Response should contain a link, but it is empty');
 			foreach ($responseArray as $element) {
-				$expectedLinkId = $this->featureContext->getLastPublicLinkShareId();
+				$expectedLinkId = (string) $this->featureContext->getLastCreatedPublicShare()->id;
 				Assert::assertEquals($element["id"], $expectedLinkId, "link IDs are different");
 			}
 		} else {
@@ -3231,7 +3219,7 @@ class SpacesContext implements Context {
 	 * @throws GuzzleException|JsonException
 	 */
 	public function publicDownloadsTheFolderFromTheLastCreatedPublicLink(string $resource) {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$response = $this->featureContext->listFolderAndReturnResponseXml(
 			$token,
 			$resource,

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1499,7 +1499,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function publicGetsSizeOfLastSharedPublicLinkUsingTheWebdavApi():void {
-		$tokenArray = $this->getLastPublicShareData()->data->token;
+		$tokenArray = $this->getLastCreatedPublicShare()->token;
 		$token = (string)$tokenArray[0];
 		$url = $this->getBaseUrl() . "/remote.php/dav/public-files/$token";
 		$this->response = HttpRequestHelper::sendRequest(
@@ -5117,7 +5117,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldContainTheseNodes(TableNode $table):void {
-		$user = $this->getLastPublicShareToken();
+		$user = $this->getLastCreatedPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
@@ -5136,7 +5136,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldNotContainTheseNodes(TableNode $table):void {
-		$user = $this->getLastPublicShareToken();
+		$user = $this->getLastCreatedPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
@@ -5155,7 +5155,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function thePublicListsTheResourcesInTheLastCreatedPublicLinkWithDepthUsingTheWebdavApi(string $depth):void {
-		$user = $this->getLastPublicShareToken();
+		$user = $this->getLastCreatedPublicShareToken();
 		$response = $this->listFolder(
 			$user,
 			'/',

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -148,7 +148,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicHasLockedLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			"/",
 			$properties,
 			true
@@ -164,7 +164,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicLocksLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			"/",
 			$properties,
 			true,
@@ -185,7 +185,7 @@ class WebDavLockingContext implements Context {
 		TableNode $properties
 	) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			$file,
 			$properties,
 			true
@@ -207,7 +207,7 @@ class WebDavLockingContext implements Context {
 		TableNode $properties
 	) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			$file,
 			$properties,
 			true,
@@ -268,7 +268,7 @@ class WebDavLockingContext implements Context {
 		string $itemToUnlock,
 		string $itemToUseLockOf
 	) {
-		$lockOwner = $this->featureContext->getLastPublicShareToken();
+		$lockOwner = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -419,7 +419,7 @@ class WebDavLockingContext implements Context {
 		string $lockOwner,
 		string $itemToUseLockOf
 	) {
-		$user = $this->featureContext->getLastPublicShareToken();
+		$user = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -437,7 +437,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 */
 	public function unlockItemAsPublicUsingWebDavAPI(string $itemToUnlock) {
-		$user = $this->featureContext->getLastPublicShareToken();
+		$user = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -592,7 +592,7 @@ class WebDavLockingContext implements Context {
 		string $itemToUseLockOf,
 		string $publicWebDAVAPIVersion
 	) {
-		$lockOwner = $this->featureContext->getLastPublicShareToken();
+		$lockOwner = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->publicUploadFileSendingLockTokenOfUser(
 			$filename,
 			$content,

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -289,7 +289,7 @@ class WebDavPropertiesContext implements Context {
 	 * @throws Exception
 	 */
 	public function publicGetsThePropertiesOfFolder(string $path, TableNode $propertiesTable):void {
-		$user = $this->featureContext->getLastPublicShareToken();
+		$user = $this->featureContext->getLastCreatedPublicShareToken();
 		$properties = null;
 		foreach ($propertiesTable->getRows() as $row) {
 			$properties[] = $row[0];
@@ -890,7 +890,7 @@ class WebDavPropertiesContext implements Context {
 				[
 					"code" => "%public_token%",
 					"function" =>
-					[$this->featureContext, "getLastPublicShareToken"],
+					[$this->featureContext, "getLastCreatedPublicShareToken"],
 					"parameter" => []
 				],
 			]


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Currently, response details of the public shares are stored in different variables like `$userWhoCreatedLastPublicShare`, `$lastPublicShareData`, `$lastPublicShareId`, etc. Instead of using different stores to store these data, all this can be stored in a single store, and needed information can be retrieved from it where required. This PR implements the storing of all the information of the created user shares in a single place `$createdPublicShares` and the important data are retrieved from it when the public share data are required

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/core/issues/40285

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
