### PR TITLE
Pass docs pipeline requests through proxies

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1818,6 +1818,14 @@ def docs():
             {
                 "name": "docs-generate",
                 "image": OC_CI_GOLANG,
+                "environment": {
+                    "HTTP_PROXY": {
+                        "from_secret": "drone_http_proxy",
+                    },
+                    "HTTPS_PROXY": {
+                        "from_secret": "drone_http_proxy",
+                    },
+                },
                 "commands": ["make docs-generate"],
             },
             {

--- a/changelog/unreleased/fix-docs-pipeline.md
+++ b/changelog/unreleased/fix-docs-pipeline.md
@@ -1,0 +1,6 @@
+Bugfix: Fix 403 in docs pipeline
+
+Docs pipeline was not routed through our proxies which could lead to requests being blacklisted
+
+https://github.com/owncloud/ocis/issues/7509
+https://github.com/owncloud/ocis/pull/7511


### PR DESCRIPTION
Hopefully fixes nasty `403` errors in docs pipeline

Fixes https://github.com/owncloud/ocis/issues/7509