### PR TITLE
Fail on errors

### DIFF
--- a/changelog/unreleased/add-rebuild-jsoncs3-index-command.md
+++ b/changelog/unreleased/add-rebuild-jsoncs3-index-command.md
@@ -2,4 +2,5 @@ Enhancement: Add command for rebuilding the jsoncs3 share manager indexes
 
 We added a command for rebuilding the jsoncs3 share manager indexes.
 
+https://github.com/owncloud/ocis/pull/6986
 https://github.com/owncloud/ocis/pull/6971

--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -187,7 +187,7 @@ func RebuildJSONCS3Indexes(cfg *config.Config) *cli.Command {
 				fmt.Printf("done\n")
 			}
 			if errorsOccured {
-				fmt.Printf("There were errors. Please review the logs.")
+				return errors.New("There were errors. Please review the logs or try again.")
 			}
 
 			return nil


### PR DESCRIPTION
This PR makes the `migrate rebuild-jsoncs3-indexes` command exit with status code 1 when something went wrong during the migration.