### PR TITLE
revert: don't make loadUserInfo configurable because web disabled it

### DIFF
--- a/services/web/pkg/config/config.go
+++ b/services/web/pkg/config/config.go
@@ -71,7 +71,6 @@ type OIDC struct {
 	ResponseType          string `json:"response_type,omitempty" yaml:"response_type" env:"WEB_OIDC_RESPONSE_TYPE" desc:"The OIDC response type to use for authentication."`
 	Scope                 string `json:"scope,omitempty" yaml:"scope" env:"WEB_OIDC_SCOPE" desc:"OIDC scopes to request during authentication to authorize access to user details. Defaults to 'openid profile email'. Values are separated by blank. More example values but not limited to are 'address' or 'phone' etc."`
 	PostLogoutRedirectURI string `json:"post_logout_redirect_uri,omitempty" yaml:"post_logout_redirect_uri" env:"WEB_OIDC_POST_LOGOUT_REDIRECT_URI" desc:"This value needs to point to a valid and reachable web page. The web client will trigger a redirect to that page directly after the logout action. The default value is empty and redirects to the login page."`
-	LoadUserInfo          bool   `json:"loadUserInfo" yaml:"load_userinfo" env:"WEB_OIDC_LOAD_USERINFO" desc:"Make a call to the oidc userinfo endpoint of the idp. For on premise AD FS this must be set to 'false'. The default is 'true'."`
 }
 
 // Application defines an application for the Web app switcher.

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -95,7 +95,6 @@ func DefaultConfig() *config.Config {
 					ClientID:     "web",
 					ResponseType: "code",
 					Scope:        "openid profile email",
-					LoadUserInfo: true,
 				},
 				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings"},
 				ExternalApps: []config.ExternalApp{


### PR DESCRIPTION
## Description
As discussed here https://github.com/owncloud/ocis/pull/7714#issuecomment-1812047910 we're removing the env var for making the LoadUserInfo bool configurable. Reason is that oC Web disabled fetching the userinfo via oidc entirely. There are different endpoints in oCIS where we get all the userinfo, so we want to omit the userinfo request entirely.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
