### PR TITLE
[tests-only] Extended test coverage for depth:infinity enabled config

### DIFF
--- a/tests/acceptance/features/apiDepthInfinity/propfind.feature
+++ b/tests/acceptance/features/apiDepthInfinity/propfind.feature
@@ -116,3 +116,30 @@ Feature: PROPFIND with depth:infinity
       | dav-path-version |
       | new              |
       | spaces           |
+
+
+  Scenario: get the list of resources in a folder shared through public link with depth infinity when depth infinity is not allowed
+    Given the following configs have been set:
+      | config                                       | value |
+      | OCDAV_ALLOW_PROPFIND_DEPTH_INFINITY          | false |
+      | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
+    And using new DAV path
+    And user "Alice" has created a public link share of folder "simple-folder"
+    When the public lists the resources in the last created public link with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "400"
+
+
+  Scenario Outline: get the list of files in the trashbin with depth infinity when depth infinity is not allowed
+    Given the config "OCDAV_ALLOW_PROPFIND_DEPTH_INFINITY" has been set to "false"
+    And using <dav-path-version> DAV path
+    And user "Alice" has deleted the following resources
+      | path          |
+      | textfile0.txt |
+      | welcome.txt   |
+      | simple-folder |
+    When user "Alice" lists the resources in the trashbin with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "400"
+    Examples:
+      | dav-path-version |
+      | new              |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
@@ -37,6 +37,8 @@ Feature: PROPFIND
       | /remote.php/dav/spaces/%spaceid% | 0        | 207       |
       | /remote.php/dav/spaces/%spaceid% | 1        | 207       |
       | /remote.php/dav/spaces/%spaceid% | infinity | 400       |
+      | /remote.php/webdav               | infinity | 400       |
+      | /remote.php/dav/files/alice      | infinity | 400       |
 
 
   Scenario: send PROPFIND request to a public link shared with password


### PR DESCRIPTION
## Description
Extended test coverage for depth:infinity enabled config.

## Related Issue
~Blocked until https://github.com/owncloud/ocis/issues/7359~

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
