### PR TITLE
Switch default registry to `nats-js-kv`

### DIFF
--- a/changelog/unreleased/default-registry.md
+++ b/changelog/unreleased/default-registry.md
@@ -1,5 +1,5 @@
 Enhancement: Make nats-js-kv the default registry
 
-The previously used default `mdns` is faulty. Deprecated it and `consul`, `nats` and `etcd` implementations
+The previously used default `mdns` is faulty. Deprecated it together with `consul`, `nats` and `etcd` implementations.
 
 https://github.com/owncloud/ocis/pull/8011

--- a/changelog/unreleased/default-registry.md
+++ b/changelog/unreleased/default-registry.md
@@ -1,0 +1,5 @@
+Enhancement: Make nats-js-kv the default registry
+
+The previously used default `mdns` is faulty. Deprecated it and `consul`, `nats` and `etcd` implementations
+
+https://github.com/owncloud/ocis/pull/8011

--- a/docs/services/general-info/registry.md
+++ b/docs/services/general-info/registry.md
@@ -1,0 +1,42 @@
+---
+title: Registry
+date: 2023-12-19T00:00:00+00:00
+weight: 20
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/services/general-info
+geekdocFilePath: registry.md
+geekdocCollapseSection: true
+---
+
+To be able to communicate with each other, services need to register in a common registry.
+
+## Configuration
+
+The type of registry to use can be configured with the `MICRO_REGISTRY` environment variable. Supported values are:
+
+### `memory`
+
+Setting the environment variable to `memory` starts an inmemory registry. This only works with the single binary deployment.
+
+### `nats-js-kv`
+
+Set the environment variable to `nats-js-kv` (or leave it empty) to use a nats-js key value store as registry.
+- Note: If not running build-in nats, `MICRO_REGISTRY_ADDRESS` needs to be set to the address of the nats-js cluster. (Same as `OCIS_EVENTS_ENDPOINT`)
+- Optional: Use `MICRO_REGISTRY_AUTH_USERNAME` and `MICRO_REGISTRY_AUTH_PASSWORD` to authenticate with the nats cluster.
+
+This is the default.
+
+### `kubernetes`
+
+When deploying in a kubernetes cluster, the kubernetes registry can be used. Additionally the `MICRO_REGISTRY_ADDRESS` environment
+variable needs to be set to the url of the kubernetes registry.
+
+### Deprecated registries
+
+These registries are currently working but will be removed in a later version. It is recommended to switch to a supported one.
+
+- `nats`. Uses a registry based on nats streams. Requires `MICRO_REGISTRY_ADDRESS` to bet set.
+- `etcd`. Uses an etcd cluster as registry. Requires `MICRO_REGISTRY_ADDRESS` to bet set.
+- `consul`. Uses `HashiCorp Consul` as registry. Requires `MICRO_REGISTRY_ADDRESS` to bet set.
+- `mdns`.  Uses multicast dns for registration. This type can have unwanted side effects when other devices in the local network use mdns too.
+

--- a/docs/services/general-info/registry.md
+++ b/docs/services/general-info/registry.md
@@ -18,20 +18,17 @@ The type of registry to use can be configured with the `MICRO_REGISTRY` environm
 
 Setting the environment variable to `memory` starts an inmemory registry. This only works with the single binary deployment.
 
-### `nats-js-kv`
+### `nats-js-kv` (Default)
 
-Set the environment variable to `nats-js-kv` (or leave it empty) to use a nats-js key value store as registry.
-- Note: If not running build-in nats, `MICRO_REGISTRY_ADDRESS` needs to be set to the address of the nats-js cluster. (Same as `OCIS_EVENTS_ENDPOINT`)
+Set the environment variable to `nats-js-kv` or leave it empty to use a nats-js key value store as registry.
+- Note: If not running build-in nats, `MICRO_REGISTRY_ADDRESS` needs to be set to the address of the nats-js cluster, which is the same value as `OCIS_EVENTS_ENDPOINT`.
 - Optional: Use `MICRO_REGISTRY_AUTH_USERNAME` and `MICRO_REGISTRY_AUTH_PASSWORD` to authenticate with the nats cluster.
-
-This is the default.
-
 ### `kubernetes`
 
 When deploying in a kubernetes cluster, the kubernetes registry can be used. Additionally the `MICRO_REGISTRY_ADDRESS` environment
 variable needs to be set to the url of the kubernetes registry.
 
-### Deprecated registries
+### Deprecated Registries
 
 These registries are currently working but will be removed in a later version. It is recommended to switch to a supported one.
 

--- a/ocis/pkg/command/server.go
+++ b/ocis/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
-	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/ocis/pkg/register"
 	"github.com/owncloud/ocis/v2/ocis/pkg/runtime"
 	"github.com/urfave/cli/v2"
@@ -21,7 +20,6 @@ func Server(cfg *config.Config) *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			// Prefer the in-memory registry as the default when running in single-binary mode
-			registry.Configure("memory")
 			r := runtime.New(cfg)
 			return r.Start()
 		},

--- a/services/graph/pkg/service/v0/graph_suite_test.go
+++ b/services/graph/pkg/service/v0/graph_suite_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func init() {
-	registry.Configure("memory")
-	r := registry.GetRegistry()
+	r := registry.GetRegistry(registry.Inmemory())
 	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",

--- a/services/notifications/pkg/service/notification_suite_test.go
+++ b/services/notifications/pkg/service/notification_suite_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func init() {
-	registry.Configure("memory")
-	r := registry.GetRegistry()
+	r := registry.GetRegistry(registry.Inmemory())
 	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",

--- a/services/search/pkg/search/search_suite_test.go
+++ b/services/search/pkg/search/search_suite_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func init() {
-	registry.Configure("memory")
-	r := registry.GetRegistry()
+	r := registry.GetRegistry(registry.Inmemory())
 	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",

--- a/services/storage-users/pkg/task/task_suite_test.go
+++ b/services/storage-users/pkg/task/task_suite_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func init() {
-	registry.Configure("memory")
-	r := registry.GetRegistry()
+	r := registry.GetRegistry(registry.Inmemory())
 	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",

--- a/services/userlog/pkg/service/service_suit_test.go
+++ b/services/userlog/pkg/service/service_suit_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func init() {
-	registry.Configure("memory")
-	r := registry.GetRegistry()
+	r := registry.GetRegistry(registry.Inmemory())
 	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",


### PR DESCRIPTION
- Switches the default registry to `nats-js-kv`
- Deprecates `consul`, `nats`, `etcd` and `mdns` registries
- Documents registry usage