### PR TITLE
[tests-only][full-ci]Adds test for getting share jail space information of the user when user has pending share

### DIFF
--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -232,7 +232,7 @@ Feature: Notification
                   },
                   "id": {
                     "type": "string",
-                    "enum": [
+                    "enim": [
                       "%user_id%"
                     ]
                   },

--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -232,7 +232,7 @@ Feature: Notification
                   },
                   "id": {
                     "type": "string",
-                    "enim": [
+                    "enum": [
                       "%user_id%"
                     ]
                   },

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -433,8 +433,8 @@ Feature: List and create spaces
     And user "Alice" has disabled auto-accepting
     And user "Brian" has uploaded file with content "this is a test file." to "test.txt"
     And the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
-    When user "Brian" shares file "/test.txt" with user "Alice" using the sharing API
-    And user "Alice" lists all available spaces via the GraphApi
+    And user "Brian" has shared file "/test.txt" with user "Alice"
+    When user "Alice" lists all available spaces via the GraphApi
     Then the HTTP status code should be "200"
     And the JSON response should contain space called "Shares" owned by "Alice" and match
     """
@@ -486,7 +486,7 @@ Feature: List and create spaces
           "properties": {
               "eTag": {
                 "type": "string",
-                "enum": ["%space_eTag%"]
+                "enum": ["%space_etag%"]
               },
               "webDavUrl": {
                 "type": "string",

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -423,6 +423,87 @@ Feature: List and create spaces
     Then the HTTP status code should be "404"
     And the json responded should not contain a space with name "Project Venus"
     Examples:
-      | role        |
+      | role       |
+      | User       |
+      | User Light |
+
+
+  Scenario Outline: get share jail space information of the user when user has a pending share
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has disabled auto-accepting
+    And user "Brian" has uploaded file with content "this is a test file." to "test.txt"
+    And the administrator has assigned the role "<userRole>" to user "Alice" using the Graph API
+    When user "Brian" shares file "/test.txt" with user "Alice" using the sharing API
+    And user "Alice" lists all available spaces via the GraphApi
+    Then the HTTP status code should be "200"
+    And the JSON response should contain space called "Shares" owned by "Alice" and match
+    """
+    {
+      "type": "object",
+      "required": [
+        "driveType",
+        "driveAlias",
+        "name",
+        "id",
+        "root",
+        "webUrl"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["Shares"]
+        },
+        "driveType": {
+           "type": "string",
+          "enum": ["virtual"]
+        },
+        "driveAlias": {
+           "type": "string",
+          "enum": ["virtual/shares"]
+        },
+        "id": {
+           "type": "string",
+          "enum": ["%space_id%"]
+        },
+        "quota": {
+           "type": "object",
+           "required": [
+            "state"
+           ],
+           "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["normal"]
+              }
+           }
+        },
+        "root": {
+          "type": "object",
+          "required": [
+            "eTag",
+            "webDavUrl"
+          ],
+          "properties": {
+              "eTag": {
+                "type": "string",
+                "enum": ["%space_eTag%"]
+              },
+              "webDavUrl": {
+                "type": "string",
+                "enum": ["%base_url%/dav/spaces/%space_id%"]
+              }
+           }
+        },
+        "webUrl": {
+          "type": "string",
+          "enum": ["%base_url%/f/%space_id%"]
+        }
+      }
+    }
+    """
+    Examples:
+      | userRole    |
+      | Admin       |
+      | Space Admin |
       | User        |
       | User Light  |

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -427,7 +427,7 @@ Feature: List and create spaces
       | User       |
       | User Light |
 
-
+  @issue-7160
   Scenario Outline: get share jail space information of the user when user has a pending share
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has disabled auto-accepting

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -388,7 +388,15 @@ class SpacesContext implements Context {
 		return \str_replace('"', '\"', $fileData["Etag"][0]);
 	}
 
-	public function getEtagOfASpace(string $user, string $spaceName) {
+	/**
+	 * @param string $user
+	 * @param string $spaceName
+	 *
+	 * @return string
+	 *
+	 * @throws GuzzleException
+	 */
+	public function getEtagOfASpace(string $user, string $spaceName): string {
 		$this->theUserLooksUpTheSingleSpaceUsingTheGraphApiByUsingItsId($user, $spaceName);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -388,6 +388,16 @@ class SpacesContext implements Context {
 		return \str_replace('"', '\"', $fileData["Etag"][0]);
 	}
 
+	public function getEtagOfASpace(string $user, string $spaceName) {
+		$this->theUserLooksUpTheSingleSpaceUsingTheGraphApiByUsingItsId($user, $spaceName);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			200,
+			"Expected response status code should be 200"
+		);
+		$decodedResponse = $this->featureContext->getJsonDecodedResponse();
+		return $decodedResponse["root"]["eTag"];
+	}
+
 	/**
 	 * @BeforeScenario
 	 *
@@ -916,6 +926,12 @@ class SpacesContext implements Context {
 						[$this, "getETag"],
 					"parameter" => [$userName, $spaceName, $fileName]
 				],
+				[
+					"code" => "%space_eTag%",
+					"function" =>
+						[$this, "getEtagOfASpace"],
+					"parameter" => [$userName, $spaceName]
+				]
 			],
 			null,
 			$userName,

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -935,7 +935,7 @@ class SpacesContext implements Context {
 					"parameter" => [$userName, $spaceName, $fileName]
 				],
 				[
-					"code" => "%space_eTag%",
+					"code" => "%space_etag%",
 					"function" =>
 						[$this, "getEtagOfASpace"],
 					"parameter" => [$userName, $spaceName]


### PR DESCRIPTION
## Description
Added test for getting virtual shares information for when the user has a pending share 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes: https://github.com/owncloud/ocis/issues/7471

## Motivation and Context
To provide test coverage for https://github.com/owncloud/ocis/issues/7160. According to the issue the etag of the virtual share drive wasn't provided when there was a pending share, so this is the test coverage to ensure that regression is caught. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
