### PR TITLE
[tests-only] Use OCIS_ASYNC_UPLOADS in docs

### DIFF
--- a/docs/templates/ADOC_global.tmpl
+++ b/docs/templates/ADOC_global.tmpl
@@ -4,7 +4,7 @@ Note that some global environment variables have been deprecated and replaced by
 
 * All envvars starting with `LDAP_`
 * All envvars starting with `IDM_` except `IDM_CREATE_DEMO_USERS`
-* The following envvars: `REVA_GATEWAY`, `STORAGE_TRANSFER_SECRET`, `OCIS_ASYNC_UPLOADS`, `USERLOG_MACHINE_AUTH_API_KEY`.
+* The following envvars: `OCIS_REVA_GATEWAY`, `STORAGE_TRANSFER_SECRET`, `OCIS_ASYNC_UPLOADS`, `USERLOG_MACHINE_AUTH_API_KEY`.
 * Note that `WEB_UI_CONFIG_FILE` is not a global envar and will dropped from the list in a later release.
 
 [.landscape]

--- a/docs/templates/ADOC_global.tmpl
+++ b/docs/templates/ADOC_global.tmpl
@@ -4,7 +4,7 @@ Note that some global environment variables have been deprecated and replaced by
 
 * All envvars starting with `LDAP_`
 * All envvars starting with `IDM_` except `IDM_CREATE_DEMO_USERS`
-* The following envvars: `REVA_GATEWAY`, `STORAGE_TRANSFER_SECRET`, `STORAGE_USERS_OCIS_ASYNC_UPLOADS`, `USERLOG_MACHINE_AUTH_API_KEY`.
+* The following envvars: `REVA_GATEWAY`, `STORAGE_TRANSFER_SECRET`, `OCIS_ASYNC_UPLOADS`, `USERLOG_MACHINE_AUTH_API_KEY`.
 * Note that `WEB_UI_CONFIG_FILE` is not a global envar and will dropped from the list in a later release.
 
 [.landscape]

--- a/services/postprocessing/README.md
+++ b/services/postprocessing/README.md
@@ -8,7 +8,7 @@ To use the postprocessing service, an event system needs to be configured for al
 
 ## Postprocessing Functionality
 
-The storageprovider service (`storage-users`) can be configured to initiate asynchronous postprocessing by setting the `STORAGE_USERS_OCIS_ASYNC_UPLOADS` environment variable to `true`. If this is the case, postprocessing will get initiated *after* uploading a file and all bytes have been received.
+The storageprovider service (`storage-users`) can be configured to initiate asynchronous postprocessing by setting the `OCIS_ASYNC_UPLOADS` environment variable to `true`. If this is the case, postprocessing will get initiated *after* uploading a file and all bytes have been received.
 
 The `postprocessing` service will then coordinate configured postprocessing steps like scanning the file for viruses. During postprocessing, the file will be in a `processing state` where only a limited set of actions are available. Note that this processing state excludes file accessibility by users.
 

--- a/tests/acceptance/features/bootstrap/OcisConfigContext.php
+++ b/tests/acceptance/features/bootstrap/OcisConfigContext.php
@@ -39,7 +39,7 @@ class OcisConfigContext implements Context {
 	 */
 	public function asyncUploadHasbeenEnabledWithDelayedPostProcessing(string $delayTime): void {
 		$envs = [
-			"STORAGE_USERS_OCIS_ASYNC_UPLOADS" => true,
+			"OCIS_ASYNC_UPLOADS" => true,
 			"OCIS_EVENTS_ENABLE_TLS" => false,
 			"POSTPROCESSING_DELAY" => $delayTime . "s",
 		];


### PR DESCRIPTION
Use `OCIS_ASYNC_UPLOADS` because `STORAGE_USERS_ASYNC_UPLOADS` is gone