### PR TITLE
Return 423 on tag create when file is locked

### DIFF
--- a/changelog/unreleased/423-on-tag-create.md
+++ b/changelog/unreleased/423-on-tag-create.md
@@ -1,0 +1,5 @@
+Bugfix: Return 423 status code on tag create
+
+When a file is locked, return 423 status code instead 500 on tag create
+
+https://github.com/owncloud/ocis/pull/7596

--- a/services/graph/pkg/service/v0/tags.go
+++ b/services/graph/pkg/service/v0/tags.go
@@ -120,7 +120,11 @@ func (g Graph) AssignTags(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 	if err != nil || resp.GetStatus().GetCode() != rpc.Code_CODE_OK {
-		g.logger.Error().Err(err).Msg("error setting tags")
+		g.logger.Error().Err(err).Interface("status", resp.GetStatus()).Msg("error setting tags")
+		if resp.GetStatus().GetCode() == rpc.Code_CODE_LOCKED {
+			errorcode.InvalidRequest.Render(w, r, http.StatusLocked, "file is locked")
+			return
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Returns `423` instead `500` when trying to create a tag on a locked file 

Fixes https://github.com/owncloud/ocis/issues/7590