### PR TITLE
[full-ci] chore: bump web to v8.0.0-alpha.3

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=1322e5b46c827d0e7f7b8f563f302e61269f8515
+WEB_COMMITID=a5b442ff9db3e9317cf163c6e2158e073ceb909d
 WEB_BRANCH=master

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.0-alpha.2
+WEB_ASSETS_VERSION = v8.0.0-alpha.3
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Brings current web master to ocis (and hopefully fix https://github.com/owncloud/web/issues/9742).