### PR TITLE
feat: allow settings service to store "zh" as language value

### DIFF
--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -296,6 +296,14 @@ var languageSetting = settingsmsg.Setting_SingleChoiceValue{
 				},
 				DisplayValue: "Türkçe",
 			},
+			{
+				Value: &settingsmsg.ListOptionValue{
+					Option: &settingsmsg.ListOptionValue_StringValue{
+						StringValue: "zh",
+					},
+				},
+				DisplayValue: "汉语",
+			},
 		},
 	},
 }


### PR DESCRIPTION
## Description
Same old problem: The settings service only allows to save values for the language that are defined in the source code.

## Related Issue
- Works towards https://github.com/owncloud/ocis/issues/7999
- Pre-requisite for https://github.com/owncloud/web/pull/10214

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
