### PR TITLE
proxy: User ReverseProxy.Rewrite instead of Director

### DIFF
--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -204,7 +204,6 @@ func evalRequestURI(l userAgentLocker, r regexp.Regexp) {
 			return
 		}
 	}
-	l.w.Header().Add(WwwAuthenticate, fmt.Sprintf("%v realm=\"%s\", charset=\"UTF-8\"", caser.String(l.fallback), l.r.Host))
 }
 
 func getTraceProvider(o Options) trace.TracerProvider {

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -89,13 +89,7 @@ func Authentication(auths []Authenticator, opts ...Option) func(next http.Handle
 				}
 
 				// if the request is not bound to any user agent, write all available challenges
-				if !touch &&
-					// This is a temporary hack... Before the authentication middleware rewrite all
-					// unauthenticated requests were still handled. The reva http services then did add
-					// the supported authentication headers to the response. Since we are not allowing the
-					// requests to continue so far we have to do it here. But we shouldn't do it for the graph service.
-					// That's the reason for this hard check here.
-					!strings.HasPrefix(r.URL.Path, "/graph") {
+				if !touch {
 					writeSupportedAuthenticateHeader(w, r)
 				}
 			}

--- a/services/proxy/pkg/proxy/proxy.go
+++ b/services/proxy/pkg/proxy/proxy.go
@@ -36,9 +36,9 @@ func NewMultiHostReverseProxy(opts ...Option) (*MultiHostReverseProxy, error) {
 		config:    options.Config,
 	}
 
-	rp.Director = func(r *http.Request) {
-		ri := router.ContextRoutingInfo(r.Context())
-		ri.Director()(r)
+	rp.Rewrite = func(r *httputil.ProxyRequest) {
+		ri := router.ContextRoutingInfo(r.In.Context())
+		ri.Rewrite()(r)
 	}
 
 	tlsConf := &tls.Config{

--- a/services/proxy/pkg/router/router_test.go
+++ b/services/proxy/pkg/router/router_test.go
@@ -1,9 +1,11 @@
 package router
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
 	"testing"
 
@@ -146,10 +148,14 @@ func TestRouter(t *testing.T) {
 			t.Errorf("TestRouter route flag unprotected expected to be %t got %t", test.unprotected, routingInfo.IsRouteUnprotected())
 		}
 
-		routingInfo.Director()(r)
+		pr := &httputil.ProxyRequest{
+			In:  r,
+			Out: r.Clone(context.Background()),
+		}
+		routingInfo.Rewrite()(pr)
 
-		if r.URL.Host != test.target {
-			t.Errorf("TestRouter got host %s expected %s", r.URL.Host, test.target)
+		if pr.Out.URL.Host != test.target {
+			t.Errorf("TestRouter got host %s expected %s", pr.Out.URL.Host, test.target)
 		}
 	}
 }


### PR DESCRIPTION
 With Go 1.20 the "Rewrite" hook for ReverseProxy was introduced to supersede of the "Director" hook (see:
https://github.com/golang/go/commit/a55793835f16d0242be18aff4ec0bd13494175bd)
    
The Rewrite hooks allows for better separation between the incoming and outgoing request. In particular it makes it pretty easy to set the  correct X-Forwarded-* Headers on the outgoing request.  The need for using "Rewrite" came up when trying to embed authelia. It uses the X-Forwarded-Host and X-Forwared-Proto headers to e.g. compute the correct return values for the various endpoints in .well-known/openid-configuration.

Note: This commit is outcome of the prove of concept work on embedding authelia into ocis: https://github.com/rhafer/ocis/tree/authelia-experiment but I think it is useful on its own.



