### PR TITLE
[docs-only] Add mdns as supported value in MICRO_REGISTRY envvar description

### DIFF
--- a/docs/helpers/extended_vars.yaml
+++ b/docs/helpers/extended_vars.yaml
@@ -39,7 +39,7 @@ variables:
   type: string
   default_value: ""
   description: 'Go micro registry type to use. Supported types are: ''nats'', ''kubernetes'',
-    ''etcd'', ''consul'' and ''memory''. Will be selected automatically. Only change
+    ''etcd'', ''consul'', ''memory'' and ''mdns''. Will be selected automatically. Only change
     on supervision of ownCloud Support.'
   do_ignore: false
 - rawname: registryAddressEnv


### PR DESCRIPTION
As discussed with @butonic, the supported value `mdns` was missing in the MICRO_REGISTRY envvar description.

