### PR TITLE
feat: add config for disabling web extensions

### DIFF
--- a/changelog/unreleased/disabled-web-extensions-config.md
+++ b/changelog/unreleased/disabled-web-extensions-config.md
@@ -1,0 +1,6 @@
+Enhancement: Config for disabling Web extensions
+
+A new config for disabling specific Web extensions via their id has been added.
+
+https://github.com/owncloud/ocis/pull/7486
+https://github.com/owncloud/web/issues/8524

--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -25,6 +25,7 @@ type Options struct {
 	PrivacyURL               string           `json:"privacyUrl,omitempty" yaml:"privacyUrl" env:"WEB_OPTION_PRIVACY_URL" desc:"Specifies the target URL for the privacy link valid for the ocis instance in the account menu."`
 	AccessDeniedHelpURL      string           `json:"accessDeniedHelpUrl,omitempty" yaml:"accessDeniedHelpUrl" env:"WEB_OPTION_ACCESS_DENIED_HELP_URL" desc:"Specifies the target URL valid for the ocis instance for the generic logged out / access denied page."`
 	TokenStorageLocal        bool             `json:"tokenStorageLocal,omitempty" yaml:"tokenStorageLocal" env:"WEB_OPTION_TOKEN_STORAGE_LOCAL" desc:"Specifies whether the access token will be stored in the local storage when set to 'true' or in the session storage when set to 'false''. If stored in the local storage, login state will be persisted across multiple browser tabs, means no additional logins are required. Defaults to 'true'."`
+	DisabledExtensions       []string         `json:"disabledExtensions,omitempty" yaml:"disabledExtensions" env:"WEB_OPTION_DISABLED_EXTENSIONS" desc:"Allows disabling specific Web extensions via their id."`
 }
 
 // AccountEditLink are the AccountEditLink options


### PR DESCRIPTION
## Description
Adds a new config for disabling specific Web extensions via their id.

See https://github.com/owncloud/web/pull/9800.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
