### PR TITLE
[tests-only] wait for few seconds before listing tags

### DIFF
--- a/tests/acceptance/features/bootstrap/TagContext.php
+++ b/tests/acceptance/features/bootstrap/TagContext.php
@@ -148,8 +148,9 @@ class TagContext implements Context {
 	 * @throws Exception
 	 */
 	public function theUserGetsAllAvailableTags(string $user):void {
-		// after creating or deleting tags, in some cases tags do not appear or disappear immediately, so we use waiting
-		sleep(1);
+		// Note: after creating or deleting tags, in some cases tags do not appear or disappear immediately,
+		// So wait is necessary before listing tags
+		sleep(5);
 		$this->featureContext->setResponse(
 			GraphHelper::getTags(
 				$this->featureContext->getBaseUrl(),


### PR DESCRIPTION
## Description
Listing tags immediately after creating one or deleting one might not return the desired result. So, we are waiting for some seconds in the test so that search indexing can complete and then do the tags listing.
This should reduce the frequent flakiness of the tags API tests that we are facing currently in the CI.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/7693

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
