### PR TITLE
[tests-only] tests: refactor test script for removing permission from share

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1541,44 +1541,6 @@ class GraphHelper {
 	}
 
 	/**
-	 * @param string $baseUrl
-	 * @param string $xRequestId
-	 * @param string $sharer
-	 * @param string $userIdOfShareeUser this is a uuidv4 of sharee
-	 * @param string $password
-	 * @param string $spaceId
-	 * @param string $itemId
-	 * @param string $shareType (user|group)
-	 *
-	 * @return string
-	 *
-	 * @throws GuzzleException
-	 * @throws \JsonException
-	 */
-	public static function getSharePermissionId(
-		string $baseUrl,
-		string $xRequestId,
-		string $sharer,
-		string $userIdOfShareeUser,
-		string $password,
-		string $spaceId,
-		string $itemId,
-		string $shareType
-	): string {
-		$response = self::getPermissionsList($baseUrl, $xRequestId, $sharer, $password, $spaceId, $itemId);
-		$permissionList = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
-		foreach ($permissionList["value"] as $value) {
-			if ($value["grantedToV2"][$shareType]["id"] === $userIdOfShareeUser) {
-				return $value["id"];
-			}
-		}
-		throw new \Exception(
-			__METHOD__
-			. " Cannot find share permission id for user"
-		);
-	}
-
-	/**
 	 * Get the role id by name
 	 *
 	 * @param string $role
@@ -1787,7 +1749,7 @@ class GraphHelper {
 	 *
 	 * @throws GuzzleException
 	 */
-	public static function removeSharePermission(
+	public static function deleteSharePermission(
 		string $baseUrl,
 		string $xRequestId,
 		string $user,

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -81,6 +81,11 @@ trait Sharing {
 	private array $shareNgCreatedLinkShares = [];
 
 	/**
+	 * @var array
+	 */
+	private array $shareNgCreatedUserGroupShares = [];
+
+	/**
 	 * @return string
 	 */
 	public function getLastCreatedPublicShareToken():string {
@@ -117,6 +122,22 @@ trait Sharing {
 	 */
 	public function shareNgGetLastCreatedLinkShare():?ResponseInterface {
 		return \end($this->shareNgCreatedLinkShares);
+	}
+
+	/**
+	 * @param ResponseInterface $response
+	 *
+	 * @return void
+	 */
+	public function shareNgAddToCreatedUserGroupShares(ResponseInterface $response): void {
+		$this->shareNgCreatedUserGroupShares[] = $response;
+	}
+
+	/**
+	 * @return ResponseInterface|null
+	 */
+	public function shareNgGetLastCreatedUserGroupShare():?ResponseInterface {
+		return \end($this->shareNgCreatedUserGroupShares);
 	}
 
 	/**
@@ -179,7 +200,7 @@ trait Sharing {
 	public function shareNgGetLastCreatedLinkShareID(): string {
 		$lastResponse = $this->shareNgGetLastCreatedLinkShare();
 		if (!isset($this->getJsonDecodedResponse($lastResponse)['id'])) {
-			throw new Error('Response did not contain share id ' . $this->getJsonDecodedResponse($lastResponse)['id'] . ' for the created public link');
+			throw new Error('Response did not contain share id for the created public link');
 		}
 		return $this->getJsonDecodedResponse($lastResponse)['id'];
 	}
@@ -194,6 +215,17 @@ trait Sharing {
 		}
 		$last_created_link_webURL =  $this->getJsonDecodedResponse($lastResponse)['link']['webUrl'];
 		return substr(strrchr($last_created_link_webURL, "/"), 1);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function shareNgGetLastCreatedUserShareShareID(): string {
+		$lastResponse = $this->shareNgGetLastCreatedUserGroupShare();
+		if (!isset($this->getJsonDecodedResponse($lastResponse)['value'][0]['id'])) {
+			throw new Error('Response did not contain share id for the last created share.');
+		}
+		return $this->getJsonDecodedResponse($lastResponse)['value'][0]['id'];
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -220,7 +220,7 @@ trait Sharing {
 	/**
 	 * @return string
 	 */
-	public function shareNgGetLastCreatedUserShareShareID(): string {
+	public function shareNgGetLastCreatedUserGroupShareID(): string {
 		$lastResponse = $this->shareNgGetLastCreatedUserGroupShare();
 		if (!isset($this->getJsonDecodedResponse($lastResponse)['value'][0]['id'])) {
 			throw new Error('Response did not contain share id for the last created share.');

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -355,7 +355,7 @@ class SharingNgContext implements Context {
 		$itemId = ($resourceType === 'folder')
 			? $this->spacesContext->getResourceId($sharer, $space, $resource)
 			: $this->spacesContext->getFileId($sharer, $space, $resource);
-		$permId = $this->featureContext->shareNgGetLastCreatedUserShareShareID();
+		$permId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$this->featureContext->setResponse(
 			GraphHelper::deleteSharePermission(
 				$this->featureContext->getBaseUrl(),

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -152,7 +152,7 @@ class SharingNgContext implements Context {
 		$permission = $rows['permission'] ?? null;
 		$expireDate = $rows["expireDate"] ?? null;
 
-		return  GraphHelper::sendSharingInvitation(
+		$response = GraphHelper::sendSharingInvitation(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
 			$user,
@@ -165,6 +165,10 @@ class SharingNgContext implements Context {
 			$permission,
 			$expireDate
 		);
+		if ($response->getStatusCode() === 200) {
+			$this->featureContext->shareNgAddToCreatedUserGroupShares($response);
+		}
+		return $response;
 	}
 
 	/**
@@ -351,21 +355,9 @@ class SharingNgContext implements Context {
 		$itemId = ($resourceType === 'folder')
 			? $this->spacesContext->getResourceId($sharer, $space, $resource)
 			: $this->spacesContext->getFileId($sharer, $space, $resource);
-		$userIdOfSharee = ($shareType === 'user')
-		? $this->featureContext->getUserIdByUserName($sharee)
-			: $this->featureContext->getGroupIdByGroupName($sharee);
-		$permId = GraphHelper::getSharePermissionId(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getStepLineRef(),
-			$sharer,
-			$userIdOfSharee,
-			$this->featureContext->getPasswordForUser($sharer),
-			$spaceId,
-			$itemId,
-			$shareType
-		);
+		$permId = $this->featureContext->shareNgGetLastCreatedUserShareShareID();
 		$this->featureContext->setResponse(
-			GraphHelper::removeSharePermission(
+			GraphHelper::deleteSharePermission(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getStepLineRef(),
 				$sharer,


### PR DESCRIPTION
## Description
Previously I fetched the `permissionId` with the extra request but the `permissionId` is what we knew to be `shareId` so we can store the shareId directly from the share invite response and use it from the stored array. This removes the necessity for extra request. 

## Related Issue
https://github.com/owncloud/ocis/issues/8008

