### PR TITLE
SSE Scalability

### DIFF
--- a/changelog/unreleased/sse-scalability.md
+++ b/changelog/unreleased/sse-scalability.md
@@ -1,0 +1,5 @@
+Enhancement: Make sse service scalable
+
+When running multiple sse instances some events would not be reported to the user. This is fixed.
+
+https://github.com/owncloud/ocis/pull/7382

--- a/services/sse/pkg/command/server.go
+++ b/services/sse/pkg/command/server.go
@@ -72,6 +72,9 @@ func Server(cfg *config.Config) *cli.Command {
 					http.RegisteredEvents(_registeredEvents),
 					http.TracerProvider(tracerProvider),
 				)
+				if err != nil {
+					return err
+				}
 
 				gr.Add(server.Run, func(_ error) {
 					cancel()

--- a/services/sse/pkg/server/http/server.go
+++ b/services/sse/pkg/server/http/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
 	"github.com/owncloud/ocis/v2/ocis-pkg/account"
 	"github.com/owncloud/ocis/v2/ocis-pkg/cors"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
@@ -78,7 +79,7 @@ func Server(opts ...Option) (http.Service, error) {
 		),
 	)
 
-	ch, err := events.Consume(options.Consumer, "sse", options.RegisteredEvents...)
+	ch, err := events.Consume(options.Consumer, "sse-"+uuid.New().String(), options.RegisteredEvents...)
 	if err != nil {
 		return http.Service{}, err
 	}


### PR DESCRIPTION
There is a technical issue when running multiple `sse` service instances.

Consider running two `sse` instances `A` and `B`. When calling `/sse` endpoint you will be connected to one of them, let's say `A`. But when an event happens only one of the services will get it, because they are both in the same consumer group. If service `B` gets the event it will not be able to send a message to the client because the `sse` library we are using is storing connections in memory (which makes sense because there is no need to persist them).

This PR adds unique consumer groups to each `sse` service. This way all services will get all events and can therefore always transmit the message to the client.