### PR TITLE
[tests-only][full-ci] Add test for copy file between personal space and share space using fileID

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
@@ -201,3 +201,43 @@ Feature: copying file using file id
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
       | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file from personal to share space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has shared folder "/folder" with user "Brian" with permissions "all"
+    And user "Brian" has uploaded file with content "some data" to "/test.txt"
+    And we save it into "FILEID"
+    When user "Brian" copies a file "/test.txt" into "Shares/folder" inside space "Shares" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Brian" folder "folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "/" of the space "Personal" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "folder" of the space "Personal" should contain these files:
+      | test.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file from share to personal space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has shared folder "/folder" with user "Brian" with permissions "all"
+    When user "Brian" copies a file "/test.txt" into "/" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Brian" folder "folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "/" of the space "Personal" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "folder" of the space "Personal" should contain these files:
+      | test.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

### Description
This PR adds the test for copying the files betweeen personal space and Shares space with the `url` consisting of the `file-id` not name

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6737


