### PR TITLE
[tests-only] Fix share creation methods

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -657,6 +657,8 @@ class HttpRequestHelper {
 	 * @return array
 	 */
 	public static function parseResponseAsXml(ResponseInterface $response):array {
+		// rewind so that we can reparse it if it was parsed already
+		$response->getBody()->rewind();
 		$body = $response->getBody()->getContents();
 		$parsedResponse = [];
 		if ($body && \substr($body, 0, 1) === '<') {

--- a/tests/acceptance/features/apiNotification/emailNotification.feature
+++ b/tests/acceptance/features/apiNotification/emailNotification.feature
@@ -30,8 +30,9 @@ Feature: Email notification
 
   Scenario: user gets an email notification when someone shares a file
     Given user "Alice" has uploaded file with content "sample text" to "lorem.txt"
-    When user "Alice" has shared file "lorem.txt" with user "Brian" with permissions "17"
+    When user "Alice" shares file "lorem.txt" with user "Brian" with permissions "17" using the sharing API
     Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
     And user "Brian" should have received the following email from user "Alice"
       """
       Hello Brian Murphy
@@ -80,8 +81,9 @@ Feature: Email notification
     And user "Brian" has switched the system language to "es"
     And user "Carol" has switched the system language to "de"
     And user "Alice" has created folder "/HelloWorld"
-    When user "Alice" has shared folder "/HelloWorld" with group "group1"
+    When user "Alice" shares folder "HelloWorld" with group "group1" using the sharing API
     Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
     And user "Brian" should have received the following email from user "Alice"
       """
       Hola Brian Murphy
@@ -108,8 +110,9 @@ Feature: Email notification
     And user "Brian" has switched the system language to "es"
     And user "Carol" has switched the system language to "de"
     And user "Alice" has uploaded file with content "hello world" to "text.txt"
-    When user "Alice" has shared file "text.txt" with group "group1"
+    When user "Alice" shares file "text.txt" with group "group1" using the sharing API
     Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
     And user "Brian" should have received the following email from user "Alice"
       """
       Hola Brian Murphy

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -341,19 +341,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user creates a share using the sharing API with settings$/
-	 *
-	 * @param TableNode|null $body
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theUserCreatesAShareWithSettings(?TableNode $body):void {
-		$response = $this->createShareWithSettings($this->currentUser, $body);
-		$this->setResponse($response);
-	}
-
-	/**
 	 * @When /^user "([^"]*)" creates a public link share using the sharing API with settings$/
 	 *
 	 * @param string $user
@@ -398,20 +385,6 @@ trait Sharing {
 	 */
 	public function theUserCreatesAPublicLinkShareWithSettings(?TableNode $body):void {
 		$this->userCreatesAPublicLinkShareWithSettings($this->currentUser, $body);
-	}
-
-	/**
-	 * @Given /^the user has created a share with settings$/
-	 *
-	 * @param TableNode|null $body
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theUserHasCreatedAShareWithSettings(?TableNode $body):void {
-		$response = $this->createShareWithSettings($this->currentUser, $body);
-		$this->theHTTPStatusCodeShouldBe(200, "", $response);
-		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
 	}
 
 	/**
@@ -875,7 +848,9 @@ trait Sharing {
 		);
 
 		// save the created share data
-		if ($response->getStatusCode() === 200) {
+		if (($response->getStatusCode() === 200)
+			&& \in_array($this->ocsContext->getOCSResponseStatusCode($response), ['100', '200'])
+		) {
 			$xmlResponse = $this->getResponseXml($response);
 			if (isset($xmlResponse->data)) {
 				$shareData = $xmlResponse->data;

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1156,7 +1156,8 @@ class SpacesContext implements Context {
 			$ownerUser = $user;
 		}
 		$this->setSpaceIDByName($ownerUser, $spaceName);
-		$this->featureContext->userCreatesFolder($user, $folder);
+		$response = $this->featureContext->createFolder($user, $folder);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3702,7 +3702,7 @@ trait WebDav {
 			$admin,
 			__METHOD__ . "The provided user is not admin but '" . $admin . "'"
 		);
-		$response = $this->createFolder($user, $destination, true);
+		$response = $this->createFolder($admin, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for admin '$admin'",
@@ -4825,10 +4825,11 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theDavElementShouldBe(string $element, string $message):void {
+		$resXmlArray = HttpRequestHelper::parseResponseAsXml($this->getResponse());
 		WebDavAssert::assertDavResponseElementIs(
 			$element,
 			$message,
-			$this->responseXml,
+			$resXmlArray,
 			__METHOD__
 		);
 	}


### PR DESCRIPTION
## Description

- Refactored share methods so that they do only the creation requests.
- Refactored Given/Then step defs and methods to not save response
- Removed used steps (related to share creation)

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/7393 :crossed_fingers: 

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
