### PR TITLE
[tests-only][full-ci] removing the setresponse in given/then step in AppConfigurationContext and AuthContext

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -149,13 +149,7 @@ class AppConfigurationContext implements Context {
 	 */
 	public function userGetsCapabilitiesCheckResponse(string $username):void {
 		$response = $this->userGetsCapabilities($username);
-		$statusCode = $response->getStatusCode();
-		if ($statusCode !== 200) {
-			throw new \Exception(
-				__METHOD__
-				. " user $username returned unexpected status $statusCode"
-			);
-		}
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -29,6 +29,7 @@ use TestHelpers\AppConfigHelper;
 use TestHelpers\OcsApiHelper;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * AppConfiguration trait
@@ -110,7 +111,8 @@ class AppConfigurationContext implements Context {
 	 */
 	public function userRetrievesCapabilities(string $username): void {
 		$user = $this->featureContext->getActualUsername($username);
-		$this->userGetsCapabilities($user, true);
+		$response = $this->userGetsCapabilities($user, true);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -118,24 +120,22 @@ class AppConfigurationContext implements Context {
 	 * @param string $username
 	 * @param boolean $formatJson // if true then formats the response in json
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function userGetsCapabilities(string $username, ?bool $formatJson = false):void {
+	public function userGetsCapabilities(string $username, ?bool $formatJson = false):ResponseInterface {
 		$user = $this->featureContext->getActualUsername($username);
 		$password = $this->featureContext->getPasswordForUser($user);
-		$this->featureContext->setResponse(
-			OcsApiHelper::sendRequest(
-				$this->featureContext->getBaseUrl(),
-				$user,
-				$password,
-				'GET',
-				'/cloud/capabilities' . ($formatJson ? '?format=json' : ''),
-				$this->featureContext->getStepLineRef(),
-				[],
-				$this->featureContext->getOcsApiVersion()
-			)
+		return OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$password,
+			'GET',
+			'/cloud/capabilities' . ($formatJson ? '?format=json' : ''),
+			$this->featureContext->getStepLineRef(),
+			[],
+			$this->featureContext->getOcsApiVersion()
 		);
 	}
 
@@ -148,8 +148,8 @@ class AppConfigurationContext implements Context {
 	 * @throws Exception
 	 */
 	public function userGetsCapabilitiesCheckResponse(string $username):void {
-		$this->userGetsCapabilities($username);
-		$statusCode = $this->featureContext->getResponse()->getStatusCode();
+		$response = $this->userGetsCapabilities($username);
+		$statusCode = $response->getStatusCode();
 		if ($statusCode !== 200) {
 			throw new \Exception(
 				__METHOD__
@@ -164,7 +164,8 @@ class AppConfigurationContext implements Context {
 	 * @return void
 	 */
 	public function theUserGetsCapabilities():void {
-		$this->userGetsCapabilities($this->featureContext->getCurrentUser());
+		$response = $this->userGetsCapabilities($this->featureContext->getCurrentUser());
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -205,7 +206,8 @@ class AppConfigurationContext implements Context {
 	 */
 	public function theAdministratorGetsCapabilities():void {
 		$user = $this->getAdminUsernameForCapabilitiesCheck();
-		$this->userGetsCapabilities($user, true);
+		$response = $this->userGetsCapabilities($user, true);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -111,8 +111,7 @@ class AppConfigurationContext implements Context {
 	 */
 	public function userRetrievesCapabilities(string $username): void {
 		$user = $this->featureContext->getActualUsername($username);
-		$response = $this->userGetsCapabilities($user, true);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->userGetsCapabilities($user, true));
 	}
 
 	/**
@@ -148,8 +147,7 @@ class AppConfigurationContext implements Context {
 	 * @throws Exception
 	 */
 	public function userGetsCapabilitiesCheckResponse(string $username):void {
-		$response = $this->userGetsCapabilities($username);
-		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $this->userGetsCapabilities($username));
 	}
 
 	/**
@@ -158,8 +156,7 @@ class AppConfigurationContext implements Context {
 	 * @return void
 	 */
 	public function theUserGetsCapabilities():void {
-		$response = $this->userGetsCapabilities($this->featureContext->getCurrentUser());
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->userGetsCapabilities($this->featureContext->getCurrentUser()));
 	}
 
 	/**
@@ -200,8 +197,7 @@ class AppConfigurationContext implements Context {
 	 */
 	public function theAdministratorGetsCapabilities():void {
 		$user = $this->getAdminUsernameForCapabilitiesCheck();
-		$response = $this->userGetsCapabilities($user, true);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->userGetsCapabilities($user, true));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -130,7 +130,7 @@ class AuthContext implements Context {
 	 */
 	public function userHasRequestedURLWith(string $url, string $method):void {
 		$response = $this->sendRequest($url, $method);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 209, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -99,8 +99,7 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function userRequestsURLWith(string $url, string $method):void {
-		$response = $this->sendRequest($url, $method);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->sendRequest($url, $method));
 	}
 
 	/**
@@ -116,8 +115,7 @@ class AuthContext implements Context {
 	public function userRequestsURLWithNoAuth(string $user, string $url, string $method):void {
 		$userRenamed = $this->featureContext->getActualUsername($user);
 		$url = $this->featureContext->substituteInLineCodes($url, $userRenamed);
-		$response = $this->sendRequest($url, $method);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->sendRequest($url, $method));
 	}
 
 	/**
@@ -129,8 +127,7 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function userHasRequestedURLWith(string $url, string $method):void {
-		$response = $this->sendRequest($url, $method);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $this->sendRequest($url, $method));
 	}
 
 	/**
@@ -782,15 +779,16 @@ class AuthContext implements Context {
 		} else {
 			$authString = $userRenamed . ":" . $this->featureContext->getActualPassword($password);
 		}
-		$response = $this->sendRequest(
-			$url,
-			$method,
-			'basic ' . \base64_encode($authString),
-			false,
-			$body,
-			$header
+		$this->featureContext->setResponse(
+			$this->sendRequest(
+				$url,
+				$method,
+				'basic ' . \base64_encode($authString),
+				false,
+				$body,
+				$header
+			)
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -819,15 +817,16 @@ class AuthContext implements Context {
 		foreach ($headersTable as $row) {
 			$headers[$row['header']] = $row ['value'];
 		}
-		$response = $this->sendRequest(
-			$url,
-			$method,
-			'basic ' . \base64_encode($authString),
-			false,
-			null,
-			$headers
+		$this->featureContext->setResponse(
+			$this->sendRequest(
+				$url,
+				$method,
+				'basic ' . \base64_encode($authString),
+				false,
+				null,
+				$headers
+			)
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -887,12 +886,13 @@ class AuthContext implements Context {
 	 */
 	public function userRequestsURLWithUsingBasicTokenAuth(string $user, string $url, string $method):void {
 		$user = $this->featureContext->getActualUsername($user);
-		$response = $this->sendRequest(
-			$url,
-			$method,
-			'basic ' . \base64_encode("$user:" . $this->clientToken)
+		$this->featureContext->setResponse(
+			$this->sendRequest(
+				$url,
+				$method,
+				'basic ' . \base64_encode("$user:" . $this->clientToken)
+			)
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -918,8 +918,7 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function userRequestsURLWithUsingAClientToken(string $url, string $method):void {
-		$response = $this->sendRequest($url, $method, 'token ' . $this->clientToken);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->sendRequest($url, $method, 'token ' . $this->clientToken));
 	}
 
 	/**
@@ -944,8 +943,7 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function userRequestsURLWithUsingAppPassword(string $url, string $method):void {
-		$response = $this->sendRequest($url, $method, 'token ' . $this->appToken);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->sendRequest($url, $method, 'token ' . $this->appToken));
 	}
 
 	/**
@@ -958,8 +956,7 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function theUserRequestsWithUsingAppPasswordNamed(string $url, string $method, string $tokenName):void {
-		$response = $this->sendRequest($url, $method, 'token ' . $this->appTokens[$tokenName]['token']);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->sendRequest($url, $method, 'token ' . $this->appTokens[$tokenName]['token']));
 	}
 
 	/**
@@ -984,8 +981,7 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function userRequestsURLWithBrowserSession(string $url, string $method):void {
-		$response = $this->sendRequest($url, $method, null, true);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->sendRequest($url, $method, null, true));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -24,6 +24,7 @@ use TestHelpers\HttpRequestHelper;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
 use TestHelpers\SetupHelper;
+use \Psr\Http\Message\ResponseInterface;
 
 /**
  * Authentication functions

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2302,9 +2302,11 @@ class FeatureContext extends BehatVariablesContext {
 		$jsonExpectedDecoded = \json_decode($jsonExpected->getRaw(), true);
 		$jsonRespondedDecoded = $this->getJsonDecodedResponse();
 
-		$this->appConfigurationContext->theAdministratorGetsCapabilitiesCheckResponse();
+		$response = $this->appConfigurationContext->userGetsCapabilities($this->appConfigurationContext->getAdminUsernameForCapabilitiesCheck());
+		$this->theHTTPStatusCodeShouldBe(200, '', $response);
+		$response_xml = $this->getResponseXml($response)->data->capabilities;
 		$edition = $this->appConfigurationContext->getParameterValueFromXml(
-			$this->appConfigurationContext->getCapabilitiesXml(__METHOD__),
+			$response_xml,
 			'core',
 			'status@@@edition'
 		);
@@ -2316,7 +2318,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$product = $this->appConfigurationContext->getParameterValueFromXml(
-			$this->appConfigurationContext->getCapabilitiesXml(__METHOD__),
+			$response_xml,
 			'core',
 			'status@@@product'
 		);
@@ -2327,7 +2329,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$productName = $this->appConfigurationContext->getParameterValueFromXml(
-			$this->appConfigurationContext->getCapabilitiesXml(__METHOD__),
+			$response_xml,
 			'core',
 			'status@@@productname'
 		);
@@ -2345,7 +2347,7 @@ class FeatureContext extends BehatVariablesContext {
 		// We are on oCIS or reva or some other implementation. We cannot do "occ status".
 		// So get the expected version values by looking in the capabilities response.
 		$version = $this->appConfigurationContext->getParameterValueFromXml(
-			$this->appConfigurationContext->getCapabilitiesXml(__METHOD__),
+			$response_xml,
 			'core',
 			'status@@@version'
 		);
@@ -2357,7 +2359,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$versionString = $this->appConfigurationContext->getParameterValueFromXml(
-			$this->appConfigurationContext->getCapabilitiesXml(__METHOD__),
+			$response_xml,
 			'core',
 			'status@@@versionstring'
 		);

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2304,9 +2304,9 @@ class FeatureContext extends BehatVariablesContext {
 
 		$response = $this->appConfigurationContext->userGetsCapabilities($this->appConfigurationContext->getAdminUsernameForCapabilitiesCheck());
 		$this->theHTTPStatusCodeShouldBe(200, '', $response);
-		$response_xml = $this->getResponseXml($response)->data->capabilities;
+		$responseXml = $this->getResponseXml($response)->data->capabilities;
 		$edition = $this->appConfigurationContext->getParameterValueFromXml(
-			$response_xml,
+			$responseXml,
 			'core',
 			'status@@@edition'
 		);
@@ -2318,7 +2318,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$product = $this->appConfigurationContext->getParameterValueFromXml(
-			$response_xml,
+			$responseXml,
 			'core',
 			'status@@@product'
 		);
@@ -2329,7 +2329,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$productName = $this->appConfigurationContext->getParameterValueFromXml(
-			$response_xml,
+			$responseXml,
 			'core',
 			'status@@@productname'
 		);
@@ -2347,7 +2347,7 @@ class FeatureContext extends BehatVariablesContext {
 		// We are on oCIS or reva or some other implementation. We cannot do "occ status".
 		// So get the expected version values by looking in the capabilities response.
 		$version = $this->appConfigurationContext->getParameterValueFromXml(
-			$response_xml,
+			$responseXml,
 			'core',
 			'status@@@version'
 		);
@@ -2359,7 +2359,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$versionString = $this->appConfigurationContext->getParameterValueFromXml(
-			$response_xml,
+			$responseXml,
 			'core',
 			'status@@@versionstring'
 		);


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `AppConfigurationContext` and `ArchiverContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 