### PR TITLE
[full-ci]Enforce pass by default. changed api tests

### DIFF
--- a/protogen/gen/ocis/messages/settings/v0/settings.pb.go
+++ b/protogen/gen/ocis/messages/settings/v0/settings.pb.go
@@ -489,13 +489,13 @@ type Bundle struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id          string      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" yaml:"id"`                                                 // @gotags: yaml:"id"
-	Name        string      `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" yaml:"name"`                                             // @gotags: yaml:"name"
-	Type        Bundle_Type `protobuf:"varint,3,opt,name=type,proto3,enum=ocis.messages.settings.v0.Bundle_Type" json:"type,omitempty" yaml:"type"` // @gotags: yaml:"type"
-	Extension   string      `protobuf:"bytes,4,opt,name=extension,proto3" json:"extension,omitempty" yaml:"extension"`                                   // @gotags: yaml:"extension"
-	DisplayName string      `protobuf:"bytes,5,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty" yaml:"display_name"`            // @gotags: yaml:"display_name"
-	Settings    []*Setting  `protobuf:"bytes,6,rep,name=settings,proto3" json:"settings,omitempty" yaml:"settings"`                                     // @gotags: yaml:"settings"
-	Resource    *Resource   `protobuf:"bytes,7,opt,name=resource,proto3" json:"resource,omitempty" yaml:"resource"`                                     // @gotags: yaml:"resource"
+	Id          string      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                 // @gotags: yaml:"id"
+	Name        string      `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`                                             // @gotags: yaml:"name"
+	Type        Bundle_Type `protobuf:"varint,3,opt,name=type,proto3,enum=ocis.messages.settings.v0.Bundle_Type" json:"type,omitempty"` // @gotags: yaml:"type"
+	Extension   string      `protobuf:"bytes,4,opt,name=extension,proto3" json:"extension,omitempty"`                                   // @gotags: yaml:"extension"
+	DisplayName string      `protobuf:"bytes,5,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`            // @gotags: yaml:"display_name"
+	Settings    []*Setting  `protobuf:"bytes,6,rep,name=settings,proto3" json:"settings,omitempty"`                                     // @gotags: yaml:"settings"
+	Resource    *Resource   `protobuf:"bytes,7,opt,name=resource,proto3" json:"resource,omitempty"`                                     // @gotags: yaml:"resource"
 }
 
 func (x *Bundle) Reset() {
@@ -584,10 +584,10 @@ type Setting struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Id          string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" yaml:"id"`                                      // @gotags: yaml:"id"
-	Name        string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" yaml:"name"`                                  // @gotags: yaml:"name"
-	DisplayName string `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty" yaml:"display_name"` // @gotags: yaml:"display_name"
-	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty" yaml:"description"`                    // @gotags: yaml:"description"
+	Id          string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                      // @gotags: yaml:"id"
+	Name        string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`                                  // @gotags: yaml:"name"
+	DisplayName string `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"` // @gotags: yaml:"display_name"
+	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`                    // @gotags: yaml:"description"
 	// Types that are assignable to Value:
 	//
 	//	*Setting_IntValue
@@ -597,7 +597,7 @@ type Setting struct {
 	//	*Setting_MultiChoiceValue
 	//	*Setting_PermissionValue
 	Value    isSetting_Value `protobuf_oneof:"value"`
-	Resource *Resource       `protobuf:"bytes,11,opt,name=resource,proto3" json:"resource,omitempty" yaml:"resource"` // @gotags: yaml:"resource"
+	Resource *Resource       `protobuf:"bytes,11,opt,name=resource,proto3" json:"resource,omitempty"` // @gotags: yaml:"resource"
 }
 
 func (x *Setting) Reset() {
@@ -721,27 +721,27 @@ type isSetting_Value interface {
 }
 
 type Setting_IntValue struct {
-	IntValue *Int `protobuf:"bytes,5,opt,name=int_value,json=intValue,proto3,oneof" yaml:"int_value"` // @gotags: yaml:"int_value"
+	IntValue *Int `protobuf:"bytes,5,opt,name=int_value,json=intValue,proto3,oneof"` // @gotags: yaml:"int_value"
 }
 
 type Setting_StringValue struct {
-	StringValue *String `protobuf:"bytes,6,opt,name=string_value,json=stringValue,proto3,oneof" yaml:"string_value"` // @gotags: yaml:"string_value"
+	StringValue *String `protobuf:"bytes,6,opt,name=string_value,json=stringValue,proto3,oneof"` // @gotags: yaml:"string_value"
 }
 
 type Setting_BoolValue struct {
-	BoolValue *Bool `protobuf:"bytes,7,opt,name=bool_value,json=boolValue,proto3,oneof" yaml:"bool_value"` // @gotags: yaml:"bool_value"
+	BoolValue *Bool `protobuf:"bytes,7,opt,name=bool_value,json=boolValue,proto3,oneof"` // @gotags: yaml:"bool_value"
 }
 
 type Setting_SingleChoiceValue struct {
-	SingleChoiceValue *SingleChoiceList `protobuf:"bytes,8,opt,name=single_choice_value,json=singleChoiceValue,proto3,oneof" yaml:"single_choice_value"` // @gotags: yaml:"single_choice_value"
+	SingleChoiceValue *SingleChoiceList `protobuf:"bytes,8,opt,name=single_choice_value,json=singleChoiceValue,proto3,oneof"` // @gotags: yaml:"single_choice_value"
 }
 
 type Setting_MultiChoiceValue struct {
-	MultiChoiceValue *MultiChoiceList `protobuf:"bytes,9,opt,name=multi_choice_value,json=multiChoiceValue,proto3,oneof" yaml:"multi_choice_value"` // @gotags: yaml:"multi_choice_value"
+	MultiChoiceValue *MultiChoiceList `protobuf:"bytes,9,opt,name=multi_choice_value,json=multiChoiceValue,proto3,oneof"` // @gotags: yaml:"multi_choice_value"
 }
 
 type Setting_PermissionValue struct {
-	PermissionValue *Permission `protobuf:"bytes,10,opt,name=permission_value,json=permissionValue,proto3,oneof" yaml:"permission_value"` // @gotags: yaml:"permission_value"
+	PermissionValue *Permission `protobuf:"bytes,10,opt,name=permission_value,json=permissionValue,proto3,oneof"` // @gotags: yaml:"permission_value"
 }
 
 func (*Setting_IntValue) isSetting_Value() {}
@@ -761,11 +761,11 @@ type Int struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Default     int64  `protobuf:"varint,1,opt,name=default,proto3" json:"default,omitempty" yaml:"default"`        // @gotags: yaml:"default"
-	Min         int64  `protobuf:"varint,2,opt,name=min,proto3" json:"min,omitempty" yaml:"min"`                // @gotags: yaml:"min"
-	Max         int64  `protobuf:"varint,3,opt,name=max,proto3" json:"max,omitempty" yaml:"max"`                // @gotags: yaml:"max"
-	Step        int64  `protobuf:"varint,4,opt,name=step,proto3" json:"step,omitempty" yaml:"step"`              // @gotags: yaml:"step"
-	Placeholder string `protobuf:"bytes,5,opt,name=placeholder,proto3" json:"placeholder,omitempty" yaml:"placeholder"` // @gotags: yaml:"placeholder"
+	Default     int64  `protobuf:"varint,1,opt,name=default,proto3" json:"default,omitempty"`        // @gotags: yaml:"default"
+	Min         int64  `protobuf:"varint,2,opt,name=min,proto3" json:"min,omitempty"`                // @gotags: yaml:"min"
+	Max         int64  `protobuf:"varint,3,opt,name=max,proto3" json:"max,omitempty"`                // @gotags: yaml:"max"
+	Step        int64  `protobuf:"varint,4,opt,name=step,proto3" json:"step,omitempty"`              // @gotags: yaml:"step"
+	Placeholder string `protobuf:"bytes,5,opt,name=placeholder,proto3" json:"placeholder,omitempty"` // @gotags: yaml:"placeholder"
 }
 
 func (x *Int) Reset() {
@@ -840,11 +840,11 @@ type String struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Default     string `protobuf:"bytes,1,opt,name=default,proto3" json:"default,omitempty" yaml:"default"`                       // @gotags: yaml:"default"
-	Required    bool   `protobuf:"varint,2,opt,name=required,proto3" json:"required,omitempty" yaml:"required"`                    // @gotags: yaml:"required"
-	MinLength   int32  `protobuf:"varint,3,opt,name=min_length,json=minLength,proto3" json:"min_length,omitempty" yaml:"min_length"` // @gotags: yaml:"min_length"
-	MaxLength   int32  `protobuf:"varint,4,opt,name=max_length,json=maxLength,proto3" json:"max_length,omitempty" yaml:"max_length"` // @gotags: yaml:"max_length"
-	Placeholder string `protobuf:"bytes,5,opt,name=placeholder,proto3" json:"placeholder,omitempty" yaml:"placeholder"`               // @gotags: yaml:"placeholder"
+	Default     string `protobuf:"bytes,1,opt,name=default,proto3" json:"default,omitempty"`                       // @gotags: yaml:"default"
+	Required    bool   `protobuf:"varint,2,opt,name=required,proto3" json:"required,omitempty"`                    // @gotags: yaml:"required"
+	MinLength   int32  `protobuf:"varint,3,opt,name=min_length,json=minLength,proto3" json:"min_length,omitempty"` // @gotags: yaml:"min_length"
+	MaxLength   int32  `protobuf:"varint,4,opt,name=max_length,json=maxLength,proto3" json:"max_length,omitempty"` // @gotags: yaml:"max_length"
+	Placeholder string `protobuf:"bytes,5,opt,name=placeholder,proto3" json:"placeholder,omitempty"`               // @gotags: yaml:"placeholder"
 }
 
 func (x *String) Reset() {
@@ -919,8 +919,8 @@ type Bool struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Default bool   `protobuf:"varint,1,opt,name=default,proto3" json:"default,omitempty" yaml:"default"` // @gotags: yaml:"default"
-	Label   string `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty" yaml:"label"`      // @gotags: yaml:"label"
+	Default bool   `protobuf:"varint,1,opt,name=default,proto3" json:"default,omitempty"` // @gotags: yaml:"default"
+	Label   string `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`      // @gotags: yaml:"label"
 }
 
 func (x *Bool) Reset() {
@@ -974,7 +974,7 @@ type SingleChoiceList struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Options []*ListOption `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty" yaml:"options"` // @gotags: yaml:"options"
+	Options []*ListOption `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty"` // @gotags: yaml:"options"
 }
 
 func (x *SingleChoiceList) Reset() {
@@ -1021,7 +1021,7 @@ type MultiChoiceList struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Options []*ListOption `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty" yaml:"options"` // @gotags: yaml:"options"
+	Options []*ListOption `protobuf:"bytes,1,rep,name=options,proto3" json:"options,omitempty"` // @gotags: yaml:"options"
 }
 
 func (x *MultiChoiceList) Reset() {
@@ -1068,9 +1068,9 @@ type ListOption struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Value        *ListOptionValue `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty" yaml:"value"`                                   // @gotags: yaml:"value"
-	Default      bool             `protobuf:"varint,2,opt,name=default,proto3" json:"default,omitempty" yaml:"default"`                              // @gotags: yaml:"default"
-	DisplayValue string           `protobuf:"bytes,3,opt,name=display_value,json=displayValue,proto3" json:"display_value,omitempty" yaml:"display_value"` // @gotags: yaml:"display_value"
+	Value        *ListOptionValue `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`                                   // @gotags: yaml:"value"
+	Default      bool             `protobuf:"varint,2,opt,name=default,proto3" json:"default,omitempty"`                              // @gotags: yaml:"default"
+	DisplayValue string           `protobuf:"bytes,3,opt,name=display_value,json=displayValue,proto3" json:"display_value,omitempty"` // @gotags: yaml:"display_value"
 }
 
 func (x *ListOption) Reset() {
@@ -1131,8 +1131,8 @@ type Permission struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Operation  Permission_Operation  `protobuf:"varint,1,opt,name=operation,proto3,enum=ocis.messages.settings.v0.Permission_Operation" json:"operation,omitempty" yaml:"operation"`    // @gotags: yaml:"operation"
-	Constraint Permission_Constraint `protobuf:"varint,2,opt,name=constraint,proto3,enum=ocis.messages.settings.v0.Permission_Constraint" json:"constraint,omitempty" yaml:"constraint"` // @gotags: yaml:"constraint"
+	Operation  Permission_Operation  `protobuf:"varint,1,opt,name=operation,proto3,enum=ocis.messages.settings.v0.Permission_Operation" json:"operation,omitempty"`    // @gotags: yaml:"operation"
+	Constraint Permission_Constraint `protobuf:"varint,2,opt,name=constraint,proto3,enum=ocis.messages.settings.v0.Permission_Constraint" json:"constraint,omitempty"` // @gotags: yaml:"constraint"
 }
 
 func (x *Permission) Reset() {
@@ -1187,12 +1187,12 @@ type Value struct {
 	unknownFields protoimpl.UnknownFields
 
 	// id is the id of the Value. It is generated on saving it.
-	Id       string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" yaml:"id"`                             // @gotags: yaml:"id"
-	BundleId string `protobuf:"bytes,2,opt,name=bundle_id,json=bundleId,proto3" json:"bundle_id,omitempty" yaml:"bundle_id"` // @gotags: yaml:"bundle_id"
+	Id       string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                             // @gotags: yaml:"id"
+	BundleId string `protobuf:"bytes,2,opt,name=bundle_id,json=bundleId,proto3" json:"bundle_id,omitempty"` // @gotags: yaml:"bundle_id"
 	// setting_id is the id of the setting from within its bundle.
-	SettingId   string    `protobuf:"bytes,3,opt,name=setting_id,json=settingId,proto3" json:"setting_id,omitempty" yaml:"setting_id"`       // @gotags: yaml:"setting_id"
-	AccountUuid string    `protobuf:"bytes,4,opt,name=account_uuid,json=accountUuid,proto3" json:"account_uuid,omitempty" yaml:"account_uuid"` // @gotags: yaml:"account_uuid"
-	Resource    *Resource `protobuf:"bytes,5,opt,name=resource,proto3" json:"resource,omitempty" yaml:"resource"`                          // @gotags: yaml:"resource"
+	SettingId   string    `protobuf:"bytes,3,opt,name=setting_id,json=settingId,proto3" json:"setting_id,omitempty"`       // @gotags: yaml:"setting_id"
+	AccountUuid string    `protobuf:"bytes,4,opt,name=account_uuid,json=accountUuid,proto3" json:"account_uuid,omitempty"` // @gotags: yaml:"account_uuid"
+	Resource    *Resource `protobuf:"bytes,5,opt,name=resource,proto3" json:"resource,omitempty"`                          // @gotags: yaml:"resource"
 	// Types that are assignable to Value:
 	//
 	//	*Value_BoolValue
@@ -1309,19 +1309,19 @@ type isValue_Value interface {
 }
 
 type Value_BoolValue struct {
-	BoolValue bool `protobuf:"varint,6,opt,name=bool_value,json=boolValue,proto3,oneof" yaml:"bool_value"` // @gotags: yaml:"bool_value"
+	BoolValue bool `protobuf:"varint,6,opt,name=bool_value,json=boolValue,proto3,oneof"` // @gotags: yaml:"bool_value"
 }
 
 type Value_IntValue struct {
-	IntValue int64 `protobuf:"varint,7,opt,name=int_value,json=intValue,proto3,oneof" yaml:"int_value"` // @gotags: yaml:"int_value"
+	IntValue int64 `protobuf:"varint,7,opt,name=int_value,json=intValue,proto3,oneof"` // @gotags: yaml:"int_value"
 }
 
 type Value_StringValue struct {
-	StringValue string `protobuf:"bytes,8,opt,name=string_value,json=stringValue,proto3,oneof" yaml:"string_value"` // @gotags: yaml:"string_value"
+	StringValue string `protobuf:"bytes,8,opt,name=string_value,json=stringValue,proto3,oneof"` // @gotags: yaml:"string_value"
 }
 
 type Value_ListValue struct {
-	ListValue *ListValue `protobuf:"bytes,9,opt,name=list_value,json=listValue,proto3,oneof" yaml:"list_value"` // @gotags: yaml:"list_value"
+	ListValue *ListValue `protobuf:"bytes,9,opt,name=list_value,json=listValue,proto3,oneof"` // @gotags: yaml:"list_value"
 }
 
 func (*Value_BoolValue) isValue_Value() {}
@@ -1337,7 +1337,7 @@ type ListValue struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Values []*ListOptionValue `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty" yaml:"values"` // @gotags: yaml:"values"
+	Values []*ListOptionValue `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"` // @gotags: yaml:"values"
 }
 
 func (x *ListValue) Reset() {
@@ -1449,11 +1449,11 @@ type isListOptionValue_Option interface {
 }
 
 type ListOptionValue_StringValue struct {
-	StringValue string `protobuf:"bytes,1,opt,name=string_value,json=stringValue,proto3,oneof" yaml:"string_value"` // @gotags: yaml:"string_value"
+	StringValue string `protobuf:"bytes,1,opt,name=string_value,json=stringValue,proto3,oneof"` // @gotags: yaml:"string_value"
 }
 
 type ListOptionValue_IntValue struct {
-	IntValue int64 `protobuf:"varint,2,opt,name=int_value,json=intValue,proto3,oneof" yaml:"int_value"` // @gotags: yaml:"int_value"
+	IntValue int64 `protobuf:"varint,2,opt,name=int_value,json=intValue,proto3,oneof"` // @gotags: yaml:"int_value"
 }
 
 func (*ListOptionValue_StringValue) isListOptionValue_Option() {}

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -106,14 +106,15 @@ func DefaultConfig() *config.Config {
 			Prefix: "data",
 		},
 		OCS: config.OCS{
-			Prefix:                  "ocs",
-			SharePrefix:             "/Shares",
-			HomeNamespace:           "/users/{{.Id.OpaqueId}}",
-			AdditionalInfoAttribute: "{{.Mail}}",
-			StatCacheType:           "noop",
-			StatCacheDatabase:       "ocis",
-			StatCacheTTL:            300 * time.Second,
-			ListOCMShares:           true,
+			Prefix:                      "ocs",
+			SharePrefix:                 "/Shares",
+			HomeNamespace:               "/users/{{.Id.OpaqueId}}",
+			AdditionalInfoAttribute:     "{{.Mail}}",
+			StatCacheType:               "noop",
+			StatCacheDatabase:           "ocis",
+			StatCacheTTL:                300 * time.Second,
+			ListOCMShares:               true,
+			PublicShareMustHavePassword: true,
 		},
 		Middleware: config.Middleware{
 			Auth: config.Auth{
@@ -126,6 +127,13 @@ func DefaultConfig() *config.Config {
 			Endpoint:  "127.0.0.1:9233",
 			Cluster:   "ocis-cluster",
 			EnableTLS: false,
+		},
+		PasswordPolicy: config.PasswordPolicy{
+			MinCharacters:          8,
+			MinLowerCaseCharacters: 1,
+			MinUpperCaseCharacters: 1,
+			MinDigits:              1,
+			MinSpecialCharacters:   1,
 		},
 	}
 }

--- a/tests/TestHelpers/OcisConfigHelper.php
+++ b/tests/TestHelpers/OcisConfigHelper.php
@@ -56,7 +56,7 @@ class OcisConfigHelper {
 		try {
 			return $client->send($request);
 		} catch (ConnectException $e) {
-			throw new Error("Cannot connect to the ociswrapper at the moment, make sure that ociswrapper is running before proceeding with the test run.\n" . $e->getMessage());
+			throw new \Error("Cannot connect to the ociswrapper at the moment, make sure that ociswrapper is running before proceeding with the test run.\n" . $e->getMessage());
 		}
 	}
 

--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -148,6 +148,7 @@ default:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
+        - OcisConfigContext:
 
     coreApiSharePublicLink2:
       paths:
@@ -158,6 +159,7 @@ default:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
+        - OcisConfigContext:
 
     coreApiSharePublicLink3:
       paths:
@@ -305,6 +307,7 @@ default:
         - PublicWebDavContext:
         - WebDavPropertiesContext:
         - TrashbinContext:
+        - OcisConfigContext:
 
     coreApiWebdavPreviews:
       paths:
@@ -379,6 +382,7 @@ default:
         - PublicWebDavContext:
         - FilesVersionsContext:
         - WebDavPropertiesContext:
+        - OcisConfigContext:
 
   extensions:
     rdx\behatvars\BehatVariablesExtension: ~

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -68,6 +68,7 @@ default:
         - SpacesTUSContext:
         - ArchiverContext:
         - GraphContext:
+        - OcisConfigContext:
 
     apiContract:
       paths:

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -190,12 +190,12 @@ cannot share a folder with create permission
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
-- [coreApiSharePublicLink2/copyFromPublicLink.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L65)
-- [coreApiSharePublicLink2/copyFromPublicLink.feature:91](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L91)
-- [coreApiSharePublicLink2/copyFromPublicLink.feature:175](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L175)
+- [coreApiSharePublicLink2/copyFromPublicLink.feature:66](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L66)
+- [coreApiSharePublicLink2/copyFromPublicLink.feature:92](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L92)
 - [coreApiSharePublicLink2/copyFromPublicLink.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L176)
-- [coreApiSharePublicLink2/copyFromPublicLink.feature:191](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L191)
+- [coreApiSharePublicLink2/copyFromPublicLink.feature:177](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L177)
 - [coreApiSharePublicLink2/copyFromPublicLink.feature:192](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L192)
+- [coreApiSharePublicLink2/copyFromPublicLink.feature:193](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L193)
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -24,12 +24,12 @@ _ocdav: double-check the webdav property parsing when custom namespaces are used
 
 #### [Cannot set custom webDav properties](https://github.com/owncloud/product/issues/264)
 
-- [coreApiWebdavProperties2/getFileProperties.feature:340](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L340)
-- [coreApiWebdavProperties2/getFileProperties.feature:341](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L341)
-- [coreApiWebdavProperties2/getFileProperties.feature:346](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L346)
-- [coreApiWebdavProperties2/getFileProperties.feature:376](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L376)
-- [coreApiWebdavProperties2/getFileProperties.feature:377](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L377)
-- [coreApiWebdavProperties2/getFileProperties.feature:382](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L382)
+- [coreApiWebdavProperties2/getFileProperties.feature:342](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L342)
+- [coreApiWebdavProperties2/getFileProperties.feature:343](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L343)
+- [coreApiWebdavProperties2/getFileProperties.feature:348](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L348)
+- [coreApiWebdavProperties2/getFileProperties.feature:378](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L378)
+- [coreApiWebdavProperties2/getFileProperties.feature:379](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L379)
+- [coreApiWebdavProperties2/getFileProperties.feature:384](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L384)
 
 #### [file versions do not report the version author](https://github.com/owncloud/ocis/issues/2914)
 
@@ -186,7 +186,7 @@ cannot share a folder with create permission
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:328](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L328)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:288](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L288)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -200,12 +200,12 @@ cannot share a folder with create permission
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
 - [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L13)
-- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:114](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L114)
+- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L121)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 
-- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:87](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L87)
-- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:96](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L96)
+- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:91](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L91)
+- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:101](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L101)
 
 #### [deleting a file inside a received shared folder is moved to the trash-bin of the sharer not the receiver](https://github.com/owncloud/ocis/issues/1124)
 
@@ -317,7 +317,7 @@ API, search, favorites, config, capabilities, not existing endpoints, CORS and o
 - [coreApiAuthOcs/ocsGETAuth.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsGETAuth.feature#L123)
 - [coreApiAuthOcs/ocsPOSTAuth.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPOSTAuth.feature#L10)
 - [coreApiAuthOcs/ocsPUTAuth.feature:7](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuthOcs/ocsPUTAuth.feature#L7)
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:318](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L318)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:277](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L277)
 
 #### [sending MKCOL requests to another or non-existing user's webDav endpoints as normal user should return 404](https://github.com/owncloud/ocis/issues/5049)
 

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -14,11 +14,11 @@ Feature: antivirus
     Then the HTTP status code should be "201"
     And as "Alice" file "/normalfile.txt" should exist
     And the content of file "/normalfile.txt" for user "Alice" should be:
-    """
-    This is a testfile.
+      """
+      This is a testfile.
 
-    Cheers.
-    """
+      Cheers.
+      """
     Examples:
       | dav-path-version |
       | old              |
@@ -55,11 +55,11 @@ Feature: antivirus
     And as "Alice" file "/aFileWithVirus.txt" should not exist
     But as "Alice" file "/normalfile.txt" should exist
     And the content of file "/normalfile.txt" for user "Alice" should be:
-    """
-    This is a testfile.
+      """
+      This is a testfile.
 
-    Cheers.
-    """
+      Cheers.
+      """
     Examples:
       | dav-path-version |
       | old              |
@@ -94,6 +94,7 @@ Feature: antivirus
       | name        | sharedlink               |
       | permissions | change                   |
       | expireDate  | 2040-01-01T23:59:59+0100 |
+      | password    | %public%                 |
     When user "Alice" uploads file "filesForUpload/filesWithVirus/<filename>" to "/<newfilename>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
@@ -119,6 +120,7 @@ Feature: antivirus
       | permissions | change                   |
       | password    | newpasswd                |
       | expireDate  | 2040-01-01T23:59:59+0100 |
+      | password    | %public%                 |
     When user "Alice" uploads file "filesForUpload/filesWithVirus/<filename>" to "/<newfilename>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
@@ -345,9 +347,10 @@ Feature: antivirus
       | new              |
       | spaces           |
 
-
+  @env-config
   Scenario Outline: try to overwrite a file with the virus content in a public link share
-    Given using <dav-path-version> DAV path
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "hello" to "test.txt"
     And user "Alice" has created a public link share with settings
       | path        | /test.txt  |

--- a/tests/acceptance/features/apiDepthInfinity/propfind.feature
+++ b/tests/acceptance/features/apiDepthInfinity/propfind.feature
@@ -73,6 +73,7 @@ Feature: PROPFIND with depth:infinity
 
   Scenario: get the list of resources in a folder shared through public link with depth infinity
     Given using new DAV path
+    And the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has created a public link share of folder "simple-folder"
     When the public lists the resources in the last created public link with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -713,8 +713,9 @@ Feature: user GDPR (General Data Protection Regulation) report
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/folderMain"
     And user "Alice" has created a public link share with settings
-      | path | /folderMain |
-      | name | sharedlink  |
+      | path     | /folderMain |
+      | name     | sharedlink  |
+      | password | %public%    |
     When user "Alice" exports her GDPR report to "/.personal_data_export.json" using the Graph API
     And user "Alice" downloads the content of GDPR report ".personal_data_export.json"
     Then the HTTP status code of responses on each endpoint should be "201, 200" respectively
@@ -751,7 +752,7 @@ Feature: user GDPR (General Data Protection Regulation) report
             },
             "PasswordProtected": {
               "type": "boolean",
-              "enum": [false]
+              "enum": [true]
             },
             "Permissions": {
               "type": "object",

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -18,7 +18,7 @@ Feature: A manager of the space can edit public link
     And user "Alice" has created a space "edit space" with the default quota using the Graph API
     And user "Alice" has created a public link share of the space "edit space" with settings:
       | permissions | 1                        |
-      | password    | qwerty                   |
+      | password    | %public%                 |
       | expireDate  | 2040-01-01T23:59:59+0100 |
       | name        | someName                 |
     And user "Alice" has uploaded a file inside space "edit space" with content "some content" to "test.txt"
@@ -46,9 +46,9 @@ Feature: A manager of the space can edit public link
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     Examples:
-      | permissions | expectedPermissions       | password | linkName |
-      | 5           | read,create               | newPass  |          |
-      | 15          | read,update,create,delete |          | newName  |
+      | permissions | expectedPermissions       | password   | linkName |
+      | 5           | read,create               | newPass:12 |          |
+      | 15          | read,update,create,delete | newPass:12 | newName  |
 
 
   Scenario Outline: members can see a created public link

--- a/tests/acceptance/features/apiSpaces/publicLink.feature
+++ b/tests/acceptance/features/apiSpaces/publicLink.feature
@@ -1,7 +1,9 @@
+@env-config
 Feature: public link for a space
 
   Background:
-    Given these users have been created with default attributes and without skeleton files:
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
     And using spaces DAV path

--- a/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
+++ b/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
@@ -12,9 +12,10 @@ Feature: Public can download folders from project space public link
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
 
-
+  @env-config
   Scenario: download a folder from public link of a space
-    Given user "Alice" has created a folder "NewFolder" in space "new-space"
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And user "Alice" has created a folder "NewFolder" in space "new-space"
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "NewFolder/test.txt"
     And user "Alice" has created a public link share of the space "new-space" with settings:
       | permissions | 1        |
@@ -25,9 +26,10 @@ Feature: Public can download folders from project space public link
       | name               | content      |
       | NewFolder/test.txt | some content |
 
-  @issue-5229
+  @env-config @issue-5229
   Scenario: download a folder from public link of a folder inside a space
-    Given user "Alice" has created a folder "NewFolder" in space "new-space"
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And user "Alice" has created a folder "NewFolder" in space "new-space"
     And user "Alice" has created a folder "NewFolder/folder" in space "new-space"
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "NewFolder/folder/test.txt"
     And user "Alice" has created a public link share inside of space "new-space" with settings:

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -41,16 +41,27 @@ Feature: Share spaces via link
     And the downloaded content should be "some content"
     But the public should not be able to download file "/test.txt" from inside the last public link shared folder using the new public WebDAV API with password "wrong pass"
     Examples:
-      | permissions | expectedPermissions       | password       | linkName | expireDate               |
-      | 1           | read                      | 123234         | link     | 2042-03-25T23:59:59+0100 |
-      | 5           | read,create               | qwerty 123     |          | 2042-03-25T23:59:59+0100 |
-      | 15          | read,update,create,delete | d*V^o*Y03R9n8Z | link     |                          |
+      | permissions | expectedPermissions       | password | linkName | expireDate               |
+      | 1           | read                      | %public% | link     | 2042-03-25T23:59:59+0100 |
+      | 5           | read,create               | %public% |          | 2042-03-25T23:59:59+0100 |
+      | 15          | read,update,create,delete | %public% | link     |                          |
+
+
+  Scenario: manager can create internal link without password
+    When user "Alice" creates a public link share of the space "share space" with settings:
+      | permissions | 0 |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the OCS status message should be "OK"
+    And the fields of the last response to user "Alice" should include
+      | permissions | 0           |
+      | share_type  | public_link |
 
 
   Scenario: uploader should be able to upload a file
     When user "Alice" creates a public link share of the space "share space" with settings:
       | permissions | 4                        |
-      | password    | 123                      |
+      | password    | %public%                 |
       | name        | forUpload                |
       | expireDate  | 2042-03-25T23:59:59+0100 |
     Then the HTTP status code should be "200"
@@ -66,7 +77,7 @@ Feature: Share spaces via link
       | displayname_owner | %displayname%        |
       | uid_owner         | %username%           |
       | name              | forUpload            |
-    And the public should be able to upload file "lorem.txt" into the last public link shared folder using the new public WebDAV API with password "123"
+    And the public should be able to upload file "lorem.txt" into the last public link shared folder using the new public WebDAV API with password "%public%"
     And for user "Alice" the space "share space" should contain these entries:
       | lorem.txt |
 
@@ -92,7 +103,8 @@ Feature: Share spaces via link
       | shareWith | Brian   |
       | role      | manager |
     When user "Brian" creates a public link share of the space "share space" with settings:
-      | permissions | 1 |
+      | permissions | 1        |
+      | password    | %public% |
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And for user "Alice" the space "share space" should contain the last created public link
@@ -101,7 +113,8 @@ Feature: Share spaces via link
   Scenario: user cannot share a disabled space to public via link
     Given user "Alice" has disabled a space "share space"
     When user "Alice" creates a public link share of the space "share space" with settings:
-      | permissions | 1 |
+      | permissions | 1        |
+      | password    | %public% |
     Then the HTTP status code should be "404"
     And the OCS status code should be "404"
     And the OCS status message should be "Wrong path, file/folder doesn't exist"
@@ -110,7 +123,8 @@ Feature: Share spaces via link
 
   Scenario: user cannot create a public link from the personal space
     When user "Alice" creates a public link share of the space "Alice Hansen" with settings:
-      | permissions | 1 |
+      | permissions | 1        |
+      | password    | %public% |
     Then the HTTP status code should be "400"
     And the OCS status message should be "Can not share space root"
     And for user "Alice" the space "Alice Hansen" should not contain the last created public link

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpaceViaPublicLink.feature
@@ -57,13 +57,13 @@ Feature: Share a file or folder that is inside a space via public link
     Examples:
       | entity          | file_target | permissions | password | name | expireDate               | item_type | mimetype             |
       | folder          | /folder     | 0           |          | link |                          | folder    | httpd/unix-directory |
-      | folder          | /folder     | 1           | 123      | link | 2042-03-25T23:59:59+0100 | folder    | httpd/unix-directory |
-      | folder          | /folder     | 4           |          |      |                          | folder    | httpd/unix-directory |
-      | folder          | /folder     | 5           | 200      |      | 2042-03-25T23:59:59+0100 | folder    | httpd/unix-directory |
-      | folder          | /folder     | 15          |          | link |                          | folder    | httpd/unix-directory |
-      | folder/file.txt | /file.txt   | 0           | 123      | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
-      | folder/file.txt | /file.txt   | 1           | 123      | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
-      | folder/file.txt | /file.txt   | 3           | 123      | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
+      | folder          | /folder     | 1           | %public% | link | 2042-03-25T23:59:59+0100 | folder    | httpd/unix-directory |
+      | folder          | /folder     | 4           | %public% |      |                          | folder    | httpd/unix-directory |
+      | folder          | /folder     | 5           | %public% |      | 2042-03-25T23:59:59+0100 | folder    | httpd/unix-directory |
+      | folder          | /folder     | 15          | %public% | link |                          | folder    | httpd/unix-directory |
+      | folder/file.txt | /file.txt   | 0           |          | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
+      | folder/file.txt | /file.txt   | 1           | %public% | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
+      | folder/file.txt | /file.txt   | 3           | %public% | link | 2042-03-25T23:59:59+0100 | file      | text/plain           |
 
   @issue-5139
   Scenario Outline: user participant of the project space with space manager role can share an entity inside project space via public link
@@ -74,7 +74,7 @@ Feature: Share a file or folder that is inside a space via public link
       | path        | <entity>                 |
       | shareType   | 3                        |
       | permissions | 1                        |
-      | password    | 123                      |
+      | password    | %public%                 |
       | name        | public link              |
       | expireDate  | 2042-03-25T23:59:59+0100 |
     Then the HTTP status code should be "200"
@@ -104,7 +104,7 @@ Feature: Share a file or folder that is inside a space via public link
       | path        | <entity>                 |
       | shareType   | 3                        |
       | permissions | 1                        |
-      | password    | 123                      |
+      | password    | %public%                 |
       | name        | public link              |
       | expireDate  | 2042-03-25T23:59:59+0100 |
     Then the HTTP status code should be "403"
@@ -124,6 +124,7 @@ Feature: Share a file or folder that is inside a space via public link
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | file.txt    |
       | permissions | read,update |
+      | password    | %public%    |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -137,8 +138,8 @@ Feature: Share a file or folder that is inside a space via public link
       | displayname_owner      | %displayname% |
       | uid_file_owner         | %username%    |
       | uid_owner              | %username%    |
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
-    And the public upload to the last publicly shared file using the new public WebDAV API should pass with HTTP status code "204"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
+    And the public upload to the last publicly shared file using the new public WebDAV API with password "%public%" should pass with HTTP status code "204"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -153,6 +154,7 @@ Feature: Share a file or folder that is inside a space via public link
       | path        | folder/file.txt |
       | shareType   | 3               |
       | permissions | 1               |
+      | password    | %public%        |
     Then the fields of the last response to user "Alice" and space "share sub-item" should include
       | item_type              | file             |
       | mimetype               | text/plain       |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -494,7 +494,7 @@ class FeatureContext extends BehatVariablesContext {
 		$this->alt4UserPassword = "ThisIsThe4thAlternatePwd";
 		$this->subAdminPassword = "IamAJuniorAdmin42";
 		$this->alternateAdminPassword = "IHave99LotsOfPriv";
-		$this->publicLinkSharePassword = "publicPwd1";
+		$this->publicLinkSharePassword = "publicPwd:1";
 
 		// in case of CI deployment we take the server url from the environment
 		$testServerUrl = \getenv('TEST_SERVER_URL');

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -134,6 +134,7 @@ class PublicWebDavContext implements Context {
 			0,
 			"public-files-$publicWebDAVAPIVersion"
 		);
+		$password = $this->featureContext->getActualPassword($password);
 		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath$fileName";
 		$userName = $this->getUsernameForPublicWebdavApi(
 			$token,
@@ -156,7 +157,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public deletes file "([^"]*)" from the last public link share using the password "([^"]*)" and (old|new) public WebDAV API$/
+	 * @When /^the public deletes (?:file|folder|entry) "([^"]*)" from the last public link share using the password "([^"]*)" and (old|new) public WebDAV API$/
 	 *
 	 * @param string $file
 	 * @param string $password
@@ -189,6 +190,7 @@ class PublicWebDavContext implements Context {
 			"public-files-$publicWebDAVAPIVersion"
 		);
 		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath$fileName";
+		$password = $this->featureContext->getActualPassword($password);
 		$destination = $this->featureContext->getBaseUrl() . "/$davPath$toFileName";
 		$userName = $this->getUsernameForPublicWebdavApi(
 			$token,
@@ -212,7 +214,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public link share using the password "([^"]*)" and (old|new) public WebDAV API$/
+	 * @When /^the public renames (?:file|folder|entry) "([^"]*)" to "([^"]*)" from the last public link share using the password "([^"]*)" and the (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $toName
@@ -490,7 +492,7 @@ class PublicWebDavContext implements Context {
 			$filename,
 			$password,
 			$body,
-			false,
+			true,
 			[],
 			$publicWebDAVAPIVersion
 		);
@@ -1075,9 +1077,10 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public upload to the last publicly shared file using the (old|new) public WebDAV API should (?:fail|pass) with HTTP status code "([^"]*)"$/
+	 * @Then /^the public upload to the last publicly shared file using the (old|new) public WebDAV API with password "([^"]*)" should (?:fail|pass) with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $publicWebDAVAPIVersion
+	 * @param string $password
 	 * @param string $expectedHttpCode
 	 *
 	 * @return void
@@ -1085,6 +1088,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publiclyUploadingShouldToSharedFileShouldFail(
 		string $publicWebDAVAPIVersion,
+		string $password,
 		string $expectedHttpCode
 	):void {
 		$filename = "";
@@ -1095,7 +1099,7 @@ class PublicWebDavContext implements Context {
 
 		$response = $this->publicUploadContent(
 			$filename,
-			'',
+			$password,
 			'test',
 			false,
 			[],
@@ -1140,6 +1144,24 @@ class PublicWebDavContext implements Context {
 			$response->getStatusCode(),
 			$response
 		);
+	}
+
+	/**
+	 * @Then /^uploading a file should not work using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public upload to the last publicly shared folder using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
+	 *
+	 * @param string $publicWebDAVAPIVersion
+	 * @param string $password
+	 * @param string|null $expectedHttpCode
+	 *
+	 * @return void
+	 */
+	public function publiclyUploadingWithPasswordShouldNotWork(
+		string $publicWebDAVAPIVersion,
+		string $password,
+		string $expectedHttpCode = null
+	):void {
+		$this->publiclyUploadingShouldNotWork($publicWebDAVAPIVersion, $expectedHttpCode, $password);
 	}
 
 	/**
@@ -1202,14 +1224,15 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^uploading a file should work using the (old|new) public WebDAV API$/
+	 * @Then /^uploading a file with password "([^"]*)" should work using the (old|new) public WebDAV API$/
 	 *
+	 * @param string $password
 	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function publiclyUploadingShouldWork(string $publicWebDAVAPIVersion):void {
+	public function publiclyUploadingShouldWork(string $password, string $publicWebDAVAPIVersion):void {
 		$path = "whateverfilefortesting-$publicWebDAVAPIVersion-publicWebDAVAPI.txt";
 		$content = "test $publicWebDAVAPIVersion";
 
@@ -1219,7 +1242,7 @@ class PublicWebDavContext implements Context {
 
 		$response = $this->publicUploadContent(
 			$path,
-			'',
+			$password,
 			$content,
 			false,
 			[],
@@ -1231,13 +1254,14 @@ class PublicWebDavContext implements Context {
 			"upload should have passed but failed with code " .
 			$response->getStatusCode()
 		);
-		$this->shouldBeAbleToDownloadFileInsidePublicSharedFolder(
+		$this->shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
 			$path,
-			$publicWebDAVAPIVersion
+			$publicWebDAVAPIVersion,
+			$password
 		);
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
-			"",
+			$password,
 			"",
 			$publicWebDAVAPIVersion
 		);
@@ -1245,8 +1269,9 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^uploading content to a public link shared file should (not|)\s?work using the (old|new) public WebDAV API$/
+	 * @Then /^uploading content to a public link shared file with password "([^"]*)" should (not|)\s?work using the (old|new) public WebDAV API$/
 	 *
+	 * @param string $password
 	 * @param string $shouldOrNot (not|)
 	 * @param string $publicWebDAVAPIVersion
 	 *
@@ -1254,6 +1279,7 @@ class PublicWebDavContext implements Context {
 	 * @throws Exception
 	 */
 	public function publiclyUploadingToPublicLinkSharedFileShouldWork(
+		string $password,
 		string $shouldOrNot,
 		string $publicWebDAVAPIVersion
 	):void {
@@ -1269,7 +1295,7 @@ class PublicWebDavContext implements Context {
 
 		$response = $this->publicUploadContent(
 			$path,
-			'',
+			$password,
 			$content,
 			false,
 			[],
@@ -1284,7 +1310,8 @@ class PublicWebDavContext implements Context {
 
 			$response = $this->downloadPublicFileWithRange(
 				"",
-				$publicWebDAVAPIVersion
+				$publicWebDAVAPIVersion,
+				$password
 			);
 
 			$this->featureContext->checkDownloadedContentMatches(
@@ -1303,9 +1330,10 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :fileName to the last public link shared folder with mtime :mtime using the :davVersion public WebDAV API
+	 * @When the public uploads file :fileName to the last public link shared folder with password :password with mtime :mtime using the :davVersion public WebDAV API
 	 *
 	 * @param String $fileName
+	 * @param String $password
 	 * @param String $mtime
 	 * @param String $davVersion
 	 *
@@ -1314,6 +1342,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function thePublicUploadsFileToLastSharedFolderWithMtimeUsingTheWebdavApi(
 		string $fileName,
+		string $password,
 		string $mtime,
 		string $davVersion = "old"
 	):void {
@@ -1322,7 +1351,7 @@ class PublicWebDavContext implements Context {
 
 		$response = $this->publicUploadContent(
 			$fileName,
-			'',
+			$password,
 			'test',
 			false,
 			["X-OC-Mtime" => $mtime],
@@ -1609,6 +1638,7 @@ class PublicWebDavContext implements Context {
 			null,
 			"public-files-$publicWebDAVAPIVersion"
 		);
+		$password = $this->featureContext->getActualPassword($password);
 		$username = $this->getUsernameForPublicWebdavApi(
 			$token,
 			$password,

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2234,7 +2234,7 @@ class SpacesContext implements Context {
 		$rows["path"] = \array_key_exists("path", $rows) ? $rows["path"] : null;
 		$rows["shareType"] = \array_key_exists("shareType", $rows) ? $rows["shareType"] : 3;
 		$rows["permissions"] = \array_key_exists("permissions", $rows) ? $rows["permissions"] : null;
-		$rows["password"] = \array_key_exists("password", $rows) ? $rows["password"] : null;
+		$rows['password'] = \array_key_exists('password', $rows) ? $this->featureContext->getActualPassword($rows['password']) : null;
 		$rows["name"] = \array_key_exists("name", $rows) ? $rows["name"] : null;
 		$rows["expireDate"] = \array_key_exists("expireDate", $rows) ? $rows["expireDate"] : null;
 
@@ -3197,7 +3197,7 @@ class SpacesContext implements Context {
 
 		$rows["shareType"] = \array_key_exists("shareType", $rows) ? $rows["shareType"] : 3;
 		$rows["permissions"] = \array_key_exists("permissions", $rows) ? $rows["permissions"] : null;
-		$rows["password"] = \array_key_exists("password", $rows) ? $rows["password"] : null;
+		$rows['password'] = \array_key_exists('password', $rows) ? $this->featureContext->getActualPassword($rows['password']) : null;
 		$rows["name"] = \array_key_exists("name", $rows) ? $rows["name"] : null;
 		$rows["expireDate"] = \array_key_exists("expireDate", $rows) ? $rows["expireDate"] : null;
 

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
@@ -23,6 +23,7 @@ Feature: get the pending shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
     And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
@@ -30,6 +31,7 @@ Feature: get the pending shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
 
 
   Scenario Outline: getting pending shares received from users

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
@@ -22,11 +22,13 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
 
 
   Scenario Outline: getting shares received from users

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
@@ -25,10 +25,12 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
     When user "Brian" gets the user shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -45,10 +47,12 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
     When user "Brian" gets the group shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -69,11 +73,13 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
     When user "Brian" gets the public link shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
@@ -22,11 +22,13 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
 
 
   Scenario Outline: getting shares shared to users

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
@@ -25,10 +25,12 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
     When user "Alice" gets the user shares shared by her using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -45,10 +47,12 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
+      | password    | %public%                 |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
+      | password    | %public%                   |
     When user "Alice" gets the group shares shared by her using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
@@ -14,13 +14,14 @@ Feature: accessing a public link share
     And user "Alice" has created a public link share with settings
       | path        | /testavatar.jpg |
       | permissions | change          |
-      | password    | testpass1       |
+      | password    | %public%        |
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "404"
 
-
+  @env-config
   Scenario: access to the preview of public shared file without password
-    Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
     And user "Alice" has created a public link share with settings
       | path        | /testavatar.jpg |
       | permissions | change          |
@@ -33,18 +34,19 @@ Feature: accessing a public link share
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile0.txt"
     And user "Alice" has created a public link share with settings
-      | path        | /FOLDER   |
-      | permissions | change    |
-      | password    | testpass1 |
+      | path        | /FOLDER  |
+      | permissions | change   |
+      | password    | %public% |
     When the public accesses the preview of the following files from the last shared public link using the sharing API
       | path           |
       | testavatar.jpg |
       | textfile0.txt  |
     Then the HTTP status code of responses on all endpoints should be "404"
 
-
+  @env-config
   Scenario: access to the preview of public shared file inside a folder without password
-    Given user "Alice" has created folder "FOLDER"
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile0.txt"
     And user "Alice" has created a public link share with settings

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -17,10 +17,10 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "parent.txt" from the last public link share using the new public WebDAV API
+      | password    | %public%      |
+    When the public deletes file "parent.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
-
     Examples:
       | permissions               | http-status-code | should-or-not |
       | read                      | 403              | should        |
@@ -33,7 +33,8 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the new public WebDAV API
+      | password    | %public%                  |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
@@ -43,16 +44,17 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
+      | password    | %public%                  |
+    When the public uploads file "lorem.txt" with password "%public%" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
 
 
   Scenario: public cannot delete file through publicly shared link with password using an invalid password with public WebDAV API
     Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
+      | path        | /PARENT  |
+      | permissions | change   |
+      | password    | %public% |
     When the public deletes file "parent.txt" from the last public link share using the password "invalid" and new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
@@ -60,20 +62,20 @@ Feature: changing a public link share
 
   Scenario: public can delete file through publicly shared link with password using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public link share using the password "newpasswd" and new public WebDAV API
+      | path        | /PARENT  |
+      | permissions | change   |
+      | password    | %public% |
+    When the public deletes file "parent.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
 
   Scenario: public tries to rename a file in a password protected share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "invalid" and new public WebDAV API
+      | path        | /PARENT  |
+      | permissions | change   |
+      | password    | %public% |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "invalid" and the new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
@@ -81,10 +83,10 @@ Feature: changing a public link share
 
   Scenario: public tries to rename a file in a password protected share using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "newpasswd" and new public WebDAV API
+      | path        | /PARENT  |
+      | permissions | change   |
+      | password    | %public% |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
@@ -92,9 +94,9 @@ Feature: changing a public link share
 
   Scenario: public tries to upload to a password protected public share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
+      | path        | /PARENT  |
+      | permissions | change   |
+      | password    | %public% |
     When the public uploads file "lorem.txt" with password "invalid" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
@@ -102,10 +104,10 @@ Feature: changing a public link share
 
   Scenario: public tries to upload to a password protected public share using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the new public WebDAV API
+      | path        | /PARENT  |
+      | permissions | change   |
+      | password    | %public% |
+    When the public uploads file "lorem.txt" with password "%public%" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
@@ -114,7 +116,8 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the new public WebDAV API
+      | password    | %public%        |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
@@ -124,6 +127,7 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public deletes file "parent.txt" from the last public link share using the new public WebDAV API
+      | password    | %public%        |
+    When the public deletes file "parent.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -296,25 +296,25 @@ Feature: create a public link share
     Then the value of the item "//s:message" in the response should be "File not found: parent.txt"
     And the HTTP status code should be "404"
 
-
+  @env-config
   Scenario: get the size of a file shared by public link
-    Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     And user "Alice" has created a public link share with settings
       | path        | test-file.txt |
       | permissions | read          |
-      | password    | %public%      |
     When the public gets the size of the last shared public link using the WebDAV API
     Then the HTTP status code should be "207"
     And the size of the file should be "19"
 
-
+  @env-config
   Scenario Outline: get the mtime of a file shared by public link
-    Given using <dav-path-version> DAV path
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using <dav-path-version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | file.txt |
       | permissions | read     |
-      | password    | %public% |
     Then the HTTP status code should be "200"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
@@ -322,15 +322,15 @@ Feature: create a public link share
       | old              |
       | new              |
 
-
+  @env-config
   Scenario Outline: get the mtime of a file inside a folder shared by public link
-    Given using <dav-path-version> DAV path
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "testFolder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testFolder |
       | permissions | read        |
-      | password    | %public%    |
     Then the HTTP status code should be "200"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
@@ -338,21 +338,22 @@ Feature: create a public link share
       | old              |
       | new              |
 
-
+  @env-config
   Scenario: get the mtime of a file inside a folder shared by public link using new webDAV version
-    Given user "Alice" has created folder "testFolder"
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And user "Alice" has created folder "testFolder"
     And user "Alice" has created a public link share with settings
       | path        | /testFolder               |
       | permissions | read,update,create,delete |
-      | password    | %public%                  |
     When the public uploads file "file.txt" to the last public link shared folder with password "%public%" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-
+  @env-config
   Scenario: overwriting a file changes its mtime (new public webDAV API)
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     Given user "Alice" has created folder "testFolder"
     When user "Alice" uploads file with content "uploaded content for file name ending with a dot" to "testFolder/file.txt" using the WebDAV API
     And user "Alice" creates a public link share using the sharing API with settings

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -9,33 +9,22 @@ Feature: create a public link share
     Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
-  Scenario Outline: new public link share of a file using the default permissions only grants read access using the public WebDAV API
+  Scenario Outline: creating public link share of a file or a folder using the default permissions without password using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
+    And user "Alice" has created folder "/PARENT"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | randomfile.txt |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" should include
-      | item_type              | file            |
-      | mimetype               | text/plain      |
-      | file_target            | /randomfile.txt |
-      | path                   | /randomfile.txt |
-      | permissions            | read            |
-      | share_type             | public_link     |
-      | displayname_file_owner | %displayname%   |
-      | displayname_owner      | %displayname%   |
-      | uid_file_owner         | %username%      |
-      | uid_owner              | %username%      |
-      | name                   |                 |
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
-    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
-    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "<http_status_code>"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | PARENT |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "<http_status_code>"
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 400              |
 
   @smokeTest
   Scenario Outline: creating a new public link share of a file with password using the new public WebDAV API
@@ -77,6 +66,7 @@ Feature: create a public link share
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | randomfile.txt            |
       | permissions | read,update,create,delete |
+      | password    | %public%                  |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -91,40 +81,8 @@ Feature: create a public link share
       | uid_file_owner         | %username%      |
       | uid_owner              | %username%      |
       | name                   |                 |
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
-    And uploading content to a public link shared file should work using the old public WebDAV API
-    And uploading content to a public link shared file should work using the new public WebDAV API
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
-
-
-  Scenario Outline: creating a new public link share of a folder using the default permissions only grants read access and can be accessed with no password or any password using the public WebDAV API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has created folder "/PARENT"
-    And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path | PARENT |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" should include
-      | item_type              | folder               |
-      | mimetype               | httpd/unix-directory |
-      | file_target            | /PARENT              |
-      | path                   | /PARENT              |
-      | permissions            | read                 |
-      | share_type             | public_link          |
-      | displayname_file_owner | %displayname%        |
-      | displayname_owner      | %displayname%        |
-      | uid_file_owner         | %username%           |
-      | uid_owner              | %username%           |
-      | name                   |                      |
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "Random data"
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
-    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
-    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
+    And uploading content to a public link shared file with password "%public%" should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -187,9 +145,10 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @env-config
   Scenario Outline: getting the share information of password less public-links hides credential placeholders
-    Given using OCS API version "<ocs_api_version>"
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | randomfile.txt |
@@ -215,15 +174,16 @@ Feature: create a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path | /afolder |
+      | path     | /afolder |
+      | password | %public% |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
       | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read        |
-    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
-    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the old public WebDAV API with password "%public%" should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the old public WebDAV API with password "%public%" should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -236,14 +196,14 @@ Feature: create a public link share
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /afolder                  |
       | permissions | read,update,create,delete |
+      | password    | %public%                  |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
       | id          | A_STRING                  |
       | share_type  | public_link               |
       | permissions | read,update,create,delete |
-    And uploading a file should work using the old public WebDAV API
-    And uploading a file should work using the new public WebDAV API
+    And uploading a file with password "%public%" should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -256,14 +216,14 @@ Feature: create a public link share
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /afolder    |
       | permissions | read,create |
+      | password    | %public%    |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
       | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read,create |
-    And uploading a file should work using the old public WebDAV API
-    And uploading a file should work using the new public WebDAV API
+    And uploading a file with password "%public%" should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -273,7 +233,8 @@ Feature: create a public link share
   Scenario Outline: Do not allow public sharing of the root on OCIS when the default permission is read and access using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path | / |
+      | path     | /        |
+      | password | %public% |
     Then the OCS status code should be "400"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -286,12 +247,11 @@ Feature: create a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt |
+      | path     | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt |
+      | password | %public%                                                                |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "long file"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "long file"
-
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "long file"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -303,12 +263,11 @@ Feature: create a public link share
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "Alice" has uploaded file with content "Random data" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
+      | path     | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
+      | password | %public%                                                            |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "Random data"
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
-
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API with password "%public%" and the content should be "Random data"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -319,10 +278,11 @@ Feature: create a public link share
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
     And user "Alice" has created a public link share with settings
-      | path        | PARENT |
-      | permissions | read   |
+      | path        | PARENT   |
+      | permissions | read     |
+      | password    | %public% |
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
-    Then the public download of file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API should fail with HTTP status code "404"
+    Then the public download of file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" should fail with HTTP status code "404"
 
   @issue-1269 @issue-1293
   Scenario: try to download from a public share that has upload only permissions using the public webdav api
@@ -331,6 +291,7 @@ Feature: create a public link share
     And user "Alice" has created a public link share with settings
       | path        | PARENT          |
       | permissions | uploadwriteonly |
+      | password    | %public%        |
     When the public downloads file "parent.txt" from inside the last public link shared folder using the new public WebDAV API
     Then the value of the item "//s:message" in the response should be "File not found: parent.txt"
     And the HTTP status code should be "404"
@@ -341,6 +302,7 @@ Feature: create a public link share
     And user "Alice" has created a public link share with settings
       | path        | test-file.txt |
       | permissions | read          |
+      | password    | %public%      |
     When the public gets the size of the last shared public link using the WebDAV API
     Then the HTTP status code should be "207"
     And the size of the file should be "19"
@@ -352,12 +314,13 @@ Feature: create a public link share
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | file.txt |
       | permissions | read     |
+      | password    | %public% |
     Then the HTTP status code should be "200"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
       | dav-path-version |
-      | old         |
-      | new         |
+      | old              |
+      | new              |
 
 
   Scenario Outline: get the mtime of a file inside a folder shared by public link
@@ -367,12 +330,13 @@ Feature: create a public link share
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testFolder |
       | permissions | read        |
+      | password    | %public%    |
     Then the HTTP status code should be "200"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
       | dav-path-version |
-      | old         |
-      | new         |
+      | old              |
+      | new              |
 
 
   Scenario: get the mtime of a file inside a folder shared by public link using new webDAV version
@@ -380,7 +344,8 @@ Feature: create a public link share
     And user "Alice" has created a public link share with settings
       | path        | /testFolder               |
       | permissions | read,update,create,delete |
-    When the public uploads file "file.txt" to the last public link shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+      | password    | %public%                  |
+    When the public uploads file "file.txt" to the last public link shared folder with password "%public%" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
@@ -393,15 +358,16 @@ Feature: create a public link share
     And user "Alice" creates a public link share using the sharing API with settings
       | path        | /testFolder               |
       | permissions | read,update,create,delete |
-    And the public uploads file "file.txt" to the last public link shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    And the public uploads file "file.txt" to the last public link shared folder with password "%public%" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "/testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-
+  @env-config
   Scenario: check the href of a public link file
-    Given using new DAV path
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using new DAV path
     And user "Alice" has uploaded file with content "Random data" to "/file.txt"
     And user "Alice" has created a public link share with settings
       | path        | file.txt |
@@ -422,9 +388,10 @@ Feature: create a public link share
     And user "Alice" has created a public link share with settings
       | path        | test.txt |
       | permissions | read     |
+      | password    | %public% |
     And user "Alice" has deleted file "test.txt"
     When user "Alice" updates the last public link share using the sharing API with
-      | password | testpassword |
+      | password | Test:123345 |
     Then the OCS status code should be "998"
     And the HTTP status code should be "<http-code>"
     And the OCS status message should be "update public share: resource not found"

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShareToShares.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShareToShares.feature
@@ -11,7 +11,8 @@ Feature: create a public link share when share_folder is set to Shares
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path | randomfile.txt |
+      | path     | randomfile.txt |
+      | password | %public%       |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include

--- a/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
@@ -11,8 +11,9 @@ Feature: delete a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     And user "Alice" has created a public link share with settings
-      | path | test-file.txt |
-      | name | sharedlink    |
+      | path     | test-file.txt |
+      | name     | sharedlink    |
+      | password | %public%      |
     When user "Alice" deletes public link share named "sharedlink" in file "test-file.txt" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs_status_code>"
@@ -27,8 +28,9 @@ Feature: delete a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     And user "Alice" has created a public link share with settings
-      | path | test-file.txt |
-      | name | sharedlink    |
+      | path     | test-file.txt |
+      | name     | sharedlink    |
+      | password | %public%      |
     When user "Alice" moves file "/test-file.txt" to "/renamed-test-file.txt" using the WebDAV API
     And user "Alice" deletes public link share named "sharedlink" in file "renamed-test-file.txt" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -44,8 +46,9 @@ Feature: delete a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "test-folder"
     And user "Alice" has created a public link share with settings
-      | path | /test-folder |
-      | name | sharedlink   |
+      | path     | /test-folder |
+      | name     | sharedlink   |
+      | password | %public%     |
     When user "Alice" deletes public link share named "sharedlink" in folder "test-folder" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs_status_code>"
@@ -61,8 +64,9 @@ Feature: delete a public link share
     And user "Alice" has created folder "test-folder"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/test-folder/testfile.txt" using the WebDAV API
     And user "Alice" has created a public link share with settings
-      | path | /test-folder/testfile.txt |
-      | name | sharedlink                |
+      | path     | /test-folder/testfile.txt |
+      | name     | sharedlink                |
+      | password | %public%                  |
     And user "Alice" deletes public link share named "sharedlink" in file "/test-folder/testfile.txt" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs_status_code>"

--- a/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature
@@ -6,6 +6,7 @@ Feature: copying from public link share
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
+    And the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
 
 
   Scenario: copy file within a public link folder new public WebDAV API

--- a/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
@@ -100,7 +100,7 @@ Feature: multi-link sharing
       | permissions  | change      |
       | name         | sharedlink2 |
     When user "Alice" updates the last public link share using the sharing API with
-      | password | %alt1% |
+      | password | New-StronPass1 |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as user "Alice" the public shares of folder "/FOLDER" should be

--- a/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -17,6 +17,7 @@ Feature: reshare as public link
     When user "Brian" creates a public link share using the sharing API with settings
       | path         | /Shares/test |
       | publicUpload | false        |
+      | password     | %public%     |
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -33,9 +34,10 @@ Feature: reshare as public link
     When user "Brian" creates a public link share using the sharing API with settings
       | path         | /Shares/test |
       | publicUpload | false        |
+      | password     | %public%     |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    When the public downloads file "file.txt" from inside the last public link shared folder with password "%public%" using the new public WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
@@ -53,6 +55,7 @@ Feature: reshare as public link
       | path         | /Shares/test              |
       | permissions  | read,update,create,delete |
       | publicUpload | true                      |
+      | password     | %public%                  |
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -68,6 +71,7 @@ Feature: reshare as public link
     When user "Brian" creates a public link share using the sharing API with settings
       | path         | /Shares/test |
       | publicUpload | true         |
+      | password     | %public%     |
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -84,9 +88,10 @@ Feature: reshare as public link
     When user "Brian" creates a public link share using the sharing API with settings
       | path         | /Shares/test |
       | publicUpload | false        |
+      | password     | %public%     |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    When the public downloads file "file.txt" from inside the last public link shared folder with password "%public%" using the new public WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
@@ -105,12 +110,13 @@ Feature: reshare as public link
       | path         | /Shares/test              |
       | permissions  | read,update,create,delete |
       | publicUpload | true                      |
+      | password     | %public%                  |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When the public downloads file "file.txt" from inside the last public link shared folder using the new public WebDAV API
+    When the public downloads file "file.txt" from inside the last public link shared folder with password "%public%" using the new public WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
-    And uploading a file should work using the new public WebDAV API
+    And uploading a file with password "%public%" should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -126,6 +132,7 @@ Feature: reshare as public link
       | path         | /Shares/test/sub          |
       | permissions  | read,update,create,delete |
       | publicUpload | true                      |
+      | password     | %public%                  |
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -143,6 +150,7 @@ Feature: reshare as public link
       | path         | /Shares/test |
       | permissions  | read         |
       | publicUpload | false        |
+      | password     | %public%     |
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "403"
@@ -163,6 +171,7 @@ Feature: reshare as public link
       | path         | /Shares/test/sub |
       | permissions  | read             |
       | publicUpload | false            |
+      | password     | %public%         |
     And uploading a file should not work using the new public WebDAV API
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |

--- a/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
@@ -329,7 +329,6 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And uploading a file with password "%public%" should work using the new public WebDAV API
-    And uploading a file with password "%public%" should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature
@@ -12,7 +12,8 @@ Feature: update a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
-      | path | FOLDER |
+      | path     | FOLDER   |
+      | password | %public% |
     When user "Alice" updates the last public link share using the sharing API with
       | expireDate | 2040-01-01T23:59:59+0100 |
     Then the OCS status code should be "<ocs_status_code>"
@@ -52,7 +53,8 @@ Feature: update a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
-      | path | FOLDER |
+      | path     | FOLDER   |
+      | password | %public% |
     And user "Alice" has updated the last public link share with
       | expireDate | 2033-01-31T23:59:59+0100 |
     When user "Alice" gets the info of the last public link share using the sharing API
@@ -122,7 +124,8 @@ Feature: update a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
-      | path | FOLDER |
+      | path     | FOLDER   |
+      | password | %public% |
     And user "Alice" has updated the last public link share with
       | password | %public% |
     When user "Alice" gets the info of the last public link share using the sharing API
@@ -154,7 +157,8 @@ Feature: update a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
-      | path | FOLDER |
+      | path     | FOLDER   |
+      | password | %public% |
     And user "Alice" has updated the last public link share with
       | permissions | read,update,create,delete |
     When user "Alice" gets the info of the last public link share using the sharing API
@@ -186,7 +190,8 @@ Feature: update a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
-      | path | FOLDER |
+      | path     | FOLDER   |
+      | password | %public% |
     And user "Alice" has updated the last public link share with
       | permissions | read,update,create,delete |
     When user "Alice" gets the info of the last public link share using the sharing API
@@ -218,7 +223,8 @@ Feature: update a public link share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
-      | path | FOLDER |
+      | path     | FOLDER   |
+      | password | %public% |
     And user "Alice" has updated the last public link share with
       | publicUpload | true |
     When user "Alice" gets the info of the last public link share using the sharing API
@@ -254,6 +260,7 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path         | /Shares/test |
       | publicUpload | false        |
+      | password     | %public%     |
     When user "Brian" updates the last public link share using the sharing API with
       | publicUpload | true |
     Then the OCS status code should be "403"
@@ -274,12 +281,13 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path         | /Shares/test |
       | publicUpload | false        |
+      | password     | %public%     |
     When user "Brian" updates the last public link share using the sharing API with
       | publicUpload | true |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And uploading a file should work using the old public WebDAV API
-    And uploading a file should work using the new public WebDAV API
+    And uploading a file with password "%public%" should work using the old public WebDAV API
+    And uploading a file with password "%public%" should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -294,6 +302,7 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path        | /Shares/test |
       | permissions | read         |
+      | password    | %public%     |
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "403"
@@ -314,12 +323,13 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path        | /Shares/test |
       | permissions | read         |
+      | password    | %public%     |
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And uploading a file should work using the old public WebDAV API
-    And uploading a file should work using the new public WebDAV API
+    And uploading a file with password "%public%" should work using the new public WebDAV API
+    And uploading a file with password "%public%" should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -334,10 +344,10 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
+      | password    | %public%                  |
     And user "Alice" has updated the last public link share with
       | permissions | read |
-    When the public deletes file "CHILD/child.txt" from the last public link share using the old public WebDAV API
-    And the public deletes file "CHILD/child.txt" from the last public link share using the new public WebDAV API
+    And the public deletes file "CHILD/child.txt" from the last public link share using the password "%public%" and new public WebDAV API
     And the HTTP status code of responses on all endpoints should be "403"
     And as "Alice" file "PARENT/CHILD/child.txt" should exist
     Examples:
@@ -353,12 +363,13 @@ Feature: update a public link share
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
     And user "Alice" has created a public link share with settings
-      | path        | /PARENT |
-      | permissions | read    |
+      | path        | /PARENT  |
+      | permissions | read     |
+      | password    | %public% |
     And user "Alice" has updated the last public link share with
       | permissions | read,update,create,delete |
-    When the public deletes file "CHILD/child.txt" from the last public link share using the new public WebDAV API
-    And the public deletes file "parent.txt" from the last public link share using the new public WebDAV API
+    When the public deletes file "CHILD/child.txt" from the last public link share using the password "%public%" and new public WebDAV API
+    And the public deletes file "parent.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
     And as "Alice" file "PARENT/CHILD/child.txt" should not exist
     And as "Alice" file "PARENT/parent.txt" should not exist
@@ -373,7 +384,8 @@ Feature: update a public link share
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
-      | path | FOLDER |
+      | path     | FOLDER   |
+      | password | %public% |
     And user "Alice" has moved folder "/FOLDER" to "/RENAMED_FOLDER"
     When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -419,7 +431,8 @@ Feature: update a public link share
     And using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "some content" to "/lorem.txt"
     And user "Alice" has created a public link share with settings
-      | path | lorem.txt |
+      | path     | lorem.txt |
+      | password | %public%  |
     And user "Alice" has moved file "/lorem.txt" to "/new-lorem.txt"
     When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -467,6 +480,7 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path        | /textfile.txt |
       | permissions | read          |
+      | password    | %public%      |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 0 |
     Then the OCS status code should be "<ocs_status_code>"

--- a/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -13,10 +13,11 @@ Feature: upload to a public link share
   Scenario: uploading same file to a public upload-only share multiple times via new API
     # The new API does the auto rename in upload-only folders
     Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
-    When the public uploads file "test.txt" with content "test" using the new public WebDAV API
-    And the public uploads file "test.txt" with content "test2" using the new public WebDAV API
+      | path        | FOLDER   |
+      | permissions | create   |
+      | password    | %public% |
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the new public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test2" using the new public WebDAV API
     Then the HTTP status code of responses on all endpoints should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
@@ -27,10 +28,11 @@ Feature: upload to a public link share
   Scenario Outline: uploading file to a public upload-only share using public API that was deleted does not work
     Given using <dav-path-version> DAV path
     And user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
+      | path        | FOLDER   |
+      | permissions | create   |
+      | password    | %public% |
     And user "Alice" has deleted folder "/FOLDER"
-    When the public uploads file "test.txt" with content "test" using the new public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test-file" using the new public WebDAV API
     And the HTTP status code should be "404"
 
     @issue-1268
@@ -47,17 +49,19 @@ Feature: upload to a public link share
   @issue-1269
   Scenario: uploading file to a public read-only share folder with public API does not work
     Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | read   |
-    When the public uploads file "test.txt" with content "test" using the new public WebDAV API
+      | path        | FOLDER   |
+      | permissions | read     |
+      | password    | %public% |
+    When the public uploads file "test.txt" with password "%public%" and content "test-file" using the new public WebDAV API
     And the HTTP status code should be "403"
 
 
   Scenario: uploading to a public upload-only share with public API
     Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
-    When the public uploads file "test.txt" with content "test-file" using the new public WebDAV API
+      | path        | FOLDER   |
+      | permissions | create   |
+      | password    | %public% |
+    When the public uploads file "test.txt" with password "%public%" and content "test-file" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
     And the following headers should match these regular expressions
@@ -86,19 +90,21 @@ Feature: upload to a public link share
 
   Scenario: uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with public API
     Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | change |
+      | path        | FOLDER   |
+      | permissions | change   |
+      | password    | %public% |
     And the quota of user "Alice" has been set to "0"
-    When the public uploads file "test.txt" with content "test-file" using the new public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test2" using the new public WebDAV API
     Then the HTTP status code should be "507"
 
   @issue-1290
   Scenario: uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with public API
     Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
+      | path        | FOLDER   |
+      | permissions | create   |
+      | password    | %public% |
     And the quota of user "Alice" has been set to "0"
-    When the public uploads file "test.txt" with content "test-file" using the new public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test2" using the new public WebDAV API
     Then the HTTP status code should be "507"
 
   @smokeTest
@@ -106,20 +112,22 @@ Feature: upload to a public link share
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
-    When the public uploads file "test.txt" with content "test-file" using the new public WebDAV API
+      | password    | %public%        |
+    When the public uploads file "test.txt" with password "%public%" and content "test2" using the new public WebDAV API
     Then the HTTP status code should be "201"
-    And the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
+    And the content of file "/FOLDER/test.txt" for user "Alice" should be "test2"
 
   @smokeTest @issue-1267
   Scenario: uploading same file to a public upload-write and no edit and no overwrite share multiple times with new public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
-    When the public uploads file "test.txt" with content "test" using the new public WebDAV API
+      | password    | %public%        |
+    When the public uploads file "test.txt" with password "%public%" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
+    When the public uploads file "test.txt" with password "%public%" and content "test2" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -208,11 +208,12 @@ Feature: propagation of etags when deleting a file or folder
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
-      | path        | upload |
-      | permissions | change |
+      | path        | upload   |
+      | permissions | change   |
+      | password    | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public deletes file "file.txt" from the last public link share using the new public WebDAV API
+    When the public deletes file "file.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "204"
     And these etags should have changed:
       | user  | path    |
@@ -233,11 +234,12 @@ Feature: propagation of etags when deleting a file or folder
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
-      | path        | upload |
-      | permissions | change |
+      | path        | upload   |
+      | permissions | change   |
+      | password    | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public deletes folder "sub" from the last public link share using the new public WebDAV API
+    When the public deletes folder "sub" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "204"
     And these etags should have changed:
       | user  | path    |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
@@ -278,11 +278,12 @@ Feature: propagation of etags when moving files or folders
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
-      | path        | upload |
-      | permissions | change |
+      | path        | upload   |
+      | permissions | change   |
+      | password    | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public renames file "file.txt" to "renamed.txt" from the last public link share using the new public WebDAV API
+    When the public renames file "file.txt" to "renamed.txt" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
       | user  | path    |
@@ -304,11 +305,12 @@ Feature: propagation of etags when moving files or folders
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
-      | path        | upload |
-      | permissions | change |
+      | path        | upload   |
+      | permissions | change   |
+      | password    | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public renames folder "sub" to "renamed" from the last public link share using the new public WebDAV API
+    When the public renames folder "sub" to "renamed" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
       | user  | path    |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
@@ -120,9 +120,10 @@ Feature: propagation of etags when copying files or folders
       | dav-path-version |
       | spaces           |
 
-  @issue-4251
+  @env-config @issue-4251
   Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
-    Given using <dav-path-version> DAV path
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
@@ -103,9 +103,10 @@ Feature: propagation of etags when creating folders
       | old              |
       | new              |
 
-  @issue-4251
+  @env-config @issue-4251
   Scenario Outline: creating a folder in a publicly shared folder changes its etag for the sharer
-    Given using <dav-path-version> DAV path
+    Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using <dav-path-version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has created a public link share with settings
       | path        | folder |

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
@@ -154,11 +154,12 @@ Feature: propagation of etags when uploading data
   Scenario Outline: uploading a file into a publicly shared folder changes its etag for the sharer
     Given using <dav-path-version> DAV path
     And user "Alice" has created a public link share with settings
-      | path        | upload |
-      | permissions | create |
+      | path        | upload   |
+      | permissions | create   |
+      | password    | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public uploads file "file.txt" with content "new content" using the new public WebDAV API
+    When the public uploads file "file.txt" with password "%public%" and content "new content" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
       | user  | path    |

--- a/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
@@ -124,9 +124,10 @@ Feature: list files
       | dav-path-version |
       | spaces           |
 
-
+  @env-config
   Scenario: get the list of resources in a folder shared through public link with depth 0
     Given using new DAV path
+    And the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has created the following folders
       | path                                                                       |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |
@@ -150,6 +151,7 @@ Feature: list files
 
   Scenario: get the list of resources in a folder shared through public link with depth 1
     Given using new DAV path
+    And the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has created the following folders
       | path                                                                       |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |

--- a/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
@@ -25,40 +25,28 @@ Feature: PROPFIND
       | depth  | <depth> |
     Then the HTTP status code should be "<http-code>"
     Examples:
-      | dav-path                    | depth    | http-code | 
-      | /remote.php/webdav          | 0        | 207       |
-      | /remote.php/webdav          | 1        | 207       |
-      | /remote.php/dav/files/alice | 0        | 207       |
-      | /remote.php/dav/files/alice | 1        | 207       |
+      | dav-path                    | depth | http-code |
+      | /remote.php/webdav          | 0     | 207       |
+      | /remote.php/webdav          | 1     | 207       |
+      | /remote.php/dav/files/alice | 0     | 207       |
+      | /remote.php/dav/files/alice | 1     | 207       |
 
     @skipOnRevaMaster
     Examples:
-      | dav-path                         | depth    | http-code | 
+      | dav-path                         | depth    | http-code |
       | /remote.php/dav/spaces/%spaceid% | 0        | 207       |
       | /remote.php/dav/spaces/%spaceid% | 1        | 207       |
       | /remote.php/dav/spaces/%spaceid% | infinity | 400       |
-
-
-  Scenario: send PROPFIND request to a public link
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/PARENT"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT |
-      | permissions | read    |
-    When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API
-    Then the HTTP status code should be "207"
-    And the value of the item "//d:href" in the response should match "/%base_path%\/remote.php\/dav\/public-files\/%public_token%\/$/"
-    And the value of the item "//oc:public-link-share-owner" in the response should be "Alice"
 
 
   Scenario: send PROPFIND request to a public link shared with password
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created a public link share with settings
-      | path        | /PARENT |
-      | permissions | read    |
-      | password    | 1111    |
-    When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API with password "1111"
+      | path        | /PARENT  |
+      | permissions | read     |
+      | password    | %public% |
+    When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API with password "%public%"
     Then the HTTP status code should be "207"
     And the value of the item "//d:href" in the response should match "/%base_path%\/remote.php\/dav\/public-files\/%public_token%\/$/"
     And the value of the item "//oc:public-link-share-owner" in the response should be "Alice"
@@ -68,9 +56,9 @@ Feature: PROPFIND
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created a public link share with settings
-      | path        | /PARENT |
-      | permissions | read    |
-      | password    | 1111    |
+      | path        | /PARENT  |
+      | permissions | read     |
+      | password    | %public% |
     When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API
     Then the HTTP status code should be "401"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotAuthenticated"
@@ -80,9 +68,9 @@ Feature: PROPFIND
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created a public link share with settings
-      | path        | /PARENT |
-      | permissions | read    |
-      | password    | 1111    |
+      | path        | /PARENT  |
+      | permissions | read     |
+      | password    | %public% |
     When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API with password "1234"
     Then the HTTP status code should be "401"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotAuthenticated"

--- a/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature
@@ -224,8 +224,9 @@ Feature: get file properties
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
     And user "Alice" has created a public link share with settings
-      | path        | test |
-      | permissions | all  |
+      | path        | test     |
+      | permissions | all      |
+      | password    | %public% |
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:share-types |
@@ -259,8 +260,9 @@ Feature: get file properties
       | permissions | all   |
       | shareWith   | grp1  |
     And user "Alice" has created a public link share with settings
-      | path        | test |
-      | permissions | all  |
+      | path        | test     |
+      | permissions | all      |
+      | password    | %public% |
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName   |
       | oc:share-types |


### PR DESCRIPTION
related https://github.com/owncloud/ocis/issues/7682

Changed api tests. public link is password protected by default. 

Note: protected linking is disabled for the webUi and e2e tests, as changes must be made to the web first 