### PR TITLE
remove obsolete cli flags

### DIFF
--- a/ocis-pkg/service/grpc/option.go
+++ b/ocis-pkg/service/grpc/option.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -22,7 +21,6 @@ type Options struct {
 	TLSCert       string
 	TLSKey        string
 	Context       context.Context
-	Flags         []cli.Flag
 	TraceProvider trace.TracerProvider
 }
 
@@ -93,13 +91,6 @@ func TLSCert(c string, k string) Option {
 func Context(ctx context.Context) Option {
 	return func(o *Options) {
 		o.Context = ctx
-	}
-}
-
-// Flags provides a function to set the flags option.
-func Flags(flags ...cli.Flag) Option {
-	return func(o *Options) {
-		o.Flags = append(o.Flags, flags...)
 	}
 }
 

--- a/ocis-pkg/service/grpc/service.go
+++ b/ocis-pkg/service/grpc/service.go
@@ -58,7 +58,6 @@ func NewServiceWithClient(client client.Client, opts ...Option) (Service, error)
 		micro.Name(strings.Join([]string{sopts.Namespace, sopts.Name}, ".")),
 		micro.Version(sopts.Version),
 		micro.Context(sopts.Context),
-		micro.Flags(sopts.Flags...),
 		micro.Registry(registry.GetRegistry()),
 		micro.RegisterTTL(time.Second * 30),
 		micro.RegisterInterval(time.Second * 10),

--- a/services/eventhistory/pkg/server/grpc/option.go
+++ b/services/eventhistory/pkg/server/grpc/option.go
@@ -7,7 +7,6 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/eventhistory/pkg/config"
 	"github.com/owncloud/ocis/v2/services/eventhistory/pkg/metrics"
-	"github.com/urfave/cli/v2"
 	"go-micro.dev/v4/store"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -24,7 +23,6 @@ type Options struct {
 	Config        *config.Config
 	Metrics       *metrics.Metrics
 	Namespace     string
-	Flags         []cli.Flag
 	Persistence   store.Store
 	Consumer      events.Consumer
 	TraceProvider trace.TracerProvider
@@ -87,13 +85,6 @@ func Metrics(val *metrics.Metrics) Option {
 func Namespace(val string) Option {
 	return func(o *Options) {
 		o.Namespace = val
-	}
-}
-
-// Flags provides a function to set the flags option.
-func Flags(flags []cli.Flag) Option {
-	return func(o *Options) {
-		o.Flags = append(o.Flags, flags...)
 	}
 }
 

--- a/services/eventhistory/pkg/server/grpc/server.go
+++ b/services/eventhistory/pkg/server/grpc/server.go
@@ -24,7 +24,6 @@ func NewService(opts ...Option) grpc.Service {
 		grpc.Version(version.GetString()),
 		grpc.Address(options.Address),
 		grpc.Context(options.Context),
-		grpc.Flags(options.Flags...),
 		grpc.Version(version.GetString()),
 		grpc.TraceProvider(options.TraceProvider),
 	)

--- a/services/search/pkg/server/grpc/option.go
+++ b/services/search/pkg/server/grpc/option.go
@@ -7,7 +7,6 @@ import (
 	"github.com/owncloud/ocis/v2/services/search/pkg/config"
 	"github.com/owncloud/ocis/v2/services/search/pkg/metrics"
 	svc "github.com/owncloud/ocis/v2/services/search/pkg/service/grpc/v0"
-	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -21,7 +20,6 @@ type Options struct {
 	Context       context.Context
 	Config        *config.Config
 	Metrics       *metrics.Metrics
-	Flags         []cli.Flag
 	Handler       *svc.Service
 	JWTSecret     string
 	TraceProvider trace.TracerProvider
@@ -70,13 +68,6 @@ func Config(val *config.Config) Option {
 func Metrics(val *metrics.Metrics) Option {
 	return func(o *Options) {
 		o.Metrics = val
-	}
-}
-
-// Flags provides a function to set the flags option.
-func Flags(val []cli.Flag) Option {
-	return func(o *Options) {
-		o.Flags = append(o.Flags, val...)
 	}
 }
 

--- a/services/search/pkg/server/grpc/server.go
+++ b/services/search/pkg/server/grpc/server.go
@@ -23,7 +23,6 @@ func Server(opts ...Option) (grpc.Service, func(), error) {
 		grpc.Address(options.Config.GRPC.Addr),
 		grpc.Namespace(options.Config.GRPC.Namespace),
 		grpc.Logger(options.Logger),
-		grpc.Flags(options.Flags...),
 		grpc.Version(version.GetString()),
 		grpc.TraceProvider(options.TraceProvider),
 	)

--- a/services/settings/pkg/server/grpc/option.go
+++ b/services/settings/pkg/server/grpc/option.go
@@ -7,7 +7,6 @@ import (
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/metrics"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/settings"
-	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -22,7 +21,6 @@ type Options struct {
 	Config         *config.Config
 	Metrics        *metrics.Metrics
 	ServiceHandler settings.ServiceHandler
-	Flags          []cli.Flag
 	TraceProvider  trace.TracerProvider
 }
 
@@ -69,13 +67,6 @@ func Config(val *config.Config) Option {
 func Metrics(val *metrics.Metrics) Option {
 	return func(o *Options) {
 		o.Metrics = val
-	}
-}
-
-// Flags provides a function to set the flags option.
-func Flags(val []cli.Flag) Option {
-	return func(o *Options) {
-		o.Flags = append(o.Flags, val...)
 	}
 }
 

--- a/services/settings/pkg/server/grpc/server.go
+++ b/services/settings/pkg/server/grpc/server.go
@@ -28,7 +28,6 @@ func Server(opts ...Option) grpc.Service {
 		grpc.Address(options.Config.GRPC.Addr),
 		grpc.Namespace(options.Config.GRPC.Namespace),
 		grpc.Context(options.Context),
-		grpc.Flags(options.Flags...),
 		grpc.TraceProvider(options.TraceProvider),
 	)
 	if err != nil {

--- a/services/store/pkg/server/grpc/option.go
+++ b/services/store/pkg/server/grpc/option.go
@@ -6,7 +6,6 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/store/pkg/config"
 	"github.com/owncloud/ocis/v2/services/store/pkg/metrics"
-	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -20,7 +19,6 @@ type Options struct {
 	Context       context.Context
 	Config        *config.Config
 	Metrics       *metrics.Metrics
-	Flags         []cli.Flag
 	TraceProvider trace.TracerProvider
 }
 
@@ -67,13 +65,6 @@ func Config(val *config.Config) Option {
 func Metrics(val *metrics.Metrics) Option {
 	return func(o *Options) {
 		o.Metrics = val
-	}
-}
-
-// Flags provides a function to set the flags option.
-func Flags(val []cli.Flag) Option {
-	return func(o *Options) {
-		o.Flags = append(o.Flags, val...)
 	}
 }
 

--- a/services/store/pkg/server/grpc/server.go
+++ b/services/store/pkg/server/grpc/server.go
@@ -24,7 +24,6 @@ func Server(opts ...Option) grpc.Service {
 		grpc.Context(options.Context),
 		grpc.Address(options.Config.GRPC.Addr),
 		grpc.Logger(options.Logger),
-		grpc.Flags(options.Flags...),
 		grpc.TraceProvider(options.TraceProvider),
 	)
 	if err != nil {

--- a/services/thumbnails/pkg/server/grpc/option.go
+++ b/services/thumbnails/pkg/server/grpc/option.go
@@ -6,7 +6,6 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/config"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/metrics"
-	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -22,7 +21,6 @@ type Options struct {
 	Config        *config.Config
 	Metrics       *metrics.Metrics
 	Namespace     string
-	Flags         []cli.Flag
 	TraceProvider trace.TracerProvider
 }
 
@@ -83,13 +81,6 @@ func Metrics(val *metrics.Metrics) Option {
 func Namespace(val string) Option {
 	return func(o *Options) {
 		o.Namespace = val
-	}
-}
-
-// Flags provides a function to set the flags option.
-func Flags(flags []cli.Flag) Option {
-	return func(o *Options) {
-		o.Flags = append(o.Flags, flags...)
 	}
 }
 

--- a/services/thumbnails/pkg/server/grpc/server.go
+++ b/services/thumbnails/pkg/server/grpc/server.go
@@ -29,7 +29,6 @@ func NewService(opts ...Option) grpc.Service {
 		grpc.Version(version.GetString()),
 		grpc.Address(options.Address),
 		grpc.Context(options.Context),
-		grpc.Flags(options.Flags...),
 		grpc.Version(version.GetString()),
 		grpc.TraceProvider(options.TraceProvider),
 	)


### PR DESCRIPTION
This PR removes leftovers from the old cli options.

refs #4088 