### PR TITLE
[tests-only][full-ci]add test for sharee searches project spaces files by content

### DIFF
--- a/tests/acceptance/features/apiFullTextSearch/search.feature
+++ b/tests/acceptance/features/apiFullTextSearch/search.feature
@@ -77,7 +77,7 @@ Feature: full text search
     When user "Alice" searches for "Content:hello" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these files:
-      | keywordAtStart.txt  |
+      | keywordAtStart.txt |
     Examples:
       | dav-path-version |
       | old              |
@@ -121,4 +121,35 @@ Feature: full text search
       | dav-path-version |
       | old              |
       | new              |
+      | spaces           |
+
+
+  Scenario Outline: sharee searches shared project space files by content
+    Given using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has shared a space "project-space" with settings:
+      | shareWith | Brian  |
+      | role      | viewer |
+    And user "Alice" has created a folder "spacesFolderWithFile/spacesSubFolder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "hello world from nepal" to "keywordAtStart.txt"
+    And user "Alice" has uploaded a file inside space "project-space" with content "saying hello to the world" to "spacesFolderWithFile/keywordAtMiddle.txt"
+    And user "Alice" has uploaded a file inside space "project-space" with content "nepal wants to say hello" to "spacesFolderWithFile/spacesSubFolder/keywordAtLast.txt"
+    And user "Alice" has uploaded a file inside space "project-space" with content "namaste from nepal" to "hello.txt"
+    And using <dav-path-version> DAV path
+    When user "Brian" searches for "Content:hello" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these files:
+      | keywordAtStart.txt                                     |
+      | spacesFolderWithFile/keywordAtMiddle.txt               |
+      | spacesFolderWithFile/spacesSubFolder/keywordAtLast.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+
+    @skipOnStable3.0
+    Examples:
+      | dav-path-version |
       | spaces           |


### PR DESCRIPTION
## Description
This PR adds the API tests for searching project space files by sharee using content. The scenarios added in this PR are
- sharee searches shared project spaces files by content

## Related Issue
- https://github.com/owncloud/ocis/issues/6606#event-9635806756

## Motivation and Context
- there was no test coverage for the API test for Sharee searches project files using content. so, this PR covers the require scenario test case

## How Has This Been Tested?
- test environment:
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
