### PR TITLE
[docs-only] Add denied error body to docs

### DIFF
--- a/services/policies/README.md
+++ b/services/policies/README.md
@@ -42,6 +42,26 @@ The gRPC API can be used by any other internal service. It can also be used for 
 
 The proxy service already includes a middleware which uses the internal [gRPC API](#grpc-api) to evaluate the policies. Since the proxy is in heavy use and every HTTP request is processed here, only simple and quick decisions should be evaluated. More complex queries such as file content evaluation are _strongly_ discouraged.
 
+When the evaluation in the proxy results in a "denied" outcome, the response will return a `403 Permission Denied` with the following response body
+
+```json
+{
+    "error":
+    {
+        "code": "deniedByPolicy",
+        "message": "Operation denied due to security policies",
+        "innererror":
+        {
+            "date": "2023-09-19T13:22:20Z",
+            "filename": "File",
+            "method": "POST",
+            "path": "/dav/spaces/some-space-id/Folder/",
+            "request-id": "9CFCE925-F9D9-4F26-AB3B-2C1C40A9CD0C"
+        }
+    }
+}
+```
+
 ### Event Service (Postprocessing)
 
 This layer is event-based and part of the postprocessing service. Since processing at this point is asynchronous, the operations can also take longer and be more expensive, like evaluating the contents of a file.

--- a/services/policies/README.md
+++ b/services/policies/README.md
@@ -42,7 +42,7 @@ The gRPC API can be used by any other internal service. It can also be used for 
 
 The proxy service already includes a middleware which uses the internal [gRPC API](#grpc-api) to evaluate the policies. Since the proxy is in heavy use and every HTTP request is processed here, only simple and quick decisions should be evaluated. More complex queries such as file content evaluation are _strongly_ discouraged.
 
-When the evaluation in the proxy results in a "denied" outcome, the response will return a `403 Permission Denied` with the following response body
+If the evaluation in the proxy results in a "denied" outcome, the response will return a `403 Permission Denied` with the following response body
 
 ```json
 {


### PR DESCRIPTION
## Description

Adds more info about a denied error response in the proxy policies middleware

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related https://github.com/owncloud/enterprise/issues/6037

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
