### PR TITLE
[tests-only][full-ci]add test for search project folders by tag

### DIFF
--- a/tests/acceptance/features/apiGraph/fullSearch.feature
+++ b/tests/acceptance/features/apiGraph/fullSearch.feature
@@ -88,6 +88,29 @@ Feature: full text search
       | spaces           |
 
 
+  Scenario Outline: search project space folders by tag
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "tag-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "spacesFolder/spacesSubFolder" in space "tag-space"
+    And user "Alice" has created a folder "unTagSpacesFolder/unTagSpacesSubFolder" in space "tag-space"
+    And user "Alice" has created the following tags for folder "spacesFolder" of the space "tag-space":
+      | tag1 |
+    And user "Alice" has created the following tags for folder "spacesFolder/spacesSubFolder" of the space "tag-space":
+      | tag1 |
+    And using <dav-path-version> DAV path
+    When user "Alice" searches for "Tags:tag1" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these files:
+      | spacesFolder    |
+      | spacesSubFolder |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+
   Scenario Outline: sharee searches shared files using a tag
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
This PR adds the API tests for full search api. The scenarios added in this PR are
- Search project space folders using a tag

## Related Issue
- https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
- there was no test coverage for api test for search project space folders using tag. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
