### PR TITLE
[tests-only] Retry listing roles if the response body is invalid

### DIFF
--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -171,7 +171,7 @@ class SettingsContext implements Context {
 			} catch (Exception $e) {
 				$tryAgain = $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
 
-				if (!$tryAgain){
+				if (!$tryAgain) {
 					throw $e;
 				}
 			}

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -168,6 +168,7 @@ class SettingsContext implements Context {
 			$rawBody =  $response->getBody()->getContents();
 			try {
 				$decodedBody = \json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+				$tryAgain = false;
 			} catch (Exception $e) {
 				$tryAgain = $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
 


### PR DESCRIPTION
## Description
While listing the user roles via settings API, sometimes the response body is incomplete causing the json decoder to throw an error. This PR has implemented retrying for certain numbers if the response body is not valid json. 

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/6524

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
