### PR TITLE
[tests-only][full-ci] removing the setresponse in given/then step in TrashbinContext and TagsContext

### DIFF
--- a/tests/acceptance/features/bootstrap/TagContext.php
+++ b/tests/acceptance/features/bootstrap/TagContext.php
@@ -85,7 +85,7 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates the following tags for (folder|file)"([^"]*)" of space "([^"]*)":$/
+	 * @When /^user "([^"]*)" creates the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)
@@ -222,7 +222,7 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the following tags for (folder|file)"([^"]*)" of space "([^"]*)":$/
+	 * @When /^user "([^"]*)" removes the following tags for (folder|file) "([^"]*)" of space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)

--- a/tests/acceptance/features/bootstrap/TagContext.php
+++ b/tests/acceptance/features/bootstrap/TagContext.php
@@ -63,7 +63,7 @@ class TagContext implements Context {
 	 * @return ResponseInterface
 	 * @throws Exception
 	 */
-	public function createFollowingTags(string $user, string $fileOrFolder, string $resource, string $space, TableNode $table):ResponseInterface {
+	public function createTags(string $user, string $fileOrFolder, string $resource, string $space, TableNode $table):ResponseInterface {
 		$tagNameArray = [];
 		foreach ($table->getRows() as $value) {
 			$tagNameArray[] = $value[0];
@@ -85,7 +85,7 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates the following tags for (folder|file)\s?"([^"]*)" of space "([^"]*)":$/
+	 * @When /^user "([^"]*)" creates the following tags for (folder|file)"([^"]*)" of space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)
@@ -97,7 +97,7 @@ class TagContext implements Context {
 	 * @throws Exception
 	 */
 	public function theUserCreatesFollowingTags(string $user, string $fileOrFolder, string $resource, string $space, TableNode $table):void {
-		$response = $this->createFollowingTags($user, $fileOrFolder, $resource, $space, $table);
+		$response = $this->createTags($user, $fileOrFolder, $resource, $space, $table);
 		$this->featureContext->setResponse($response);
 	}
 
@@ -114,7 +114,7 @@ class TagContext implements Context {
 	 * @throws Exception
 	 */
 	public function theUserHasCreatedFollowingTags(string $user, string $fileOrFolder, string $resource, string $space, TableNode $table):void {
-		$response = $this->createFollowingTags($user, $fileOrFolder, $resource, $space, $table);
+		$response = $this->createTags($user, $fileOrFolder, $resource, $space, $table);
 		$this->featureContext->theHttpStatusCodeShouldBe(200, "", $response);
 	}
 
@@ -222,7 +222,7 @@ class TagContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the following tags for (folder|file)\s?"([^"]*)" of space "([^"]*)":$/
+	 * @When /^user "([^"]*)" removes the following tags for (folder|file)"([^"]*)" of space "([^"]*)":$/
 	 *
 	 * @param string $user
 	 * @param string $fileOrFolder   (file|folder)

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -61,11 +61,11 @@ class TrashbinContext implements Context {
 	/**
 	 * @When user :user empties the trashbin using the trashbin API
 	 *
-	 * @param string|null $user user
+	 * @param string $user user
 	 *
-	 * @return ResponseInterface
+	 * @return void
 	 */
-	public function userEmptiesTrashbin(?string $user): void {
+	public function userEmptiesTrashbin(string $user): void {
 		$this->featureContext->setResponse($this->emptyTrashbin($user));
 	}
 	/**


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `TrashbinContext.php` and `TagsContext.php`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 