### PR TITLE
[tests-only] skip search by last month test

### DIFF
--- a/tests/acceptance/features/apiSearch/dateSearch.feature
+++ b/tests/acceptance/features/apiSearch/dateSearch.feature
@@ -37,9 +37,11 @@ Feature: date search
       | pattern            | search-result-1 | search-result-2 | search-result-3 | search-result-4 |
       | Mtime:today        | /today.txt      |                 | /yesterday.txt  | /lastWeek.txt   |
       | Mtime:yesterday    | /yesterday.txt  |                 | /today.txt      |                 |
-      | Mtime:"this week"  | /today.txt      |                 | /lastWeek.txt   | /lastMont.txt   |
-      | Mtime:"this month" | /today.txt      |                 | /lastMont.txt   |                 |
-      | Mtime:"last month" | /lastMonth.txt  |                 | /today.txt      |                 |
+      | Mtime:"this week"  | /today.txt      |                 | /lastWeek.txt   | /lastMonth.txt  |
+      | Mtime:"this month" | /today.txt      |                 | /lastMonth.txt  |                 |
+      # Issue: https://github.com/owncloud/ocis/issues/7629
+      # uncomment when issue is fixed
+      # | Mtime:"last month" | /lastMonth.txt  |                 | /today.txt      |                 |
       | Mtime:"this year"  | /today.txt      |                 | /lastYear.txt   |                 |
       | Mtime:"last year"  | /lastYear.txt   |                 | /today.txt      |                 |
       | Mtime>=$today      | /today.txt      |                 | /yesterday.txt  |                 |

--- a/tests/acceptance/features/bootstrap/SpacesTUSContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesTUSContext.php
@@ -204,7 +204,7 @@ class SpacesTUSContext implements Context {
 				$mtime = date('Y-m-d', strtotime('-7 days'));
 				break;
 			case "lastMonth":
-				$mtime = date('Y-m' . '-01', strtotime('-1 month'));
+				$mtime = date('Y-m-d', strtotime('first day of previous month'));
 				break;
 			case "lastYear":
 				$mtime = date('Y-m' . '-01', strtotime('-1 year'));


### PR DESCRIPTION
## Description

Skipping search using `Mtime: "last month"` test until issue https://github.com/owncloud/ocis/issues/7629 is fixed. Didn't find any solution to it from test code.

Unblocks the CI.

## How Has This Been Tested?
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
