### PR TITLE
[tests-only][full-ci]Add tests for searching for resources with whitespace chars in its name

### DIFF
--- a/tests/acceptance/features/apiSearch/apiSpaceSearch.feature
+++ b/tests/acceptance/features/apiSearch/apiSpaceSearch.feature
@@ -217,6 +217,42 @@ Feature: Search
       | new              |
       | spaces           |
 
+  @issue-7114
+  Scenario Outline: search files inside the folder with white space character in its name
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created folder "/New Folder"
+    And user "Alice" has uploaded file with content "hello world inside folder" to "/New Folder/file.txt"
+    And user "Alice" has created folder "/New Folder/Sub Folder"
+    And user "Alice" has uploaded file with content "hello world inside sub folder" to "/New Folder/Sub Folder/file1.txt"
+    When user "Alice" searches for "*file*" inside folder "/New Folder" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /New Folder/file.txt             |
+      | /New Folder/Sub Folder/file1.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+  @issue-7114
+  Scenario Outline: search files with white space character in its name
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created folder "/New Folder"
+    And user "Alice" has uploaded file with content "hello world" to "/new file.txt"
+    And user "Alice" has created folder "/New Folder/New Sub Folder"
+    When user "Alice" searches for "*new*" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /New Folder                |
+      | /New Folder/New Sub Folder |
+      | /new file.txt              |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
   @issue-enterprise-6000 @issue-7028 @issue-7092
   Scenario Outline: sharee cannot find resources that are not shared
     Given using <dav-path-version> DAV path


### PR DESCRIPTION
## Description
This PR adds tests for searching for resources with white space in its name

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes: https://github.com/owncloud/ocis/issues/7552

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
