### PR TITLE
[tests-only][full-ci] removing the setresponse in given/then step in SettingContext and TUSContext

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3391,6 +3391,7 @@ class FeatureContext extends BehatVariablesContext {
 		if (\count(WebDavHelper::$spacesIdRef) > 0) {
 			WebDavHelper::$spacesIdRef = [];
 		}
+		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -349,12 +349,12 @@ class SettingsContext implements Context {
 	 * @param string $user
 	 * @param string $language
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 *
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
-	public function sendRequestToSwitchSystemLanguage(string $user, string $language): void {
+	public function sendRequestToSwitchSystemLanguage(string $user, string $language): ResponseInterface {
 		$profileBundlesList = $this->getBundlesList($user, "Profile");
 		Assert::assertNotEmpty($profileBundlesList, "bundles list is empty");
 
@@ -390,10 +390,7 @@ class SettingsContext implements Context {
 			],
 			JSON_THROW_ON_ERROR
 		);
-
-		$this->featureContext->setResponse(
-			$this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body, $this->featureContext->getStepLineRef())
-		);
+		return $this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body, $this->featureContext->getStepLineRef());
 	}
 
 	/**
@@ -405,12 +402,13 @@ class SettingsContext implements Context {
 	 * @return void
 	 *
 	 * @throws Exception
+	 * @throws GuzzleException
 	 */
-	public function theUserHasSwitchedSysemLanguage(string $user, string $language): void {
-		$this->sendRequestToSwitchSystemLanguage($user, $language);
+	public function theUserHasSwitchedSystemLanguage(string $user, string $language): void {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
-			"Expected response status code should be 201"
+			"Expected response status code should be 201",
+			$this->sendRequestToSwitchSystemLanguage($user, $language)
 		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -390,7 +390,13 @@ class SettingsContext implements Context {
 			],
 			JSON_THROW_ON_ERROR
 		);
-		return $this->spacesContext->sendPostRequestToUrl($fullUrl, $user, $this->featureContext->getPasswordForUser($user), $body, $this->featureContext->getStepLineRef());
+		return $this->spacesContext->sendPostRequestToUrl(
+			$fullUrl,
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$body,
+			$this->featureContext->getStepLineRef()
+		);
 	}
 
 	/**
@@ -405,10 +411,11 @@ class SettingsContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function theUserHasSwitchedSystemLanguage(string $user, string $language): void {
+		$response = $this->sendRequestToSwitchSystemLanguage($user, $language);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201",
-			$this->sendRequestToSwitchSystemLanguage($user, $language)
+			$response
 		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/SpacesTUSContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesTUSContext.php
@@ -126,7 +126,8 @@ class SpacesTUSContext implements Context {
 		TableNode $headers
 	): void {
 		$this->spacesContext->setSpaceIDByName($user, $spaceName);
-		$this->tusContext->createNewTUSResourceWithHeaders($user, $headers, $content);
+		$response = $this->tusContext->createNewTUSResourceWithHeaders($user, $headers, $content);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -104,7 +104,7 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
-	public function createNewTUSResource(string $user, TableNode $headers): void {
+	public function userHasCreatedNewTUSResourceWithHeaders(string $user, TableNode $headers): void {
 		$rows = $headers->getRows();
 		$rows[] = ['Tus-Resumable', '1.0.0'];
 		$response = $this->createNewTUSResourceWithHeaders($user, new TableNode($rows));
@@ -125,7 +125,7 @@ class TUSContext implements Context {
 	public function sendsAChunkToTUSLocationWithOffsetAndData(string $user, string $offset, string $data, string $checksum = ''): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$password = $this->featureContext->getUserPassword($user);
-		$response = HttpRequestHelper::sendRequest(
+		return HttpRequestHelper::sendRequest(
 			$this->resourceLocation,
 			$this->featureContext->getStepLineRef(),
 			'PATCH',
@@ -139,24 +139,22 @@ class TUSContext implements Context {
 			],
 			$data
 		);
-		return $response;
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends a chunk to the last created TUS Location with offset "([^"]*)" and data "([^"]*)" using the WebDAV API$/
+	 * @When user :user sends a chunk to the last created TUS Location with offset :offset and data :data using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $offset
 	 * @param string $data
-	 * @param string $checksum
 	 *
 	 * @return void
 	 *
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function userSendsAChunkToTUSLocationWithOffsetAndData(string $user, string $offset, string $data, string $checksum = ''): void {
-		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
+	public function userSendsAChunkToTUSLocationWithOffsetAndData(string $user, string $offset, string $data): void {
+		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data);
 		$this->featureContext->setResponse($response);
 		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
@@ -511,7 +509,7 @@ class TUSContext implements Context {
 	 * @throws Exception
 	 */
 	public function userOverwritesFileWithChecksum(string $user, string $offset, string $data, string $checksum, TableNode $headers): void {
-		$this->createNewTUSResource($user, $headers);
+		$this->userHasCreatedNewTUSResourceWithHeaders($user, $headers);
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -69,6 +69,10 @@ class TUSContext implements Context {
 			false,
 			$password
 		);
+		$locationHeader = $response->getHeader('Location');
+		if (\sizeof($locationHeader) > 0) {
+			$this->resourceLocation = $locationHeader[0];
+		}
 		return $response;
 	}
 
@@ -87,10 +91,6 @@ class TUSContext implements Context {
 	public function userCreateNewTUSResourceWithHeaders(string $user, TableNode $headers, string $content = ''): void {
 		$response = $this->createNewTUSResourceWithHeaders($user, $headers, $content);
 		$this->featureContext->setResponse($response);
-		$locationHeader = $this->featureContext->getResponse()->getHeader('Location');
-		if (\sizeof($locationHeader) > 0) {
-			$this->resourceLocation = $locationHeader[0];
-		}
 	}
 
 	/**
@@ -109,10 +109,6 @@ class TUSContext implements Context {
 		$rows[] = ['Tus-Resumable', '1.0.0'];
 		$response = $this->createNewTUSResourceWithHeaders($user, new TableNode($rows));
 		$this->featureContext->theHTTPStatusCodeShouldBe(201, "", $response);
-		$locationHeader = $response->getHeader('Location');
-		if (\sizeof($locationHeader) > 0) {
-			$this->resourceLocation = $locationHeader[0];
-		}
 	}
 
 	/**
@@ -395,10 +391,6 @@ class TUSContext implements Context {
 	): void {
 		$response = $this->createNewTUSResourceWithHeaders($user, $headers, $content);
 		$this->featureContext->setResponse($response);
-		$locationHeader = $this->featureContext->getResponse()->getHeader('Location');
-		if (\sizeof($locationHeader) > 0) {
-			$this->resourceLocation = $locationHeader[0];
-		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -156,7 +156,6 @@ class TUSContext implements Context {
 	public function userSendsAChunkToTUSLocationWithOffsetAndData(string $user, string $offset, string $data): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data);
 		$this->featureContext->setResponse($response);
-		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -438,7 +437,6 @@ class TUSContext implements Context {
 	): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
 		$this->featureContext->setResponse($response);
-		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -460,7 +458,6 @@ class TUSContext implements Context {
 	): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
-		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -477,7 +474,6 @@ class TUSContext implements Context {
 	public function userUploadsChunkFileWithChecksum(string $user, string $offset, string $data, string $checksum): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->setResponse($response);
-		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -494,7 +490,6 @@ class TUSContext implements Context {
 	public function userHasUploadedChunkFileWithChecksum(string $user, string $offset, string $data, string $checksum): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
-		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -516,6 +511,5 @@ class TUSContext implements Context {
 		$this->userHasCreatedNewTUSResourceWithHeaders($user, $headers);
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->setResponse($response);
-		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 }

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -438,6 +438,7 @@ class TUSContext implements Context {
 	): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
 		$this->featureContext->setResponse($response);
+		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -459,6 +460,7 @@ class TUSContext implements Context {
 	): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
+		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -475,6 +477,7 @@ class TUSContext implements Context {
 	public function userUploadsChunkFileWithChecksum(string $user, string $offset, string $data, string $checksum): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->setResponse($response);
+		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -491,6 +494,7 @@ class TUSContext implements Context {
 	public function userHasUploadedChunkFileWithChecksum(string $user, string $offset, string $data, string $checksum): void {
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
+		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 
 	/**
@@ -512,5 +516,6 @@ class TUSContext implements Context {
 		$this->userHasCreatedNewTUSResourceWithHeaders($user, $headers);
 		$response = $this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->setResponse($response);
+		WebDavHelper::$SPACE_ID_FROM_OCIS = '';
 	}
 }


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `SettingContext` and `TUSContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 