### PR TITLE
[tests-only] Add 60 seconds default timeout for the API requests

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -368,7 +368,7 @@ class HttpRequestHelper {
 		}
 		$options['stream'] = $stream;
 		$options['verify'] = false;
-		$options['timeout'] = $timeout;
+		$options['timeout'] = $timeout ?: self::getRequestTimeout();
 		return new Client($options);
 	}
 
@@ -676,5 +676,13 @@ class HttpRequestHelper {
 			}
 		}
 		return $parsedResponse;
+	}
+
+	/**
+	 * @return int
+	 */
+	public static function getRequestTimeout(): int {
+		$timeout = \getenv("REQUEST_TIMEOUT");
+		return (int)$timeout ?: 60;
 	}
 }


### PR DESCRIPTION
## Description
Add 60 seconds default timeout for the API requests so that the test will fail with a timeout error if the request is not resolved due to some problem. This prevents the CI from being stuck forever.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/7841

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
