### PR TITLE
[tests-only][ci] Run k6 tests only for master branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2829,5 +2829,8 @@ def k6LoadTests(ctx):
             "event": [
                 "cron",
             ],
+            "ref": [
+                "refs/heads/master",
+            ],
         },
     }]


### PR DESCRIPTION
## Description
Since k6 pipeline uses the remote servers to run ocis server and k6 tests, we cannot run more than one k6 pipeline parallelly. So we have to run k6 pipeline only in on of the branches. This PR makes it to run only with master branch.

## Related Issue

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
