### PR TITLE
[tes-only] change restore cache for e2e

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1161,7 +1161,7 @@ def e2eTests(ctx):
     for name, suite in test_suites.items():
         steps = \
             skipIfUnchanged(ctx, "e2e-tests") + \
-            restoreBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin/ocis") + \
+            restoreBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin") + \
             restoreWebCache() + \
             restoreWebPnpmCache() + \
             (tikaService() if suite["tikaNeeded"] else []) + \


### PR DESCRIPTION
this PR https://github.com/owncloud/ocis/pull/7748 included a link to the password for the e2e test.
but now the e2e test doesn't work because we don't have the required password window, as when `ocis` uses `"OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD": False`

example: 
https://drone.owncloud.com/owncloud/ocis/28961/40/12
https://drone.owncloud.com/owncloud/ocis/28964/60/11
https://drone.owncloud.com/owncloud/ocis/28976/40/12

it's really strange, It seems that the server is somehow misconfigured in CI or it is some kind of cache problem. 
@saw-jan do you have ideas why it happens?