### PR TITLE
fix group id claim

### DIFF
--- a/services/graph/pkg/identity/cs3.go
+++ b/services/graph/pkg/identity/cs3.go
@@ -169,7 +169,7 @@ func (i *CS3) GetGroup(ctx context.Context, groupID string, queryParam url.Value
 	}
 
 	res, err := gatewayClient.GetGroupByClaim(ctx, &cs3group.GetGroupByClaimRequest{
-		Claim: "groupid", // FIXME add consts to reva
+		Claim: "group_id", // FIXME add consts to reva
 		Value: groupID,
 	})
 


### PR DESCRIPTION
reva never uses `groupid`. actually only the ldap group manager knows about `group_id`. the fixme makes a little funny.