### PR TITLE
use capabilites and not `me/drives` in ociswrapper to check if ocis is online

### DIFF
--- a/tests/ociswrapper/cmd/cmd.go
+++ b/tests/ociswrapper/cmd/cmd.go
@@ -33,8 +33,6 @@ func serveCmd() *cobra.Command {
 			ocisConfig.Set("bin", cmd.Flag("bin").Value.String())
 			ocisConfig.Set("url", cmd.Flag("url").Value.String())
 			ocisConfig.Set("retry", cmd.Flag("retry").Value.String())
-			ocisConfig.Set("adminUsername", cmd.Flag("admin-username").Value.String())
-			ocisConfig.Set("adminPassword", cmd.Flag("admin-password").Value.String())
 
 			go ocis.Start(nil)
 			go wrapper.Start(cmd.Flag("port").Value.String())
@@ -47,8 +45,6 @@ func serveCmd() *cobra.Command {
 	serveCmd.Flags().StringP("url", "", ocisConfig.Get("url"), "oCIS server url")
 	serveCmd.Flags().StringP("retry", "", ocisConfig.Get("retry"), "Number of retries to start oCIS server")
 	serveCmd.Flags().StringP("port", "p", wrapperConfig.Get("port"), "Wrapper API server port")
-	serveCmd.Flags().StringP("admin-username", "", ocisConfig.Get("adminUsername"), "admin username for oCIS server")
-	serveCmd.Flags().StringP("admin-password", "", ocisConfig.Get("adminPassword"), "admin password for oCIS server")
 
 	return serveCmd
 }

--- a/tests/ociswrapper/ocis/config/config.go
+++ b/tests/ociswrapper/ocis/config/config.go
@@ -1,11 +1,9 @@
 package config
 
 var config = map[string]string{
-	"bin":           "/usr/bin/ocis",
-	"url":           "https://localhost:9200",
-	"retry":         "5",
-	"adminUsername": "admin",
-	"adminPassword": "admin",
+	"bin":   "/usr/bin/ocis",
+	"url":   "https://localhost:9200",
+	"retry": "5",
 }
 
 func Set(key string, value string) {

--- a/tests/ociswrapper/ocis/ocis.go
+++ b/tests/ociswrapper/ocis/ocis.go
@@ -137,9 +137,7 @@ func WaitForConnection() bool {
 		Transport: transport,
 	}
 
-	req, _ := http.NewRequest("GET", config.Get("url")+"/graph/v1.0/me/drives", nil)
-	req.SetBasicAuth(config.Get("adminUsername"), config.Get("adminPassword"))
-
+	req, _ := http.NewRequest("GET", config.Get("url")+"/ocs/v1.php/cloud/capabilities?format=json", nil)
 	timeout := time.After(timeoutValue)
 
 	for {


### PR DESCRIPTION
## Description

That way we don't need to have authentication, nor have to enable basic auth in the SUT