### PR TITLE
[tests-only][full-ci]Added tests for setting password in a public share link

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1701,4 +1701,39 @@ class GraphHelper {
 			$body
 		);
 	}
+
+
+    /**
+     * @param string $baseUrl
+     * @param string $xRequestId
+     * @param string $user
+     * @param string $password
+     * @param string $spaceId
+     * @param string $itemId
+     * @param mixed $body
+     * @param string $shareId
+     *
+     * @return ResponseInterface
+     * @throws GuzzleException
+     */
+    public static function setPassword(
+        string $baseUrl,
+        string $xRequestId,
+        string $user,
+        string $password,
+        string $spaceId,
+        string $itemId,
+               $body,
+        string $shareId
+    ): ResponseInterface {
+        $url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$shareId/setPassword");
+        return HttpRequestHelper::post(
+            $url,
+            $xRequestId,
+            $user,
+            $password,
+            self::getRequestHeaders(),
+            $body
+        );
+    }
 }

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1702,38 +1702,37 @@ class GraphHelper {
 		);
 	}
 
-
-    /**
-     * @param string $baseUrl
-     * @param string $xRequestId
-     * @param string $user
-     * @param string $password
-     * @param string $spaceId
-     * @param string $itemId
-     * @param mixed $body
-     * @param string $shareId
-     *
-     * @return ResponseInterface
-     * @throws GuzzleException
-     */
-    public static function setPassword(
-        string $baseUrl,
-        string $xRequestId,
-        string $user,
-        string $password,
-        string $spaceId,
-        string $itemId,
-               $body,
-        string $shareId
-    ): ResponseInterface {
-        $url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$shareId/setPassword");
-        return HttpRequestHelper::post(
-            $url,
-            $xRequestId,
-            $user,
-            $password,
-            self::getRequestHeaders(),
-            $body
-        );
-    }
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $spaceId
+	 * @param string $itemId
+	 * @param mixed $body
+	 * @param string $shareId
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function setPassword(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $spaceId,
+		string $itemId,
+		$body,
+		string $shareId
+	): ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$shareId/setPassword");
+		return HttpRequestHelper::post(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			$body
+		);
+	}
 }

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1715,7 +1715,7 @@ class GraphHelper {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public static function setPassword(
+	public static function setLinkSharePassword(
 		string $baseUrl,
 		string $xRequestId,
 		string $user,

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -262,6 +262,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - SpacesContext:
         - SharingNgContext:
+        - PublicWebDavContext:
         - OcisConfigContext:
 
 

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -562,7 +562,7 @@ Feature: Create a share link for a resource
       | space        | Personal      |
       | role         | view          |
       | password     | $heLlo*1234*  |
-    When user "Alice" sets password for the last public link share using the Graph API with
+    When user "Alice" updates password for the last public link share using the Graph API with
       | resourceType | file          |
       | resource     | textfile1.txt |
       | space        | Personal      |
@@ -584,3 +584,4 @@ Feature: Create a share link for a resource
       }
       """
     And the public should be able to download file "textfile1.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" for sharingNG and the content should be "other data"
+    And the public download of file "textfile1.txt" from inside the last public link shared folder using the new public WebDAV API with password "$heLlo*1234*" for shareNg should fail with HTTP status code "401"

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -551,7 +551,7 @@ Feature: Create a share link for a resource
         }
       }
       """
-    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" for sharingNG and the content should be "other data"
+    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder for shareNg using the new public WebDAV API with password "%public%" and the content should be "other data"
 
 
   Scenario: update password for a file's link share
@@ -583,5 +583,5 @@ Feature: Create a share link for a resource
         }
       }
       """
-    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" for sharingNG and the content should be "other data"
-    And the public download of file "textfile1.txt" from inside the last public link shared folder using the new public WebDAV API with password "$heLlo*1234*" for shareNg should fail with HTTP status code "401"
+    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder for shareNg using the new public WebDAV API with password "%public%" and the content should be "other data"
+    And the public download of file "textfile1.txt" from inside the last public link shared folder for shareNg using the new public WebDAV API with password "$heLlo*1234*" should fail with HTTP status code "401"

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -518,3 +518,69 @@ Feature: Create a share link for a resource
         }
       }
       """
+
+  @env-config
+  Scenario: set password for a file's link share
+    Given the following configs have been set:
+      | config                                       | value |
+      | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
+    And user "Alice" has uploaded file with content "other data" to "textfile1.txt"
+    And user "Alice" has created the following link share:
+      | resourceType | file          |
+      | resource     | textfile1.txt |
+      | space        | Personal      |
+      | role         | view          |
+    When user "Alice" sets password for the last public link share using the Graph API with
+      | resourceType | file          |
+      | resource     | textfile1.txt |
+      | space        | Personal      |
+      | password     | %public%      |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "hasPassword"
+        ],
+        "properties": {
+          "hasPassword": {
+            "type": "boolean",
+            "enum": [true]
+          }
+        }
+      }
+      """
+    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" for sharingNG and the content should be "other data"
+
+
+  Scenario: update password for a file's link share
+    Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
+    And user "Alice" has created the following link share:
+      | resourceType | file          |
+      | resource     | textfile1.txt |
+      | space        | Personal      |
+      | role         | view          |
+      | password     | $heLlo*1234*  |
+    When user "Alice" sets password for the last public link share using the Graph API with
+      | resourceType | file          |
+      | resource     | textfile1.txt |
+      | space        | Personal      |
+      | password     | %public%      |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "hasPassword"
+        ],
+        "properties": {
+          "hasPassword": {
+            "type": "boolean",
+            "enum": [true]
+          }
+        }
+      }
+      """
+    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" for sharingNG and the content should be "other data"

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -530,7 +530,7 @@ Feature: Create a share link for a resource
       | resource     | textfile1.txt |
       | space        | Personal      |
       | role         | view          |
-    When user "Alice" sets the following password for the last public link share using the Graph API:
+    When user "Alice" sets the following password for the last link share using the Graph API:
       | resourceType | file          |
       | resource     | textfile1.txt |
       | space        | Personal      |
@@ -551,8 +551,7 @@ Feature: Create a share link for a resource
         }
       }
       """
-    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder for shareNg using the new public WebDAV API with password "%public%" and the content should be "other data"
-
+    And the public should be able to download file "textfile1.txt" from the last link share with password "%public%" and the content should be "other data"
 
   Scenario: update password of a file's link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
@@ -562,7 +561,7 @@ Feature: Create a share link for a resource
       | space        | Personal      |
       | role         | view          |
       | password     | $heLlo*1234*  |
-    When user "Alice" updates the following password for the last public link share using the Graph API:
+    When user "Alice" updates the following password for the last link share using the Graph API:
       | resourceType | file          |
       | resource     | textfile1.txt |
       | space        | Personal      |
@@ -583,5 +582,5 @@ Feature: Create a share link for a resource
         }
       }
       """
-    And the public should be able to download file "textfile1.txt" from inside the last public link shared folder for shareNg using the new public WebDAV API with password "%public%" and the content should be "other data"
-    And the public download of file "textfile1.txt" from inside the last public link shared folder for shareNg using the new public WebDAV API with password "$heLlo*1234*" should fail with HTTP status code "401"
+    And the public should be able to download file "textfile1.txt" from the last link share with password "%public%" and the content should be "other data"
+    And the public download of file "textfile1.txt" from the last link share with password "$heLlo*1234*" should fail with HTTP status code "401" using shareNg

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -520,7 +520,7 @@ Feature: Create a share link for a resource
       """
 
   @env-config
-  Scenario: set password for a file's link share
+  Scenario: set password on a file's link share
     Given the following configs have been set:
       | config                                       | value |
       | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
@@ -530,7 +530,7 @@ Feature: Create a share link for a resource
       | resource     | textfile1.txt |
       | space        | Personal      |
       | role         | view          |
-    When user "Alice" sets password for the last public link share using the Graph API with
+    When user "Alice" sets the following password for the last public link share using the Graph API:
       | resourceType | file          |
       | resource     | textfile1.txt |
       | space        | Personal      |
@@ -554,7 +554,7 @@ Feature: Create a share link for a resource
     And the public should be able to download file "textfile1.txt" from inside the last public link shared folder for shareNg using the new public WebDAV API with password "%public%" and the content should be "other data"
 
 
-  Scenario: update password for a file's link share
+  Scenario: update password of a file's link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     And user "Alice" has created the following link share:
       | resourceType | file          |
@@ -562,7 +562,7 @@ Feature: Create a share link for a resource
       | space        | Personal      |
       | role         | view          |
       | password     | $heLlo*1234*  |
-    When user "Alice" updates password for the last public link share using the Graph API with
+    When user "Alice" updates the following password for the last public link share using the Graph API:
       | resourceType | file          |
       | resource     | textfile1.txt |
       | space        | Personal      |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -920,10 +920,9 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder for shareNg using the (old|new) public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download file "([^"]*)" from the last link share with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
-	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 * @param string $content
 	 *
@@ -932,19 +931,14 @@ class PublicWebDavContext implements Context {
 	 */
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordForSharingNGAndContentShouldBe(
 		string $path,
-		string $publicWebDAVAPIVersion,
 		string $password,
 		string $content
 	):void {
-		if ($publicWebDAVAPIVersion === "old") {
-			return;
-		}
-
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			"",
-			$publicWebDAVAPIVersion,
+			"new",
 			true
 		);
 
@@ -997,10 +991,9 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder for shareNg using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
+	 * @Then /^the public download of file "([^"]*)" from the last link share with password "([^"]*)" should fail with HTTP status code "([^"]*)" using shareNg$/
 	 *
 	 * @param string $path
-	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 * @param string $expectedHttpCode
 	 *
@@ -1008,14 +1001,13 @@ class PublicWebDavContext implements Context {
 	 */
 	public function shouldNotBeAbleToDownloadFileWithPasswordForShareNg(
 		string $path,
-		string $publicWebDAVAPIVersion,
 		string $password,
 		string $expectedHttpCode = "401"
 	):void {
 		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
 			"",
 			$path,
-			$publicWebDAVAPIVersion,
+			"new",
 			$password,
 			$expectedHttpCode,
 			true

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -288,7 +288,7 @@ class PublicWebDavContext implements Context {
 	 * @param string $password
 	 * @param string $range ignored when empty
 	 * @param string $publicWebDAVAPIVersion
-	 * @param bool $downloadForShareNG
+	 * @param bool $shareNg
 	 *
 	 * @return ResponseInterface
 	 */
@@ -297,12 +297,12 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $range,
 		string $publicWebDAVAPIVersion = "old",
-		bool $downloadForShareNG = false
+		bool $shareNg = false
 	):ResponseInterface {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
-		if ($downloadForShareNG) {
-			$token = $this->featureContext->shareNGGetLastCreatedPublicLinkShareToken();
+		if ($shareNg) {
+			$token = $this->featureContext->shareNgGetLastCreatedLinkShareToken();
 		} else {
 			$token = $this->featureContext->getLastCreatedPublicShareToken();
 		}
@@ -947,9 +947,9 @@ class PublicWebDavContext implements Context {
 			$publicWebDAVAPIVersion,
 			true
 		);
-		$this->featureContext->checkDownloadedContentMatches($content, "", $response);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
+		$this->featureContext->checkDownloadedContentMatches($content, "", $response);
 	}
 
 	/**
@@ -1060,7 +1060,7 @@ class PublicWebDavContext implements Context {
 	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 * @param string $expectedHttpCode
-	 * @param bool $downloadForShareNG
+	 * @param bool $shareNg
 	 *
 	 * @return void
 	 * @throws Exception
@@ -1071,7 +1071,7 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion,
 		string $password,
 		string $expectedHttpCode = "401",
-		bool $downloadForShareNG = false
+		bool $shareNg = false
 	):void {
 		if ($publicWebDAVAPIVersion === "old") {
 			return;
@@ -1082,7 +1082,7 @@ class PublicWebDavContext implements Context {
 			$password,
 			$range,
 			$publicWebDAVAPIVersion,
-			$downloadForShareNG
+			$shareNg
 		);
 
 		$responseContent = $response->getBody()->getContents();

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -920,7 +920,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" for sharingNG and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder for shareNg using the (old|new) public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
@@ -997,7 +997,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" for shareNg should fail with HTTP status code "([^"]*)"$/
+	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder for shareNg using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -288,7 +288,7 @@ class PublicWebDavContext implements Context {
 	 * @param string $password
 	 * @param string $range ignored when empty
 	 * @param string $publicWebDAVAPIVersion
-     * @param bool $downloadForShareNG
+	 * @param bool $downloadForShareNG
 	 *
 	 * @return ResponseInterface
 	 */
@@ -297,15 +297,15 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $range,
 		string $publicWebDAVAPIVersion = "old",
-        bool $downloadForShareNG = false
+		bool $downloadForShareNG = false
 	):ResponseInterface {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
-        if($downloadForShareNG) {
-            $token = $this->featureContext->shareNGGetLastCreatedPublicLinkShareToken();
-        } else {
-            $token = $this->featureContext->getLastCreatedPublicShareToken();
-        }
+		if ($downloadForShareNG) {
+			$token = $this->featureContext->shareNGGetLastCreatedPublicLinkShareToken();
+		} else {
+			$token = $this->featureContext->getLastCreatedPublicShareToken();
+		}
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -919,38 +919,38 @@ class PublicWebDavContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 	}
 
-    /**
-     * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" for sharingNG and the content should be "([^"]*)"$/
-     *
-     * @param string $path
-     * @param string $publicWebDAVAPIVersion
-     * @param string $password
-     * @param string $content
-     *
-     * @return void
-     * @throws Exception
-     */
-    public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordForSharingNGAndContentShouldBe(
-        string $path,
-        string $publicWebDAVAPIVersion,
-        string $password,
-        string $content
-    ):void {
-        if ($publicWebDAVAPIVersion === "old") {
-            return;
-        }
+	/**
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" for sharingNG and the content should be "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
+	 * @param string $password
+	 * @param string $content
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordForSharingNGAndContentShouldBe(
+		string $path,
+		string $publicWebDAVAPIVersion,
+		string $password,
+		string $content
+	):void {
+		if ($publicWebDAVAPIVersion === "old") {
+			return;
+		}
 
-        $response = $this->downloadFileFromPublicFolder(
-            $path,
-            $password,
-            "",
-            $publicWebDAVAPIVersion,
-            true
-        );
-        $this->featureContext->checkDownloadedContentMatches($content, "", $response);
+		$response = $this->downloadFileFromPublicFolder(
+			$path,
+			$password,
+			"",
+			$publicWebDAVAPIVersion,
+			true
+		);
+		$this->featureContext->checkDownloadedContentMatches($content, "", $response);
 
-        $this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
-    }
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
+	}
 
 	/**
 	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API without password and the content should be "([^"]*)"$/
@@ -997,6 +997,32 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" for shareNg should fail with HTTP status code "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
+	 * @param string $password
+	 * @param string $expectedHttpCode
+	 *
+	 * @return void
+	 */
+	public function shouldNotBeAbleToDownloadFileWithPasswordForShareNg(
+		string $path,
+		string $publicWebDAVAPIVersion,
+		string $password,
+		string $expectedHttpCode = "401"
+	):void {
+		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
+			"",
+			$path,
+			$publicWebDAVAPIVersion,
+			$password,
+			$expectedHttpCode,
+			true
+		);
+	}
+
+	/**
 	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)""$/
 	 *
 	 * @param string $range
@@ -1034,6 +1060,7 @@ class PublicWebDavContext implements Context {
 	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
 	 * @param string $expectedHttpCode
+	 * @param bool $downloadForShareNG
 	 *
 	 * @return void
 	 * @throws Exception
@@ -1043,7 +1070,8 @@ class PublicWebDavContext implements Context {
 		string $path,
 		string $publicWebDAVAPIVersion,
 		string $password,
-		string $expectedHttpCode = "401"
+		string $expectedHttpCode = "401",
+		bool $downloadForShareNG = false
 	):void {
 		if ($publicWebDAVAPIVersion === "old") {
 			return;
@@ -1053,7 +1081,8 @@ class PublicWebDavContext implements Context {
 			$path,
 			$password,
 			$range,
-			$publicWebDAVAPIVersion
+			$publicWebDAVAPIVersion,
+			$downloadForShareNG
 		);
 
 		$responseContent = $response->getBody()->getContents();

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -187,7 +187,7 @@ trait Sharing {
 	/**
 	 * @return string
 	 */
-	public function shareNGGetLastCreatedPublicLinkShareToken(): string {
+	public function shareNgGetLastCreatedLinkShareToken(): string {
 		$lastResponse = $this->shareNgGetLastCreatedLinkShare();
 		if (!isset($this->getJsonDecodedResponse($lastResponse)['link']['webUrl'])) {
 			throw new Error('Response did not contain share id ' . $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'] . ' for the created public link');

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -184,17 +184,17 @@ trait Sharing {
 		return $this->getJsonDecodedResponse($lastResponse)['id'];
 	}
 
-    /**
-     * @return string
-     */
-    public function shareNGGetLastCreatedPublicLinkShareToken(): string {
-        $lastResponse = $this->shareNGGetLastCreatedPublicShare();
-        if (!isset($this->getJsonDecodedResponse($lastResponse)['link']['webUrl'])) {
-            throw new Error('Response did not contain share id ' . $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'] . ' for the created public link');
-        }
-        $last_created_link_webURL =  $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'];
-        return substr(strrchr($last_created_link_webURL, "/"), 1);
-    }
+	/**
+	 * @return string
+	 */
+	public function shareNGGetLastCreatedPublicLinkShareToken(): string {
+		$lastResponse = $this->shareNgGetLastCreatedLinkShare();
+		if (!isset($this->getJsonDecodedResponse($lastResponse)['link']['webUrl'])) {
+			throw new Error('Response did not contain share id ' . $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'] . ' for the created public link');
+		}
+		$last_created_link_webURL =  $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'];
+		return substr(strrchr($last_created_link_webURL, "/"), 1);
+	}
 
 	/**
 	 * Split given permissions string each separated with "," into array of strings

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -184,6 +184,18 @@ trait Sharing {
 		return $this->getJsonDecodedResponse($lastResponse)['id'];
 	}
 
+    /**
+     * @return string
+     */
+    public function shareNGGetLastCreatedPublicLinkShareToken(): string {
+        $lastResponse = $this->shareNGGetLastCreatedPublicShare();
+        if (!isset($this->getJsonDecodedResponse($lastResponse)['link']['webUrl'])) {
+            throw new Error('Response did not contain share id ' . $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'] . ' for the created public link');
+        }
+        $last_created_link_webURL =  $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'];
+        return substr(strrchr($last_created_link_webURL, "/"), 1);
+    }
+
 	/**
 	 * Split given permissions string each separated with "," into array of strings
 	 *

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -253,7 +253,7 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user sets/updates password for the last public link share using the Graph API with
+	 * @When user :user sets/updates the following password for the last public link share using the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
@@ -282,7 +282,7 @@ class SharingNgContext implements Context {
 			throw new Error('Password is missing to set for share link!');
 		}
 
-		$response = GraphHelper::setPassword(
+		$response = GraphHelper::setLinkSharePassword(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
 			$user,

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -253,48 +253,47 @@ class SharingNgContext implements Context {
 		);
 	}
 
+	/**
+	 * @When user :user sets/updates password for the last public link share using the Graph API with
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 * @throws Exception
+	 * @throws \GuzzleHttp\Exception\GuzzleException
+	 */
+	public function clearuserSetsPasswordForLastPublicLinkShare(string $user, TableNode  $body):void {
+		$bodyRows = $body->getRowsHash();
+		$space = $bodyRows['space'];
+		$resourceType = $bodyRows['resourceType'];
+		$resource = $bodyRows['resource'];
+		$spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
+		if ($resourceType === 'folder') {
+			$itemId = $this->spacesContext->getResourceId($user, $space, $resource);
+		} else {
+			$itemId = $this->spacesContext->getFileId($user, $space, $resource);
+		}
 
-    /**
-     * @When /^user "([^"]*)" sets password for the last public link share using the Graph API with$/
-     *
-     * @param string $user
-     * @param TableNode|null $body
-     *
-     * @return void
-     * @throws Exception
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     */
-    public function clearuserSetsPasswordForLastPublicLinkShare(string $user, TableNode  $body):void {
-        $bodyRows = $body->getRowsHash();
-        $space = $bodyRows['space'];
-        $resourceType = $bodyRows['resourceType'];
-        $resource = $bodyRows['resource'];
-        $spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
-        if ($resourceType === 'folder') {
-            $itemId = $this->spacesContext->getResourceId($user, $space, $resource);
-        } else {
-            $itemId = $this->spacesContext->getFileId($user, $space, $resource);
-        }
+		if (\array_key_exists('password', $bodyRows)) {
+			$body = [
+				"password" => $this->featureContext->getActualPassword($bodyRows['password']),
+			];
+		} else {
+			throw new Error('Password is missing to set for share link!');
+		}
 
-        if (\array_key_exists('password', $bodyRows)) {
-            $body = [
-                "password" => $this->featureContext->getActualPassword($bodyRows['password']),
-            ];
-        } else {
-            throw new Error('Password is missing to set for share link!');
-        }
-
-        $this->featureContext->setResponse(
-            GraphHelper::setPassword(
-                $this->featureContext->getBaseUrl(),
-                $this->featureContext->getStepLineRef(),
-                $user,
-                $this->featureContext->getPasswordForUser($user),
-                $spaceId,
-                $itemId,
-                \json_encode($body),
-                $this->featureContext->shareNGGetLastCreatedPublicLinkShareID()
-            )
-        );
-    }
+		$this->featureContext->setResponse(
+			GraphHelper::setPassword(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getStepLineRef(),
+				$user,
+				$this->featureContext->getPasswordForUser($user),
+				$spaceId,
+				$itemId,
+				\json_encode($body),
+				$this->featureContext->shareNgGetLastCreatedLinkShareID()
+			)
+		);
+	}
 }

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -253,7 +253,7 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user sets/updates the following password for the last public link share using the Graph API:
+	 * @When user :user sets/updates the following password for the last link share using the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body
@@ -262,7 +262,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function userSetsOrUpdatesPasswordForPublicLinkShareUsingTheGraphApiWith(string $user, TableNode  $body):void {
+	public function userSetsOrUpdatesFollowingPasswordForLastLinkShareUsingTheGraphApi(string $user, TableNode  $body):void {
 		$bodyRows = $body->getRowsHash();
 		$space = $bodyRows['space'];
 		$resourceType = $bodyRows['resourceType'];

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -252,4 +252,49 @@ class SharingNgContext implements Context {
 			)
 		);
 	}
+
+
+    /**
+     * @When /^user "([^"]*)" sets password for the last public link share using the Graph API with$/
+     *
+     * @param string $user
+     * @param TableNode|null $body
+     *
+     * @return void
+     * @throws Exception
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function clearuserSetsPasswordForLastPublicLinkShare(string $user, TableNode  $body):void {
+        $bodyRows = $body->getRowsHash();
+        $space = $bodyRows['space'];
+        $resourceType = $bodyRows['resourceType'];
+        $resource = $bodyRows['resource'];
+        $spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
+        if ($resourceType === 'folder') {
+            $itemId = $this->spacesContext->getResourceId($user, $space, $resource);
+        } else {
+            $itemId = $this->spacesContext->getFileId($user, $space, $resource);
+        }
+
+        if (\array_key_exists('password', $bodyRows)) {
+            $body = [
+                "password" => $this->featureContext->getActualPassword($bodyRows['password']),
+            ];
+        } else {
+            throw new Error('Password is missing to set for share link!');
+        }
+
+        $this->featureContext->setResponse(
+            GraphHelper::setPassword(
+                $this->featureContext->getBaseUrl(),
+                $this->featureContext->getStepLineRef(),
+                $user,
+                $this->featureContext->getPasswordForUser($user),
+                $spaceId,
+                $itemId,
+                \json_encode($body),
+                $this->featureContext->shareNGGetLastCreatedPublicLinkShareID()
+            )
+        );
+    }
 }

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -239,18 +239,17 @@ class SharingNgContext implements Context {
 			throw new Error('Expiration date or role is missing to update for share link!');
 		}
 
-		$this->featureContext->setResponse(
-			GraphHelper::updateLinkShare(
-				$this->featureContext->getBaseUrl(),
-				$this->featureContext->getStepLineRef(),
-				$user,
-				$this->featureContext->getPasswordForUser($user),
-				$spaceId,
-				$itemId,
-				\json_encode($body),
-				$this->featureContext->shareNgGetLastCreatedLinkShareID()
-			)
+		$response = GraphHelper::updateLinkShare(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$spaceId,
+			$itemId,
+			\json_encode($body),
+			$this->featureContext->shareNgGetLastCreatedLinkShareID()
 		);
+		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -263,7 +262,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function clearuserSetsPasswordForLastPublicLinkShare(string $user, TableNode  $body):void {
+	public function userSetsOrUpdatesPasswordForPublicLinkShareUsingTheGraphApiWith(string $user, TableNode  $body):void {
 		$bodyRows = $body->getRowsHash();
 		$space = $bodyRows['space'];
 		$resourceType = $bodyRows['resourceType'];
@@ -283,17 +282,16 @@ class SharingNgContext implements Context {
 			throw new Error('Password is missing to set for share link!');
 		}
 
-		$this->featureContext->setResponse(
-			GraphHelper::setPassword(
-				$this->featureContext->getBaseUrl(),
-				$this->featureContext->getStepLineRef(),
-				$user,
-				$this->featureContext->getPasswordForUser($user),
-				$spaceId,
-				$itemId,
-				\json_encode($body),
-				$this->featureContext->shareNgGetLastCreatedLinkShareID()
-			)
+		$response = GraphHelper::setPassword(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$spaceId,
+			$itemId,
+			\json_encode($body),
+			$this->featureContext->shareNgGetLastCreatedLinkShareID()
 		);
+		$this->featureContext->setResponse($response);
 	}
 }


### PR DESCRIPTION
### Description
This PR adds the tests scenarios to set and update(if already created) the password for the public link share for shareNg
```feature
Scenario: set password for a file's link share
Scenario: update password for a file's link share
```

### Related Issue:
https://github.com/owncloud/ocis/issues/7968