### PR TITLE
Do not reset received share state to pending if there is a state already

### DIFF
--- a/changelog/unreleased/do-not-reset-received-share-state.md
+++ b/changelog/unreleased/do-not-reset-received-share-state.md
@@ -1,0 +1,6 @@
+Bugfix: Do not reset received share state to pending
+
+We fixed a problem where the states of received shares were reset to PENDING
+in the "ocis migrate rebuild-jsoncs3-indexes" command
+
+https://github.com/owncloud/ocis/issues/7319


### PR DESCRIPTION
Backport fix for https://github.com/owncloud/ocis/issues/7319