### PR TITLE
fix default language fallback

### DIFF
--- a/changelog/unreleased/fix-default-mail-language-fallback.md
+++ b/changelog/unreleased/fix-default-mail-language-fallback.md
@@ -1,5 +1,5 @@
 Bugfix: Fix default language fallback
 
-Add the default language for the userlog and notification
+Add the default language for the settings, userlog and notification service
 
 https://github.com/owncloud/ocis/issues/7465

--- a/changelog/unreleased/fix-default-mail-language-fallback.md
+++ b/changelog/unreleased/fix-default-mail-language-fallback.md
@@ -1,0 +1,5 @@
+Bugfix: Fix default language fallback
+
+Add the default language for the userlog and notification
+
+https://github.com/owncloud/ocis/issues/7465

--- a/changelog/unreleased/fix-default-mail-language-fallback.md
+++ b/changelog/unreleased/fix-default-mail-language-fallback.md
@@ -1,5 +1,6 @@
 Bugfix: Fix default language fallback
 
-Add the default language for the settings, userlog and notification service
+Add the default language for the webui,
+the settings, userlog and notification service.
 
 https://github.com/owncloud/ocis/issues/7465

--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -66,3 +66,7 @@ Important: For the time being, the embedded ownCloud Web frontend only supports 
 *   If a requested language code is not available, the service tries to fall back to the base language if available. For example, if the requested language-code `de_DE` is not available, the service tries to fall back to translations in the `de` folder.
 *   If the base language `de` is also not available, the service falls back to the system's default English (`en`),
 which is the source of the texts provided by the code.
+
+## Default Language
+
+The default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. See the `settings` service for a detailed description.

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -116,7 +116,7 @@ func Server(cfg *config.Config) *cli.Command {
 				logger.Fatal().Err(err).Str("addr", cfg.Notifications.RevaGateway).Msg("could not get reva gateway selector")
 			}
 			valueService := settingssvc.NewValueService("com.owncloud.api.settings", grpcClient)
-			svc := service.NewEventsNotifier(evts, channel, logger, gatewaySelector, valueService, cfg.ServiceAccount.ServiceAccountID, cfg.ServiceAccount.ServiceAccountSecret, cfg.Notifications.EmailTemplatePath, cfg.WebUIURL)
+			svc := service.NewEventsNotifier(evts, channel, logger, gatewaySelector, valueService, cfg.ServiceAccount.ServiceAccountID, cfg.ServiceAccount.ServiceAccountSecret, cfg.Notifications.EmailTemplatePath, cfg.Notifications.DefaultLanguage, cfg.WebUIURL)
 
 			gr.Add(svc.Run, func(error) {
 				cancel()

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -1,3 +1,4 @@
+// Package config provides the service configuration.
 package config
 
 import (
@@ -31,6 +32,7 @@ type Notifications struct {
 	Events            Events                `yaml:"events"`
 	EmailTemplatePath string                `yaml:"email_template_path" env:"OCIS_EMAIL_TEMPLATE_PATH;NOTIFICATIONS_EMAIL_TEMPLATE_PATH" desc:"Path to Email notification templates overriding embedded ones."`
 	TranslationPath   string                `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH,NOTIFICATIONS_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
+	DefaultLanguage   string                `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,NOTIFICATIONS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
 	RevaGateway       string                `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	GRPCClientTLS     *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 }

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -32,7 +32,7 @@ type Notifications struct {
 	Events            Events                `yaml:"events"`
 	EmailTemplatePath string                `yaml:"email_template_path" env:"OCIS_EMAIL_TEMPLATE_PATH;NOTIFICATIONS_EMAIL_TEMPLATE_PATH" desc:"Path to Email notification templates overriding embedded ones."`
 	TranslationPath   string                `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH,NOTIFICATIONS_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
-	DefaultLanguage   string                `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,NOTIFICATIONS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
+	DefaultLanguage   string                `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,NOTIFICATIONS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
 	RevaGateway       string                `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	GRPCClientTLS     *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 }

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -32,7 +32,7 @@ type Notifications struct {
 	Events            Events                `yaml:"events"`
 	EmailTemplatePath string                `yaml:"email_template_path" env:"OCIS_EMAIL_TEMPLATE_PATH;NOTIFICATIONS_EMAIL_TEMPLATE_PATH" desc:"Path to Email notification templates overriding embedded ones."`
 	TranslationPath   string                `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH,NOTIFICATIONS_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
-	DefaultLanguage   string                `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,NOTIFICATIONS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
+	DefaultLanguage   string                `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
 	RevaGateway       string                `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	GRPCClientTLS     *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 }

--- a/services/notifications/pkg/config/config.go
+++ b/services/notifications/pkg/config/config.go
@@ -32,7 +32,7 @@ type Notifications struct {
 	Events            Events                `yaml:"events"`
 	EmailTemplatePath string                `yaml:"email_template_path" env:"OCIS_EMAIL_TEMPLATE_PATH;NOTIFICATIONS_EMAIL_TEMPLATE_PATH" desc:"Path to Email notification templates overriding embedded ones."`
 	TranslationPath   string                `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH,NOTIFICATIONS_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
-	DefaultLanguage   string                `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
+	DefaultLanguage   string                `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"The default language used by services and the WebUI. If not defined, English will be used as default. See the documentation for more details."`
 	RevaGateway       string                `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	GRPCClientTLS     *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 }

--- a/services/notifications/pkg/email/composer.go
+++ b/services/notifications/pkg/email/composer.go
@@ -9,9 +9,9 @@ import (
 )
 
 // NewTextTemplate replace the body message template placeholders with the translated template
-func NewTextTemplate(mt MessageTemplate, locale string, translationPath string, vars map[string]string) (MessageTemplate, error) {
+func NewTextTemplate(mt MessageTemplate, locale, defaultLocale string, translationPath string, vars map[string]string) (MessageTemplate, error) {
 	var err error
-	t := l10n.NewTranslator(locale, translationPath)
+	t := l10n.NewTranslator(locale, defaultLocale, translationPath)
 	mt.Subject, err = composeMessage(t.Translate(mt.Subject), vars)
 	if err != nil {
 		return mt, err
@@ -32,9 +32,9 @@ func NewTextTemplate(mt MessageTemplate, locale string, translationPath string, 
 }
 
 // NewHTMLTemplate replace the body message template placeholders with the translated template
-func NewHTMLTemplate(mt MessageTemplate, locale string, translationPath string, vars map[string]string) (MessageTemplate, error) {
+func NewHTMLTemplate(mt MessageTemplate, locale, defaultLocale string, translationPath string, vars map[string]string) (MessageTemplate, error) {
 	var err error
-	t := l10n.NewTranslator(locale, translationPath)
+	t := l10n.NewTranslator(locale, defaultLocale, translationPath)
 	mt.Subject, err = composeMessage(t.Translate(mt.Subject), vars)
 	if err != nil {
 		return mt, err

--- a/services/notifications/pkg/email/email.go
+++ b/services/notifications/pkg/email/email.go
@@ -26,8 +26,8 @@ var (
 )
 
 // RenderEmailTemplate renders the email template for a new share
-func RenderEmailTemplate(mt MessageTemplate, locale string, emailTemplatePath string, translationPath string, vars map[string]string) (*channels.Message, error) {
-	textMt, err := NewTextTemplate(mt, locale, translationPath, vars)
+func RenderEmailTemplate(mt MessageTemplate, locale, defaultLocale string, emailTemplatePath string, translationPath string, vars map[string]string) (*channels.Message, error) {
+	textMt, err := NewTextTemplate(mt, locale, defaultLocale, translationPath, vars)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func RenderEmailTemplate(mt MessageTemplate, locale string, emailTemplatePath st
 	if err != nil {
 		return nil, err
 	}
-	htmlMt, err := NewHTMLTemplate(mt, locale, translationPath, escapeStringMap(vars))
+	htmlMt, err := NewHTMLTemplate(mt, locale, defaultLocale, translationPath, escapeStringMap(vars))
 	if err != nil {
 		return nil, err
 	}

--- a/services/notifications/pkg/email/l10n/locate.go
+++ b/services/notifications/pkg/email/l10n/locate.go
@@ -22,11 +22,19 @@ type Translator interface {
 }
 
 type translator struct {
-	l *gotext.Locale
+	locale *gotext.Locale
 }
 
 // NewTranslator Create Translator with library path and language code and load default domain
-func NewTranslator(local string, path string) Translator {
+func NewTranslator(locale, defaultLocale string, path string) Translator {
+	l := newLocate(locale, path)
+	if locale != "en" && len(l.GetTranslations()) == 0 {
+		l = newLocate(defaultLocale, path)
+	}
+	return &translator{locale: l}
+}
+
+func newLocate(local string, path string) *gotext.Locale {
 	var l *gotext.Locale
 	if path == "" {
 		filesystem, _ := fs.Sub(_translationFS, "locale")
@@ -35,9 +43,9 @@ func NewTranslator(local string, path string) Translator {
 		l = gotext.NewLocale(path, local)
 	}
 	l.AddDomain(_domain) // make domain configurable only if needed
-	return &translator{l: l}
+	return l
 }
 
 func (t *translator) Translate(str string) string {
-	return t.l.Get(str)
+	return t.locale.Get(str)
 }

--- a/services/notifications/pkg/service/service.go
+++ b/services/notifications/pkg/service/service.go
@@ -42,7 +42,7 @@ func NewEventsNotifier(
 	logger log.Logger,
 	gatewaySelector pool.Selectable[gateway.GatewayAPIClient],
 	valueService settingssvc.ValueService,
-	serviceAccountID, serviceAccountSecret, emailTemplatePath, ocisURL string) Service {
+	serviceAccountID, serviceAccountSecret, emailTemplatePath, defaultLanguage, ocisURL string) Service {
 
 	return eventsNotifier{
 		logger:               logger,
@@ -54,6 +54,7 @@ func NewEventsNotifier(
 		serviceAccountID:     serviceAccountID,
 		serviceAccountSecret: serviceAccountSecret,
 		emailTemplatePath:    emailTemplatePath,
+		defaultLanguage:      defaultLanguage,
 		ocisURL:              ocisURL,
 	}
 }
@@ -67,6 +68,7 @@ type eventsNotifier struct {
 	valueService         settingssvc.ValueService
 	emailTemplatePath    string
 	translationPath      string
+	defaultLanguage      string
 	ocisURL              string
 	serviceAccountID     string
 	serviceAccountSecret string
@@ -109,7 +111,7 @@ func (s eventsNotifier) render(ctx context.Context, template email.MessageTempla
 		locale := s.getUserLang(ctx, usr.GetId())
 		fields[granteeFieldName] = usr.GetDisplayName()
 
-		rendered, err := email.RenderEmailTemplate(template, locale, s.emailTemplatePath, s.translationPath, fields)
+		rendered, err := email.RenderEmailTemplate(template, locale, s.defaultLanguage, s.emailTemplatePath, s.translationPath, fields)
 		if err != nil {
 			return nil, err
 		}

--- a/services/notifications/pkg/service/service_test.go
+++ b/services/notifications/pkg/service/service_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Notifications", func() {
 			cfg := defaults.FullDefaultConfig()
 			cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 			ch := make(chan events.Event)
-			evts := service.NewEventsNotifier(ch, tc, log.NewLogger(), gatewaySelector, vs, "", "", "", "")
+			evts := service.NewEventsNotifier(ch, tc, log.NewLogger(), gatewaySelector, vs, "", "", "", "", "")
 			go evts.Run()
 
 			ch <- ev
@@ -275,7 +275,7 @@ var _ = Describe("Notifications X-Site Scripting", func() {
 			cfg := defaults.FullDefaultConfig()
 			cfg.GRPCClientTLS = &shared.GRPCClientTLS{}
 			ch := make(chan events.Event)
-			evts := service.NewEventsNotifier(ch, tc, log.NewLogger(), gatewaySelector, vs, "", "", "", "")
+			evts := service.NewEventsNotifier(ch, tc, log.NewLogger(), gatewaySelector, vs, "", "", "", "", "")
 			go evts.Run()
 
 			ch <- ev

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -76,6 +76,6 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 ## Default Language
 
-The default language can be defined via `SETTINGS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for invitation emails.
+The default language can be defined via `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for notification and invitation emails.
 
 Important developer note: the list of supported languages is at the moment not easy defineable, as it is the minimum intersection of languages shown in the WebUI and languages defined in the ocis code for the use of notifications. Even more, not all languages where there are translations available on transifex, are available in the WebUI respectively for ocis notifications, and the translation rate for existing languages is partially not that high. You will see therefore quite often English default strings though a supported language may exist and was selected.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -79,3 +79,14 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 The default language can be defined via `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for notification and invitation emails.
 
 Important developer note: the list of supported languages is at the moment not easy defineable, as it is the minimum intersection of languages shown in the WebUI and languages defined in the ocis code for the use of notifications. Even more, not all languages where there are translations available on transifex, are available in the WebUI respectively for ocis notifications, and the translation rate for existing languages is partially not that high. You will see therefore quite often English default strings though a supported language may exist and was selected.
+
+The `OCIS_DEFAULT_LANGUAGE` impact `notification` and `userlog` services and UI and depends on existing translation.
+
+If  `OCIS_DEFAULT_LANGUAGE` is not set the expected behavior is: `notification` and `userlog` services and UI use
+English by default until a user sets another language in an Account-> Language. If a user sets another language in an
+Account-> Language then `notification` and `userlog` services and UI use a user language but if no translation found falls back to English.
+
+If  `OCIS_DEFAULT_LANGUAGE` is set the expected behavior is: `notification` and `userlog` services and UI
+use `OCIS_DEFAULT_LANGUAGE`  by default until a user sets another language in an Account-> Language. If a user sets
+another language in an Account-> Language then `notification` and `userlog` services and UI to use a user language
+but if no translation found falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.

--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -76,17 +76,16 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 ## Default Language
 
-The default language can be defined via `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for notification and invitation emails.
+The default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for notification and invitation emails.
 
-Important developer note: the list of supported languages is at the moment not easy defineable, as it is the minimum intersection of languages shown in the WebUI and languages defined in the ocis code for the use of notifications. Even more, not all languages where there are translations available on transifex, are available in the WebUI respectively for ocis notifications, and the translation rate for existing languages is partially not that high. You will see therefore quite often English default strings though a supported language may exist and was selected.
+Important developer note: the list of supported languages is at the moment not easy defineable, as it is the minimum intersection of languages shown in the WebUI and languages defined in the ocis code for the use of notifications and userlog. Even more, not all languages where there are translations available on transifex, are available in the WebUI respectively for ocis notifications, and the translation rate for existing languages is partially not that high. You will see therefore quite often English default strings though a supported language may exist and was selected.
 
-The `OCIS_DEFAULT_LANGUAGE` impact `notification` and `userlog` services and UI and depends on existing translation.
+The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` services and the WebUI. Note that translations must exist for all named components to be presented correctly.
 
-If  `OCIS_DEFAULT_LANGUAGE` is not set the expected behavior is: `notification` and `userlog` services and UI use
-English by default until a user sets another language in an Account-> Language. If a user sets another language in an
-Account-> Language then `notification` and `userlog` services and UI use a user language but if no translation found falls back to English.
+*   If  `OCIS_DEFAULT_LANGUAGE` **is not set**, the expected behavior is:
+    *   The `notification` and `userlog` services and the WebUI use English by default until a user sets another language in the WebUI via _Account -> Language_.
+    *    If a user sets another language in the WebUI in _Account -> Language_, then the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to English.
 
-If  `OCIS_DEFAULT_LANGUAGE` is set the expected behavior is: `notification` and `userlog` services and UI
-use `OCIS_DEFAULT_LANGUAGE`  by default until a user sets another language in an Account-> Language. If a user sets
-another language in an Account-> Language then `notification` and `userlog` services and UI to use a user language
-but if no translation found falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.
+*   If  `OCIS_DEFAULT_LANGUAGE` **is set**, the expected behavior is:
+    *   The `notification` and `userlog` services and the WebUI use `OCIS_DEFAULT_LANGUAGE`  by default until a user sets another language in the WebUI via _Account -> Language_.
+    *   If a user sets another language in the WebUI in _Account -> Language_, the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 
 	ServiceAccountIDAdmin string `yaml:"service_account_id_admin" env:"OCIS_SERVICE_ACCOUNT_ID;SETTINGS_SERVICE_ACCOUNT_ID_ADMIN" desc:"The ID of the service account having the admin role. See the 'auth-service' service description for more details."`
 
-	DefaultLanguage string `yaml:"default_language" env:"SETTINGS_DEFAULT_LANGUAGE" desc:"The default language. If not defined, English will be used as default. See the documentation for more details."`
+	DefaultLanguage string `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,SETTINGS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 
 	ServiceAccountIDAdmin string `yaml:"service_account_id_admin" env:"OCIS_SERVICE_ACCOUNT_ID;SETTINGS_SERVICE_ACCOUNT_ID_ADMIN" desc:"The ID of the service account having the admin role. See the 'auth-service' service description for more details."`
 
-	DefaultLanguage string `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,SETTINGS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
+	DefaultLanguage string `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 
 	ServiceAccountIDAdmin string `yaml:"service_account_id_admin" env:"OCIS_SERVICE_ACCOUNT_ID;SETTINGS_SERVICE_ACCOUNT_ID_ADMIN" desc:"The ID of the service account having the admin role. See the 'auth-service' service description for more details."`
 
-	DefaultLanguage string `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
+	DefaultLanguage string `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"The default language used by services and the WebUI. If not defined, English will be used as default. See the documentation for more details."`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/userlog/README.md
+++ b/services/userlog/README.md
@@ -76,3 +76,7 @@ Important: For the time being, the embedded ownCloud Web frontend only supports 
 *   If a requested language code is not available, the service tries to fall back to the base language if available. For example, if the requested language-code `de_DE` is not available, the service tries to fall back to translations in the `de` folder.
 *   If the base language `de` is also not available, the service falls back to the system's default English (`en`),
 which is the source of the texts provided by the code.
+
+## Default Language
+
+The default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. See the `settings` service for a detailed description.

--- a/services/userlog/pkg/config/config.go
+++ b/services/userlog/pkg/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 
 	RevaGateway     string      `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	TranslationPath string      `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH;USERLOG_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
+	DefaultLanguage string      `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,USERLOG_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
 	Events          Events      `yaml:"events"`
 	Persistence     Persistence `yaml:"persistence"`
 

--- a/services/userlog/pkg/config/config.go
+++ b/services/userlog/pkg/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 
 	RevaGateway     string      `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	TranslationPath string      `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH;USERLOG_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
-	DefaultLanguage string      `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,USERLOG_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
+	DefaultLanguage string      `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
 	Events          Events      `yaml:"events"`
 	Persistence     Persistence `yaml:"persistence"`
 

--- a/services/userlog/pkg/config/config.go
+++ b/services/userlog/pkg/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 
 	RevaGateway     string      `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	TranslationPath string      `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH;USERLOG_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
-	DefaultLanguage string      `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,USERLOG_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the documentation for more details."`
+	DefaultLanguage string      `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE,USERLOG_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
 	Events          Events      `yaml:"events"`
 	Persistence     Persistence `yaml:"persistence"`
 

--- a/services/userlog/pkg/config/config.go
+++ b/services/userlog/pkg/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 
 	RevaGateway     string      `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata"`
 	TranslationPath string      `yaml:"translation_path" env:"OCIS_TRANSLATION_PATH;USERLOG_TRANSLATION_PATH" desc:"(optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details."`
-	DefaultLanguage string      `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"(optional) The default language. If not defined, English will be used as default. See the 'settings' service documentation for more details."`
+	DefaultLanguage string      `yaml:"default_language" env:"OCIS_DEFAULT_LANGUAGE" desc:"The default language used by services and the WebUI. If not defined, English will be used as default. See the documentation for more details."`
 	Events          Events      `yaml:"events"`
 	Persistence     Persistence `yaml:"persistence"`
 

--- a/services/userlog/pkg/service/http.go
+++ b/services/userlog/pkg/service/http.go
@@ -59,7 +59,7 @@ func (ul *UserlogService) HandleGetEvents(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	conv := NewConverter(ctx, r.Header.Get(HeaderAcceptLanguage), gwc, ul.cfg.Service.Name, ul.cfg.TranslationPath)
+	conv := NewConverter(ctx, r.Header.Get(HeaderAcceptLanguage), gwc, ul.cfg.Service.Name, ul.cfg.TranslationPath, ul.cfg.DefaultLanguage)
 
 	var outdatedEvents []string
 	resp := GetEventResponseOC10{}

--- a/services/userlog/pkg/service/service.go
+++ b/services/userlog/pkg/service/service.go
@@ -337,7 +337,7 @@ func (ul *UserlogService) addEventToUser(ctx context.Context, userid string, eve
 }
 
 func (ul *UserlogService) sendSSE(ctx context.Context, userid string, event events.Event, gwc gateway.GatewayAPIClient) error {
-	ev, err := NewConverter(ctx, ul.getUserLocale(userid), gwc, ul.cfg.Service.Name, ul.cfg.TranslationPath).ConvertEvent(event.ID, event.Event)
+	ev, err := NewConverter(ctx, ul.getUserLocale(userid), gwc, ul.cfg.Service.Name, ul.cfg.TranslationPath, ul.cfg.DefaultLanguage).ConvertEvent(event.ID, event.Event)
 	if err != nil {
 		return err
 	}

--- a/tests/acceptance/features/apiNotification/emailNotification.feature
+++ b/tests/acceptance/features/apiNotification/emailNotification.feature
@@ -183,7 +183,7 @@ Feature: Email notification
 
   @env-config
   Scenario: group members get an email notification in default language when someone shares a file with the group
-    Given the config "SETTINGS_DEFAULT_LANGUAGE" has been set to "de"
+    Given the config "OCIS_DEFAULT_LANGUAGE" has been set to "de"
     And user "Carol" has been created with default attributes and without skeleton files
     And group "group1" has been created
     And user "Brian" has been added to group "group1"

--- a/tests/acceptance/features/apiNotification/notification.feature
+++ b/tests/acceptance/features/apiNotification/notification.feature
@@ -270,7 +270,7 @@ Feature: Notification
 
   @env-config
   Scenario: get a notification about a file share in default languages
-    Given the config "SETTINGS_DEFAULT_LANGUAGE" has been set to "de"
+    Given the config "OCIS_DEFAULT_LANGUAGE" has been set to "de"
     And user "Alice" has shared entry "textfile1.txt" with user "Brian" with permissions "17"
     When user "Brian" lists all notifications
     Then the HTTP status code should be "200"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added the global variable OCIS_DEFAULT_LANGUAGE. Now `settings`, `notification`, and `userlog` services support the default language fallback.

The `OCIS_DEFAULT_LANGUAGE` impacts depend on existing translation.

These changes are needed because if the transaction does not exist for notification or userlog services we want to fall down to the OCIS_DEFAULT_LANGUAGE first and after that to the English

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [https://github.com/owncloud/ocis/issues/7465](https://github.com/owncloud/ocis/issues/7465)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
