### PR TITLE
chore: bump web to v8.0.0-alpha.10

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=7fd9f43ea4d9ba6024259f480ba72820db4e9b6c
+WEB_COMMITID=9eaba7e2b21d44bf58c7c8b47e077d10cc531e84
 WEB_BRANCH=master

--- a/changelog/5.0.0_2023-11-08/update-web-8.0.0.md
+++ b/changelog/5.0.0_2023-11-08/update-web-8.0.0.md
@@ -70,5 +70,5 @@ We updated ownCloud Web to v8.0.0. Please refer to the changelog (linked) for de
 * Enhancement [owncloud/web#9912](https://github.com/owncloud/web/pull/9912) - Add media type filter chip
 
 
-https://github.com/owncloud/ocis/pull/7748
-https://github.com/owncloud/web/releases/tag/v8.0.0-alpha.9
+https://github.com/owncloud/ocis/pull/7773
+https://github.com/owncloud/web/releases/tag/v8.0.0-alpha.10

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.0-alpha.9
+WEB_ASSETS_VERSION = v8.0.0-alpha.10
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Includes the latest changes regarding the Web embed mode.