### PR TITLE
[tests-only][full-ci] added test scenario for searching inside folder in shares

### DIFF
--- a/tests/acceptance/features/apiSpaces/search.feature
+++ b/tests/acceptance/features/apiSpaces/search.feature
@@ -121,3 +121,19 @@ Feature: Search
       | /SubFolder1/subFOLDER2/insideTheFolder.txt |
     But the search result of user "Alice" should not contain these entries:
       | /folderMain |
+
+
+  Scenario: search inside folder in shares
+    Given user "Alice" has created a share inside of space "find data" with settings:
+      | path      | folderMain |
+      | shareWith | Brian      |
+      | role      | viewer     |
+    And user "Brian" has accepted share "/folderMain" offered by user "Alice"
+    When user "Brian" searches for "folder" inside folder "/folderMain" in space "Shares" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Brian" should contain only these entries:
+      | /SubFolder1                                |
+      | /SubFolder1/subFOLDER2                     |
+      | /SubFolder1/subFOLDER2/insideTheFolder.txt |
+    But the search result of user "Brian" should not contain these entries:
+      | /folderMain |


### PR DESCRIPTION

## Description
This PR adds Api test for searching inside current folder in shares(Location Filter). Following scenario is added:
- user can search inside folder in shares

## Related Issue
https://github.com/owncloud/ocis/issues/6606

## Motivation and Context
There is no test coverage for api test for searching by enabling current folder on where files and folders are searched inside that particular folder in shares

## How Has This Been Tested?

- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
