### PR TITLE
feat: add more accepted languages

### DIFF
--- a/services/settings/pkg/service/v0/settings.go
+++ b/services/settings/pkg/service/v0/settings.go
@@ -138,6 +138,14 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 			{
 				Value: &settingsmsg.ListOptionValue{
 					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "bg",
+					},
+				},
+				DisplayValue: "български",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
 						StringValue: "cs",
 					},
 				},
@@ -158,7 +166,6 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 					},
 				},
 				DisplayValue: "English",
-				Default:      true,
 			},
 			{
 				Value: &settingsmsg.ListOptionValue{
@@ -191,6 +198,46 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 					},
 				},
 				DisplayValue: "Italiano",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "nl",
+					},
+				},
+				DisplayValue: "Nederlands",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "ko",
+					},
+				},
+				DisplayValue: "한국어",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "sq",
+					},
+				},
+				DisplayValue: "Shqipja",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "sv",
+					},
+				},
+				DisplayValue: "Svenska",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "tr",
+					},
+				},
+				DisplayValue: "Türkçe",
 			},
 		},
 	},

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -196,6 +196,14 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 			{
 				Value: &settingsmsg.ListOptionValue{
 					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "bg",
+					},
+				},
+				DisplayValue: "български",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
 						StringValue: "cs",
 					},
 				},
@@ -248,6 +256,46 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 					},
 				},
 				DisplayValue: "Italiano",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "nl",
+					},
+				},
+				DisplayValue: "Nederlands",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "ko",
+					},
+				},
+				DisplayValue: "한국어",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "sq",
+					},
+				},
+				DisplayValue: "Shqipja",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "sv",
+					},
+				},
+				DisplayValue: "Svenska",
+			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "tr",
+					},
+				},
+				DisplayValue: "Türkçe",
 			},
 		},
 	},


### PR DESCRIPTION
## Description

This PR adds languages to the list of accepted languages which have 70% or more translation coverage in transifex + Swedish by request of a community member who promised to help with translations, see https://github.com/owncloud/web/issues/10007 

The reason for this change is that the settings services only persists language codes which are known in the definition of the setting. The user facing changes (available languages in the dropdown of the account page) will happen in web only. Hence I didn't include a changelog item, yet. Will be part of the next web bump then.

## Related Issue
- Brought up by https://github.com/owncloud/web/issues/10007 

## Motivation and Context
Make community happy.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
