### PR TITLE
Edit public links and setPassword

### DIFF
--- a/changelog/unreleased/add-edit-public-share.md
+++ b/changelog/unreleased/add-edit-public-share.md
@@ -1,0 +1,6 @@
+Enhancement: Add edit public share to sharing NG
+
+We added the ability to edit public shares to the sharing NG endpoints.
+
+https://github.com/owncloud/ocis/pull/7908/
+https://github.com/owncloud/ocis/issues/6993

--- a/services/graph/pkg/errorcode/cs3.go
+++ b/services/graph/pkg/errorcode/cs3.go
@@ -45,7 +45,7 @@ func FromCS3Status(status *cs3rpc.Status, inerr error, ignore ...cs3rpc.Code) *E
 	case code == cs3rpc.Code_CODE_ALREADY_EXISTS:
 		err.errorCode = NameAlreadyExists
 	case code == cs3rpc.Code_CODE_FAILED_PRECONDITION:
-		err.errorCode = PreconditionFailed
+		err.errorCode = InvalidRequest
 	case code == cs3rpc.Code_CODE_OUT_OF_RANGE:
 		err.errorCode = InvalidRange
 	case code == cs3rpc.Code_CODE_UNIMPLEMENTED:

--- a/services/graph/pkg/errorcode/cs3_test.go
+++ b/services/graph/pkg/errorcode/cs3_test.go
@@ -29,7 +29,7 @@ func TestFromCS3Status(t *testing.T) {
 		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_UNAUTHENTICATED, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.Unauthenticated, "msg"))},
 		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_INVALID_ARGUMENT, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.InvalidRequest, "msg"))},
 		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_ALREADY_EXISTS, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.NameAlreadyExists, "msg"))},
-		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_FAILED_PRECONDITION, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.PreconditionFailed, "msg"))},
+		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_FAILED_PRECONDITION, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.InvalidRequest, "msg"))},
 		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_UNIMPLEMENTED, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.NotSupported, "msg"))},
 		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_INVALID, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.GeneralException, "msg"))},
 		{&cs3rpc.Status{Code: cs3rpc.Code_CODE_CANCELLED, Message: "msg"}, nil, nil, conversions.ToPointer(errorcode.New(errorcode.GeneralException, "msg"))},

--- a/services/graph/pkg/errorcode/errorcode.go
+++ b/services/graph/pkg/errorcode/errorcode.go
@@ -135,6 +135,8 @@ func (e Error) Render(w http.ResponseWriter, r *http.Request) {
 		status = http.StatusMethodNotAllowed
 	case ItemIsLocked:
 		status = http.StatusLocked
+	case PreconditionFailed:
+		status = http.StatusPreconditionFailed
 	default:
 		status = http.StatusInternalServerError
 	}

--- a/services/graph/pkg/linktype/linktype.go
+++ b/services/graph/pkg/linktype/linktype.go
@@ -31,6 +31,9 @@ func (l *LinkType) GetPermissions() *provider.ResourcePermissions {
 // SharingLinkTypeFromCS3Permissions creates a libregraph link type
 // It returns a list of libregraph actions when the conversion is not possible
 func SharingLinkTypeFromCS3Permissions(permissions *linkv1beta1.PublicSharePermissions) (*libregraph.SharingLinkType, []string) {
+	if permissions == nil {
+		return nil, nil
+	}
 	linkTypes := GetAvailableLinkTypes()
 	for _, linkType := range linkTypes {
 		if grants.PermissionsEqual(linkType.GetPermissions(), permissions.GetPermissions()) {

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -654,11 +654,18 @@ func (g Graph) UpdatePermission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// We don't implement updating link permissions yet
+	// This is a public link
 	if _, ok := oldPermission.GetLinkOk(); ok {
-		errorcode.NotSupported.Render(w, r, http.StatusNotImplemented, "not implemented")
+		updatedPermission, err := g.updatePublicLinkPermission(ctx, permissionID, &itemID, permission)
+		if err != nil {
+			errorcode.RenderError(w, r, err)
+			return
+		}
+		render.Status(r, http.StatusOK)
+		render.JSON(w, r, &updatedPermission)
 		return
 	}
+
 	// This is a user share
 	updatedPermission, err := g.updateUserShare(ctx, permissionID, oldPermission, permission)
 	if err != nil {

--- a/services/graph/pkg/service/v0/links.go
+++ b/services/graph/pkg/service/v0/links.go
@@ -263,13 +263,9 @@ func (g Graph) updatePublicLinkPermission(ctx context.Context, permissionID stri
 				Path:       ".",
 			},
 		})
-	if err != nil {
-		g.logger.Error().Err(err).Msg("transport error, could not stat resource")
-		return nil, errorcode.New(errorcode.GeneralException, err.Error())
-	}
-	if code := statResp.GetStatus().GetCode(); code != rpc.Code_CODE_OK {
-		g.logger.Debug().Interface("itemID", itemID).Msg(statResp.GetStatus().GetMessage())
-		return nil, errorcode.New(cs3StatusToErrCode(code), statResp.GetStatus().GetMessage())
+
+	if errCode := errorcode.FromCS3Status(statResp.GetStatus(), err); errCode != nil {
+		return nil, *errCode
 	}
 
 	if newPermission.HasExpirationDateTime() {

--- a/services/graph/pkg/service/v0/links.go
+++ b/services/graph/pkg/service/v0/links.go
@@ -14,6 +14,8 @@ import (
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/utils"
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/errorcode"
@@ -53,6 +55,52 @@ func (g Graph) CreateLink(w http.ResponseWriter, r *http.Request) {
 
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, *perm)
+}
+
+// SetLinkPassword sets public link password on the cs3 api
+func (g Graph) SetLinkPassword(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, itemID, err := g.GetDriveAndItemIDParam(r)
+	if err != nil {
+		errorcode.RenderError(w, r, err)
+		return
+	}
+
+	permissionID, err := url.PathUnescape(chi.URLParam(r, "permissionID"))
+	if err != nil {
+		g.logger.Debug().Err(err).Msg("could not parse permissionID")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid permissionID")
+		return
+	}
+
+	password := &libregraph.SharingLinkPassword{}
+	if err := StrictJSONUnmarshal(r.Body, password); err != nil {
+		g.logger.Debug().Err(err).Interface("Body", r.Body).Msg("failed unmarshalling request body")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	publicShare, err := g.getCS3PublicShareByID(ctx, permissionID)
+	if err != nil {
+		errorcode.RenderError(w, r, err)
+		return
+	}
+
+	// The resourceID of the shared resource need to match the item ID from the Request Path
+	// otherwise this is an invalid Request.
+	if !utils.ResourceIDEqual(publicShare.GetResourceId(), &itemID) {
+		g.logger.Debug().Msg("resourceID of shared does not match itemID")
+		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "permissionID and itemID do not match")
+		return
+	}
+
+	newPermission, err := g.updatePublicLinkPassword(ctx, permissionID, password.GetPassword())
+	if err != nil {
+		errorcode.RenderError(w, r, err)
+	}
+
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, *newPermission)
 }
 
 func (g Graph) createLink(ctx context.Context, driveItemID *providerv1beta1.ResourceId, createLink libregraph.DriveItemCreateLink) (*link.PublicShare, error) {
@@ -146,6 +194,9 @@ func (g Graph) libreGraphPermissionFromCS3PublicShare(createdLink *link.PublicSh
 	if createdLink.GetExpiration() != nil {
 		perm.SetExpirationDateTime(cs3TimestampToTime(createdLink.GetExpiration()).UTC())
 	}
+
+	perm.SetHasPassword(createdLink.GetPasswordProtected())
+
 	return perm, nil
 }
 
@@ -164,4 +215,111 @@ func parseAndFillUpTime(t *time.Time) *types.Timestamp {
 		Seconds: uint64(final / 1000000000),
 		Nanos:   uint32(final % 1000000000),
 	}
+}
+
+func (g Graph) updatePublicLinkPassword(ctx context.Context, permissionID string, password string) (*libregraph.Permission, error) {
+	gatewayClient, err := g.gatewaySelector.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	changeLinkRes, err := gatewayClient.UpdatePublicShare(ctx, &link.UpdatePublicShareRequest{
+		Update: &link.UpdatePublicShareRequest_Update{
+			Type: link.UpdatePublicShareRequest_Update_TYPE_PASSWORD,
+			Grant: &link.Grant{
+				Password: password,
+			},
+		},
+		Ref: &link.PublicShareReference{
+			Spec: &link.PublicShareReference_Id{
+				Id: &link.PublicShareId{
+					OpaqueId: permissionID,
+				},
+			},
+		},
+	})
+	if errCode := errorcode.FromCS3Status(changeLinkRes.GetStatus(), err); errCode != nil {
+		return nil, *errCode
+	}
+	permission, err := g.libreGraphPermissionFromCS3PublicShare(changeLinkRes.GetShare())
+	if err != nil {
+		return nil, err
+	}
+	return permission, nil
+}
+
+func (g Graph) updatePublicLinkPermission(ctx context.Context, permissionID string, info *providerv1beta1.ResourceInfo, newPermission *libregraph.Permission) (perm *libregraph.Permission, err error) {
+	if newPermission.HasExpirationDateTime() {
+		expirationDate := newPermission.GetExpirationDateTime()
+		update := &link.UpdatePublicShareRequest_Update{
+			Type:  link.UpdatePublicShareRequest_Update_TYPE_EXPIRATION,
+			Grant: &link.Grant{Expiration: parseAndFillUpTime(&expirationDate)},
+		}
+		perm, err = g.updatePublicLink(ctx, permissionID, update)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if newPermission.HasLink() && newPermission.Link.HasLibreGraphDisplayName() {
+		changedLink := newPermission.GetLink()
+		update := &link.UpdatePublicShareRequest_Update{
+			Type:        link.UpdatePublicShareRequest_Update_TYPE_DISPLAYNAME,
+			DisplayName: changedLink.GetLibreGraphDisplayName(),
+		}
+		perm, err = g.updatePublicLink(ctx, permissionID, update)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if newPermission.HasLink() && newPermission.Link.HasType() {
+		changedLink := newPermission.Link.GetType()
+		permissions, err := linktype.CS3ResourcePermissionsFromSharingLink(
+			libregraph.DriveItemCreateLink{
+				Type: &changedLink,
+			},
+			info.GetType(),
+		)
+		update := &link.UpdatePublicShareRequest_Update{
+			Type: link.UpdatePublicShareRequest_Update_TYPE_PERMISSIONS,
+			Grant: &link.Grant{
+				Permissions: &link.PublicSharePermissions{Permissions: permissions},
+			},
+		}
+		perm, err = g.updatePublicLink(ctx, permissionID, update)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return perm, err
+}
+
+func (g Graph) updatePublicLink(ctx context.Context, permissionID string, update *link.UpdatePublicShareRequest_Update) (*libregraph.Permission, error) {
+	gatewayClient, err := g.gatewaySelector.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	changeLinkRes, err := gatewayClient.UpdatePublicShare(ctx, &link.UpdatePublicShareRequest{
+		Update: update,
+		Ref: &link.PublicShareReference{
+			Spec: &link.PublicShareReference_Id{
+				Id: &link.PublicShareId{
+					OpaqueId: permissionID,
+				},
+			},
+		},
+	})
+
+	if errCode := errorcode.FromCS3Status(changeLinkRes.GetStatus(), err); errCode != nil {
+		return nil, *errCode
+	}
+
+	permission, err := g.libreGraphPermissionFromCS3PublicShare(changeLinkRes.GetShare())
+	if err != nil {
+		return nil, err
+	}
+	return permission, nil
 }

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -110,6 +110,7 @@ type Service interface {
 	GetDriveItem(w http.ResponseWriter, r *http.Request)
 	GetDriveItemChildren(w http.ResponseWriter, r *http.Request)
 	CreateLink(w http.ResponseWriter, r *http.Request)
+	SetLinkPassword(writer http.ResponseWriter, request *http.Request)
 
 	Invite(w http.ResponseWriter, r *http.Request)
 	ListPermissions(w http.ResponseWriter, r *http.Request)
@@ -218,6 +219,7 @@ func NewService(opts ...Option) (Graph, error) {
 					r.Route("/{permissionID}", func(r chi.Router) {
 						r.Delete("/", svc.DeletePermission)
 						r.Patch("/", svc.UpdatePermission)
+						r.Post("/setPassword", svc.SetLinkPassword)
 					})
 				})
 				r.Post("/createLink", svc.CreateLink)

--- a/services/graph/pkg/validate/libregraph.go
+++ b/services/graph/pkg/validate/libregraph.go
@@ -47,6 +47,10 @@ func permission(v *validator.Validate) {
 			sl.ReportError(permission.Id, "Id", "Id", "readonly", "")
 		}
 
+		if _, ok := permission.GetHasPasswordOk(); ok {
+			sl.ReportError(permission.HasPassword, "hasPassword", "HasPassword", "readonly", "")
+		}
+
 		rolesAndActions(sl, permission.Roles, permission.LibreGraphPermissionsActions, true)
 	}, s)
 }


### PR DESCRIPTION
## Description

- [x] Add https://owncloud.dev/libre-graph-api/#/drives.permissions/UpdatePermission for public shares
- [x] Add https://owncloud.dev/libre-graph-api/#/drives.permissions/SetPermissionPassword

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Relates to #6993 

## Motivation and Context

Improve our APIs 🎉 

## How Has This Been Tested?
- manually
- unit tests


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
