### PR TITLE
[docs-only] Add `auth-service` to `port-ranges.md`

### DIFF
--- a/docs/services/general-info/port-ranges.md
+++ b/docs/services/general-info/port-ranges.md
@@ -49,7 +49,8 @@ We also suggest to use the last port in your extensions' range as a debug/metric
 | 9180-9184  | FREE (formerly used by accounts)                                                       |
 | 9185-9189  | [thumbnails]({{< ref "../thumbnails/_index.md" >}})                                    |
 | 9190-9194  | [settings]({{< ref "../settings/_index.md" >}})                                        |
-| 9195-9199  | FREE                                                                                   |
+| 9195-9197  | FREE                                                                                   |
+| 9198-9199  | [auth-service]({{< ref "../auth-service/_index.md" >}})                                |
 | 9200-9204  | [proxy]({{< ref "../proxy/_index.md" >}})                                              |
 | 9205-9209  | [proxy]({{< ref "../proxy/_index.md" >}})                                              |
 | 9210-9214  | [userlog]({{< ref "../userlog/_index.md" >}})                                          |
@@ -62,7 +63,7 @@ We also suggest to use the last port in your extensions' range as a debug/metric
 | 9245-9249  | FREE                                                                                   |
 | 9250-9254  | [ocis server (runtime)](https://github.com/owncloud/ocis/tree/master/ocis/pkg/runtime) |
 | 9255-9259  | [postprocessing]({{< ref "../postprocessing/_index.md" >}})                            |
-| 9260-9264  | [clientlog]({{ ref "../clientlog/index.md" }})                                         |
+| 9260-9264  | [clientlog]({{< ref "../clientlog/_index.md" >}})                                       |
 | 9265-9269  | FREE                                                                                   |
 | 9270-9274  | [eventhistory]({{< ref "../eventhistory/_index.md" >}})                                |
 | 9275-9279  | FREE                                                                                   |

--- a/services/auth-service/pkg/config/defaults/defaultconfig.go
+++ b/services/auth-service/pkg/config/defaults/defaultconfig.go
@@ -18,7 +18,7 @@ func FullDefaultConfig() *config.Config {
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		Debug: config.Debug{
-			Addr:   "127.0.0.1:9169",
+			Addr:   "127.0.0.1:9198",
 			Token:  "",
 			Pprof:  false,
 			Zpages: false,


### PR DESCRIPTION
Adds the missing auth service to the port-ranges.md