### PR TITLE
drop unused reva config from policies

### DIFF
--- a/services/policies/pkg/config/config.go
+++ b/services/policies/pkg/config/config.go
@@ -13,9 +13,7 @@ type Config struct {
 	GRPC           GRPC                  `yaml:"grpc"`
 	Service        Service               `yaml:"-"`
 	Debug          Debug                 `yaml:"debug"`
-	TokenManager   *TokenManager         `yaml:"token_manager"`
 	Events         Events                `yaml:"events"`
-	Reva           *shared.Reva          `yaml:"reva"`
 	GRPCClientTLS  *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 	Context        context.Context       `yaml:"-"`
 	Log            *Log                  `yaml:"log"`

--- a/services/policies/pkg/config/defaults/defaultconfig.go
+++ b/services/policies/pkg/config/defaults/defaultconfig.go
@@ -3,7 +3,6 @@ package defaults
 import (
 	"time"
 
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/policies/pkg/config"
 )
@@ -32,7 +31,6 @@ func DefaultConfig() *config.Config {
 			Addr:      "127.0.0.1:9125",
 			Namespace: "com.owncloud.api",
 		},
-		Reva: shared.DefaultRevaConfig(),
 		Events: config.Events{
 			Endpoint:  "127.0.0.1:9233",
 			Cluster:   "ocis-cluster",
@@ -45,23 +43,6 @@ func DefaultConfig() *config.Config {
 }
 
 func EnsureDefaults(cfg *config.Config) {
-	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
-		cfg.TokenManager = &config.TokenManager{
-			JWTSecret: cfg.Commons.TokenManager.JWTSecret,
-		}
-	} else if cfg.TokenManager == nil {
-		cfg.TokenManager = &config.TokenManager{}
-	}
-
-	if cfg.Reva == nil && cfg.Commons != nil && cfg.Commons.Reva != nil {
-		cfg.Reva = &shared.Reva{
-			Address: cfg.Commons.Reva.Address,
-			TLS:     cfg.Commons.Reva.TLS,
-		}
-	} else if cfg.Reva == nil {
-		cfg.Reva = &shared.Reva{}
-	}
-
 	if cfg.Log == nil && cfg.Commons != nil && cfg.Commons.Log != nil {
 		cfg.Log = &config.Log{
 			Level:  cfg.Commons.Log.Level,

--- a/services/policies/pkg/config/parser/parse.go
+++ b/services/policies/pkg/config/parser/parse.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/policies/pkg/config"
 	"github.com/owncloud/ocis/v2/services/policies/pkg/config/defaults"
 
@@ -34,9 +33,5 @@ func ParseConfig(cfg *config.Config) error {
 }
 
 func Validate(cfg *config.Config) error {
-	if cfg.TokenManager.JWTSecret == "" {
-		return shared.MissingJWTTokenError(cfg.Service.Name)
-	}
-
 	return nil
 }


### PR DESCRIPTION
While tracing the calls for a diagram I noticed that the postprocessing service does not actually use the reva config options that can be configured.

so, only killing dead code, AFAICT