### PR TITLE
return only single permission on link creation

### DIFF
--- a/services/graph/pkg/service/v0/links.go
+++ b/services/graph/pkg/service/v0/links.go
@@ -52,7 +52,7 @@ func (g Graph) CreateLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	render.Status(r, http.StatusOK)
-	render.JSON(w, r, []libregraph.Permission{*perm})
+	render.JSON(w, r, *perm)
 }
 
 func (g Graph) createLink(ctx context.Context, driveItemID *providerv1beta1.ResourceId, createLink libregraph.DriveItemCreateLink) (*link.PublicShare, error) {

--- a/services/graph/pkg/service/v0/links_test.go
+++ b/services/graph/pkg/service/v0/links_test.go
@@ -165,15 +165,14 @@ var _ = Describe("createLinkTests", func() {
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
-			var createLinkResponseBody []*libregraph.Permission
+			var createLinkResponseBody *libregraph.Permission
 			err := json.Unmarshal(rr.Body.Bytes(), &createLinkResponseBody)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(createLinkResponseBody)).To(Equal(1))
-			Expect(createLinkResponseBody[0].GetId()).To(Equal("123"))
-			Expect(createLinkResponseBody[0].GetExpirationDateTime().Unix()).To(Equal(driveItemCreateLink.ExpirationDateTime.Unix()))
-			Expect(createLinkResponseBody[0].GetHasPassword()).To(Equal(false))
-			Expect(createLinkResponseBody[0].GetLink().LibreGraphDisplayName).To(Equal(libregraph.PtrString(ViewerLinkString)))
-			link := createLinkResponseBody[0].GetLink()
+			Expect(createLinkResponseBody.GetId()).To(Equal("123"))
+			Expect(createLinkResponseBody.GetExpirationDateTime().Unix()).To(Equal(driveItemCreateLink.ExpirationDateTime.Unix()))
+			Expect(createLinkResponseBody.GetHasPassword()).To(Equal(false))
+			Expect(createLinkResponseBody.GetLink().LibreGraphDisplayName).To(Equal(libregraph.PtrString(ViewerLinkString)))
+			link := createLinkResponseBody.GetLink()
 			respLinkType := link.GetType()
 			expected, err := libregraph.NewSharingLinkTypeFromValue("view")
 			Expect(err).ToNot(HaveOccurred())
@@ -357,15 +356,14 @@ var _ = Describe("createLinkTests", func() {
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
-			var createLinkResponseBody []*libregraph.Permission
+			var createLinkResponseBody *libregraph.Permission
 			err = json.Unmarshal(rr.Body.Bytes(), &createLinkResponseBody)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(createLinkResponseBody)).To(Equal(1))
-			Expect(createLinkResponseBody[0].GetId()).To(Equal("123"))
-			Expect(createLinkResponseBody[0].GetExpirationDateTime().Unix()).To(Equal(driveItemCreateLink.ExpirationDateTime.Unix()))
-			Expect(createLinkResponseBody[0].GetHasPassword()).To(Equal(false))
-			Expect(createLinkResponseBody[0].GetLink().LibreGraphDisplayName).To(Equal(libregraph.PtrString(ViewerLinkString)))
-			respLink := createLinkResponseBody[0].GetLink()
+			Expect(createLinkResponseBody.GetId()).To(Equal("123"))
+			Expect(createLinkResponseBody.GetExpirationDateTime().Unix()).To(Equal(driveItemCreateLink.ExpirationDateTime.Unix()))
+			Expect(createLinkResponseBody.GetHasPassword()).To(Equal(false))
+			Expect(createLinkResponseBody.GetLink().LibreGraphDisplayName).To(Equal(libregraph.PtrString(ViewerLinkString)))
+			respLink := createLinkResponseBody.GetLink()
 			// some conversion gymnastics
 			respLinkType := respLink.GetType()
 			Expect(err).ToNot(HaveOccurred())
@@ -374,7 +372,7 @@ var _ = Describe("createLinkTests", func() {
 			mockLink.Type = lt
 			expectedType := mockLink.GetType()
 			Expect(&respLinkType).To(Equal(&expectedType))
-			libreGraphActions := createLinkResponseBody[0].LibreGraphPermissionsActions
+			libreGraphActions := createLinkResponseBody.LibreGraphPermissionsActions
 			Expect(libreGraphActions[0]).To(Equal("libre.graph/driveItem/children/create"))
 			Expect(libreGraphActions[1]).To(Equal("libre.graph/driveItem/upload/create"))
 			Expect(libreGraphActions[2]).To(Equal("libre.graph/driveItem/path/update"))


### PR DESCRIPTION
## Description
according to the [libre-graph definition](https://github.com/owncloud/libre-graph-api/blob/main/api/openapi-spec/v1.0.yaml#L427-L430), the return of the create link call should be a single permission, not an array of permissions

## Motivation and Context
do what the specification says

## How Has This Been Tested?
- :robot: with unit tests
- creating links in integration tests of ocis-php-sdk

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
