### PR TITLE
Init search service correctly

### DIFF
--- a/changelog/unreleased/fix-search-service-init.md
+++ b/changelog/unreleased/fix-search-service-init.md
@@ -1,0 +1,5 @@
+Bugfix: Fix search service start
+
+The `search` service would sometimes not start correctly because config values are overwritten by default configuration.
+
+https://github.com/owncloud/ocis/pull/7795

--- a/ocis-pkg/config/defaultconfig.go
+++ b/ocis-pkg/config/defaultconfig.go
@@ -76,7 +76,7 @@ func DefaultConfig() *Config {
 		Postprocessing:    postprocessing.DefaultConfig(),
 		Policies:          policies.DefaultConfig(),
 		Proxy:             proxy.DefaultConfig(),
-		Search:            search.FullDefaultConfig(),
+		Search:            search.DefaultConfig(),
 		Settings:          settings.DefaultConfig(),
 		Sharing:           sharing.DefaultConfig(),
 		SSE:               sse.DefaultConfig(),

--- a/services/search/pkg/config/parser/parse.go
+++ b/services/search/pkg/config/parser/parse.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/search/pkg/config"
 	"github.com/owncloud/ocis/v2/services/search/pkg/config/defaults"
 
@@ -33,5 +34,8 @@ func ParseConfig(cfg *config.Config) error {
 }
 
 func Validate(cfg *config.Config) error {
+	if cfg.TokenManager.JWTSecret == "" {
+		return shared.MissingJWTTokenError(cfg.Service.Name)
+	}
 	return nil
 }


### PR DESCRIPTION
Fixes a bug with search service crashing on startup because it can't find the jwt secret

Fixes https://github.com/owncloud/ocis/issues/7757