### PR TITLE
fix typo in test

### DIFF
--- a/tests/acceptance/features/apiNotification/notification.feature
+++ b/tests/acceptance/features/apiNotification/notification.feature
@@ -199,7 +199,7 @@ Feature: Notification
                 },
                 "id": {
                   "type": "string",
-                  "enim": ["%user_id%"]
+                  "enum": ["%user_id%"]
                 },
                 "name": {
                   "type": "string",

--- a/tests/acceptance/features/apiNotification/notification.feature
+++ b/tests/acceptance/features/apiNotification/notification.feature
@@ -199,7 +199,7 @@ Feature: Notification
                 },
                 "id": {
                   "type": "string",
-                  "enum": ["%user_id%"]
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
                 },
                 "name": {
                   "type": "string",


### PR DESCRIPTION
## Description
`enum` was misspelled and because of that not used
The whole test only checked for `string` type.
After fixing the typo I understood that `%user_id%` is the wrong thing in the first place. `%user_id%` is substituted to the requesting user, but in this case its the id of the user that initiated the share

## Motivation and Context
that check does not work with that type

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
