### PR TITLE
[tests-only][full-ci] wait for ocis server with timeout (5 mins timeout)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -896,9 +896,9 @@ def wopiValidatorTests(ctx, storage, accounts_hash_difficulty = 4):
                      },
                      {
                          "name": "wait-for-fakeoffice",
-                         "image": OC_CI_ALPINE,
+                         "image": OC_CI_WAIT_FOR,
                          "commands": [
-                             "curl -k --fail --retry-connrefused --retry 9 --retry-all-errors 'http://fakeoffice:8080'",
+                             "wait-for -it fakeoffice:8080 -t 300",
                          ],
                      },
                  ] +
@@ -916,9 +916,9 @@ def wopiValidatorTests(ctx, storage, accounts_hash_difficulty = 4):
                      },
                      {
                          "name": "wait-for-wopi-server",
-                         "image": OC_CI_ALPINE,
+                         "image": OC_CI_WAIT_FOR,
                          "commands": [
-                             "curl -k --fail --retry-connrefused --retry 9 --retry-all-errors 'http://wopiserver:8880/wopi'",
+                             "wait-for -it wopiserver:8880 -t 300",
                          ],
                      },
                      {
@@ -1968,7 +1968,8 @@ def ocisServer(storage, accounts_hash_difficulty = 4, volumes = [], depends_on =
         "name": "wait-for-ocis-server",
         "image": OC_CI_ALPINE,
         "commands": [
-            "curl -k -u admin:admin --fail --retry-connrefused --retry 7 --retry-all-errors 'https://ocis-server:9200/graph/v1.0/users/admin'",
+            # wait for ocis-server to be ready (5 minutes)
+            "timeout 300 bash -c 'while [ $(curl -sk -uadmin:admin https://ocis-server:9200/graph/v1.0/users/admin -w %{http_code} -o /dev/null) != 200 ]; do sleep 1; done'",
         ],
         "depends_on": depends_on,
     }


### PR DESCRIPTION
## Description
We used to have 300 seconds (5 mins) timeout for service to be ready with wait-for -it. command to wait for ocis connection was changed and the timeout was approx. ~2 mins. There can be some pipeline where image pull could take some time and `wait-for-ocis-server` step fails due to timeout. e.g. https://drone.owncloud.com/owncloud/ocis/30033/11/6

With this PR, we are waiting for ocis to be ready with the same old curl command but with the added timeout of 300 seconds

## Related Issue

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
