### PR TITLE
graph: reuse user- and group cache in graph/sharedbyme

### DIFF
--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -5,7 +5,8 @@ import (
 	"net/url"
 
 	"github.com/CiscoM31/godata"
-	cs3 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	cs3group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	cs3user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 )
@@ -103,14 +104,26 @@ type EducationBackend interface {
 	RemoveTeacherFromEducationClass(ctx context.Context, classID string, teacherID string) error
 }
 
-func CreateUserModelFromCS3(u *cs3.User) *libregraph.User {
+// CreateUserModelFromCS3 converts a cs3 User object into a libregraph.User
+func CreateUserModelFromCS3(u *cs3user.User) *libregraph.User {
 	if u.Id == nil {
-		u.Id = &cs3.UserId{}
+		u.Id = &cs3user.UserId{}
 	}
 	return &libregraph.User{
 		DisplayName:              &u.DisplayName,
 		Mail:                     &u.Mail,
 		OnPremisesSamAccountName: &u.Username,
 		Id:                       &u.Id.OpaqueId,
+	}
+}
+
+// CreateGroupModelFromCS3 converts a cs3 Group object into a libregraph.Group
+func CreateGroupModelFromCS3(g *cs3group.Group) *libregraph.Group {
+	if g.Id == nil {
+		g.Id = &cs3group.GroupId{}
+	}
+	return &libregraph.Group{
+		Id:          &g.Id.OpaqueId,
+		DisplayName: &g.GroupName,
 	}
 }

--- a/services/graph/pkg/identity/cache.go
+++ b/services/graph/pkg/identity/cache.go
@@ -1,0 +1,139 @@
+package identity
+
+import (
+	"context"
+	"time"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	cs3Group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	cs3User "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
+	revautils "github.com/cs3org/reva/v2/pkg/utils"
+	"github.com/jellydator/ttlcache/v3"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
+)
+
+// IdentityCache implements a simple ttl based cache for looking up users and groups by ID
+type IdentityCache struct {
+	users           *ttlcache.Cache[string, libregraph.User]
+	groups          *ttlcache.Cache[string, libregraph.Group]
+	gatewaySelector pool.Selectable[gateway.GatewayAPIClient]
+}
+
+type identityCacheOptions struct {
+	gatewaySelector pool.Selectable[gateway.GatewayAPIClient]
+	usersTTL        time.Duration
+	groupsTTL       time.Duration
+}
+
+// IdentityCacheOptiondefines a single option function.
+type IdentityCacheOption func(o *identityCacheOptions)
+
+// IdentityCacheWithGatewaySelector set the gatewaySelector for the Identity Cache
+func IdentityCacheWithGatewaySelector(gatewaySelector pool.Selectable[gateway.GatewayAPIClient]) IdentityCacheOption {
+	return func(o *identityCacheOptions) {
+		o.gatewaySelector = gatewaySelector
+	}
+}
+
+// IdentityCacheWithUsersTTL sets the TTL for the users cache
+func IdentityCacheWithUsersTTL(ttl time.Duration) IdentityCacheOption {
+	return func(o *identityCacheOptions) {
+		o.usersTTL = ttl
+	}
+}
+
+// IdentityCacheWithGroupsTTL sets the TTL for the groups cache
+func IdentityCacheWithGroupsTTL(ttl time.Duration) IdentityCacheOption {
+	return func(o *identityCacheOptions) {
+		o.groupsTTL = ttl
+	}
+}
+
+func newOptions(opts ...IdentityCacheOption) identityCacheOptions {
+	opt := identityCacheOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// NewIdentityCache instanciates a new IdentityCache and sets the supplied options
+func NewIdentityCache(opts ...IdentityCacheOption) IdentityCache {
+	opt := newOptions(opts...)
+
+	var cache IdentityCache
+
+	cache.users = ttlcache.New(
+		ttlcache.WithTTL[string, libregraph.User](opt.usersTTL),
+		ttlcache.WithDisableTouchOnHit[string, libregraph.User](),
+	)
+	go cache.users.Start()
+
+	cache.groups = ttlcache.New(
+		ttlcache.WithTTL[string, libregraph.Group](opt.groupsTTL),
+		ttlcache.WithDisableTouchOnHit[string, libregraph.Group](),
+	)
+	go cache.groups.Start()
+
+	cache.gatewaySelector = opt.gatewaySelector
+
+	return cache
+}
+
+// GetUser looks up a user by id, if the user is not cached yet it will do a lookup via the CS3 API
+func (cache IdentityCache) GetUser(ctx context.Context, userid string) (libregraph.User, error) {
+	var user libregraph.User
+	if item := cache.users.Get(userid); item == nil {
+		gatewayClient, err := cache.gatewaySelector.Next()
+		cs3UserID := &cs3User.UserId{
+			OpaqueId: userid,
+		}
+		cs3User, err := revautils.GetUser(cs3UserID, gatewayClient)
+		if err != nil {
+			if revautils.IsErrNotFound(err) {
+				return libregraph.User{}, ErrNotFound
+			}
+			return libregraph.User{}, errorcode.New(errorcode.GeneralException, err.Error())
+		}
+		user = *CreateUserModelFromCS3(cs3User)
+		cache.users.Set(userid, user, ttlcache.DefaultTTL)
+
+	} else {
+		user = item.Value()
+	}
+	return user, nil
+}
+
+// GetUser looks up a group by id, if the group is not cached yet it will do a lookup via the CS3 API
+func (cache IdentityCache) GetGroup(ctx context.Context, groupid string) (libregraph.Group, error) {
+	var group libregraph.Group
+	if item := cache.groups.Get(groupid); item == nil {
+		gatewayClient, err := cache.gatewaySelector.Next()
+		cs3GroupID := &cs3Group.GroupId{
+			OpaqueId: groupid,
+		}
+		req := cs3Group.GetGroupRequest{
+			GroupId: cs3GroupID,
+		}
+		res, err := gatewayClient.GetGroup(ctx, &req)
+		if err != nil {
+			return group, errorcode.New(errorcode.GeneralException, err.Error())
+		}
+		switch res.Status.Code {
+		case rpc.Code_CODE_OK:
+			cs3Group := res.GetGroup()
+			group = *CreateGroupModelFromCS3(cs3Group)
+			cache.groups.Set(groupid, group, ttlcache.DefaultTTL)
+		case rpc.Code_CODE_NOT_FOUND:
+			return group, ErrNotFound
+		default:
+			return group, errorcode.New(errorcode.GeneralException, res.Status.Message)
+		}
+	} else {
+		group = item.Value()
+	}
+	return group, nil
+}

--- a/services/graph/pkg/identity/cs3.go
+++ b/services/graph/pkg/identity/cs3.go
@@ -147,7 +147,7 @@ func (i *CS3) GetGroups(ctx context.Context, queryParam url.Values) ([]*libregra
 	groups := make([]*libregraph.Group, 0, len(res.Groups))
 
 	for _, group := range res.Groups {
-		groups = append(groups, createGroupModelFromCS3(group))
+		groups = append(groups, CreateGroupModelFromCS3(group))
 	}
 
 	return groups, nil
@@ -185,7 +185,7 @@ func (i *CS3) GetGroup(ctx context.Context, groupID string, queryParam url.Value
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 
-	return createGroupModelFromCS3(res.Group), nil
+	return CreateGroupModelFromCS3(res.Group), nil
 }
 
 // DeleteGroup implements the Backend Interface. It's currently not supported for the CS3 backend
@@ -211,15 +211,4 @@ func (i *CS3) AddMembersToGroup(ctx context.Context, groupID string, memberID []
 // RemoveMemberFromGroup implements the Backend Interface. It's currently not supported for the CS3 backend
 func (i *CS3) RemoveMemberFromGroup(ctx context.Context, groupID string, memberID string) error {
 	return errorcode.New(errorcode.NotSupported, "not implemented")
-}
-
-func createGroupModelFromCS3(g *cs3group.Group) *libregraph.Group {
-	if g.Id == nil {
-		g.Id = &cs3group.GroupId{}
-	}
-	return &libregraph.Group{
-		Id:          &g.Id.OpaqueId,
-		DisplayName: &g.GroupName,
-		// TODO when to fetch and expand memberof, usernames or ids?
-	}
 }

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/go-chi/chi/v5"
 	"github.com/jellydator/ttlcache/v3"
-	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/ocis-pkg/keycloak"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	ehsvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/eventhistory/v0"
@@ -71,8 +70,7 @@ type Graph struct {
 	roleService              RoleService
 	permissionsService       Permissions
 	specialDriveItemsCache   *ttlcache.Cache[string, interface{}]
-	usersCache               *ttlcache.Cache[string, libregraph.User]
-	groupsCache              *ttlcache.Cache[string, libregraph.Group]
+	identityCache            identity.IdentityCache
 	eventsPublisher          events.Publisher
 	searchService            searchsvc.SearchProviderService
 	keycloakClient           keycloak.Client


### PR DESCRIPTION
This makes the  user and group lookup cache in drives.go re-usable so that it e.g. graph/sharedbyme can use it as well.