### PR TITLE
[tests-only]Added test for the `move` with file-id in `web-dav-url`

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
@@ -1,0 +1,154 @@
+Feature: moving/renaming file using file id
+  As a user
+  I want to be able to move or rename files using file id
+  So that I can manage my file system
+
+  Background:
+    Given using spaces DAV path
+    And user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario Outline: move a file into a folder inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "/textfile.txt" into "/folder" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | folder/textfile.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file into a sub-folder inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has created folder "folder/sub-folder"
+    And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "/textfile.txt" into "/folder/sub-folder" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | folder/sub-folder/textfile.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file from folder to root inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "folder/textfile.txt" into "/" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | textfile.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | folder/textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file from sub-folder to root inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has created folder "folder/sub-folder"
+    And user "Alice" has uploaded file with content "some data" to "folder/sub-folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "folder/sub-folder/textfile.txt" into "/" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | textfile.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | folder/sub-folder/textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: rename a root file inside personal space
+    Given user "Alice" has uploaded file with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" renames a file "textfile.txt" into "renamed.txt" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | renamed.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: rename a file and move into a folder inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" renames a file "textfile.txt" into "/folder/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | folder/renamed.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: rename a file and move into a sub-folder inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has created folder "folder/sub-folder"
+    And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" renames a file "textfile.txt" into "/folder/sub-folder/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | folder/sub-folder/renamed.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: rename a file and move from a folder to root inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" renames a file "folder/textfile.txt" into "/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | renamed.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | folder/textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: rename a file and move from sub-folder to root inside personal space
+    Given user "Alice" has created folder "/folder"
+    And user "Alice" has created folder "folder/sub-folder"
+    And user "Alice" has uploaded file with content "some data" to "folder/sub-folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" renames a file "folder/sub-folder/textfile.txt" into "/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | renamed.txt |
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | folder/sub-folder/textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |

--- a/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
@@ -7,15 +7,16 @@ Feature: moving/renaming file using file id
     Given using spaces DAV path
     And user "Alice" has been created with default attributes and without skeleton files
 
+
   Scenario Outline: move a file into a folder inside personal space
     Given user "Alice" has created folder "/folder"
     And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
     And we save it into "FILEID"
     When user "Alice" moves a file "/textfile.txt" into "/folder" inside space "Personal" using file-id path "<dav-path>"
     Then the HTTP status code should be "201"
-    And for user "Alice" the space "Personal" should contain these entries:
-      | folder/textfile.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
+    And for user "Alice" folder "folder" of the space "Personal" should contain these files:
+      | textfile.txt |
+    But for user "Alice" the space "Personal" should not contain these entries:
       | textfile.txt |
     Examples:
       | dav-path                          |
@@ -30,9 +31,9 @@ Feature: moving/renaming file using file id
     And we save it into "FILEID"
     When user "Alice" moves a file "/textfile.txt" into "/folder/sub-folder" inside space "Personal" using file-id path "<dav-path>"
     Then the HTTP status code should be "201"
-    And for user "Alice" the space "Personal" should contain these entries:
-      | folder/sub-folder/textfile.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
+    And for user "Alice" folder "folder/sub-folder/" of the space "Personal" should contain these files:
+      | textfile.txt |
+    But for user "Alice" the space "Personal" should not contain these entries:
       | textfile.txt |
     Examples:
       | dav-path                          |
@@ -48,8 +49,8 @@ Feature: moving/renaming file using file id
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | textfile.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
-      | folder/textfile.txt |
+    But for user "Alice" folder "folder" of the space "Personal" should not contain these files:
+      | textfile.txt |
     Examples:
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
@@ -65,8 +66,8 @@ Feature: moving/renaming file using file id
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | textfile.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
-      | folder/sub-folder/textfile.txt |
+    But for user "Alice" folder "folder/sub-folder" of the space "Personal" should not contain these files:
+      | textfile.txt |
     Examples:
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
@@ -80,7 +81,7 @@ Feature: moving/renaming file using file id
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | renamed.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
+    But for user "Alice" the space "Personal" should not contain these entries:
       | textfile.txt |
     Examples:
       | dav-path                          |
@@ -94,9 +95,9 @@ Feature: moving/renaming file using file id
     And we save it into "FILEID"
     When user "Alice" renames a file "textfile.txt" into "/folder/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
     Then the HTTP status code should be "201"
-    And for user "Alice" the space "Personal" should contain these entries:
-      | folder/renamed.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
+    And for user "Alice" folder "folder" of the space "Personal" should contain these files:
+      | renamed.txt |
+    But for user "Alice" the space "Personal" should not contain these entries:
       | textfile.txt |
     Examples:
       | dav-path                          |
@@ -111,9 +112,9 @@ Feature: moving/renaming file using file id
     And we save it into "FILEID"
     When user "Alice" renames a file "textfile.txt" into "/folder/sub-folder/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
     Then the HTTP status code should be "201"
-    And for user "Alice" the space "Personal" should contain these entries:
-      | folder/sub-folder/renamed.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
+    And for user "Alice" folder "folder/sub-folder" of the space "Personal" should contain these files:
+      | renamed.txt |
+    But for user "Alice" the space "Personal" should not contain these entries:
       | textfile.txt |
     Examples:
       | dav-path                          |
@@ -129,8 +130,8 @@ Feature: moving/renaming file using file id
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | renamed.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
-      | folder/textfile.txt |
+    But for user "Alice" folder "folder" of the space "Personal" should not contain these files:
+      | renamed.txt |
     Examples:
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
@@ -146,8 +147,8 @@ Feature: moving/renaming file using file id
     Then the HTTP status code should be "201"
     And for user "Alice" the space "Personal" should contain these entries:
       | renamed.txt |
-    And for user "Alice" the space "Personal" should not contain these entries:
-      | folder/sub-folder/textfile.txt |
+    But for user "Alice" folder "folder/sub-folder" of the space "Personal" should not contain these files:
+      | textfile.txt |
     Examples:
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |


### PR DESCRIPTION
### Description
This PR adds test coverage for moving/renaming the files within personal space with the `url` consisting of the `file-id` not name.
This PR adds moving/renaming with file id only within `Personal` Space

### Related issue: 
https://github.com/owncloud/ocis/issues/6737