### PR TITLE
[tests-only][full-ci] removing the setresponse in given/when/then step in Notification Context

### DIFF
--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -118,6 +118,25 @@ class NotificationContext implements Context {
 	}
 
 	/**
+	 * @param string $user
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function deleteAllNotifications(string $user):ResponseInterface {
+		$this->userListAllNotifications($user);
+		if (isset($this->featureContext->getJsonDecodedResponseBodyContent()->ocs->data)) {
+			$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->ocs->data;
+			foreach ($responseBody as $value) {
+				// set notificationId
+				$this->notificationIds[] = $value->notification_id;
+			}
+		}
+		return $this->userDeletesNotification($user);
+	}
+
+	/**
 	 * @When user :user deletes all notifications
 	 *
 	 * @param string $user
@@ -127,15 +146,8 @@ class NotificationContext implements Context {
 	 * @throws JsonException
 	 */
 	public function userDeletesAllNotifications(string $user):void {
-		$this->userListAllNotifications($user);
-		if (isset($this->featureContext->getJsonDecodedResponseBodyContent()->ocs->data)) {
-			$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->ocs->data;
-			foreach ($responseBody as $value) {
-				// set notificationId
-				$this->notificationIds[] = $value->notification_id;
-			}
-		}
-		$this->featureContext->setResponse($this->userDeletesNotification($user));
+		$response = $this->deleteAllNotifications($user);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -148,8 +160,8 @@ class NotificationContext implements Context {
 	 * @throws JsonException
 	 */
 	public function userHasDeletedAllNotifications(string $user):void {
-		$this->userDeletesAllNotifications($user);
-		$this->featureContext->thenTheHTTPStatusCodeShouldBe(200);
+		$response = $this->deleteAllNotifications($user);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 	}
 
 	/**
@@ -174,7 +186,7 @@ class NotificationContext implements Context {
 	 *
 	 * @param string $user
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
@@ -524,7 +536,7 @@ class NotificationContext implements Context {
 	 * @param string|null $deprovision_date
 	 * @param string|null $deprovision_date_format
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 *
 	 * @throws GuzzleException
 	 *
@@ -589,8 +601,8 @@ class NotificationContext implements Context {
 	 * @return void
 	 */
 	public function userHasCreatedDeprovisioningNotification():void {
-		$this->userCreatesDeprovisioningNotification();
-		$this->featureContext->thenTheHTTPStatusCodeShouldBe(200);
+		$response = $this->userCreatesDeprovisioningNotification();
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -100,7 +100,7 @@ class NotificationContext implements Context {
 	public function listAllNotifications(string $user):ResponseInterface {
 		$this->setUserRecipient($user);
 		$headers = ["accept-language" => $this->settingsContext->getSettingLanguageValue($user)];
-		$response = OcsApiHelper::sendRequest(
+		return OcsApiHelper::sendRequest(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
@@ -111,7 +111,6 @@ class NotificationContext implements Context {
 			2,
 			$headers
 		);
-		return $response;
 	}
 
 	/**


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `NotificationContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 