### PR TITLE
[test-only] skip tests moving between shares jail

### DIFF
--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -261,36 +261,36 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Alice" should not be able to delete folder "/Shares/child1/child2"
 
 
-  # Scenario: sharing parent folder to user with all permissions and its child folder to group with read permission then check reshare operation
-  #   Given group "grp1" has been created
-  #   And user "Carol" has been created with default attributes and without skeleton files
-  #   And user "Carol" has created the following folders
-  #     | path                  |
-  #     | /parent               |
-  #     | /parent/child1        |
-  #     | /parent/child1/child2 |
-  #   And user "Alice" has been added to group "grp1"
-  #   And user "Brian" has been added to group "grp1"
-  #   And user "Carol" has created a share with settings
-  #     | path        | /parent |
-  #     | shareType   | user    |
-  #     | shareWith   | Brian   |
-  #     | permissions | all     |
-  #   And user "Carol" has created a share with settings
-  #     | path        | /parent/child1 |
-  #     | shareType   | group          |
-  #     | shareWith   | grp1           |
-  #     | permissions | read           |
-  #   When user "Brian" creates a share using the sharing API with settings
-  #     | path        | /Shares/parent |
-  #     | shareType   | user           |
-  #     | shareWith   | Alice          |
-  #     | permissions | read           |
-  #   Then the HTTP status code should be "200"
-  #   And the OCS status code should be "100"
-  #   And as "Brian" folder "/Shares/child1" should exist
-  #   And as "Alice" folder "/Shares/child1" should exist
-  #   And as "Alice" folder "/Shares/parent" should exist
+  Scenario: sharing parent folder to user with all permissions and its child folder to group with read permission then check reshare operation
+    Given group "grp1" has been created
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Carol" has created the following folders
+      | path                  |
+      | /parent               |
+      | /parent/child1        |
+      | /parent/child1/child2 |
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has created a share with settings
+      | path        | /parent |
+      | shareType   | user    |
+      | shareWith   | Brian   |
+      | permissions | all     |
+    And user "Carol" has created a share with settings
+      | path        | /parent/child1 |
+      | shareType   | group          |
+      | shareWith   | grp1           |
+      | permissions | read           |
+    When user "Brian" creates a share using the sharing API with settings
+      | path        | /Shares/parent |
+      | shareType   | user           |
+      | shareWith   | Alice          |
+      | permissions | read           |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And as "Brian" folder "/Shares/child1" should exist
+    And as "Alice" folder "/Shares/child1" should exist
+    And as "Alice" folder "/Shares/parent" should exist
 
 
   Scenario: sharing parent folder to group with read permission and its child folder to user with all permissions then check create operation
@@ -458,8 +458,8 @@ Feature: share resources where the sharee receives the share in multiple ways
     And as "Brian" folder "Shares/sharedParent" should exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should exist
 
-
-  Scenario Outline: share receiver renames a group share and receives same resource through user share with additional permissions
+  @skip @issue-7555
+  Scenario Outline: share receiver renames a group share and receives same resource through user share with additional permissions 
     Given using OCS API version "<ocs_api_version>"
     And group "grp" has been created
     And user "Brian" has been added to group "grp"

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -469,7 +469,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-2146 @issue-764
+  @issue-2146 @issue-764 @issue-7555
   Scenario: share a file by multiple channels and download from sub-folder and direct file share
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -11,7 +11,7 @@ Feature: sharing
       | Brian    |
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
 
-
+  @issue-7555
   Scenario Outline: delete all group shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created

--- a/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
@@ -28,7 +28,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-1289
+  @issue-1289 @issue-7555
   Scenario Outline: keep group permissions in sync when the share is renamed by the receiver and then the permissions are updated by sharer
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
@@ -7,7 +7,7 @@ Feature: using trashbin together with sharing
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
 
-  @smokeTest
+  @smokeTest @issue-7555
   Scenario Outline: deleting a received folder doesn't move it to trashbin
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -27,7 +27,7 @@ Feature: using trashbin together with sharing
       | dav-path-version |
       | spaces           |
 
-
+  @issue-7555
   Scenario Outline: deleting a file in a received folder moves it to trashbin of both users
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -150,7 +150,7 @@ Feature: using trashbin together with sharing
       | dav-path-version |
       | spaces           |
 
-
+  @issue-7555
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature
@@ -144,7 +144,7 @@ Feature: file versions remember the author of each version
       | 1     | Brian  |
       | 2     | Alice  |
 
-
+  @issue-7555
   Scenario: enable file versioning and check the history of changes in sharer after renaming file by sharee
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"


### PR DESCRIPTION
related https://github.com/owncloud/ocis/issues/7555

tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:462 is flaky
I run it some times and get different result. I skip this test to don't unexpected failures unexpected success in CI

