### PR TITLE
[full-ci] chore: bump web to v8.0.0-rc.1

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=fd1349c4ff15c11a0a520c1e66be7db554d88241
-WEB_BRANCH=master
+WEB_COMMITID=934efe5fc60831b2bc6c353c8256c21972066398
+WEB_BRANCH=stable-8.0

--- a/changelog/unreleased/update-web-8.0.0.md
+++ b/changelog/unreleased/update-web-8.0.0.md
@@ -1,0 +1,18 @@
+Enhancement: Update web to v8.0.0-rc.1
+
+Tags: web
+
+We updated ownCloud Web to v8.0.0-rc.1. Please refer to the changelog (linked) for details on the web release.
+
+## Summary
+* Enhancement [owncloud/web#10224](https://github.com/owncloud/web/issues/10224): Harmonize AppSwitcher icon colors
+* Bugfix [owncloud/web#10230](https://github.com/owncloud/web/issues/10230): Configurable concurrent requests
+* Bugfix [owncloud/web#10158](https://github.com/owncloud/web/issues/10158): GDPR export polling
+* Bugfix [owncloud/web#10220](https://github.com/owncloud/web/issues/10220): Loading indicator during conflict dialog
+* Bugfix [owncloud/web#10156](https://github.com/owncloud/web/issues/10156): Uploading the same files parallel
+* Bugfix [owncloud/web#10179](https://github.com/owncloud/web/issues/10179): Space navigate to trash missing
+* Bugfix [owncloud/web#10118](https://github.com/owncloud/web/issues/10118): Tilesview has whitespace
+* Bugfix [owncloud/web#10182](https://github.com/owncloud/web/issues/10182): Make versions panel readonly in viewers and editors
+
+https://github.com/owncloud/ocis/pull/8055
+https://github.com/owncloud/web/releases/tag/v8.0.0-rc.1

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.0-beta.2
+WEB_ASSETS_VERSION = v8.0.0-rc.1
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bumps Web to `v8.0.0-rc.1`. Please see the changelog for more details.

Known issue: some German translation strings are missing.