### PR TITLE
notifcations: Sanitize SMTP configuration

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -138,6 +138,7 @@ config = {
                 "NOTIFICATIONS_SMTP_HOST": "email",
                 "NOTIFICATIONS_SMTP_PORT": "2500",
                 "NOTIFICATIONS_SMTP_INSECURE": "true",
+                "NOTIFICATIONS_SMTP_SENDER": "ownCloud <noreply@example.com>",
             },
         },
         "apiAntivirus": {

--- a/changelog/unreleased/enhancement-notifications-auto-auth-settings.md
+++ b/changelog/unreleased/enhancement-notifications-auto-auth-settings.md
@@ -1,0 +1,7 @@
+Enhancement: New value `auto` for NOTIFICATIONS_SMTP_AUTHENTICATION
+
+This cause the notifications service to automatically pick a suitable authentication
+method to use with the configured SMTP server. This is also the new default behavior.
+The previous default was to not use authentication at all.
+
+https://github.com/owncloud/ocis/issues/7356

--- a/changelog/unreleased/fix-notifications-redundant-settings.md
+++ b/changelog/unreleased/fix-notifications-redundant-settings.md
@@ -1,0 +1,8 @@
+Bugfix: Deprecate redundant encryptions settings for notification service
+
+The values `tls` and `ssl` for the `smtp_encryption` configuration setting are
+duplicates of `starttls` and `ssltls`. They have been marked as deprecated.
+A warning will be logged when they are still used. Please use `starttls` instead
+for `tls` and `ssltls` instead of `ssl.
+
+https://github.com/owncloud/ocis/issues/7345

--- a/services/notifications/pkg/channels/channels.go
+++ b/services/notifications/pkg/channels/channels.go
@@ -69,6 +69,8 @@ func (m Mail) getMailClient() (*mail.SMTPClient, error) {
 		server.Authentication = mail.AuthCRAMMD5
 	case "none":
 		server.Authentication = mail.AuthNone
+	case "auto", "":
+		server.Authentication = mail.AuthAuto
 	default:
 		return nil, errors.New("unknown mail authentication method")
 	}

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -44,7 +44,7 @@ type SMTP struct {
 	Password       string `yaml:"smtp_password" env:"NOTIFICATIONS_SMTP_PASSWORD" desc:"Password for the SMTP host to connect to."`
 	Insecure       bool   `yaml:"insecure" env:"NOTIFICATIONS_SMTP_INSECURE" desc:"Allow insecure connections to the SMTP server."`
 	Authentication string `yaml:"smtp_authentication" env:"NOTIFICATIONS_SMTP_AUTHENTICATION" desc:"Authentication method for the SMTP communication. Possible values are 'login', 'plain', 'crammd5', 'none'"`
-	Encryption     string `yaml:"smtp_encryption" env:"NOTIFICATIONS_SMTP_ENCRYPTION" desc:"Encryption method for the SMTP communication. Possible values  are 'starttls', 'ssl', 'ssltls', 'tls'  and 'none'."`
+	Encryption     string `yaml:"smtp_encryption" env:"NOTIFICATIONS_SMTP_ENCRYPTION" desc:"Encryption method for the SMTP communication. Possible values  are 'starttls', 'ssl', 'ssltls', 'tls'  and 'none'." deprecationVersion:"5.0.0" removalVersion:"6.0.0" deprecationInfo:"The NOTIFICATIONS_SMTP_ENCRYPTION values 'ssl' and 'tls' are deprecated and will be removed in the future." deprecationReplacement:"Use 'starttls' instead of 'tls' and 'ssltls' instead of 'ssl'."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -39,11 +39,11 @@ type Notifications struct {
 type SMTP struct {
 	Host           string `yaml:"smtp_host" env:"NOTIFICATIONS_SMTP_HOST" desc:"SMTP host to connect to."`
 	Port           int    `yaml:"smtp_port" env:"NOTIFICATIONS_SMTP_PORT" desc:"Port of the SMTP host to connect to."`
-	Sender         string `yaml:"smtp_sender" env:"NOTIFICATIONS_SMTP_SENDER" desc:"Sender address of emails that will be sent."`
+	Sender         string `yaml:"smtp_sender" env:"NOTIFICATIONS_SMTP_SENDER" desc:"Sender address of emails that will be sent (e.g. 'ownCloud <noreply@example.com>'."`
 	Username       string `yaml:"smtp_username" env:"NOTIFICATIONS_SMTP_USERNAME" desc:"Username for the SMTP host to connect to."`
 	Password       string `yaml:"smtp_password" env:"NOTIFICATIONS_SMTP_PASSWORD" desc:"Password for the SMTP host to connect to."`
 	Insecure       bool   `yaml:"insecure" env:"NOTIFICATIONS_SMTP_INSECURE" desc:"Allow insecure connections to the SMTP server."`
-	Authentication string `yaml:"smtp_authentication" env:"NOTIFICATIONS_SMTP_AUTHENTICATION" desc:"Authentication method for the SMTP communication. Possible values are 'login', 'plain', 'crammd5', 'none'"`
+	Authentication string `yaml:"smtp_authentication" env:"NOTIFICATIONS_SMTP_AUTHENTICATION" desc:"Authentication method for the SMTP communication. Possible values are 'login', 'plain', 'crammd5', 'none' or 'auto'. If set to 'auto' or unset, the authentication method is automatically negotiated with the server."`
 	Encryption     string `yaml:"smtp_encryption" env:"NOTIFICATIONS_SMTP_ENCRYPTION" desc:"Encryption method for the SMTP communication. Possible values  are 'starttls', 'ssl', 'ssltls', 'tls'  and 'none'." deprecationVersion:"5.0.0" removalVersion:"6.0.0" deprecationInfo:"The NOTIFICATIONS_SMTP_ENCRYPTION values 'ssl' and 'tls' are deprecated and will be removed in the future." deprecationReplacement:"Use 'starttls' instead of 'tls' and 'ssltls' instead of 'ssl'."`
 }
 

--- a/services/notifications/pkg/config/defaults/defaultconfig.go
+++ b/services/notifications/pkg/config/defaults/defaultconfig.go
@@ -31,11 +31,7 @@ func DefaultConfig() *config.Config {
 		WebUIURL: "https://localhost:9200",
 		Notifications: config.Notifications{
 			SMTP: config.SMTP{
-				Host:           "",
-				Port:           1025,
-				Sender:         "ownCloud <noreply@example.com>",
-				Authentication: "none",
-				Encryption:     "none",
+				Encryption: "none",
 			},
 			Events: config.Events{
 				Endpoint:  "127.0.0.1:9233",

--- a/services/notifications/pkg/config/parser/parse.go
+++ b/services/notifications/pkg/config/parser/parse.go
@@ -2,10 +2,12 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config/defaults"
+	"github.com/owncloud/ocis/v2/services/notifications/pkg/logging"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/envdecode"
 )
@@ -33,5 +35,22 @@ func ParseConfig(cfg *config.Config) error {
 }
 
 func Validate(cfg *config.Config) error {
+	logger := logging.Configure(cfg.Service.Name, cfg.Log)
+
+	if cfg.Notifications.SMTP.Host != "" {
+		switch cfg.Notifications.SMTP.Encryption {
+		case "tls":
+			logger.Warn().Msg("The smtp_encryption value 'tls' is deprecated. Please use the value 'starttls' instead.")
+		case "ssl":
+			logger.Warn().Msg("The smtp_encryption value 'ssl' is deprecated. Please use the value 'ssltls' instead.")
+		case "starttls", "ssltls", "none":
+			break
+		default:
+			return fmt.Errorf(
+				"unknown value '%s' for 'smtp_encryption' in service %s. Allowed values are 'starttls', 'ssltls' or 'none'",
+				cfg.Notifications.SMTP.Encryption, cfg.Service.Name,
+			)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
This makes a couple changes to the Mail client configuration of the notifications service

- automatically pick a suitable auth mechanism
- deprecate some redundant setting of the encryption config
- remove some not really helpful default settings of the config

Please specifically review the deprecation notice. As were not deprecating a whole config variable but just specific configuration settings.

Closes: #7356 #7345 