### PR TITLE
[tests-only][full-ci] Remove `@skipOnStable2.0` tag

### DIFF
--- a/tests/acceptance/features/apiGraph/assignRole.feature
+++ b/tests/acceptance/features/apiGraph/assignRole.feature
@@ -1,4 +1,4 @@
-@api @skipOnStable2.0
+@api 
 Feature: assign role
   As an admin,
   I want to assign roles to users.

--- a/tests/acceptance/features/apiGraph/createUser.feature
+++ b/tests/acceptance/features/apiGraph/createUser.feature
@@ -34,12 +34,8 @@ Feature: create user
       | name.with.dots               | user                                    | name.w.dots@example.org | 123                          | 200  | true   | should      |
       | 123456789                    | user                                    | 123456789@example.org   | 123                          | 400  | true   | should not  |
       | 0.0                          | user                                    | float@example.org       | 123                          | 400  | true   | should not  |
-
-    @skipOnStable2.0
-    Examples:
-      | userName     | displayName   | email           | password | code | enable | shouldOrNot |
-      | withoutEmail | without email |                 | 123      | 200  | true   | should      |
-      | Alice        | same userName | new@example.org | 123      | 409  | true   | should      |
+      | withoutEmail                 | without email                           |                         | 123                          | 200  | true   | should      |
+      | Alice                        | same userName                           | new@example.org         | 123                          | 409  | true   | should      |
 
 
   Scenario: user cannot be created with empty name
@@ -82,7 +78,7 @@ Feature: create user
       | accountEnabled | true                  |
     Then the HTTP status code should be "409"
 
-  @skipOnStable2.0
+
   Scenario: user can be created with the name of the deleted user
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
@@ -129,7 +125,7 @@ Feature: create user
     When the administrator retrieves the assigned role of user "sam" using the Graph API
     Then the HTTP status code should be "200"
     And the Graph API response should have no role
-    
+
 
   @env-config
   Scenario: create user with setting OCIS assign the default user role

--- a/tests/acceptance/features/apiGraph/editUser.feature
+++ b/tests/acceptance/features/apiGraph/editUser.feature
@@ -43,7 +43,7 @@ Feature: edit user
       | empty mail                |                      | 400  | brian@example.com    |
       | change to a invalid email | invalidEmail         | 400  | brian@example.com    |
 
-  @skipOnStable2.0 @issue-5763
+   @issue-5763
   Scenario Outline: admin user can edit another user's name
     Given user "Carol" has been created with default attributes and without skeleton files
     When the user "Alice" changes the user name of user "Carol" to "<userName>" using the Graph API
@@ -70,7 +70,7 @@ Feature: edit user
       | change to existing user name | Brian    | 409  | Brian       |
       | empty user name              |          | 400  | Brian       |
 
-  @skipOnStable2.0
+  
   Scenario: admin user changes the name of a user to the name of an existing disabled user
     Given the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | sam             |
@@ -96,7 +96,7 @@ Feature: edit user
     }
     """
 
-  @skipOnStable2.0
+  
   Scenario: admin user changes the name of a user to the name of a previously deleted user
     Given the user "Alice" has created a new user using the Graph API with the following settings:
       | userName    | sam             |
@@ -318,7 +318,7 @@ Feature: edit user
       | User Light  | User Light  |
       | User Light  | Admin       |
 
-  @skipOnStable2.0
+  
   Scenario: admin user disables another user
     When the user "Alice" disables user "Brian" using the Graph API
     Then the HTTP status code should be "200"
@@ -360,7 +360,7 @@ Feature: edit user
     }
     """
 
-  @skipOnStable2.0
+  
   Scenario Outline: normal user should not be able to disable another user
     Given user "Carol" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
@@ -409,7 +409,7 @@ Feature: edit user
       | User        |
       | User Light  |
 
-  @skipOnStable2.0
+  
   Scenario: admin user enables disabled user
     Given the user "Alice" has disabled user "Brian" using the Graph API
     When the user "Alice" enables user "Brian" using the Graph API
@@ -452,7 +452,7 @@ Feature: edit user
     }
     """
 
-  @skipOnStable2.0
+  
   Scenario Outline: normal user should not be able to enable another user
     Given user "Carol" has been created with default attributes and without skeleton files
     And the user "Alice" has disabled user "Carol" using the Graph API

--- a/tests/acceptance/features/apiGraph/getApplications.feature
+++ b/tests/acceptance/features/apiGraph/getApplications.feature
@@ -1,4 +1,4 @@
-@api @skipOnStable2.0
+@api
 Feature: get applications
   As a user
   I want to be able to get application information with existing roles
@@ -13,9 +13,9 @@ Feature: get applications
     When user "Alice" gets all applications using the Graph API
     Then the HTTP status code should be "200"
     And the user API response should contain the following application information:
-      | key                        | value                   |
-      | displayName                | ownCloud Infinite Scale |
-      | id                         | %uuid_v4%               |
+      | key         | value                   |
+      | displayName | ownCloud Infinite Scale |
+      | id          | %uuid_v4%               |
     And the user API response should contain the following app roles:
       | Admin       |
       | Space Admin |

--- a/tests/acceptance/features/apiGraph/getUser.feature
+++ b/tests/acceptance/features/apiGraph/getUser.feature
@@ -10,7 +10,7 @@ Feature: get users
       | Alice    |
       | Brian    |
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets the information of a user
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When user "Alice" gets information of user "Brian" using Graph API
@@ -93,7 +93,7 @@ Feature: get users
       | User Light  | User Light  |
       | User Light  | Admin       |
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets all users
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When user "Alice" gets all users using the Graph API
@@ -159,7 +159,7 @@ Feature: get users
     }
     """
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets all users include disabled users
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And the user "Alice" has disabled user "Brian" using the Graph API
@@ -258,7 +258,7 @@ Feature: get users
       | User        |
       | User Light  |
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets the drive information of a user
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     When the user "Alice" gets user "Brian" along with his drive information using Graph API
@@ -381,7 +381,7 @@ Feature: get users
       }
     """
 
-  @skipOnStable2.0
+  
   Scenario Outline: non-admin user gets his/her own drive information
     Given the administrator has assigned the role "<userRole>" to user "Brian" using the Graph API
     When the user "Brian" gets his drive information using Graph API
@@ -509,7 +509,7 @@ Feature: get users
       | User        |
       | User Light  |
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets the group information of a user
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And group "tea-lover" has been created
@@ -617,7 +617,7 @@ Feature: get users
       | User Light  | User Light  |
       | User Light  | Admin       |
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets all users of certain groups
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Carol" has been created with default attributes and without skeleton files
@@ -751,7 +751,7 @@ Feature: get users
     And the JSON data of the response should not contain the user "Alice Hansen" in the item 'value'
 
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets all users of two groups
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Carol" has been created with default attributes and without skeleton files
@@ -825,7 +825,7 @@ Feature: get users
     """
     But the JSON data of the response should not contain the user "Carol King" in the item 'value'
 
-  @skipOnStable2.0
+  
   Scenario Outline: non admin user tries to get users of certain groups
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And the administrator has assigned the role "<role>" to user "Brian" using the Graph API
@@ -860,7 +860,7 @@ Feature: get users
       | User        |
       | User Light  |
 
-  @skipOnStable2.0
+  
   Scenario: admin user gets all users with certain roles and members of a certain group
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Carol" has been created with default attributes and without skeleton files
@@ -965,7 +965,7 @@ Feature: get users
     """
     But the JSON data of the response should not contain the user "Carol King" in the item 'value'
 
-  @skipOnStable2.0
+  
   Scenario Outline: non-admin user tries to get users with a certain role
     Given the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
     When the user "Alice" gets all users with role "<role>" using the Graph API

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -90,7 +90,7 @@ Feature: Space management
     And the json responded should not contain a space with name "Project"
     And the json responded should not contain a space with name "Alice Hansen"
 
-  @skipOnStable2.0
+  
   Scenario: space admin user changes the name of the project space
     When user "Brian" changes the name of the "Project" space to "New Name" owned by user "Alice"
     Then the HTTP status code should be "200"
@@ -116,7 +116,7 @@ Feature: Space management
     Then the HTTP status code should be "404"
     And the user "Alice" should have a space called "Project"
 
-  @skipOnStable2.0
+  
   Scenario: space admin user changes the description of the project space
     When user "Brian" changes the description of the "Project" space to "New description" owned by user "Alice"
     Then the HTTP status code should be "200"
@@ -142,7 +142,7 @@ Feature: Space management
     When user "Carol" tries to change the description of the "Project" space to "New description" owned by user "Alice"
     Then the HTTP status code should be "404"
 
-  @skipOnStable2.0
+  
   Scenario: space admin user disables the project space
     When user "Brian" disables a space "Project" owned by user "Alice"
     Then the HTTP status code should be "204"
@@ -162,7 +162,7 @@ Feature: Space management
       | Brian |
       | Carol |
 
-  @skipOnStable2.0
+  
   Scenario: space admin user deletes the project space
     Given user "Alice" has disabled a space "Project"
     When user "Brian" deletes a space "Project" owned by user "Alice"
@@ -175,7 +175,7 @@ Feature: Space management
     When user "Carol" tries to delete a space "Project" owned by user "Alice"
     Then the HTTP status code should be "404"
 
-  @skipOnStable2.0
+  
   Scenario: space admin user enables the project space
     Given user "Alice" has disabled a space "Project"
     When user "Brian" restores a disabled space "Project" owned by user "Alice"

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -1,4 +1,4 @@
-@api @skipOnStable2.0
+@api 
 Feature: Tag
   As a user
   I want to tag resources

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
@@ -119,7 +119,7 @@ Feature: Share a file or folder that is inside a space
     And the information about the last share for user "Brian" should include
       | expiration | 2042-01-01 |
 
-  @skipOnStable2.0
+  
   Scenario: user changes the expiration date
     Given user "Alice" has created a share inside of space "share sub-item" with settings:
       | path       | folder                   |
@@ -147,7 +147,7 @@ Feature: Share a file or folder that is inside a space
     And the information about the last share for user "Brian" should include
       | expiration |  |
 
-  @skipOnStable2.0
+  
   Scenario: check the end of expiration date in user share
     Given user "Alice" has created a share inside of space "share sub-item" with settings:
       | path       | folder                   |
@@ -159,7 +159,7 @@ Feature: Share a file or folder that is inside a space
     Then the HTTP status code should be "200"
     Then as "Brian" folder "Shares/folder" should not exist
 
-  @issue-5823 @skipOnStable2.0
+  @issue-5823 
   Scenario: check the end of expiration date in group share
     Given group "sales" has been created
     And the administrator has added a user "Brian" to the group "sales" using GraphApi


### PR DESCRIPTION
Part of: https://github.com/owncloud/ocis/issues/6726

As we don't run the tests in `stable-2.0` branch these tags are not need so this PR removes them