### PR TITLE
Use KV store in nats registry

### DIFF
--- a/changelog/unreleased/kv-nats-registry.md
+++ b/changelog/unreleased/kv-nats-registry.md
@@ -1,0 +1,5 @@
+Enhancement: Use kv store in natsjs registry
+
+Replaces the nats object store with the nats kv store in the natsjs registry
+
+https://github.com/owncloud/ocis/pull/7987

--- a/ocis-pkg/natsjsregistry/registry.go
+++ b/ocis-pkg/natsjsregistry/registry.go
@@ -1,4 +1,4 @@
-// Package natsjsregistry implements a registry using natsjs object store
+// Package natsjsregistry implements a registry using natsjs kv store
 package natsjsregistry
 
 import (
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"time"
 
-	natsjs "github.com/go-micro/plugins/v4/store/nats-js"
+	natsjskv "github.com/go-micro/plugins/v4/store/nats-js-kv"
 	"go-micro.dev/v4/registry"
 	"go-micro.dev/v4/store"
 	"go-micro.dev/v4/util/cmd"
@@ -30,7 +30,7 @@ func NewRegistry(opts ...registry.Option) registry.Registry {
 	exp, _ := options.Context.Value(expiryKey{}).(time.Duration)
 	return &storeregistry{
 		opts:   options,
-		store:  natsjs.NewStore(storeOptions(options)...),
+		store:  natsjskv.NewStore(storeOptions(options)...),
 		typ:    _registryName,
 		expiry: exp,
 	}


### PR DESCRIPTION
Uses the new natsjs-kv store instead of the object store in the nats registry