### PR TITLE
Fix reva config of frontend service to not try to contact auth-bearer

### DIFF
--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -110,7 +110,6 @@ func FrontendConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string
 				},
 				"auth": map[string]interface{}{
 					"credentials_by_user_agent": cfg.Middleware.Auth.CredentialsByUserAgent,
-					"credential_chain":          []string{"bearer"},
 				},
 				"prometheus": map[string]interface{}{
 					"namespace": "ocis",


### PR DESCRIPTION
Set an empty Credentials chain. In ocis all non-reva token authentication is
handled by the proxy. This avoid irritating error messages about the missing
 'auth-bearer' service.
    
Fixes: #6692
