### PR TITLE
Backport-4.0: deployment: Disable username validation for keycloak example

### DIFF
--- a/changelog/unreleased/fix-keycloak-example-username-validation.md
+++ b/changelog/unreleased/fix-keycloak-example-username-validation.md
@@ -1,0 +1,6 @@
+Bugfix: Disable username validation for keycloak example
+
+Set 'GRAPH_USERNAME_MATCH' to 'none'. To accept any username that is
+also valid for keycloak.
+
+https://github.com/owncloud/ocis/pull/7230

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       OCIS_ADMIN_USER_ID: ""
       OCIS_EXCLUDE_RUN_SERVICES: "idp"
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: "false"
+      GRAPH_USERNAME_MATCH: "none"
     volumes:
       - ocis-config:/etc/ocis
       - ocis-data:/var/lib/ocis


### PR DESCRIPTION
Set 'GRAPH_USERNAME_MATCH' to 'none'. To accept any username that is also valid for keycloak.

(cherry picked from commit 48306cbef31a45c4d35e430d7f9b5573ad95f4d6)