### PR TITLE
[full-ci][ociswrapper] Check ocis connection by requesting user info

### DIFF
--- a/tests/ociswrapper/cmd/cmd.go
+++ b/tests/ociswrapper/cmd/cmd.go
@@ -32,6 +32,8 @@ func serveCmd() *cobra.Command {
 			ocisConfig.Set("bin", cmd.Flag("bin").Value.String())
 			ocisConfig.Set("url", cmd.Flag("url").Value.String())
 			ocisConfig.Set("retry", cmd.Flag("retry").Value.String())
+			ocisConfig.Set("adminUsername", cmd.Flag("admin-username").Value.String())
+			ocisConfig.Set("adminPassword", cmd.Flag("admin-password").Value.String())
 		},
 	}
 
@@ -41,6 +43,8 @@ func serveCmd() *cobra.Command {
 	serveCmd.Flags().StringP("url", "", ocisConfig.Get("url"), "oCIS server url")
 	serveCmd.Flags().StringP("retry", "", ocisConfig.Get("retry"), "Number of retries to start oCIS server")
 	serveCmd.Flags().StringP("port", "p", wrapperConfig.Get("port"), "Wrapper API server port")
+	serveCmd.Flags().StringP("admin-username", "", ocisConfig.Get("adminUsername"), "admin username for oCIS server")
+	serveCmd.Flags().StringP("admin-password", "", ocisConfig.Get("adminPassword"), "admin password for oCIS server")
 
 	return serveCmd
 }

--- a/tests/ociswrapper/ocis/config/config.go
+++ b/tests/ociswrapper/ocis/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 var config = map[string]string{
-	"bin":   "/usr/bin/ocis",
-	"url":   "https://localhost:9200",
-	"retry": "5",
+	"bin":           "/usr/bin/ocis",
+	"url":           "https://localhost:9200",
+	"retry":         "5",
+	"adminUsername": "admin",
+	"adminPassword": "admin",
 }
 
 func Set(key string, value string) {

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -83,13 +83,16 @@ func WaitForConnection() bool {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
-	// 5 seconds timeout
-	timeoutValue := 5 * time.Second
+	// 30 seconds timeout
+	timeoutValue := 30 * time.Second
 
 	client := http.Client{
 		Timeout:   timeoutValue,
 		Transport: transport,
 	}
+
+	req, _ := http.NewRequest("GET", config.Get("url")+"/graph/v1.0/users/"+config.Get("adminUsername"), nil)
+	req.SetBasicAuth(config.Get("adminUsername"), config.Get("adminPassword"))
 
 	timeout := time.After(timeoutValue)
 
@@ -99,13 +102,15 @@ func WaitForConnection() bool {
 			log.Println(fmt.Sprintf("%v seconds timeout waiting for oCIS server", int64(timeoutValue.Seconds())))
 			return false
 		default:
-			_, err := client.Get(config.Get("url"))
-			if err == nil {
-				log.Println("oCIS server is ready to accept requests")
-				return true
+			res, err := client.Do(req)
+			if err != nil || res.StatusCode != 200 {
+				// 500 milliseconds poll interval
+				time.Sleep(500 * time.Millisecond)
+				continue
 			}
-			// 500 milliseconds poll interval
-			time.Sleep(500 * time.Millisecond)
+
+			log.Println("oCIS server is ready to accept requests")
+			return true
 		}
 	}
 }

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -102,6 +102,8 @@ func WaitForConnection() bool {
 			log.Println(fmt.Sprintf("%v seconds timeout waiting for oCIS server", int64(timeoutValue.Seconds())))
 			return false
 		default:
+			req.Header.Set("X-Request-ID", "ociswrapper-"+strconv.Itoa(int(time.Now().UnixMilli())))
+
 			res, err := client.Do(req)
 			if err != nil || res.StatusCode != 200 {
 				// 500 milliseconds poll interval


### PR DESCRIPTION
## Description
Instead of just sending request to server's base url, we now send request to get admin user information to check whether ocis is ready or not

## Related Issue

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
