### PR TITLE
[tests-only] Fix the test step keyword ordering

### DIFF
--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -18,7 +18,7 @@ Feature: enforce password on public link
       | path        | /testfile.txt |
       | permissions | 3             |
     Then the HTTP status code should be "<http-code>"
-    Then the OCS status code should be "400"
+    And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
       | ocs-api-version | http-code |
@@ -34,7 +34,7 @@ Feature: enforce password on public link
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3 |
     Then the HTTP status code should be "<http-code>"
-    Then the OCS status code should be "400"
+    And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
       | ocs-api-version | http-code |

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -100,7 +100,7 @@ Feature: State of the quota
 
 
   Scenario: file cannot be overwritten if there is insufficient quota
-    When user "Alice" has created a space "Project Delta" of type "project" with quota "10"
+    Given user "Alice" has created a space "Project Delta" of type "project" with quota "10"
     And user "Alice" has uploaded a file inside space "Project Delta" with content "7 bytes" to "test.txt"
     When user "Alice" uploads a file inside space "Project Delta" with content "00011 bytes" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "507"

--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -60,7 +60,7 @@ Feature: Upload files into a space
     When user "Alice" creates a folder "NewFolder" in space "Project Ceres" using the WebDav Api
     Then the HTTP status code should be "201"
     And user "Alice" uploads a file inside space "Project Ceres" with content "Test" to "test.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
+    And the HTTP status code should be "201"
     And for user "Alice" the space "Project Ceres" should contain these entries:
       | NewFolder |
       | test.txt  |

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
@@ -156,7 +156,7 @@ Feature: Share a file or folder that is inside a space
     And user "Brian" has accepted share "/folder" offered by user "Alice"
     When user "Alice" expires the last share
     Then the HTTP status code should be "200"
-    Then as "Brian" folder "Shares/folder" should not exist
+    And as "Brian" folder "Shares/folder" should not exist
 
   @issue-5823
   Scenario: check the end of expiration date in group share
@@ -171,4 +171,4 @@ Feature: Share a file or folder that is inside a space
     And user "Brian" has accepted share "/folder" offered by user "Alice"
     When user "Alice" expires the last share
     Then the HTTP status code should be "200"
-    Then as "Brian" folder "Shares/folder" should not exist
+    And as "Brian" folder "Shares/folder" should not exist

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -147,7 +147,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs_status_code>"
     And user "Alice" should be able to accept pending share "/zzzfolder" offered by user "Carol"
-    Then as "Alice" the info about the last share by user "Carol" with user "Alice" should include
+    And as "Alice" the info about the last share by user "Carol" with user "Alice" should include
       | uid_owner   | %username%     |
       | share_with  | %username%     |
       | file_target | /zzzfolder (2) |

--- a/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
@@ -314,7 +314,7 @@ Feature: accept/decline shares coming from internal users
     And user "Carol" has created folder "FOLDER"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
     And user "Alice" shares folder "/FOLDER" with group "grp1" using the sharing API
-    When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
+    And user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
     And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
     And user "Carol" accepts share "/PARENT" offered by user "Alice" using the sharing API
     And user "Carol" accepts share "/FOLDER" offered by user "Alice" using the sharing API
@@ -353,7 +353,7 @@ Feature: accept/decline shares coming from internal users
     And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     And user "Alice" shares file "/textfile1.txt" with group "grp1" using the sharing API
-    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     And user "Brian" accepts share "/textfile1.txt" offered by user "Alice" using the sharing API
     And user "Carol" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     And user "Carol" accepts share "/textfile1.txt" offered by user "Alice" using the sharing API
@@ -407,7 +407,7 @@ Feature: accept/decline shares coming from internal users
     But user "Carol" should not see the following elements
       | /Shares/textfile0.txt |
     When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    When user "Carol" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    And user "Carol" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the OCS status code of responses on all endpoints should be "100"
     And the HTTP status code of responses on all endpoints should be "200"
     And user "Brian" should see the following elements

--- a/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -102,7 +102,7 @@ Feature: upload to a public link share
     Then the HTTP status code should be "507"
 
   @smokeTest
-  Scenario:uploading to a public upload-write and no edit and no overwrite share with public API
+  Scenario: uploading to a public upload-write and no edit and no overwrite share with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |

--- a/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -85,7 +85,7 @@ Feature: upload to a public link share
 
 
   Scenario: uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with public API
-    When user "Alice" creates a public link share using the sharing API with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | change |
     And the quota of user "Alice" has been set to "0"
@@ -94,7 +94,7 @@ Feature: upload to a public link share
 
   @issue-1290
   Scenario: uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with public API
-    When user "Alice" creates a public link share using the sharing API with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     And the quota of user "Alice" has been set to "0"
@@ -102,7 +102,7 @@ Feature: upload to a public link share
     Then the HTTP status code should be "507"
 
   @smokeTest
-  Scenario:uUploading to a public upload-write and no edit and no overwrite share with public API
+  Scenario:uploading to a public upload-write and no edit and no overwrite share with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |


### PR DESCRIPTION
fix some of the steps ordering in the tests 

I was trying to run https://github.com/JankariTech/expected-failures-updater to check if the app still works in catching the repetitive `Given` `Then` step and these are some of the changes the app made. Some of the changes were also manually done depending on the context of the scenario 