### PR TITLE
[tests-only][full-ci]add test for copy file between project and personal space

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
@@ -75,8 +75,7 @@ Feature: copying file using file id
 
 
   Scenario Outline: copy a file into a folder in project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the GraphApi
     And user "Alice" has created a folder "/folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
@@ -94,8 +93,7 @@ Feature: copying file using file id
 
 
   Scenario Outline: copy a file into a sub-folder in project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the GraphApi
     And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
@@ -113,8 +111,7 @@ Feature: copying file using file id
 
 
   Scenario Outline: copy a file from a folder into root of project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the GraphApi
     And user "Alice" has created a folder "folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/textfile.txt"
@@ -132,8 +129,7 @@ Feature: copying file using file id
 
 
   Scenario Outline: copy a file from sub-folder into root of project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the GraphApi
     And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/sub-folder/textfile.txt"
@@ -143,6 +139,40 @@ Feature: copying file using file id
     And for user "Alice" folder "/" of the space "project-space" should contain these files:
       | textfile.txt |
     And for user "Alice" folder "folder/sub-folder" of the space "project-space" should contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file from personal to project space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has uploaded file with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" copies a file "/textfile.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    And for user "Alice" folder "/" of the space "Personal" should contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file from project to personal space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the GraphApi
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" copies a file "/textfile.txt" into "/" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    And for user "Alice" folder "/" of the space "Personal" should contain these files:
       | textfile.txt |
     Examples:
       | dav-path                          |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

### Description
This PR adds the test for copying the files betweeen project space and personal space with the `url` consisting of the `file-id` not name

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6737


