### PR TITLE
deployment: Disable username validation for keycloak example

### DIFF
--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       OCIS_ADMIN_USER_ID: ""
       OCIS_EXCLUDE_RUN_SERVICES: "idp"
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: "false"
+      GRAPH_USERNAME_MATCH: "none"
     volumes:
       - ocis-config:/etc/ocis
       - ocis-data:/var/lib/ocis


### PR DESCRIPTION
Set 'GRAPH_USERNAME_MATCH' to 'none'. To accept any username that is also valid for keycloak.
