### PR TITLE
[tests-only][full-ci]Added tests for creating link for a resource

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1631,7 +1631,7 @@ class GraphHelper {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public static function createShareLink(
+	public static function createLinkShare(
 		string $baseUrl,
 		string $xRequestId,
 		string $user,

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1618,4 +1618,36 @@ class GraphHelper {
 			\json_encode($body)
 		);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $spaceId
+	 * @param string $itemId
+	 * @param mixed $body
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function createShareLink(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $spaceId,
+		string $itemId,
+		$body
+	): ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/createLink");
+		return HttpRequestHelper::post(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			$body
+		);
+	}
 }

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -255,6 +255,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiLocks/lockFiles.feature:456](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiLocks/lockFiles.feature#L456)
 - [apiLocks/lockFiles.feature:457](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiLocks/lockFiles.feature#L457)
 
+### [blocksDownload link type is not implemented yet (sharing-ng)](https://github.com/owncloud/ocis/issues/7879)
+- [apiSharingNg/createLink.feature:78](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/createLink.feature#L78)
+- [apiSharingNg/createLink.feature:147](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/createLink.feature#L147)
 
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSharingNg/createLink.feature
+++ b/tests/acceptance/features/apiSharingNg/createLink.feature
@@ -6,11 +6,15 @@ Feature: Create a share link for a resource
       | username |
       | Alice    |
 
-  Scenario Outline: create a sharing link for a folder
+
+  Scenario Outline: create a link share of a folder
     Given user "Alice" has created folder "folder"
-    When user "Alice" creates a share link for a folder "folder" of the space "Personal" using the Graph API with settings:
-      | role     | <role>   |
-      | password | %public% |
+    When user "Alice" creates the following link share using the Graph API:
+      | resourceType | folder   |
+      | resource     | folder   |
+      | space        | Personal |
+      | role         | <role>   |
+      | password     | %public% |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -71,13 +75,17 @@ Feature: Create a share link for a resource
       | edit           |
       | upload         |
       | createOnly     |
+      | blocksDownload |
 
 
-  Scenario Outline: create a sharing link for a file
-    Given user "Alice" has uploaded file with content "other data" to "/textfile1.txt"
-    When user "Alice" creates a share link for a file "textfile1.txt" of the space "Personal" using the Graph API with settings:
-      | role     | <role>   |
-      | password | %public% |
+  Scenario Outline: create a link share of a file
+    Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
+    When user "Alice" creates the following link share using the Graph API:
+      | resourceType | file          |
+      | resource     | textfile1.txt |
+      | space        | Personal      |
+      | role         | <role>        |
+      | password     | %public%      |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -136,3 +144,4 @@ Feature: Create a share link for a resource
       | role           |
       | view           |
       | edit           |
+      | blocksDownload |

--- a/tests/acceptance/features/apiSharingNg/createLink.feature
+++ b/tests/acceptance/features/apiSharingNg/createLink.feature
@@ -1,0 +1,138 @@
+Feature: Create a share link for a resource
+  https://owncloud.dev/libre-graph-api/#/drives.permissions/CreateLink
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+
+  Scenario Outline: create a sharing link for a folder
+    Given user "Alice" has created folder "folder"
+    When user "Alice" creates a share link for a folder "folder" of the space "Personal" using the Graph API with settings:
+      | role     | <role>   |
+      | password | %public% |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "hasPassword",
+          "id",
+          "link"
+        ],
+        "properties": {
+          "hasPassword": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]{15}$"
+          },
+          "link": {
+            "type": "object",
+            "required": [
+              "@libre.graph.displayName",
+              "@libre.graph.quickLink",
+              "preventsDownload",
+              "type",
+              "webUrl"
+            ],
+            "properties": {
+              "@libre.graph.displayName": {
+                "type": "string",
+                "enum": [""]
+              },
+              "@libre.graph.quickLink": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "preventsDownload": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "type": {
+                "type": "string",
+                "enum": ["<role>"]
+              },
+              "webUrl": {
+                "type": "string",
+                "pattern": "^%base_url%\/s\/[a-zA-Z]{15}$"
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | role           |
+      | view           |
+      | edit           |
+      | upload         |
+      | createOnly     |
+
+
+  Scenario Outline: create a sharing link for a file
+    Given user "Alice" has uploaded file with content "other data" to "/textfile1.txt"
+    When user "Alice" creates a share link for a file "textfile1.txt" of the space "Personal" using the Graph API with settings:
+      | role     | <role>   |
+      | password | %public% |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "hasPassword",
+          "id",
+          "link"
+        ],
+        "properties": {
+          "hasPassword": {
+            "type": "boolean",
+            "enum": [true]
+          },
+          "id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]{15}$"
+          },
+          "link": {
+            "type": "object",
+            "required": [
+              "@libre.graph.displayName",
+              "@libre.graph.quickLink",
+              "preventsDownload",
+              "type",
+              "webUrl"
+            ],
+            "properties": {
+              "@libre.graph.displayName": {
+                "type": "string",
+                "enum": [""]
+              },
+              "@libre.graph.quickLink": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "preventsDownload": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "type": {
+                "type": "string",
+                "enum": ["<role>"]
+              },
+              "webUrl": {
+                "type": "string",
+                "pattern": "^%base_url%\/s\/[a-zA-Z]{15}$"
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | role           |
+      | view           |
+      | edit           |

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -120,29 +120,27 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a share link for a (folder|file) "([^"]*)" of the space "([^"]*)" using the Graph API with settings:$/
+	 * @When /^user "([^"]*)" creates the following link share using the Graph API:$/
 	 *
 	 * @param string $user
-	 * @param string $fileOrFolder (file|folder)
-	 * @param string $resource
-	 * @param string $space
 	 * @param TableNode|null $body
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userCreatesAPublicLinkShareWithSettings($user, $fileOrFolder, $resource, $space, $body):void {
+	public function userCreatesAPublicLinkShareWithSettings(string $user, TableNode  $body):void {
+		$bodyRows = $body->getRowsHash();
+		$space = $bodyRows['space'];
+		$resourceType = $bodyRows['resourceType'];
+		$resource = $bodyRows['resource'];
+
 		$spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
-		if ($fileOrFolder === 'folder') {
+		if ($resourceType === 'folder') {
 			$itemId = $this->spacesContext->getResourceId($user, $space, $resource);
 		} else {
 			$itemId = $this->spacesContext->getFileId($user, $space, $resource);
 		}
-		$bodyRows = $body->getRowsHash();
-		Assert::assertTrue(
-			\array_key_exists('password', $bodyRows),
-			'"Password" needs to be provided while creating a share link'
-		);
+
 		$bodyRows['displayName'] = \array_key_exists('displayName', $bodyRows) ? $bodyRows['displayName'] : null;
 		$bodyRows['expirationDateTime'] = \array_key_exists('expirationDateTime', $bodyRows) ? $bodyRows['expirationDateTime'] : null;
 		$body = [
@@ -153,7 +151,7 @@ class SharingNgContext implements Context {
 		];
 
 		$this->featureContext->setResponse(
-			GraphHelper::createShareLink(
+			GraphHelper::createLinkShare(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getStepLineRef(),
 				$user,


### PR DESCRIPTION
### Description
This PR adds the implementation for new `v1beta1` graph-api to create a share link with different roles.

```feature
Scenario Outline: create a link share of a folder
Scenario Outline: create a link share of a file
```

### Related Issue:
https://github.com/owncloud/ocis/issues/7968