### PR TITLE
don't run CD on stable-4.0 branch cronjob

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2267,7 +2267,6 @@ def deploy(ctx, config, rebuild):
         ],
         "trigger": {
             "ref": [
-                "refs/heads/stable-*",
                 "refs/tags/v*",
             ],
         },


### PR DESCRIPTION
## Description
we're currently running the nighly continous deployment cronjob on both the master and stable-4.0 branches.
That proabably leads to race conditions that breaks the deployments.

## Related Issue
- Broken example deployments

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
