### PR TITLE
[tests-only][full-ci] added test scenario for searching inside folder in space

### DIFF
--- a/tests/acceptance/features/apiSpaces/search.feature
+++ b/tests/acceptance/features/apiSpaces/search.feature
@@ -1,6 +1,6 @@
-@api 
+@api
 Feature: Search
-  As a user 
+  As a user
   I want to search for resources in the space
   So that I can get them quickly
 
@@ -109,3 +109,15 @@ Feature: Search
     Then the HTTP status code should be "207"
     And the search result should contain "1" entries
     And for user "Alice" the search result should contain space "find data"
+
+
+  Scenario: user can search inside folder in space
+    When user "Alice" searches for "folder" inside folder "/folderMain" in space "find data" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "3" entries
+    And the search result of user "Alice" should contain only these entries:
+      | /SubFolder1                                |
+      | /SubFolder1/subFOLDER2                     |
+      | /SubFolder1/subFOLDER2/insideTheFolder.txt |
+    But the search result of user "Alice" should not contain these entries:
+      | /folderMain |

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -40,11 +40,13 @@ class SearchContext implements Context {
 	 * @When user :user searches for :pattern using the WebDAV API requesting these properties:
 	 * @When user :user searches for :pattern and limits the results to :limit items using the WebDAV API requesting these properties:
 	 * @When user :user searches for :pattern inside folder :scope using the WebDAV API
+	 * @When user :user searches for :pattern inside folder :scope in space :spaceName using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $pattern
 	 * @param string|null $limit
 	 * @param string|null $scope
+	 * @param string|null $spaceName
 	 * @param TableNode|null $properties
 	 *
 	 * @return void
@@ -54,6 +56,7 @@ class SearchContext implements Context {
 		string $pattern,
 		?string	$limit = null,
 		?string $scope = null,
+		?string $spaceName = null,
 		TableNode $properties = null
 	):void {
 		// Because indexing of newly uploaded files or directories with ocis is decoupled and occurs asynchronously, a short wait is necessary before searching files or folders.
@@ -66,7 +69,11 @@ class SearchContext implements Context {
 			= "<?xml version='1.0' encoding='utf-8' ?>\n" .
 			"	<oc:search-files xmlns:a='DAV:' xmlns:oc='http://owncloud.org/ns' >\n" .
 			"		<oc:search>\n";
-		if ($scope !== null) {
+		if ($scope !== null && $spaceName !== null) {
+			$scope = \trim($scope, "/");
+			$spaceId = $this->featureContext->spacesContext->getSpaceIdByName($user, $spaceName);
+			$pattern .= " scope:$spaceId/$scope";
+		} elseif ($scope !== null) {
 			$scope = \trim($scope, "/");
 			if ($this->featureContext->getDavPathVersion() === 3) {
 				$rootPath = $this->featureContext->getPersonalSpaceIdForUser($user);


### PR DESCRIPTION
## Description
This PR adds Api test for searching inside current folder in space(Location Filter). Following scenario is added:
- user can search inside folder in space

## Related Issue
https://github.com/owncloud/ocis/issues/6606

## Motivation and Context
There is no test coverage for api test for searching by enabling current folder on where files and folders are searched inside that particular folder only in spaces

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
