### PR TITLE
Also log the traceid alongside the request id

### DIFF
--- a/changelog/unreleased/fix-empty-traceids.md
+++ b/changelog/unreleased/fix-empty-traceids.md
@@ -2,4 +2,5 @@ Bugfix: Fix empty trace ids
 
 We changed the default tracing to produce non-empty traceids.
 
+https://github.com/owncloud/ocis/pull/8023
 https://github.com/owncloud/ocis/pull/8017

--- a/services/proxy/pkg/middleware/accesslog.go
+++ b/services/proxy/pkg/middleware/accesslog.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // AccessLog is a middleware to log http requests at info level logging.
@@ -19,9 +20,11 @@ func AccessLog(logger log.Logger) func(http.Handler) http.Handler {
 			wrap := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(wrap, r)
 
+			spanContext := trace.SpanContextFromContext(r.Context())
 			logger.Info().
 				Str("proto", r.Proto).
 				Str(log.RequestIDString, requestID).
+				Str("traceid", spanContext.TraceID().String()).
 				Str("remote-addr", r.RemoteAddr).
 				Str("method", r.Method).
 				Int("status", wrap.Status()).


### PR DESCRIPTION
Also log the traceid alongside the request id.