### PR TITLE
fix: double quotes will be trimmed from the search token

### DIFF
--- a/changelog/unreleased/fix-search-by-exact-mail.md
+++ b/changelog/unreleased/fix-search-by-exact-mail.md
@@ -1,0 +1,7 @@
+Bugfix: Fix search by exact email
+
+Users can be searched by exact email by using double quotes on the search
+parameter. Note that double quotes are required because the "@" char is
+being interpreted by the parser.
+
+https://github.com/owncloud/ocis/pull/8035

--- a/services/graph/pkg/identity/odata.go
+++ b/services/graph/pkg/identity/odata.go
@@ -41,9 +41,6 @@ func GetSearchValues(req *godata.GoDataQuery) (string, error) {
 		return "", godata.NotImplementedError("complex search queries are not supported")
 	}
 
-	searchValue := req.Search.Tree.Token.Value
-	if strings.HasPrefix(searchValue, "\"") && strings.HasSuffix(searchValue, "\"") {
-		searchValue = strings.Trim(searchValue, "\"")
-	}
+	searchValue := strings.Trim(req.Search.Tree.Token.Value, "\"")
 	return searchValue, nil
 }

--- a/services/graph/pkg/identity/odata.go
+++ b/services/graph/pkg/identity/odata.go
@@ -1,6 +1,10 @@
 package identity
 
-import "github.com/CiscoM31/godata"
+import (
+	"strings"
+
+	"github.com/CiscoM31/godata"
+)
 
 // GetExpandValues extracts the values of the $expand query parameter and
 // returns them in a []string, rejects any $expand value that consists of more
@@ -37,5 +41,9 @@ func GetSearchValues(req *godata.GoDataQuery) (string, error) {
 		return "", godata.NotImplementedError("complex search queries are not supported")
 	}
 
-	return req.Search.Tree.Token.Value, nil
+	searchValue := req.Search.Tree.Token.Value
+	if strings.HasPrefix(searchValue, "\"") && strings.HasSuffix(searchValue, "\"") {
+		searchValue = strings.Trim(searchValue, "\"")
+	}
+	return searchValue, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Search terms from the graph API can be enclosed with double quotes. The double quotes are intended to prevent the interpretation of some tokens from the parser. However, the parser doesn't remove the double quotes.
This PR will remove those double quotes.

As a practical example, searching by email (such as `marie@example.org`) can give problems because the `@` char is interpreted as a different token (likely as a parameter alias, although I'm not fully sure). With this PR, you can search it by enclosing the email in double quotes, like `$search="marie@example.org"` (note that url-encoding might be needed)

## Related Issue
https://github.com/owncloud/ocis/issues/7990

## Motivation and Context
Allow searching users by email

## How Has This Been Tested?
Manually tested via API, running something like `curl -vk -ueinstein:relativity https://localhost:9200/graph/v1.0/users?%24search=%22marie%40example.org%22`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
