### PR TITLE
backport: actually use skip user info config option

### DIFF
--- a/changelog/unreleased/fix-skip-user-info-option.md
+++ b/changelog/unreleased/fix-skip-user-info-option.md
@@ -1,0 +1,3 @@
+Bugfix: actually pass PROXY_OIDC_SKIP_USER_INFO option to oidc client middleware
+
+https://github.com/owncloud/ocis/pull/7220

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -361,6 +361,7 @@ func loadMiddlewares(ctx context.Context, logger log.Logger, cfg *config.Config,
 			oidc.WithOidcIssuer(cfg.OIDC.Issuer),
 			oidc.WithJWKSOptions(cfg.OIDC.JWKS),
 		)),
+		middleware.SkipUserInfo(cfg.OIDC.SkipUserInfo),
 	))
 	authenticators = append(authenticators, middleware.SignedURLAuthenticator{
 		Logger:             logger,


### PR DESCRIPTION
backport https://github.com/owncloud/ocis/pull/7216 to stable 4.0