### PR TITLE
[full-ci] chore: bump web to v7.1.0-rc.5

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=45f6a7f53398bcd0cc77fea96e473092b485bd7a
+WEB_COMMITID=779be73d9cfa3b91535044d7a191282d7c3c2578
 WEB_BRANCH=stable-7.1

--- a/changelog/3.1.0_2023-08-02/update-web-7.1.0-rc.5.md
+++ b/changelog/3.1.0_2023-08-02/update-web-7.1.0-rc.5.md
@@ -1,8 +1,8 @@
-Enhancement: Update web to v7.1.0-rc.4
+Enhancement: Update web to v7.1.0-rc.5
 
 Tags: web
 
-We updated ownCloud Web to v7.1.0-rc.4. Please refer to the changelog (linked) for details on the web release.
+We updated ownCloud Web to v7.1.0-rc.5. Please refer to the changelog (linked) for details on the web release.
 
 ## Summary
 * Bugfix [owncloud/web#9078](https://github.com/owncloud/web/pull/9078): Favorites list update on removal
@@ -57,6 +57,9 @@ We updated ownCloud Web to v7.1.0-rc.4. Please refer to the changelog (linked) f
 * Enhancement [owncloud/web#9377](https://github.com/owncloud/web/issues/9377): User notification for blocked pop-ups and redirects
 * Enhancement [owncloud/web#9386](https://github.com/owncloud/web/pull/9386): Allow local storage for auth token
 * Enhancement [owncloud/web#9394](https://github.com/owncloud/web/pull/9394): Button styling
+* Enhancement [owncloud/web#9449](https://github.com/owncloud/web/issues/9449): Error notifications include x-request-id
+* Enhancement [owncloud/web#9426](https://github.com/owncloud/web/pull/9426): Add error log to upload dialog
 
-https://github.com/owncloud/ocis/pull/6925
-https://github.com/owncloud/web/releases/tag/v7.1.0-rc.4
+
+https://github.com/owncloud/ocis/pull/6944
+https://github.com/owncloud/web/releases/tag/v7.1.0-rc.5

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.1.0-rc.4
+WEB_ASSETS_VERSION = v7.1.0-rc.5
 
 include ../../.make/recursion.mk
 

--- a/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
@@ -22,7 +22,7 @@ Other free text and Markdown formatting can be used elsewhere in the document if
 -   [webUIFavorites/favoritesFile.feature:73](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L73)
 -   [webUIFavorites/favoritesFile.feature:80](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L80)
 -   [webUIFavorites/favoritesFile.feature:105](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L105)
--   [webUIFavorites/favoritesFile.feature:124](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L124)
+-   [webUIFavorites/favoritesFile.feature:126](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L126)
 -   [webUIFavorites/unfavoriteFile.feature:12](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature#L12)
 -   [webUIFavorites/unfavoriteFile.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature#L33)
 -   [webUIFavorites/unfavoriteFile.feature:54](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature#L53)
@@ -32,7 +32,7 @@ Other free text and Markdown formatting can be used elsewhere in the document if
 -   [webUIResharing1/reshareUsers.feature:177](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L177)
 
 ### [when sharer renames the shared resource, sharee get the updated name](https://github.com/owncloud/ocis/issues/2256)
--   [webUIRenameFiles/renameFiles.feature:226](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L226)
+-   [webUIRenameFiles/renameFiles.feature:227](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L227)
 
 ### [Cannot create users with special characters](https://github.com/owncloud/ocis/issues/1417)
 -   [webUISharingAutocompletion/shareAutocompletionSpecialChars.feature:37](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature#L37)
@@ -120,7 +120,7 @@ Other free text and Markdown formatting can be used elsewhere in the document if
 ### [Favorites deactivated in ocis temporarily](https://github.com/owncloud/ocis/issues/1228)
 -   [webUIFilesDetails/fileDetails.feature:47](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L47)
 -   [webUIFilesDetails/fileDetails.feature:67](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L67)
--   [webUIRenameFiles/renameFiles.feature:249](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L249)
+-   [webUIRenameFiles/renameFiles.feature:250](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L250)
 
 ### [PROPFIND to sub-folder of a shared resources with same name gives 404](https://github.com/owncloud/ocis/issues/3859)
 -   [webUISharingAcceptShares/acceptShares.feature:240](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L240)


### PR DESCRIPTION
Changes since the last rc:

* Enhancement [owncloud/web#9449](https://github.com/owncloud/web/issues/9449): Error notifications include x-request-id
* Enhancement [owncloud/web#9426](https://github.com/owncloud/web/pull/9426): Add error log to upload dialog