### PR TITLE
[test-only] KQL api search tests

### DIFF
--- a/tests/acceptance/features/apiSearch/apiSpaceSearch.feature
+++ b/tests/acceptance/features/apiSearch/apiSpaceSearch.feature
@@ -16,10 +16,10 @@ Feature: Search
     And user "Alice" has created a space "find data" with the default quota using the GraphApi
     And user "Alice" has created a folder "folderMain/SubFolder1/subFOLDER2" in space "find data"
     And user "Alice" has uploaded a file inside space "find data" with content "some content" to "folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt"
-    And using new DAV path
 
 
-  Scenario: user can find data from the project space
+  Scenario Outline: user can find data from the project space
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "*fol*" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "4" entries
@@ -28,9 +28,15 @@ Feature: Search
       | /folderMain/SubFolder1                                |
       | /folderMain/SubFolder1/subFOLDER2                     |
       | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user can only find data that they searched for from the project space
+  Scenario Outline: user can only find data that they searched for from the project space
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "*SUB*" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "2" entries
@@ -40,10 +46,16 @@ Feature: Search
     But the search result of user "Alice" should not contain these entries:
       | /folderMain                                           |
       | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user can find data from the shares
-    Given user "Alice" has created a share inside of space "find data" with settings:
+  Scenario Outline: user can find data from the shares
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a share inside of space "find data" with settings:
       | path      | folderMain |
       | shareWith | Brian      |
       | role      | viewer     |
@@ -56,19 +68,31 @@ Feature: Search
       | /SubFolder1/subFOLDER2                     |
       | /SubFolder1/subFOLDER2/insideTheFolder.txt |
     And for user "Brian" the search result should contain space "mountpoint/folderMain"
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user can find hidden file
-    Given user "Alice" has created a folder ".space" in space "find data"
+  Scenario Outline: user can find hidden file
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a folder ".space" in space "find data"
     When user "Alice" searches for "*.sp*" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "1" entries
     And the search result of user "Alice" should contain these entries:
       | /.space |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user cannot find pending share
-    Given user "Alice" has created a share inside of space "find data" with settings:
+  Scenario Outline: user cannot find pending share
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a share inside of space "find data" with settings:
       | path      | folderMain |
       | shareWith | Brian      |
       | role      | viewer     |
@@ -79,10 +103,16 @@ Feature: Search
       | /SubFolder1                                |
       | /SubFolder1/subFOLDER2                     |
       | /SubFolder1/subFOLDER2/insideTheFolder.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user cannot find declined share
-    Given user "Alice" has created a share inside of space "find data" with settings:
+  Scenario Outline: user cannot find declined share
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a share inside of space "find data" with settings:
       | path      | folderMain |
       | shareWith | Brian      |
       | role      | viewer     |
@@ -94,23 +124,41 @@ Feature: Search
       | /SubFolder1                                |
       | /SubFolder1/subFOLDER2                     |
       | /SubFolder1/subFOLDER2/insideTheFolder.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user cannot find deleted folder
-    Given user "Alice" has removed the folder "folderMain" from space "find data"
+  Scenario Outline: user cannot find deleted folder
+    Given using <dav-path-version> DAV path
+    And user "Alice" has removed the folder "folderMain" from space "find data"
     When user "Alice" searches for "*folderMain*" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "0" entries
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user can find project space by name
+  Scenario Outline: user can find project space by name
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for '"*find data*"' using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "1" entries
     And for user "Alice" the search result should contain space "find data"
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: user can search inside folder in space
+  Scenario Outline: user can search inside folder in space
+    Given using <dav-path-version> DAV path
     When user "Alice" searches for "*folder*" inside folder "/folderMain" in space "find data" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "3" entries
@@ -120,10 +168,16 @@ Feature: Search
       | /SubFolder1/subFOLDER2/insideTheFolder.txt |
     But the search result of user "Alice" should not contain these entries:
       | /folderMain |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
 
-  Scenario: search inside folder in shares
-    Given user "Alice" has created a share inside of space "find data" with settings:
+  Scenario Outline: search inside folder in shares
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a share inside of space "find data" with settings:
       | path      | folderMain |
       | shareWith | Brian      |
       | role      | viewer     |
@@ -136,10 +190,38 @@ Feature: Search
       | /SubFolder1/subFOLDER2/insideTheFolder.txt |
     But the search result of user "Brian" should not contain these entries:
       | /folderMain |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
 
-  @issue-enterprise-6000
-  Scenario: sharee cannot find resources that are not shared
-    Given user "Alice" has created a folder "foo/sharedToBrian" in space "Alice Hansen"
+
+  @skipOnStable3.0
+  Scenario Outline: search files inside the folder
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "hello world inside root" to "file1.txt"
+    And user "Alice" has created folder "/Folder"
+    And user "Alice" has uploaded file with content "hello world inside folder" to "/Folder/file2.txt"
+    And user "Alice" has created folder "/Folder/SubFolder"
+    And user "Alice" has uploaded file with content "hello world inside sub-folder" to "/Folder/SubFolder/file3.txt"
+    When user "Alice" searches for "*file*" inside folder "/Folder" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | file2.txt |
+      | file3.txt |
+    But the search result of user "Alice" should not contain these entries:
+      | file1.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+  @issue-enterprise-6000 @issue-7028 @issue-7092
+  Scenario Outline: sharee cannot find resources that are not shared
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created a folder "foo/sharedToBrian" in space "Alice Hansen"
     And user "Alice" has created a folder "sharedToCarol" in space "Alice Hansen"
     And user "Alice" has created a share inside of space "Alice Hansen" with settings:
       | path      | foo    |
@@ -152,3 +234,25 @@ Feature: Search
       | /sharedToBrian |
     But the search result of user "Brian" should not contain these entries:
       | /sharedToCarol |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+
+  Scenario Outline: search resources using different search patterns (KQL feature)
+    Given using spaces DAV path
+    And user "Alice" has created a folder "subfolder" in space "find data"
+    When user "Alice" searches for '<pattern>' using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "1" entries
+    And the search result of user "Alice" should contain these entries:
+      | <search-result> |
+    Examples:
+      | description                                            | pattern      | search-result                     |
+      | starts with                                            | fold*        | /folderMain                       |
+      | ends with                                              | *der1        | /folderMain/SubFolder1            |
+      | strict search                                          | subfolder    | /subfolder                        |
+      | using patern "name:"                                   | name:*der2   | /folderMain/SubFolder1/subFOLDER2 |
+      | using the pattern "name:" where the value is in quotes | name:"*der2" | /folderMain/SubFolder1/subFOLDER2 |

--- a/tests/acceptance/features/apiSearch/contentSearch.feature
+++ b/tests/acceptance/features/apiSearch/contentSearch.feature
@@ -46,10 +46,6 @@ Feature: content search
       | dav-path-version |
       | old              |
       | new              |
-
-    @skipOnStable3.0
-    Examples:
-      | dav-path-version |
       | spaces           |
 
 
@@ -125,10 +121,6 @@ Feature: content search
       | dav-path-version |
       | old              |
       | new              |
-
-    @skipOnStable3.0
-    Examples:
-      | dav-path-version |
       | spaces           |
 
 
@@ -156,8 +148,27 @@ Feature: content search
       | dav-path-version |
       | old              |
       | new              |
-
-    @skipOnStable3.0
-    Examples:
-      | dav-path-version |
       | spaces           |
+
+
+  Scenario Outline: search resources using different search patterns (KQL feature)
+    Given using spaces DAV path
+    And user "Alice" has uploaded file with content "hello world, let start to test" to "technical task.txt"
+    And user "Alice" has uploaded file with content "it's been hell" to "task comments.txt"
+    And user "Alice" has tagged the following files of the space "Personal":
+      | path               | tagName |
+      | technical task.txt | test    |
+    When user "Alice" searches for '<pattern>' using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "<result-count>" entries
+    And the search result of user "Alice" should contain these entries:
+      | <search-result-1> |
+      | <search-result-2> |
+    Examples:
+      | pattern                                     | result-count | search-result-1     | search-result-2    |
+      | Content:hello                               | 1            | /technical task.txt |                    |
+      | content:hello                               | 1            | /technical task.txt |                    |
+      | content:"hello"                             | 1            | /technical task.txt |                    |
+      | content:hel*                                | 2            | /technical task.txt | /task comments.txt |
+      | content:hel* AND tag:test                   | 1            | /technical task.txt |                    |
+      | (name:*task* AND content:hel*) NOT tag:test | 1            | /task comments.txt  |                    |

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -169,28 +169,4 @@ class SearchContext implements Context {
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
 	}
-
-	/**
-	 * @Then the search result by tags for user :user should contain these entries:
-	 *
-	 * @param string|null $user
-	 * @param TableNode $expectedEntries
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theSearchResultByTagsForUserShouldContainTheseEntries(
-		?string $user,
-		TableNode $expectedEntries
-	):void {
-		$user = $this->featureContext->getActualUsername($user);
-		$this->featureContext->verifyTableNodeColumnsCount($expectedEntries, 1);
-		$expectedEntries = $expectedEntries->getRows();
-		$expectedEntriesArray = [];
-		$responseResourcesArray = $this->featureContext->findEntryFromReportResponse($user);
-		foreach ($expectedEntries as $item) {
-			$expectedEntriesArray[] = $item[0];
-		}
-		Assert::assertEqualsCanonicalizing($expectedEntriesArray, $responseResourcesArray);
-	}
 }


### PR DESCRIPTION
KQL feature:
- [x] search by file name. using different pattern
- [x] search by tag. using different pattern
- [x] search by content. using different pattern


Another
- [x] ApiSpaceSearch feature uses old new spaces Path 
- [x] moved test `search files inside the folder` from` tagSearch.feature` to  `ApiSpaceSearch`
- [x] removed unused code

@2403905 I commented out failed tests