### PR TITLE
[docs-only] Fix Makefile Help

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@ include ../.bingo/Variables.mk
 
 .PHONY: help
 help:
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk -F'[:;##]' '{printf "\033[36m%-30s\033[0m %s\n", $$2, $$NF}'
 
 .PHONY: docs-generate
 docs-generate: ## run docs-generate for all oCIS services


### PR DESCRIPTION
Fixes the `make help` command in docs folder to include the relevant information

![Screenshot from 2023-12-07 11-46-45](https://github.com/owncloud/ocis/assets/12297468/488b8666-5b13-4654-a23b-28634c301dbd)
