### PR TITLE
fix: request to preview gives 500 error for old/new webdav if file is in processing

### DIFF
--- a/changelog/unreleased/fix-too-early-preview-request.md
+++ b/changelog/unreleased/fix-too-early-preview-request.md
@@ -1,0 +1,6 @@
+Bugfix: Fix preview request 500 error when made too early
+
+Fix the status code and message when a thumbnail request is made too early.
+
+https://github.com/owncloud/ocis/issues/7502
+https://github.com/owncloud/ocis/pull/7507

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -260,7 +260,7 @@ func (g Webdav) SpacesThumbnail(w http.ResponseWriter, r *http.Request) {
 			return
 		case http.StatusTooEarly:
 			// StatusTooEarly if file is processing
-			renderError(w, r, errTooEarly(err.Error()))
+			renderError(w, r, errTooEarly(e.Detail))
 			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(e.Detail))
@@ -350,6 +350,10 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		case http.StatusNotFound:
 			// StatusNotFound is expected for unsupported files
 			renderError(w, r, errNotFound(notFoundMsg(tr.Filename)))
+			return
+		case http.StatusTooEarly:
+			// StatusTooEarly if file is processing
+			renderError(w, r, errTooEarly(e.Detail))
 			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(e.Detail))


### PR DESCRIPTION
## Description
Fix the status code and message when a thumbnail request is made too early.

For `old`/`new`/`spaces` endpoints.

**Current:**
```xml
< HTTP/1.1 500 Internal Server Error
< 
<?xml version="1.0" encoding="UTF-8"?>
<d:error xmlns:d="DAV" xmlns:s="http://sabredav.org/ns">
  <s:exception></s:exception>
  <s:message>
    {&#34;id&#34;:&#34;com.owncloud.api.thumbnails&#34;,&#34;code&#34;:425,&#34;detail&#34;:&#34;File Processing&#34;,&#34;status&#34;:&#34;Too Early&#34;}
  </s:message>
</d:error>
```

**With Fix:**
```xml
< HTTP/1.1 425 Too Early
< 
<?xml version="1.0" encoding="UTF-8"?>
<d:error xmlns:d="DAV" xmlns:s="http://sabredav.org/ns">
  <s:exception></s:exception>
  <s:message>File Processing</s:message>
</d:error>
```

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/7502
- Closes https://github.com/owncloud/ocis/issues/7338

## How Has This Been Tested?
- test environment: local


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
