### PR TITLE
[tests-only][full-ci]add test for copy with fileID

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
@@ -72,3 +72,79 @@ Feature: copying file using file id
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
       | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file into a folder in project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "/folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" copies a file "/textfile.txt" into "/folder" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    And for user "Alice" folder "folder" of the space "project-space" should contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file into a sub-folder in project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" copies a file "/textfile.txt" into "/folder/sub-folder" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    And for user "Alice" folder "folder/sub-folder" of the space "project-space" should contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file from a folder into root of project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" copies a file "folder/textfile.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    And for user "Alice" folder "folder" of the space "project-space" should contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file from sub-folder into root of project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/sub-folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" copies a file "folder/sub-folder/textfile.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    And for user "Alice" folder "folder/sub-folder" of the space "project-space" should contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |


### PR DESCRIPTION
### Description
This PR adds test coverage for copying the files within project space with the `url` consisting of the `file-id` not name.
This PR adds copying with file id only within `Project` Space

### Related issue: 
- https://github.com/owncloud/ocis/issues/6737