### PR TITLE
[tests-only][full-CI] make httpresponse check function able to accept response object as parameter

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1298,11 +1298,13 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @param int|int[]|string|string[] $expectedStatusCode
 	 * @param string|null $message
+	 * @param ResponseInterface|null $response
 	 *
 	 * @return void
 	 */
-	public function theHTTPStatusCodeShouldBe($expectedStatusCode, ?string $message = ""): void {
-		$actualStatusCode = $this->response->getStatusCode();
+	public function theHTTPStatusCodeShouldBe($expectedStatusCode, ?string $message = "", ?ResponseInterface $response = null): void {
+		$response = $response ?? $this->response;
+		$actualStatusCode = $response->getStatusCode();
 		if (\is_array($expectedStatusCode)) {
 			if ($message === "") {
 				$message = "HTTP status code $actualStatusCode is not one of the expected values " . \implode(" or ", $expectedStatusCode);
@@ -1424,14 +1426,17 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @param int|string $minStatusCode
 	 * @param int|string $maxStatusCode
+	 * @param ResponseInterface|null $response
 	 *
 	 * @return void
 	 */
 	public function theHTTPStatusCodeShouldBeBetween(
 		$minStatusCode,
-		$maxStatusCode
+		$maxStatusCode,
+		?ResponseInterface $response= null
 	): void {
-		$statusCode = $this->response->getStatusCode();
+		$response = $response ?? $this->response;
+		$statusCode = $response->getStatusCode();
 		$message = "The HTTP status code $statusCode is not between $minStatusCode and $maxStatusCode";
 		Assert::assertGreaterThanOrEqual(
 			$minStatusCode,


### PR DESCRIPTION

## Description
Currently theHTTPStatusCodeShouldBe() uses response that is set early to check status code. This pr refactors theHTTPStatusCodeShouldBe() so that it can also accept response object as parameter to get statuscode from and check it.

## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
As we are removing the setResponse() in given steps we should make theHTTPStatusCodeShouldBe() also to be able to take the returned response as parameter and check the status code from it to verify that given steps have passed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
