### PR TITLE
[tests-only][full-ci]add test for move with fileID in project space

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
@@ -74,6 +74,82 @@ Feature: moving/renaming file using file id
       | /dav/spaces/<<FILEID>>            |
 
 
+  Scenario Outline: move a file into a folder inside project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "/folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "/textfile.txt" into "/folder" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "folder" of the space "project-space" should contain these files:
+      | textfile.txt |
+    But for user "Alice" the space "project-space" should not contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file into a sub-folder inside project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "/textfile.txt" into "/folder/sub-folder" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "folder/sub-folder/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    But for user "Alice" the space "Personal" should not contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file from folder to root inside project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "folder/textfile.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "project-space" should contain these entries:
+      | textfile.txt |
+    But for user "Alice" folder "folder" of the space "project-space" should not contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file from sub-folder to root inside project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/sub-folder/textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "folder/sub-folder/textfile.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" the space "project-space" should contain these entries:
+      | textfile.txt |
+    But for user "Alice" folder "folder/sub-folder" of the space "project-space" should not contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
   Scenario Outline: rename a root file inside personal space
     Given user "Alice" has uploaded file with content "some data" to "textfile.txt"
     And we save it into "FILEID"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

### Description
This PR adds test coverage for moving the files within project space with the `url` consisting of the `file-id` not name.
This PR adds moving with file id only within `Project` Space

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6737


