### PR TITLE
allow to configure smtp encryption auto

### DIFF
--- a/services/notifications/pkg/config/parser/parse.go
+++ b/services/notifications/pkg/config/parser/parse.go
@@ -43,7 +43,7 @@ func Validate(cfg *config.Config) error {
 			logger.Warn().Msg("The smtp_encryption value 'tls' is deprecated. Please use the value 'starttls' instead.")
 		case "ssl":
 			logger.Warn().Msg("The smtp_encryption value 'ssl' is deprecated. Please use the value 'ssltls' instead.")
-		case "starttls", "ssltls", "none":
+		case "auto", "starttls", "ssltls", "none":
 			break
 		default:
 			return fmt.Errorf(


### PR DESCRIPTION
## Description

follow up of #7361, which introduced the smtp encryption "auto" option, but does not allow to actually configure it (except by not configuring it and relying on the default)

Does not need a changelog because already covered by #7361 (not yet released)

## Related Issue
- Unblocks https://github.com/owncloud/ocis-charts/pull/414

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- https://github.com/owncloud/ocis-charts/pull/414#pullrequestreview-1689325459

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
