### PR TITLE
[tests-only][full-ci] Update local test docker-compose setup to allow unicode preview tests

### DIFF
--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -499,3 +499,20 @@ TEST_SERVER_URL="https://localhost:9200" \
 BEHAT_FEATURE="tests/acceptance/features/apiAntivirus/antivirus.feature" \
 make test-acceptance-api
 ```
+
+## Running Text Preview Tests Containing Unicode Characters
+
+There are some tests that check the text preview of files containing Unicode characters. The oCIS server by default cannot generate the thumbnail of such files correctly but it provides an environment variable to allow the use of custom fonts that support Unicode characters. So to run such tests successfully, we have to run the oCIS server with this environment variable.
+
+```bash
+...
+THUMBNAILS_TXT_FONTMAP_FILE="/path/to/fontsMap.json"
+ocis/bin/ocis server
+```
+
+The sample `fontsMap.json` file is located in `tests/config/drone/fontsMap.json`.
+```json
+{
+  "defaultFont": "/path/to/ocis/tests/config/drone/NotoSans.ttf"
+}
+```

--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -175,7 +175,7 @@ $(targets):
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: testSuite
-testSuite: $(OCIS_WRAPPER) build-dev-image clean-docker-container
+testSuite: $(OCIS_WRAPPER) build-dev-image clean-docker-container ../../../vendor-bin/behat/composer.lock ../../../composer.lock
 	@if [ -n "${START_CEPH}" ]; then \
 		COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		COMPOSE_FILE=src/ceph.yml \
@@ -257,3 +257,11 @@ clean-files:
 
 .PHONY: clean
 clean: clean-docker-container clean-docker-volumes clean-dev-docker-image clean-files ## clean all
+
+../../../vendor-bin/behat/composer.lock: ../../../vendor-bin/behat/composer.json
+	@echo behat composer.lock is not up to date.
+	@composer update --no-progress -d ../../../vendor-bin/behat
+
+../../../composer.lock: ../../../composer.json
+	@echo composer.lock is not up to date.
+	@composer update --no-progress -d ../../../

--- a/tests/acceptance/docker/src/ocis-base.yml
+++ b/tests/acceptance/docker/src/ocis-base.yml
@@ -42,6 +42,9 @@ services:
 
       # postprocessing step
       POSTPROCESSING_STEPS: $POSTPROCESSING_STEPS
+
+      # fonts map for txt thumbnails (including unicode support)
+      THUMBNAILS_TXT_FONTMAP_FILE: "/drone/src/tests/config/drone/fontsMap.json"
     volumes:
       - ../../../config:/drone/src/tests/config
       - ../../../ociswrapper/bin/ociswrapper:/usr/bin/ociswrapper


### PR DESCRIPTION
## Description
Updated local docker-compose setup for tests making it able to run Unicode text preview tests locally. Also, updated the testing docs indicating the requirement of a special env variable when starting the oCIS server to run such tests.

## Related Issue
follow up https://github.com/owncloud/ocis/issues/6931

## Motivation and Context
run tests locally

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
