### PR TITLE
Reuse existing mountpoints on auto accept

### DIFF
--- a/changelog/unreleased/fix-mountpoint-autoaccept.md
+++ b/changelog/unreleased/fix-mountpoint-autoaccept.md
@@ -1,0 +1,5 @@
+Bugfix: set existing mountpoint on auto accept
+
+When already having a share for a specific resource, auto accept would use custom mountpoints which lead to other errors. Now auto-accept is using the existing mountpoint of a share.
+
+https://github.com/owncloud/ocis/pull/7592


### PR DESCRIPTION
When already having a share for a specific resource, auto accept would use custom mountpoints which lead to other errors. Now auto-accept is using the existing mountpoint of a share.


Fixes: https://github.com/owncloud/ocis/issues/7541
