### PR TITLE
[docs-only] fix envvar where a semicolon was a remnant

### DIFF
--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -123,7 +123,7 @@ type OCISDriver struct {
 	MaxAcquireLockCycles    int    `yaml:"max_acquire_lock_cycles" env:"STORAGE_USERS_OCIS_MAX_ACQUIRE_LOCK_CYCLES" desc:"When trying to lock files, ocis will try this amount of times to acquire the lock before failing. After each try it will wait for an increasing amount of time. Values of 0 or below will be ignored and the default value of 20 will be used."`
 	LockCycleDurationFactor int    `yaml:"lock_cycle_duration_factor" env:"STORAGE_USERS_OCIS_LOCK_CYCLE_DURATION_FACTOR" desc:"When trying to lock files, ocis will multiply the cycle with this factor and use it as a millisecond timeout. Values of 0 or below will be ignored and the default value of 30 will be used."`
 	MaxConcurrency          int    `yaml:"max_concurrency" env:"STORAGE_USERS_OCIS_MAX_CONCURRENCY" desc:"Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause more load on the system. Values of 0 or below will be ignored and the default value of 100 will be used."`
-	AsyncUploads            bool   `yaml:"async_uploads" env:"OCIS_ASYNC_UPLOADS;" desc:"Enable asynchronous file uploads."`
+	AsyncUploads            bool   `yaml:"async_uploads" env:"OCIS_ASYNC_UPLOADS" desc:"Enable asynchronous file uploads."`
 	MaxQuota                uint64 `yaml:"max_quota" env:"OCIS_SPACES_MAX_QUOTA;STORAGE_USERS_OCIS_MAX_QUOTA" desc:"Set a global max quota for spaces in bytes. A value of 0 equals unlimited. If not using the global OCIS_SPACES_MAX_QUOTA, you must define the FRONTEND_MAX_QUOTA in the frontend service."`
 }
 


### PR DESCRIPTION
This is just a small fix where the envvar `OCIS_ASYNC_UPLOADS` in the `storage-users` service contained a semicolon as remnant. This caused the envvar to appear in the docs as the following. Note the single quotes in the next line:

![image](https://github.com/owncloud/ocis/assets/3321281/e523f977-e110-44d2-8472-1cdf4874ca59)
 