### PR TITLE
[tests-only][full-ci] tests: update tests related to deletion of public link password to use ocsv2 as well

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -517,7 +517,8 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 
 #### [Normal users can update the public link to delete its password if permission is not sent in data](https://github.com/owncloud/ocis/issues/7821)
 
-- [coreApiSharePublicLink1/changingPublicLinkShare.feature:154](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature#L154)
+- [coreApiSharePublicLink1/changingPublicLinkShare.feature:171](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature#L171)
+- [coreApiSharePublicLink1/changingPublicLinkShare.feature:172](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature#L172)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSpacesShares/shareOperations.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareOperations.feature
@@ -355,6 +355,7 @@ Feature: sharing
 
   Scenario Outline: space admin tries to remove password of a public link share (change/create permission)
     Given using spaces DAV path
+    And using OCS API version "<ocs_api_version>"
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
@@ -365,17 +366,20 @@ Feature: sharing
       | path        | /FOLDER       |
       | permissions | <permissions> |
       | password    |               |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
-      | permissions |
-      | change      |
-      | create      |
+      | ocs_api_version | permissions | http_status_code |
+      | 1               | change      | 200              |
+      | 2               | change      | 400              |
+      | 1               | create      | 200              |
+      | 2               | create      | 400              |
 
 
-  Scenario: space admin removes password of a public link share (read permission)
+  Scenario Outline: space admin removes password of a public link share (read permission)
     Given using spaces DAV path
+    And using OCS API version "<ocs_api_version>"
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
@@ -387,4 +391,8 @@ Feature: sharing
       | permissions | read    |
       | password    |         |
     Then the HTTP status code should be "200"
-    And the OCS status code should be "100"
+    And the OCS status code should be "<ocs_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -150,20 +150,24 @@ Feature: Share spaces via link
 
 
   Scenario Outline: space admin tries to remove password of a public link share of a space (various permission)
-    Given user "Alice" has created a public link share of the space "share space" with settings:
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created a public link share of the space "share space" with settings:
       | permissions | <permissions> |
       | password    | %public%      |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | <permissions> |
       | password    |               |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
-      | permissions |
-      | 5           |
-      | 15          |
-      | 4           |
+      | ocs_api_version | permissions | http_status_code |
+      | 1               | 5           | 200              |
+      | 2               | 5           | 400              |
+      | 1               | 15          | 200              |
+      | 2               | 15          | 400              |
+      | 1               | 4           | 200              |
+      | 2               | 4           | 400              |
 
 
   Scenario Outline: space admin removes password of a public link share of a space (invite permission)
@@ -183,8 +187,9 @@ Feature: Share spaces via link
       | 2               | 200             |
 
 
-  Scenario: space manager tries to remove password of a public link share of a space (read permission)
-    Given user "Alice" has shared a space "share space" with settings:
+  Scenario Outline: space manager tries to remove password of a public link share of a space (read permission)
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared a space "share space" with settings:
       | shareWith | Brian   |
       | role      | manager |
     And user "Brian" has created a public link share of the space "share space" with settings:
@@ -193,13 +198,18 @@ Feature: Share spaces via link
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | 1 |
       | password    |   |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "104"
     And the OCS status message should be "user is not allowed to delete the password from the public link"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 403              |
 
 
   Scenario Outline: space manager tries to remove password of a public link share of a space (various permission)
-    Given user "Alice" has shared a space "share space" with settings:
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared a space "share space" with settings:
       | shareWith | Brian   |
       | role      | manager |
     And user "Brian" has created a public link share of the space "share space" with settings:
@@ -208,14 +218,17 @@ Feature: Share spaces via link
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | <permissions> |
       | password    |               |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
-      | permissions |
-      | 5           |
-      | 15          |
-      | 4           |
+      | ocs_api_version | permissions | http_status_code |
+      | 1               | 5           | 200              |
+      | 2               | 5           | 400              |
+      | 1               | 15          | 200              |
+      | 2               | 15          | 400              |
+      | 1               | 4           | 200              |
+      | 2               | 4           | 400              |
 
 
   Scenario Outline: space manager removes password of a public link share of a space (invite permission)

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -163,13 +163,13 @@ Feature: changing a public link share
     When user "Alice" updates the last public link share using the sharing API with
       | path     | /PARENT |
       | password |         |
-    Then the HTTP status code should be "200"
-    And the OCS status code should be "400"
-    And the OCS status message should be "missing required password"
+    Then the HTTP status code should be "<http_status_code>"
+    And the OCS status code should be "104"
+    And the OCS status message should be "user is not allowed to delete the password from the public link"
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 403              |
 
 
   Scenario Outline: normal user removes password of a public link (invite only public link)

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -134,7 +134,8 @@ Feature: changing a public link share
 
 
   Scenario Outline: normal user tries to remove password of a public link share (change/create permission)
-    Given user "Alice" has created a public link share with settings
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
       | password    | %public%      |
@@ -142,17 +143,20 @@ Feature: changing a public link share
       | path        | /PARENT       |
       | permissions | <permissions> |
       | password    |               |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
-      | permissions |
-      | change      |
-      | create      |
+      | ocs_api_version | permissions | http_status_code |
+      | 1               | change      | 200              |
+      | 2               | change      | 400              |
+      | 1               | create      | 200              |
+      | 2               | create      | 400              |
 
   @issue-7821
-  Scenario: normal user tries to remove password of a public link (update without sending permissions)
-    Given user "Alice" has created a public link share with settings
+  Scenario Outline: normal user tries to remove password of a public link (update without sending permissions)
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created a public link share with settings
       | path        | /PARENT  |
       | permissions | change   |
       | password    | %public% |
@@ -162,6 +166,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "200"
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
+    Examples:
+      | ocs_api_version |
+      | 1               |
+      | 2               |
 
 
   Scenario Outline: normal user removes password of a public link (invite only public link)
@@ -184,8 +192,9 @@ Feature: changing a public link share
       | 2               | 200             |
 
 
-  Scenario: administrator removes password of a read-only public link
-    Given admin has created folder "/PARENT"
+  Scenario Outline: administrator removes password of a read-only public link
+    Given using OCS API version "<ocs_api_version>"
+    And admin has created folder "/PARENT"
     And user "admin" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "admin" has created a public link share with settings
       | path        | /PARENT  |
@@ -196,12 +205,17 @@ Feature: changing a public link share
       | permissions | read    |
       | password    |         |
     Then the HTTP status code should be "200"
-    And the OCS status code should be "100"
+    And the OCS status code should be "<ocs_status_code>"
     And the public should be able to download file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API with password ""
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: administrator tries to remove password of a public link share (change/create permission)
-    Given admin has created folder "/PARENT"
+    Given using OCS API version "<ocs_api_version>"
+    And admin has created folder "/PARENT"
     And user "admin" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
@@ -210,10 +224,12 @@ Feature: changing a public link share
       | path        | /PARENT       |
       | permissions | <permissions> |
       | password    |               |
-    Then the HTTP status code should be "200"
+    Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
-      | permissions |
-      | change      |
-      | create      |
+      | ocs_api_version | permissions | http_status_code |
+      | 1               | change      | 200              |
+      | 2               | change      | 400              |
+      | 1               | create      | 200              |
+      | 2               | create      | 400              |


### PR DESCRIPTION
Part of: https://github.com/owncloud/ocis/issues/7823
Updates the scenarios added in https://github.com/owncloud/ocis/pull/7540 to use `ocs-v2` as well