### PR TITLE
[tests-only][full-ci] Forwardport added test coverage for previewing shared resources using spaces dav path

### DIFF
--- a/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
@@ -141,7 +141,7 @@ Feature: previews of files downloaded through the webdav API
     And user "Alice" has uploaded file "filesForUpload/<resource>" to "/<resource>"
     And user "Alice" has shared file "/<resource>" with user "Brian"
     And user "Brian" has accepted share "/<resource>" offered by user "Alice"
-    When user "Brian" downloads the preview of "/Shares/<resource>" with width "32" and height "32" using the WebDAV API
+    When user "Brian" downloads the preview of shared resource "/Shares/<resource>" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
     Examples:
@@ -150,6 +150,8 @@ Feature: previews of files downloaded through the webdav API
       | old              | example.gif |
       | new              | lorem.txt   |
       | new              | example.gif |
+      | spaces           | lorem.txt   |
+      | spaces           | example.gif |
 
 
   Scenario Outline: user tries to download previews of other users files
@@ -213,14 +215,15 @@ Feature: previews of files downloaded through the webdav API
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And user "Alice" has shared file "/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
-    And user "Brian" has downloaded the preview of "/Shares/parent.txt" with width "32" and height "32"
+    And user "Brian" has downloaded the preview of shared resource "/Shares/parent.txt" with width "32" and height "32"
     When user "Alice" uploads file with content "this is a file to upload" to "/parent.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as user "Brian" the preview of "/Shares/parent.txt" with width "32" and height "32" should have been changed
+    And as user "Brian" the preview of shared resource "/Shares/parent.txt" with width "32" and height "32" should have been changed
     Examples:
       | dav-path-version |
       | old              |
       | new              |
+      | spaces           |
 
 
   Scenario Outline: it should update the preview content if the file content is updated (content with UTF chars)
@@ -246,19 +249,20 @@ Feature: previews of files downloaded through the webdav API
     And user "Alice" has shared folder "FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
-    And user "Brian" has downloaded the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32"
+    And user "Brian" has downloaded the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32"
     When user "Alice" uploads file "filesForUpload/lorem.txt" to "/FOLDER/lorem.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    When user "Brian" uploads file with content "new uploaded content" to "Shares/FOLDER/lorem.txt" using the WebDAV API
+    And as user "Brian" the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    When user "Brian" uploads file with content "new uploaded content" to shared resource "Shares/FOLDER/lorem.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Brian" the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     Examples:
       | dav-path-version |
       | old              |
       | new              |
+      | spaces           |
 
 
   Scenario Outline: updates to a group shared file should change the preview for both sharees and sharers
@@ -274,19 +278,20 @@ Feature: previews of files downloaded through the webdav API
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     And user "Carol" has accepted share "/FOLDER" offered by user "Alice"
     And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
-    And user "Brian" has downloaded the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32"
-    And user "Carol" has downloaded the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32"
+    And user "Brian" has downloaded the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32"
+    And user "Carol" has downloaded the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32"
     When user "Alice" uploads file "filesForUpload/lorem.txt" to "/FOLDER/lorem.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    And as user "Carol" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    When user "Brian" uploads file with content "new uploaded content" to "Shares/FOLDER/lorem.txt" using the WebDAV API
+    And as user "Brian" the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Carol" the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    When user "Brian" uploads file with content "new uploaded content" to shared resource "Shares/FOLDER/lorem.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-    And as user "Carol" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Brian" the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Carol" the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     Examples:
       | dav-path-version |
       | old              |
       | new              |
+      | spaces           |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR forward port: https://github.com/owncloud/ocis/pull/7234

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
