### PR TITLE
[docs-only] Typo fix in OCM service example

### DIFF
--- a/services/ocm/README.md
+++ b/services/ocm/README.md
@@ -27,7 +27,7 @@ Example `providers.json` file:
         "full_name": "Example provider",
         "organization": "Owncloud",
         "domain": "example.com",
-        "homepage": "https://example.com.com",
+        "homepage": "https://example.com",
         "services": [
             {
                 "endpoint": {


### PR DESCRIPTION
There is a typo in the `providers.json` example. `https://example.com.com` --> `https://example.com`
