### PR TITLE
ci: do not skip sonarcloud and codacy even if golint and unit-tests are skipped

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -595,7 +595,6 @@ def uploadScanResults(ctx):
                                 "git checkout $DRONE_COMMIT",
                             ],
             },
-        ] + skipIfUnchanged(ctx, "unit-tests") + [
             {
                 "name": "sync-from-cache",
                 "image": MINIO_MC,
@@ -603,7 +602,7 @@ def uploadScanResults(ctx):
                 "commands": [
                     "mkdir -p cache",
                     "mc alias set cachebucket $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                    "mc mirror cachebucket/$CACHE_BUCKET/%s/%s/cache cache/" % (ctx.repo.slug, ctx.build.commit + "-${DRONE_BUILD_NUMBER}"),
+                    "mc mirror cachebucket/$CACHE_BUCKET/%s/%s/cache cache/ || true" % (ctx.repo.slug, ctx.build.commit + "-${DRONE_BUILD_NUMBER}"),
                 ],
             },
             {
@@ -626,7 +625,7 @@ def uploadScanResults(ctx):
                 "environment": MINIO_MC_ENV,
                 "commands": [
                     "mc alias set cachebucket $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                    "mc rm --recursive --force cachebucket/$CACHE_BUCKET/%s/%s/cache" % (ctx.repo.slug, ctx.build.commit + "-${DRONE_BUILD_NUMBER}"),
+                    "mc rm --recursive --force cachebucket/$CACHE_BUCKET/%s/%s/cache || true" % (ctx.repo.slug, ctx.build.commit + "-${DRONE_BUILD_NUMBER}"),
                 ],
             },
         ],


### PR DESCRIPTION
## Description
Allow sonarcloud and codacy to run even if the golint and unit test pipelines are skipped

## Related Issue
prevents sonarcloud checks from being stuck

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
