### PR TITLE
[tests-only][full-ci] Add test for copy file between project spaces

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
@@ -241,3 +241,23 @@ Feature: copying file using file id
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
       | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: copy a file between two project spaces
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "first-project-space" with the default quota using the Graph API
+    And user "Alice" has created a space "second-project-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "first-project-space" with content "data from first project space" to "firstProjectSpacetextfile.txt"
+    And user "Alice" has uploaded a file inside space "second-project-space" with content "data from second project space" to "secondProjectSpacetextfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" copies a file "/secondProjectSpacetextfile.txt" into "/" inside space "first-project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Alice" folder "/" of the space "first-project-space" should contain these files:
+      | firstProjectSpacetextfile.txt  |
+      | secondProjectSpacetextfile.txt |
+    And for user "Alice" folder "/" of the space "second-project-space" should contain these files:
+      | secondProjectSpacetextfile.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

### Description
This PR adds the test for copying the file between spaces in project space with the `url` consisting of the `file-id` not name

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/6737