### PR TITLE
Use a on-sampling instead of noop traceprovider to get proper traceids

### DIFF
--- a/changelog/unreleased/fix-empty-traceids.md
+++ b/changelog/unreleased/fix-empty-traceids.md
@@ -1,0 +1,5 @@
+Bugfix: Fix empty trace ids
+
+We changed the default tracing to produce non-empty traceids.
+
+https://github.com/owncloud/ocis/pull/8017

--- a/ocis-pkg/tracing/tracing.go
+++ b/ocis-pkg/tracing/tracing.go
@@ -39,7 +39,13 @@ func GetServiceTraceProvider(c ConfigConverter, serviceName string) (trace.Trace
 	if cfg.Enabled {
 		return GetTraceProvider(cfg.Endpoint, cfg.Collector, serviceName, cfg.Type)
 	}
-	return trace.NewNoopTracerProvider(), nil
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.NeverSample()),
+	)
+	rtrace.SetDefaultTracerProvider(tp)
+
+	return tp, nil
 }
 
 // GetPropagator gets a configured propagator.


### PR DESCRIPTION
Fixes #7928 (in combination with https://github.com/cs3org/reva/pull/4422)