### PR TITLE
run k6 test in remote server nightly

### DIFF
--- a/tests/config/drone/run_k6_tests.sh
+++ b/tests/config/drone/run_k6_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# start ocis server
+sshpass -p "$SSH_OCIS_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" \
+    "OCIS_URL=${TEST_SERVER_URL} \
+    OCIS_COMMIT_ID=${DRONE_COMMIT} \
+    bash ~/scripts/ocis.sh start"
+
+# start k6 tests
+sshpass -p "$SSH_K6_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_K6_USERNAME@$SSH_K6_REMOTE" \
+    "TEST_SERVER_URL=${TEST_SERVER_URL} \
+    bash ~/scripts/k6-tests.sh"
+
+# stop ocis server
+sshpass -p "$SSH_OCIS_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" "bash ~/scripts/ocis.sh stop"

--- a/tests/config/drone/ssh_login.sh
+++ b/tests/config/drone/ssh_login.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-apk add --no-cache openssh-client sshpass
-
-sshpass -p "$SSH_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_USERNAME@$SSH_SERVER" "$SSH_COMMAND"


### PR DESCRIPTION
NOTE: after this PR is ready, we have to:
- [x] enable it only for nightly
- [x] disable secrets for PRs