### PR TITLE
[docs-only] add capabilities docs for password policy

### DIFF
--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -76,17 +76,40 @@ The validation against the banned passwords list can be configured via a text fi
 
 Following environment variables can be set to define the password policy behaviour:
 
--   `FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS`  
+-   `FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS`
 Define the minimum password length.
--   `FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS`  
+-   `FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS`
 Define the minimum number of uppercase letters.
--   `FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS`  
+-   `FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS`
 Define the minimum number of lowercase letters.
--   `FRONTEND_PASSWORD_POLICY_MIN_DIGITS`  
+-   `FRONTEND_PASSWORD_POLICY_MIN_DIGITS`
 Define the minimum number of digits.
--   `FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS`  
+-   `FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS`
 Define the minimum number of special characters.
--   `FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST`  
+-   `FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST`
 Path to the 'banned passwords list' file.
 
 Note that a password can have a maximum length of **72 bytes**. Depending on the alphabet used, a character is encoded by 1 to 4 bytes, defining the maximum length of a password indirectly. While US-ASCII will only need one byte, Latin alphabets and also Greek or Cyrillic ones need two bytes. Three bytes are needed for characters in Chinese, Japanese and Korean etc.
+
+### The password policy capability
+
+The capabilities endpoint (e.g. https://ocis.test/ocs/v1.php/cloud/capabilities?format=json) gives you following capabilities which are relevant for the password policy:
+
+```json
+{
+  "ocs": {
+    "data": {
+      "capabilities": {
+        "password_policy": {
+          "min_characters": 10,
+          "max_characters": 72,
+          "min_lowercase_characters": 1,
+          "min_uppercase_characters": 2,
+          "min_digits": 1,
+          "min_special_characters": 1
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION

## Description


Add capabilities docs to frontend service.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
