### PR TITLE
fix: allow a maximum of one invite at a time

### DIFF
--- a/services/graph/pkg/validate/libregraph.go
+++ b/services/graph/pkg/validate/libregraph.go
@@ -11,16 +11,21 @@ import (
 
 // initLibregraph initializes libregraph validation
 func initLibregraph(v *validator.Validate) {
-	driveItemInvite(v)
-	permission(v)
+	for _, f := range []func(*validator.Validate){
+		libregraphDriveItemInvite,
+		libregraphDriveRecipient,
+		libregraphPermission,
+	} {
+		f(v)
+	}
 }
 
-// driveItemInvite validates libregraph.DriveItemInvite
-func driveItemInvite(v *validator.Validate) {
+// libregraphDriveItemInvite validates libregraph.DriveItemInvite
+func libregraphDriveItemInvite(v *validator.Validate) {
 	s := libregraph.DriveItemInvite{}
 
 	v.RegisterStructValidationMapRules(map[string]string{
-		"Recipients":         "min=1",
+		"Recipients":         "len=1,dive",
 		"Roles":              "max=1",
 		"ExpirationDateTime": "omitnil,gt",
 	}, s)
@@ -29,12 +34,19 @@ func driveItemInvite(v *validator.Validate) {
 		driveItemInvite := sl.Current().Interface().(libregraph.DriveItemInvite)
 
 		rolesAndActions(sl, driveItemInvite.Roles, driveItemInvite.LibreGraphPermissionsActions, false)
-
 	}, s)
 }
 
-// permission validates libregraph.Permission
-func permission(v *validator.Validate) {
+// libregraphDriveRecipient validates libregraph.DriveRecipient
+func libregraphDriveRecipient(v *validator.Validate) {
+	v.RegisterStructValidationMapRules(map[string]string{
+		"ObjectId":                "ne=",
+		"LibreGraphRecipientType": "oneof=user group",
+	}, libregraph.DriveRecipient{})
+}
+
+// libregraphPermission validates libregraph.Permission
+func libregraphPermission(v *validator.Validate) {
 	s := libregraph.Permission{}
 
 	v.RegisterStructValidationMapRules(map[string]string{

--- a/services/graph/pkg/validate/libregraph_test.go
+++ b/services/graph/pkg/validate/libregraph_test.go
@@ -8,86 +8,155 @@ import (
 	. "github.com/onsi/gomega"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/conversions"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/unifiedrole"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/validate"
 )
 
-var _ = Describe("libregraph", func() {
+type validatableFactory[T any] func() (T, bool)
 
+var _ = Describe("libregraph", func() {
 	var driveItemInvite libregraph.DriveItemInvite
+	var driveRecipient libregraph.DriveRecipient
 
 	BeforeEach(func() {
+		driveRecipient = libregraph.DriveRecipient{
+			ObjectId:                conversions.ToPointer("1"),
+			LibreGraphRecipientType: conversions.ToPointer("user"),
+		}
+
 		driveItemInvite = libregraph.DriveItemInvite{
-			Recipients:                   []libregraph.DriveRecipient{{ObjectId: libregraph.PtrString("1")}},
+			Recipients:                   []libregraph.DriveRecipient{driveRecipient},
 			Roles:                        []string{unifiedrole.UnifiedRoleEditorID},
 			LibreGraphPermissionsActions: []string{unifiedrole.DriveItemVersionsUpdate},
 			ExpirationDateTime:           libregraph.PtrTime(time.Now().Add(time.Hour)),
 		}
+
 	})
 
 	DescribeTable("DriveItemInvite",
-		func(factory func() libregraph.DriveItemInvite, expectError bool) {
-			f := factory()
-			switch err := validate.StructCtx(context.Background(), f); expectError {
-			case true:
-				Expect(err).To(HaveOccurred())
-			default:
-				Expect(err).ToNot(HaveOccurred())
+		func(factories ...validatableFactory[libregraph.DriveItemInvite]) {
+			for _, factory := range factories {
+				s, pass := factory()
+				switch err := validate.StructCtx(context.Background(), s); pass {
+				case false:
+					Expect(err).To(HaveOccurred())
+				default:
+					Expect(err).ToNot(HaveOccurred())
+				}
 			}
-
 		},
-		Entry("succeed: roles", func() libregraph.DriveItemInvite {
+		Entry("succeed: roles only", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.LibreGraphPermissionsActions = nil
-			return driveItemInvite
-		}, false),
-		Entry("succeed: permission actions", func() libregraph.DriveItemInvite {
+			return driveItemInvite, true
+		}),
+		Entry("succeed: actions only", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = nil
-			return driveItemInvite
-		}, false),
-		Entry("succeed: without ExpirationDateTime", func() libregraph.DriveItemInvite {
+			return driveItemInvite, true
+		}),
+		Entry("succeed: no ExpirationDateTime", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = nil
 			driveItemInvite.ExpirationDateTime = nil
-			return driveItemInvite
-		}, false),
-		Entry("fail: multiple role assignment", func() libregraph.DriveItemInvite {
+			return driveItemInvite, true
+		}),
+		Entry("fail: multiple role assignment", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = []string{
 				unifiedrole.UnifiedRoleEditorID,
 				unifiedrole.UnifiedRoleManagerID,
 			}
 			driveItemInvite.LibreGraphPermissionsActions = nil
-			return driveItemInvite
-		}, true),
-		Entry("fail: unknown role", func() libregraph.DriveItemInvite {
+			return driveItemInvite, false
+		}),
+		Entry("fail: unknown role", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = []string{"foo"}
 			driveItemInvite.LibreGraphPermissionsActions = nil
-			return driveItemInvite
-		}, true),
-		Entry("fail: unknown action", func() libregraph.DriveItemInvite {
+			return driveItemInvite, false
+		}),
+		Entry("fail: unknown action", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = nil
 			driveItemInvite.LibreGraphPermissionsActions = []string{"foo"}
-			return driveItemInvite
-		}, true),
-		Entry("fail: missing roles or permission actions", func() libregraph.DriveItemInvite {
+			return driveItemInvite, false
+		}),
+		Entry("fail: missing roles or permission actions", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = nil
 			driveItemInvite.LibreGraphPermissionsActions = nil
-			return driveItemInvite
-		}, true),
-		Entry("fail: different number of roles and actions", func() libregraph.DriveItemInvite {
+			return driveItemInvite, false
+		}),
+		Entry("fail: different number of roles and actions", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.LibreGraphPermissionsActions = []string{
 				unifiedrole.DriveItemVersionsUpdate,
 				unifiedrole.DriveItemChildrenCreate,
 			}
-			return driveItemInvite
-		}, true),
-		Entry("fail: missing recipients", func() libregraph.DriveItemInvite {
+			return driveItemInvite, false
+		}),
+		Entry("fail: missing recipients", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = nil
 			driveItemInvite.Recipients = nil
-			return driveItemInvite
-		}, true),
-		Entry("fail: expirationDateTime in the past", func() libregraph.DriveItemInvite {
+			return driveItemInvite, false
+		}),
+		Entry("fail: dive recipients", func() (libregraph.DriveItemInvite, bool) {
+			driveItemInvite.Roles = nil
+			driveItemInvite.Recipients = []libregraph.DriveRecipient{
+				{ObjectId: libregraph.PtrString("1"), LibreGraphRecipientType: libregraph.PtrString("dive")},
+			}
+			return driveItemInvite, false
+		}),
+		Entry("fail: more than 1 recipient", func() (libregraph.DriveItemInvite, bool) {
+			driveItemInvite.Roles = nil
+			driveItemInvite.Recipients = []libregraph.DriveRecipient{
+				driveRecipient,
+				{ObjectId: libregraph.PtrString("2"), LibreGraphRecipientType: libregraph.PtrString("group")},
+			}
+			return driveItemInvite, false
+		}),
+		Entry("fail: expirationDateTime in the past", func() (libregraph.DriveItemInvite, bool) {
 			driveItemInvite.Roles = nil
 			driveItemInvite.ExpirationDateTime = libregraph.PtrTime(time.Now().Add(-time.Hour))
-			return driveItemInvite
-		}, true),
+			return driveItemInvite, false
+		}),
+	)
+
+	DescribeTable("DriveRecipient",
+		func(factories ...validatableFactory[libregraph.DriveRecipient]) {
+			for _, factory := range factories {
+				s, pass := factory()
+				switch err := validate.StructCtx(context.Background(), s); pass {
+				case false:
+					Expect(err).To(HaveOccurred())
+				default:
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+		},
+		Entry("fail: invalid objectId",
+			func() (libregraph.DriveRecipient, bool) {
+				driveRecipient.ObjectId = nil
+				return driveRecipient, false
+			},
+			func() (libregraph.DriveRecipient, bool) {
+				driveRecipient.ObjectId = conversions.ToPointer("")
+				return driveRecipient, false
+			},
+		),
+		Entry("succeed: valid role",
+			func() (libregraph.DriveRecipient, bool) {
+				driveRecipient.LibreGraphRecipientType = conversions.ToPointer("user")
+				return driveRecipient, true
+			},
+			func() (libregraph.DriveRecipient, bool) {
+				driveRecipient.LibreGraphRecipientType = conversions.ToPointer("group")
+				return driveRecipient, true
+			},
+		),
+		Entry("fail: invalid role",
+			func() (libregraph.DriveRecipient, bool) {
+				driveRecipient.LibreGraphRecipientType = conversions.ToPointer("foo")
+				return driveRecipient, false
+			},
+			func() (libregraph.DriveRecipient, bool) {
+				driveRecipient.LibreGraphRecipientType = nil
+				return driveRecipient, false
+			},
+		),
 	)
 })


### PR DESCRIPTION
## Description
as described in #7962 multi invites could get problematic, specially the error handling.
Therefore we've decided to restrict invitations to a maximum of one!

It contains validation (allow only user and group types, id), error handling and tests for that.

* already shared to the user // group -> 409
* wrong or empty libre.graph.recipient.type (group && user allowed) -> 400
* unknown user -> 400
* unknown group -> 400
* ~~disabled user  -> TODO~~ not part of this pr, will be handled globally via reva 

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/7962

## Motivation and Context
explicit error handling

## How Has This Been Tested?
- unit tests
- manual tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
