### PR TITLE
support AD FS

### DIFF
--- a/changelog/unreleased/access-token-issuer.md
+++ b/changelog/unreleased/access-token-issuer.md
@@ -1,0 +1,5 @@
+Enhancement: Support spec violating AD FS access token issuer
+
+AD FS `/adfs/.well-known/openid-configuration` has an optional `access_token_issuer` which, in violation of the OpenID Connect spec, takes precedence over `issuer`.
+
+https://github.com/owncloud/ocis/pull/7138

--- a/ocis-pkg/oidc/client.go
+++ b/ocis-pkg/oidc/client.go
@@ -308,15 +308,14 @@ func (c *oidcClient) verifyAccessTokenJWT(token string) (RegClaimsWithSID, jwt.M
 		return claims, mapClaims, err
 	}
 
-	validIssuer := false
+	issuer := c.issuer
 	if c.provider.AccessTokenIssuer != "" {
 		// AD FS .well-known/openid-configuration has an optional `access_token_issuer` which takes precedence over `issuer`
 		// See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oidce/586de7dd-3385-47c7-93a2-935d9e90441c
-		validIssuer = claims.VerifyIssuer(c.provider.AccessTokenIssuer, true)
-	} else {
-		validIssuer = claims.VerifyIssuer(c.issuer, true)
+		issuer = c.provider.AccessTokenIssuer
 	}
-	if !validIssuer {
+
+	if !claims.VerifyIssuer(issuer, true) {
 		vErr := jwt.ValidationError{}
 		vErr.Inner = jwt.ErrTokenInvalidIssuer
 		vErr.Errors |= jwt.ValidationErrorIssuer

--- a/ocis-pkg/oidc/client.go
+++ b/ocis-pkg/oidc/client.go
@@ -308,7 +308,15 @@ func (c *oidcClient) verifyAccessTokenJWT(token string) (RegClaimsWithSID, jwt.M
 		return claims, mapClaims, err
 	}
 
-	if !claims.VerifyIssuer(c.issuer, true) {
+	validIssuer := false
+	if c.provider.AccessTokenIssuer != "" {
+		// AD FS .well-known/openid-configuration has an optional `access_token_issuer` which takes precedence over `issuer`
+		// See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oidce/586de7dd-3385-47c7-93a2-935d9e90441c
+		validIssuer = claims.VerifyIssuer(c.provider.AccessTokenIssuer, true)
+	} else {
+		validIssuer = claims.VerifyIssuer(c.issuer, true)
+	}
+	if !validIssuer {
 		vErr := jwt.ValidationError{}
 		vErr.Inner = jwt.ErrTokenInvalidIssuer
 		vErr.Errors |= jwt.ValidationErrorIssuer

--- a/ocis-pkg/oidc/metadata.go
+++ b/ocis-pkg/oidc/metadata.go
@@ -21,7 +21,10 @@ type ProviderMetadata struct {
 	//grant_types_supported
 	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported,omitempty"`
 	Issuer                           string   `json:"issuer,omitempty"`
-	JwksURI                          string   `json:"jwks_uri,omitempty"`
+	// AccessTokenIssuer is only used by AD FS and needs to be used when validating the iss of its access tokens
+	// See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oidce/586de7dd-3385-47c7-93a2-935d9e90441c
+	AccessTokenIssuer string `json:"access_token_issuer,omitempty"`
+	JwksURI           string `json:"jwks_uri,omitempty"`
 	//registration_endpoint
 	//request_object_signing_alg_values_supported
 	//request_parameter_supported


### PR DESCRIPTION
AD FS `/adfs/.well-known/openid-configuration` has an optional `access_token_issuer` which, in violation of the OpenID Connect spec, takes precedence over `issuer`.

Evn MS had to patch its own clients: https://jpassing.com/2022/02/04/using-adfs-access-tokens-for-workload-identity-federation/