### PR TITLE
chore: bump web to v7.1.1

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=a26f7920d4ef8bf57488b18e451525d16e246e9e
-WEB_BRANCH=stable-7.1
+WEB_COMMITID=5fec611688782cdf97fafa31993fe40018f6c132
+WEB_BRANCH=release-7.1.1

--- a/changelog/unreleased/bump-web-7.1.1.md
+++ b/changelog/unreleased/bump-web-7.1.1.md
@@ -1,0 +1,11 @@
+Enhancement: Update web to v7.1.1
+
+Tags: web
+
+We updated ownCloud Web to v7.1.1. Please refer to the changelog (linked) for details on the web release.
+
+## Summary
+* Bugfix [owncloud/web#9833](https://github.com/owncloud/web/pull/9833): Resolving external URLs
+
+https://github.com/owncloud/ocis/pull/7601
+https://github.com/owncloud/web/releases/tag/v7.1.1

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v7.1.0
+WEB_ASSETS_VERSION = v7.1.1
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bumps Web to `v7.1.1`. This includes the following fixes:

* Bugfix [owncloud/web#9833](https://github.com/owncloud/web/pull/9833): Resolving external URLs