### PR TITLE
Natsjs registry

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1901,6 +1901,8 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
         "FRONTEND_SEARCH_MIN_LENGTH": "2",
         "OCIS_ASYNC_UPLOADS": True,
         "OCIS_EVENTS_ENABLE_TLS": False,
+        "MICRO_REGISTRY": "natsjs",
+        "MICRO_REGISTRY_ADDRESS": "127.0.0.1:9233",
     }
 
     if deploy_type == "":

--- a/changelog/unreleased/natsjs-registry.md
+++ b/changelog/unreleased/natsjs-registry.md
@@ -1,0 +1,6 @@
+Enhancement: Introduce natsjs registry
+
+Introduce a registry based on the natsjs object store
+
+https://github.com/owncloud/ocis/issues/7272
+https://github.com/owncloud/ocis/pull/7487

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-micro/plugins/v4/registry/nats v1.2.2-0.20230723205323-1ada01245674
 	github.com/go-micro/plugins/v4/server/grpc v1.2.0
 	github.com/go-micro/plugins/v4/server/http v1.2.2
+	github.com/go-micro/plugins/v4/store/nats-js v1.2.1-0.20230807070816-bc05fb076ce7
 	github.com/go-micro/plugins/v4/wrapper/breaker/gobreaker v1.2.0
 	github.com/go-micro/plugins/v4/wrapper/monitoring/prometheus v1.2.0
 	github.com/go-micro/plugins/v4/wrapper/trace/opentelemetry v1.2.0
@@ -190,7 +191,6 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-micro/plugins/v4/events/natsjs v1.2.2-0.20230807070816-bc05fb076ce7 // indirect
-	github.com/go-micro/plugins/v4/store/nats-js v1.1.0 // indirect
 	github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d // indirect
 	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
@@ -340,3 +340,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/go-micro/plugins/v4/store/nats-js => github.com/kobergj/plugins/v4/store/nats-js v1.2.1-0.20231020092801-9463c820c19a

--- a/go.sum
+++ b/go.sum
@@ -1198,8 +1198,6 @@ github.com/go-micro/plugins/v4/server/grpc v1.2.0 h1:lXfM+/0oE/u1g0hVBYsvbP4lYOY
 github.com/go-micro/plugins/v4/server/grpc v1.2.0/go.mod h1:+Ah9Pf/vMSXxBM3fup/hc3N+zN2as3nIpcRaR4sBjnY=
 github.com/go-micro/plugins/v4/server/http v1.2.2 h1:UK2/09AU0zV3wHELuR72TZzVU2vTUhbx9qrRGrQSIWg=
 github.com/go-micro/plugins/v4/server/http v1.2.2/go.mod h1:YuAjaSPxcn3LI8j2FUsqx0Rxunrj4YwDV41Ax76rLl0=
-github.com/go-micro/plugins/v4/store/nats-js v1.1.0 h1:6Fe1/eLtg8kRyaGvMILp4olYtTDGwYNBXyb1sYfAWGk=
-github.com/go-micro/plugins/v4/store/nats-js v1.1.0/go.mod h1:jJf7Gm39OafZlT3s3UE2/9NIYj6OlI2fmZ4czSA3gvo=
 github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d h1:HQoDDVyMfdkrgXNo03ZY4vzhoOXMDZVZ4SnpBDVID6E=
 github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d/go.mod h1:MbCG0YiyPqETTtm7uHFmxQNCaW1o9hBoYtFwhbVjLUg=
 github.com/go-micro/plugins/v4/transport/grpc v1.1.0 h1:mXfDYfFQLnVDzjGY3o84oe4prfux9h8txsnA19dKsj8=
@@ -1575,6 +1573,8 @@ github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0 h1:eyi1Ad2aNJMW95zcSbmGg7Cg6cq3ADwLpMAP96d8rF0=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/kobergj/plugins/v4/store/nats-js v1.2.1-0.20231020092801-9463c820c19a h1:W+itvdTLFGLuFh+E5IzW08n2BS02cHK91qnMo7SUxbA=
+github.com/kobergj/plugins/v4/store/nats-js v1.2.1-0.20231020092801-9463c820c19a/go.mod h1:wt51O2yNmgF/F7E00IYIH0awseRGqtnmjZGn6RjbZSk=
 github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b/go.mod h1:o03bZfuBwAXHetKXuInt4S7omeXUu62/A845kiycsSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/ocis-pkg/natsjsregistry/options.go
+++ b/ocis-pkg/natsjsregistry/options.go
@@ -1,0 +1,32 @@
+package natsjsregistry
+
+import (
+	"context"
+	"time"
+
+	"go-micro.dev/v4/registry"
+	"go-micro.dev/v4/store"
+)
+
+type storeOptionsKey struct{}
+type expiryKey struct{}
+
+// StoreOptions sets the options for the underlying store
+func StoreOptions(opts []store.Option) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, storeOptionsKey{}, opts)
+	}
+}
+
+// ServiceExpiry allows setting an expiry time for service registrations
+func ServiceExpiry(t time.Duration) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, expiryKey{}, t)
+	}
+}

--- a/ocis-pkg/natsjsregistry/registry.go
+++ b/ocis-pkg/natsjsregistry/registry.go
@@ -1,0 +1,137 @@
+// Package natsjsregistry implements a registry using natsjs object store
+package natsjsregistry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	natsjs "github.com/go-micro/plugins/v4/store/nats-js"
+	"go-micro.dev/v4/registry"
+	"go-micro.dev/v4/store"
+	"go-micro.dev/v4/util/cmd"
+)
+
+var _registryName = "natsjs"
+
+func init() {
+	cmd.DefaultRegistries[_registryName] = NewRegistry
+}
+
+// NewRegistry returns a new natsjs registry
+func NewRegistry(opts ...registry.Option) registry.Registry {
+	options := registry.Options{
+		Context: context.Background(),
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+	exp, _ := options.Context.Value(expiryKey{}).(time.Duration)
+	return &storeregistry{
+		opts:   options,
+		store:  natsjs.NewStore(storeOptions(options)...),
+		typ:    _registryName,
+		expiry: exp,
+	}
+}
+
+type storeregistry struct {
+	opts   registry.Options
+	store  store.Store
+	typ    string
+	expiry time.Duration
+}
+
+// Init inits the registry
+func (n *storeregistry) Init(opts ...registry.Option) error {
+	for _, o := range opts {
+		o(&n.opts)
+	}
+	return n.store.Init(storeOptions(n.opts)...)
+}
+
+// Options returns the configured options
+func (n *storeregistry) Options() registry.Options {
+	return n.opts
+}
+
+// Register adds a service to the registry
+func (n *storeregistry) Register(s *registry.Service, _ ...registry.RegisterOption) error {
+	if s == nil {
+		return errors.New("wont store nil service")
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return n.store.Write(&store.Record{
+		Key:    s.Name,
+		Value:  b,
+		Expiry: n.expiry,
+	})
+}
+
+// Deregister removes a service from the registry
+func (n *storeregistry) Deregister(s *registry.Service, _ ...registry.DeregisterOption) error {
+	return n.store.Delete(s.Name)
+}
+
+// GetService gets a specific service from the registry
+func (n *storeregistry) GetService(s string, _ ...registry.GetOption) ([]*registry.Service, error) {
+	recs, err := n.store.Read(s)
+	if err != nil {
+		return nil, err
+	}
+	svcs := make([]*registry.Service, 0, len(recs))
+	for _, rec := range recs {
+		var s registry.Service
+		if err := json.Unmarshal(rec.Value, &s); err != nil {
+			return nil, err
+		}
+		svcs = append(svcs, &s)
+	}
+	return svcs, nil
+}
+
+// ListServices lists all registered services
+func (n *storeregistry) ListServices(...registry.ListOption) ([]*registry.Service, error) {
+	keys, err := n.store.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var svcs []*registry.Service
+	for _, k := range keys {
+		s, err := n.GetService(k)
+		if err != nil {
+			// TODO: continue ?
+			return nil, err
+		}
+		svcs = append(svcs, s...)
+
+	}
+	return svcs, nil
+}
+
+// Watch allowes following the changes in the registry if it would be implemented
+func (n *storeregistry) Watch(...registry.WatchOption) (registry.Watcher, error) {
+	return nil, errors.New("watcher not implemented")
+}
+
+// String returns the name of the registry
+func (n *storeregistry) String() string {
+	return n.typ
+}
+
+func storeOptions(opts registry.Options) []store.Option {
+	storeoptions := []store.Option{
+		store.Nodes(opts.Addrs...),
+		store.Database("service-registry"),
+		store.Table("service-registry"),
+	}
+	if so, ok := opts.Context.Value(storeOptionsKey{}).([]store.Option); ok {
+		storeoptions = append(storeoptions, so...)
+	}
+	return storeoptions
+}

--- a/ocis-pkg/registry/registry.go
+++ b/ocis-pkg/registry/registry.go
@@ -13,6 +13,7 @@ import (
 	mdnsr "github.com/go-micro/plugins/v4/registry/mdns"
 	memr "github.com/go-micro/plugins/v4/registry/memory"
 	natsr "github.com/go-micro/plugins/v4/registry/nats"
+	"github.com/owncloud/ocis/v2/ocis-pkg/natsjsregistry"
 	mRegistry "go-micro.dev/v4/registry"
 	"go-micro.dev/v4/registry/cache"
 )
@@ -28,6 +29,7 @@ var (
 	reg       mRegistry.Registry
 )
 
+// Configure configures the registry
 func Configure(plugin string) {
 	if reg == nil {
 		regPlugin = plugin
@@ -66,6 +68,10 @@ func GetRegistry() mRegistry.Registry {
 			)
 		case "memory":
 			reg = memr.NewRegistry()
+		case "natsjs":
+			reg = natsjsregistry.NewRegistry(
+				mRegistry.Addrs(addresses...),
+			)
 		default:
 			reg = mdnsr.NewRegistry()
 		}

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -162,11 +162,6 @@ func NewService(options ...Option) (*Service, error) {
 		cfg.EventHistory.Commons = cfg.Commons
 		return eventhistory.Execute(cfg.EventHistory)
 	})
-	reg(opts.Config.Frontend.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
-		cfg.Frontend.Context = ctx
-		cfg.Frontend.Commons = cfg.Commons
-		return frontend.Execute(cfg.Frontend)
-	})
 	reg(opts.Config.Gateway.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Gateway.Context = ctx
 		cfg.Gateway.Commons = cfg.Commons
@@ -302,6 +297,11 @@ func NewService(options ...Option) (*Service, error) {
 	dreg := func(name string, exec func(context.Context, *ociscfg.Config) error) {
 		s.Delayed[name] = NewSutureServiceBuilder(exec)
 	}
+	dreg(opts.Config.Frontend.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
+		cfg.Frontend.Context = ctx
+		cfg.Frontend.Commons = cfg.Commons
+		return frontend.Execute(cfg.Frontend)
+	})
 	dreg(opts.Config.IDP.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.IDP.Context = ctx
 		cfg.IDP.Commons = cfg.Commons

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -64,6 +64,8 @@ import (
 var (
 	// runset keeps track of which services to start supervised.
 	runset map[string]struct{}
+	// time to wait between starting service groups (preliminary, main, delayed)
+	_startDelay = 2 * time.Second
 )
 
 type serviceFuncMap map[string]func(*ociscfg.Config) suture.Service
@@ -412,7 +414,7 @@ func Start(o ...Option) error {
 	go trap(s, halt)
 
 	// grace period for supervisor to get up
-	time.Sleep(time.Second)
+	time.Sleep(_startDelay)
 
 	// schedule services that we are sure don't have interdependencies.
 	scheduleServiceTokens(s, s.ServicesRegistry)
@@ -421,7 +423,7 @@ func Start(o ...Option) error {
 	scheduleServiceTokens(s, s.Additional)
 
 	// add services with delayed execution.
-	time.Sleep(1 * time.Second)
+	time.Sleep(_startDelay)
 	scheduleServiceTokens(s, s.Delayed)
 
 	return http.Serve(l, nil)

--- a/vendor/github.com/go-micro/plugins/v4/store/nats-js/context.go
+++ b/vendor/github.com/go-micro/plugins/v4/store/nats-js/context.go
@@ -6,7 +6,7 @@ import (
 	"go-micro.dev/v4/store"
 )
 
-// setStoreOption returns a function to setup a context with given value
+// setStoreOption returns a function to setup a context with given value.
 func setStoreOption(k, v interface{}) store.Option {
 	return func(o *store.Options) {
 		if o.Context == nil {

--- a/vendor/github.com/go-micro/plugins/v4/store/nats-js/options.go
+++ b/vendor/github.com/go-micro/plugins/v4/store/nats-js/options.go
@@ -7,7 +7,7 @@ import (
 	"go-micro.dev/v4/store"
 )
 
-// store.Option
+// store.Option.
 type natsOptionsKey struct{}
 type jsOptionsKey struct{}
 type objOptionsKey struct{}
@@ -15,15 +15,15 @@ type ttlOptionsKey struct{}
 type memoryOptionsKey struct{}
 type descriptionOptionsKey struct{}
 
-// store.DeleteOption
+// store.DeleteOption.
 type delBucketOptionsKey struct{}
 
-// NatsOptions accepts nats.Options
+// NatsOptions accepts nats.Options.
 func NatsOptions(opts nats.Options) store.Option {
 	return setStoreOption(natsOptionsKey{}, opts)
 }
 
-// JetStreamOptions accepts multiple nats.JSOpt
+// JetStreamOptions accepts multiple nats.JSOpt.
 func JetStreamOptions(opts ...nats.JSOpt) store.Option {
 	return setStoreOption(jsOptionsKey{}, opts)
 }
@@ -35,34 +35,42 @@ func ObjectStoreOptions(cfg ...*nats.ObjectStoreConfig) store.Option {
 }
 
 // DefaultTTL sets the default TTL to use for new buckets
-//  By default no TTL is set.
+//
+//	By default no TTL is set.
 //
 // TTL ON INDIVIDUAL WRITE CALLS IS NOT SUPPORTED, only bucket wide TTL.
 // Either set a default TTL with this option or provide bucket specific options
-//  with ObjectStoreOptions
+//
+//	with ObjectStoreOptions
 func DefaultTTL(ttl time.Duration) store.Option {
 	return setStoreOption(ttlOptionsKey{}, ttl)
 }
 
 // DefaultMemory sets the default storage type to memory only.
 //
-//  The default is file storage, persisting storage between service restarts.
+//	The default is file storage, persisting storage between service restarts.
+//
 // Be aware that the default storage location of NATS the /tmp dir is, and thus
-//  won't persist reboots.
+//
+//	won't persist reboots.
 func DefaultMemory() store.Option {
 	return setStoreOption(memoryOptionsKey{}, nats.MemoryStorage)
 }
 
 // DefaultDescription sets the default description to use when creating new
-//  buckets. The default is "Store managed by go-micro"
+//
+//	buckets. The default is "Store managed by go-micro"
 func DefaultDescription(text string) store.Option {
 	return setStoreOption(descriptionOptionsKey{}, text)
 }
 
 // DeleteBucket will use the key passed to Delete as a bucket (database) name,
-//  and delete the bucket.
+//
+//	and delete the bucket.
+//
 // This option should not be combined with the store.DeleteFrom option, as
-//  that will overwrite the delete action.
+//
+//	that will overwrite the delete action.
 func DeleteBucket() store.DeleteOption {
 	return func(d *store.DeleteOptions) {
 		d.Table = "DELETE_BUCKET"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -929,7 +929,7 @@ github.com/go-micro/plugins/v4/server/grpc
 # github.com/go-micro/plugins/v4/server/http v1.2.2
 ## explicit; go 1.17
 github.com/go-micro/plugins/v4/server/http
-# github.com/go-micro/plugins/v4/store/nats-js v1.1.0
+# github.com/go-micro/plugins/v4/store/nats-js v1.2.1-0.20230807070816-bc05fb076ce7 => github.com/kobergj/plugins/v4/store/nats-js v1.2.1-0.20231020092801-9463c820c19a
 ## explicit; go 1.17
 github.com/go-micro/plugins/v4/store/nats-js
 # github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230510195111-07cd57e1bc9d
@@ -2259,3 +2259,4 @@ stash.kopano.io/kgol/oidc-go
 # stash.kopano.io/kgol/rndm v1.1.2
 ## explicit; go 1.13
 stash.kopano.io/kgol/rndm
+# github.com/go-micro/plugins/v4/store/nats-js => github.com/kobergj/plugins/v4/store/nats-js v1.2.1-0.20231020092801-9463c820c19a


### PR DESCRIPTION
Introduces  a natsjs based registry

Basic functionality works, but breaking bug:
- [x] services crash when nats service isn't up first
- [ ] concurrent map writes in go-micro https://github.com/go-micro/plugins/pull/123
- [x] nats still not up fast enough?

To use natsjs based registry:
```bash
export MICRO_REGISTRY=natsjs # set natsjs as registry
export MICRO_REGISTRY_ADDRESS="127.0.0.1:9233" # set address for nats
```
