### PR TITLE
return 200 on successful invite

### DIFF
--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -494,7 +494,7 @@ func (g Graph) Invite(w http.ResponseWriter, r *http.Request) {
 	case hasErrors && hasSuccesses:
 		render.Status(r, http.StatusMultiStatus)
 	case hasSuccesses:
-		render.Status(r, http.StatusCreated)
+		render.Status(r, http.StatusOK)
 	default:
 		render.Status(r, http.StatusInternalServerError)
 	}

--- a/services/graph/pkg/service/v0/driveitems_test.go
+++ b/services/graph/pkg/service/v0/driveitems_test.go
@@ -322,7 +322,7 @@ var _ = Describe("Driveitems", func() {
 
 			jsonData := gjson.Get(rr.Body.String(), "value")
 
-			Expect(rr.Code).To(Equal(http.StatusCreated))
+			Expect(rr.Code).To(Equal(http.StatusOK))
 			Expect(jsonData.Get("#").Num).To(Equal(float64(2)))
 
 			Expect(jsonData.Get("0.id").Str).To(Equal("123"))
@@ -347,7 +347,7 @@ var _ = Describe("Driveitems", func() {
 
 			jsonData := gjson.Get(rr.Body.String(), "value")
 
-			Expect(rr.Code).To(Equal(http.StatusCreated))
+			Expect(rr.Code).To(Equal(http.StatusOK))
 
 			Expect(jsonData.Get(`0.@libre\.graph\.permissions\.actions`).Exists()).To(BeFalse())
 			Expect(jsonData.Get("0.roles.#").Num).To(Equal(float64(1)))
@@ -365,7 +365,7 @@ var _ = Describe("Driveitems", func() {
 
 			jsonData := gjson.Get(rr.Body.String(), "value")
 
-			Expect(rr.Code).To(Equal(http.StatusCreated))
+			Expect(rr.Code).To(Equal(http.StatusOK))
 
 			Expect(jsonData.Get("0.roles").Exists()).To(BeFalse())
 			Expect(jsonData.Get(`0.@libre\.graph\.permissions\.actions.#`).Num).To(Equal(float64(1)))


### PR DESCRIPTION
## Description
Don't return 201 on a successful share creation (invite) but 200

## Related Issue
https://github.com/owncloud/libre-graph-api/pull/147

## Motivation and Context
get the behavior straight with the API definition

## How Has This Been Tested?
- :robot: 
- running tests of https://github.com/owncloud/ocis-php-sdk/pull/77

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
