### PR TITLE
Remove the hello and parallel deployments from drone config

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2195,9 +2195,7 @@ def example_deploys(ctx):
         "ocis_keycloak/latest.yml",
         "ocis_traefik/latest.yml",
         "ocis_wopi/latest.yml",
-        "ocis_hello/latest.yml",
         "ocis_s3/latest.yml",
-        "oc10_ocis_parallel/latest.yml",
     ]
     nightly_deploy = [
         "ocis_ldap/released.yml",


### PR DESCRIPTION
The deployments configs were already removed with commit 84381750f0e5d. So let's cleanup the drone steps as well.
