### PR TITLE
[tests-only][ociswrapper] Fix oCIS restart when it exits unexpectedly during startup

### DIFF
--- a/tests/ociswrapper/log/log.go
+++ b/tests/ociswrapper/log/log.go
@@ -7,5 +7,9 @@ func Println(message string) {
 }
 
 func Panic(err error) {
-	log.Panic("[ociswrapper] ", err.Error())
+	log.Panic("[ociswrapper]", err.Error())
+}
+
+func Fatalln(err error) {
+	log.Fatalln("[ociswrapper]", err.Error())
 }

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -72,10 +72,6 @@ func Start(envMap map[string]any) {
 
 				// retry to start oCIS server
 				retryCount++
-				retryCount++
-
-				retryCount++
-
 				maxRetry, _ := strconv.Atoi(config.Get("retry"))
 				if retryCount <= maxRetry {
 					log.Println(fmt.Sprintf("Retry starting oCIS server... (retry %v)", retryCount))

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"syscall"
 	"time"
 
 	"ociswrapper/common"
@@ -58,23 +59,38 @@ func Start(envMap map[string]any) {
 	for outputScanner.Scan() {
 		m := outputScanner.Text()
 		fmt.Println(m)
-		retryCount++
+	}
 
-		maxRetry, _ := strconv.Atoi(config.Get("retry"))
-		if retryCount <= maxRetry {
-			log.Println(fmt.Sprintf("Retry starting oCIS server... (retry %v)", retryCount))
-			// Stop and start again
-			Stop()
-			Start(envMap)
+	if err := cmd.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			status := exitErr.Sys().(syscall.WaitStatus)
+			// retry only if oCIS server exited with code > 0
+			// -1 exit code means that the process was killed by a signal (cmd.Process.Kill())
+			if status.ExitStatus() > 0 {
+				log.Println(fmt.Sprintf("oCIS server exited with code %v", status.ExitStatus()))
+
+				// retry to start oCIS server
+				retryCount++
+				retryCount++
+
+				retryCount++
+
+				maxRetry, _ := strconv.Atoi(config.Get("retry"))
+				if retryCount <= maxRetry {
+					log.Println(fmt.Sprintf("Retry starting oCIS server... (retry %v)", retryCount))
+					// Stop and start again
+					Stop()
+					Start(envMap)
+				}
+			}
 		}
 	}
-	cmd.Wait()
 }
 
 func Stop() {
 	err := cmd.Process.Kill()
 	if err != nil {
-		log.Panic(err)
+		log.Fatalln(err)
 	}
 	cmd.Wait()
 }

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -120,11 +120,7 @@ func WaitForConnection() bool {
 			req.Header.Set("X-Request-ID", "ociswrapper-"+strconv.Itoa(int(time.Now().UnixMilli())))
 
 			res, err := client.Do(req)
-			if err != nil || res.StatusCode >= 400 {
-				if res != nil {
-					log.Println(fmt.Sprintf("oCIS server up but request failed: %v", res.StatusCode))
-					return true
-				}
+			if err != nil || res.StatusCode != 200 {
 				// 500 milliseconds poll interval
 				time.Sleep(500 * time.Millisecond)
 				continue

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -90,7 +91,9 @@ func Start(envMap map[string]any) {
 func Stop() {
 	err := cmd.Process.Kill()
 	if err != nil {
-		log.Fatalln(err)
+		if !strings.HasSuffix(err.Error(), "process already finished") {
+			log.Fatalln(err)
+		}
 	}
 	cmd.Wait()
 }

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -124,7 +124,11 @@ func WaitForConnection() bool {
 			req.Header.Set("X-Request-ID", "ociswrapper-"+strconv.Itoa(int(time.Now().UnixMilli())))
 
 			res, err := client.Do(req)
-			if err != nil || res.StatusCode != 200 {
+			if err != nil || res.StatusCode >= 400 {
+				if res != nil {
+					log.Println(fmt.Sprintf("oCIS server up but request failed: %v", res.StatusCode))
+					return true
+				}
 				// 500 milliseconds poll interval
 				time.Sleep(500 * time.Millisecond)
 				continue

--- a/tests/ociswrapper/wrapper/handlers/handler.go
+++ b/tests/ociswrapper/wrapper/handlers/handler.go
@@ -31,7 +31,7 @@ func sendResponse(res http.ResponseWriter, ocisStatus bool) {
 	} else {
 		res.WriteHeader(http.StatusInternalServerError)
 		resBody["status"] = "ERROR"
-		resBody["message"] = "oCIS server error"
+		resBody["message"] = "Unable to start oCIS server"
 	}
 	res.Header().Set("Content-Type", "application/json")
 


### PR DESCRIPTION
## Description
Improves:
- restart ocis server if it exists with error during startup
- do not panic if the process is already finished while stopping the process
- mark server ready if the server sends the response

## Related Issue
Part of https://github.com/owncloud/ocis/issues/6850


## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
