### PR TITLE
Backport tracing fixes

### DIFF
--- a/changelog/unreleased/fix-traces.md
+++ b/changelog/unreleased/fix-traces.md
@@ -1,0 +1,5 @@
+Bugfix: Fix trace ids
+
+We changed the default tracing to produce non-empty traceids and fixed a problem where traces got disconnected further down the stack.
+
+https://github.com/owncloud/ocis/pull/8026

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/cs3org/go-cs3apis v0.0.0-20230516150832-730ac860c71d
-	github.com/cs3org/reva/v2 v2.16.4-0.20231212083844-00de22ceb749
+	github.com/cs3org/reva/v2 v2.16.4-0.20231220070538-82b93f6a66bc
 	github.com/disintegration/imaging v1.6.2
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e
 	github.com/egirna/icap-client v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -864,8 +864,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
-github.com/cs3org/reva/v2 v2.16.4-0.20231212083844-00de22ceb749 h1:oCktbSObMu5VTGwcux3tlabQwQT+e0CycuheKvzbQow=
-github.com/cs3org/reva/v2 v2.16.4-0.20231212083844-00de22ceb749/go.mod h1:RvhuweTFqzezjUFU0SIdTXakrEx9vJlMvQ7znPXSP1g=
+github.com/cs3org/reva/v2 v2.16.4-0.20231220070538-82b93f6a66bc h1:IvoFfeOCbd8jFr7cXPuj9lt8aJjd4jLMhfZaoilpsNQ=
+github.com/cs3org/reva/v2 v2.16.4-0.20231220070538-82b93f6a66bc/go.mod h1:RvhuweTFqzezjUFU0SIdTXakrEx9vJlMvQ7znPXSP1g=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/ocis-pkg/tracing/tracing.go
+++ b/ocis-pkg/tracing/tracing.go
@@ -39,7 +39,13 @@ func GetServiceTraceProvider(c ConfigConverter, serviceName string) (trace.Trace
 	if cfg.Enabled {
 		return GetTraceProvider(cfg.Endpoint, cfg.Collector, serviceName, cfg.Type)
 	}
-	return trace.NewNoopTracerProvider(), nil
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.NeverSample()),
+	)
+	rtrace.SetDefaultTracerProvider(tp)
+
+	return tp, nil
 }
 
 // GetPropagator gets a configured propagator.

--- a/services/proxy/pkg/middleware/accesslog.go
+++ b/services/proxy/pkg/middleware/accesslog.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // AccessLog is a middleware to log http requests at info level logging.
@@ -19,9 +20,11 @@ func AccessLog(logger log.Logger) func(http.Handler) http.Handler {
 			wrap := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(wrap, r)
 
+			spanContext := trace.SpanContextFromContext(r.Context())
 			logger.Info().
 				Str("proto", r.Proto).
 				Str(log.RequestIDString, requestID).
+				Str("traceid", spanContext.TraceID().String()).
 				Str("remote-addr", r.RemoteAddr).
 				Str("method", r.Method).
 				Int("status", wrap.Status()).

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -354,7 +354,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.16.4-0.20231212083844-00de22ceb749
+# github.com/cs3org/reva/v2 v2.16.4-0.20231220070538-82b93f6a66bc
 ## explicit; go 1.20
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
Backport the tracing fixes to always generate proper trace ids and properly pass the trace ids down the stack.