### PR TITLE
fix auth service env variable

### DIFF
--- a/changelog/unreleased/fix-auth-service-jwt.md
+++ b/changelog/unreleased/fix-auth-service-jwt.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the auth service env variable
+
+We the auth service env variable to the service specific name. Before it was configurable via `AUTH_MACHINE_JWT_SECRET` and now is configurable via `AUTH_SERVICE_JWT_SECRET`.
+
+https://github.com/owncloud/ocis/pull/7523

--- a/services/auth-service/pkg/config/reva.go
+++ b/services/auth-service/pkg/config/reva.go
@@ -2,5 +2,5 @@ package config
 
 // TokenManager is the config for using the reva token manager
 type TokenManager struct {
-	JWTSecret string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;AUTH_MACHINE_JWT_SECRET" desc:"The secret to mint and validate jwt tokens."`
+	JWTSecret string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;AUTH_SERVICE_JWT_SECRET" desc:"The secret to mint and validate jwt tokens."`
 }


### PR DESCRIPTION
## Description
fix the auth service env variable to the service specific name. Before it was configurable via `AUTH_MACHINE_JWT_SECRET` and now is configurable via `AUTH_SERVICE_JWT_SECRET`.

## Related Issue

## Motivation and Context
Consistent env variable naming

## How Has This Been Tested?
- not tested other than CI

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
