### PR TITLE
graph: update permissions

### DIFF
--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -27,6 +27,7 @@ import (
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"golang.org/x/crypto/sha3"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/cs3org/reva/v2/pkg/publicshare"
 	"github.com/cs3org/reva/v2/pkg/share"
@@ -609,6 +610,65 @@ func (g Graph) Invite(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, &ListResponse{Value: value})
 }
 
+// UpdatePermission updates a Permission of a Drive item
+func (g Graph) UpdatePermission(w http.ResponseWriter, r *http.Request) {
+	_, itemID, err := g.GetDriveAndItemIDParam(r)
+	if err != nil {
+		errorcode.RenderError(w, r, err)
+		return
+	}
+
+	permissionID, err := url.PathUnescape(chi.URLParam(r, "permissionID"))
+
+	if err != nil {
+		g.logger.Debug().Err(err).Msg("could not parse permissionID")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid permissionID")
+		return
+	}
+
+	permission := &libregraph.Permission{}
+	if err := StrictJSONUnmarshal(r.Body, permission); err != nil {
+		g.logger.Debug().Err(err).Interface("Body", r.Body).Msg("failed unmarshalling request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	ctx := r.Context()
+	if err := validate.StructCtx(ctx, permission); err != nil {
+		g.logger.Debug().Err(err).Interface("Body", r.Body).Msg("invalid request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	oldPermission, sharedResourceId, err := g.getPermissionByID(ctx, permissionID)
+	if err != nil {
+		errorcode.RenderError(w, r, err)
+		return
+	}
+
+	// The resourceID of the shared resource need to match the item ID from the Request Path
+	// otherwise this is an invalid Request.
+	if !utils.ResourceIDEqual(sharedResourceId, &itemID) {
+		g.logger.Debug().Msg("resourceID of shared does not match itemID")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "permissionID and itemID do not match")
+		return
+	}
+
+	// We don't implement updating link permissions yet
+	if _, ok := oldPermission.GetLinkOk(); ok {
+		errorcode.NotSupported.Render(w, r, http.StatusNotImplemented, "not implemented")
+		return
+	}
+	// This is a user share
+	updatedPermission, err := g.updateUserShare(ctx, permissionID, oldPermission, permission)
+	if err != nil {
+		errorcode.RenderError(w, r, err)
+	}
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, &updatedPermission)
+	return
+}
+
 // DeletePermission removes a Permission from a Drive item
 func (g Graph) DeletePermission(w http.ResponseWriter, r *http.Request) {
 	_, itemID, err := g.GetDriveAndItemIDParam(r)
@@ -666,7 +726,43 @@ func (g Graph) DeletePermission(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+func (g Graph) getPermissionByID(ctx context.Context, permissionID string) (*libregraph.Permission, *storageprovider.ResourceId, error) {
+	share, err := g.getCS3UserShareByID(ctx, permissionID)
+	if err == nil {
+		permission, err := g.cs3UserShareToPermission(ctx, share)
+		if err != nil {
+			return nil, nil, err
+		}
+		return permission, share.GetResourceId(), nil
+	}
+
+	var errcode errorcode.Error
+	if errors.As(err, &errcode) && errcode.GetCode() == errorcode.ItemNotFound {
+		// there is no user share with that id, check if this is a public link
+		publicShare, err := g.getCS3PublicShareByID(ctx, permissionID)
+		if err != nil {
+			return nil, nil, err
+		}
+		permission, err := g.libreGraphPermissionFromCS3PublicShare(publicShare)
+		if err != nil {
+			return nil, nil, err
+		}
+		return permission, publicShare.GetResourceId(), nil
+	}
+
+	return nil, nil, err
+
+}
+
 func (g Graph) getUserPermissionResourceID(ctx context.Context, permissionID string) (*storageprovider.ResourceId, error) {
+	share, err := g.getCS3UserShareByID(ctx, permissionID)
+	if err != nil {
+		return nil, err
+	}
+	return share.GetResourceId(), nil
+}
+
+func (g Graph) getCS3UserShareByID(ctx context.Context, permissionID string) (*collaboration.Share, error) {
 	gatewayClient, err := g.gatewaySelector.Next()
 	if err != nil {
 		g.logger.Debug().Err(err).Msg("selecting gatewaySelector failed")
@@ -686,7 +782,84 @@ func (g Graph) getUserPermissionResourceID(ctx context.Context, permissionID str
 	if errCode := errorcode.FromCS3Status(getShareResp.GetStatus(), err); errCode != nil {
 		return nil, *errCode
 	}
-	return getShareResp.Share.GetResourceId(), nil
+	return getShareResp.GetShare(), nil
+}
+
+func (g Graph) updateUserShare(ctx context.Context, permissionID string, oldPermission, newPermission *libregraph.Permission) (*libregraph.Permission, error) {
+	gatewayClient, err := g.gatewaySelector.Next()
+	if err != nil {
+		g.logger.Debug().Err(err).Msg("selecting gatewaySelector failed")
+		return nil, err
+	}
+
+	cs3UpdateShareReq := &collaboration.UpdateShareRequest{
+		Ref: &collaboration.ShareReference{
+			Spec: &collaboration.ShareReference_Id{
+				Id: &collaboration.ShareId{
+					OpaqueId: permissionID,
+				},
+			},
+		},
+		Share: &collaboration.Share{},
+	}
+	fieldmask := []string{}
+	if expiration, ok := newPermission.GetExpirationDateTimeOk(); ok {
+		fieldmask = append(fieldmask, "expiration")
+		if expiration != nil {
+			cs3UpdateShareReq.Share.Expiration = utils.TimeToTS(*expiration)
+		}
+	}
+	var roles, allowedResourceActions []string
+	var permissionsUpdated, ok bool
+	if roles, ok = newPermission.GetRolesOk(); ok && len(roles) > 0 {
+		for _, roleId := range roles {
+			role, err := unifiedrole.NewUnifiedRoleFromID(roleId, g.config.FilesSharing.EnableResharing)
+			if err != nil {
+				g.logger.Debug().Err(err).Interface("role", role).Msg("unable to convert requested role")
+				return nil, err
+			}
+
+			// FIXME: When setting permissions on a space, we need to use UnifiedRoleConditionOwner here
+			allowedResourceActions = unifiedrole.GetAllowedResourceActions(role, unifiedrole.UnifiedRoleConditionGrantee)
+			if len(allowedResourceActions) == 0 {
+				return nil, errorcode.New(errorcode.InvalidRequest, "role not applicable to this resource")
+			}
+		}
+		permissionsUpdated = true
+	} else if allowedResourceActions, ok = newPermission.GetLibreGraphPermissionsActionsOk(); ok && len(allowedResourceActions) > 0 {
+		permissionsUpdated = true
+	}
+
+	if permissionsUpdated {
+		cs3ResourcePermissions := unifiedrole.PermissionsToCS3ResourcePermissions(
+			[]*libregraph.UnifiedRolePermission{
+				{
+
+					AllowedResourceActions: allowedResourceActions,
+				},
+			},
+		)
+		cs3UpdateShareReq.Share.Permissions = &collaboration.SharePermissions{
+			Permissions: cs3ResourcePermissions,
+		}
+		fieldmask = append(fieldmask, "permissions")
+	}
+
+	cs3UpdateShareReq.UpdateMask = &fieldmaskpb.FieldMask{
+		Paths: fieldmask,
+	}
+
+	updateUserShareResp, err := gatewayClient.UpdateShare(ctx, cs3UpdateShareReq)
+	if errCode := errorcode.FromCS3Status(updateUserShareResp.GetStatus(), err); errCode != nil {
+		return nil, *errCode
+	}
+
+	permission, err := g.cs3UserShareToPermission(ctx, updateUserShareResp.GetShare())
+	if err != nil {
+		return nil, err
+	}
+
+	return permission, nil
 }
 
 func (g Graph) removeUserShare(ctx context.Context, permissionID string) error {
@@ -715,6 +888,14 @@ func (g Graph) removeUserShare(ctx context.Context, permissionID string) error {
 }
 
 func (g Graph) getLinkPermissionResourceID(ctx context.Context, permissionID string) (*storageprovider.ResourceId, error) {
+	share, err := g.getCS3PublicShareByID(ctx, permissionID)
+	if err != nil {
+		return nil, err
+	}
+	return share.GetResourceId(), nil
+}
+
+func (g Graph) getCS3PublicShareByID(ctx context.Context, permissionID string) (*link.PublicShare, error) {
 	gatewayClient, err := g.gatewaySelector.Next()
 	if err != nil {
 		g.logger.Debug().Err(err).Msg("selecting gatewaySelector failed")
@@ -735,7 +916,7 @@ func (g Graph) getLinkPermissionResourceID(ctx context.Context, permissionID str
 	if errCode := errorcode.FromCS3Status(getPublicShareResp.GetStatus(), err); errCode != nil {
 		return nil, *errCode
 	}
-	return getPublicShareResp.Share.GetResourceId(), nil
+	return getPublicShareResp.GetShare(), nil
 }
 
 func (g Graph) removePublicShare(ctx context.Context, permissionID string) error {

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -629,7 +629,7 @@ func (g Graph) DeletePermission(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the id is refering to a User Share
 	sharedResourceId, err := g.getUserPermissionResourceID(ctx, permissionID)
-	var errcode *errorcode.Error
+	var errcode errorcode.Error
 	if err != nil && errors.As(err, &errcode) && errcode.GetCode() == errorcode.ItemNotFound {
 		// there is no user share with that ID, so lets check if it is referring to a public link
 		isUserPermission = false
@@ -684,7 +684,7 @@ func (g Graph) getUserPermissionResourceID(ctx context.Context, permissionID str
 			},
 		})
 	if errCode := errorcode.FromCS3Status(getShareResp.GetStatus(), err); errCode != nil {
-		return nil, errCode
+		return nil, *errCode
 	}
 	return getShareResp.Share.GetResourceId(), nil
 }
@@ -708,7 +708,7 @@ func (g Graph) removeUserShare(ctx context.Context, permissionID string) error {
 		})
 
 	if errCode := errorcode.FromCS3Status(removeShareResp.GetStatus(), err); errCode != nil {
-		return errCode
+		return *errCode
 	}
 	// We need to return an untyped nil here otherwise the error==nil check won't work
 	return nil
@@ -733,7 +733,7 @@ func (g Graph) getLinkPermissionResourceID(ctx context.Context, permissionID str
 		},
 	)
 	if errCode := errorcode.FromCS3Status(getPublicShareResp.GetStatus(), err); errCode != nil {
-		return nil, errCode
+		return nil, *errCode
 	}
 	return getPublicShareResp.Share.GetResourceId(), nil
 }
@@ -756,7 +756,7 @@ func (g Graph) removePublicShare(ctx context.Context, permissionID string) error
 			},
 		})
 	if errcode := errorcode.FromCS3Status(removePublicShareResp.GetStatus(), err); errcode != nil {
-		return errcode
+		return *errcode
 	}
 	// We need to return an untyped nil here otherwise the error==nil check won't work
 	return nil

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -113,6 +113,7 @@ type Service interface {
 
 	Invite(w http.ResponseWriter, r *http.Request)
 	ListPermissions(w http.ResponseWriter, r *http.Request)
+	UpdatePermission(w http.ResponseWriter, r *http.Request)
 	DeletePermission(w http.ResponseWriter, r *http.Request)
 
 	CreateUploadSession(w http.ResponseWriter, r *http.Request)
@@ -209,6 +210,17 @@ func NewService(opts ...Option) (Graph, error) {
 					r.Get("/sharedByMe", svc.GetSharedByMe)
 					r.Get("/sharedWithMe", svc.ListSharedWithMe)
 				})
+			})
+			r.Route("/drives/{driveID}/items/{itemID}", func(r chi.Router) {
+				r.Post("/invite", svc.Invite)
+				r.Route("/permissions", func(r chi.Router) {
+					r.Get("/", svc.ListPermissions)
+					r.Route("/{permissionID}", func(r chi.Router) {
+						r.Delete("/", svc.DeletePermission)
+						r.Patch("/", svc.UpdatePermission)
+					})
+				})
+				r.Post("/createLink", svc.CreateLink)
 			})
 
 			r.Route("/drives", func(r chi.Router) {

--- a/services/graph/pkg/service/v0/sharedbyme.go
+++ b/services/graph/pkg/service/v0/sharedbyme.go
@@ -146,7 +146,7 @@ func (g Graph) cs3UserShareToPermission(ctx context.Context, share *collaboratio
 	perm.SetId(share.Id.OpaqueId)
 	grantedTo := libregraph.SharePointIdentitySet{}
 	var li libregraph.Identity
-	switch share.Grantee.Type {
+	switch share.GetGrantee().GetType() {
 	case storageprovider.GranteeType_GRANTEE_TYPE_USER:
 		user, err := g.identityCache.GetUser(ctx, share.Grantee.GetUserId().GetOpaqueId())
 		switch {

--- a/services/graph/pkg/service/v0/sharedbyme.go
+++ b/services/graph/pkg/service/v0/sharedbyme.go
@@ -124,63 +124,77 @@ func (g Graph) cs3UserSharesToDriveItems(ctx context.Context, shares []*collabor
 			}
 			item = *itemptr
 		}
-		perm := libregraph.Permission{}
-		perm.SetRoles([]string{})
-		perm.SetId(s.Id.OpaqueId)
-		grantedTo := libregraph.SharePointIdentitySet{}
-		var li libregraph.Identity
-		switch s.Grantee.Type {
-		case storageprovider.GranteeType_GRANTEE_TYPE_USER:
-			user, err := g.identityCache.GetUser(ctx, s.Grantee.GetUserId().GetOpaqueId())
-			switch {
-			case errors.Is(err, identity.ErrNotFound):
-				g.logger.Warn().Str("userid", s.Grantee.GetUserId().GetOpaqueId()).Msg("User not found by id")
-				// User does not seem to exist anymore, don't add a permission for this
-				continue
-			case err != nil:
-				return driveItems, errorcode.New(errorcode.GeneralException, err.Error())
-			default:
-				li.SetDisplayName(user.GetDisplayName())
-				li.SetId(user.GetId())
-				grantedTo.SetUser(li)
-			}
-		case storageprovider.GranteeType_GRANTEE_TYPE_GROUP:
-			group, err := g.identityCache.GetGroup(ctx, s.Grantee.GetGroupId().GetOpaqueId())
-			switch {
-			case errors.Is(err, identity.ErrNotFound):
-				g.logger.Warn().Str("groupid", s.Grantee.GetGroupId().GetOpaqueId()).Msg("Group not found by id")
-				// Group not seem to exist anymore, don't add a permission for this
-				continue
-			case err != nil:
-				return driveItems, errorcode.New(errorcode.GeneralException, err.Error())
-			default:
-				li.SetDisplayName(group.GetDisplayName())
-				li.SetId(group.GetId())
-				grantedTo.SetGroup(li)
-			}
-		}
+		perm, err := g.cs3UserShareToPermission(ctx, s)
 
-		// set expiration date
-		if s.GetExpiration() != nil {
-			perm.SetExpirationDateTime(cs3TimestampToTime(s.GetExpiration()))
+		var errcode errorcode.Error
+		switch {
+		case errors.As(err, &errcode) && errcode.GetCode() == errorcode.ItemNotFound:
+			// The Grantee couldn't be found (user/group does not exist anymore)
+			continue
+		case err != nil:
+			return driveItems, err
 		}
-		role := unifiedrole.CS3ResourcePermissionsToUnifiedRole(
-			*s.GetPermissions().GetPermissions(),
-			unifiedrole.UnifiedRoleConditionGrantee,
-			g.config.FilesSharing.EnableResharing,
-		)
-		if role != nil {
-			perm.SetRoles([]string{role.GetId()})
-		} else {
-			actions := unifiedrole.CS3ResourcePermissionsToLibregraphActions(*s.GetPermissions().GetPermissions())
-			perm.SetLibreGraphPermissionsActions(actions)
-			perm.SetRoles(nil)
-		}
-		perm.SetGrantedToV2(grantedTo)
-		item.Permissions = append(item.Permissions, perm)
+		item.Permissions = append(item.Permissions, *perm)
 		driveItems[resIDStr] = item
 	}
 	return driveItems, nil
+}
+
+func (g Graph) cs3UserShareToPermission(ctx context.Context, share *collaboration.Share) (*libregraph.Permission, error) {
+	perm := libregraph.Permission{}
+	perm.SetRoles([]string{})
+	perm.SetId(share.Id.OpaqueId)
+	grantedTo := libregraph.SharePointIdentitySet{}
+	var li libregraph.Identity
+	switch share.Grantee.Type {
+	case storageprovider.GranteeType_GRANTEE_TYPE_USER:
+		user, err := g.identityCache.GetUser(ctx, share.Grantee.GetUserId().GetOpaqueId())
+		switch {
+		case errors.Is(err, identity.ErrNotFound):
+			g.logger.Warn().Str("userid", share.Grantee.GetUserId().GetOpaqueId()).Msg("User not found by id")
+			// User does not seem to exist anymore, don't add a permission for this
+			return nil, errorcode.New(errorcode.ItemNotFound, "grantee does not exist")
+		case err != nil:
+			return nil, errorcode.New(errorcode.GeneralException, err.Error())
+		default:
+			li.SetDisplayName(user.GetDisplayName())
+			li.SetId(user.GetId())
+			grantedTo.SetUser(li)
+		}
+	case storageprovider.GranteeType_GRANTEE_TYPE_GROUP:
+		group, err := g.identityCache.GetGroup(ctx, share.Grantee.GetGroupId().GetOpaqueId())
+		switch {
+		case errors.Is(err, identity.ErrNotFound):
+			g.logger.Warn().Str("groupid", share.Grantee.GetGroupId().GetOpaqueId()).Msg("Group not found by id")
+			// Group not seem to exist anymore, don't add a permission for this
+			return nil, errorcode.New(errorcode.ItemNotFound, "grantee does not exist")
+		case err != nil:
+			return nil, errorcode.New(errorcode.GeneralException, err.Error())
+		default:
+			li.SetDisplayName(group.GetDisplayName())
+			li.SetId(group.GetId())
+			grantedTo.SetGroup(li)
+		}
+	}
+
+	// set expiration date
+	if share.GetExpiration() != nil {
+		perm.SetExpirationDateTime(cs3TimestampToTime(share.GetExpiration()))
+	}
+	role := unifiedrole.CS3ResourcePermissionsToUnifiedRole(
+		*share.GetPermissions().GetPermissions(),
+		unifiedrole.UnifiedRoleConditionGrantee,
+		g.config.FilesSharing.EnableResharing,
+	)
+	if role != nil {
+		perm.SetRoles([]string{role.GetId()})
+	} else {
+		actions := unifiedrole.CS3ResourcePermissionsToLibregraphActions(*share.GetPermissions().GetPermissions())
+		perm.SetLibreGraphPermissionsActions(actions)
+		perm.SetRoles(nil)
+	}
+	perm.SetGrantedToV2(grantedTo)
+	return &perm, nil
 }
 
 func (g Graph) cs3PublicSharesToDriveItems(ctx context.Context, shares []*link.PublicShare, driveItems driveItemsByResourceID) (driveItemsByResourceID, error) {

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -486,3 +486,12 @@ func convert(role *conversions.Role) []string {
 	}
 	return CS3ResourcePermissionsToLibregraphActions(*role.CS3ResourcePermissions())
 }
+
+func GetAllowedResourceActions(role *libregraph.UnifiedRoleDefinition, condition string) []string {
+	for _, p := range role.GetRolePermissions() {
+		if p.GetCondition() == condition {
+			return p.GetAllowedResourceActions()
+		}
+	}
+	return []string{}
+}


### PR DESCRIPTION
This is an initial implementation of PATCH support on drives/{driveid}/items/{itemid}/permissions/{id}.
It focusses on updating user shares for now. It's possible to update the expirationDate, roles and/or libregraphResourceActions.

Updating the permissions of a space root or a public link share is currently not implemented. Both should come with a follow up PR.

Somehow the usershareprovider is also still lacking checks if the sharer is actually allowed to set the requested permissions (e.g. when re-sharing). Still need to investigate that, but that something for a reva PR.
