### PR TITLE
[tests-only] removing the setresponse in given/when/then step in ocs and webdavlocking context

### DIFF
--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -46,7 +46,8 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theUserSendsToOcsApiEndpoint(string $verb, string $url):void {
-		$this->theUserSendsToOcsApiEndpointWithBody($verb, $url);
+		$response = $this->theUserSendsToOcsApiEndpointWithBody($verb, $url);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -58,8 +59,8 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theUserHasSentToOcsApiEndpoint(string $verb, string $url):void {
-		$this->theUserSendsToOcsApiEndpointWithBody($verb, $url);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->theUserSendsToOcsApiEndpointWithBody($verb, $url);
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -74,13 +75,14 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function userSendsToOcsApiEndpoint(string $user, string $verb, string $url, ?string $password = null):void {
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$verb,
 			$url,
 			null,
 			$password
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -94,14 +96,14 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function userHasSentToOcsApiEndpoint(string $user, string $verb, string $url, ?string $password = null):void {
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$verb,
 			$url,
 			null,
 			$password
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -112,7 +114,7 @@ class OCSContext implements Context {
 	 * @param string|null $password
 	 * @param array|null $headers
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
 	public function userSendsHTTPMethodToOcsApiEndpointWithBody(
 		string $user,
@@ -121,7 +123,7 @@ class OCSContext implements Context {
 		?TableNode $body = null,
 		?string $password = null,
 		?array $headers = null
-	):void {
+	):ResponseInterface {
 		/**
 		 * array of the data to be sent in the body.
 		 * contains $body data converted to an array
@@ -140,7 +142,7 @@ class OCSContext implements Context {
 			$user = null;
 			$password = null;
 		}
-		$response = OcsApiHelper::sendRequest(
+		return OcsApiHelper::sendRequest(
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$password,
@@ -151,7 +153,6 @@ class OCSContext implements Context {
 			$this->featureContext->getOcsApiVersion(),
 			$headers
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -159,15 +160,15 @@ class OCSContext implements Context {
 	 * @param string $url
 	 * @param TableNode|null $body
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
 	public function adminSendsHttpMethodToOcsApiEndpointWithBody(
 		string $verb,
 		string $url,
 		?TableNode $body
-	):void {
+	):ResponseInterface {
 		$admin = $this->featureContext->getAdminUsername();
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		return $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$admin,
 			$verb,
 			$url,
@@ -180,10 +181,10 @@ class OCSContext implements Context {
 	 * @param string $url
 	 * @param TableNode|null $body
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function theUserSendsToOcsApiEndpointWithBody(string $verb, string $url, ?TableNode $body = null):void {
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+	public function theUserSendsToOcsApiEndpointWithBody(string $verb, string $url, ?TableNode $body = null):ResponseInterface {
+		return $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->featureContext->getCurrentUser(),
 			$verb,
 			$url,
@@ -209,13 +210,14 @@ class OCSContext implements Context {
 		?TableNode $body = null,
 		?string $password = null
 	):void {
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$verb,
 			$url,
 			$body,
 			$password
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -236,14 +238,14 @@ class OCSContext implements Context {
 		?TableNode $body = null,
 		?string $password = null
 	):void {
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$verb,
 			$url,
 			$body,
 			$password
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -399,11 +401,12 @@ class OCSContext implements Context {
 		string $url,
 		?TableNode $body
 	):void {
-		$this->adminSendsHttpMethodToOcsApiEndpointWithBody(
+		$response = $this->adminSendsHttpMethodToOcsApiEndpointWithBody(
 			$verb,
 			$url,
 			$body
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -420,12 +423,12 @@ class OCSContext implements Context {
 		string $url,
 		?TableNode $body
 	):void {
-		$this->adminSendsHttpMethodToOcsApiEndpointWithBody(
+		$response = $this->adminSendsHttpMethodToOcsApiEndpointWithBody(
 			$verb,
 			$url,
 			$body
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -438,11 +441,12 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theUserSendsHTTPMethodToOcsApiEndpointWithBody(string $verb, string $url, TableNode $body):void {
-		$this->theUserSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->theUserSendsToOcsApiEndpointWithBody(
 			$verb,
 			$url,
 			$body
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -455,12 +459,12 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theUserHasSentHTTPMethodToOcsApiEndpointWithBody(string $verb, string $url, TableNode $body):void {
-		$this->theUserSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->theUserSendsToOcsApiEndpointWithBody(
 			$verb,
 			$url,
 			$body
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -480,13 +484,14 @@ class OCSContext implements Context {
 		TableNode $body
 	):void {
 		$admin = $this->featureContext->getAdminUsername();
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$admin,
 			$verb,
 			$url,
 			$body,
 			$password
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -507,13 +512,14 @@ class OCSContext implements Context {
 		string $password,
 		TableNode $body
 	):void {
-		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$verb,
 			$url,
 			$body,
 			$password
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -787,14 +787,16 @@ class OCSContext implements Context {
 	 *
 	 * @param string $statusCode
 	 * @param string $message
+	 * @param ResponseInterface|null $response
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theOCSStatusCodeShouldBe(string $statusCode, string $message = ""):void {
+	public function theOCSStatusCodeShouldBe(string $statusCode, string $message = "", ?ResponseInterface $response = null):void {
 		$statusCodes = explode(",", $statusCode);
+		$response = $response ?? $this->featureContext->getResponse();
 		$responseStatusCode = $this->getOCSResponseStatusCode(
-			$this->featureContext->getResponse()
+			$response
 		);
 		if (\is_array($statusCodes)) {
 			if ($message === "") {
@@ -1000,16 +1002,18 @@ class OCSContext implements Context {
 	 * this function is aware of the currently used OCS version
 	 *
 	 * @param string|null $message
+	 * @param ResponseInterface|null $response
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function assertOCSResponseIndicatesSuccess(?string $message = ""):void {
-		$this->featureContext->theHTTPStatusCodeShouldBe('200', $message);
+	public function assertOCSResponseIndicatesSuccess(?string $message = "", ?ResponseInterface $response = null):void {
+		$response = $response ?? $this->featureContext->getResponse();
+		$this->featureContext->theHTTPStatusCodeShouldBe('200', $message, $response);
 		if ($this->featureContext->getOcsApiVersion() === 1) {
-			$this->theOCSStatusCodeShouldBe('100', $message);
+			$this->theOCSStatusCodeShouldBe('100', $message, $response);
 		} else {
-			$this->theOCSStatusCodeShouldBe('200', $message);
+			$this->theOCSStatusCodeShouldBe('200', $message, $response);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -72,11 +72,12 @@ class ShareesContext implements Context {
 			$url .= '?' . \implode('&', $parameters);
 		}
 
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			$url
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2150,13 +2150,14 @@ trait Sharing {
 		} else {
 			$rawShareTypes = SharingHelper::SHARE_TYPES[$shareType];
 		}
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			$this->getSharesEndpointPath(
 				"?shared_with_me=true" . $pendingClause . "&share_types=" . $rawShareTypes
 			)
 		);
+		$this->setResponse($response);
 	}
 
 	/**
@@ -2171,11 +2172,12 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 		$url = "/apps/files_sharing/api/"
 			. "v$this->sharingApiVersion/shares?shared_with_me=true&path=$path";
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			$url
 		);
+		$this->setResponse($response);
 	}
 
 	/**
@@ -3029,17 +3031,17 @@ trait Sharing {
 	 * @param string $name
 	 * @param string $path
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
 	public function deletePublicLinkShareUsingTheSharingApi(
 		string $user,
 		string $name,
 		string $path
-	):void {
+	):ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);
 		$url = $this->getSharesEndpointPath("/$share_id");
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		return $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			"DELETE",
 			$url
@@ -3060,11 +3062,12 @@ trait Sharing {
 		string $name,
 		string $path
 	):void {
-		$this->deletePublicLinkShareUsingTheSharingApi(
+		$response = $this->deletePublicLinkShareUsingTheSharingApi(
 			$user,
 			$name,
 			$path
 		);
+		$this->setResponse($response);
 	}
 
 	/**
@@ -3081,12 +3084,12 @@ trait Sharing {
 		string $name,
 		string $path
 	):void {
-		$this->deletePublicLinkShareUsingTheSharingApi(
+		$response = $this->deletePublicLinkShareUsingTheSharingApi(
 			$user,
 			$name,
 			$path
 		);
-		$this->theHTTPStatusCodeShouldBeSuccess();
+		$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -3144,11 +3147,12 @@ trait Sharing {
 			$httpRequestMethod = "POST";
 		}
 
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$httpRequestMethod,
 			$url
 		);
+		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -3202,11 +3206,12 @@ trait Sharing {
 			$httpRequestMethod = "POST";
 		}
 
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$httpRequestMethod,
 			$url
 		);
+		$this->setResponse($response);
 	}
 
 	/**
@@ -3394,11 +3399,12 @@ trait Sharing {
 			__METHOD__ . " could not find share, offered by $sharer to $sharee"
 		);
 
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$sharer,
 			'DELETE',
 			'/apps/files_sharing/api/v' . $this->sharingApiVersion . '/shares/' . $shareId
 		);
+		$this->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1846,7 +1846,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function theUserDeletesLastShareUsingTheSharingAPI():void {
-		$this->deleteLastShareUsingSharingApiByCurrentUser();
+		$this->setResponse($this->deleteLastShareUsingSharingApiByCurrentUser());
 	}
 
 	/**
@@ -1855,8 +1855,8 @@ trait Sharing {
 	 * @return void
 	 */
 	public function theUserHasDeletedLastShareUsingTheSharingAPI():void {
-		$this->deleteLastShareUsingSharingApiByCurrentUser();
-		$this->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->deleteLastShareUsingSharingApiByCurrentUser();
+		$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -1864,9 +1864,9 @@ trait Sharing {
 	 * @param string|null $sharer the specific user whose share will be deleted (if specified)
 	 * @param bool $deleteLastPublicLink
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function deleteLastShareUsingSharingApi(string $user, string $sharer = null, bool $deleteLastPublicLink = false):void {
+	public function deleteLastShareUsingSharingApi(string $user, string $sharer = null, bool $deleteLastPublicLink = false):ResponseInterface {
 		$user = $this->getActualUsername($user);
 		if ($deleteLastPublicLink) {
 			$shareId = (string) $this->getLastCreatedPublicShare()->id;
@@ -1878,7 +1878,7 @@ trait Sharing {
 			}
 		}
 		$url = $this->getSharesEndpointPath("/$shareId");
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		return $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			"DELETE",
 			$url
@@ -1886,10 +1886,10 @@ trait Sharing {
 	}
 
 	/**
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function deleteLastShareUsingSharingApiByCurrentUser():void {
-		$this->deleteLastShareUsingSharingApi($this->currentUser);
+	public function deleteLastShareUsingSharingApiByCurrentUser():ResponseInterface {
+		return $this->deleteLastShareUsingSharingApi($this->currentUser);
 	}
 
 	/**
@@ -1901,7 +1901,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userDeletesLastShareUsingTheSharingApi(string $user):void {
-		$this->deleteLastShareUsingSharingApi($user);
+		$this->setResponse($this->deleteLastShareUsingSharingApi($user));
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -1914,7 +1914,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userDeletesLastPublicLinkShareUsingTheSharingApi(string $user):void {
-		$this->deleteLastShareUsingSharingApi($user, null, true);
+		$this->setResponse($this->deleteLastShareUsingSharingApi($user, null, true));
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -1928,7 +1928,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userDeletesLastShareOfUserUsingTheSharingApi(string $user, string $sharer):void {
-		$this->deleteLastShareUsingSharingApi($user, $sharer);
+		$this->setResponse($this->deleteLastShareUsingSharingApi($user, $sharer));
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -1940,8 +1940,8 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userHasDeletedLastShareUsingTheSharingApi(string $user):void {
-		$this->deleteLastShareUsingSharingApi($user);
-		$this->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->deleteLastShareUsingSharingApi($user);
+		$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
 
 	/**
@@ -1967,7 +1967,7 @@ trait Sharing {
 	public function userGetsInfoOfLastShareUsingTheSharingApi(string $user, ?string $language = null):void {
 		$shareId = $this->getLastCreatedUserGroupShareId();
 		$language = TranslationHelper::getLanguage($language);
-		$this->getShareData($user, $shareId, $language);
+		$this->setResponse($this->getShareData($user, $shareId, $language));
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -2000,7 +2000,7 @@ trait Sharing {
 			);
 		}
 		$language = TranslationHelper::getLanguage($language);
-		$this->getShareData($user, $shareId, $language);
+		$this->setResponse($this->getShareData($user, $shareId, $language));
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -2073,16 +2073,16 @@ trait Sharing {
 	 * @param string $share_id
 	 * @param string|null $language
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function getShareData(string $user, string $share_id, ?string $language = null):void {
+	public function getShareData(string $user, string $share_id, ?string $language = null):ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$url = $this->getSharesEndpointPath("/$share_id");
 		$headers = [];
 		if ($language !== null) {
 			$headers['Accept-Language'] = $language;
 		}
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		return $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			"GET",
 			$url,
@@ -2102,11 +2102,12 @@ trait Sharing {
 	public function userGetsAllTheSharesSharedWithHimUsingTheSharingApi(string $user):void {
 		$user = $this->getActualUsername($user);
 		$url = "/apps/files_sharing/api/v1/shares?shared_with_me=true";
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			$url
 		);
+		$this->setResponse($response);
 	}
 
 	/**
@@ -2120,8 +2121,9 @@ trait Sharing {
 	public function userGetsTheLastShareSharedWithHimUsingTheSharingApi(string $user, TableNode $table):void {
 		$user = $this->getActualUsername($user);
 		$shareId = (string) $this->getLastCreatedPublicShare()->id;
-		$this->getShareData($user, $shareId);
-		$this->checkFields($user, $table);
+		$response = $this->getShareData($user, $shareId);
+		var_dump($response->getBody()->getContents());
+		$this->checkFields($user, $table, $response);
 	}
 
 	/**
@@ -2295,19 +2297,21 @@ trait Sharing {
 	):void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
-		$this->getShareData($user, $this->getLastCreatedUserGroupShareId());
+		$response = $this->getShareData($user, $this->getLastCreatedUserGroupShareId());
 		$this->theHTTPStatusCodeShouldBe(
 			200,
-			"Error getting info of last share for user $user"
+			"Error getting info of last share for user $user",
+			$response
 		);
 		$this->ocsContext->assertOCSResponseIndicatesSuccess(
 			__METHOD__ .
 			' Error getting info of last share for user $user\n' .
 			$this->ocsContext->getOCSResponseStatusMessage(
-				$this->getResponse()
-			) . '"'
+				$response
+			) . '"',
+			$response
 		);
-		$this->checkFields($user, $body);
+		$this->checkFields($user, $body, $response);
 	}
 
 	/**
@@ -2543,11 +2547,14 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
+	 * @param ResponseInterface|null $response
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function checkFields(string $user, ?TableNode $body):void {
+	public function checkFields(string $user, ?TableNode $body, ?ResponseInterface $response = null):void {
+		$response = $response ?? $this->getResponse();
+		$data = $this->getResponseXml($response, __METHOD__)->data[0];
 		$this->verifyTableNodeColumnsCount($body, 2);
 		$bodyRows = $body->getRowsHash();
 		$userRelatedFieldNames = [
@@ -2568,8 +2575,8 @@ trait Sharing {
 			$value = $this->getActualUsername($value);
 			$value = $this->replaceValuesFromTable($field, $value);
 			Assert::assertTrue(
-				$this->isFieldInResponse($field, $value),
-				"$field doesn't have value '$value'"
+				$this->isFieldInResponse($field, $value, true, $data),
+				"$field doesn't have value '$value'",
 			);
 		}
 	}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3460,19 +3460,18 @@ trait Sharing {
 					__METHOD__ . ' invalid "state" given'
 				);
 		}
-
 		$url = $this->getSharesEndpointPath("?format=json&shared_with_me=true&state=$stateCode");
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			"GET",
 			$url
 		);
-		if ($this->response->getStatusCode() !== 200) {
+		if ($response->getStatusCode() !== 200) {
 			throw new Exception(
 				__METHOD__ . " could not retrieve information about shares"
 			);
 		}
-		$result = $this->response->getBody()->getContents();
+		$result = $response->getBody()->getContents();
 		$usersShares = \json_decode($result, true);
 		if (!\is_array($usersShares)) {
 			throw new Exception(

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2122,7 +2122,6 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 		$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		$response = $this->getShareData($user, $shareId);
-		var_dump($response->getBody()->getContents());
 		$this->checkFields($user, $table, $response);
 	}
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2970,14 +2970,14 @@ class SpacesContext implements Context {
 
 		$url = "/apps/files_sharing/api/v1/shares?reshares=true&space_ref=" . $body;
 
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+		$response = $this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			'GET',
 			$url,
 		);
 
 		$should = ($shouldOrNot !== "not");
-		$responseArray = json_decode(json_encode($this->featureContext->getResponseXml()->data), true, 512, JSON_THROW_ON_ERROR);
+		$responseArray = json_decode(json_encode($this->featureContext->getResponseXml($response)->data), true, 512, JSON_THROW_ON_ERROR);
 
 		if ($should) {
 			Assert::assertNotEmpty($responseArray, __METHOD__ . ' Response should contain a link, but it is empty');


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `OCSContext` and `WebDavLockingContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 