### PR TITLE
[docs-only] Text fix for thumbnail README.md

### DIFF
--- a/services/thumbnails/README.md
+++ b/services/thumbnails/README.md
@@ -52,16 +52,14 @@ Returned: 15x10
 ## Thumbnail Processors
 
 Normally, an image might get cropped when creating a preview, depending on the aspect ratio of the original image. This can have negative 
-impacts on previews as only a part of the image will be shown. When using an _optional_ processor in the request, cropping can be avoided by 
-defining on how the preview image generation will be done. The following processors are available:
+impacts on previews as only a part of the image will be shown. When using an _optional_ processor in the request, cropping can be avoided by defining on how the preview image generation will be done. The following processors are available:
 
 *   `resize`
 *   `fit`
 *   `fill`
 *   `thumbnail`
 
-To apply one of those, a query parameter has to be added to the request, like `?processor=fit`. If no query parameter or processor 
-is added, the default behaviour applies which is `resize` for gif's and `thumbnail` for all others.
+To apply one of those, a query parameter has to be added to the request, like `?processor=fit`. If no query parameter or processor is added, the default behaviour applies which is `resize` for gif's and `thumbnail` for all others.
 
 ## Deleting Thumbnails
 

--- a/services/thumbnails/README.md
+++ b/services/thumbnails/README.md
@@ -45,20 +45,23 @@ Various resolutions can be defined via `THUMBNAILS_RESOLUTIONS`. A requestor can
 
 Example:
 
-Requested: 18x12
-Available: 30x20, 15x10, 9x6
-Returned: 15x10
+Requested: 18x12  
+Available: 30x20, 15x10, 9x6  
+Returned: 15x10  
 
 ## Thumbnail Processors
 
-Image generation can be configured by defining different processors, following processors are available:
+Normally, an image might get cropped when creating a preview, depending on the aspect ratio of the original image. This can have negative 
+impacts on previews as only a part of the image will be shown. When using an _optional_ processor in the request, cropping can be avoided by 
+defining on how the preview image generation will be done. The following processors are available:
 
 *   `resize`
 *   `fit`
 *   `fill`
 *   `thumbnail`
 
-To apply one of those, a query parameter has to be added to the request, e.g. `?processor=fit`
+To apply one of those, a query parameter has to be added to the request, like `?processor=fit`. If no query parameter or processor 
+is added, the default behaviour applies which is `resize` for gif's and `thumbnail` for all others.
 
 ## Deleting Thumbnails
 


### PR DESCRIPTION
References: #7409 (feature(thumbnails): add the ability to define custom image processors)

The `Thumbnail Processor` section needed an update to clarify the usecase and behaviour. In addition, the list of sizes above now shows as in a single line each and not in one line.
