### PR TITLE
allow configuring loadUserInfo for web

### DIFF
--- a/services/web/pkg/config/config.go
+++ b/services/web/pkg/config/config.go
@@ -71,6 +71,7 @@ type OIDC struct {
 	ResponseType          string `json:"response_type,omitempty" yaml:"response_type" env:"WEB_OIDC_RESPONSE_TYPE" desc:"The OIDC response type to use for authentication."`
 	Scope                 string `json:"scope,omitempty" yaml:"scope" env:"WEB_OIDC_SCOPE" desc:"OIDC scopes to request during authentication to authorize access to user details. Defaults to 'openid profile email'. Values are separated by blank. More example values but not limited to are 'address' or 'phone' etc."`
 	PostLogoutRedirectURI string `json:"post_logout_redirect_uri,omitempty" yaml:"post_logout_redirect_uri" env:"WEB_OIDC_POST_LOGOUT_REDIRECT_URI" desc:"This value needs to point to a valid and reachable web page. The web client will trigger a redirect to that page directly after the logout action. The default value is empty and redirects to the login page."`
+	LoadUserInfo          bool   `json:"loadUserInfo" yaml:"load_userinfo" env:"WEB_OIDC_LOAD_USERINFO" desc:"Make a call to the oidc userinfo endpoint of the idp. For on premise AD FS this must be set to 'false'. The default is 'true'."`
 }
 
 // Application defines an application for the Web app switcher.

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -95,6 +95,7 @@ func DefaultConfig() *config.Config {
 					ClientID:     "web",
 					ResponseType: "code",
 					Scope:        "openid profile email",
+					LoadUserInfo: true,
 				},
 				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings"},
 				ExternalApps: []config.ExternalApp{


### PR DESCRIPTION
Adds a config option for the `loadUserInfo` property of the ocis web oidc client. For AD FS this must be set to false because that idp is ... picky and will not return userinfo ... for whatever reason.

@kulmann I think we can omit that request completely, because web sibsequently makes graph api calls to fetch user metdadata. So we could default it to `false` instead of the current `true`.

Allows setting an ENV var to make AD FS support in the helm charts more manageable, see https://github.com/owncloud/ocis-charts/issues/425