### PR TITLE
apiTest. set recipient type in body

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1580,7 +1580,7 @@ class GraphHelper {
 	 * @param string $itemId
 	 * @param string $shareeId
 	 * @param string $shareType
-   * @param string|null $role
+	 * @param string|null $role
 	 *
 	 * @return ResponseInterface
 	 * @throws \JsonException

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1579,7 +1579,8 @@ class GraphHelper {
 	 * @param string $spaceId
 	 * @param string $itemId
 	 * @param string $shareeId
-	 * @param string|null $role
+	 * @param string $shareType
+   * @param string|null $role
 	 *
 	 * @return ResponseInterface
 	 * @throws \JsonException
@@ -1592,12 +1593,15 @@ class GraphHelper {
 		string $spaceId,
 		string $itemId,
 		string $shareeId,
+		string $shareType,
 		?string $role
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/invite");
 		$body = [];
 
 		$recipients['objectId'] = $shareeId;
+		$recipients['@libre.graph.recipient.type'] = $shareType;
+
 		$body['recipients'] = [$recipients];
 
 		if ($role !== null) {

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -112,6 +112,7 @@ class SharingNgContext implements Context {
 				$spaceId,
 				$itemId,
 				$shareeId,
+				$rows['shareType'],
 				$rows['role']
 			)
 		);


### PR DESCRIPTION
If `libre.graph.recipient.type` is empty, we expect a 400 error, so I changed the tests

fix tests for https://github.com/owncloud/ocis/pull/8019
@fschade please rebase after merging this PR


cc @grgprarup 