### PR TITLE
[tests-only][full-ci]Update expected to failure based on correct issue

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -22,7 +22,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 - [apiSpacesShares/changingFilesShare.feature:14](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature#L14)
 
-### [copy to overwrite (file and folder) from Personal to Shares Jail behaves differently](https://github.com/owncloud/ocis/issues/4393)
+### [Shared mount folder gets deleted when overwritten by a file from personal space](https://github.com/owncloud/ocis/issues/7208)
 
 - [apiSpacesShares/copySpaces.feature:528](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L528)
 - [apiSpacesShares/copySpaces.feature:542](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/copySpaces.feature#L542)

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -524,7 +524,7 @@ Feature: copy file
     Then the HTTP status code should be "403"
     And for user "Alice" the content of the file "/testshare/overwritethis.txt" of the space "Shares" should be "ownCloud test text file 1"
 
-  @issue-4393
+  @issue-7208
   Scenario: copy a file over the top of an existing folder received as a user share
     Given using spaces DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
@@ -538,7 +538,7 @@ Feature: copy file
     And as "Alice" file "/textfile1.txt" should exist
     And user "Alice" should not have any received shares
 
-  @issue-4393
+  @issue-7208
   Scenario: copy a folder over the top of an existing file received as a user share
     Given using spaces DAV path
     And user "Alice" has created folder "/FOLDER"


### PR DESCRIPTION
### Description
Since this issue https://github.com/owncloud/ocis/issues/4393 was closed so that needs to be updated according to this issue linke for it. https://github.com/owncloud/ocis/issues/4393#issuecomment-1672885146. But New issue is created according to the actual behavior since the expected behavior is unknown. So This PR updates the expected to failure with the new issue created for the same failing test.


### Related Issue:
https://github.com/owncloud/ocis/issues/4393#issuecomment-1672885146