### PR TITLE
give graph driveItems some love

### DIFF
--- a/services/graph/pkg/service/v0/educationclasses_test.go
+++ b/services/graph/pkg/service/v0/educationclasses_test.go
@@ -134,7 +134,7 @@ var _ = Describe("EducationClass", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/education/classes", nil)
 			svc.GetEducationClasses(rr, r)
 
-			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
 			data, err := io.ReadAll(rr.Body)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/services/graph/pkg/service/v0/educationschools_test.go
+++ b/services/graph/pkg/service/v0/educationschools_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Schools", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/education/schools", nil)
 			svc.GetEducationSchools(rr, r)
 
-			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
 			data, err := io.ReadAll(rr.Body)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -268,7 +268,7 @@ var _ = Describe("Schools", func() {
 
 			svc.PostEducationSchool(rr, r)
 
-			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
 		})
 
 		It("creates the school", func() {

--- a/services/graph/pkg/service/v0/errorcode/errorcode.go
+++ b/services/graph/pkg/service/v0/errorcode/errorcode.go
@@ -18,6 +18,7 @@ type Error struct {
 	msg       string
 }
 
+// List taken from https://github.com/microsoft/microsoft-graph-docs-1/blob/main/concepts/errors.md#code-property
 const (
 	// AccessDenied defines the error if the caller doesn't have permission to perform the action.
 	AccessDenied ErrorCode = iota
@@ -47,6 +48,8 @@ const (
 	ResyncRequired
 	// ServiceNotAvailable defines the error if the service is not available. Try the request again after a delay. There may be a Retry-After header.
 	ServiceNotAvailable
+	// The sync state generation is not found. The delta token is expired and data must be synchronized again.
+	SyncStateNotFound
 	// QuotaLimitReached the user has reached their quota limit.
 	QuotaLimitReached
 	// Unauthenticated the caller is not authenticated.
@@ -70,6 +73,7 @@ var errorCodes = [...]string{
 	"resourceModified",
 	"resyncRequired",
 	"serviceNotAvailable",
+	"syncStateNotFound",
 	"quotaLimitReached",
 	"unauthenticated",
 	"preconditionFailed",
@@ -103,12 +107,18 @@ func (e ErrorCode) Render(w http.ResponseWriter, r *http.Request, status int, ms
 func (e Error) Render(w http.ResponseWriter, r *http.Request) {
 	var status int
 	switch e.errorCode {
+	case AccessDenied:
+		status = http.StatusForbidden
+	case InvalidRange:
+		status = http.StatusRequestedRangeNotSatisfiable
+	case InvalidRequest:
+		status = http.StatusBadRequest
 	case ItemNotFound:
 		status = http.StatusNotFound
 	case NameAlreadyExists:
 		status = http.StatusConflict
 	case NotAllowed:
-		status = http.StatusForbidden
+		status = http.StatusMethodNotAllowed
 	default:
 		status = http.StatusInternalServerError
 	}

--- a/services/graph/pkg/service/v0/groups_test.go
+++ b/services/graph/pkg/service/v0/groups_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Groups", func() {
 			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups", nil)
 			svc.GetGroups(rr, r)
 
-			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
 			data, err := io.ReadAll(rr.Body)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -96,10 +96,13 @@ type Service interface {
 	GetDrives(w http.ResponseWriter, r *http.Request)
 	GetSingleDrive(w http.ResponseWriter, r *http.Request)
 	GetAllDrives(w http.ResponseWriter, r *http.Request)
-	GetRootDriveChildren(w http.ResponseWriter, r *http.Request)
 	CreateDrive(w http.ResponseWriter, r *http.Request)
 	UpdateDrive(w http.ResponseWriter, r *http.Request)
 	DeleteDrive(w http.ResponseWriter, r *http.Request)
+
+	GetRootDriveChildren(w http.ResponseWriter, r *http.Request)
+	GetDriveItem(w http.ResponseWriter, r *http.Request)
+	GetDriveItemChildren(w http.ResponseWriter, r *http.Request)
 
 	GetTags(w http.ResponseWriter, r *http.Request)
 	AssignTags(w http.ResponseWriter, r *http.Request)

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -252,6 +252,10 @@ func NewService(opts ...Option) (Graph, error) {
 					r.Patch("/", svc.UpdateDrive)
 					r.Get("/", svc.GetSingleDrive)
 					r.Delete("/", svc.DeleteDrive)
+					r.Route("/items/{driveItemID}", func(r chi.Router) {
+						r.Get("/", svc.GetDriveItem)
+						r.Get("/children", svc.GetDriveItemChildren)
+					})
 				})
 			})
 			r.With(requireAdmin).Route("/education", func(r chi.Router) {


### PR DESCRIPTION
This PR adds two endpoints that allow navigating the file tree via the graph API:
* `/drives/{driveID}/items/{driveItemID}` as a stat
* `/drives/{driveID}/items/{driveItemID}/children` to list all children of a folder

This is just a basic implementation, but I needed some fun today ...

- [x] It also works around the flakyness of `/me/drive/root/children` ... path based ListContainer requests for `/users/some-u-u-i-d` sometimes are routed to the sharesstorageprovider because that is mounted at `/users/some-u-u-i-d/Shares`. And the gateway just picks the first storage provider it encounters ... Urgh ... this might be  worth an issue ... for future me ... tracked in https://github.com/owncloud/ocis/issues/7255

- [x] we need better error handling in the graph service ... a consistent way to map cs3 codes to graph apis ... also something for future me ... tracked in https://github.com/owncloud/ocis/issues/7256

