### PR TITLE
[tests-only][full-ci] add tests for copy file within shares using file-id

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
@@ -178,3 +178,26 @@ Feature: copying file using file id
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
       | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file from sub-folder to root folder inside Shares space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has created folder "folder/sub-folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/sub-folder/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has shared folder "/folder" with user "Brian" with permissions "all"
+    When user "Brian" copies a file "Shares/folder/sub-folder/test.txt" into "Shares/folder" inside space "Shares" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Brian" folder "folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "folder/sub-folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "folder" of the space "Personal" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "folder/sub-folder" of the space "Personal" should contain these files:
+      | test.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -610,7 +610,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$logMessage = "## $scenario ($scenarioLine)\n";
-	
+
 		// Delete previous scenario's log file
 		if (\file_exists(HttpLogger::getScenarioLogPath())) {
 			\unlink(HttpLogger::getScenarioLogPath());

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -1965,8 +1965,15 @@ class SpacesContext implements Context {
 		} elseif ($actionType === 'renames') {
 			$fileDestination = $destinationFile;
 		}
-		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName, $url);
-		$fullUrl = $this->featureContext->getBaseUrl() . $url;
+		$baseUrl = $this->featureContext->getBaseUrl();
+		if ($toSpaceName === 'Shares') {
+			$sharesPath = $this->featureContext->getMountSharesPath($user, $fileDestination);
+			$davPath = WebDavHelper::getDavPath($user, $this->featureContext->getDavPathVersion());
+			$headers['Destination'] = $baseUrl . $davPath . $sharesPath;
+		} else {
+			$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName, $url);
+		}
+		$fullUrl = $baseUrl . $url;
 		if ($actionType === 'copies') {
 			$this->featureContext->setResponse($this->copyFilesAndFoldersRequest($user, $fullUrl, $headers));
 		} elseif ($actionType === 'moves' || $actionType === 'renames') {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

### Description
This PR adds the test for copying the files of shares space with the `url` consisting of the `file-id` not name
In this PR following scenario are added:
- Copy a file from sub-folder to root inside share space


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6737


