### PR TITLE
[tests-only] removing the setresponse in given/when/then step in webdavproperties context

### DIFF
--- a/tests/acceptance/features/apiSpacesShares/shareOperations.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareOperations.feature
@@ -19,7 +19,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "19"
 
 
@@ -36,7 +36,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "19"
 
 
@@ -63,7 +63,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "3"
 
 
@@ -90,7 +90,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/tmp.txt" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "17"
 
 
@@ -101,7 +101,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "31"
 
 
@@ -117,7 +117,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "31"
 
 
@@ -144,7 +144,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "29"
 
 
@@ -171,7 +171,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "27"
 
 
@@ -198,7 +198,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "23"
 
 
@@ -225,7 +225,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/tmp" inside space "Shares" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "15"
 
 

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3021,7 +3021,6 @@ class SpacesContext implements Context {
 		$this->setSpaceIDByName($user, $spaceName);
 		$response = $this->webDavPropertiesContext->getPropertiesOfFolder($user, $resourceName, $propertiesTable);
 		$this->featureContext->setResponse($response);
-		$this->featureContext->setResponseXmlObject(HttpRequestHelper::getResponseXml($response));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3019,7 +3019,9 @@ class SpacesContext implements Context {
 		TableNode $propertiesTable
 	):void {
 		$this->setSpaceIDByName($user, $spaceName);
-		$this->webDavPropertiesContext->userGetsPropertiesOfFolder($user, $resourceName, $propertiesTable);
+		$response = $this->webDavPropertiesContext->getPropertiesOfFolder($user, $resourceName, $propertiesTable);
+		$this->featureContext->setResponse($response);
+		$this->featureContext->setResponseXmlObject(HttpRequestHelper::getResponseXml($response));
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2740,8 +2740,8 @@ class SpacesContext implements Context {
 	 */
 	public function userGetsEtagOfElementInASpace(string $user, string $space, string $path) {
 		$this->setSpaceIDByName($user, $space);
-		$this->webDavPropertiesContext->storeEtagOfElement($user, $path);
-		return $this->featureContext->getEtagFromResponseXmlObject();
+		$xmlObject = $this->webDavPropertiesContext->storeEtagOfElement($user, $path);
+		return $this->featureContext->getEtagFromResponseXmlObject($xmlObject);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -148,11 +148,12 @@ trait WebDav {
 	}
 
 	/**
+	 * @param SimpleXMLElement|null $xmlObject
 	 *
 	 * @return string the etag or an empty string if the getetag property does not exist
 	 */
-	public function getEtagFromResponseXmlObject():string {
-		$xmlObject = $this->getResponseXmlObject();
+	public function getEtagFromResponseXmlObject(?SimpleXMLElement $xmlObject = null):string {
+		$xmlObject = $xmlObject ?? $this->getResponseXmlObject();
 		$xmlPart = $xmlObject->xpath("//d:prop/d:getetag");
 		if (!\is_array($xmlPart) || (\count($xmlPart) === 0)) {
 			return '';

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -152,8 +152,8 @@ trait WebDav {
 	 *
 	 * @return string the etag or an empty string if the getetag property does not exist
 	 */
-	public function getEtagFromResponseXmlObject(?SimpleXMLElement $xmlObject = null):string {
-		$xmlObject = $xmlObject ?? $this->getResponseXmlObject();
+	public function getEtagFromResponseXmlObject(?SimpleXMLElement $xmlObject = null): string {
+		$xmlObject = $xmlObject ?? $this->getResponseXml();
 		$xmlPart = $xmlObject->xpath("//d:prop/d:getetag");
 		if (!\is_array($xmlPart) || (\count($xmlPart) === 0)) {
 			return '';

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -167,10 +167,7 @@ trait WebDav {
 	 *
 	 * @return boolean
 	 */
-	public function isEtagValid(?string $eTag = null):bool {
-		if ($eTag === null) {
-			$eTag = $this->getEtagFromResponseXmlObject();
-		}
+	public function isEtagValid($eTag):bool {
 		if (\preg_match("/^\"[a-f0-9:\.]{1,32}\"$/", $eTag)
 		) {
 			return true;
@@ -1690,7 +1687,7 @@ trait WebDav {
 		$statusCode = $response->getStatusCode();
 		if ($statusCode < 401 || $statusCode > 404) {
 			try {
-				$this->responseXmlObject = HttpRequestHelper::getResponseXml(
+				$responseXml = $this->featureContext->getResponseXml(
 					$response,
 					__METHOD__
 				);
@@ -1700,10 +1697,10 @@ trait WebDav {
 				);
 			}
 			Assert::assertTrue(
-				$this->isEtagValid(),
+				$this->isEtagValid($this->getEtagFromResponseXmlObject($responseXml)),
 				"$entry '$path' should not exist. But API returned $statusCode without an etag in the body"
 			);
-			$isCollection = $this->getResponseXmlObject()->xpath("//d:prop/d:resourcetype/d:collection");
+			$isCollection = $responseXml->xpath("//d:prop/d:resourcetype/d:collection");
 			if (\count($isCollection) === 0) {
 				$actualResourceType = "file";
 			} else {
@@ -1759,7 +1756,7 @@ trait WebDav {
 	):void {
 		$user = $this->getActualUsername($user);
 		$path = $this->substituteInLineCodes($path);
-		$this->responseXmlObject = $this->listFolderAndReturnResponseXml(
+		$responseXml = $this->listFolderAndReturnResponseXml(
 			$user,
 			$path,
 			'0',
@@ -1767,16 +1764,15 @@ trait WebDav {
 			$type
 		);
 		Assert::assertTrue(
-			$this->isEtagValid(),
+			$this->isEtagValid($this->getEtagFromResponseXmlObject($responseXml)),
 			"$entry '$path' expected to exist for user $user but not found"
 		);
-		$isCollection = $this->getResponseXmlObject()->xpath("//d:prop/d:resourcetype/d:collection");
+		$isCollection = $responseXml->xpath("//d:prop/d:resourcetype/d:collection");
 		if ($entry === "folder") {
 			Assert::assertEquals(\count($isCollection), 1, "Unexpectedly, `$path` is not a folder");
 		} elseif ($entry === "file") {
 			Assert::assertEquals(\count($isCollection), 0, "Unexpectedly, `$path` is not a file");
 		}
-		$this->emptyLastHTTPStatusCodesArray();
 	}
 
 	/**
@@ -1840,12 +1836,12 @@ trait WebDav {
 		$numEntriesThatExist = 0;
 		foreach ($table->getTable() as $row) {
 			$path = $this->substituteInLineCodes($row[0]);
-			$this->responseXmlObject = $this->listFolderAndReturnResponseXml(
+			$responseXml = $this->listFolderAndReturnResponseXml(
 				$user,
 				$path,
 				'0'
 			);
-			if ($this->isEtagValid()) {
+			if ($this->isEtagValid($this->getEtagFromResponseXmlObject($responseXml))) {
 				$numEntriesThatExist = $numEntriesThatExist + 1;
 			}
 		}

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -163,11 +163,11 @@ trait WebDav {
 
 	/**
 	 *
-	 * @param string|null $eTag if null then get eTag from response XML object
+	 * @param string $eTag
 	 *
 	 * @return boolean
 	 */
-	public function isEtagValid($eTag):bool {
+	public function isEtagValid(string $eTag): bool {
 		if (\preg_match("/^\"[a-f0-9:\.]{1,32}\"$/", $eTag)
 		) {
 			return true;

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -1108,10 +1108,10 @@ class WebDavPropertiesContext implements Context {
 	 * @param string $path
 	 * @param string|null $storePath
 	 *
-	 * @return void
+	 * @return SimpleXMLElement
 	 * @throws Exception
 	 */
-	public function storeEtagOfElement(string $user, string $path, ?string $storePath = ""):void {
+	public function storeEtagOfElement(string $user, string $path, ?string $storePath = ""):SimpleXMLElement {
 		if ($storePath === "") {
 			$storePath = $path;
 		}
@@ -1122,8 +1122,10 @@ class WebDavPropertiesContext implements Context {
 			$path,
 			$propertiesTable
 		);
+		$xmlObject = HttpRequestHelper::getResponseXml($response);
 		$this->storedETAG[$user][$storePath]
-			= $this->featureContext->getEtagFromResponseXmlObject(HttpRequestHelper::getResponseXml($response));
+			= $this->featureContext->getEtagFromResponseXmlObject($xmlObject);
+		return $xmlObject;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -125,7 +125,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userGetsPropertiesOfFolder(
+	public function userGetsFollowingPropertiesOfEntryUsingWebDavApi(
 		string $user,
 		string $path,
 		TableNode $propertiesTable
@@ -227,7 +227,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return ResponseInterface
 	 * @throws Exception
 	 */
-	public function getPropertiesOfPublicFolder(string $path, TableNode $propertiesTable): ResponseInterface {
+	public function getPropertiesOfEntryFromLastLinkShare(string $path, TableNode $propertiesTable): ResponseInterface {
 		$user = $this->featureContext->getLastCreatedPublicShareToken();
 		$properties = null;
 		foreach ($propertiesTable->getRows() as $row) {
@@ -251,8 +251,8 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function publicGetsThePropertiesOfFolder(string $path, TableNode $propertiesTable):void {
-		$response = $this->getPropertiesOfPublicFolder($path, $propertiesTable);
+	public function thePublicGetsFollowingPropertiesOfEntryFromLastLinkShare(string $path, TableNode $propertiesTable):void {
+		$response = $this->getPropertiesOfEntryFromLastLinkShare($path, $propertiesTable);
 		$this->featureContext->setResponse($response);
 	}
 
@@ -727,7 +727,7 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function publicGetsThePropertiesOfFolderAndAssertValueOfItemInResponseRegExp(string $xpath, string $path, string $pattern):void {
 		$propertiesTable = new TableNode([['propertyName'],['d:lockdiscovery']]);
-		$response = $this->getPropertiesOfPublicFolder($path, $propertiesTable);
+		$response = $this->getPropertiesOfEntryFromLastLinkShare($path, $propertiesTable);
 		$this->featureContext->theHTTPStatusCodeShouldBe('207', "", $response);
 		$this->assertXpathValueMatchesPattern(
 			$this->featureContext->getResponseXml($response),
@@ -847,7 +847,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function assertValueOfItemInResponseToUserRegExp(string $xpath, ?string $user, string $pattern, ?SimpleXMLElement $responseXml = null):void {
+	public function theValueOfItemInResponseToUserShouldMatch(string $xpath, ?string $user, string $pattern, ?SimpleXMLElement $responseXml = null):void {
 		$resXml = $this->featureContext->getResponseXml();
 		$this->assertXpathValueMatchesPattern($resXml, $xpath, $pattern, $user);
 	}

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -62,7 +62,6 @@ class WebDavPropertiesContext implements Context {
 			'0'
 		);
 		$this->featureContext->setResponse($response);
-		$this->featureContext->setResponseXmlObject(HttpRequestHelper::getResponseXml($response));
 	}
 
 	/**
@@ -86,7 +85,6 @@ class WebDavPropertiesContext implements Context {
 			$depth
 		);
 		$this->featureContext->setResponse($response);
-		$this->featureContext->setResponseXmlObject(HttpRequestHelper::getResponseXml($response));
 	}
 
 	/**
@@ -135,79 +133,7 @@ class WebDavPropertiesContext implements Context {
 	):void {
 		$response = $this->getPropertiesOfFolder($user, $path, $propertiesTable);
 		$this->featureContext->setResponse($response);
-		$this->featureContext->setResponseXmlObject(HttpRequestHelper::getResponseXml($response));
 		$this->featureContext->pushToLastStatusCodesArrays();
-	}
-
-	/**
-	 * @param string $user
-	 * @param string $path
-	 * @param TableNode $propertiesTable
-	 * @param string $depth
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function getFollowingCommentPropertiesOfFileUsingWebDAVPropfindApi(
-		string $user,
-		string $path,
-		TableNode $propertiesTable,
-		string $depth = "1"
-	):void {
-		$properties = null;
-		$this->featureContext->verifyTableNodeColumns($propertiesTable, ["propertyName"]);
-		$this->featureContext->verifyTableNodeColumnsCount($propertiesTable, 1);
-		foreach ($propertiesTable->getColumnsHash() as $row) {
-			$properties[] = $row["propertyName"];
-		}
-
-		$user = $this->featureContext->getActualUsername($user);
-		$fileId = $this->featureContext->getFileIdForPath($user, $path);
-		$commentsPath = "/comments/files/$fileId/";
-		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolderAndReturnResponseXml(
-				$user,
-				$commentsPath,
-				$depth,
-				$properties,
-				"comments"
-			)
-		);
-	}
-
-	/**
-	 * @When user :user gets the following comment properties of file :path using the WebDAV PROPFIND API
-	 *
-	 * @param string $user
-	 * @param string $path
-	 * @param TableNode $propertiesTable
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userGetsFollowingCommentPropertiesOfFileUsingWebDAVPropfindApi(string $user, string $path, TableNode $propertiesTable) {
-		$this->getFollowingCommentPropertiesOfFileUsingWebDAVPropfindApi(
-			$user,
-			$path,
-			$propertiesTable
-		);
-	}
-
-	/**
-	 * @When the user gets the following comment properties of file :arg1 using the WebDAV PROPFIND API
-	 *
-	 * @param string $path
-	 * @param TableNode $propertiesTable
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theUserGetsFollowingCommentPropertiesOfFileUsingWebDAVPropfindApi(string $path, TableNode $propertiesTable) {
-		$this->getFollowingCommentPropertiesOfFileUsingWebDAVPropfindApi(
-			$this->featureContext->getCurrentUser(),
-			$path,
-			$propertiesTable
-		);
 	}
 
 	/**
@@ -226,7 +152,6 @@ class WebDavPropertiesContext implements Context {
 			$propertiesTable
 		);
 		$this->featureContext->setResponse($response);
-		$this->featureContext->setResponseXmlObject(HttpRequestHelper::getResponseXml($response));
 	}
 
 	/**
@@ -331,7 +256,6 @@ class WebDavPropertiesContext implements Context {
 	public function publicGetsThePropertiesOfFolder(string $path, TableNode $propertiesTable):void {
 		$response = $this->publicGetThePropertiesOfFolder($path, $propertiesTable);
 		$this->featureContext->setResponse($response);
-		$this->featureContext->setResponseXmlObject(HttpRequestHelper::getResponseXml($response));
 	}
 
 	/**
@@ -438,13 +362,7 @@ class WebDavPropertiesContext implements Context {
 		string $namespaceString,
 		string $propertyValue
 	):void {
-		$this->featureContext->setResponseXmlObject(
-			HttpRequestHelper::getResponseXml(
-				$this->featureContext->getResponse(),
-				__METHOD__
-			)
-		);
-		$responseXmlObject = $this->featureContext->getResponseXmlObject();
+		$responseXmlObject = $this->featureContext->getResponseXml();
 		//calculate the namespace prefix and namespace
 		$matches = [];
 		\preg_match("/^(.*)='(.*)'$/", $namespaceString, $matches);
@@ -487,13 +405,7 @@ class WebDavPropertiesContext implements Context {
 	):void {
 		// let's unescape quotes first
 		$propertyValue = \str_replace('\"', '"', $propertyValue);
-		$this->featureContext->setResponseXmlObject(
-			HttpRequestHelper::getResponseXml(
-				$this->featureContext->getResponse(),
-				__METHOD__
-			)
-		);
-		$responseXmlObject = $this->featureContext->getResponseXmlObject();
+		$responseXmlObject = $this->featureContext->getResponseXml();
 		//calculate the namespace prefix and namespace
 		$matches = [];
 		\preg_match("/^(.*)='(.*)'$/", $namespaceString, $matches);
@@ -555,7 +467,8 @@ class WebDavPropertiesContext implements Context {
 		string $key,
 		string $expectedValue
 	):void {
-		$this->checkSingleResponseContainsAPropertyWithValueAndAlternative(
+		$this->checkResponseContainsAPropertyWithValue(
+			$this->featureContext->getResponse(),
 			$key,
 			$expectedValue,
 			$expectedValue
@@ -577,7 +490,8 @@ class WebDavPropertiesContext implements Context {
 		string $key,
 		string $expectedValue
 	):void {
-		$this->checkSingleResponseContainsAPropertyWithValueAndAlternative(
+		$this->checkResponseContainsAPropertyWithValue(
+			$this->featureContext->getResponse(),
 			$key,
 			$expectedValue,
 			$expectedValue,
@@ -600,7 +514,8 @@ class WebDavPropertiesContext implements Context {
 		string $expectedValue,
 		string $altExpectedValue
 	):void {
-		$this->checkSingleResponseContainsAPropertyWithValueAndAlternative(
+		$this->checkResponseContainsAPropertyWithValue(
+			$this->featureContext->getResponse(),
 			$key,
 			$expectedValue,
 			$altExpectedValue
@@ -608,6 +523,7 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @param ResponseInterface $response
 	 * @param string $key
 	 * @param string $expectedValue
 	 * @param string $altExpectedValue
@@ -616,13 +532,14 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function checkSingleResponseContainsAPropertyWithValueAndAlternative(
+	public function checkResponseContainsAPropertyWithValue(
+		ResponseInterface $response,
 		string $key,
 		string $expectedValue,
 		string $altExpectedValue,
 		?string $user = null
 	):void {
-		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
+		$xmlPart = $this->featureContext->getResponseXml($response)->xpath(
 			"//d:prop/$key"
 		);
 		Assert::assertTrue(
@@ -995,15 +912,14 @@ class WebDavPropertiesContext implements Context {
 		string $expectedValue,
 		string $altExpectedValue
 	):void {
-		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolderAndReturnResponseXml(
-				$user,
-				$path,
-				'0',
-				[$property]
-			)
+		$response = $this->featureContext->listFolder(
+			$user,
+			$path,
+			'0',
+			[$property]
 		);
-		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
+		$this->checkResponseContainsAPropertyWithValue(
+			$response,
 			$property,
 			$expectedValue,
 			$altExpectedValue

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -181,7 +181,7 @@ class WebDavPropertiesContext implements Context {
 			$this->featureContext->getStepLineRef(),
 			$this->featureContext->getDavPathVersion()
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBe(207, "", $response);
 	}
 
 	/**
@@ -342,7 +342,7 @@ class WebDavPropertiesContext implements Context {
 			$path,
 			$propertyValue
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
+		$this->featureContext->theHTTPStatusCodeShouldBe(207, "", $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -360,7 +360,10 @@ class WebDavPropertiesContext implements Context {
 		string $namespaceString,
 		string $propertyValue
 	):void {
-		$responseXmlObject = $this->featureContext->getResponseXml();
+		$responseXmlObject = $this->featureContext->getResponseXml(
+			$this->featureContext->getResponse(),
+			__METHOD__
+		);
 		//calculate the namespace prefix and namespace
 		$matches = [];
 		\preg_match("/^(.*)='(.*)'$/", $namespaceString, $matches);
@@ -403,7 +406,10 @@ class WebDavPropertiesContext implements Context {
 	):void {
 		// let's unescape quotes first
 		$propertyValue = \str_replace('\"', '"', $propertyValue);
-		$responseXmlObject = $this->featureContext->getResponseXml();
+		$responseXmlObject = $this->featureContext->getResponseXml(
+			$this->featureContext->getResponse(),
+			__METHOD__
+		);
 		//calculate the namespace prefix and namespace
 		$matches = [];
 		\preg_match("/^(.*)='(.*)'$/", $namespaceString, $matches);
@@ -537,9 +543,7 @@ class WebDavPropertiesContext implements Context {
 		string $altExpectedValue,
 		?string $user = null
 	):void {
-		var_dump($response->getStatusCode());
 		$xmlPart = $this->featureContext->getResponseXml($response);
-		var_dump($xmlPart);
 		$xmlPart = $xmlPart->xpath(
 			"//d:prop/$key"
 		);
@@ -613,7 +617,10 @@ class WebDavPropertiesContext implements Context {
 	 * @throws Exception
 	 */
 	public function assertValueOfItemInResponseAboutUserIs(string $xpath, ?string $user, string $expectedValue):void {
-		$resXml = $this->featureContext->getResponseXml();
+		$resXml = $this->featureContext->getResponseXml(
+			$this->featureContext->getResponse(),
+			__METHOD__
+		);
 		$value = $this->getXmlItemByXpath($resXml, $xpath);
 		$user = $this->featureContext->getActualUsername($user);
 		$expectedValue = $this->featureContext->substituteInLineCodes(
@@ -647,7 +654,10 @@ class WebDavPropertiesContext implements Context {
 		if (!$expectedValue2) {
 			$expectedValue2 = $expectedValue1;
 		}
-		$resXml = $this->featureContext->getResponseXml();
+		$resXml = $this->featureContext->getResponseXml(
+			$this->featureContext->getResponse(),
+			__METHOD__
+		);
 		$value = $this->getXmlItemByXpath($resXml, $xpath);
 		$user = $this->featureContext->getActualUsername($user);
 		$expectedValue1 = $this->featureContext->substituteInLineCodes(
@@ -736,7 +746,10 @@ class WebDavPropertiesContext implements Context {
 	 * @throws Exception
 	 */
 	public function assertEntryWithHrefMatchingRegExpInResponseToUser(string $expectedHref, string $user):void {
-		$resXml = $this->featureContext->getResponseXml();
+		$resXml = $this->featureContext->getResponseXml(
+			$this->featureContext->getResponse(),
+			__METHOD__
+		);
 
 		$user = $this->featureContext->getActualUsername($user);
 		$expectedHref = $this->featureContext->substituteInLineCodes(
@@ -1102,7 +1115,7 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function thePropertiesResponseShouldContainAnEtag():void {
 		Assert::assertTrue(
-			$this->featureContext->isEtagValid(),
+			$this->featureContext->isEtagValid($this->featureContext->getEtagFromResponseXmlObject()),
 			__METHOD__
 			. " getetag not found in response"
 		);

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -17,7 +17,7 @@ Feature: sharing
     When user "Alice" gets the following properties of file "/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
       | dav-path-version |
@@ -38,7 +38,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/Shares/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
       | dav-path-version |
@@ -60,7 +60,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/Shares/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
       | dav-path-version |
@@ -75,7 +75,7 @@ Feature: sharing
     And user "Brian" has accepted share "/tmp.txt" offered by user "Alice"
     When user "Alice" updates the last share using the sharing API with
       | permissions | update,read |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And as user "Brian" file "/Shares/tmp.txt" should contain a property "ocs:share-permissions" with value "3"
     Examples:
       | dav-path-version |
@@ -97,7 +97,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/Shares/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "3"
     Examples:
       | dav-path-version |
@@ -112,7 +112,7 @@ Feature: sharing
     And user "Brian" has accepted share "/tmp.txt" offered by user "Alice"
     When user "Alice" updates the last share using the sharing API with
       | permissions | share,read |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And as user "Brian" file "/Shares/tmp.txt" should contain a property "ocs:share-permissions" with value "17"
     Examples:
       | dav-path-version |
@@ -134,7 +134,7 @@ Feature: sharing
     When user "Brian" gets the following properties of file "/Shares/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "17"
     Examples:
       | dav-path-version |
@@ -148,7 +148,7 @@ Feature: sharing
     When user "Alice" gets the following properties of folder "/" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
       | dav-path-version |
@@ -169,7 +169,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
       | dav-path-version |
@@ -190,7 +190,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
       | dav-path-version |
@@ -227,7 +227,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "29"
     Examples:
       | dav-path-version |
@@ -264,7 +264,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "27"
     Examples:
       | dav-path-version |
@@ -301,7 +301,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "23"
     Examples:
       | dav-path-version |
@@ -338,7 +338,7 @@ Feature: sharing
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "ocs:share-permissions" with value "15"
     Examples:
       | dav-path-version |

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -75,7 +75,7 @@ Feature: sharing
     And user "Brian" has accepted share "/tmp.txt" offered by user "Alice"
     When user "Alice" updates the last share using the sharing API with
       | permissions | update,read |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And as user "Brian" file "/Shares/tmp.txt" should contain a property "ocs:share-permissions" with value "3"
     Examples:
       | dav-path-version |
@@ -112,7 +112,7 @@ Feature: sharing
     And user "Brian" has accepted share "/tmp.txt" offered by user "Alice"
     When user "Alice" updates the last share using the sharing API with
       | permissions | share,read |
-    Then the HTTP status code should be "207"
+    Then the HTTP status code should be "200"
     And as user "Brian" file "/Shares/tmp.txt" should contain a property "ocs:share-permissions" with value "17"
     Examples:
       | dav-path-version |

--- a/tests/acceptance/features/coreApiWebdavProperties1/createFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/createFileFolder.feature
@@ -51,7 +51,7 @@ Feature: create files and folder
     When user "Alice" gets the following properties of folder "/test_folder" using the WebDAV API
       | propertyName   |
       | d:resourcetype |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:
       | dav-path-version |
@@ -70,7 +70,7 @@ Feature: create files and folder
     When user "Alice" gets the following properties of folder "/test_folder:5" using the WebDAV API
       | propertyName   |
       | d:resourcetype |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:
       | dav-path-version |

--- a/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
@@ -12,7 +12,7 @@ Feature: get file properties
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "<file_name>"
     When user "Alice" gets the properties of file "<file_name>" using the WebDAV API
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the properties response should contain an etag
     Examples:
       | dav-path-version | file_name         |
@@ -38,7 +38,7 @@ Feature: get file properties
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "<file_name>"
     When user "Alice" gets the properties of file "<file_name>" using the WebDAV API
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the properties response should contain an etag
     And there should be an entry with href containing "<expected_href>" in the response to user "Alice"
     Examples:
@@ -67,7 +67,7 @@ Feature: get file properties
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file1.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file2.txt"
     When user "Alice" gets the properties of folder "<folder_name>" with depth 1 using the WebDAV API
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And there should be an entry with href containing "<expected_href>/" in the response to user "Alice"
     And there should be an entry with href containing "<expected_href>/file1.txt" in the response to user "Alice"
     And there should be an entry with href containing "<expected_href>/file2.txt" in the response to user "Alice"
@@ -105,7 +105,7 @@ Feature: get file properties
     And user "Alice" has created folder "<folder_name>"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/<file_name>"
     When user "Alice" gets the properties of file "<folder_name>/<file_name>" using the WebDAV API
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the properties response should contain an etag
     Examples:
       | dav-path-version | folder_name                      | file_name                     |
@@ -136,7 +136,7 @@ Feature: get file properties
     And user "Alice" has created folder "/folder ?2.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/folder ?2.txt/file ?2.txt"
     When user "Alice" gets the properties of file "/folder ?2.txt/file ?2.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the properties response should contain an etag
     Examples:
       | dav-path-version |
@@ -155,7 +155,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:share-types |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the response should contain an empty property "oc:share-types"
     Examples:
       | dav-path-version |
@@ -180,7 +180,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:share-types |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the response should contain a share-types property with
       | 0 |
     Examples:
@@ -206,7 +206,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:share-types |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the response should contain a share-types property with
       | 1 |
     Examples:
@@ -229,7 +229,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:share-types |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the response should contain a share-types property with
       | 3 |
     Examples:
@@ -264,7 +264,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:share-types |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "207"
     And the response should contain a share-types property with
       | 0 |
       | 1 |
@@ -286,7 +286,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of file "/somefile.txt" using the WebDAV API
       | propertyName   |
       | oc:privatelink |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
     Examples:
       | dav-path-version |
@@ -329,7 +329,7 @@ Feature: get file properties
       | propertyName |
       | oc:testprop1 |
       | oc:testprop2 |
-    Then the HTTP status code should be success
+    Then the HTTP status code should be "207"
     And as user "Alice" the last response should have the following properties
       | resource              | propertyName | propertyValue   |
       | /TestFolder/test1.txt | testprop1    | AAAAA           |
@@ -363,7 +363,7 @@ Feature: get file properties
       | propertyName |
       | oc:testprop1 |
       | oc:testprop2 |
-    Then the HTTP status code should be success
+    Then the HTTP status code should be "207"
     And as user "Alice" the last response should have the following properties
       | resource              | propertyName | propertyValue          |
       | /TestFolder/test1.txt | testprop1    | AAAAA                  |
@@ -388,7 +388,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName      |
       | d:getlastmodified |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "d:getlastmodified" with value like "/^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$/"
     Examples:
       | dav-path-version |
@@ -407,7 +407,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName     |
       | d:getcontenttype |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "d:getcontenttype" with value ""
     Examples:
       | dav-path-version |
@@ -426,7 +426,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName     |
       | d:getcontenttype |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "d:getcontenttype" with value "text/plain.*"
     Examples:
       | dav-path-version |
@@ -445,7 +445,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName |
       | d:getetag    |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "d:getetag" with value like '%\"[a-z0-9:]{1,32}\"%'
     Examples:
       | dav-path-version |
@@ -464,7 +464,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName   |
       | d:resourcetype |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "d:resourcetype" with value ""
     Examples:
       | dav-path-version |
@@ -483,7 +483,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName |
       | oc:size      |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:size" with value "16"
     Examples:
       | dav-path-version |
@@ -502,7 +502,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName |
       | oc:size      |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:size" with value "0"
     Examples:
       | dav-path-version |
@@ -521,7 +521,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName |
       | oc:fileid    |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:fileid" with value like '/[a-zA-Z0-9]+/'
     Examples:
       | dav-path-version |
@@ -540,7 +540,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName |
       | oc:fileid    |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:fileid" with value like '/[a-zA-Z0-9]+/'
     Examples:
       | dav-path-version |
@@ -559,7 +559,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of file "file.txt" using the WebDAV API
       | propertyName          |
       | oc:owner-display-name |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response about the file owned by "Alice" should contain a property "oc:owner-display-name" with value "%displayname%"
     Examples:
       | dav-path-version |
@@ -578,7 +578,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName          |
       | oc:owner-display-name |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response about the file owned by "Alice" should contain a property "oc:owner-display-name" with value "%displayname%"
     Examples:
       | dav-path-version |
@@ -597,7 +597,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName   |
       | oc:permissions |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:permissions" with value like '/RM{0,1}DNVW/'
     Examples:
       | dav-path-version |
@@ -616,7 +616,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:permissions |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:permissions" with value like '/RM{0,1}DNVCK/'
     Examples:
       | dav-path-version |
@@ -640,7 +640,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName |
       | oc:size      |
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "207"
     And the single response should contain a property "oc:size" with value "5"
     Examples:
       | dav-path-version |


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `WebdavPropertiesContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 