### PR TITLE
[tests-only] Extend API test coverage for MOVE between spaces

### DIFF
--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -286,6 +286,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebDavPropertiesContext:
+        - FilesVersionsContext:
 
     coreApiWebdavOperations:
       paths:

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -154,20 +154,6 @@ cannot share a folder with create permission
 - [coreApiShareOperationsToShares2/uploadToShare.feature:202](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature#L202)
 - [coreApiShareOperationsToShares2/uploadToShare.feature:203](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature#L203)
 
-#### [not possible to move file into a received folder](https://github.com/owncloud/ocis/issues/764)
-
-- [coreApiShareOperationsToShares1/changingFilesShare.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L25)
-- [coreApiShareOperationsToShares1/changingFilesShare.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L26)
-- [coreApiShareOperationsToShares1/changingFilesShare.feature:65](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L65)
-- [coreApiShareOperationsToShares1/changingFilesShare.feature:66](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L66)
-- [coreApiShareOperationsToShares1/changingFilesShare.feature:85](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L85)
-- [coreApiShareOperationsToShares1/changingFilesShare.feature:86](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature#L86)
-- [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:474](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L474)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:28](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L28)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:30](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L30)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:93](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L93)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:95](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L95)
-
 #### [Expiration date for shares is not implemented](https://github.com/owncloud/ocis/issues/1250)
 
 #### Expiration date of user shares

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -426,9 +426,9 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [coreApiWebdavUpload1/uploadFile.feature:181](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUpload1/uploadFile.feature#L181)
 - [coreApiWebdavUpload1/uploadFile.feature:180](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUpload1/uploadFile.feature#L180)
 - [coreApiWebdavUpload1/uploadFile.feature:186](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUpload1/uploadFile.feature#L186)
-- [coreApiWebdavMove2/moveFile.feature:175](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L175)
-- [coreApiWebdavMove2/moveFile.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L176)
-- [coreApiWebdavMove2/moveFile.feature:181](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L181)
+- [coreApiWebdavMove2/moveFile.feature:178](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L178)
+- [coreApiWebdavMove2/moveFile.feature:179](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L179)
+- [coreApiWebdavMove2/moveFile.feature:184](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L184)
 
 #### [cannot set blacklisted file names](https://github.com/owncloud/product/issues/260)
 
@@ -469,7 +469,7 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [coreApiWebdavMove1/moveFolder.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature#L26)
 - [coreApiWebdavMove1/moveFolder.feature:44](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature#L44)
 - [coreApiWebdavMove1/moveFolder.feature:62](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature#L62)
-- [coreApiWebdavMove2/moveFile.feature:137](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L137)
+- [coreApiWebdavMove2/moveFile.feature:140](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L140)
 - [coreApiWebdavMove2/moveFileToBlacklistedName.feature:24](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature#L24)
 
 #### [REPORT method on spaces returns an incorrect d:href response](https://github.com/owncloud/ocis/issues/3111)

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -116,10 +116,13 @@ Feature: move (rename) file
       | role    | permissions |
       | manager | 31          |
       | editor  | 31          |
+      | viewer  | 31          |
       | manager | 17          |
       | editor  | 17          |
-      | viewer  | 31          |
       | viewer  | 17          |
+      | manager | 1           |
+      | editor  | 1           |
+      | viewer  | 1           |
 
 
   Scenario Outline: user moves a file from space personal to space project with different role
@@ -199,58 +202,40 @@ Feature: move (rename) file
       | manager | 17          |
       | editor  | 17          |
       | viewer  | 17          |
+      | manager | 1           |
+      | editor  | 1           |
+      | viewer  | 1           |
 
 
-  Scenario: user moves a file from space Shares with role editor to space Shares with role editor
+  Scenario Outline: user moves a file from space Shares to another space Shares with different role (permissions)
     Given user "Brian" has created folder "/testshare1"
     And user "Brian" has created folder "/testshare2"
     And user "Brian" has uploaded file with content "testshare1 content" to "/testshare1/testshare1.txt"
-    And user "Brian" has shared folder "/testshare1" with user "Alice" with permissions "31"
-    And user "Brian" has shared folder "/testshare2" with user "Alice" with permissions "31"
+    And user "Brian" has shared folder "/testshare1" with user "Alice" with permissions "<from_permissions>"
+    And user "Brian" has shared folder "/testshare2" with user "Alice" with permissions "<to_permissions>"
     When user "Alice" moves file "/testshare1/testshare1.txt" from space "Shares" to "/testshare2/testshare1.txt" inside space "Shares" using the WebDAV API
     Then the HTTP status code should be "403"
     And for user "Alice" folder "testshare1" of the space "Shares" should contain these entries:
       | testshare1.txt |
     But for user "Alice" folder "testshare2" of the space "Shares" should not contain these entries:
       | testshare1.txt |
+    Examples:
+      | from_permissions | to_permissions |
+      | 31               | 31             |
+      | 31               | 17             |
+      | 31               | 1              |
+      | 17               | 31             |
+      | 17               | 17             |
+      | 17               | 1              |
+      | 1                | 31             |
+      | 1                | 17             |
+      | 1                | 1              |
 
 
-  Scenario: user moves a file from space Shares with role editor to space Shares with role viewer
-    Given user "Brian" has created folder "/testshare1"
-    And user "Brian" has created folder "/testshare2"
-    And user "Brian" has uploaded file with content "testshare1 content" to "/testshare1/testshare1.txt"
-    And user "Brian" has shared folder "/testshare1" with user "Alice" with permissions "31"
-    And user "Brian" has shared folder "/testshare2" with user "Alice" with permissions "17"
-    When user "Alice" moves file "/testshare1/testshare1.txt" from space "Shares" to "/testshare2/testshare1.txt" inside space "Shares" using the WebDAV API
-    Then the HTTP status code should be "403"
-    And for user "Alice" folder "testshare1" of the space "Shares" should contain these entries:
-      | testshare1.txt |
-    But for user "Alice" folder "testshare2" of the space "Shares" should not contain these entries:
-      | testshare1.txt |
-
-
-  Scenario: user moves a file from space Shares with role viewer to space Shares with role editor
-    Given user "Brian" has created folder "/testshare1"
-    And user "Brian" has created folder "/testshare2"
-    And user "Brian" has uploaded file with content "testshare1 content" to "/testshare1/testshare1.txt"
-    And user "Brian" has shared folder "/testshare1" with user "Alice" with permissions "17"
-    And user "Brian" has shared folder "/testshare2" with user "Alice" with permissions "31"
-    When user "Alice" moves file "/testshare1/testshare1.txt" from space "Shares" to "/testshare2/testshare1.txt" inside space "Shares" using the WebDAV API
-    Then the HTTP status code should be "403"
-    And for user "Alice" folder "testshare1" of the space "Shares" should contain these entries:
-      | testshare1.txt |
-    But for user "Alice" folder "testshare2" of the space "Shares" should not contain these entries:
-      | testshare1.txt |
-
-
-  Scenario: moving a file out of a shared folder as a sharer
+  Scenario Outline: moving a file out of a shared folder as a sharer
     Given user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
-    And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
+    And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
     When user "Brian" moves file "/testshare/testfile.txt" from space "Personal" to "/testfile.txt" inside space "Personal" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/testfile.txt" for user "Brian" should be "test data"
@@ -258,19 +243,20 @@ Feature: move (rename) file
       | testfile.txt |
     And for user "Brian" folder "testshare" of the space "Personal" should not contain these entries:
       | testfile.txt |
+    Examples:
+      | permissions |
+      | 31          |
+      | 17          |
+      | 1           |
 
 
-  Scenario: moving a folder out of a shared folder as a sharer
+  Scenario Outline: moving a folder out of a shared folder as a sharer
     Given user "Brian" has created the following folders
       | path                     |
       | /testshare               |
       | /testshare/testsubfolder |
     And user "Brian" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
-    And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
+    And user "Brian" has shared folder "/testshare" with user "Alice" with permissions "<permissions>"
     When user "Brian" moves folder "/testshare/testsubfolder" from space "Personal" to "/testsubfolder" inside space "Personal" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/testsubfolder/testfile.txt" for user "Brian" should be "test data"
@@ -278,19 +264,57 @@ Feature: move (rename) file
       | testsubfolder |
     And for user "Brian" folder "testshare" of the space "Personal" should not contain these entries:
       | testsubfolder |
+    Examples:
+      | permissions |
+      | 31          |
+      | 17          |
+      | 1           |
 
 
-  Scenario: overwriting a file while moving
-    Given user "Brian" has created folder "/folder"
-    And user "Brian" has uploaded file with content "some content" to "/folder/testfile.txt"
-    And user "Brian" has uploaded file with content "old data version 1" to "/testfile.txt"
-    And user "Brian" has uploaded file with content "new data version 2" to "/testfile.txt"
-    When user "Brian" overwrites file "/testfile.txt" from space "Personal" to "folder/testfile.txt" inside space "Personal" while moving using the WebDAV API
+  Scenario Outline: sharee moves a file within a Shares space (all/change permissions)
+    Given user "Brian" has created folder "testshare"
+    Given user "Brian" has created folder "testshare/child"
+    And user "Brian" has uploaded file with content "test file content" to "/testshare/testfile.txt"
+    And user "Brian" has shared folder "testshare" with user "Alice" with permissions "<permissions>"
+    When user "Alice" moves file "testshare/testfile.txt" from space "Shares" to "testshare/child/testfile.txt" inside space "Shares" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And for user "Alice" the content of the file "testshare/child/testfile.txt" of the space "Shares" should be "test file content"
+    And for user "Alice" folder "testshare" of the space "Shares" should not contain these entries:
+      | testfile.txt |
+    Examples:
+      | permissions |
+      | all         |
+      | change      |
+
+
+  Scenario: sharee moves a file within a Shares space (read permissions)
+    Given user "Brian" has created folder "testshare"
+    Given user "Brian" has created folder "testshare/child"
+    And user "Brian" has uploaded file with content "test file content" to "/testshare/testfile.txt"
+    And user "Brian" has shared folder "testshare" with user "Alice" with permissions "read"
+    When user "Alice" moves file "testshare/testfile.txt" from space "Shares" to "testshare/child/testfile.txt" inside space "Shares" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And for user "Alice" folder "testshare/child" of the space "Shares" should not contain these entries:
+      | testfile.txt |
+    But for user "Alice" folder "testshare" of the space "Shares" should contain these entries:
+      | testfile.txt |
+
+
+  Scenario: overwrite a file while moving in project space
+    Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
+    And user "Brian" has created a space "Project" with the default quota using the Graph API
+    And user "Brian" has created a folder "folder" in space "Project"
+    And user "Brian" has uploaded a file inside space "Project" with content "root file v1" to "testfile.txt"
+    And user "Brian" has uploaded a file inside space "Project" with content "root file v2" to "testfile.txt"
+    And user "Brian" has uploaded a file inside space "Project" with content "same name file" to "folder/testfile.txt"
+    And user "Brian" has shared a space "Project" with settings:
+      | shareWith | Alice  |
+      | role      | editor |
+    When user "Alice" overwrites file "testfile.txt" from space "Project" to "folder/testfile.txt" inside space "Project" while moving using the WebDAV API
     Then the HTTP status code should be "204"
-    And the content of file "/folder/testfile.txt" for user "Brian" should be "new data version 2"
-    And for user "Brian" the space "Personal" should not contain these entries:
-      | /testfile.txt |
-    When user "Brian" downloads version of the file "/folder/testfile.txt" with the index "1" of the space "Personal" using the WebDAV API
+    And for user "Alice" the content of the file "folder/testfile.txt" of the space "Project" should be "root file v2"
+    And for user "Alice" the space "Project" should not contain these entries:
+      | testfile.txt |
+    When user "Brian" downloads version of the file "folder/testfile.txt" with the index "1" of the space "Project" using the WebDAV API
     Then the HTTP status code should be "200"
-    And the downloaded content should be "old data version 1"
-    And as "Brian" file "testfile.txt" should exist in the trashbin of the space "Personal"
+    And the downloaded content should be "root file v1"

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -460,7 +460,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should exist
 
   @issue-7555
-  Scenario Outline: share receiver renames a group share and receives same resource through user share with additional permissions 
+  Scenario Outline: share receiver renames a group share and receives same resource through user share with additional permissions
     Given using OCS API version "<ocs_api_version>"
     And group "grp" has been created
     And user "Brian" has been added to group "grp"

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -470,7 +470,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-2146 @issue-764 @issue-7555
+  @issue-764 @issue-7555
   Scenario: share a file by multiple channels and download from sub-folder and direct file share
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -481,11 +481,11 @@ Feature: sharing
     And user "Carol" has been added to group "grp1"
     And user "Alice" has created folder "/common"
     And user "Alice" has created folder "/common/sub"
+    And user "Alice" has uploaded file with content "ownCloud" to "/textfile0.txt"
     And user "Alice" has shared folder "common" with group "grp1"
-    And user "Brian" has uploaded file with content "ownCloud" to "/textfile0.txt"
-    And user "Brian" has shared file "textfile0.txt" with user "Carol"
-    And user "Brian" has moved file "/textfile0.txt" to "/Shares/common/textfile0.txt"
-    And user "Brian" has moved file "/Shares/common/textfile0.txt" to "/Shares/common/sub/textfile0.txt"
+    And user "Alice" has shared file "textfile0.txt" with user "Carol"
+    And user "Alice" has moved file "/textfile0.txt" to "/common/textfile0.txt"
+    And user "Alice" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
     When user "Carol" uploads file "filesForUpload/file_to_overwrite.txt" to "/Shares/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/Shares/common/sub/textfile0.txt" for user "Carol" should be "BLABLABLA" plus end-of-line

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
@@ -10,21 +10,6 @@ Feature: sharing
       | Alice    |
       | Brian    |
 
-  @smokeTest
-  Scenario Outline: moving a file into a share as recipient
-    Given using <dav-path-version> DAV path
-    And user "Alice" has created folder "/shared"
-    And user "Alice" has shared folder "/shared" with user "Brian"
-    And user "Brian" has uploaded file with content "some data" to "/textfile0.txt"
-    When user "Brian" moves file "textfile0.txt" to "/Shares/shared/shared_file.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Brian" file "/Shares/shared/shared_file.txt" should exist
-    And as "Alice" file "/shared/shared_file.txt" should exist
-    Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
-
 
   Scenario Outline: move files between shares by same user
     Given using <dav-path-version> DAV path
@@ -40,46 +25,6 @@ Feature: sharing
     And as "Alice" file "share1/textfile0.txt" should exist
     But as "Brian" file "/Shares/share2/textfile0.txt" should not exist
     And as "Alice" file "share2/textfile0.txt" should not exist
-    Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
-
-
-  Scenario Outline: move files between shares by same user added by sharee
-    Given using <dav-path-version> DAV path
-    And user "Alice" has created folder "share1"
-    And user "Alice" has created folder "share2"
-    And user "Brian" has uploaded file with content "some data" to "/textfile0.txt"
-    And user "Alice" has shared folder "/share1" with user "Brian"
-    And user "Alice" has shared folder "/share2" with user "Brian"
-    When user "Brian" moves file "textfile0.txt" to "/Shares/share1/shared_file.txt" using the WebDAV API
-    And user "Brian" moves file "/Shares/share1/shared_file.txt" to "/Shares/share2/shared_file.txt" using the WebDAV API
-    Then the HTTP status code of responses on all endpoints should be "201"
-    And as "Brian" file "/Shares/share1/shared_file.txt" should not exist
-    And as "Alice" file "share1/shared_file.txt" should not exist
-    But as "Brian" file "/Shares/share2/shared_file.txt" should exist
-    And as "Alice" file "share2/shared_file.txt" should exist
-    Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
-
-
-  Scenario Outline: move files between shares by different users
-    Given using <dav-path-version> DAV path
-    And user "Carol" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
-    And user "Alice" has created folder "/PARENT"
-    And user "Brian" has created folder "/PARENT"
-    And user "Alice" has moved file "textfile0.txt" to "PARENT/shared_file.txt"
-    And user "Alice" has shared folder "/PARENT" with user "Carol"
-    And user "Brian" has shared folder "/PARENT" with user "Carol"
-    When user "Carol" moves file "/Shares/PARENT/shared_file.txt" to "/Shares/PARENT (2)/shared_file.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Carol" file "/Shares/PARENT (2)/shared_file.txt" should exist
-    And as "Brian" file "PARENT/shared_file.txt" should exist
-    But as "Alice" file "PARENT/shared_file.txt" should not exist
     Examples:
       | dav-path-version |
       | old              |

--- a/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature
@@ -30,13 +30,16 @@ Feature: move (rename) file
   @smokeTest
   Scenario Outline: moving and overwriting a file
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0 v1" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0 v2" to "textfile0.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     When user "Alice" moves file "/textfile0.txt" to "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0"
+    And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0 v2"
+    And the content of version index "1" of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0 v1"
+    And as "Alice" file "/textfile0.txt" should not exist
     Examples:
       | dav-path-version |
       | old              |

--- a/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: move (rename) file
   As a user
   I want to be able to move and rename files
@@ -7,93 +8,156 @@ Feature: move (rename) file
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnReva
-  Scenario Outline: moving a file into a shared folder as the sharee and as the sharer
+
+  Scenario Outline: sharer moves a file into a shared folder
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
-    And user "<mover>" has uploaded file with content "test data" to "/testfile.txt"
-    When user "<mover>" moves file "/testfile.txt" to "<destination_folder>/testfile.txt" using the WebDAV API
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
+    And user "Brian" has uploaded file with content "test data" to "/testfile.txt"
+    When user "Brian" moves file "/testfile.txt" to "testshare/testfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/Shares/testshare/testfile.txt" for user "Alice" should be "test data"
     And the content of file "/testshare/testfile.txt" for user "Brian" should be "test data"
-    And as "<mover>" file "/testfile.txt" should not exist
+    And as "Brian" file "/testfile.txt" should not exist
     Examples:
-      | dav-path-version | mover | destination_folder |
-      | old              | Alice | /Shares/testshare  |
-      | old              | Brian | /testshare         |
-      | new              | Alice | /Shares/testshare  |
-      | new              | Brian | /testshare         |
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
 
-  @skipOnReva
+
+  Scenario Outline: sharee tries to move a file into a shared folder
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created a share with settings
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
+    And user "Alice" has uploaded file with content "test data" to "/testfile.txt"
+    When user "Alice" moves file "/testfile.txt" to "Shares/testshare/testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "Shares/testshare/testfile.txt" should not exist
+    And as "Brian" file "testshare/testfile.txt" should not exist
+    But as "Alice" file "/testfile.txt" should exist
+    Examples:
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
+
+
   Scenario Outline: moving a file out of a shared folder as the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
     When user "Brian" moves file "/testshare/testfile.txt" to "/testfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/testfile.txt" for user "Brian" should be "test data"
     And as "Alice" file "/Shares/testshare/testfile.txt" should not exist
     And as "Brian" file "/testshare/testfile.txt" should not exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
 
-  @skipOnReva
+
   Scenario Outline: moving a file out of a shared folder as the sharee
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
     When user "Alice" moves file "/Shares/testshare/testfile.txt" to "/testfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/Shares/testshare/testfile.txt" should exist
     And as "Brian" file "/testshare/testfile.txt" should exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
 
-  @skipOnReva
-  Scenario Outline: moving a folder into a shared folder as the sharee and as the sharer
+
+  Scenario Outline: moving a folder into a shared folder the sharer
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
-    And user "<mover>" has created folder "/testsubfolder"
-    And user "<mover>" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
-    When user "<mover>" moves folder "/testsubfolder" to "<destination_folder>/testsubfolder" using the WebDAV API
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
+    And user "Brian" has created folder "/testsubfolder"
+    And user "Brian" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
+    When user "Brian" moves folder "/testsubfolder" to "testshare/testsubfolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/Shares/testshare/testsubfolder/testfile.txt" for user "Alice" should be "test data"
     And the content of file "/testshare/testsubfolder/testfile.txt" for user "Brian" should be "test data"
-    And as "<mover>" file "/testsubfolder" should not exist
+    And as "Brian" file "/testsubfolder" should not exist
     Examples:
-      | dav-path-version | mover | destination_folder |
-      | old              | Alice | /Shares/testshare  |
-      | old              | Brian | /testshare         |
-      | new              | Alice | /Shares/testshare  |
-      | new              | Brian | /testshare         |
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
+
+
+  Scenario Outline: moving a folder into a shared folder as the sharee
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created a share with settings
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
+    And user "Alice" has created folder "/testsubfolder"
+    And user "Alice" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
+    When user "Alice" moves folder "/testsubfolder" to "Shares/testshare/testsubfolder" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" folder "/Shares/testshare/testsubfolder" should not exist
+    And as "Brian" folder "/testshare/testsubfolder" should not exist
+    But as "Alice" folder "/testsubfolder" should exist
+    Examples:
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
 
 
   Scenario Outline: moving a folder out of a shared folder as the sharer
@@ -105,21 +169,25 @@ Feature: move (rename) file
       | /testshare/testsubfolder |
     And user "Brian" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
     When user "Brian" moves folder "/testshare/testsubfolder" to "/testsubfolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/testsubfolder/testfile.txt" for user "Brian" should be "test data"
     And as "Alice" folder "/testshare/testsubfolder" should not exist
     And as "Brian" folder "/testshare/testsubfolder" should not exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
 
-  @skipOnReva
+
   Scenario Outline: moving a folder out of a shared folder as the sharee
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -129,54 +197,66 @@ Feature: move (rename) file
       | /testshare/testsubfolder |
     And user "Brian" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
     When user "Alice" moves folder "/Shares/testshare/testsubfolder" to "/testsubfolder" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" folder "/Shares/testshare/testsubfolder" should exist
     And as "Brian" folder "/testshare/testsubfolder" should exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
 
-  @skipOnReva
-  Scenario Outline: moving a file to a shared folder with no permissions
+
+  Scenario Outline: sharee moves a file within a shared folder (change/all permissions)
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created folder "testshare"
+    And user "Brian" has created folder "testshare/child"
+    And user "Brian" has uploaded file with content "test data" to "testshare/testfile.txt"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | read      |
-      | shareWith   | Alice     |
-    When user "Alice" moves file "/textfile0.txt" to "/Shares/testshare/textfile0.txt" using the WebDAV API
-    Then the HTTP status code should be "403"
-    And user "Alice" should not be able to download file "/Shares/testshare/textfile0.txt"
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
+    When user "Alice" moves folder "Shares/testshare/testfile.txt" to "Shares/testshare/child/testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/Shares/testshare/child/testfile.txt" should exist
+    And as "Brian" file "/testshare/child/testfile.txt" should exist
+    And as "Alice" file "/Shares/testshare/testfile.txt" should not exist
+    And as "Brian" file "/testshare/testfile.txt" should not exist
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | permissions |
+      | old              | change      |
+      | old              | all         |
+      | new              | change      |
+      | new              | all         |
 
-  @skipOnReva
-  Scenario Outline: moving a file to overwrite a file in a shared folder with no permissions
+
+  Scenario Outline: sharee tries to move a file within a shared folder (read permissions)
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "/testshare"
-    And user "Brian" has uploaded file with content "Welcome to ownCloud" to "fileToCopy.txt"
+    And user "Brian" has created folder "testshare"
+    And user "Brian" has created folder "testshare/child"
+    And user "Brian" has uploaded file with content "test data" to "testshare/testfile.txt"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | read      |
-      | shareWith   | Alice     |
-    And user "Brian" has copied file "/fileToCopy.txt" to "/testshare/overwritethis.txt"
-    When user "Alice" moves file "/textfile0.txt" to "/Shares/testshare/overwritethis.txt" using the WebDAV API
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | read          |
+      | shareWith   | Alice         |
+    When user "Alice" moves folder "Shares/testshare/testfile.txt" to "Shares/testshare/child/testfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
-    And the content of file "/Shares/testshare/overwritethis.txt" for user "Alice" should be "Welcome to ownCloud"
+    And as "Alice" file "/Shares/testshare/child/testfile.txt" should not exist
+    And as "Brian" file "/testshare/child/testfile.txt" should not exist
+    And as "Alice" file "/Shares/testshare/testfile.txt" should exist
+    And as "Brian" file "/testshare/testfile.txt" should exist
     Examples:
       | dav-path-version |
       | old              |


### PR DESCRIPTION
## Description
Extends MOVE API test coverage:

**Using file path**

| from       | from (role)           | to                  | to (role)             | result         | API coverage       |
| ---------- | --------------------- | ------------------- | --------------------- | -------------- | ------------------ |
| project    | manager/editor        | project(same)       |                       | 201 :+1:       | :heavy_check_mark: |
| project    | viewer                | project(same)       |                       | 403 :+1:       | :heavy_check_mark: |
| project    | manager/editor        | project             | manager/editor        | 502 :question: | :heavy_check_mark: |
| project    | manager/editor        | project             | viewer                | 403 :+1:       | :heavy_check_mark: |
| project    | viewer                | project             | manager/editor/viewer | 403 :+1:       | :heavy_check_mark: |
| project    | manager/editor        | personal            |                       | 502 :question: | :heavy_check_mark: |
| project    | viewer                | personal            |                       | 403 :+1:       | :heavy_check_mark: |
| project    | manager/editor/viewer | share jail          | all/editor/viewer     | 403 :+1:       | :heavy_check_mark: |
| personal   |                       | personal(same)      |                       | 201 :+1:       | :heavy_check_mark: |
| personal   |                       | personal(subfolder) |                       | 201 :+1:       | :heavy_check_mark: |
| personal   |                       | project             | manager/editor        | 502 :question: | :heavy_check_mark: |
| personal   |                       | project             | viewer                | 403 :+1:       | :heavy_check_mark: |
| personal   |                       | share jail          | all/editor/viewer     | 403 :+1:       | :heavy_check_mark: |
| share jail | all/editor/viewer     | personal            |                       | 403 :+1:       | :heavy_check_mark: |
| share jail | all/editor/viewer     | project             | manager/editor/viewer | 403 :+1:       | :heavy_check_mark: |
| share jail | all/editor/viewer     | share jail          | all/editor/viewer     | 403 :+1:       | :heavy_check_mark: |
| share jail | all/editor            | share jail(same)    |                       | 201 :+1:       | :heavy_check_mark: |
| share jail | viewer                | share jail(same)    |                       | 403 :+1:       | :heavy_check_mark: |


## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/764
- https://github.com/owncloud/ocis/issues/8063
- https://github.com/owncloud/ocis/issues/7618
- https://github.com/owncloud/ocis/issues/8116
- https://github.com/owncloud/ocis/issues/6737

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
