### PR TITLE
[docs-only] fix changelog template for the date field

### DIFF
--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -1,7 +1,7 @@
 # Table of Contents
 
 {{ range . -}}
-  * [Changelog for {{ .Version }}](#changelog-for-{{ .Version | replace "." ""}}-{{ .Date -}})
+  * [Changelog for {{ .Version }}](#changelog-for-{{ .Version | replace "." ""}}-{{ .Date | lower -}})
 {{ end -}}
 {{ $allVersions := . }}
 {{- range $index, $changes := . }}{{ with $changes -}}


### PR DESCRIPTION
References: #7691 ([docs-only] add toc to changelog)

After checking the outcome for the part where we have a text as date field, it turned out that the required casing for markdown was wrong. This is already corrected in the other repos.

* link created: `changelog-for-unreleased-UNRELEASED`
* link required: `changelog-for-unreleased-unreleased`

