### PR TITLE
[tests-only] [full-ci] removing the setresponse in given/then step in publicwebdav context

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -204,7 +204,7 @@ cannot share a folder with create permission
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:329](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L329)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:328](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L328)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -340,7 +340,7 @@ API, search, favorites, config, capabilities, not existing endpoints, CORS and o
 - [coreApiAuthOcs/ocsGETAuth.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L123)
 - [coreApiAuthOcs/ocsPOSTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPOSTAuth.feature#L10)
 - [coreApiAuthOcs/ocsPUTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L10)
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:319](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L319)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:318](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L318)
 
 #### [sending MKCOL requests to another or non-existing user's webDav endpoints as normal user should return 404](https://github.com/owncloud/ocis/issues/5049)
 

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -339,7 +339,7 @@ API, search, favorites, config, capabilities, not existing endpoints, CORS and o
 - [coreApiAuthOcs/ocsGETAuth.feature:106](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L106)
 - [coreApiAuthOcs/ocsGETAuth.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L123)
 - [coreApiAuthOcs/ocsPOSTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPOSTAuth.feature#L10)
-- [coreApiAuthOcs/ocsPUTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L10)
+- [coreApiAuthOcs/ocsPUTAuth.feature:7](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L7)
 - [coreApiSharePublicLink1/createPublicLinkShare.feature:318](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L318)
 
 #### [sending MKCOL requests to another or non-existing user's webDav endpoints as normal user should return 404](https://github.com/owncloud/ocis/issues/5049)

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -204,7 +204,7 @@ cannot share a folder with create permission
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:327](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L327)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:329](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L329)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -339,8 +339,8 @@ API, search, favorites, config, capabilities, not existing endpoints, CORS and o
 - [coreApiAuthOcs/ocsGETAuth.feature:106](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L106)
 - [coreApiAuthOcs/ocsGETAuth.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L123)
 - [coreApiAuthOcs/ocsPOSTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPOSTAuth.feature#L10)
-- [coreApiAuthOcs/ocsPUTAuth.feature:7](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L7)
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:317](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L317)
+- [coreApiAuthOcs/ocsPUTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L10)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:319](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L319)
 
 #### [sending MKCOL requests to another or non-existing user's webDav endpoints as normal user should return 404](https://github.com/owncloud/ocis/issues/5049)
 

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -42,9 +42,9 @@ Feature: A manager of the space can edit public link
       | share_type        | public_link           |
       | displayname_owner | %displayname%         |
       | name              | <linkName>            |
-    And the public should be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
     When the public downloads file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
-    Then the downloaded content should be "some content"
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "some content"
     Examples:
       | permissions | expectedPermissions       | password | linkName |
       | 5           | read,create               | newPass  |          |

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -43,7 +43,8 @@ Feature: A manager of the space can edit public link
       | displayname_owner | %displayname%         |
       | name              | <linkName>            |
     And the public should be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
-    And the downloaded content should be "some content"
+    When the public downloads file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
+    Then the downloaded content should be "some content"
     Examples:
       | permissions | expectedPermissions       | password | linkName |
       | 5           | read,create               | newPass  |          |

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -42,7 +42,7 @@ Feature: A manager of the space can edit public link
       | share_type        | public_link           |
       | displayname_owner | %displayname%         |
       | name              | <linkName>            |
-    When the public downloads file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
+    When the public downloads file "/test.txt" from inside the last public link shared folder with password "<password>" using the new public WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     Examples:

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -36,7 +36,7 @@ Feature: Share spaces via link
       | displayname_owner | %displayname%         |
       | uid_owner         | %username%            |
       | name              | <linkName>            |
-    When the public downloads file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
+    When the public downloads file "/test.txt" from inside the last public link shared folder with password "<password>" using the new public WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     But the public should not be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -37,7 +37,8 @@ Feature: Share spaces via link
       | uid_owner         | %username%            |
       | name              | <linkName>            |
     And the public should be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
-    And the downloaded content should be "some content"
+    When the public downloads file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
+    Then the downloaded content should be "some content"
     But the public should not be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
     Examples:
       | permissions | expectedPermissions       | password       | linkName | expireDate               |

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -36,9 +36,9 @@ Feature: Share spaces via link
       | displayname_owner | %displayname%         |
       | uid_owner         | %username%            |
       | name              | <linkName>            |
-    And the public should be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
     When the public downloads file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
-    Then the downloaded content should be "some content"
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "some content"
     But the public should not be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
     Examples:
       | permissions | expectedPermissions       | password       | linkName | expireDate               |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -56,7 +56,7 @@ class PublicWebDavContext implements Context {
 		} else {
 			$path = "";
 		}
-		return $this->downloadTheFileInsideThePublicSharedFolder(
+		return $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			$range,
@@ -79,7 +79,7 @@ class PublicWebDavContext implements Context {
 		} else {
 			$path = "";
 		}
-		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			$range,
@@ -232,7 +232,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function downloadPublicFileInsideAFolder(string $path, string $publicWebDAVAPIVersion = "old"):void {
-		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			"",
 			"",
@@ -251,33 +251,13 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function downloadPublicFileInsideAFolderWithPassword(string $path, string $publicWebDAVAPIVersion = "old", string $password = ""):void {
-		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			"",
 			$publicWebDAVAPIVersion
 		);
 		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @param string $path
-	 * @param string|null $password
-	 * @param string $publicWebDAVAPIVersion
-	 *
-	 * @return ResponseInterface
-	 */
-	public function downloadTheFileInsideThePublicSharedFolderWithPassword(
-		string $path,
-		?string $password = "",
-		string $publicWebDAVAPIVersion = "old"
-	):ResponseInterface {
-		return $this->downloadTheFileInsideThePublicSharedFolder(
-			$path,
-			$password,
-			"",
-			$publicWebDAVAPIVersion
-		);
 	}
 
 	/**
@@ -290,7 +270,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function downloadPublicFileInsideAFolderWithRange(string $path, string $range, string  $publicWebDAVAPIVersion):void {
-		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			"",
 			$range,
@@ -307,7 +287,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return ResponseInterface
 	 */
-	public function downloadTheFileInsideThePublicSharedFolder(
+	public function downloadFileFromPublicFolder(
 		string $path,
 		string $password,
 		string $range,
@@ -885,9 +865,10 @@ class PublicWebDavContext implements Context {
 			return;
 		}
 
-		$response = $this->downloadTheFileInsideThePublicSharedFolderWithPassword(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
+			"",
 			$publicWebDAVAPIVersion
 		);
 
@@ -917,12 +898,12 @@ class PublicWebDavContext implements Context {
 			return;
 		}
 
-		$response = $this->downloadTheFileInsideThePublicSharedFolderWithPassword(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
+			"",
 			$publicWebDAVAPIVersion
 		);
-
 		$this->featureContext->checkDownloadedContentMatches($content, "", $response);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -993,7 +974,7 @@ class PublicWebDavContext implements Context {
 			return;
 		}
 
-		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			$range,
@@ -1025,7 +1006,7 @@ class PublicWebDavContext implements Context {
 			return;
 		}
 
-		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			$range,
@@ -1252,7 +1233,7 @@ class PublicWebDavContext implements Context {
 			$path,
 			$publicWebDAVAPIVersion
 		);
-		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			"",
 			"",

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -242,6 +242,25 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function downloadPublicFileInsideAFolderWithPassword(string $path, string $publicWebDAVAPIVersion = "old", string $password = ""):void {
+		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+			$path,
+			$password,
+			"",
+			$publicWebDAVAPIVersion
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @param string $path
 	 * @param string|null $password
 	 * @param string $publicWebDAVAPIVersion
@@ -1233,7 +1252,13 @@ class PublicWebDavContext implements Context {
 			$path,
 			$publicWebDAVAPIVersion
 		);
-		$this->featureContext->checkDownloadedContentMatches($content);
+		$response = $this->downloadTheFileInsideThePublicSharedFolder(
+			$path,
+			"",
+			"",
+			$publicWebDAVAPIVersion
+		);
+		$this->featureContext->checkDownloadedContentMatches($content, "", $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -26,6 +26,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
+use Psr\Http\Message\ResponseInterface;
 
 require_once 'bootstrap.php';
 
@@ -329,10 +330,10 @@ class PublicWebDavContext implements Context {
 	 * @param string $source target file name
 	 * @param string $publicWebDAVAPIVersion
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function publiclyUploadingFile(string $source, string $publicWebDAVAPIVersion):void {
-		$this->publicUploadContent(
+	public function publiclyUploadingFile(string $source, string $publicWebDAVAPIVersion):ResponseInterface {
+		 return $this->publicUploadContent(
 			\basename($source),
 			'',
 			\file_get_contents($source),
@@ -351,10 +352,11 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicUploadsFileUsingTheWebDAVApi(string $source, string $publicWebDAVAPIVersion):void {
-		$this->publiclyUploadingFile(
+		$response = $this->publiclyUploadingFile(
 			$source,
 			$publicWebDAVAPIVersion
 		);
+        $this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -425,11 +427,11 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicHasUploadedFileUsingTheWebDAVApi(string $source, string $publicWebDAVAPIVersion):void {
-		$this->publiclyUploadingFile(
+		$response = $this->publiclyUploadingFile(
 			$source,
 			$publicWebDAVAPIVersion
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
 	}
 
 	/**
@@ -439,10 +441,10 @@ class PublicWebDavContext implements Context {
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function publiclyUploadingContentAutoRename(string $filename, string $body = 'test'):void {
-		$this->publicUploadContent($filename, '', $body, true);
+	public function publiclyUploadingContentAutoRename(string $filename, string $body = 'test'):ResponseInterface {
+		return $this->publicUploadContent($filename, '', $body, true);
 	}
 
 	/**
@@ -454,7 +456,8 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicUploadsFileWithContentWithAutoRenameMode(string $filename, string $body = 'test'):void {
-		$this->publiclyUploadingContentAutoRename($filename, $body);
+		$response = $this->publiclyUploadingContentAutoRename($filename, $body);
+        $this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -466,8 +469,8 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicHasUploadedFileWithContentWithAutoRenameMode(string $filename, string $body = 'test'):void {
-		$this->publiclyUploadingContentAutoRename($filename, $body);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->publiclyUploadingContentAutoRename($filename, $body);
+		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
 	}
 
 	/**
@@ -476,15 +479,15 @@ class PublicWebDavContext implements Context {
 	 * @param string $body content to upload
 	 * @param string $publicWebDAVAPIVersion
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
 	public function publiclyUploadingContentWithPassword(
 		string $filename,
 		string $password = '',
 		string $body = 'test',
 		string $publicWebDAVAPIVersion = "old"
-	):void {
-		$this->publicUploadContent(
+	):ResponseInterface {
+		return $this->publicUploadContent(
 			$filename,
 			$password,
 			$body,
@@ -510,12 +513,13 @@ class PublicWebDavContext implements Context {
 		string $body = 'test',
 		string $publicWebDAVAPIVersion = "old"
 	):void {
-		$this->publiclyUploadingContentWithPassword(
+		$response = $this->publiclyUploadingContentWithPassword(
 			$filename,
 			$password,
 			$body,
 			$publicWebDAVAPIVersion
 		);
+        $this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -534,13 +538,13 @@ class PublicWebDavContext implements Context {
 		string $body = 'test',
 		string $publicWebDAVAPIVersion = "old"
 	):void {
-		$this->publiclyUploadingContentWithPassword(
+		$response = $this->publiclyUploadingContentWithPassword(
 			$filename,
 			$password,
 			$body,
 			$publicWebDAVAPIVersion
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
 	}
 
 	/**
@@ -548,10 +552,10 @@ class PublicWebDavContext implements Context {
 	 * @param string $body content to upload
 	 * @param string $publicWebDAVAPIVersion
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
-	public function publiclyOverwritingContent(string $filename, string $body = 'test', string $publicWebDAVAPIVersion = 'old'):void {
-		$this->publicUploadContent($filename, '', $body, false, [], $publicWebDAVAPIVersion);
+	public function publiclyOverwritingContent(string $filename, string $body = 'test', string $publicWebDAVAPIVersion = 'old'):ResponseInterface {
+		return $this->publicUploadContent($filename, '', $body, false, [], $publicWebDAVAPIVersion);
 	}
 
 	/**
@@ -564,11 +568,12 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicOverwritesFileWithContentUsingWebDavApi(string $filename, string $body = 'test', string $publicWebDAVAPIVersion = 'old'):void {
-		$this->publiclyOverwritingContent(
+		$response = $this->publiclyOverwritingContent(
 			$filename,
 			$body,
 			$publicWebDAVAPIVersion
 		);
+        $this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -580,11 +585,11 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicHasOverwrittenFileWithContentUsingOldWebDavApi(string $filename, string $body = 'test'):void {
-		$this->publiclyOverwritingContent(
+		$response = $this->publiclyOverwritingContent(
 			$filename,
 			$body
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 	}
 
 	/**
@@ -592,14 +597,14 @@ class PublicWebDavContext implements Context {
 	 * @param string $body content to upload
 	 * @param string $publicWebDAVAPIVersion
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
 	public function publiclyUploadingContent(
 		string $filename,
 		string $body = 'test',
 		string $publicWebDAVAPIVersion = "old"
-	):void {
-		$this->publicUploadContent(
+	):ResponseInterface {
+		return $this->publicUploadContent(
 			$filename,
 			'',
 			$body,
@@ -623,11 +628,12 @@ class PublicWebDavContext implements Context {
 		string $body = 'test',
 		string $publicWebDAVAPIVersion = "old"
 	):void {
-		$this->publiclyUploadingContent(
+		$response = $this->publiclyUploadingContent(
 			$filename,
 			$body,
 			$publicWebDAVAPIVersion
 		);
+        $this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastStatusCodesArrays();
 	}
 
@@ -645,12 +651,12 @@ class PublicWebDavContext implements Context {
 		string $body = 'test',
 		string $publicWebDAVAPIVersion = "old"
 	):void {
-		$this->publiclyUploadingContent(
+		$response = $this->publiclyUploadingContent(
 			$filename,
 			$body,
 			$publicWebDAVAPIVersion
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
 	}
 
 	/**
@@ -1088,7 +1094,7 @@ class PublicWebDavContext implements Context {
 		}
 		$filename = (string)$this->featureContext->getLastCreatedPublicShare()->file_target;
 
-		$this->publicUploadContent(
+		$response = $this->publicUploadContent(
 			$filename,
 			'',
 			'test',
@@ -1097,7 +1103,7 @@ class PublicWebDavContext implements Context {
 			$publicWebDAVAPIVersion
 		);
 
-		$this->featureContext->theHTTPStatusCodeShouldBe($expectedHttpCode);
+		$this->featureContext->theHTTPStatusCodeShouldBe($expectedHttpCode, "", $response);
 	}
 
 	/**
@@ -1117,7 +1123,7 @@ class PublicWebDavContext implements Context {
 			return;
 		}
 
-		$this->publicUploadContent(
+		$response = $this->publicUploadContent(
 			'whateverfilefortesting.txt',
 			'',
 			'test',
@@ -1126,14 +1132,14 @@ class PublicWebDavContext implements Context {
 			$publicWebDAVAPIVersion
 		);
 
-		$response = $this->featureContext->getResponse();
 		if ($expectedHttpCode === null) {
 			$expectedHttpCode = [507, 400, 401, 403, 404, 423];
 		}
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHttpCode,
 			"upload should have failed but passed with code " .
-			$response->getStatusCode()
+			$response->getStatusCode(),
+            $response
 		);
 	}
 
@@ -1151,7 +1157,7 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion,
 		string $password
 	):void {
-		$this->publicUploadContent(
+		$response = $this->publicUploadContent(
 			$filename,
 			$password,
 			'test',
@@ -1160,7 +1166,7 @@ class PublicWebDavContext implements Context {
 			$publicWebDAVAPIVersion
 		);
 
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
 	}
 
 	/**
@@ -1179,7 +1185,7 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $expectedHttpCode
 	):void {
-		$this->publicUploadContent(
+		$response = $this->publicUploadContent(
 			$filename,
 			$password,
 			'test',
@@ -1188,11 +1194,11 @@ class PublicWebDavContext implements Context {
 			$publicWebDAVAPIVersion
 		);
 
-		$response = $this->featureContext->getResponse();
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHttpCode,
 			"upload of $filename into the last publicly shared folder should have failed with code " .
-			$expectedHttpCode . " but the code was " . $response->getStatusCode()
+			$expectedHttpCode . " but the code was " . $response->getStatusCode(),
+            $response
 		);
 	}
 
@@ -1212,7 +1218,7 @@ class PublicWebDavContext implements Context {
 			return;
 		}
 
-		$this->publicUploadContent(
+		$response = $this->publicUploadContent(
 			$path,
 			'',
 			$content,
@@ -1220,7 +1226,7 @@ class PublicWebDavContext implements Context {
 			[],
 			$publicWebDAVAPIVersion
 		);
-		$response = $this->featureContext->getResponse();
+
 		Assert::assertTrue(
 			($response->getStatusCode() == 201),
 			"upload should have passed but failed with code " .
@@ -1256,7 +1262,7 @@ class PublicWebDavContext implements Context {
 			$path = "";
 		}
 
-		$this->publicUploadContent(
+		$response = $this->publicUploadContent(
 			$path,
 			'',
 			$content,
@@ -1264,7 +1270,6 @@ class PublicWebDavContext implements Context {
 			[],
 			$publicWebDAVAPIVersion
 		);
-		$response = $this->featureContext->getResponse();
 		if ($should) {
 			Assert::assertTrue(
 				($response->getStatusCode() == 204),
@@ -1309,7 +1314,7 @@ class PublicWebDavContext implements Context {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
 
-		$this->publicUploadContent(
+		$response = $this->publicUploadContent(
 			$fileName,
 			'',
 			'test',
@@ -1317,6 +1322,7 @@ class PublicWebDavContext implements Context {
 			["X-OC-Mtime" => $mtime],
 			$davVersion
 		);
+        $this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -1473,7 +1479,7 @@ class PublicWebDavContext implements Context {
 	 * @param array $additionalHeaders
 	 * @param string $publicWebDAVAPIVersion
 	 *
-	 * @return void
+	 * @return ResponseInterface|null
 	 */
 	public function publicUploadContent(
 		string $filename,
@@ -1482,9 +1488,9 @@ class PublicWebDavContext implements Context {
 		bool $autoRename = false,
 		array $additionalHeaders = [],
 		string $publicWebDAVAPIVersion = "old"
-	):void {
+	):?ResponseInterface {
 		if ($publicWebDAVAPIVersion === "old") {
-			return;
+			return null;
 		}
 		$password = $this->featureContext->getActualPassword($password);
 		$token = $this->featureContext->getLastCreatedPublicShareToken();
@@ -1515,7 +1521,7 @@ class PublicWebDavContext implements Context {
 			$headers['OC-Autorename'] = 1;
 		}
 		$headers = \array_merge($headers, $additionalHeaders);
-		$response = HttpRequestHelper::put(
+		return HttpRequestHelper::put(
 			$url,
 			$this->featureContext->getStepLineRef(),
 			$userName,
@@ -1523,7 +1529,6 @@ class PublicWebDavContext implements Context {
 			$headers,
 			$body
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -90,6 +90,7 @@ class PublicWebDavContext implements Context {
 
 	/**
 	 * @When /^the public downloads the last public link shared file using the (old|new) public WebDAV API$/
+	 * @When /^the public tries to download the last public link shared file using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $publicWebDAVAPIVersion
 	 *
@@ -102,6 +103,7 @@ class PublicWebDavContext implements Context {
 
 	/**
 	 * @When /^the public downloads the last public link shared file with password "([^"]*)" using the (old|new) public WebDAV API$/
+	 * @When /^the public tries to download the last public link shared file with password "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $password
 	 * @param string $publicWebDAVAPIVersion
@@ -242,15 +244,15 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder with password "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
-	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */
-	public function downloadPublicFileInsideAFolderWithPassword(string $path, string $publicWebDAVAPIVersion = "old", string $password = ""):void {
+	public function publicDownloadsFileFromInsideLastPublicSharedFolderWithPassword(string $path, string $password = "", string $publicWebDAVAPIVersion = "old"):void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
@@ -721,13 +723,13 @@ class PublicWebDavContext implements Context {
 			$password
 		);
 
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
+
 		$this->featureContext->checkDownloadedContentMatches(
 			$expectedContent,
 			"Checking the content of the last public shared file after downloading with the $publicWebDAVAPIVersion public WebDAV API",
 			$response
 		);
-
-		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -85,7 +85,7 @@ class PublicWebDavContext implements Context {
 			$range,
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -97,7 +97,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFile(string $publicWebDAVAPIVersion):void {
 		$response = $this->downloadPublicFileWithRange("", $publicWebDAVAPIVersion);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -110,7 +110,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFileWithPassword(string $password, string $publicWebDAVAPIVersion):void {
 		$response = $this->downloadPublicFileWithRange("", $publicWebDAVAPIVersion, $password);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -238,7 +238,7 @@ class PublicWebDavContext implements Context {
 			"",
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -277,7 +277,7 @@ class PublicWebDavContext implements Context {
 			$range,
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -330,8 +330,8 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return ResponseInterface
 	 */
-	public function publiclyUploadingFile(string $source, string $publicWebDAVAPIVersion):ResponseInterface {
-		 return $this->publicUploadContent(
+	public function publicUploadFile(string $source, string $publicWebDAVAPIVersion):ResponseInterface {
+		return $this->publicUploadContent(
 			\basename($source),
 			'',
 			\file_get_contents($source),
@@ -350,11 +350,11 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicUploadsFileUsingTheWebDAVApi(string $source, string $publicWebDAVAPIVersion):void {
-		$response = $this->publiclyUploadingFile(
+		$response = $this->publiclUploadFile(
 			$source,
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -367,20 +367,20 @@ class PublicWebDavContext implements Context {
 	 * @param string $source
 	 * @param string $destination
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
 	public function publiclyCopyingFile(
 		string $baseUrl,
 		string $source,
 		string $destination
-	):void {
+	):ResponseInterface {
 		$fullSourceUrl = $baseUrl . $source;
 		$fullDestUrl = WebDavHelper::sanitizeUrl(
 			$baseUrl . $destination
 		);
 
 		$headers["Destination"] = $fullDestUrl;
-		$response = HttpRequestHelper::sendRequest(
+		return HttpRequestHelper::sendRequest(
 			$fullSourceUrl,
 			$this->featureContext->getStepLineRef(),
 			"COPY",
@@ -388,7 +388,6 @@ class PublicWebDavContext implements Context {
 			null,
 			$headers
 		);
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -409,11 +408,12 @@ class PublicWebDavContext implements Context {
 		);
 		$baseUrl = $this->featureContext->getLocalBaseUrl() . '/' . $davPath;
 
-		$this->publiclyCopyingFile(
+		$response = $this->publiclyCopyingFile(
 			$baseUrl,
 			$source,
 			$destination
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -425,7 +425,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicHasUploadedFileUsingTheWebDAVApi(string $source, string $publicWebDAVAPIVersion):void {
-		$response = $this->publiclyUploadingFile(
+		$response = $this->publicUploadFile(
 			$source,
 			$publicWebDAVAPIVersion
 		);
@@ -455,7 +455,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function thePublicUploadsFileWithContentWithAutoRenameMode(string $filename, string $body = 'test'):void {
 		$response = $this->publiclyUploadingContentAutoRename($filename, $body);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -517,7 +517,7 @@ class PublicWebDavContext implements Context {
 			$body,
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -571,7 +571,7 @@ class PublicWebDavContext implements Context {
 			$body,
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -631,7 +631,7 @@ class PublicWebDavContext implements Context {
 			$body,
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastStatusCodesArrays();
 	}
 
@@ -675,7 +675,6 @@ class PublicWebDavContext implements Context {
 			"",
 			$expectedContent
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**
@@ -696,7 +695,6 @@ class PublicWebDavContext implements Context {
 			"",
 			"$expectedContent\n"
 		);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
 	}
 
 	/**
@@ -727,7 +725,7 @@ class PublicWebDavContext implements Context {
 		$this->featureContext->checkDownloadedContentMatches(
 			$expectedContent,
 			"Checking the content of the last public shared file after downloading with the $publicWebDAVAPIVersion public WebDAV API",
-            $response
+			$response
 		);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -1138,7 +1136,7 @@ class PublicWebDavContext implements Context {
 			$expectedHttpCode,
 			"upload should have failed but passed with code " .
 			$response->getStatusCode(),
-            $response
+			$response
 		);
 	}
 
@@ -1197,7 +1195,7 @@ class PublicWebDavContext implements Context {
 			$expectedHttpCode,
 			"upload of $filename into the last publicly shared folder should have failed with code " .
 			$expectedHttpCode . " but the code was " . $response->getStatusCode(),
-            $response
+			$response
 		);
 	}
 
@@ -1284,7 +1282,7 @@ class PublicWebDavContext implements Context {
 			$this->featureContext->checkDownloadedContentMatches(
 				$content,
 				"Checking the content of the last public shared file after downloading with the $publicWebDAVAPIVersion public WebDAV API",
-                $response
+				$response
 			);
 		} else {
 			$expectedCode = 403;
@@ -1322,19 +1320,19 @@ class PublicWebDavContext implements Context {
 			["X-OC-Mtime" => $mtime],
 			$davVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
 	 * @param string $destination
 	 * @param string $password
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 */
 	public function publicCreatesFolderUsingPassword(
 		string $destination,
 		string $password
-	):void {
+	):ResponseInterface {
 		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
@@ -1354,14 +1352,12 @@ class PublicWebDavContext implements Context {
 		);
 		$url .= \ltrim($foldername, '/');
 
-		$this->featureContext->setResponse(
-			HttpRequestHelper::sendRequest(
-				$url,
-				$this->featureContext->getStepLineRef(),
-				'MKCOL',
-				$userName,
-				$password
-			)
+		return HttpRequestHelper::sendRequest(
+			$url,
+			$this->featureContext->getStepLineRef(),
+			'MKCOL',
+			$userName,
+			$password
 		);
 	}
 
@@ -1373,7 +1369,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function publicCreatesFolder(string $destination):void {
-		$this->publicCreatesFolderUsingPassword($destination, '');
+		$this->featureContext->setResponse($this->publicCreatesFolderUsingPassword($destination, ''));
 	}
 
 	/**
@@ -1388,8 +1384,8 @@ class PublicWebDavContext implements Context {
 		string $foldername,
 		string $password
 	):void {
-		$this->publicCreatesFolderUsingPassword($foldername, $password);
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$response = $this->publicCreatesFolderUsingPassword($foldername, $password);
+		$this->featureContext->theHTTPStatusCodeShouldBe(201, "", $response);
 	}
 
 	/**
@@ -1406,11 +1402,12 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $expectedHttpCode
 	):void {
-		$this->publicCreatesFolderUsingPassword($foldername, $password);
+		$response = $this->publicCreatesFolderUsingPassword($foldername, $password);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHttpCode,
 			"creation of $foldername in the last publicly shared folder should have failed with code " .
-			$expectedHttpCode
+			$expectedHttpCode,
+			$response
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -627,7 +627,7 @@ class WebDavLockingContext implements Context {
 			$headers,
 			$publicWebDAVAPIVersion
 		);
-        $this->featureContext->setResponse($response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -619,7 +619,7 @@ class WebDavLockingContext implements Context {
 		$headers = [
 			"If" => "(<" . $this->tokenOfLastLock[$lockOwner][$itemToUseLockOf] . ">)"
 		];
-		$this->publicWebDavContext->publicUploadContent(
+		$response = $this->publicWebDavContext->publicUploadContent(
 			$filename,
 			'',
 			$content,
@@ -627,6 +627,7 @@ class WebDavLockingContext implements Context {
 			$headers,
 			$publicWebDAVAPIVersion
 		);
+        $this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -61,9 +61,11 @@ Feature: create a public link share
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
     And the HTTP status code should be "200"
     And the public download of the last publicly shared file using the new public WebDAV API with password "%regular%" should fail with HTTP status code "401"
-    And the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
+    When the public downloads the last public link shared file with password "%regular%" using the new public WebDAV API
+    Then the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
     And the public download of the last publicly shared file using the new public WebDAV API without a password should fail with HTTP status code "401"
-    And the value of the item "//s:message" in the response should match "/No 'Authorization: Basic' header found/"
+    When the public downloads the last public link shared file using the new public WebDAV API
+    Then the value of the item "//s:message" in the response should match "/No 'Authorization: Basic' header found/"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -59,13 +59,12 @@ Feature: create a public link share
       | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
-    And the HTTP status code should be "200"
-    And the public download of the last publicly shared file using the new public WebDAV API with password "%regular%" should fail with HTTP status code "401"
     When the public downloads the last public link shared file with password "%regular%" using the new public WebDAV API
-    Then the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
-    And the public download of the last publicly shared file using the new public WebDAV API without a password should fail with HTTP status code "401"
+    Then the HTTP status code should be "401"
+    And the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
     When the public downloads the last public link shared file using the new public WebDAV API
-    Then the value of the item "//s:message" in the response should match "/No 'Authorization: Basic' header found/"
+    Then the HTTP status code should be "401"
+    And the value of the item "//s:message" in the response should match "/No 'Authorization: Basic' header found/"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -59,10 +59,10 @@ Feature: create a public link share
       | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
-    When the public downloads the last public link shared file with password "%regular%" using the new public WebDAV API
+    When the public tries to download the last public link shared file with password "%regular%" using the new public WebDAV API
     Then the HTTP status code should be "401"
     And the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
-    When the public downloads the last public link shared file using the new public WebDAV API
+    When the public tries to download the last public link shared file using the new public WebDAV API
     Then the HTTP status code should be "401"
     And the value of the item "//s:message" in the response should match "/No 'Authorization: Basic' header found/"
     Examples:

--- a/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -37,9 +37,9 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
     When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
-    Then the downloaded content should be "some content"
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -91,9 +91,9 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
     When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
-    Then the downloaded content should be "some content"
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -113,9 +113,9 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
     When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
-    Then the downloaded content should be "some content"
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "some content"
     And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |

--- a/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -38,7 +38,8 @@ Feature: reshare as public link
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
-    And the downloaded content should be "some content"
+    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    Then the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -91,7 +92,8 @@ Feature: reshare as public link
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
-    And the downloaded content should be "some content"
+    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    Then the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -112,7 +114,8 @@ Feature: reshare as public link
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
-    And the downloaded content should be "some content"
+    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    Then the downloaded content should be "some content"
     And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `PublicWebdavContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 