### PR TITLE
allow creating an upload session via graph

### DIFF
--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -113,6 +113,8 @@ type Service interface {
 	ListPermissions(w http.ResponseWriter, r *http.Request)
 	DeletePermission(w http.ResponseWriter, r *http.Request)
 
+	CreateUploadSession(w http.ResponseWriter, r *http.Request)
+
 	GetTags(w http.ResponseWriter, r *http.Request)
 	AssignTags(w http.ResponseWriter, r *http.Request)
 	UnassignTags(w http.ResponseWriter, r *http.Request)
@@ -274,6 +276,7 @@ func NewService(opts ...Option) (Graph, error) {
 					r.Route("/items/{driveItemID}", func(r chi.Router) {
 						r.Get("/", svc.GetDriveItem)
 						r.Get("/children", svc.GetDriveItemChildren)
+						r.Post("/createUploadSession", svc.CreateUploadSession)
 					})
 				})
 			})


### PR DESCRIPTION
I needed a way to create an upload session and checked out how it is done in ms graph. This PR implements a PoC for this.

Unfortunately, the ms graph api can only return a single url while cs3 supports multiple protocols. To work around that I added a `cs3protocols` that can be used to access all possible uploads.

This might help when trying to debug some uploads, because the existing upload methods via TUS or simple PUT do not expose the simple PUT url endpoint, which I was trying to debug.