### PR TITLE
[tests-only] [full-ci] removing the setresponse in given/then step in spacestus context

### DIFF
--- a/tests/acceptance/features/bootstrap/SpacesTUSContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesTUSContext.php
@@ -57,7 +57,8 @@ class SpacesTUSContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userHasUploadedFileViaTusInSpace(string $user, string $source, string $destination, string $spaceName): void {
-		$this->userUploadsAFileViaTusInsideOfTheSpaceUsingTheWebdavApi($user, $source, $destination, $spaceName);
+		$this->spacesContext->setSpaceIDByName($user, $spaceName);
+		$this->tusContext->userUploadsUsingTusAFileTo($user, $source, $destination);
 	}
 
 	/**
@@ -152,7 +153,7 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" has uploaded a file with content "([^"]*)" to "([^"]*)" via TUS inside of the space "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has uploaded a file with content "([^"]*)" to "([^"]*)" via TUS inside of the space "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $content
@@ -239,7 +240,7 @@ class SpacesTUSContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" uploads file with checksum "([^"]*)" to the last created TUS Location with offset "([^"]*)" and content "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
+	 * @When /^user "([^"]*)" uploads file with checksum "([^"]*)" to the last created TUS Location with offset "([^"]*)" and content "([^"]*)" via TUS inside of the space "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $checksum
@@ -259,7 +260,7 @@ class SpacesTUSContext implements Context {
 	): void {
 		$this->spacesContext->setSpaceIDByName($user, $spaceName);
 		$response = $this->tusContext->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
-		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SpacesTUSContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesTUSContext.php
@@ -58,7 +58,6 @@ class SpacesTUSContext implements Context {
 	 */
 	public function userHasUploadedFileViaTusInSpace(string $user, string $source, string $destination, string $spaceName): void {
 		$this->userUploadsAFileViaTusInsideOfTheSpaceUsingTheWebdavApi($user, $source, $destination, $spaceName);
-		$this->featureContext->theHTTPStatusCodeShouldBe(200, "Expected response status code should be 200");
 	}
 
 	/**
@@ -102,8 +101,9 @@ class SpacesTUSContext implements Context {
 		string $content,
 		TableNode $headers
 	): void {
-		$this->userCreatesANewTusResourceForTheSpaceUsingTheWebdavApiWithTheseHeaders($user, $spaceName, $content, $headers);
-		$this->featureContext->theHTTPStatusCodeShouldBe(201, "Expected response status code should be 201");
+		$this->spacesContext->setSpaceIDByName($user, $spaceName);
+		$response = $this->tusContext->createNewTUSResourceWithHeaders($user, $headers, $content);
+		$this->featureContext->theHTTPStatusCodeShouldBe(201, "Expected response status code should be 201", $response);
 	}
 
 	/**
@@ -169,10 +169,6 @@ class SpacesTUSContext implements Context {
 		string $spaceName
 	): void {
 		$this->userUploadsAFileWithContentToViaTusInsideOfTheSpaceUsingTheWebdavApi($user, $content, $resource, $spaceName);
-		$this->featureContext->theHTTPStatusCodeShouldBe(
-			200,
-			"Expected response status code should be 200"
-		);
 	}
 
 	/**
@@ -262,7 +258,8 @@ class SpacesTUSContext implements Context {
 		string $spaceName
 	): void {
 		$this->spacesContext->setSpaceIDByName($user, $spaceName);
-		$this->tusContext->userUploadsFileWithChecksum($user, $checksum, $offset, $content);
+		$response = $this->tusContext->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
+		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 	}
 
 	/**


### PR DESCRIPTION
## Description
We have used setResponse() and $this->response in the Given/Then steps and some helper functions (maybe to reuse existing available methods). But storing responses from Given/Then steps and helper functions is not a good idea because it can lead to a false positive assertion in the Then steps.
So, check the use of setResponse() and $this->response in
- Given steps
- Then steps (Then steps can use $this->response but must prevent saving to it)
- Helper functions

So this pr make the above changes in `SpacesTusContext`
## Related Issue
https://github.com/owncloud/ocis/issues/7082

## Motivation and Context
- To  remove setResponse() and $this->response in the Given/Then steps and some helper functions
- To avoid false positive assertions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 