### PR TITLE
fix: reduce mtime keywords to the required ones

### DIFF
--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -300,7 +300,7 @@ func FrontendConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string
 										"enabled": true,
 									},
 									"mtime": map[string]interface{}{
-										"keywords": []string{"today", "yesterday", "this week", "last week", "last 7 days", "this month", "last month", "last 30 days", "this year", "last year"},
+										"keywords": []string{"today", "last 7 days", "last 30 days", "this year", "last year"},
 										"enabled":  true,
 									},
 									"size": map[string]interface{}{


### PR DESCRIPTION
## Description
As per product management requirements, this PR reduces the set of available `mdate` filter keywords, see https://github.com/owncloud/web/issues/9779#issuecomment-1807930111

## Related Issue
- Relates to https://github.com/owncloud/web/issues/9779#issuecomment-1807930111

## Motivation and Context
Keep filter options simple until we have more feedback what's actually needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
