### PR TITLE
[tests-only][full-ci] Add tests for move file within shares using file-id

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -241,6 +241,7 @@ default:
       context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
+        - WebDavPropertiesContext:
 
     apiLocks:
       paths:

--- a/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
@@ -150,6 +150,30 @@ Feature: moving/renaming file using file id
       | /dav/spaces/<<FILEID>>            |
 
 
+  Scenario Outline: move a file from sub-folder to root folder inside shares space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has created folder "folder/sub-folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/sub-folder/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has shared folder "/folder" with user "Brian" with permissions "all"
+    When user "Brian" moves a file "Shares/folder/sub-folder/test.txt" into "Shares/folder" inside space "Shares" using file-id path "<dav-path>"
+    Then the HTTP status code should be "502"
+    And the value of the item "/d:error/s:message" in the response about user "Brian" should be "gateway does not support cross storage move, use copy and delete"
+    And for user "Brian" folder "folder/sub-folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "folder" of the space "Shares" should not contain these files:
+      | test.txt |
+    And for user "Alice" folder "folder/sub-folder" of the space "Personal" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "folder" of the space "Personal" should not contain these files:
+      | test.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
   Scenario Outline: rename a root file inside personal space
     Given user "Alice" has uploaded file with content "some data" to "textfile.txt"
     And we save it into "FILEID"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

### Description
This PR adds the test for moving the files of shares space with the `url` consisting of the `file-id` not name
In this PR following scenario are added:
- move a file from sub-folder to root inside Shares space


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6737


