### PR TITLE
[tests-only] skip sharing tests in reva

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -159,21 +159,21 @@ File and sync features in a shared scenario
 - [coreApiShareManagementToShares/acceptShares.feature:269](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L269)
 - [coreApiShareManagementToShares/acceptShares.feature:480](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L480)
 - [coreApiShareManagementToShares/acceptShares.feature:546](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L546)
-- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:38](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L38)
 - [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:39](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L39)
-- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:125](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L125)
+- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:40](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L40)
 - [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L126)
-- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L158)
+- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:127](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L127)
 - [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:159](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L159)
+- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:160](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L160)
 
 #### [sharing the shares folder to users exits with different status code than in oc10 backend](https://github.com/owncloud/ocis/issues/2215)
 
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:653](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L653)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:654](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L654)
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:671](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L671)
+- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:655](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L655)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:672](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L672)
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:686](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L686)
+- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:673](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L673)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:687](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L687)
+- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:688](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L688)
 
 #### [file_target of an auto-renamed file is not correct directly after sharing](https://github.com/owncloud/core/issues/32322)
 
@@ -195,13 +195,13 @@ cannot share a folder with create permission
 
 #### [OCS error message for attempting to access share via share id as an unauthorized user is not informative](https://github.com/owncloud/ocis/issues/1233)
 
-- [coreApiShareOperationsToShares1/gettingShares.feature:143](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature#L143)
 - [coreApiShareOperationsToShares1/gettingShares.feature:144](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature#L144)
+- [coreApiShareOperationsToShares1/gettingShares.feature:145](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature#L145)
 
 #### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
 
-- [coreApiShareOperationsToShares1/gettingShares.feature:177](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature#L177)
 - [coreApiShareOperationsToShares1/gettingShares.feature:178](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature#L178)
+- [coreApiShareOperationsToShares1/gettingShares.feature:179](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature#L179)
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
@@ -228,17 +228,17 @@ cannot share a folder with create permission
 
 #### [deleting a file inside a received shared folder is moved to the trash-bin of the sharer not the receiver](https://github.com/owncloud/ocis/issues/1124)
 
-- [coreApiTrashbin/trashbinSharingToShares.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L28)
-- [coreApiTrashbin/trashbinSharingToShares.feature:44](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L44)
-- [coreApiTrashbin/trashbinSharingToShares.feature:49](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L49)
-- [coreApiTrashbin/trashbinSharingToShares.feature:69](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L69)
-- [coreApiTrashbin/trashbinSharingToShares.feature:74](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L74)
-- [coreApiTrashbin/trashbinSharingToShares.feature:120](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L120)
-- [coreApiTrashbin/trashbinSharingToShares.feature:125](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L125)
-- [coreApiTrashbin/trashbinSharingToShares.feature:173](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L173)
-- [coreApiTrashbin/trashbinSharingToShares.feature:178](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L178)
-- [coreApiTrashbin/trashbinSharingToShares.feature:200](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L200)
-- [coreApiTrashbin/trashbinSharingToShares.feature:223](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L223)
+- [coreApiTrashbin/trashbinSharingToShares.feature:29](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L29)
+- [coreApiTrashbin/trashbinSharingToShares.feature:45](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L45)
+- [coreApiTrashbin/trashbinSharingToShares.feature:50](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L50)
+- [coreApiTrashbin/trashbinSharingToShares.feature:70](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L70)
+- [coreApiTrashbin/trashbinSharingToShares.feature:75](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L75)
+- [coreApiTrashbin/trashbinSharingToShares.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L121)
+- [coreApiTrashbin/trashbinSharingToShares.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L126)
+- [coreApiTrashbin/trashbinSharingToShares.feature:174](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L174)
+- [coreApiTrashbin/trashbinSharingToShares.feature:179](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L179)
+- [coreApiTrashbin/trashbinSharingToShares.feature:201](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L201)
+- [coreApiTrashbin/trashbinSharingToShares.feature:224](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L224)
 
 #### [changing user quota gives ocs status 103 / Cannot set quota](https://github.com/owncloud/product/issues/247)
 
@@ -253,7 +253,7 @@ cannot share a folder with create permission
 - [coreApiShareOperationsToShares1/changingFilesShare.feature:66](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L66)
 - [coreApiShareOperationsToShares1/changingFilesShare.feature:85](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L85)
 - [coreApiShareOperationsToShares1/changingFilesShare.feature:86](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L86)
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:473](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L473)
+- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:474](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L474)
 - [coreApiWebdavMove2/moveShareOnOcis.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L28)
 - [coreApiWebdavMove2/moveShareOnOcis.feature:30](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L30)
 - [coreApiWebdavMove2/moveShareOnOcis.feature:93](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L93)
@@ -275,15 +275,15 @@ cannot share a folder with create permission
 
 #### [Cannot move folder/file from one received share to another](https://github.com/owncloud/ocis/issues/2442)
 
-- [coreApiShareUpdateToShares/updateShare.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L123)
-- [coreApiShareUpdateToShares/updateShare.feature:153](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L153)
+- [coreApiShareUpdateToShares/updateShare.feature:124](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L124)
+- [coreApiShareUpdateToShares/updateShare.feature:154](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L154)
 
 #### [Sharing folder and sub-folder with same user but different permission,the permission of sub-folder is not obeyed ](https://github.com/owncloud/ocis/issues/2440)
 
-- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:212](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L212)
-- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:323](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L323)
-- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:349](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L349)
-- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:238](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L238)
+- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:213](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L213)
+- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:239](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L239)
+- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:324](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L324)
+- [coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:350](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L350)
 
 #### [Empty OCS response for a share create request using a disabled user](https://github.com/owncloud/ocis/issues/2212)
 
@@ -292,13 +292,13 @@ cannot share a folder with create permission
 
 #### [Edit user share response has a "name" field](https://github.com/owncloud/ocis/issues/1225)
 
-- [coreApiShareUpdateToShares/updateShare.feature:226](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L226)
 - [coreApiShareUpdateToShares/updateShare.feature:227](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L227)
+- [coreApiShareUpdateToShares/updateShare.feature:228](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L228)
 
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:593](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L593)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:594](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L594)
+- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:595](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L595)
 
 #### [deleting a share with wrong authentication returns OCS status 996 / HTTP 500](https://github.com/owncloud/ocis/issues/1229)
 
@@ -418,8 +418,8 @@ And other missing implementation of favorites
 - [coreApiFavorites/favorites.feature:202](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favorites.feature#L202)
 - [coreApiFavorites/favorites.feature:203](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favorites.feature#L203)
 - [coreApiFavorites/favorites.feature:208](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favorites.feature#L208)
-- [coreApiFavorites/favoritesSharingToShares.feature:63](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature#L63)
 - [coreApiFavorites/favoritesSharingToShares.feature:64](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature#L64)
+- [coreApiFavorites/favoritesSharingToShares.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature#L65)
 
 #### [WWW-Authenticate header for unauthenticated requests is not clear](https://github.com/owncloud/ocis/issues/2285)
 
@@ -432,8 +432,8 @@ And other missing implementation of favorites
 
 #### [Sharing a same file twice to the same group](https://github.com/owncloud/ocis/issues/1710)
 
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:637](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L637)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:638](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L638)
+- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:639](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L639)
 
 #### [PATCH request for TUS upload with wrong checksum gives incorrect response](https://github.com/owncloud/ocis/issues/1755)
 
@@ -460,16 +460,16 @@ And other missing implementation of favorites
 - [coreApiWebdavUploadTUS/checksums.feature:293](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/checksums.feature#L293)
 - [coreApiWebdavUploadTUS/optionsRequest.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/optionsRequest.feature#L10)
 - [coreApiWebdavUploadTUS/optionsRequest.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/optionsRequest.feature#L25)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:165](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L165)
 - [coreApiWebdavUploadTUS/uploadToShare.feature:166](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L166)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:183](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L183)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:167](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L167)
 - [coreApiWebdavUploadTUS/uploadToShare.feature:184](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L184)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:201](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L201)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:185](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L185)
 - [coreApiWebdavUploadTUS/uploadToShare.feature:202](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L202)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:238](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L238)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:203](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L203)
 - [coreApiWebdavUploadTUS/uploadToShare.feature:239](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L239)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:278](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L278)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:240](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L240)
 - [coreApiWebdavUploadTUS/uploadToShare.feature:279](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L279)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:280](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L280)
 
 #### [TUS OPTIONS requests do not reply with TUS headers when invalid password](https://github.com/owncloud/ocis/issues/1012)
 
@@ -501,8 +501,8 @@ And other missing implementation of favorites
 
 #### [Shares to deleted group listed in the response](https://github.com/owncloud/ocis/issues/2441)
 
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:469](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L469)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:470](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L470)
+- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:471](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L471)
 
 #### [copying the file inside Shares folder returns 404](https://github.com/owncloud/ocis/issues/3874)
 
@@ -573,9 +573,9 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 
 #### [moveShareInsideAnotherShare behaves differently on oCIS than oC10](https://github.com/owncloud/ocis/issues/3047)
 
-- [coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:20](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature#L20)
-- [coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:40](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature#L40)
-- [coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:54](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature#L54)
+- [coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:21](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature#L21)
+- [coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:41](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature#L41)
+- [coreApiShareManagementToShares/moveShareInsideAnotherShare.feature:55](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature#L55)
 
 #### [Renaming resource to banned name is allowed in spaces webdav](https://github.com/owncloud/ocis/issues/3099)
 

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -242,8 +242,8 @@ cannot share a folder with create permission
 
 #### [changing user quota gives ocs status 103 / Cannot set quota](https://github.com/owncloud/product/issues/247)
 
-- [coreApiShareOperationsToShares2/uploadToShare.feature:201](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature#L201)
 - [coreApiShareOperationsToShares2/uploadToShare.feature:202](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature#L202)
+- [coreApiShareOperationsToShares2/uploadToShare.feature:203](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature#L203)
 
 #### [not possible to move file into a received folder](https://github.com/owncloud/ocis/issues/764)
 
@@ -313,7 +313,6 @@ User and group management features
 
 _ocs: api compatibility, return correct status code_
 
-- [coreApiShareOperationsToShares2/shareAccessByID.feature:47](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L47)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:48](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L48)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:49](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L49)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:50](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L50)
@@ -321,6 +320,7 @@ _ocs: api compatibility, return correct status code_
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:52](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L52)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:53](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L53)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:54](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L54)
+- [coreApiShareOperationsToShares2/shareAccessByID.feature:55](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L55)
 
 ### Other
 
@@ -478,7 +478,6 @@ And other missing implementation of favorites
 
 #### [Trying to accept a share with invalid ID gives incorrect OCS and HTTP status](https://github.com/owncloud/ocis/issues/2111)
 
-- [coreApiShareOperationsToShares2/shareAccessByID.feature:81](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L81)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:82](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L82)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:83](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L83)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:84](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L84)
@@ -486,9 +485,9 @@ And other missing implementation of favorites
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:86](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L86)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:87](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L87)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:88](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L88)
-- [coreApiShareOperationsToShares2/shareAccessByID.feature:98](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L98)
+- [coreApiShareOperationsToShares2/shareAccessByID.feature:89](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L89)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:99](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L99)
-- [coreApiShareOperationsToShares2/shareAccessByID.feature:128](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L128)
+- [coreApiShareOperationsToShares2/shareAccessByID.feature:100](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L100)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:129](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L129)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:130](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L130)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:131](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L131)
@@ -496,8 +495,9 @@ And other missing implementation of favorites
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:133](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L133)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:134](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L134)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:135](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L135)
-- [coreApiShareOperationsToShares2/shareAccessByID.feature:146](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L146)
+- [coreApiShareOperationsToShares2/shareAccessByID.feature:136](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L136)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:147](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L147)
+- [coreApiShareOperationsToShares2/shareAccessByID.feature:148](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L148)
 
 #### [Shares to deleted group listed in the response](https://github.com/owncloud/ocis/issues/2441)
 
@@ -554,8 +554,8 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [coreApiShareManagementToShares/acceptShares.feature:190](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L190)
 - [coreApiShareManagementToShares/acceptShares.feature:238](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L238)
 - [coreApiShareManagementToShares/acceptShares.feature:457](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L457)
-- [coreApiShareOperationsToShares2/shareAccessByID.feature:116](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L116)
 - [coreApiShareOperationsToShares2/shareAccessByID.feature:117](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L117)
+- [coreApiShareOperationsToShares2/shareAccessByID.feature:118](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature#L118)
 - [coreApiShareManagementBasicToShares/deleteShareFromShares.feature:161](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature#L161)
 - [coreApiShareManagementBasicToShares/deleteShareFromShares.feature:162](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature#L162)
 - [coreApiShareManagementBasicToShares/deleteShareFromShares.feature:163](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature#L163)

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1388,7 +1388,6 @@ class FeatureContext extends BehatVariablesContext {
 				$message
 			);
 		}
-		$this->emptyLastHTTPStatusCodesArray();
 	}
 
 	/**

--- a/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature
+++ b/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: favorite
   As a user
   I want to favorite the shared resources

--- a/tests/acceptance/features/coreApiMain/checksums.feature
+++ b/tests/acceptance/features/coreApiMain/checksums.feature
@@ -174,7 +174,7 @@ Feature: checksums
       | dav-path-version |
       | spaces           |
 
-  @issue-1291
+  @issue-1291 @skipOnReva
   Scenario: sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -184,7 +184,7 @@ Feature: checksums
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
-  @issue-1291
+  @issue-1291 @skipOnReva
   Scenario: modifying a shared file should return correct checksum in the propfind using new DAV path
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receivers side
   As a user
   I want to share resources with case sensitive names

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: resources shared with the same name are received with unique names
   As a user
   I want to share resources with same name

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
@@ -1,4 +1,4 @@
-@issue-1327
+@skipOnReva @issue-1327
 Feature: shares are received in the default folder for received shares
   As a user
   I want to share the default Shares folder

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: sharing works when a username and group name are the same
   As a user
   I want to share resources with group and users having same name

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: share resources where the sharee receives the share in multiple ways
   As a user
   I want to receives the same resource share from multiple channels

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
@@ -1,4 +1,4 @@
-@issue-1328
+@skipOnReva @issue-1328
 Feature: share resources with a disabled user
   As a user
   I want to share resources to disabled user

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: sharing
   As a user
   I want to share resources to others

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -1,4 +1,4 @@
-@issue-1328 @issue-1289
+@skipOnReva @issue-1328 @issue-1289
 Feature: sharing
   As a user
   I want to delete shares

--- a/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
@@ -1,4 +1,4 @@
-@issue-1289 @issue-1328
+@skipOnReva @issue-1289 @issue-1328
 Feature: accept/decline shares coming from internal users
   As a user
   I want to have control of which received shares I accept

--- a/tests/acceptance/features/coreApiShareManagementToShares/acceptSharesToSharesFolder.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/acceptSharesToSharesFolder.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: accept/decline shares coming from internal users to the Shares folder
   As a user
   I want to have control of which received shares I accept

--- a/tests/acceptance/features/coreApiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/mergeShare.feature
@@ -1,4 +1,4 @@
-@issue-1328 @issues-1289
+@skipOnReva @issue-1328 @issues-1289
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@issue-1289 @issue-1328
+@skipOnReva @issue-1289 @issue-1328
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: moving a share inside another share
   As a user
   I want to move a shared resource inside another shared resource

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/accessToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/accessToShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: sharing
   As a user
   I want to share resources with other users

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@issue-1289 @issue-1328
+@skipOnReva @issue-1289 @issue-1328
 Feature: sharing
   As a user
   I want to move shares that I received

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: sharing
   As a user
   I want to get all the shares

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: get the pending shares filtered by type (user, group etc)
   As a user
   I want to filter the pending shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to filter the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to filter the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to filter the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to filter the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -29,7 +29,7 @@ Feature: sharing
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: check webdav share-permissions for received file with edit and reshare permissions
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -65,7 +65,7 @@ Feature: sharing
       | old              |
       | new              |
 
-  @issue-2213
+  @skipOnReva @issue-2213
   Scenario Outline: check webdav share-permissions for received file with edit permissions but no reshare permissions
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -100,7 +100,7 @@ Feature: sharing
       | old              |
       | new              |
 
-  @issue-2213
+  @skipOnReva @issue-2213
   Scenario Outline: check webdav share-permissions for received file with reshare permissions but no edit permissions
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -154,7 +154,7 @@ Feature: sharing
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: check webdav share-permissions for received folder with all permissions
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
@@ -189,7 +189,7 @@ Feature: sharing
       | old              |
       | new              |
 
-  @issue-2213
+  @skipOnReva @issue-2213
   Scenario Outline: check webdav share-permissions for received folder with all permissions but edit
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
@@ -224,7 +224,7 @@ Feature: sharing
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: check webdav share-permissions for received folder with all permissions but create
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
@@ -259,7 +259,7 @@ Feature: sharing
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: check webdav share-permissions for received folder with all permissions but delete
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"
@@ -294,7 +294,7 @@ Feature: sharing
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: check webdav share-permissions for received folder with all permissions but share
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/tmp"

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: sharing
   As a user
   I want to check the webdav share permissions

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature
@@ -53,7 +53,7 @@ Feature: share access by ID
       | 1               | 0          | 200              |
       | 2               | 0          | 404              |
 
-
+  @skipOnReva
   Scenario Outline: accept a share using the share Id
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: share access by ID
   As an API consumer (app)
   I want to access a share by its id
@@ -53,7 +54,7 @@ Feature: share access by ID
       | 1               | 0          | 200              |
       | 2               | 0          | 404              |
 
-  @skipOnReva
+
   Scenario Outline: accept a share using the share Id
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: sharing
   As a user
   I want to upload resources to a folder shared to me
@@ -139,7 +140,7 @@ Feature: sharing
       | old              |
       | new              |
 
-  @smokeTest @skipOnGraph @skipOnReva
+  @smokeTest @skipOnGraph
   Scenario Outline: check quota of owners parent directory of a shared file
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -260,7 +261,7 @@ Feature: sharing
       | old              | change      |
       | new              | create      |
 
-  @skipOnReva
+
   Scenario Outline: upload an empty file (size zero byte) to a shared folder
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
@@ -139,7 +139,7 @@ Feature: sharing
       | old              |
       | new              |
 
-  @smokeTest @skipOnGraph
+  @smokeTest @skipOnGraph @skipOnReva
   Scenario Outline: check quota of owners parent directory of a shared file
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -260,7 +260,7 @@ Feature: sharing
       | old              | change      |
       | new              | create      |
 
-
+  @skipOnReva
   Scenario Outline: upload an empty file (size zero byte) to a shared folder
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -9,7 +9,7 @@ Feature: reshare as public link
       | Alice    |
       | Brian    |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: creating a public link from a share with read permission only is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -24,7 +24,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 403              |
 
-
+  @skipOnReva
   Scenario Outline: creating a public link from a share with share+read only permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -44,7 +44,7 @@ Feature: reshare as public link
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: creating an upload public link from a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -60,7 +60,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 403              |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: creating a public link from a share with read+write permissions only is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -75,7 +75,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 403              |
 
-
+  @skipOnReva
   Scenario Outline: creating a public link from a share with share+read+write permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -95,7 +95,7 @@ Feature: reshare as public link
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnReva
   Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -116,7 +116,7 @@ Feature: reshare as public link
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: creating an upload public link from a sub-folder of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -133,7 +133,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 403              |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: increasing permissions of a public link of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -153,7 +153,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 403              |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: increasing permissions of a public link from a sub-folder of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"

--- a/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
@@ -245,7 +245,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: adding public upload to a read only shared folder as recipient is not allowed using the public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -265,7 +265,7 @@ Feature: update a public link share
       | 1               | 200              |
       | 2               | 403              |
 
-
+  @skipOnReva
   Scenario Outline:adding public upload to a shared folder as recipient is allowed with permissions using the public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -285,7 +285,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnRevaMaster
+  @skipOnReva
   Scenario Outline: adding public link with all permissions to a read only shared folder as recipient is not allowed using the public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -305,7 +305,7 @@ Feature: update a public link share
       | 1               | 200              |
       | 2               | 403              |
 
-
+  @skipOnReva
   Scenario Outline: adding public link with all permissions to a read only shared folder as recipient is allowed with permissions using the public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiShareReshareToShares1/reShare.feature
+++ b/tests/acceptance/features/coreApiShareReshareToShares1/reShare.feature
@@ -1,4 +1,4 @@
-@issue-1328
+@issue-1328 @skipOnReva
 Feature: sharing
   As a user
   I want to re-share a resource

--- a/tests/acceptance/features/coreApiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/coreApiShareReshareToShares2/reShareChain.feature
@@ -1,4 +1,4 @@
-@issue-2141
+@issue-2141 @skipOnReva
 Feature: resharing can be done on a reshared resource
   As a user
   I want to re-share a resource

--- a/tests/acceptance/features/coreApiShareReshareToShares2/reShareDisabled.feature
+++ b/tests/acceptance/features/coreApiShareReshareToShares2/reShareDisabled.feature
@@ -1,4 +1,4 @@
-@issue-1328
+@issue-1328 @skipOnReva
 Feature: resharing can be disabled
   As a user
   I want to share a resource without reshare permission

--- a/tests/acceptance/features/coreApiShareReshareToShares2/reShareSubfolder.feature
+++ b/tests/acceptance/features/coreApiShareReshareToShares2/reShareSubfolder.feature
@@ -1,4 +1,4 @@
-@issue-1328
+@issue-1328 @skipOnReva
 Feature: a subfolder of a received share can be reshared
   As a user
   I want to re-share a resource

--- a/tests/acceptance/features/coreApiShareReshareToShares3/reShareUpdate.feature
+++ b/tests/acceptance/features/coreApiShareReshareToShares3/reShareUpdate.feature
@@ -1,4 +1,4 @@
-@issue-1328
+@issue-1328 @skipOnReva
 Feature: sharing
   As a user
   I want to update share permissions

--- a/tests/acceptance/features/coreApiShareReshareToShares3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/coreApiShareReshareToShares3/reShareWithExpiryDate.feature
@@ -1,4 +1,4 @@
-@issue-1328
+@issue-1328 @skipOnReva
 Feature: resharing a resource with an expiration date
   As a user
   I want to reshare resources with expiration date

--- a/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: sharing
   As a user
   I want to update share permissions

--- a/tests/acceptance/features/coreApiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/coreApiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@issue-1289 @issue-1328
+@issue-1289 @issue-1328 @skipOnReva
 Feature: updating shares to users and groups that have the same name
   As a user
   I want to update share permissions

--- a/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: using trashbin together with sharing
   As a user
   I want the deletion of the resources that I shared to end up in my trashbin

--- a/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature
@@ -1,4 +1,4 @@
-@issue-2914
+@issue-2914 @skipOnReva
 Feature: file versions remember the author of each version
   As a user
   I want to know the author of each version of a file

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -358,7 +358,7 @@ Feature: dav-versions
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Carol" should be "First content"
 
-
+  @skipOnReva
   Scenario Outline: moving a file (with versions) into a shared folder as the sharee and as the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -270,7 +270,7 @@ Feature: dav-versions
     Then the HTTP status code should be "204"
     And the version folder of file "/file.txt" for user "Alice" should contain "0" element
 
-
+  @skipOnReva
   Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "First content" to "sharefile.txt"
@@ -281,7 +281,7 @@ Feature: dav-versions
     When user "Brian" gets the number of versions of file "/Shares/sharefile.txt"
     Then the HTTP status code should be "403"
 
-
+  @skipOnReva
   Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "First content" to "sharefile.txt"
@@ -292,7 +292,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/Shares/sharefile.txt" for user "Brian" should be "First content"
 
-
+  @skipOnReva
   Scenario: sharer can restore a file inside a shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -304,7 +304,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
-
+  @skipOnReva
   Scenario: sharee cannot see a version of a file inside a shared folder when modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -316,7 +316,7 @@ Feature: dav-versions
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "Second content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "Second content"
 
-
+  @skipOnReva
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -328,7 +328,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
-
+  @skipOnReva
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -340,7 +340,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-
+  @skipOnReva
   Scenario: sharer can restore a file inside a group shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
@@ -416,7 +416,7 @@ Feature: dav-versions
     Then the HTTP status code should be "404"
     And the value of the item "//s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @skipOnStorage:ceph
+  @skipOnStorage:ceph @skipOnReva
   Scenario: receiver tries get file versions of shared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
@@ -427,7 +427,7 @@ Feature: dav-versions
     When user "Brian" tries to get versions of file "textfile0.txt" from "Alice"
     Then the HTTP status code should be "403"
 
-
+  @skipOnReva
   Scenario: receiver tries get file versions of shared file before receiving it
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -83,7 +83,7 @@ Feature: propagation of etags when deleting a file or folder
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: sharee deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -113,7 +113,7 @@ Feature: propagation of etags when deleting a file or folder
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: sharer deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -143,7 +143,7 @@ Feature: propagation of etags when deleting a file or folder
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharee deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -173,7 +173,7 @@ Feature: propagation of etags when deleting a file or folder
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
@@ -156,7 +156,7 @@ Feature: propagation of etags when moving files or folders
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: sharee renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -182,7 +182,7 @@ Feature: propagation of etags when moving files or folders
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -208,7 +208,7 @@ Feature: propagation of etags when moving files or folders
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -240,7 +240,7 @@ Feature: propagation of etags when moving files or folders
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: sharee moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -272,7 +272,7 @@ Feature: propagation of etags when moving files or folders
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -304,7 +304,7 @@ Feature: propagation of etags when moving files or folders
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: sharee moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
@@ -153,7 +153,7 @@ Feature: propagation of etags when copying files or folders
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: sharee copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -189,7 +189,7 @@ Feature: propagation of etags when copying files or folders
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
@@ -53,7 +53,7 @@ Feature: propagation of etags when creating folders
       | dav-path-version |
       | spaces           |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharee creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -78,7 +78,7 @@ Feature: propagation of etags when creating folders
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharer creating a folder inside a shared folder changes etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
@@ -52,7 +52,7 @@ Feature: propagation of etags when uploading data
       | dav-path-version |
       | spaces           |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharee uploading a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -76,7 +76,7 @@ Feature: propagation of etags when uploading data
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -100,7 +100,7 @@ Feature: propagation of etags when uploading data
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: sharee overwriting a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path
@@ -125,7 +125,7 @@ Feature: propagation of etags when uploading data
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav-path-version> DAV path

--- a/tests/acceptance/features/coreApiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/coreApiWebdavLocks/requestsWithToken.feature
@@ -1,4 +1,4 @@
-@issue-1284
+@issue-1284 @skipOnReva
 Feature: actions on a locked item are possible if the token is sent with the request
   As a user
   I want to share the lock token of a resource

--- a/tests/acceptance/features/coreApiWebdavLocks2/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/coreApiWebdavLocks2/independentLocksShareToShares.feature
@@ -1,4 +1,4 @@
-@issue-1284
+@issue-1284 @skipOnReva
 Feature: independent locks - make sure all locks are independent and don't interact with other items that have the same name
   As a user
   I want to independently lock resources shared with me

--- a/tests/acceptance/features/coreApiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/coreApiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -1,4 +1,4 @@
-@issue-1284
+@issue-1284 @skipOnReva
 Feature: UNLOCK locked items (sharing)
   As a user
   I want to unlock a shared resource that has been locked by me to be restricted

--- a/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
@@ -7,7 +7,7 @@ Feature: move (rename) file
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-
+  @skipOnReva
   Scenario Outline: moving a file into a shared folder as the sharee and as the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -30,7 +30,7 @@ Feature: move (rename) file
       | new              | Alice | /Shares/testshare  |
       | new              | Brian | /testshare         |
 
-
+  @skipOnReva
   Scenario Outline: moving a file out of a shared folder as the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -51,7 +51,7 @@ Feature: move (rename) file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: moving a file out of a shared folder as the sharee
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -71,7 +71,7 @@ Feature: move (rename) file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: moving a folder into a shared folder as the sharee and as the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -119,7 +119,7 @@ Feature: move (rename) file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: moving a folder out of a shared folder as the sharee
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -142,7 +142,7 @@ Feature: move (rename) file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: moving a file to a shared folder with no permissions
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -161,7 +161,7 @@ Feature: move (rename) file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: moving a file to overwrite a file in a shared folder with no permissions
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"

--- a/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
@@ -182,7 +182,7 @@ Feature: move (rename) file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: checking file id after a move between received shares
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
@@ -134,7 +134,7 @@ Feature: previews of files downloaded through the webdav API
       | new              |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: download previews of shared files (to shares folder)
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -207,7 +207,7 @@ Feature: previews of files downloaded through the webdav API
       | new              |
       | spaces           |
 
-  @issue-2538
+  @issue-2538 @skipOnReva
   Scenario Outline: when owner updates a shared file, previews for sharee are also updated (to shared folder)
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -238,7 +238,7 @@ Feature: previews of files downloaded through the webdav API
       | new              |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: updates to a file should change the preview for both sharees and sharers
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -261,7 +261,7 @@ Feature: previews of files downloaded through the webdav API
       | new              |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: updates to a group shared file should change the preview for both sharees and sharers
     Given using <dav-path-version> DAV path
     And group "grp1" has been created

--- a/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
@@ -250,7 +250,7 @@ Feature: copy file
       | dav-path-version |
       | spaces           |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a file over the top of an existing folder received as a user share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -268,7 +268,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a folder over the top of an existing file received as a user share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -285,7 +285,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -307,7 +307,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a file into a folder at different level received as a user share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -331,7 +331,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a file into a file at different level received as a user share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -354,7 +354,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a folder into a file at different level received as a user share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -377,7 +377,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a file over the top of an existing folder received as a group share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -403,7 +403,7 @@ Feature: copy file
       | dav-path-version |
       | spaces           |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a folder over the top of an existing file received as a group share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -428,7 +428,7 @@ Feature: copy file
       | dav-path-version |
       | spaces           |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a folder into another folder at different level which is received as a group share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -453,7 +453,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a file into a folder at different level received as a group share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -480,7 +480,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a file into a file at different level received as a group share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -506,7 +506,7 @@ Feature: copy file
       | old              |
       | new              |
 
-  @issue-1239
+  @issue-1239 @skipOnReva
   Scenario Outline: copy a folder into a file at different level received as a group share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature
@@ -60,7 +60,7 @@ Feature: copy file
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: copying a file to a folder with no permissions
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -78,7 +78,7 @@ Feature: copy file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: copying a file to overwrite a file into a folder with no permissions
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -602,7 +602,7 @@ Feature: copy file
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: copying a file into a shared folder as the sharee
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -621,7 +621,7 @@ Feature: copy file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: copying a file into a shared folder as the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -641,7 +641,7 @@ Feature: copy file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: copying a file out of a shared folder as the sharee
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -662,7 +662,7 @@ Feature: copy file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: copying a file out of a shared folder as the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -710,7 +710,7 @@ Feature: copy file
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: copying a file between shares received from different users
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -739,7 +739,7 @@ Feature: copy file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: copying a folder between shares received from different users
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -769,7 +769,7 @@ Feature: copy file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: copying a file to a folder that is shared with multiple users
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/createFileFolderWhenSharesExist.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: create file or folder named similar to Shares folder
   As a user
   I want to be able to create files and folders when the Shares folder exists

--- a/tests/acceptance/features/coreApiWebdavProperties1/getQuota.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties1/getQuota.feature
@@ -71,7 +71,7 @@ Feature: get quota
       | new              |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: retrieving folder quota when quota is set and a file was received
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtimeShares.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtimeShares.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: upload file
   As a user
   I want the mtime of an uploaded file to be the creation date on upload source not the upload date

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToNonExistingFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToNonExistingFolder.feature
@@ -34,7 +34,7 @@ Feature: upload file
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: attempt to upload a file into a nonexistent folder within correctly received share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -48,7 +48,7 @@ Feature: upload file
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: attempt to upload a file into a nonexistent folder within correctly received read only share
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: upload file to shared folder
   As a user
   I want to upload files on a shared folder


### PR DESCRIPTION
## Description
https://github.com/cs3org/reva/pull/4269#issuecomment-1772363016
>After talking to kobergj, we decided to skip all failed tests related to auto accepts in reva, auto accepts is an ocis feature and we cannot use it in reva. please use @skipOnReva.

## Related Issue


## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
