### PR TITLE
enhancement: improve content extraction stop word cleaning

### DIFF
--- a/changelog/unreleased/enhancement-search-content-extraction-cleanup.md
+++ b/changelog/unreleased/enhancement-search-content-extraction-cleanup.md
@@ -1,9 +1,11 @@
 Enhancement: Tika content extraction cleanup for search
 
-So far it has not been possible to determine whether
-the content for the search should be cleaned of stop words or not.
+So far it has not been possible to determine whether the
+content for search should be cleaned up of 'stop words' or not.
+Stop words are filling words like "I, you, have, am" etc and
+defined by the search engine.
 
-This can now be set with the newly introduced settings option `SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS=false`
+The behaviour can now be set with the newly introduced settings option `SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS=false`
 which is enabled by default.
 
 In addition, the stop word cleanup is no longer as aggressive and now ignores numbers, urls,

--- a/changelog/unreleased/enhancement-search-content-extraction-cleanup.md
+++ b/changelog/unreleased/enhancement-search-content-extraction-cleanup.md
@@ -1,0 +1,13 @@
+Enhancement: Tika content extraction cleanup for search
+
+So far it has not been possible to determine whether
+the content for the search should be cleaned of stop words or not.
+
+This can now be set with the newly introduced settings option `SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS=false`
+which is enabled by default.
+
+In addition, the stop word cleanup is no longer as aggressive and now ignores numbers, urls,
+basically everything except the defined stop words.
+
+https://github.com/owncloud/ocis/pull/7553
+https://github.com/owncloud/ocis/issues/6674

--- a/services/search/README.md
+++ b/services/search/README.md
@@ -70,6 +70,9 @@ When the search service can reach Tika, it begins to read out the content on dem
 
 Content extraction and handling the extracted content can be very resource intensive. Content extraction is therefore limited to files with a certain file size. The default limit is 20MB and can be configured using the `SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT` variable.
 
+When extracting the content you can specify whether filler words are ignored or not.
+To keep them, the environment variable `SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS` must be set to false.
+
 When using the Tika container and docker-compose, consider the following:
 
 *   See the [ocis_wopi](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_wopi) example.

--- a/services/search/pkg/config/content.go
+++ b/services/search/pkg/config/content.go
@@ -9,5 +9,6 @@ type Extractor struct {
 
 // ExtractorTika configures the Tika extractor
 type ExtractorTika struct {
-	TikaURL string `yaml:"tika_url" env:"SEARCH_EXTRACTOR_TIKA_TIKA_URL" desc:"URL of the tika server."`
+	TikaURL        string `yaml:"tika_url" env:"SEARCH_EXTRACTOR_TIKA_TIKA_URL" desc:"URL of the tika server."`
+	CleanStopWords bool   `yaml:"clean_stop_words" env:"SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS" desc:"Defines if stop words should be cleaned or not."`
 }

--- a/services/search/pkg/config/content.go
+++ b/services/search/pkg/config/content.go
@@ -10,5 +10,5 @@ type Extractor struct {
 // ExtractorTika configures the Tika extractor
 type ExtractorTika struct {
 	TikaURL        string `yaml:"tika_url" env:"SEARCH_EXTRACTOR_TIKA_TIKA_URL" desc:"URL of the tika server."`
-	CleanStopWords bool   `yaml:"clean_stop_words" env:"SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS" desc:"Defines if stop words should be cleaned or not."`
+	CleanStopWords bool   `yaml:"clean_stop_words" env:"SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS" desc:"Defines if stop words should be cleaned or not. See the documentation for more details."`
 }

--- a/services/search/pkg/config/defaults/defaultconfig.go
+++ b/services/search/pkg/config/defaults/defaultconfig.go
@@ -43,7 +43,8 @@ func DefaultConfig() *config.Config {
 			Type:             "basic",
 			CS3AllowInsecure: false,
 			Tika: config.ExtractorTika{
-				TikaURL: "http://127.0.0.1:9998",
+				TikaURL:        "http://127.0.0.1:9998",
+				CleanStopWords: true,
 			},
 		},
 		Events: config.Events{

--- a/services/search/pkg/content/content.go
+++ b/services/search/pkg/content/content.go
@@ -1,5 +1,15 @@
 package content
 
+import (
+	"strings"
+
+	"github.com/bbalet/stopwords"
+)
+
+func init() {
+	stopwords.OverwriteWordSegmenter(`[^ ]+`)
+}
+
 // Document wraps all resource meta fields,
 // it is used as a content extraction result.
 type Document struct {
@@ -10,4 +20,8 @@ type Document struct {
 	Mtime    string
 	MimeType string
 	Tags     []string
+}
+
+func CleanString(content, langCode string) string {
+	return strings.TrimSpace(stopwords.CleanString(content, langCode, true))
 }

--- a/services/search/pkg/content/content_test.go
+++ b/services/search/pkg/content/content_test.go
@@ -1,0 +1,36 @@
+package content_test
+
+import (
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+
+	"github.com/owncloud/ocis/v2/services/search/pkg/content"
+)
+
+func TestCleanContent(t *testing.T) {
+	tests := []struct {
+		given  string
+		expect string
+	}{
+		{
+			given:  "find can keeper should keeper will",
+			expect: "keeper keeper",
+		},
+		{
+			given:  "user1 shares the file to Marie",
+			expect: "user1 shares file marie",
+		},
+		{
+			given:  "content contains https://localhost/remote.php/dav/files/admin/Photos/San%20Francisco.jpg and stop word",
+			expect: "content contains https://localhost/remote.php/dav/files/admin/photos/san%20francisco.jpg stop word",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.given, func(t *testing.T) {
+			Equal(t, tc.expect, content.CleanString(tc.given, "en"))
+		})
+	}
+}

--- a/services/search/pkg/content/tika.go
+++ b/services/search/pkg/content/tika.go
@@ -20,8 +20,8 @@ type Tika struct {
 	*Basic
 	Retriever
 	tika                       *tika.Client
-	contentExtractionSizeLimit uint64
-	cleanStopWords             bool
+	ContentExtractionSizeLimit uint64
+	CleanStopWords             bool
 }
 
 // NewTikaExtractor creates a new Tika instance.
@@ -42,8 +42,8 @@ func NewTikaExtractor(gatewaySelector pool.Selectable[gateway.GatewayAPIClient],
 		Basic:                      basic,
 		Retriever:                  newCS3Retriever(gatewaySelector, logger, cfg.Extractor.CS3AllowInsecure),
 		tika:                       tika.NewClient(nil, cfg.Extractor.Tika.TikaURL),
-		contentExtractionSizeLimit: cfg.ContentExtractionSizeLimit,
-		cleanStopWords:             cfg.Extractor.Tika.CleanStopWords,
+		ContentExtractionSizeLimit: cfg.ContentExtractionSizeLimit,
+		CleanStopWords:             cfg.Extractor.Tika.CleanStopWords,
 	}, nil
 }
 
@@ -58,7 +58,7 @@ func (t Tika) Extract(ctx context.Context, ri *provider.ResourceInfo) (Document,
 		return doc, nil
 	}
 
-	if ri.Size > t.contentExtractionSizeLimit {
+	if ri.Size > t.ContentExtractionSizeLimit {
 		t.logger.Info().Interface("ResourceID", ri.Id).Str("Name", ri.Name).Msg("file exceeds content extraction size limit. skipping.")
 		return doc, nil
 	}
@@ -88,7 +88,7 @@ func (t Tika) Extract(ctx context.Context, ri *provider.ResourceInfo) (Document,
 		}
 	}
 
-	if langCode, _ := t.tika.LanguageString(ctx, doc.Content); langCode != "" && t.cleanStopWords {
+	if langCode, _ := t.tika.LanguageString(ctx, doc.Content); langCode != "" && t.CleanStopWords {
 		doc.Content = CleanString(doc.Content, langCode)
 	}
 


### PR DESCRIPTION
## Description
So far it has not been possible to determine whether
the content for the search should be cleaned of stop words or not.

This can now be set with the newly introduced settings option `SEARCH_EXTRACTOR_TIKA_CLEAN_STOP_WORDS=false`
which is enabled by default.

In addition, the stop word cleanup is no longer as aggressive and now ignores numbers, urls,
basically everything except the defined stop words.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/6674

## Motivation and Context
..., no bugs, ... yummy
![ezgif-2-09128abecb](https://github.com/owncloud/ocis/assets/49308105/6d903618-ca23-4c50-9bd3-a534d3c6cc5d)

## How Has This Been Tested?
- unit tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
