### PR TITLE
[full-ci] [tests-only] Add test to send share invitation with empty recipient type

### DIFF
--- a/tests/acceptance/features/apiSharingNg/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/shareInvitations.feature
@@ -1386,3 +1386,103 @@ Feature: Send a sharing invitations
       | resource-type | path           |
       | file          | /textfile1.txt |
       | folder        | FolderToShare  |
+
+
+  Scenario Outline: send share invitation to user with empty recipient type
+    Given user "Alice" has uploaded file with content "to share" to "textfile1.txt"
+    And user "Alice" has created folder "FolderToShare"
+    When user "Alice" tries to send the following share invitation using the Graph API:
+      | resourceType    | <resource-type> |
+      | resource        | <path>          |
+      | space           | Personal        |
+      | sharee          | Brian           |
+      | shareType       |                 |
+      | permissionsRole | Viewer          |
+    Then the HTTP status code should be "400"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": ["invalidRequest"]
+              },
+              "message": {
+                "type": "string",
+                "enum": [
+                  "Key: 'DriveItemInvite.Recipients[0].LibreGraphRecipientType' Error:Field validation for 'LibreGraphRecipientType' failed on the 'oneof' tag"
+                ]
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | resource-type | path           |
+      | file          | /textfile1.txt |
+      | folder        | FolderToShare  |
+
+
+  Scenario Outline: send share invitation to group with empty recipient type
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "to share" to "textfile1.txt"
+    And user "Alice" has created folder "FolderToShare"
+    And group "grp1" has been created
+    And the following users have been added to the following groups
+      | username | groupname |
+      | Brian    | grp1      |
+      | Carol    | grp1      |
+    When user "Alice" tries to send the following share invitation using the Graph API:
+      | resourceType    | <resource-type> |
+      | resource        | <path>          |
+      | space           | Personal        |
+      | sharee          | grp1            |
+      | shareType       |                 |
+      | permissionsRole | Viewer          |
+    Then the HTTP status code should be "400"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": ["invalidRequest"]
+              },
+              "message": {
+                "type": "string",
+                "enum": [
+                  "Key: 'DriveItemInvite.Recipients[0].LibreGraphRecipientType' Error:Field validation for 'LibreGraphRecipientType' failed on the 'oneof' tag"
+                ]
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | resource-type | path           |
+      | file          | /textfile1.txt |
+      | folder        | FolderToShare  |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added Scenarios:
- Scenario Outline: send share invitation to user with empty recipient type
- Scenario Outline: send share invitation to group with empty recipient type

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/7947

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
