### PR TITLE
enhancement: make use of unified role for the graph invitation endpoint

### DIFF
--- a/changelog/5.0.0_2023-11-22/enhancement-sharing-ng.md
+++ b/changelog/5.0.0_2023-11-22/enhancement-sharing-ng.md
@@ -15,6 +15,7 @@ https://github.com/owncloud/ocis/pull/7684
 https://github.com/owncloud/ocis/pull/7683
 https://github.com/owncloud/ocis/pull/7239
 https://github.com/owncloud/ocis/pull/7687
+https://github.com/owncloud/ocis/pull/7751
 https://github.com/owncloud/libre-graph-api/pull/112
 https://github.com/owncloud/ocis/issues/7436
 https://github.com/owncloud/ocis/issues/6993

--- a/services/graph/pkg/unifiedrole/unifiedrole_test.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole_test.go
@@ -1,10 +1,14 @@
 package unifiedrole_test
 
 import (
+	"fmt"
+
 	"github.com/cs3org/reva/v2/pkg/conversions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	libregraph "github.com/owncloud/libre-graph-api-go"
+
 	"github.com/owncloud/ocis/v2/services/graph/pkg/unifiedrole"
 )
 
@@ -23,4 +27,64 @@ var _ = Describe("unifiedroles", func() {
 		Entry(conversions.RoleCoowner, conversions.NewCoownerRole(), unifiedrole.NewCoownerUnifiedRole()),
 		Entry(conversions.RoleManager, conversions.NewManagerRole(), unifiedrole.NewManagerUnifiedRole()),
 	)
+
+	DescribeTable("UnifiedRolePermissionsToCS3ResourcePermissions",
+		func(cs3Role *conversions.Role, libregraphRole *libregraph.UnifiedRoleDefinition, match bool) {
+			permsFromCS3 := cs3Role.CS3ResourcePermissions()
+			permsFromUnifiedRole := unifiedrole.PermissionsToCS3ResourcePermissions(libregraphRole.RolePermissions)
+
+			var matcher types.GomegaMatcher
+
+			if match {
+				matcher = Equal(permsFromUnifiedRole)
+			} else {
+				matcher = Not(Equal(permsFromUnifiedRole))
+			}
+
+			Expect(permsFromCS3).To(matcher)
+		},
+		Entry(conversions.RoleViewer, conversions.NewViewerRole(true), unifiedrole.NewViewerUnifiedRole(true), true),
+		Entry(conversions.RoleEditor, conversions.NewEditorRole(true), unifiedrole.NewEditorUnifiedRole(true), true),
+		Entry(conversions.RoleFileEditor, conversions.NewFileEditorRole(true), unifiedrole.NewFileEditorUnifiedRole(true), true),
+		Entry(conversions.RoleCoowner, conversions.NewCoownerRole(), unifiedrole.NewCoownerUnifiedRole(), true),
+		Entry(conversions.RoleManager, conversions.NewManagerRole(), unifiedrole.NewManagerUnifiedRole(), true),
+		Entry("no match", conversions.NewFileEditorRole(true), unifiedrole.NewManagerUnifiedRole(), false),
+	)
+
+	{
+		var newUnifiedRoleFromIDEntries []TableEntry
+		for _, resharing := range []bool{true, false} {
+			attachEntry := func(name, id string, definition *libregraph.UnifiedRoleDefinition, errors bool) {
+				e := Entry(
+					fmt.Sprintf("%s - resharing: %t", name, resharing),
+					id,
+					resharing,
+					definition,
+					errors,
+				)
+
+				newUnifiedRoleFromIDEntries = append(newUnifiedRoleFromIDEntries, e)
+			}
+
+			for _, definition := range unifiedrole.GetBuiltinRoleDefinitionList(resharing) {
+				attachEntry(definition.GetDisplayName(), definition.GetId(), definition, false)
+			}
+
+			attachEntry("unknown", "123", nil, true)
+		}
+
+		DescribeTable("NewUnifiedRoleFromID",
+			func(id string, resharing bool, expectedRole *libregraph.UnifiedRoleDefinition, expectError bool) {
+				role, err := unifiedrole.NewUnifiedRoleFromID(id, resharing)
+
+				if expectError {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(role).To(Equal(expectedRole))
+				}
+			},
+			newUnifiedRoleFromIDEntries,
+		)
+	}
 })

--- a/services/graph/pkg/validate/libregraph.go
+++ b/services/graph/pkg/validate/libregraph.go
@@ -1,0 +1,81 @@
+package validate
+
+import (
+	"github.com/go-playground/validator/v10"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+
+	"golang.org/x/exp/slices"
+
+	"github.com/owncloud/ocis/v2/services/graph/pkg/unifiedrole"
+)
+
+// initLibregraph initializes libregraph validation
+func initLibregraph(v *validator.Validate) {
+	driveItemInvite(v)
+}
+
+// driveItemInvite validates libregraph.DriveItemInvite
+func driveItemInvite(v *validator.Validate) {
+	s := libregraph.DriveItemInvite{}
+
+	v.RegisterStructValidationMapRules(map[string]string{
+		"Recipients":         "min=1",
+		"Roles":              "max=1",
+		"ExpirationDateTime": "omitnil,gt",
+	}, s)
+
+	v.RegisterStructValidation(func(sl validator.StructLevel) {
+		driveItemInvite := sl.Current().Interface().(libregraph.DriveItemInvite)
+
+		totalRoles := len(driveItemInvite.Roles)
+		totalActions := len(driveItemInvite.LibreGraphPermissionsActions)
+
+		switch {
+		case totalRoles != 0 && totalActions != 0:
+			fallthrough
+		case totalRoles == totalActions:
+			sl.ReportError(driveItemInvite.Roles, "Roles", "Roles", "one_or_another", "")
+			sl.ReportError(driveItemInvite.LibreGraphPermissionsActions, "LibreGraphPermissionsActions", "LibreGraphPermissionsActions", "one_or_another", "")
+		}
+
+		var availableRoles []string
+		var availableActions []string
+		for _, definition := range append(
+			unifiedrole.GetBuiltinRoleDefinitionList(true),
+			unifiedrole.GetBuiltinRoleDefinitionList(false)...,
+		) {
+			if slices.Contains(availableRoles, definition.GetId()) {
+				continue
+			}
+
+			availableRoles = append(availableRoles, definition.GetId())
+
+			for _, permission := range definition.GetRolePermissions() {
+				for _, action := range permission.GetAllowedResourceActions() {
+					if slices.Contains(availableActions, action) {
+						continue
+					}
+
+					availableActions = append(availableActions, action)
+				}
+			}
+		}
+
+		for _, role := range driveItemInvite.Roles {
+			if slices.Contains(availableRoles, role) {
+				continue
+			}
+
+			sl.ReportError(driveItemInvite.Roles, "Roles", "Roles", "available_role", "")
+		}
+
+		for _, role := range driveItemInvite.LibreGraphPermissionsActions {
+			if slices.Contains(availableActions, role) {
+				continue
+			}
+
+			sl.ReportError(driveItemInvite.LibreGraphPermissionsActions, "LibreGraphPermissionsActions", "LibreGraphPermissionsActions", "available_action", "")
+		}
+
+	}, s)
+}

--- a/services/graph/pkg/validate/libregraph_test.go
+++ b/services/graph/pkg/validate/libregraph_test.go
@@ -1,0 +1,93 @@
+package validate_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+
+	"github.com/owncloud/ocis/v2/services/graph/pkg/unifiedrole"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/validate"
+)
+
+var _ = Describe("libregraph", func() {
+
+	var driveItemInvite libregraph.DriveItemInvite
+
+	BeforeEach(func() {
+		driveItemInvite = libregraph.DriveItemInvite{
+			Recipients:                   []libregraph.DriveRecipient{{ObjectId: libregraph.PtrString("1")}},
+			Roles:                        []string{unifiedrole.UnifiedRoleEditorID},
+			LibreGraphPermissionsActions: []string{unifiedrole.DriveItemVersionsUpdate},
+			ExpirationDateTime:           libregraph.PtrTime(time.Now().Add(time.Hour)),
+		}
+	})
+
+	DescribeTable("DriveItemInvite",
+		func(factory func() libregraph.DriveItemInvite, expectError bool) {
+			f := factory()
+			switch err := validate.StructCtx(context.Background(), f); expectError {
+			case true:
+				Expect(err).To(HaveOccurred())
+			default:
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+		},
+		Entry("succeed: roles", func() libregraph.DriveItemInvite {
+			driveItemInvite.LibreGraphPermissionsActions = nil
+			return driveItemInvite
+		}, false),
+		Entry("succeed: permission actions", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = nil
+			return driveItemInvite
+		}, false),
+		Entry("succeed: without ExpirationDateTime", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = nil
+			driveItemInvite.ExpirationDateTime = nil
+			return driveItemInvite
+		}, false),
+		Entry("fail: multiple role assignment", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = []string{
+				unifiedrole.UnifiedRoleEditorID,
+				unifiedrole.UnifiedRoleManagerID,
+			}
+			driveItemInvite.LibreGraphPermissionsActions = nil
+			return driveItemInvite
+		}, true),
+		Entry("fail: unknown role", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = []string{"foo"}
+			driveItemInvite.LibreGraphPermissionsActions = nil
+			return driveItemInvite
+		}, true),
+		Entry("fail: unknown action", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = nil
+			driveItemInvite.LibreGraphPermissionsActions = []string{"foo"}
+			return driveItemInvite
+		}, true),
+		Entry("fail: missing roles or permission actions", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = nil
+			driveItemInvite.LibreGraphPermissionsActions = nil
+			return driveItemInvite
+		}, true),
+		Entry("fail: different number of roles and actions", func() libregraph.DriveItemInvite {
+			driveItemInvite.LibreGraphPermissionsActions = []string{
+				unifiedrole.DriveItemVersionsUpdate,
+				unifiedrole.DriveItemChildrenCreate,
+			}
+			return driveItemInvite
+		}, true),
+		Entry("fail: missing recipients", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = nil
+			driveItemInvite.Recipients = nil
+			return driveItemInvite
+		}, true),
+		Entry("fail: expirationDateTime in the past", func() libregraph.DriveItemInvite {
+			driveItemInvite.Roles = nil
+			driveItemInvite.ExpirationDateTime = libregraph.PtrTime(time.Now().Add(-time.Hour))
+			return driveItemInvite
+		}, true),
+	)
+})

--- a/services/graph/pkg/validate/validate.go
+++ b/services/graph/pkg/validate/validate.go
@@ -5,24 +5,14 @@ import (
 	"sync/atomic"
 
 	"github.com/go-playground/validator/v10"
-	libregraph "github.com/owncloud/libre-graph-api-go"
 )
 
 var defaultValidator atomic.Value
-var structMapValidations = map[any]map[string]string{
-	&libregraph.DriveItemInvite{}: {
-		"Recipients":         "min=1",
-		"Roles":              "len=1", // currently it is not possible to set more than one role
-		"ExpirationDateTime": "omitnil,gt",
-	},
-}
 
 func init() {
 	v := validator.New()
 
-	for s, rules := range structMapValidations {
-		v.RegisterStructValidationMapRules(rules, s)
-	}
+	initLibregraph(v)
 
 	defaultValidator.Store(v)
 }

--- a/services/graph/pkg/validate/validate_suite_test.go
+++ b/services/graph/pkg/validate/validate_suite_test.go
@@ -1,0 +1,13 @@
+package validate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGraph(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validate Suite")
+}


### PR DESCRIPTION
## Description
Up to now the graph beta invitation endpoint made use of the cs3 permission objects (named set aka role). 
With the implementation of the new unified roles the api is now able to use those as described in the [swagger spec](https://owncloud.dev/libre-graph-api/#/drives.permissions/Invite).

## Related Issue
* https://github.com/owncloud/ocis/pull/7633
* https://github.com/owncloud/ocis/pull/7686
* https://github.com/owncloud/ocis/pull/7684
* https://github.com/owncloud/ocis/pull/7683
* https://github.com/owncloud/ocis/pull/7239
* https://github.com/owncloud/ocis/pull/7687
* https://github.com/owncloud/ocis/pull/7751
* https://github.com/owncloud/libre-graph-api/pull/112
* https://github.com/owncloud/ocis/issues/7436
* https://github.com/owncloud/ocis/issues/6993

## Motivation and Context
make use of the unified roles as described in the openAPI spec.

## How Has This Been Tested?
- manual testing
- unit tests

## example:

### request
```
POST {{host}}/graph/v1beta1/drives/{{drive-id}}/items/{{item-id}}/invite
Authorization: Basic {{user_admin_login}} {{user_admin_password}}
Content-Type: application/json
```

### body (roles)
```json
{
  "recipients":[
    {"objectId": "{{user_marie_id}}"}
  ],
  "ExpirationDateTime": "2055-07-15T14:00:00.000Z",
  "roles": [
    "{{role_viewer_id}}",
  ]
}
```

### response (roles)
```json
{
  "value": [
    {
      "expirationDateTime": "2055-07-15T16:00:00+02:00",
      "grantedToV2": {
        "user": {
          "displayName": "Marie Skłodowska Curie",
          "id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
        }
      },
      "id": "3496f80c-b4c7-40cd-9ee9-f7bfb77c671c:4353a0e1-a947-4588-8be2-7730ac879eda:592a5934-9dda-41f9-8925-ae96411dbdb8",
      "roles": [
        "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"
      ]
    }
  ]
}
```

### body (@libre.graph.permissions.actions)
```json
{
  "recipients":[
    {"objectId": "{{user_marie_id}}"}
  ],
  "ExpirationDateTime": "2055-07-15T14:00:00.000Z",
  "@libre.graph.permissions.actions":[
    "libre.graph/driveItem/content/read"
  ]
}
```

### response (@libre.graph.permissions.actions)
```json
{
  "value": [
    {
      "@libre.graph.permissions.actions": [
        "libre.graph/driveItem/content/read"
      ],
      "expirationDateTime": "2055-07-15T16:00:00+02:00",
      "grantedToV2": {
        "user": {
          "displayName": "Marie Skłodowska Curie",
          "id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
        }
      },
      "id": "3496f80c-b4c7-40cd-9ee9-f7bfb77c671c:4353a0e1-a947-4588-8be2-7730ac879eda:53cff278-5c94-47b1-99ca-5ce89095b385"
    }
  ]
}
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
