### PR TITLE
[full-ci] graph sharing: Fixes for UpdateShare

### DIFF
--- a/changelog/unreleased/bump-reva.md
+++ b/changelog/unreleased/bump-reva.md
@@ -5,3 +5,4 @@ Bumps reva version
 https://github.com/owncloud/ocis/pull/7793
 https://github.com/owncloud/ocis/pull/7978
 https://github.com/owncloud/ocis/pull/7979
+https://github.com/owncloud/ocis/pull/7963

--- a/changelog/unreleased/fix-update-share-ng.md
+++ b/changelog/unreleased/fix-update-share-ng.md
@@ -1,0 +1,6 @@
+Bugfix: Update permission validation
+
+We fixed a bug where the permission validation was not working correctly.
+
+https://github.com/owncloud/ocis/pull/7963
+https://github.com/cs3org/reva/pull/4405

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/cs3org/go-cs3apis v0.0.0-20231023073225-7748710e0781
-	github.com/cs3org/reva/v2 v2.17.1-0.20231215113433-48c0ea55bf47
+	github.com/cs3org/reva/v2 v2.17.1-0.20231215134723-5142bf31838d
 	github.com/dhowden/tag v0.0.0-20230630033851-978a0926ee25
 	github.com/disintegration/imaging v1.6.2
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e

--- a/go.sum
+++ b/go.sum
@@ -1023,6 +1023,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20231023073225-7748710e0781 h1:BUdwkIlf8IS2F
 github.com/cs3org/go-cs3apis v0.0.0-20231023073225-7748710e0781/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/reva/v2 v2.17.1-0.20231215113433-48c0ea55bf47 h1:6DfMeFpCXoqlfm/+FJ/mFs8Ul5WCZNlorsbDM9Z/ATE=
 github.com/cs3org/reva/v2 v2.17.1-0.20231215113433-48c0ea55bf47/go.mod h1:oX1YtLKGr7jatGk0CpPM4GKbSEIdHhmsQuSAYElnN1U=
+github.com/cs3org/reva/v2 v2.17.1-0.20231215134723-5142bf31838d h1:OYkjbcOAntD5JBMAuyj+bR1bg5jM+BjRvFBiTlmnxWQ=
+github.com/cs3org/reva/v2 v2.17.1-0.20231215134723-5142bf31838d/go.mod h1:JyvlRw2v8BTH5t+ISj1Yc+EMDBcyf8LMB5o98HufWis=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -800,14 +800,11 @@ func (g Graph) updateUserShare(ctx context.Context, permissionID string, oldPerm
 	}
 
 	cs3UpdateShareReq := &collaboration.UpdateShareRequest{
-		Ref: &collaboration.ShareReference{
-			Spec: &collaboration.ShareReference_Id{
-				Id: &collaboration.ShareId{
-					OpaqueId: permissionID,
-				},
+		Share: &collaboration.Share{
+			Id: &collaboration.ShareId{
+				OpaqueId: permissionID,
 			},
 		},
-		Share: &collaboration.Share{},
 	}
 	fieldmask := []string{}
 	if expiration, ok := newPermission.GetExpirationDateTimeOk(); ok {

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -670,6 +670,7 @@ func (g Graph) UpdatePermission(w http.ResponseWriter, r *http.Request) {
 	updatedPermission, err := g.updateUserShare(ctx, permissionID, oldPermission, permission)
 	if err != nil {
 		errorcode.RenderError(w, r, err)
+		return
 	}
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, &updatedPermission)

--- a/services/graph/pkg/service/v0/driveitems_test.go
+++ b/services/graph/pkg/service/v0/driveitems_test.go
@@ -597,7 +597,7 @@ var _ = Describe("Driveitems", func() {
 			updateShareMock := gatewayClient.On("UpdateShare",
 				mock.Anything,
 				mock.MatchedBy(func(req *collaboration.UpdateShareRequest) bool {
-					if req.GetRef().GetId().GetOpaqueId() == "permissionid" {
+					if req.GetShare().GetId().GetOpaqueId() == "permissionid" {
 						return expiration.Equal(utils.TSToTime(req.GetShare().GetExpiration()))
 					}
 					return false
@@ -628,7 +628,7 @@ var _ = Describe("Driveitems", func() {
 			updateShareMock := gatewayClient.On("UpdateShare",
 				mock.Anything,
 				mock.MatchedBy(func(req *collaboration.UpdateShareRequest) bool {
-					if req.GetRef().GetId().GetOpaqueId() == "permissionid" {
+					if req.GetShare().GetId().GetOpaqueId() == "permissionid" {
 						return true
 					}
 					return false
@@ -659,7 +659,7 @@ var _ = Describe("Driveitems", func() {
 			updateShareMock := gatewayClient.On("UpdateShare",
 				mock.Anything,
 				mock.MatchedBy(func(req *collaboration.UpdateShareRequest) bool {
-					return req.GetRef().GetId().GetOpaqueId() == "permissionid"
+					return req.GetShare().GetId().GetOpaqueId() == "permissionid"
 				}),
 			)
 			updateShareMock.Return(updateShareMockResponse, nil)
@@ -687,7 +687,7 @@ var _ = Describe("Driveitems", func() {
 			updateShareMock := gatewayClient.On("UpdateShare",
 				mock.Anything,
 				mock.MatchedBy(func(req *collaboration.UpdateShareRequest) bool {
-					return req.GetRef().GetId().GetOpaqueId() == "permissionid"
+					return req.GetShare().GetId().GetOpaqueId() == "permissionid"
 				}),
 			)
 			updateShareMockResponse.Share.Permissions = &collaboration.SharePermissions{

--- a/vendor/github.com/cs3org/reva/v2/internal/grpc/services/gateway/usershareprovider.go
+++ b/vendor/github.com/cs3org/reva/v2/internal/grpc/services/gateway/usershareprovider.go
@@ -119,6 +119,9 @@ func (s *svc) updateShare(ctx context.Context, req *collaboration.UpdateShareReq
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling UpdateShare")
 	}
+	if res.GetStatus().GetCode() != rpc.Code_CODE_OK {
+		return res, nil
+	}
 
 	if s.c.CommitShareToStorageGrant {
 		creator := ctxpkg.ContextMustGetUser(ctx)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -362,7 +362,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.17.1-0.20231215113433-48c0ea55bf47
+# github.com/cs3org/reva/v2 v2.17.1-0.20231215134723-5142bf31838d
 ## explicit; go 1.21
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
This fixes two smaller issue in the UpdateShare handler:
- We were using some deprecated attribute in the CS3 UpdateShare request
- a return statement was missing under some error conditions we return an invalid response

This needs: https://github.com/cs3org/reva/pull/4405