### PR TITLE
[test-only] ApiTest. test for password policy

### DIFF
--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -67,11 +67,11 @@ Feature: enforce password on public link
     Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
-      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
-      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 2     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS                | 13    |
+      | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS      | 3     |
+      | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_DIGITS                    | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS        | 2     |
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
@@ -91,15 +91,15 @@ Feature: enforce password on public link
       | 2               | 200      |
 
 
-  Scenario Outline: try to create a public link with a password that does not comply with the password policy 
+  Scenario Outline: try to create a public link with a password that does not comply with the password policy
     Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
-      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
-      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 2     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS                | 13    |
+      | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS      | 3     |
+      | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_DIGITS                    | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS        | 2     |
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
@@ -120,11 +120,11 @@ Feature: enforce password on public link
     Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
-      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
-      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 1     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS                | 13    |
+      | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS      | 3     |
+      | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_DIGITS                    | 1     |
+      | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS        | 2     |
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
@@ -150,11 +150,11 @@ Feature: enforce password on public link
     Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
-      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
-      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 1     |
-      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS                | 13    |
+      | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS      | 3     |
+      | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS      | 2     |
+      | FRONTEND_PASSWORD_POLICY_MIN_DIGITS                    | 1     |
+      | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS        | 2     |
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
@@ -201,15 +201,15 @@ Feature: enforce password on public link
     And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
     But the public should be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
     Examples:
-      | config                                              | config-value | password                          |
-      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS           | 5            | 12345                             |
-      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS           | 10           | with space                        |
-      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS | 3            | Test                              |
-      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS | 3            | TeST                              |
-      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS               | 1            | test1                             |
-      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS   | 1            | test pass                         |
-      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS   | 33           | ! #$%&'()*+,-./:;<=>?@[\]^_`{  }~ |
-      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS   | 5            | sameCharacterShouldWork!!!!!      |
+      | config                                            | config-value | password                          |
+      | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS           | 5            | 12345                             |
+      | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS           | 10           | with space                        |
+      | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS | 3            | Test                              |
+      | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS | 3            | TeST                              |
+      | FRONTEND_PASSWORD_POLICY_MIN_DIGITS               | 1            | test1                             |
+      | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 1            | test pass                         |
+      | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 33           | ! #$%&'()*+,-./:;<=>?@[\]^_`{  }~ |
+      | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 5            | sameCharacterShouldWork!!!!!      |
 
 
   Scenario Outline: try to update a public link with a password that does not comply with the password policy (invalid cases)
@@ -230,8 +230,8 @@ Feature: enforce password on public link
     And the OCS status code should be "400"
     And the OCS status message should be "<message>"
     Examples:
-      | config                                              | config-value | password | message                                                             |
-      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS           | 5            | 1234     | missing required password at least 5 characters are required        |
-      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS | 3            | TesT     | missing required password at least 3 lowercase letters are required |
-      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS | 3            | TesT     | missing required password at least 3 uppercase letters are required |
-      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS               | 2            | test1    | missing required password at least 2 numbers are required           |
+      | config                                            | config-value | password | message                                                             |
+      | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS           | 5            | 1234     | missing required password at least 5 characters are required        |
+      | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS | 3            | TesT     | missing required password at least 3 lowercase letters are required |
+      | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS | 3            | TesT     | missing required password at least 3 uppercase letters are required |
+      | FRONTEND_PASSWORD_POLICY_MIN_DIGITS               | 2            | test1    | missing required password at least 2 numbers are required           |

--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -5,15 +5,15 @@ Feature: enforce password on public link
   So that the password is required to access the contents of the link
 
   Background:
-    Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
-    And these users have been created with default attributes and without skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
 
 
   Scenario Outline: create a public link with edit permission without a password when enforce-password is enabled
-    Given using OCS API version "<ocs-api-version>"
+    Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
+    And using OCS API version "<ocs-api-version>"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testfile.txt |
       | permissions | 3             |
@@ -27,7 +27,8 @@ Feature: enforce password on public link
 
 
   Scenario Outline: update a public link to edit permission without a password
-    Given using OCS API version "<ocs-api-version>"
+    Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
+    And using OCS API version "<ocs-api-version>"
     And user "Alice" has created a public link share with settings
       | path        | /testfile.txt |
       | permissions | 1             |
@@ -43,10 +44,11 @@ Feature: enforce password on public link
 
 
   Scenario Outline: updates a public link to edit permission with a password
-    Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has created a public link share with settings
-      | path        | /testfile.txt |
-      | permissions | 1             |
+    Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
+    And using OCS API version "<ocs-api-version>"
+    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
+      | path        | testfile.txt |
+      | permissions | 1            |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3            |
       | password    | testpassword |
@@ -60,3 +62,165 @@ Feature: enforce password on public link
       | ocs-api-version | ocs-code |
       | 1               | 100      |
       | 2               | 200      |
+
+
+  Scenario Outline: create a public link with a password in accordance with the password policy
+    Given using OCS API version "<ocs-api-version>"
+    And the following configs have been set:
+      | config                                                 | value |
+      | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
+      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
+      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 2     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | /testfile.txt |
+      | permissions | 3             |
+      | password    | 3s:5WW9uE5h=A |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-code>"
+    And the OCS status message should be "OK"
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API without a password
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
+    But the public should be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "3s:5WW9uE5h=A"
+    Examples:
+      | ocs-api-version | ocs-code |
+      | 1               | 100      |
+      | 2               | 200      |
+
+
+  Scenario Outline: try to create a public link with a password that does not comply with the password policy
+    Given using OCS API version "<ocs-api-version>"
+    And the following configs have been set:
+      | config                                                 | value |
+      | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
+      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
+      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 2     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | /testfile.txt |
+      | permissions | 3             |
+      | password    | Pas1          |
+    Then the HTTP status code should be "<http-code>"
+    And the OCS status code should be "400"
+    And the OCS status message should be "password validation failed"
+    Examples:
+      | ocs-api-version | http-code |
+      | 1               | 200       |
+      | 2               | 400       |
+
+
+  Scenario Outline: update a public link with a password in accordance with the password policy
+    Given using OCS API version "<ocs-api-version>"
+    And the following configs have been set:
+      | config                                                 | value |
+      | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
+      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
+      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 1     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
+      | path        | testfile.txt |
+      | permissions | 1            |
+    When user "Alice" updates the last public link share using the sharing API with
+      | permissions | 3             |
+      | password    | 6a0Q;A3 +i^m[ |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-code>"
+    And the OCS status message should be "OK"
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API without a password
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
+    But the public should be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "6a0Q;A3 +i^m["
+    Examples:
+      | ocs-api-version | ocs-code |
+      | 1               | 100      |
+      | 2               | 200      |
+
+
+  Scenario Outline: try to update a public link with a password that does not comply with the password policy
+    Given using OCS API version "<ocs-api-version>"
+    And the following configs have been set:
+      | config                                                 | value |
+      | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
+      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
+      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS    | 3     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 1     |
+      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
+      | path        | testfile.txt |
+      | permissions | 1            |
+    When user "Alice" updates the last public link share using the sharing API with
+      | permissions | 3    |
+      | password    | Pws^ |
+    Then the HTTP status code should be "<http-code>"
+    And the OCS status code should be "400"
+    And the OCS status message should be:
+      """
+      missing required password at least 13 characters are required
+      at least 3 lowercase letters are required
+      at least 2 uppercase letters are required
+      at least 1 numbers are required
+      at least 2 special characters are required.  !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+      """
+    Examples:
+      | ocs-api-version | http-code |
+      | 1               | 200       |
+      | 2               | 400       |
+
+
+  Scenario Outline: update a public link with a password in accordance with the password policy (valid cases)
+    Given the following configs have been set:
+      | config                                                 | value          |
+      | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true           |
+      | <config>                                               | <config-value> |
+    And using OCS API version "2"
+    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
+      | path        | testfile.txt |
+      | permissions | 1            |
+    When user "Alice" updates the last public link share using the sharing API with
+      | permissions | 3          |
+      | password    | <password> |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API without a password
+    And the public should not be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
+    But the public should be able to download file "/textfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
+    Examples:
+      | config                                              | config-value | password                          |
+      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS           | 5            | 12345                             |
+      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS           | 10           | with space                        |
+      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS | 3            | Test                              |
+      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS | 3            | TeST                              |
+      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS               | 1            | test1                             |
+      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS   | 1            | test pass                         |
+      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS   | 33           | ! #$%&'()*+,-./:;<=>?@[\]^_`{  }~ |
+      | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS   | 5            | sameCharacterShouldWork!!!!!      |
+
+
+  Scenario Outline: try to update a public link with a password that does not comply with the password policy (invalid cases)
+    Given the following configs have been set:
+      | config                                                 | value          |
+      | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true           |
+      | <config>                                               | <config-value> |
+    And using OCS API version "2"
+    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
+      | path        | testfile.txt |
+      | permissions | 1            |
+    When user "Alice" updates the last public link share using the sharing API with
+      | permissions | 3          |
+      | password    | <password> |
+    Then the HTTP status code should be "400"
+    And the OCS status code should be "400"
+    And the OCS status message should be "<message>"
+    Examples:
+      | config                                              | config-value | password | message                                                             |
+      | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS           | 5            | 1234     | missing required password at least 5 characters are required        |
+      | FRONTEND_PASSWORD_POLICIES_MIN_LOWERCASE_CHARACTERS | 3            | TesT     | missing required password at least 3 lowercase letters are required |
+      | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS | 3            | TesT     | missing required password at least 3 uppercase letters are required |
+      | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS               | 2            | test1    | missing required password at least 2 numbers are required           |

--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -4,15 +4,10 @@ Feature: enforce password on public link
   I want to enforce passwords on public links shared with upload, edit, or contribute permission
   So that the password is required to access the contents of the link
 
-  Background:
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | Alice    |
-    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
-
-
   Scenario Outline: create a public link with edit permission without a password when enforce-password is enabled
     Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testfile.txt |
@@ -28,6 +23,8 @@ Feature: enforce password on public link
 
   Scenario Outline: update a public link to edit permission without a password
     Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
     And user "Alice" has created a public link share with settings
       | path        | /testfile.txt |
@@ -45,10 +42,12 @@ Feature: enforce password on public link
 
   Scenario Outline: updates a public link to edit permission with a password
     Given the config "OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" has been set to "true"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
-    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
-      | path        | testfile.txt |
-      | permissions | 1            |
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 1             |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3            |
       | password    | testpassword |
@@ -65,8 +64,7 @@ Feature: enforce password on public link
 
 
   Scenario Outline: create a public link with a password in accordance with the password policy
-    Given using OCS API version "<ocs-api-version>"
-    And the following configs have been set:
+    Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
       | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
@@ -74,6 +72,9 @@ Feature: enforce password on public link
       | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
       | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 2     |
       | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
+    And using OCS API version "<ocs-api-version>"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testfile.txt |
       | permissions | 3             |
@@ -90,9 +91,8 @@ Feature: enforce password on public link
       | 2               | 200      |
 
 
-  Scenario Outline: try to create a public link with a password that does not comply with the password policy
-    Given using OCS API version "<ocs-api-version>"
-    And the following configs have been set:
+  Scenario Outline: try to create a public link with a password that does not comply with the password policy 
+    Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
       | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
@@ -100,6 +100,9 @@ Feature: enforce password on public link
       | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
       | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 2     |
       | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
+    And using OCS API version "<ocs-api-version>"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testfile.txt |
       | permissions | 3             |
@@ -114,8 +117,7 @@ Feature: enforce password on public link
 
 
   Scenario Outline: update a public link with a password in accordance with the password policy
-    Given using OCS API version "<ocs-api-version>"
-    And the following configs have been set:
+    Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
       | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
@@ -123,9 +125,12 @@ Feature: enforce password on public link
       | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
       | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 1     |
       | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
-    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
-      | path        | testfile.txt |
-      | permissions | 1            |
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
+    And using OCS API version "<ocs-api-version>"
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 1             |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3             |
       | password    | 6a0Q;A3 +i^m[ |
@@ -142,8 +147,7 @@ Feature: enforce password on public link
 
 
   Scenario Outline: try to update a public link with a password that does not comply with the password policy
-    Given using OCS API version "<ocs-api-version>"
-    And the following configs have been set:
+    Given the following configs have been set:
       | config                                                 | value |
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
       | FRONTEND_PASSWORD_POLICIES_MIN_CHARACTERS              | 13    |
@@ -151,9 +155,12 @@ Feature: enforce password on public link
       | FRONTEND_PASSWORD_POLICIES_MIN_UPPERCASE_CHARACTERS    | 2     |
       | FRONTEND_PASSWORD_POLICIES_MIN_DIGITS                  | 1     |
       | FRONTEND_PASSWORD_POLICIES_MIN_SPECIAL_CHARACTERS      | 2     |
-    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
-      | path        | testfile.txt |
-      | permissions | 1            |
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
+    And using OCS API version "<ocs-api-version>"
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 1             |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3    |
       | password    | Pws^ |
@@ -179,9 +186,11 @@ Feature: enforce password on public link
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true           |
       | <config>                                               | <config-value> |
     And using OCS API version "2"
-    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
-      | path        | testfile.txt |
-      | permissions | 1            |
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 1             |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3          |
       | password    | <password> |
@@ -209,9 +218,11 @@ Feature: enforce password on public link
       | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true           |
       | <config>                                               | <config-value> |
     And using OCS API version "2"
-    And user "Alice" has created a public link share inside of space "Alice Hansen" with settings:
-      | path        | testfile.txt |
-      | permissions | 1            |
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /testfile.txt |
+      | permissions | 1             |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3          |
       | password    | <password> |

--- a/tests/acceptance/features/bootstrap/OcisConfigContext.php
+++ b/tests/acceptance/features/bootstrap/OcisConfigContext.php
@@ -21,6 +21,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\GuzzleException;
 use TestHelpers\OcisConfigHelper;
 use PHPUnit\Framework\Assert;
@@ -71,6 +72,28 @@ class OcisConfigContext implements Context {
 			200,
 			$response->getStatusCode(),
 			"Failed to set config $configVariable=$configValue"
+		);
+	}
+
+	/**
+	 * @Given the following configs have been set:
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theConfigHasBeenSetToValue(TableNode $table): void {
+		$envs = [];
+		foreach ($table->getHash() as $row) {
+			$envs[$row['config']] = $row['value'];
+		}
+
+		$response =  OcisConfigHelper::reConfigureOcis($envs);
+		Assert::assertEquals(
+			200,
+			$response->getStatusCode(),
+			"Failed to set config"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2023,7 +2023,7 @@ class SpacesContext implements Context {
 		$rows = $table->getRowsHash();
 
 		$rows["path"] = \array_key_exists("path", $rows) ? $rows["path"] : null;
-		$rows["shareType"] = \array_key_exists("shareType", $rows) ? $rows["shareType"] : null;
+		$rows["shareType"] = \array_key_exists("shareType", $rows) ? $rows["shareType"] : 3;
 		$rows["permissions"] = \array_key_exists("permissions", $rows) ? $rows["permissions"] : null;
 		$rows["password"] = \array_key_exists("password", $rows) ? $rows["password"] : null;
 		$rows["name"] = \array_key_exists("name", $rows) ? $rows["name"] : null;


### PR DESCRIPTION
- [x] added api test for password policy feature. see here https://github.com/owncloud/ocis/pull/7195
- [x] added method when we use more than one env 

