### PR TITLE
[tests-only][full-ci] removing the setresponse in given/then step in CheckSumContext and FavoritesContext

### DIFF
--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -101,7 +101,7 @@ class ChecksumContext implements Context {
 			$destination,
 			$checksum
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBe([201,204], '', $response);
 	}
 
 	/**
@@ -164,7 +164,7 @@ class ChecksumContext implements Context {
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
 		$response = $this->uploadFileWithContentAndChecksumToUsingTheAPI($user, $content, $checksum, $destination);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBe(201, '', $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -75,8 +75,7 @@ class ChecksumContext implements Context {
 		string  $destination,
 		string  $checksum
 	):void {
-		$response = $this->uploadFileToWithChecksumUsingTheAPI($user, $source, $destination, $checksum);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->uploadFileToWithChecksumUsingTheAPI($user, $source, $destination, $checksum));
 	}
 
 	/**
@@ -144,8 +143,7 @@ class ChecksumContext implements Context {
 		string $checksum,
 		string $destination
 	):void {
-		$response = $this->uploadFileWithContentAndChecksumToUsingTheAPI($user, $content, $checksum, $destination);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->uploadFileWithContentAndChecksumToUsingTheAPI($user, $content, $checksum, $destination));
 	}
 
 	/**
@@ -425,14 +423,13 @@ class ChecksumContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		$num -= 1;
 		$file = "$destination-chunking-42-$total-$num";
-		$response = $this->featureContext->makeDavRequest(
+		return $this->featureContext->makeDavRequest(
 			$user,
 			'PUT',
 			$file,
 			['OC-Checksum' => $expectedChecksum, 'OC-Chunked' => '1'],
 			$data
 		);
-		return $response;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -23,6 +23,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;
 use TestHelpers\WebDavHelper;
+use Psr\Http\Message\ResponseInterface;
 
 require_once 'bootstrap.php';
 
@@ -31,6 +32,32 @@ require_once 'bootstrap.php';
  */
 class ChecksumContext implements Context {
 	private FeatureContext $featureContext;
+
+	/**
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destination
+	 * @param string $checksum
+	 *
+	 * @return ResponseInterface
+	 */
+	public function uploadFileToWithChecksumUsingTheAPI(
+		string $user,
+		string  $source,
+		string  $destination,
+		string  $checksum
+	):ResponseInterface {
+		$file = \file_get_contents(
+			$this->featureContext->acceptanceTestsDirLocation() . $source
+		);
+		return $this->featureContext->makeDavRequest(
+			$user,
+			'PUT',
+			$destination,
+			['OC-Checksum' => $checksum],
+			$file
+		);
+	}
 
 	/**
 	 * @When user :user uploads file :source to :destination with checksum :checksum using the WebDAV API
@@ -48,16 +75,7 @@ class ChecksumContext implements Context {
 		string  $destination,
 		string  $checksum
 	):void {
-		$file = \file_get_contents(
-			$this->featureContext->acceptanceTestsDirLocation() . $source
-		);
-		$response = $this->featureContext->makeDavRequest(
-			$user,
-			'PUT',
-			$destination,
-			['OC-Checksum' => $checksum],
-			$file
-		);
+		$response = $this->uploadFileToWithChecksumUsingTheAPI($user, $source, $destination, $checksum);
 		$this->featureContext->setResponse($response);
 	}
 
@@ -78,13 +96,36 @@ class ChecksumContext implements Context {
 		string $checksum
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
-		$this->userUploadsFileToWithChecksumUsingTheAPI(
+		$response = $this->uploadFileToWithChecksumUsingTheAPI(
 			$user,
 			$source,
 			$destination,
 			$checksum
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $content
+	 * @param string $checksum
+	 * @param string $destination
+	 *
+	 * @return ResponseInterface
+	 */
+	public function uploadFileWithContentAndChecksumToUsingTheAPI(
+		string $user,
+		string $content,
+		string $checksum,
+		string $destination
+	):ResponseInterface {
+		return $this->featureContext->makeDavRequest(
+			$user,
+			'PUT',
+			$destination,
+			['OC-Checksum' => $checksum],
+			$content
+		);
 	}
 
 	/**
@@ -103,13 +144,7 @@ class ChecksumContext implements Context {
 		string $checksum,
 		string $destination
 	):void {
-		$response = $this->featureContext->makeDavRequest(
-			$user,
-			'PUT',
-			$destination,
-			['OC-Checksum' => $checksum],
-			$content
-		);
+		$response = $this->uploadFileWithContentAndChecksumToUsingTheAPI($user, $content, $checksum, $destination);
 		$this->featureContext->setResponse($response);
 	}
 
@@ -130,13 +165,8 @@ class ChecksumContext implements Context {
 		string $destination
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
-		$this->userUploadsFileWithContentAndChecksumToUsingTheAPI(
-			$user,
-			$content,
-			$checksum,
-			$destination
-		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->uploadFileWithContentAndChecksumToUsingTheAPI($user, $content, $checksum, $destination);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -375,6 +405,37 @@ class ChecksumContext implements Context {
 	}
 
 	/**
+	 * @param string $user
+	 * @param int $num
+	 * @param int $total
+	 * @param string $data
+	 * @param string $destination
+	 * @param string $expectedChecksum
+	 *
+	 * @return ResponseInterface
+	 */
+	public function uploadChunkFileOfWithToWithChecksum(
+		string $user,
+		int $num,
+		int $total,
+		string $data,
+		string $destination,
+		string $expectedChecksum
+	):ResponseInterface {
+		$user = $this->featureContext->getActualUsername($user);
+		$num -= 1;
+		$file = "$destination-chunking-42-$total-$num";
+		$response = $this->featureContext->makeDavRequest(
+			$user,
+			'PUT',
+			$file,
+			['OC-Checksum' => $expectedChecksum, 'OC-Chunked' => '1'],
+			$data
+		);
+		return $response;
+	}
+
+	/**
 	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :expectedChecksum using the WebDAV API
 	 *
 	 * @param string $user
@@ -394,16 +455,7 @@ class ChecksumContext implements Context {
 		string $destination,
 		string $expectedChecksum
 	):void {
-		$user = $this->featureContext->getActualUsername($user);
-		$num -= 1;
-		$file = "$destination-chunking-42-$total-$num";
-		$response = $this->featureContext->makeDavRequest(
-			$user,
-			'PUT',
-			$file,
-			['OC-Checksum' => $expectedChecksum, 'OC-Chunked' => '1'],
-			$data
-		);
+		$response = $this->uploadChunkFileOfWithToWithChecksum($user, $num, $total, $data, $destination, $expectedChecksum);
 		$this->featureContext->setResponse($response);
 	}
 
@@ -427,15 +479,12 @@ class ChecksumContext implements Context {
 		string $destination,
 		string $expectedChecksum
 	):void {
-		$this->userUploadsChunkFileOfWithToWithChecksum(
-			$user,
-			$num,
-			$total,
-			$data,
-			$destination,
-			$expectedChecksum
+		$response = $this->uploadChunkFileOfWithToWithChecksum($user, $num, $total, $data, $destination, $expectedChecksum);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			[201, 206],
+			'',
+			$response
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeOr(201, 206);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -70,7 +70,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userHasFavoritedElementUsingWebDavApi(string $user, string $path):void {
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 209, $this->userFavoritesElement($user, $path));
+		$this->featureContext->theHTTPStatusCodeShouldBe(207, '', $this->userFavoritesElement($user, $path));
 	}
 
 	/**
@@ -142,7 +142,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userHasUnfavoritedElementUsingWebDavApi(string $user, string $path):void {
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $this->userUnfavoritesElement($user, $path));
+		$this->featureContext->theHTTPStatusCodeShouldBe(207, '', $this->userUnfavoritesElement($user, $path));
 	}
 
 	/**
@@ -238,7 +238,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function theUserHasUnfavoritedElementUsingWebDavApi(string $path):void {
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $this->theUserUnfavoritesElement($path));
+		$this->featureContext->theHTTPStatusCodeShouldBe(207, '', $this->theUserUnfavoritesElement($path));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -39,15 +39,14 @@ class FavoritesContext implements Context {
 	 * @param string$user
 	 * @param string $path
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function userFavoritesElement(string $user, string $path):void {
-		$response = $this->changeFavStateOfAnElement(
+	public function userFavoritesElement(string $user, string $path):ResponseInterface {
+		return $this->changeFavStateOfAnElement(
 			$user,
 			$path,
 			1
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -59,7 +58,8 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userFavoritesElementUsingWebDavApi(string $user, string $path):void {
-		$this->userFavoritesElement($user, $path);
+		$response = $this->userFavoritesElement($user, $path);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -71,8 +71,8 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userHasFavoritedElementUsingWebDavApi(string $user, string $path):void {
-		$this->userFavoritesElement($user, $path);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->userFavoritesElement($user, $path);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 209, $response);
 	}
 
 	/**
@@ -83,10 +83,11 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function theUserFavoritesElement(string $path):void {
-		$this->userFavoritesElement(
+		$response = $this->userFavoritesElement(
 			$this->featureContext->getCurrentUser(),
 			$path
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -97,13 +98,14 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function theUserHasFavoritedElement(string $path):void {
-		$this->userFavoritesElement(
+		$response = $this->userFavoritesElement(
 			$this->featureContext->getCurrentUser(),
 			$path
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			207,
-			"Expected response status code to be 207 (Multi-status), but not found! "
+			"Expected response status code to be 207 (Multi-status), but not found! ",
+			$response
 		);
 	}
 
@@ -111,15 +113,14 @@ class FavoritesContext implements Context {
 	 * @param string $user
 	 * @param string $path
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function userUnfavoritesElement(string $user, string $path):void {
-		$response = $this->changeFavStateOfAnElement(
+	public function userUnfavoritesElement(string $user, string $path):ResponseInterface {
+		return $this->changeFavStateOfAnElement(
 			$user,
 			$path,
 			0
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -131,7 +132,8 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userUnfavoritesElementUsingWebDavApi(string $user, string $path):void {
-		$this->userUnfavoritesElement($user, $path);
+		$response = $this->userUnfavoritesElement($user, $path);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -143,8 +145,8 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userHasUnfavoritedElementUsingWebDavApi(string $user, string $path):void {
-		$this->userUnfavoritesElement($user, $path);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->userUnfavoritesElement($user, $path);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -212,10 +214,10 @@ class FavoritesContext implements Context {
 	/**
 	 * @param string $path
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function theUserUnfavoritesElement(string $path):void {
-		$this->userUnfavoritesElement(
+	public function theUserUnfavoritesElement(string $path):ResponseInterface {
+		return $this->userUnfavoritesElement(
 			$this->featureContext->getCurrentUser(),
 			$path
 		);
@@ -229,7 +231,8 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function theUserUnfavoritesElementUsingWebDavApi(string $path):void {
-		$this->theUserUnfavoritesElement($path);
+		$response = $this->theUserUnfavoritesElement($path);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -240,8 +243,8 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function theUserHasUnfavoritedElementUsingWebDavApi(string $path):void {
-		$this->theUserUnfavoritesElement($path);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->theUserUnfavoritesElement($path);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -58,8 +58,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userFavoritesElementUsingWebDavApi(string $user, string $path):void {
-		$response = $this->userFavoritesElement($user, $path);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->userFavoritesElement($user, $path));
 	}
 
 	/**
@@ -71,8 +70,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userHasFavoritedElementUsingWebDavApi(string $user, string $path):void {
-		$response = $this->userFavoritesElement($user, $path);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 209, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 209, $this->userFavoritesElement($user, $path));
 	}
 
 	/**
@@ -132,8 +130,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userUnfavoritesElementUsingWebDavApi(string $user, string $path):void {
-		$response = $this->userUnfavoritesElement($user, $path);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->userUnfavoritesElement($user, $path));
 	}
 
 	/**
@@ -145,8 +142,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function userHasUnfavoritedElementUsingWebDavApi(string $user, string $path):void {
-		$response = $this->userUnfavoritesElement($user, $path);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $this->userUnfavoritesElement($user, $path));
 	}
 
 	/**
@@ -231,8 +227,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function theUserUnfavoritesElementUsingWebDavApi(string $path):void {
-		$response = $this->theUserUnfavoritesElement($path);
-		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($this->theUserUnfavoritesElement($path));
 	}
 
 	/**
@@ -243,8 +238,7 @@ class FavoritesContext implements Context {
 	 * @return void
 	 */
 	public function theUserHasUnfavoritedElementUsingWebDavApi(string $path):void {
-		$response = $this->theUserUnfavoritesElement($path);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $this->theUserUnfavoritesElement($path));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3038,7 +3038,7 @@ class SpacesContext implements Context {
 	 */
 	public function userFavoritesElementInSpaceUsingTheWebdavApi(string $user, string $path, string $spaceName): void {
 		$this->setSpaceIDByName($user, $spaceName);
-		$this->favoritesContext->userFavoritesElement($user, $path);
+		$this->featureContext->setResponse($this->favoritesContext->userFavoritesElement($user, $path));
 	}
 
 	/**


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `CheckSumContext.php` and `FavoritesContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 