### PR TITLE
[docs-only] Update dev-docs to collaps major nav entries

### DIFF
--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -1,10 +1,11 @@
 ---
-title: "Architecture"
-date: 2020-03-03T10:34:00+01:00
+title: Architecture
+date: 2023-12-06T13:00:00+01:00
 weight: 25
 geekdocRepo: https://github.com/owncloud/ocis
 geekdocEditPath: edit/master/docs/architecture
 geekdocFilePath: _index.md
+geekdocCollapseSection: true
 ---
 
 In the architecture part of the documentation we collect useful developer documentation on different aspects of the architecture. We are using mermaid.js to collaborate on the necessary diagrams.

--- a/docs/clients/_index.md
+++ b/docs/clients/_index.md
@@ -1,0 +1,9 @@
+---
+title: Clients
+date: 2023-12-06T13:00:00+01:00
+weight: 10
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/clients/
+geekdocFilePath: _index.md
+geekdocCollapseSection: true
+---

--- a/docs/ocis/_index.md
+++ b/docs/ocis/_index.md
@@ -5,6 +5,7 @@ weight: -10
 geekdocRepo: https://github.com/owncloud/ocis
 geekdocEditPath: edit/master/docs
 geekdocFilePath: _index.md
+geekdocCollapseSection: true
 ---
 
 {{< figure class="floatright" src="/media/is.png" width="70%" height="auto" >}}

--- a/docs/ocis/getting-started/_index.md
+++ b/docs/ocis/getting-started/_index.md
@@ -5,6 +5,7 @@ weight: 0
 geekdocRepo: https://github.com/owncloud/ocis
 geekdocEditPath: edit/master/docs/ocis/getting-started
 geekdocFilePath: _index.md
+geekdocCollapseSection: true
 ---
 
 {{< toc >}}

--- a/docs/services/_index.md
+++ b/docs/services/_index.md
@@ -1,0 +1,9 @@
+---
+title: Services
+date: 2023-12-06T13:00:00+01:00
+weight: 10
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/services/
+geekdocFilePath: _index.md
+geekdocCollapseSection: true
+---


### PR DESCRIPTION
This PR makes nav entries in dev docs containing sub elements collapsable. This eases readability a lot.