### PR TITLE
[full-ci] chore: bump web to v8.0.0-beta.2

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=f3b6c0699537483a1497c69c2493b271f45def9d
+WEB_COMMITID=fd1349c4ff15c11a0a520c1e66be7db554d88241
 WEB_BRANCH=master

--- a/changelog/unreleased/update-web-8.0.0.md
+++ b/changelog/unreleased/update-web-8.0.0.md
@@ -1,0 +1,14 @@
+Enhancement: Update web to v8.0.0-beta.2
+
+Tags: web
+
+We updated ownCloud Web to v8.0.0-beta.2. Please refer to the changelog (linked) for details on the web release.
+
+## Summary
+* Bugfix [owncloud/web#10010](https://github.com/owncloud/web/issues/10010): Displaying full video in their dimensions
+* Bugfix [owncloud/web#10149](https://github.com/owncloud/web/pull/10149): Spaces files list previews cropped
+* Bugfix [owncloud/web#10149](https://github.com/owncloud/web/pull/10149): Spaces overview tile previews zoomed
+* Bugfix [owncloud/web#10154](https://github.com/owncloud/web/pull/10154): Resolving links without drive alias
+
+https://github.com/owncloud/ocis/pull/7952
+https://github.com/owncloud/web/releases/tag/v8.0.0-beta.2

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.0-beta.1
+WEB_ASSETS_VERSION = v8.0.0-beta.2
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
This includes some fixes for the most recent right sidebar panel enhancement.