### PR TITLE
[tests-only][full-ci]add test for search version restored files by content

### DIFF
--- a/tests/acceptance/features/apiFullTextSearch/search.feature
+++ b/tests/acceptance/features/apiFullTextSearch/search.feature
@@ -47,6 +47,7 @@ Feature: full text search
       | dav-path-version |
       | old              |
       | new              |
+      | spaces           |
 
 
   Scenario Outline: search deleted files by content
@@ -78,6 +79,22 @@ Feature: full text search
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these files:
       | keywordAtStart.txt  |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+
+  Scenario Outline: search restored version of a file by content
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "hello world" to "test.txt"
+    And user "Alice" has uploaded file with content "Namaste nepal" to "test.txt"
+    And user "Alice" has restored version index "1" of file "test.txt"
+    When user "Alice" searches for "Content:hello" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these files:
+      | test.txt |
     Examples:
       | dav-path-version |
       | old              |


### PR DESCRIPTION
## Description
This PR adds the API tests for search version restored files through a content. The scenarios added in this PR are
- search version restored files using a content

## Related Issue
- https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
- there was no test coverage for api test for search version restored files through a content. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
