### PR TITLE
[tests-only][full-ci]Added tests for create link share without password

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -262,6 +262,8 @@ default:
         - FeatureContext: *common_feature_context_params
         - SpacesContext:
         - SharingNgContext:
+        - OcisConfigContext:
+
 
   extensions:
     rdx\behatvars\BehatVariablesExtension: ~

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -260,6 +260,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSharingNg/createLink.feature:147](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/createLink.feature#L147)
 - [apiSharingNg/createLink.feature:225](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/createLink.feature#L225)
 - [apiSharingNg/createLink.feature:301](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/createLink.feature#L301)
+- [apiSharingNg/createLink.feature:372](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/createLink.feature#L372)
 
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSharingNg/createLink.feature
+++ b/tests/acceptance/features/apiSharingNg/createLink.feature
@@ -299,3 +299,74 @@ Feature: Create a share link for a resource
       | view           |
       | edit           |
       | blocksDownload |
+
+  @env-config
+  Scenario Outline: create a link share of a file without password
+    Given the following configs have been set:
+      | config                                                 | value |
+      | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD           | false |
+    And user "Alice" has uploaded file with content "other data" to "textfile1.txt"
+    When user "Alice" creates the following link share using the Graph API:
+      | resourceType | file          |
+      | resource     | textfile1.txt |
+      | space        | Personal      |
+      | role         | <role>        |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "hasPassword",
+          "id",
+          "link"
+        ],
+        "properties": {
+          "hasPassword": {
+            "type": "boolean",
+            "enum": [false]
+          },
+          "id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]{15}$"
+          },
+          "link": {
+            "type": "object",
+            "required": [
+              "@libre.graph.displayName",
+              "@libre.graph.quickLink",
+              "preventsDownload",
+              "type",
+              "webUrl"
+            ],
+            "properties": {
+              "@libre.graph.displayName": {
+                "type": "string",
+                "enum": [""]
+              },
+              "@libre.graph.quickLink": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "preventsDownload": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "type": {
+                "type": "string",
+                "enum": ["<role>"]
+              },
+              "webUrl": {
+                "type": "string",
+                "pattern": "^%base_url%\/s\/[a-zA-Z]{15}$"
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | role           |
+      | view           |
+      | edit           |
+      | blocksDownload |

--- a/tests/acceptance/features/apiSharingNg/createLink.feature
+++ b/tests/acceptance/features/apiSharingNg/createLink.feature
@@ -303,8 +303,8 @@ Feature: Create a share link for a resource
   @env-config
   Scenario Outline: create a link share of a file without password
     Given the following configs have been set:
-      | config                                                 | value |
-      | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD           | false |
+      | config                                       | value |
+      | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
     And user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     When user "Alice" creates the following link share using the Graph API:
       | resourceType | file          |

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -141,9 +141,9 @@ class SharingNgContext implements Context {
 			$itemId = $this->spacesContext->getFileId($user, $space, $resource);
 		}
 
-		$bodyRows['displayName'] = \array_key_exists('displayName', $bodyRows) ? $bodyRows['displayName'] : null;
-		$bodyRows['expirationDateTime'] = \array_key_exists('expirationDateTime', $bodyRows) ? $bodyRows['expirationDateTime'] : null;
-		$bodyRows['password'] = \array_key_exists('password', $bodyRows) ? $bodyRows['password'] : null;
+		$bodyRows['displayName'] = $bodyRows['displayName'] ?? null;
+		$bodyRows['expirationDateTime'] = $bodyRows['expirationDateTime'] ?? null;
+		$bodyRows['password'] = $bodyRows['password'] ?? null;
 		$body = [
 			'type' => $bodyRows['role'],
 			'displayName' => $bodyRows['displayName'],

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -143,6 +143,7 @@ class SharingNgContext implements Context {
 
 		$bodyRows['displayName'] = \array_key_exists('displayName', $bodyRows) ? $bodyRows['displayName'] : null;
 		$bodyRows['expirationDateTime'] = \array_key_exists('expirationDateTime', $bodyRows) ? $bodyRows['expirationDateTime'] : null;
+		$bodyRows['password'] = \array_key_exists('password', $bodyRows) ? $bodyRows['password'] : null;
 		$body = [
 			'type' => $bodyRows['role'],
 			'displayName' => $bodyRows['displayName'],


### PR DESCRIPTION
### Description
Added tests for creating share link without password.

```feature
Scenario Outline: create a link share of a file without password
```

### Relates Issue:
https://github.com/owncloud/ocis/issues/7968