### PR TITLE
the default language added to the setting service

### DIFF
--- a/changelog/unreleased/default-language.md
+++ b/changelog/unreleased/default-language.md
@@ -1,0 +1,6 @@
+Enhancement: The default language added
+
+The ability of configuration the default language has been added to the setting service.
+
+https://github.com/owncloud/ocis/pull/7417
+https://github.com/owncloud/enterprise/issues/5915

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -74,4 +74,4 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 ## Default language
 
-The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default. The value has ISO 639-1 format ("de", "en", etc.) and limited by the supported languages. This setting can be used to set the default language for invitation emails.
+The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for invitation emails.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -74,4 +74,4 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 ## Default language
 
-The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default.
+The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default. This setting can be used to set the default language for invitation emails.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -74,4 +74,4 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 ## Default language
 
-The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, the English language will be used as default.
+The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -71,3 +71,7 @@ Services can set or query ocis *setting values* of a user from settings bundles.
 ## Service Accounts
 
 The settings service needs to know the ID's of service accounts but it doesn't need their secrets. Currently only one service account can be configured which has the admin role. This can be set with the `SETTINGS_SERVICE_ACCOUNT_ID_ADMIN` envvar, but it will also pick up the global `OCIS_SERVICE_ACCOUNT_ID` envvar. Also see the 'auth-service' service description for additional details.
+
+## Default language
+
+The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, the English language will be used as default.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -72,6 +72,6 @@ Services can set or query ocis *setting values* of a user from settings bundles.
 
 The settings service needs to know the ID's of service accounts but it doesn't need their secrets. Currently only one service account can be configured which has the admin role. This can be set with the `SETTINGS_SERVICE_ACCOUNT_ID_ADMIN` envvar, but it will also pick up the global `OCIS_SERVICE_ACCOUNT_ID` envvar. Also see the 'auth-service' service description for additional details.
 
-## Default language
+## Default Language
 
 The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for invitation emails.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -74,4 +74,4 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 ## Default language
 
-The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default. This setting can be used to set the default language for invitation emails.
+The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default. The value has ISO 639-1 format ("de", "en", etc.) and limited by the supported languages. This setting can be used to set the default language for invitation emails.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -75,3 +75,5 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 ## Default Language
 
 The default language can be defined via SETTINGS_DEFAULT_LANGUAGE environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for invitation emails.
+
+Important developer note: the list of supported languages is at the moment not easy defineable, as it is the minimum intersection of languages shown in the WebUI and languages defined in the ocis code for the use of notifications. Even more, not all languages where there are translations available on transifex, are available in the WebUI respectively for ocis notifications, and the translation rate for existing languages is partially not that high. You will see therefore quite often English default strings though a supported language may exist and was selected.

--- a/services/settings/pkg/command/server.go
+++ b/services/settings/pkg/command/server.go
@@ -55,7 +55,7 @@ func Server(cfg *config.Config) *cli.Command {
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
-			handle := svc.NewService(cfg, logger)
+			handle := svc.NewDefaultLanguageService(cfg, svc.NewService(cfg, logger))
 
 			// prepare an HTTP server and add it to the group run.
 			httpServer, err := http.Server(

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -39,6 +39,8 @@ type Config struct {
 
 	ServiceAccountIDAdmin string `yaml:"service_account_id_admin" env:"OCIS_SERVICE_ACCOUNT_ID;SETTINGS_SERVICE_ACCOUNT_ID_ADMIN" desc:"The ID of the service account having the admin role. See the 'auth-service' service description for more details."`
 
+	DefaultLanguage string `yaml:"default_language" env:"SETTINGS_DEFAULT_LANGUAGE" desc:"The default language. If not defined, the English will be used as default."`
+
 	Context context.Context `yaml:"-"`
 }
 

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 
 	ServiceAccountIDAdmin string `yaml:"service_account_id_admin" env:"OCIS_SERVICE_ACCOUNT_ID;SETTINGS_SERVICE_ACCOUNT_ID_ADMIN" desc:"The ID of the service account having the admin role. See the 'auth-service' service description for more details."`
 
-	DefaultLanguage string `yaml:"default_language" env:"SETTINGS_DEFAULT_LANGUAGE" desc:"The default language. If not defined, the English will be used as default."`
+	DefaultLanguage string `yaml:"default_language" env:"SETTINGS_DEFAULT_LANGUAGE" desc:"The default language. If not defined, English will be used as default."`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 
 	ServiceAccountIDAdmin string `yaml:"service_account_id_admin" env:"OCIS_SERVICE_ACCOUNT_ID;SETTINGS_SERVICE_ACCOUNT_ID_ADMIN" desc:"The ID of the service account having the admin role. See the 'auth-service' service description for more details."`
 
-	DefaultLanguage string `yaml:"default_language" env:"SETTINGS_DEFAULT_LANGUAGE" desc:"The default language. If not defined, English will be used as default."`
+	DefaultLanguage string `yaml:"default_language" env:"SETTINGS_DEFAULT_LANGUAGE" desc:"The default language. If not defined, English will be used as default. See the documentation for more details."`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/settings/pkg/server/grpc/option.go
+++ b/services/settings/pkg/server/grpc/option.go
@@ -6,7 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/metrics"
-	svc "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
+	"github.com/owncloud/ocis/v2/services/settings/pkg/settings"
 	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -21,7 +21,7 @@ type Options struct {
 	Context        context.Context
 	Config         *config.Config
 	Metrics        *metrics.Metrics
-	ServiceHandler svc.Service
+	ServiceHandler settings.ServiceHandler
 	Flags          []cli.Flag
 	TraceProvider  trace.TracerProvider
 }
@@ -80,7 +80,7 @@ func Flags(val []cli.Flag) Option {
 }
 
 // ServiceHandler provides a function to set the ServiceHandler option
-func ServiceHandler(val svc.Service) Option {
+func ServiceHandler(val settings.ServiceHandler) Option {
 	return func(o *Options) {
 		o.ServiceHandler = val
 	}

--- a/services/settings/pkg/server/http/option.go
+++ b/services/settings/pkg/server/http/option.go
@@ -6,7 +6,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/metrics"
-	svc "github.com/owncloud/ocis/v2/services/settings/pkg/service/v0"
+	"github.com/owncloud/ocis/v2/services/settings/pkg/settings"
 	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -21,7 +21,7 @@ type Options struct {
 	Context        context.Context
 	Config         *config.Config
 	Metrics        *metrics.Metrics
-	ServiceHandler svc.Service
+	ServiceHandler settings.ServiceHandler
 	Flags          []cli.Flag
 	TraceProvider  trace.TracerProvider
 }
@@ -80,7 +80,7 @@ func Flags(val []cli.Flag) Option {
 }
 
 // ServiceHandler provides a function to set the ServiceHandler option
-func ServiceHandler(val svc.Service) Option {
+func ServiceHandler(val settings.ServiceHandler) Option {
 	return func(o *Options) {
 		o.ServiceHandler = val
 	}

--- a/services/settings/pkg/service/v0/service.go
+++ b/services/settings/pkg/service/v0/service.go
@@ -33,7 +33,7 @@ type Service struct {
 }
 
 // NewService returns a service implementation for Service.
-func NewService(cfg *config.Config, logger log.Logger) Service {
+func NewService(cfg *config.Config, logger log.Logger) settings.ServiceHandler {
 	service := Service{
 		id:     "ocis-settings",
 		config: cfg,

--- a/services/settings/pkg/service/v0/servicedecorator.go
+++ b/services/settings/pkg/service/v0/servicedecorator.go
@@ -11,11 +11,13 @@ import (
 	"github.com/owncloud/ocis/v2/services/settings/pkg/store/defaults"
 )
 
+var _defaultLanguage = "en"
+
 // NewDefaultLanguageService returns a default language decorator for ServiceHandler.
 func NewDefaultLanguageService(cfg *config.Config, serviceHandler settings.ServiceHandler) settings.ServiceHandler {
 	defaultLanguage := cfg.DefaultLanguage
 	if defaultLanguage == "" {
-		defaultLanguage = "en"
+		defaultLanguage = _defaultLanguage
 	}
 	return &defaultLanguageDecorator{defaultLanguage: defaultLanguage, ServiceHandler: serviceHandler}
 }

--- a/services/settings/pkg/service/v0/servicedecorator.go
+++ b/services/settings/pkg/service/v0/servicedecorator.go
@@ -1,0 +1,83 @@
+package svc
+
+import (
+	"context"
+
+	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
+	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
+	"github.com/owncloud/ocis/v2/services/settings/pkg/settings"
+
+	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
+	"github.com/owncloud/ocis/v2/services/settings/pkg/store/defaults"
+)
+
+// NewDefaultLanguageService returns a default language decorator for ServiceHandler.
+func NewDefaultLanguageService(cfg *config.Config, serviceHandler settings.ServiceHandler) settings.ServiceHandler {
+	defaultLanguage := cfg.DefaultLanguage
+	if defaultLanguage == "" {
+		defaultLanguage = "en"
+	}
+	return &defaultLanguageDecorator{defaultLanguage: defaultLanguage, ServiceHandler: serviceHandler}
+}
+
+type defaultLanguageDecorator struct {
+	defaultLanguage string
+	settings.ServiceHandler
+}
+
+// GetValueByUniqueIdentifiers implements the ValueService interface
+func (s *defaultLanguageDecorator) GetValueByUniqueIdentifiers(ctx context.Context, req *settingssvc.GetValueByUniqueIdentifiersRequest, res *settingssvc.GetValueResponse) error {
+	err := s.ServiceHandler.GetValueByUniqueIdentifiers(ctx, req, res)
+	if err != nil {
+		return err
+	}
+	if res.Value == nil {
+		res.Value = s.withDefaultLanguageSetting(req.AccountUuid)
+	}
+	return nil
+}
+
+// ListValues implements the ValueServiceHandler interface
+func (s *defaultLanguageDecorator) ListValues(ctx context.Context, req *settingssvc.ListValuesRequest, res *settingssvc.ListValuesResponse) error {
+	err := s.ServiceHandler.ListValues(ctx, req, res)
+	if err != nil {
+		return err
+	}
+	for _, v := range res.Values {
+		if v.GetValue().GetSettingId() == defaults.SettingUUIDProfileLanguage {
+			return nil
+		}
+	}
+
+	res.Values = append(res.Values, s.withDefaultLanguageSetting(req.AccountUuid))
+	return nil
+}
+
+func (s *defaultLanguageDecorator) withDefaultLanguageSetting(accountUUID string) *settingsmsg.ValueWithIdentifier {
+	bundle := generateBundleProfileRequest()
+	return &settingsmsg.ValueWithIdentifier{
+		Identifier: &settingsmsg.Identifier{
+			Extension: bundle.Extension,
+			Bundle:    bundle.Name,
+			Setting:   "language",
+		},
+		Value: &settingsmsg.Value{
+			Id:          "",
+			BundleId:    defaults.BundleUUIDProfile,
+			SettingId:   defaults.SettingUUIDProfileLanguage,
+			AccountUuid: accountUUID,
+			Resource: &settingsmsg.Resource{
+				Type: settingsmsg.Resource_TYPE_USER,
+			},
+			Value: &settingsmsg.Value_ListValue{
+				ListValue: &settingsmsg.ListValue{Values: []*settingsmsg.ListOptionValue{
+					{
+						Option: &settingsmsg.ListOptionValue_StringValue{
+							StringValue: s.defaultLanguage,
+						},
+					},
+				}},
+			},
+		},
+	}
+}

--- a/services/settings/pkg/settings/settings.go
+++ b/services/settings/pkg/settings/settings.go
@@ -3,7 +3,9 @@ package settings
 import (
 	"errors"
 
+	cs3permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
+	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
 )
 
@@ -24,6 +26,15 @@ var (
 type RegisterFunc func(*config.Config) Manager
 
 //go:generate mockery --name=Manager
+
+// ServiceHandler combines handlers interfaces
+type ServiceHandler interface {
+	settingssvc.BundleServiceHandler
+	settingssvc.ValueServiceHandler
+	settingssvc.RoleServiceHandler
+	settingssvc.PermissionServiceHandler
+	cs3permissions.PermissionsAPIServer
+}
 
 // Manager combines service interfaces for abstraction of storage implementations
 type Manager interface {

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -18,6 +18,9 @@ const (
 	// BundleUUIDRoleUserLight represents the user light role.
 	BundleUUIDRoleUserLight = "38071a68-456a-4553-846a-fa67bf5596cc"
 
+	// BundleUUIDProfile represents the user profile
+	BundleUUIDProfile = "2a506de7-99bd-4f0d-994e-c38e72c28fd9"
+
 	// RoleManagementPermissionID is the hardcoded setting UUID for the role management permission
 	RoleManagementPermissionID string = "a53e601e-571f-4f86-8fec-d4576ef49c62"
 	// RoleManagementPermissionName is the hardcoded setting name for the role management permission
@@ -767,7 +770,7 @@ func generateBundleUserLightRole() *settingsmsg.Bundle {
 
 func generateBundleProfileRequest() *settingsmsg.Bundle {
 	return &settingsmsg.Bundle{
-		Id:        "2a506de7-99bd-4f0d-994e-c38e72c28fd9",
+		Id:        BundleUUIDProfile,
 		Name:      "profile",
 		Extension: "ocis-accounts",
 		Type:      settingsmsg.Bundle_TYPE_DEFAULT,
@@ -837,7 +840,6 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 					},
 				},
 				DisplayValue: "English",
-				Default:      true,
 			},
 			{
 				Value: &settingsmsg.ListOptionValue{
@@ -885,10 +887,12 @@ func DefaultRoleAssignments(cfg *config.Config) []*settingsmsg.UserRoleAssignmen
 			{
 				AccountUuid: "4c510ada-c86b-4815-8820-42cdf82c3d51",
 				RoleId:      BundleUUIDRoleUser,
-			}, {
+			},
+			{
 				AccountUuid: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
 				RoleId:      BundleUUIDRoleUser,
-			}, {
+			},
+			{
 				AccountUuid: "932b4540-8d16-481e-8ef4-588e4b6b151c",
 				RoleId:      BundleUUIDRoleUser,
 			},
@@ -896,7 +900,8 @@ func DefaultRoleAssignments(cfg *config.Config) []*settingsmsg.UserRoleAssignmen
 				// additional admin user
 				AccountUuid: "058bff95-6708-4fe5-91e4-9ea3d377588b", // demo user "moss"
 				RoleId:      BundleUUIDRoleAdmin,
-			}, {
+			},
+			{
 				// default users with role "spaceadmin"
 				AccountUuid: "534bb038-6f9d-4093-946f-133be61fa4e7",
 				RoleId:      BundleUUIDRoleSpaceAdmin,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [https://github.com/owncloud/enterprise/issues/5915](https://github.com/owncloud/enterprise/issues/5915)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Local.
- Please fist read the notice in a readme!
- test case 1: Set SETTINGS_DEFAULT_LANGUAGE=de, run ocis. Log in as admin, the UI language has to be DE. admin creates a file and shares it with einstein. 
Expected result: 
- If einstein did change a language in a setting to a language different from DE then einstein would receive a letter in DE.
- If einstein already changed a language in a setting to language then einstein would receive a letter in selected language. But not all languages that we can see in a setting already exist for email notifications! If the language exits for UI but not exist for the email notifications then email notifications fail to EN.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
