### PR TITLE
[tests-only][full-ci] Extend API test coverage for replacing file with zero-byte file via TUS upload

### DIFF
--- a/tests/acceptance/features/apiSpaces/tusUpload.feature
+++ b/tests/acceptance/features/apiSpaces/tusUpload.feature
@@ -39,3 +39,82 @@ Feature: upload resources using TUS protocol
     Then for user "Alice" the space "Alice Hansen" should contain these entries:
       | test.txt   |
       | upload.txt |
+
+
+  Scenario Outline: upload a zero-byte file inside a shared folder
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "testFolder"
+    And user "Alice" has shared folder "testFolder" with user "Brian" with permissions "all"
+    When user "Brian" uploads file "filesForUpload/zerobyte.txt" to "Shares/testFolder/textfile.txt" using the TUS protocol on the WebDAV API
+    Then the content of file "Shares/testFolder/textfile.txt" for user "Brian" should be ""
+    And the content of file "testFolder/textfile.txt" for user "Alice" should be ""
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+
+
+  Scenario: upload a zero-byte file inside a shared folder (spaces dav path)
+    Given using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "testFolder"
+    And user "Alice" has shared folder "testFolder" with user "Brian" with permissions "all"
+    When user "Brian" uploads a file from "filesForUpload/zerobyte.txt" to "testFolder/textfile.txt" via TUS inside of the space "Shares" using the WebDAV API
+    Then for user "Brian" the content of the file "testFolder/textfile.txt" of the space "Shares" should be ""
+    And for user "Alice" the content of the file "testFolder/textfile.txt" of the space "Personal" should be ""
+
+
+  Scenario: upload a zero-byte file inside a project space
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    When user "Alice" uploads a file from "filesForUpload/zerobyte.txt" to "textfile.txt" via TUS inside of the space "new-space" using the WebDAV API
+    Then for user "Alice" the content of the file "textfile.txt" of the space "new-space" should be ""
+
+  @issue-8003
+  Scenario Outline: replace a shared file with zero-byte file
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "This is TUS upload" to "textfile.txt"
+    And user "Alice" has shared file "textfile.txt" with user "Brian" with permissions "read,update"
+    When user "Brian" uploads file "filesForUpload/zerobyte.txt" to "Shares/textfile.txt" using the TUS protocol on the WebDAV API
+    Then the content of file "Shares/textfile.txt" for user "Brian" should be ""
+    And the content of file "textfile.txt" for user "Alice" should be ""
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+
+  @issue-8003
+  Scenario: replace a shared file with zero-byte file (spaces dav path)
+    Given using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "This is TUS upload" to "textfile.txt"
+    And user "Alice" has shared file "textfile.txt" with user "Brian" with permissions "read,update"
+    When user "Brian" uploads a file from "filesForUpload/zerobyte.txt" to "textfile.txt" via TUS inside of the space "Shares" using the WebDAV API
+    Then for user "Brian" the content of the file "textfile.txt" of the space "Shares" should be ""
+    And for user "Alice" the content of the file "textfile.txt" of the space "Personal" should be ""
+
+  @issue-8003
+  Scenario: replace a file inside a project space with zero-byte file
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "new-space" with content "This is TUS upload" to "textfile.txt"
+    When user "Alice" uploads a file from "filesForUpload/zerobyte.txt" to "textfile.txt" via TUS inside of the space "new-space" using the WebDAV API
+    Then for user "Alice" the content of the file "textfile.txt" of the space "new-space" should be ""
+
+  @issue-8003
+  Scenario: replace a file inside a shared project space with zero-byte file
+    Given using spaces DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "new-space" with content "This is TUS upload" to "textfile.txt"
+    And user "Alice" has shared a space "new-space" with settings:
+      | shareWith | Brian  |
+      | role      | editor |
+    When user "Brian" uploads a file from "filesForUpload/zerobyte.txt" to "textfile.txt" via TUS inside of the space "new-space" using the WebDAV API
+    Then for user "Brian" the content of the file "textfile.txt" of the space "new-space" should be ""
+    And for user "Alice" the content of the file "textfile.txt" of the space "new-space" should be ""

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -209,7 +209,8 @@ class TUSContext implements Context {
 
 		$client = new Client(
 			$this->featureContext->getBaseUrl(),
-			['verify' => false,
+			[
+				'verify' => false,
 				'headers' => $headers
 			]
 		);
@@ -230,6 +231,8 @@ class TUSContext implements Context {
 
 		if ($bytes !== null) {
 			$client->file($sourceFile, $destination)->createWithUpload($client->getKey(), $bytes);
+		} elseif (\filesize($sourceFile) === 0) {
+			$client->file($sourceFile, $destination)->createWithUpload($client->getKey(), 0);
 		} elseif ($noOfChunks === 1) {
 			$client->file($sourceFile, $destination)->upload();
 		} else {

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature
@@ -208,3 +208,39 @@ Feature: upload file
       | spaces           | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
       | spaces           | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
       | spaces           | "my\\file"              | bXkMaWxl                     |
+
+
+  Scenario Outline: upload a zero-byte file
+    Given using <dav-path-version> DAV path
+    When user "Alice" uploads file "filesForUpload/zerobyte.txt" to "textfile.txt" using the TUS protocol on the WebDAV API
+    Then the content of file "textfile.txt" for user "Alice" should be ""
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+  @issue-8003
+  Scenario Outline: replace a file with zero-byte file
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "This is TUS upload" to "textfile.txt"
+    When user "Alice" uploads file "filesForUpload/zerobyte.txt" to "textfile.txt" using the TUS protocol on the WebDAV API
+    Then the content of file "textfile.txt" for user "Alice" should be ""
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+  @issue-8003
+  Scenario Outline: replace a file inside a folder with zero-byte file
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created folder "testFolder"
+    And user "Alice" has uploaded file with content "This is TUS upload" to "testFolder/textfile.txt"
+    When user "Alice" uploads file "filesForUpload/zerobyte.txt" to "testFolder/textfile.txt" using the TUS protocol on the WebDAV API
+    Then the content of file "testFolder/textfile.txt" for user "Alice" should be ""
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |


### PR DESCRIPTION
## Description
This PR extends the API test coverage for replacing file with zero-byte file via TUS upload

Added scenarios:
```feature
Scenario Outline: upload a zero-byte file in a shared folder
Scenario: upload a zero-byte file in a shared folder (spaces dav path)
Scenario: upload a zero-byte file in a project space
Scenario Outline: replace a shared file with zero-byte file
Scenario: replace a shared file with zero-byte file (spaces dav path)
Scenario: replace a file inside a project space with zero-byte file
Scenario: replace a file inside a shared project space with zero-byte file
Scenario Outline: upload a zero-byte file
Scenario Outline: replace a file with zero-byte file
Scenario Outline: replace a file inside a folder with zero-byte file
```

## Related Issue
Closes https://github.com/owncloud/ocis/issues/8044

## Motivation and Context
Test coverage for bug fix

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
