### PR TITLE
Do not reset share state

### DIFF
--- a/changelog/unreleased/fix-jsoncs3-share-manager-migration.md
+++ b/changelog/unreleased/fix-jsoncs3-share-manager-migration.md
@@ -1,0 +1,5 @@
+Bugfix: Do not reset state of received shares when rebuilding the jsoncs3 index
+
+We fixed a problem with the "ocis migrate rebuild-jsoncs3-indexes" command which reset the state of received shares to "pending".
+
+https://github.com/owncloud/ocis/issues/7319


### PR DESCRIPTION
This PR fixes a problem with the "ocis migrate rebuild-jsoncs3-indexes" command which reset the state of received shares to "pending".

Fixes https://github.com/owncloud/ocis/issues/7319