### PR TITLE
add user filter startsWith and contains

### DIFF
--- a/changelog/unreleased/add-user-filter-startswith-and-contains.md
+++ b/changelog/unreleased/add-user-filter-startswith-and-contains.md
@@ -1,0 +1,8 @@
+Enhancement: Add user filter startswith and contains
+
+We add two new filters to the user list endpoint. The `startswith` filter allows to
+filter users by the beginning of their name. The `contains` filter allows to
+filter users by a substring of their name.
+
+https://github.com/owncloud/ocis/pull/7739
+https://github.com/owncloud/ocis/issues/5486


### PR DESCRIPTION
Enhancement: Add user filter startswith and contains

We add two new filters to the user list endpoint. The `startswith` filter allows to
filter users by the beginning of their name. The `contains` filter allows to
filter users by a substring of their name.

refs #5486 