### PR TITLE
[tests-only][full-ci]Check `multistatus` response strictly in test code

### DIFF
--- a/tests/acceptance/features/apiContract/spacesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesReport.feature
@@ -18,8 +18,10 @@ Feature: REPORT request to project space
     And using new DAV path
     When user "Alice" searches for "testFile.txt" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /testFile.txt |
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key                | value               |
       | oc:fileid          | UUIDof:testFile.txt |
@@ -36,8 +38,10 @@ Feature: REPORT request to project space
     And using new DAV path
     When user "Alice" searches for "insideTheFolder.txt" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key                | value                                                       |
       | oc:fileid          | UUIDof:folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
@@ -53,8 +57,10 @@ Feature: REPORT request to project space
     And using new DAV path
     When user "Alice" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /folderMain |
     And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
+      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | UUIDof:folderMain    |
@@ -69,9 +75,11 @@ Feature: REPORT request to project space
     Given user "Alice" has created a folder "folderMain/sub-folder" in space "findData"
     And using new DAV path
     When user "Alice" searches for "sub" using the WebDAV API
-    And the following headers should match these regular expressions
-      | X-Request-Id                | /^[a-f0-9!\-]{36}$/    |
     Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /folderMain/sub-folder |
+    And the following headers should match these regular expressions
+      | X-Request-Id | /^[a-f0-9!\-]{36}$/ |
     And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
       | key              | value                        |
       | oc:fileid        | UUIDof:folderMain/sub-folder |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3170,6 +3170,10 @@ class SpacesContext implements Context {
 		$xmlRes = $this->featureContext->getResponseXml();
 		foreach ($table->getHash() as $row) {
 			$findItem = $row['key'];
+			Assert::assertNotEmpty(
+				$xmlRes->xpath("//d:response/d:propstat/d:prop/$findItem"),
+				'The xml response "' . $xmlRes->asXML() . '" did not contain "<' . $findItem . '>" element'
+			);
 			$responseValue = $xmlRes->xpath("//d:response/d:propstat/d:prop/$findItem")[0]->__toString();
 			$value = str_replace('UUIDof:', '', $row['value']);
 			switch ($findItem) {


### PR DESCRIPTION
### Description
While searching with `REPORT` request in our test code only the status code is checked as asserting `207` while the request gives the status `207` when the response is empty. So This PR adds some strict checks to the `multistatus` response from `REPORT` request.

### More Information
https://github.com/owncloud/ocis/issues/7185#issuecomment-1702422487

### Related Issue: 
fixes: https://github.com/owncloud/ocis/issues/7185