### PR TITLE
[tests-only] [full-ci] backport refactor publicwebdav context removing setresponse in given/then steps

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -204,7 +204,7 @@ cannot share a folder with create permission
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:327](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L327)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:328](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L328)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -340,7 +340,7 @@ API, search, favorites, config, capabilities, not existing endpoints, CORS and o
 - [coreApiAuthOcs/ocsGETAuth.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L123)
 - [coreApiAuthOcs/ocsPOSTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPOSTAuth.feature#L10)
 - [coreApiAuthOcs/ocsPUTAuth.feature:7](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L7)
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:317](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L317)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:318](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L318)
 
 #### [sending MKCOL requests to another or non-existing user's webDav endpoints as normal user should return 404](https://github.com/owncloud/ocis/issues/5049)
 

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -42,7 +42,8 @@ Feature: A manager of the space can edit public link
       | share_type        | public_link           |
       | displayname_owner | %displayname%         |
       | name              | <linkName>            |
-    And the public should be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
+    When the public downloads file "/test.txt" from inside the last public link shared folder with password "<password>" using the new public WebDAV API
+    Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     Examples:
       | permissions | expectedPermissions       | password | linkName |

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -36,7 +36,8 @@ Feature: Share spaces via link
       | displayname_owner | %displayname%         |
       | uid_owner         | %username%            |
       | name              | <linkName>            |
-    And the public should be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "<password>"
+    When the public downloads file "/test.txt" from inside the last public link shared folder with password "<password>" using the new public WebDAV API
+    Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     But the public should not be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
     Examples:

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -619,7 +619,7 @@ class WebDavLockingContext implements Context {
 		$headers = [
 			"If" => "(<" . $this->tokenOfLastLock[$lockOwner][$itemToUseLockOf] . ">)"
 		];
-		$this->publicWebDavContext->publicUploadContent(
+		$response = $this->publicWebDavContext->publicUploadContent(
 			$filename,
 			'',
 			$content,
@@ -627,6 +627,7 @@ class WebDavLockingContext implements Context {
 			$headers,
 			$publicWebDAVAPIVersion
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -59,10 +59,11 @@ Feature: create a public link share
       | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
-    And the HTTP status code should be "200"
-    And the public download of the last publicly shared file using the new public WebDAV API with password "%regular%" should fail with HTTP status code "401"
+    When the public tries to download the last public link shared file with password "%regular%" using the new public WebDAV API
+    Then the HTTP status code should be "401"
     And the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
-    And the public download of the last publicly shared file using the new public WebDAV API without a password should fail with HTTP status code "401"
+    When the public tries to download the last public link shared file using the new public WebDAV API
+    Then the HTTP status code should be "401"
     And the value of the item "//s:message" in the response should match "/No 'Authorization: Basic' header found/"
     Examples:
       | ocs_api_version | ocs_status_code |

--- a/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -37,7 +37,8 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
@@ -90,7 +91,8 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
@@ -111,7 +113,8 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     And uploading a file should work using the new public WebDAV API
     Examples:


### PR DESCRIPTION
## Description
This pr backports https://github.com/owncloud/ocis/pull/7439 from master to stable-4.0
