### PR TITLE
[tests-only][full-ci] removing the setresponse in given/then step in FileVersionsContext

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -174,12 +174,7 @@ class FilesVersionsContext implements Context {
 	 */
 	public function userRestoredVersionIndexOfFile(string $user, int $versionIndex, string $path):void {
 		$response = $this->restoreVersionIndexOfFile($user, $versionIndex, $path);
-		$actualStatusCode = $response->getStatusCode();
-		Assert::assertEquals(
-			'204',
-			$actualStatusCode,
-			"HTTP status code was $actualStatusCode Restoring version index of file was not successful"
-		);
+		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -172,7 +172,7 @@ class FilesVersionsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userRestoredVersionIndexOfFile(string $user, int $versionIndex, string $path):void {
+	public function userHasRestoredVersionIndexOfFile(string $user, int $versionIndex, string $path):void {
 		$response = $this->restoreVersionIndexOfFile($user, $versionIndex, $path);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 	}

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2673,7 +2673,7 @@ class SpacesContext implements Context {
 		string $spaceName
 	): void {
 		$this->setSpaceIDByName($user, $spaceName);
-		$this->filesVersionsContext->downloadVersion($user, $fileName, $index);
+		$this->featureContext->setResponse($this->filesVersionsContext->downloadVersion($user, $fileName, $index));
 		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1053,14 +1053,17 @@ trait WebDav {
 	/**
 	 * @param string $expectedContent
 	 * @param string $extraErrorText
+	 * @param ResponseInterface|null $response
 	 *
 	 * @return void
 	 */
 	public function checkDownloadedContentMatches(
 		string $expectedContent,
-		string $extraErrorText = ""
+		string $extraErrorText = "",
+		?ResponseInterface $response = null
 	):void {
-		$actualContent = (string) $this->response->getBody();
+		$response = $response ?? $this->response;
+		$actualContent = (string) $response->getBody();
 		// For this test we really care about the content.
 		// A separate "Then" step can specifically check the HTTP status.
 		// But if the content is wrong (e.g. empty) then it is useful to

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -455,9 +455,9 @@ trait WebDav {
 	 * @param string|null $width
 	 * @param string|null $height
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function downloadPreviews(string $user, ?string $path, ?string $doDavRequestAsUser, ?string $width, ?string $height):void {
+	public function downloadPreviews(string $user, ?string $path, ?string $doDavRequestAsUser, ?string $width, ?string $height):ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$doDavRequestAsUser = $this->getActualUsername($doDavRequestAsUser);
 		$urlParameter = [
@@ -466,7 +466,7 @@ trait WebDav {
 			'forceIcon' => '0',
 			'preview' => '1'
 		];
-		$this->response = $this->makeDavRequest(
+		return $this->makeDavRequest(
 			$user,
 			"GET",
 			$path,
@@ -4637,13 +4637,14 @@ trait WebDav {
 	 * @return void
 	 */
 	public function downloadPreviewOfFiles(string $user, string $path, string $width, string $height):void {
-		$this->downloadPreviews(
+		$response = $this->downloadPreviews(
 			$user,
 			$path,
 			null,
 			$width,
 			$height
 		);
+		$this->setResponse($response);
 	}
 
 	/**
@@ -4658,13 +4659,14 @@ trait WebDav {
 	 * @return void
 	 */
 	public function downloadPreviewOfOtherUser(string $user1, string $path, string $doDavRequestAsUser, string $width, string $height):void {
-		$this->downloadPreviews(
+		$response = $this->downloadPreviews(
 			$user1,
 			$path,
 			$doDavRequestAsUser,
 			$width,
 			$height
 		);
+		$this->setResponse($response);
 	}
 
 	/**


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
