### PR TITLE
[tests-only][full-ci]send X-Request-Id in header of every request

### DIFF
--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -133,7 +133,7 @@ class EmailHelper {
 		$endTime = $currentTime + $waitTimeSec;
 		$mailBox = self::getMailBoxFromEmail($emailAddress);
 		while ($currentTime <= $endTime) {
-			$mailboxResponse = self::getMailboxInformation($mailBox);
+			$mailboxResponse = self::getMailboxInformation($mailBox, $xRequestId);
 			if (!empty($mailboxResponse) && \sizeof($mailboxResponse) >= $emailNumber) {
 				$mailboxId = $mailboxResponse[\sizeof($mailboxResponse) - $emailNumber]->id;
 				$response = self::getBodyOfAnEmailById($mailBox, $mailboxId, $xRequestId);

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -992,6 +992,7 @@ class GraphHelper {
 	 * @param  string $user
 	 * @param  string $password
 	 * @param  string $spaceId
+	 * @param string $xRequestId
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -1000,13 +1001,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $spaceId
+		string $spaceId,
+		string $xRequestId
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'drives/' . $spaceId);
 		$header = ["restore" => true];
 		$body = '{}';
 
-		return HttpRequestHelper::sendRequest($url, '', 'PATCH', $user, $password, $header, $body);
+		return HttpRequestHelper::sendRequest($url, $xRequestId, 'PATCH', $user, $password, $header, $body);
 	}
 
 	/**

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -202,7 +202,6 @@ class WebDavHelper {
 			throw new InvalidArgumentException('Invalid depth value ' . $folderDepth);
 		}
 		$headers['Depth'] = $folderDepth;
-		$headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		return self::makeDavRequest(
 			$baseUrl,
 			$user,

--- a/tests/acceptance/features/apiContract/copy.feature
+++ b/tests/acceptance/features/apiContract/copy.feature
@@ -19,7 +19,7 @@ Feature: Copy test
     When user "Alice" copies file "testfile.txt" from space "new-space" to "/new/testfile.txt" inside space "new-space" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
-      | Oc-Fileid                   | /^[a-f0-9!\$\-]{110}$/ |
-      | Access-Control-Allow-Origin | /^[*]{1}$/             |
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | Oc-Fileid                   | /^[a-f0-9!\$\-]{110}$/                       |
+      | Access-Control-Allow-Origin | /^[*]{1}$/                                   |
+      | X-Request-Id                | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
 

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -18,7 +18,7 @@ Feature: Propfind test
     When user "Alice" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
       | key            | value            |
       | oc:fileid      | UUIDof:new-space |
@@ -36,7 +36,7 @@ Feature: Propfind test
     When user "Brian" sends PROPFIND request to space "new-space" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
       | key            | value            |
       | oc:fileid      | UUIDof:new-space |

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -20,7 +20,7 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:SubFolder1    |
@@ -42,7 +42,7 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "frodo.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key                | value                                  |
       | oc:fileid          | UUIDof:SubFolder1/subFOLDER2/frodo.txt |
@@ -63,7 +63,7 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the search result should contain "0" entries
     Examples:
       | dav-path-version |

--- a/tests/acceptance/features/apiContract/spacesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesReport.feature
@@ -21,7 +21,7 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /testFile.txt |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key                | value               |
       | oc:fileid          | UUIDof:testFile.txt |
@@ -41,7 +41,7 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key                | value                                                       |
       | oc:fileid          | UUIDof:folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
@@ -60,7 +60,7 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /folderMain |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:folderMain    |
@@ -79,7 +79,8 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /folderMain/sub-folder |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+    Then the HTTP status code should be "207"
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key              | value                        |
       | oc:fileid        | UUIDof:folderMain/sub-folder |

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -28,7 +28,7 @@ Feature: Report test
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:SubFolder1    |
@@ -49,7 +49,7 @@ Feature: Report test
     When user "Brian" searches for "insideTheFolder.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
       | key                | value                                            |
       | oc:fileid          | UUIDof:SubFolder1/subFOLDER2/insideTheFolder.txt |
@@ -69,5 +69,5 @@ Feature: Report test
     When user "Brian" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the search result should contain "0" entries

--- a/tests/acceptance/features/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/features/bootstrap/ArchiverContext.php
@@ -166,7 +166,7 @@ class ArchiverContext implements Context {
 		$queryString = $this->getArchiverQueryString($owner, $resource, $addressType);
 		return HttpRequestHelper::get(
 			$this->featureContext->getBaseUrl() . '/archiver?' . $queryString,
-			'',
+			$this->featureContext->getStepLineRef(),
 			$downloader,
 			$this->featureContext->getPasswordForUser($downloader),
 			$headers
@@ -199,7 +199,7 @@ class ArchiverContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$this->featureContext->getBaseUrl() . '/archiver?' . $queryString,
-				'',
+				$this->featureContext->getStepLineRef(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 			)

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -432,7 +432,9 @@ class NotificationContext implements Context {
 			GraphHelper::getMySpaces(
 				$this->featureContext->getBaseUrl(),
 				$user,
-				$this->featureContext->getPasswordForUser($user)
+				$this->featureContext->getPasswordForUser($user),
+				'',
+				$this->featureContext->getStepLineRef()
 			)
 		);
 		$expectedEmailBodyContent = $this->featureContext->substituteInLineCodes(
@@ -541,7 +543,7 @@ class NotificationContext implements Context {
 			$user ? $this->featureContext->getPasswordForUser($user) : $this->featureContext->getAdminPassword(),
 			'POST',
 			$this->globalNotificationEndpointPath,
-			'',
+			$this->featureContext->getStepLineRef(),
 			json_encode($payload),
 			2
 		);
@@ -608,7 +610,7 @@ class NotificationContext implements Context {
 			$user ? $this->featureContext->getPasswordForUser($user) : $this->featureContext->getAdminPassword(),
 			'DELETE',
 			$this->globalNotificationEndpointPath,
-			'',
+			$this->featureContext->getStepLineRef(),
 			json_encode($payload),
 			2
 		);

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -64,7 +64,6 @@ class SearchContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$password = $this->featureContext->getPasswordForUser($user);
-		$headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		$body
 			= "<?xml version='1.0' encoding='utf-8' ?>\n" .
 			"	<oc:search-files xmlns:a='DAV:' xmlns:oc='http://owncloud.org/ns' >\n" .
@@ -103,7 +102,7 @@ class SearchContext implements Context {
 			$password,
 			"REPORT",
 			"/",
-			$headers,
+			null,
 			$this->featureContext->getStepLineRef(),
 			$body,
 			$this->featureContext->getDavPathVersion()

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -58,7 +58,7 @@ class SettingsContext implements Context {
 	public function getAllExistingRoles(string $user): void {
 		$fullUrl = $this->baseUrl . $this->settingsUrl . "roles-list";
 		$this->featureContext->setResponse(
-			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), "{}")
+			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), "{}", $this->featureContext->getStepLineRef())
 		);
 	}
 
@@ -77,7 +77,7 @@ class SettingsContext implements Context {
 		$body = json_encode(["account_uuid" => $userId, "role_id" => $roleId], JSON_THROW_ON_ERROR);
 
 		$this->featureContext->setResponse(
-			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body)
+			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body, $this->featureContext->getStepLineRef())
 		);
 	}
 
@@ -93,7 +93,7 @@ class SettingsContext implements Context {
 	public function sendRequestAssignmentsList(string $user, string $userId): ResponseInterface {
 		$fullUrl = $this->baseUrl . $this->settingsUrl . "assignments-list";
 		$body = json_encode(["account_uuid" => $userId], JSON_THROW_ON_ERROR);
-		return $this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body);
+		return $this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body, $this->featureContext->getStepLineRef());
 	}
 
 	/**
@@ -271,7 +271,7 @@ class SettingsContext implements Context {
 	public function sendRequestGetBundlesList(string $user): void {
 		$fullUrl = $this->baseUrl . $this->settingsUrl . "bundles-list";
 		$this->featureContext->setResponse(
-			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), '{}')
+			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), '{}', $this->featureContext->getStepLineRef())
 		);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe(
@@ -312,7 +312,7 @@ class SettingsContext implements Context {
 		$fullUrl = $this->baseUrl . $this->settingsUrl . "values-list";
 		$body = json_encode(["account_uuid" => "me"], JSON_THROW_ON_ERROR);
 		$this->featureContext->setResponse(
-			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body)
+			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body, $this->featureContext->getStepLineRef())
 		);
 
 		Assert::assertEquals(
@@ -392,7 +392,7 @@ class SettingsContext implements Context {
 		);
 
 		$this->featureContext->setResponse(
-			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body)
+			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body, $this->featureContext->getStepLineRef())
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -272,7 +272,7 @@ class SpacesContext implements Context {
 
 		return HttpRequestHelper::get(
 			$fullUrl,
-			"",
+			$this->featureContext->getStepLineRef(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			[],
@@ -341,7 +341,7 @@ class SpacesContext implements Context {
 			$this->featureContext->getPasswordForUser($user),
 			"",
 			['oc:privatelink'],
-			"",
+			$this->featureContext->getStepLineRef(),
 			"0",
 			"files",
 			WebDavHelper::DAV_VERSION_SPACES
@@ -437,14 +437,16 @@ class SpacesContext implements Context {
 					$this->featureContext->getBaseUrl(),
 					$userAdmin,
 					$this->featureContext->getPasswordForUser($userAdmin),
-					$value["id"]
+					$value["id"],
+					$this->featureContext->getStepLineRef()
 				);
 			}
 			GraphHelper::deleteSpace(
 				$this->featureContext->getBaseUrl(),
 				$userAdmin,
 				$this->featureContext->getPasswordForUser($userAdmin),
-				$value["id"]
+				$value["id"],
+				$this->featureContext->getStepLineRef()
 			);
 		}
 	}
@@ -517,7 +519,8 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				"?" . $query
+				"?" . $query,
+				$this->featureContext->getStepLineRef()
 			)
 		);
 		$this->rememberTheAvailableSpaces();
@@ -544,7 +547,8 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				"?" . $query
+				"?" . $query,
+				$this->featureContext->getStepLineRef()
 			)
 		);
 		$this->rememberTheAvailableSpaces();
@@ -571,7 +575,9 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$space["id"]
+				$space["id"],
+				'',
+				$this->featureContext->getStepLineRef()
 			)
 		);
 	}
@@ -603,7 +609,8 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$body
+				$body,
+				$this->featureContext->getStepLineRef()
 			)
 		);
 		$this->setSpaceCreator($spaceName, $user);
@@ -659,7 +666,7 @@ class SpacesContext implements Context {
 				$this->featureContext->getPasswordForUser($user),
 				$foldersPath,
 				[],
-				'',
+				$this->featureContext->getStepLineRef(),
 				'infinity',
 				'files',
 				WebDavHelper::DAV_VERSION_SPACES
@@ -686,7 +693,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::sendRequest(
 				$url,
-				"",
+				$this->featureContext->getStepLineRef(),
 				"PATCH",
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
@@ -1251,7 +1258,8 @@ class SpacesContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$body,
-			$spaceId
+			$spaceId,
+			$this->featureContext->getStepLineRef()
 		);
 	}
 
@@ -1408,7 +1416,8 @@ class SpacesContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				$body,
-				$spaceId
+				$spaceId,
+				$this->featureContext->getStepLineRef()
 			)
 		);
 	}
@@ -1505,7 +1514,8 @@ class SpacesContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$body
+			$body,
+			$this->featureContext->getStepLineRef()
 		);
 	}
 
@@ -1641,7 +1651,6 @@ class SpacesContext implements Context {
 	):void {
 		$space = $this->getSpaceByName($user, $fromSpaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName);
-		$headers['X-Request-Id'] = WebDavHelper::generateUUIDv4();
 		$fullUrl = $space["root"]["webDavUrl"] . '/' . ltrim($fileSource, "/");
 		$this->featureContext->setResponse($this->copyFilesAndFoldersRequest($user, $fullUrl, $headers));
 	}
@@ -1853,7 +1862,8 @@ class SpacesContext implements Context {
 			$fullUrl,
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$body
+			$body,
+			$this->featureContext->getStepLineRef()
 		);
 	}
 
@@ -1911,7 +1921,8 @@ class SpacesContext implements Context {
 				$fullUrl,
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$body
+				$body,
+				$this->featureContext->getStepLineRef()
 			)
 		);
 		$response = $this->featureContext->getResponseXml(null, __METHOD__);
@@ -1972,7 +1983,7 @@ class SpacesContext implements Context {
 		$fullUrl = $this->baseUrl . $this->ocsApiUrl . '/' . $shareId;
 		return  HttpRequestHelper::sendRequest(
 			$fullUrl,
-			"",
+			$this->featureContext->getStepLineRef(),
 			"PUT",
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
@@ -2034,7 +2045,8 @@ class SpacesContext implements Context {
 				$fullUrl,
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$body
+				$body,
+				$this->featureContext->getStepLineRef()
 			)
 		);
 
@@ -2134,7 +2146,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::delete(
 				$fullUrl,
-				"",
+				$this->featureContext->getStepLineRef(),
 				$user,
 				$this->featureContext->getPasswordForUser($user)
 			)
@@ -2161,7 +2173,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::delete(
 				$spaceWebDavUrl,
-				"",
+				$this->featureContext->getStepLineRef(),
 				$user,
 				$this->featureContext->getPasswordForUser($user)
 			)
@@ -2210,7 +2222,8 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$space["id"]
+				$space["id"],
+				$this->featureContext->getStepLineRef()
 			)
 		);
 	}
@@ -2282,7 +2295,8 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$space["id"]
+				$space["id"],
+				$this->featureContext->getStepLineRef()
 			)
 		);
 	}
@@ -2309,7 +2323,8 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$space["id"]
+				$space["id"],
+				$this->featureContext->getStepLineRef()
 			)
 		);
 	}
@@ -2351,7 +2366,7 @@ class SpacesContext implements Context {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$fullUrl = $this->baseUrl . $this->davSpacesUrl . "trash-bin/" . $space["id"];
 		$this->featureContext->setResponse(
-			HttpRequestHelper::sendRequest($fullUrl, '', 'PROPFIND', $user, $this->featureContext->getPasswordForUser($user))
+			HttpRequestHelper::sendRequest($fullUrl, $this->featureContext->getStepLineRef(), 'PROPFIND', $user, $this->featureContext->getPasswordForUser($user))
 		);
 	}
 
@@ -2371,7 +2386,7 @@ class SpacesContext implements Context {
 		$space = $this->getSpaceByNameManager($user, $spaceName);
 		$fullUrl = $this->baseUrl . $this->davSpacesUrl . "trash-bin/" . $space["id"];
 		$this->featureContext->setResponse(
-			HttpRequestHelper::sendRequest($fullUrl, '', 'PROPFIND', $user, $this->featureContext->getPasswordForUser($user))
+			HttpRequestHelper::sendRequest($fullUrl, $this->featureContext->getStepLineRef(), 'PROPFIND', $user, $this->featureContext->getPasswordForUser($user))
 		);
 	}
 
@@ -2480,7 +2495,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::sendRequest(
 				$fullUrl,
-				"",
+				$this->featureContext->getStepLineRef(),
 				'MOVE',
 				$user,
 				$this->featureContext->getPasswordForUser($user),
@@ -2524,7 +2539,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::sendRequest(
 				$fullUrl,
-				"",
+				$this->featureContext->getStepLineRef(),
 				'DELETE',
 				$user,
 				$this->featureContext->getPasswordForUser($user),
@@ -2572,7 +2587,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$fullUrl,
-				"",
+				$this->featureContext->getStepLineRef(),
 				$user,
 				$this->featureContext->getPasswordForUser($user)
 			)
@@ -2867,7 +2882,8 @@ class SpacesContext implements Context {
 				$fullUrl,
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$body
+				$body,
+				$this->featureContext->getStepLineRef()
 			)
 		);
 
@@ -3115,7 +3131,7 @@ class SpacesContext implements Context {
 				$this->featureContext->getPasswordForUser($user),
 				$resource,
 				$properties,
-				"",
+				$this->featureContext->getStepLineRef(),
 				"0",
 				"files",
 				WebDavHelper::DAV_VERSION_SPACES
@@ -3237,7 +3253,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$this->featureContext->getBaseUrl() . '/archiver?' . $queryString,
-				'',
+				$this->featureContext->getStepLineRef(),
 				'',
 				'',
 			)
@@ -3328,7 +3344,7 @@ class SpacesContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$url,
-				'',
+				$this->featureContext->getStepLineRef(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 			)

--- a/tests/acceptance/features/bootstrap/TagContext.php
+++ b/tests/acceptance/features/bootstrap/TagContext.php
@@ -139,7 +139,8 @@ class TagContext implements Context {
 			GraphHelper::getTags(
 				$this->featureContext->getBaseUrl(),
 				$user,
-				$this->featureContext->getPasswordForUser($user)
+				$this->featureContext->getPasswordForUser($user),
+				$this->featureContext->getStepLineRef()
 			)
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -642,6 +642,7 @@ class WebDavLockingContext implements Context {
 			$password,
 			'GET',
 			"/apps/testing/api/v1/app/core/lock-breaker-groups",
+			$this->featureContext->getStepLineRef(),
 			(string) $ocsApiVersion
 		);
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR includes the use of `X-Request-Id` header in each API requests. The `X-Request-Id` header consists the line reference of the scenario under test. If any of the test fails then oCIS server will log the error which contains `request-id` which represents the line reference of the failed scenario. For example, when any of the test fails oCIS server will provide the log as:

`
{"level":"error","service":"ocdav","name":"com.owncloud.web.ocdav","traceid":"00000000000000000000000000000000","request-id":"apiContract/propfind.feature:16-18","spaceid":"a428260f-6f47-4e9d-a939-6236977c3f8a$bbac7138-4375-4c27-8241-7ebe1e5af89d","path":"/","status":{"code":15,"message":"error getting upload id: Decomposedfs: error walking path: Decomposedfs: error walking path: decomposedfs: Wrap: readlink error: readlink /home/prajwol/.ocis/storage/users/spaces/bb/ac7138-4375-4c27-8241-7ebe1e5af89d/nodes/bb/ac/71/38/-4375-4c27-8241-7ebe1e5af89d: invalid argument","trace":"00000000000000000000000000000000"},"code":500,"time":"2023-09-05T15:14:31.495096701+05:45","message":"Internal Server Error"}
`

The server log consists of `"request-id":"apiContract/propfind.feature:16-18"`, which indicates the `apiContract` test suite, `propfind` feature, the scenario at line `16` and the test step at line `18` has failed. Using this server information tracking of the failed scenario and its step will be easier.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/7022

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
