### PR TITLE
[docs-only]Remove deprecated env

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -801,7 +801,6 @@ def localApiTests(suite, storage, extra_environment = {}):
         "TEST_SERVER_URL": "https://ocis-server:9200",
         "OCIS_REVA_DATA_ROOT": "%s" % (dirs["ocisRevaDataRoot"] if storage == "owncloud" else ""),
         "OCIS_SKELETON_STRATEGY": "%s" % ("copy" if storage == "owncloud" else "upload"),
-        "TEST_OCIS": "true",
         "SEND_SCENARIO_LINE_REFERENCES": "true",
         "STORAGE_DRIVER": storage,
         "BEHAT_SUITE": suite,
@@ -986,7 +985,6 @@ def coreApiTests(ctx, part_number = 1, number_of_parts = 1, storage = "ocis", ac
                              "TEST_SERVER_URL": "https://ocis-server:9200",
                              "OCIS_REVA_DATA_ROOT": "%s" % (dirs["ocisRevaDataRoot"] if storage == "owncloud" else ""),
                              "OCIS_SKELETON_STRATEGY": "%s" % ("copy" if storage == "owncloud" else "upload"),
-                             "TEST_OCIS": "true",
                              "SEND_SCENARIO_LINE_REFERENCES": "true",
                              "STORAGE_DRIVER": storage,
                              "BEHAT_FILTER_TAGS": filterTags,
@@ -1095,7 +1093,6 @@ def uiTestPipeline(ctx, filterTags, runPart = 1, numberOfParts = 1, storage = "o
                          "environment": {
                              "SERVER_HOST": "https://ocis-server:9200",
                              "BACKEND_HOST": "https://ocis-server:9200",
-                             "RUN_ON_OCIS": "true",
                              "OCIS_REVA_DATA_ROOT": "%s" % dirs["ocisRevaDataRoot"],
                              "WEB_UI_CONFIG_FILE": "%s/%s" % (dirs["base"], dirs["ocisConfig"]),
                              "TEST_TAGS": finalFilterTags,

--- a/docs/ocis/development/testing.md
+++ b/docs/ocis/development/testing.md
@@ -224,7 +224,6 @@ ocis/bin/ocis server
 make test-acceptance-api \
 TEST_SERVER_URL=https://localhost:9200 \
 TEST_WITH_GRAPH_API=true \
-TEST_OCIS=true \
 ```
 
 #### Run Tests Transferred From ownCloud Core (prefix `coreApi`)
@@ -233,7 +232,6 @@ TEST_OCIS=true \
 make test-acceptance-from-core-api \
 TEST_SERVER_URL=https://localhost:9200 \
 TEST_WITH_GRAPH_API=true \
-TEST_OCIS=true \
 ```
 
 Useful environment variables:
@@ -291,7 +289,6 @@ If you want to work on a specific issue
    ```bash
    make test-acceptance-from-core-api \
    TEST_SERVER_URL=https://localhost:9200 \
-   TEST_OCIS=true \
    TEST_WITH_GRAPH_API=true \
    STORAGE_DRIVER=OCIS \
    BEHAT_FEATURE='tests/acceptance/features/coreApiVersions/fileVersions.feature:147'
@@ -330,7 +327,6 @@ PROXY_ENABLE_BASIC_AUTH=true \
 ```bash
 OCIS_WRAPPER_URL=http://localhost:5200 \
 TEST_WITH_GRAPH_API=true \
-TEST_OCIS=true \
 TEST_SERVER_URL="https://localhost:9200" \
 BEHAT_FEATURE=tests/acceptance/features/apiAsyncUpload/delayPostprocessing.feature \
 make test-acceptance-api
@@ -379,7 +375,6 @@ Run the acceptance test with the following command:
 
 ```bash
 TEST_WITH_GRAPH_API=true \
-TEST_OCIS=true \
 TEST_SERVER_URL="https://localhost:9200" \
 EMAIL_HOST="localhost" \
 EMAIL_PORT=9000 \
@@ -423,7 +418,6 @@ Run the acceptance test with the following command:
 
 ```bash
 TEST_WITH_GRAPH_API=true \
-TEST_OCIS=true \
 TEST_SERVER_URL="https://localhost:9200" \
 BEHAT_FEATURE="tests/acceptance/features/apiSearch/contentSearch.feature" \
 make test-acceptance-api
@@ -464,7 +458,6 @@ make test-paralleldeployment-api \
 TEST_SERVER_URL="https://cloud.owncloud.test" \
 TEST_OC10_URL="http://localhost:8080" \
 TEST_PARALLEL_DEPLOYMENT=true \
-TEST_OCIS=true \
 TEST_WITH_LDAP=true \
 PATH_TO_CORE="<path_to_core>" \
 SKELETON_DIR="<path_to_core>/apps/testing/data/apiSkeleton"
@@ -547,7 +540,6 @@ Run the acceptance test with the following command:
 
 ```bash
 TEST_WITH_GRAPH_API=true \
-TEST_OCIS=true \
 TEST_SERVER_URL="https://localhost:9200" \
 BEHAT_FEATURE="tests/acceptance/features/apiAntivirus/antivirus.feature" \
 make test-acceptance-api

--- a/tests/acceptance/docker/src/acceptance.yml
+++ b/tests/acceptance/docker/src/acceptance.yml
@@ -5,8 +5,6 @@ services:
     command: /bin/bash /test/run-tests.sh
     environment:
       OCIS_ROOT: /drone/src
-      TEST_OCIS: "true"
-      RUN_ON_OCIS: "true"
       TEST_SERVER_URL: https://ocis-server:9200
       TEST_WITH_GRAPH_API: "true"
       OCIS_WRAPPER_URL: http://ocis-server:5200

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -529,14 +529,6 @@ export IPV4_URL
 export IPV6_URL
 export FILES_FOR_UPLOAD="${SCRIPT_PATH}/filesForUpload/"
 
-if [ "${TEST_OCIS}" != "true" ] && [ "${TEST_REVA}" != "true" ]
-then
-	# We are testing on an ownCloud core server.
-	# Tell the tests to wait 1 second between each upload/delete action
-	# to avoid problems with actions that depend on timestamps in seconds.
-	export UPLOAD_DELETE_WAIT_TIME=1
-fi
-
 TEST_LOG_FILE=$(mktemp)
 SCENARIOS_THAT_PASSED=0
 SCENARIOS_THAT_FAILED=0


### PR DESCRIPTION
## Description
Now core tests have been transferred to ocis repo so we don't need `TEST_OCIS` and `RUN_ON_OCIS` env. So removing `TEST_OCIS` and `RUN_ON_OCIS`

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/7300

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
