### PR TITLE
[tests-only][full-ci] Eliminate local system PHP-dependent code for running tests in Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,9 +138,11 @@ vendor-bin/behat/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/behat/com
 
 vendor-bin/behat/composer.lock: vendor-bin/behat/composer.json
 	@echo behat composer.lock is not up to date.
+	@rm vendor-bin/behat/composer.lock || true
 
 composer.lock: composer.json
 	@echo composer.lock is not up to date.
+	@rm composer.lock || true
 
 .PHONY: generate
 generate:

--- a/tests/acceptance/docker/Makefile
+++ b/tests/acceptance/docker/Makefile
@@ -175,7 +175,7 @@ $(targets):
 	$(MAKE) --no-print-directory testSuite
 
 .PHONY: testSuite
-testSuite: $(OCIS_WRAPPER) build-dev-image clean-docker-container ../../../vendor-bin/behat/composer.lock ../../../composer.lock
+testSuite: $(OCIS_WRAPPER) build-dev-image clean-docker-container
 	@if [ -n "${START_CEPH}" ]; then \
 		COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		COMPOSE_FILE=src/ceph.yml \
@@ -257,11 +257,3 @@ clean-files:
 
 .PHONY: clean
 clean: clean-docker-container clean-docker-volumes clean-dev-docker-image clean-files ## clean all
-
-../../../vendor-bin/behat/composer.lock: ../../../vendor-bin/behat/composer.json
-	@echo behat composer.lock is not up to date.
-	@composer update --no-progress -d ../../../vendor-bin/behat
-
-../../../composer.lock: ../../../composer.json
-	@echo composer.lock is not up to date.
-	@composer update --no-progress -d ../../../


### PR DESCRIPTION
## Description
Currently run tests with docker depend in local php due to `composer update`. This PR removes that part of code.

```
../../../vendor-bin/behat/composer.lock: ../../../vendor-bin/behat/composer.json
	@echo behat composer.lock is not up to date.
	@composer update --no-progress -d ../../../vendor-bin/behat

../../../composer.lock: ../../../composer.json
	@echo composer.lock is not up to date.
	@composer update --no-progress -d ../../../
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/7071

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
