### PR TITLE
graph: Set roles/actions in `sharedByMe` response

### DIFF
--- a/services/graph/pkg/service/v0/rolemanagement.go
+++ b/services/graph/pkg/service/v0/rolemanagement.go
@@ -15,7 +15,7 @@ import (
 // GetRoleDefinitions a list of permission roles than can be used when sharing with users or groups
 func (g Graph) GetRoleDefinitions(w http.ResponseWriter, r *http.Request) {
 	render.Status(r, http.StatusOK)
-	render.JSON(w, r, getRoleDefinitionList(g.config.FilesSharing.EnableResharing))
+	render.JSON(w, r, unifiedrole.GetBuiltinRoleDefinitionList(g.config.FilesSharing.EnableResharing))
 }
 
 // GetRoleDefinition a permission role than can be used when sharing with users or groups
@@ -37,21 +37,8 @@ func (g Graph) GetRoleDefinition(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, role)
 }
 
-func getRoleDefinitionList(resharing bool) []*libregraph.UnifiedRoleDefinition {
-	return []*libregraph.UnifiedRoleDefinition{
-		unifiedrole.NewViewerUnifiedRole(resharing),
-		unifiedrole.NewSpaceViewerUnifiedRole(),
-		unifiedrole.NewEditorUnifiedRole(resharing),
-		unifiedrole.NewSpaceEditorUnifiedRole(),
-		unifiedrole.NewFileEditorUnifiedRole(resharing),
-		unifiedrole.NewCoownerUnifiedRole(),
-		unifiedrole.NewUploaderUnifiedRole(),
-		unifiedrole.NewManagerUnifiedRole(),
-	}
-}
-
 func getRoleDefinition(roleID string, resharing bool) (*libregraph.UnifiedRoleDefinition, error) {
-	roleList := getRoleDefinitionList(resharing)
+	roleList := unifiedrole.GetBuiltinRoleDefinitionList(resharing)
 	for _, role := range roleList {
 		if role != nil && role.Id != nil && *role.Id == roleID {
 			return role, nil

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -1,6 +1,7 @@
 package unifiedrole
 
 import (
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/conversions"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"google.golang.org/protobuf/proto"
@@ -168,40 +169,9 @@ func NewManagerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	}
 }
 
-func displayName(role *conversions.Role) *string {
-	if role == nil {
-		return nil
-	}
-	var displayName string
-	switch role.Name {
-	case conversions.RoleViewer:
-		displayName = "Viewer"
-	case conversions.RoleSpaceViewer:
-		displayName = "Space Viewer"
-	case conversions.RoleEditor:
-		displayName = "Editor"
-	case conversions.RoleSpaceEditor:
-		displayName = "Space Editor"
-	case conversions.RoleFileEditor:
-		displayName = "File Editor"
-	case conversions.RoleCoowner:
-		displayName = "Co Owner"
-	case conversions.RoleUploader:
-		displayName = "Uploader"
-	case conversions.RoleManager:
-		displayName = "Manager"
-	default:
-		return nil
-	}
-	return proto.String(displayName)
-}
-
-func convert(role *conversions.Role) []string {
-	actions := make([]string, 0, 8)
-	if role == nil && role.CS3ResourcePermissions() == nil {
-		return actions
-	}
-	p := role.CS3ResourcePermissions()
+// CS3ResourcePermissionsToLibregraphActions converts the provided cs3 ResourcePermissions to a list of
+// libregraph actions
+func CS3ResourcePermissionsToLibregraphActions(p provider.ResourcePermissions) (actions []string) {
 	if p.AddGrant {
 		actions = append(actions, "libre.graph/driveItem/permissions/create")
 	}
@@ -260,4 +230,40 @@ func convert(role *conversions.Role) []string {
 		actions = append(actions, "libre.graph/driveItem/permissions/deny")
 	}
 	return actions
+}
+
+func displayName(role *conversions.Role) *string {
+	if role == nil {
+		return nil
+	}
+	var displayName string
+	switch role.Name {
+	case conversions.RoleViewer:
+		displayName = "Viewer"
+	case conversions.RoleSpaceViewer:
+		displayName = "Space Viewer"
+	case conversions.RoleEditor:
+		displayName = "Editor"
+	case conversions.RoleSpaceEditor:
+		displayName = "Space Editor"
+	case conversions.RoleFileEditor:
+		displayName = "File Editor"
+	case conversions.RoleCoowner:
+		displayName = "Co Owner"
+	case conversions.RoleUploader:
+		displayName = "Uploader"
+	case conversions.RoleManager:
+		displayName = "Manager"
+	default:
+		return nil
+	}
+	return proto.String(displayName)
+}
+
+func convert(role *conversions.Role) []string {
+	actions := make([]string, 0, 8)
+	if role == nil && role.CS3ResourcePermissions() == nil {
+		return actions
+	}
+	return CS3ResourcePermissionsToLibregraphActions(*role.CS3ResourcePermissions())
 }

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -31,6 +31,26 @@ const (
 	UnifiedRoleConditionOwner = "@Subject.objectId Any_of @Resource.owners"
 	// UnifiedRoleConditionGrantee does not exist in MS Graph, but we use it to express permissions on shared resources
 	UnifiedRoleConditionGrantee = "@Subject.objectId Any_of @Resource.grantee"
+
+	DriveItemPermissionsCreate = "libre.graph/driveItem/permissions/create"
+	DriveItemChildrenCreate    = "libre.graph/driveItem/children/create"
+	DriveItemStandardDelete    = "libre.graph/driveItem/standard/delete"
+	DriveItemPathRead          = "libre.graph/driveItem/path/read"
+	DriveItemQuotaRead         = "libre.graph/driveItem/quota/read"
+	DriveItemContentRead       = "libre.graph/driveItem/content/read"
+	DriveItemUploadCreate      = "libre.graph/driveItem/upload/create"
+	DriveItemPermissionsRead   = "libre.graph/driveItem/permissions/read"
+	DriveItemChildrenRead      = "libre.graph/driveItem/children/read"
+	DriveItemVersionsRead      = "libre.graph/driveItem/versions/read"
+	DriveItemDeletedRead       = "libre.graph/driveItem/deleted/read"
+	DriveItemPathUpdate        = "libre.graph/driveItem/path/update"
+	DriveItemPermissionsDelete = "libre.graph/driveItem/permissions/delete"
+	DriveItemDeletedDelete     = "libre.graph/driveItem/deleted/delete"
+	DriveItemVersionsUpdate    = "libre.graph/driveItem/versions/update"
+	DriveItemDeletedUpdate     = "libre.graph/driveItem/deleted/update"
+	DriveItemBasicRead         = "libre.graph/driveItem/basic/read"
+	DriveItemPermissionsUpdate = "libre.graph/driveItem/permissions/update"
+	DriveItemPermissionsDeny   = "libre.graph/driveItem/permissions/deny"
 )
 
 // NewViewerUnifiedRole creates a viewer role. `sharing` indicates if sharing permission should be added
@@ -186,61 +206,61 @@ func GetBuiltinRoleDefinitionList(resharing bool) []*libregraph.UnifiedRoleDefin
 // libregraph actions
 func CS3ResourcePermissionsToLibregraphActions(p provider.ResourcePermissions) (actions []string) {
 	if p.AddGrant {
-		actions = append(actions, "libre.graph/driveItem/permissions/create")
+		actions = append(actions, DriveItemPermissionsCreate)
 	}
 	if p.CreateContainer {
-		actions = append(actions, "libre.graph/driveItem/children/create")
+		actions = append(actions, DriveItemChildrenCreate)
 	}
 	if p.Delete {
-		actions = append(actions, "libre.graph/driveItem/standard/delete")
+		actions = append(actions, DriveItemStandardDelete)
 	}
 	if p.GetPath {
-		actions = append(actions, "libre.graph/driveItem/path/read")
+		actions = append(actions, DriveItemPathRead)
 	}
 	if p.GetQuota {
-		actions = append(actions, "libre.graph/driveItem/quota/read")
+		actions = append(actions, DriveItemQuotaRead)
 	}
 	if p.InitiateFileDownload {
-		actions = append(actions, "libre.graph/driveItem/content/read")
+		actions = append(actions, DriveItemContentRead)
 	}
 	if p.InitiateFileUpload {
-		actions = append(actions, "libre.graph/driveItem/upload/create")
+		actions = append(actions, DriveItemUploadCreate)
 	}
 	if p.ListGrants {
-		actions = append(actions, "libre.graph/driveItem/permissions/read")
+		actions = append(actions, DriveItemPermissionsRead)
 	}
 	if p.ListContainer {
-		actions = append(actions, "libre.graph/driveItem/children/read")
+		actions = append(actions, DriveItemChildrenRead)
 	}
 	if p.ListFileVersions {
-		actions = append(actions, "libre.graph/driveItem/versions/read")
+		actions = append(actions, DriveItemVersionsRead)
 	}
 	if p.ListRecycle {
-		actions = append(actions, "libre.graph/driveItem/deleted/read")
+		actions = append(actions, DriveItemDeletedRead)
 	}
 	if p.Move {
-		actions = append(actions, "libre.graph/driveItem/path/update")
+		actions = append(actions, DriveItemPathUpdate)
 	}
 	if p.RemoveGrant {
-		actions = append(actions, "libre.graph/driveItem/permissions/delete")
+		actions = append(actions, DriveItemPermissionsDelete)
 	}
 	if p.PurgeRecycle {
-		actions = append(actions, "libre.graph/driveItem/deleted/delete")
+		actions = append(actions, DriveItemDeletedDelete)
 	}
 	if p.RestoreFileVersion {
-		actions = append(actions, "libre.graph/driveItem/versions/update")
+		actions = append(actions, DriveItemVersionsUpdate)
 	}
 	if p.RestoreRecycleItem {
-		actions = append(actions, "libre.graph/driveItem/deleted/update")
+		actions = append(actions, DriveItemDeletedUpdate)
 	}
 	if p.Stat {
-		actions = append(actions, "libre.graph/driveItem/basic/read")
+		actions = append(actions, DriveItemBasicRead)
 	}
 	if p.UpdateGrant {
-		actions = append(actions, "libre.graph/driveItem/permissions/update")
+		actions = append(actions, DriveItemPermissionsUpdate)
 	}
 	if p.DenyGrant {
-		actions = append(actions, "libre.graph/driveItem/permissions/deny")
+		actions = append(actions, DriveItemPermissionsDeny)
 	}
 	return actions
 }

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -25,12 +25,12 @@ const (
 	// UnifiedRoleManagerID Unified role manager id.
 	UnifiedRoleManagerID = "312c0871-5ef7-4b3a-85b6-0e4074c64049"
 
-	// UnifiedRoleConditionSelf TODO defines constraints
-	UnifiedRoleConditionSelf = "Self: @Subject.objectId == @Resource.objectId"
+	// UnifiedRoleConditionSelf defines constraint where the principal matches the target resource
+	UnifiedRoleConditionSelf = "@Subject.objectId == @Resource.objectId"
 	// UnifiedRoleConditionOwner defines constraints when the principal is the owner of the target resource
-	UnifiedRoleConditionOwner = "Owner: @Subject.objectId Any_of @Resource.owners"
+	UnifiedRoleConditionOwner = "@Subject.objectId Any_of @Resource.owners"
 	// UnifiedRoleConditionGrantee does not exist in MS Graph, but we use it to express permissions on shared resources
-	UnifiedRoleConditionGrantee = "Grantee: @Subject.objectId Any_of @Resource.grantee"
+	UnifiedRoleConditionGrantee = "@Subject.objectId Any_of @Resource.grantee"
 )
 
 // NewViewerUnifiedRole creates a viewer role. `sharing` indicates if sharing permission should be added

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -169,6 +169,19 @@ func NewManagerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	}
 }
 
+func GetBuiltinRoleDefinitionList(resharing bool) []*libregraph.UnifiedRoleDefinition {
+	return []*libregraph.UnifiedRoleDefinition{
+		NewViewerUnifiedRole(resharing),
+		NewSpaceViewerUnifiedRole(),
+		NewEditorUnifiedRole(resharing),
+		NewSpaceEditorUnifiedRole(),
+		NewFileEditorUnifiedRole(resharing),
+		NewCoownerUnifiedRole(),
+		NewUploaderUnifiedRole(),
+		NewManagerUnifiedRole(),
+	}
+}
+
 // CS3ResourcePermissionsToLibregraphActions converts the provided cs3 ResourcePermissions to a list of
 // libregraph actions
 func CS3ResourcePermissionsToLibregraphActions(p provider.ResourcePermissions) (actions []string) {

--- a/services/graph/pkg/unifiedrole/unifiedrole_suite_test.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole_suite_test.go
@@ -1,0 +1,13 @@
+package unifiedrole_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUnifiedrole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Unifiedrole Suite")
+}

--- a/services/graph/pkg/unifiedrole/unifiedrole_test.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole_test.go
@@ -1,0 +1,26 @@
+package unifiedrole_test
+
+import (
+	"github.com/cs3org/reva/v2/pkg/conversions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/unifiedrole"
+)
+
+var _ = Describe("unifiedroles", func() {
+	DescribeTable("CS3ResourcePermissionsToUnifiedRole",
+		func(legacyRole *conversions.Role, unifiedRole *libregraph.UnifiedRoleDefinition) {
+			cs3perm := legacyRole.CS3ResourcePermissions()
+
+			r := unifiedrole.CS3ResourcePermissionsToUnifiedRole(*cs3perm, unifiedrole.UnifiedRoleConditionGrantee, true)
+			Expect(r.GetId()).To(Equal(unifiedRole.GetId()))
+
+		},
+		Entry(conversions.RoleViewer, conversions.NewViewerRole(true), unifiedrole.NewViewerUnifiedRole(true)),
+		Entry(conversions.RoleEditor, conversions.NewEditorRole(true), unifiedrole.NewEditorUnifiedRole(true)),
+		Entry(conversions.RoleFileEditor, conversions.NewFileEditorRole(true), unifiedrole.NewFileEditorUnifiedRole(true)),
+		Entry(conversions.RoleCoowner, conversions.NewCoownerRole(), unifiedrole.NewCoownerUnifiedRole()),
+		Entry(conversions.RoleManager, conversions.NewManagerRole(), unifiedrole.NewManagerUnifiedRole()),
+	)
+})


### PR DESCRIPTION
Try to map CS3 resource permissions on a share to one of the default libregraph
UnifiedRoleDefinitions. If a match if found return the roleid in 'permissions.roles'
attribute of the response. If no match if found convert the
ResourcePermissions in to `libre.graph.permissions.actions` and return
those in the response.