### PR TITLE
[tests-only][full-ci] Add tests for move rename file between personal and project space with file id

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -241,6 +241,7 @@ default:
       context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebDavPropertiesContext:
 
     apiLocks:
       paths:

--- a/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
@@ -75,8 +75,7 @@ Feature: moving/renaming file using file id
 
 
   Scenario Outline: move a file into a folder inside project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the Graph API
     And user "Alice" has created a folder "/folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
@@ -94,8 +93,7 @@ Feature: moving/renaming file using file id
 
 
   Scenario Outline: move a file into a sub-folder inside project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the Graph API
     And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "/textfile.txt"
@@ -113,8 +111,7 @@ Feature: moving/renaming file using file id
 
 
   Scenario Outline: move a file from folder to root inside project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the Graph API
     And user "Alice" has created a folder "folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/textfile.txt"
@@ -132,8 +129,7 @@ Feature: moving/renaming file using file id
 
 
   Scenario Outline: move a file from sub-folder to root inside project space
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the Graph API
     And user "Alice" has created a folder "folder/sub-folder" in space "project-space"
     And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "folder/sub-folder/textfile.txt"
@@ -221,10 +217,82 @@ Feature: moving/renaming file using file id
     And we save it into "FILEID"
     When user "Alice" renames a file "folder/sub-folder/textfile.txt" into "/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
     Then the HTTP status code should be "201"
-    And for user "Alice" the space "Personal" should contain these entries:
+    And for user "Alice" the space "Personal" should contain these files:
       | renamed.txt |
     But for user "Alice" folder "folder/sub-folder" of the space "Personal" should not contain these files:
       | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file from project to personal space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "/textfile.txt" into "/" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "502"
+    And the value of the item "/d:error/s:message" in the response about user "Alice" should be "move:error: not supported: cannot move across spaces"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    But for user "Alice" folder "/" of the space "Personal" should not contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file from personal to project space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "Personal" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "/textfile.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "502"
+    And the value of the item "/d:error/s:message" in the response about user "Alice" should be "move:error: not supported: cannot move across spaces"
+    And for user "Alice" folder "/" of the space "Personal" should contain these files:
+      | textfile.txt |
+    But for user "Alice" folder "/" of the space "project-space" should not contain these files:
+      | textfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file to different name from project space to personal space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "project-space" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" renames a file "/textfile.txt" into "/renamed.txt" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "502"
+    And the value of the item "/d:error/s:message" in the response about user "Alice" should be "move:error: not supported: cannot move across spaces"
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | textfile.txt |
+    But for user "Alice" folder "/" of the space "Personal" should not contain these files:
+      | renamed.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: move a file to different name from personal space to project space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "Personal" with content "some data" to "textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" renames a file "/textfile.txt" into "/renamed.txt" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "502"
+    And the value of the item "/d:error/s:message" in the response about user "Alice" should be "move:error: not supported: cannot move across spaces"
+    And for user "Alice" folder "/" of the space "Personal" should contain these files:
+      | textfile.txt |
+    But for user "Alice" folder "/" of the space "project-space" should not contain these files:
+      | renamed.txt |
     Examples:
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

### Description
This PR adds the test for moving and renaming the files betweeen project space and personal space with the `url` consisting of the `file-id` not name
In this PR following scenario are added:
- move a file from project to personal space
- move a file from personal to project space
- rename a file and move a file from project space to personal space
- rename a file and move a file from personal space to project space


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6737


