### PR TITLE
[test-only] Change naming in sharingNG api-tests

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -63,7 +63,7 @@ class GraphHelper {
 	/**
 	 * @return string
 	 */
-	public static function getShareIdRegex(): string {
+	public static function getPermissionsIdRegex(): string {
 		return self::getUUIDv4Regex() . ':' . self::getUUIDv4Regex() . ':' . self::getUUIDv4Regex();
 	}
 
@@ -1543,16 +1543,16 @@ class GraphHelper {
 	/**
 	 * Get the role id by name
 	 *
-	 * @param string $role
+	 * @param string $permissionsRole
 	 *
 	 * @return string
 	 *
 	 * @throws \Exception
 	 */
-	public static function getRoleIdByName(
-		string $role
+	public static function getPermissionsRoleIdByName(
+		string $permissionsRole
 	): string {
-		switch ($role) {
+		switch ($permissionsRole) {
 			case 'Viewer':
 				return 'b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5';
 			case 'Space Viewer':
@@ -1570,7 +1570,7 @@ class GraphHelper {
 			case 'Manager':
 				return '312c0871-5ef7-4b3a-85b6-0e4074c64049';
 			default:
-				throw new \Exception('Role ' . $role . ' not found');
+				throw new \Exception('Role ' . $permissionsRole . ' not found');
 		}
 	}
 
@@ -1583,8 +1583,8 @@ class GraphHelper {
 	 * @param string $itemId
 	 * @param string $shareeId
 	 * @param string $shareType
-	 * @param string|null $role
-	 * @param string|null $permission
+	 * @param string|null $permissionsRole
+	 * @param string|null $permissionsAction
 	 * @param string|null $expireDate
 	 *
 	 * @return ResponseInterface
@@ -1600,8 +1600,8 @@ class GraphHelper {
 		string $itemId,
 		string $shareeId,
 		string $shareType,
-		?string $role,
-		?string $permission,
+		?string $permissionsRole,
+		?string $permissionsAction,
 		?string $expireDate
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/invite");
@@ -1612,13 +1612,13 @@ class GraphHelper {
 
 		$body['recipients'] = [$recipients];
 
-		if ($role !== null) {
-			$roleId = self::getRoleIdByName($role);
+		if ($permissionsRole !== null) {
+			$roleId = self::getPermissionsRoleIdByName($permissionsRole);
 			$body['roles'] = [$roleId];
 		}
 
-		if ($permission !== null) {
-			$body['@libre.graph.permissions.actions'] = ['libre.graph/driveItem/' . $permission];
+		if ($permissionsAction !== null) {
+			$body['@libre.graph.permissions.actions'] = ['libre.graph/driveItem/' . $permissionsAction];
 		}
 
 		if ($expireDate !== null) {
@@ -1675,7 +1675,7 @@ class GraphHelper {
 	 * @param string $spaceId
 	 * @param string $itemId
 	 * @param mixed $body
-	 * @param string $shareId
+	 * @param string $permissionsId
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -1688,9 +1688,9 @@ class GraphHelper {
 		string $spaceId,
 		string $itemId,
 		$body,
-		string $shareId
+		string $permissionsId
 	): ResponseInterface {
-		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$shareId");
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permissionsId");
 		return HttpRequestHelper::sendRequestOnce(
 			$url,
 			$xRequestId,
@@ -1710,7 +1710,7 @@ class GraphHelper {
 	 * @param string $spaceId
 	 * @param string $itemId
 	 * @param mixed $body
-	 * @param string $shareId
+	 * @param string $permissionsId
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -1723,9 +1723,9 @@ class GraphHelper {
 		string $spaceId,
 		string $itemId,
 		$body,
-		string $shareId
+		string $permissionsId
 	): ResponseInterface {
-		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$shareId/setPassword");
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permissionsId/setPassword");
 		return HttpRequestHelper::post(
 			$url,
 			$xRequestId,

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -10,11 +10,11 @@ Feature: Create a share link for a resource
   Scenario Outline: create a link share of a folder
     Given user "Alice" has created folder "folder"
     When user "Alice" creates the following link share using the Graph API:
-      | resourceType | folder   |
-      | resource     | folder   |
-      | space        | Personal |
-      | role         | <role>   |
-      | password     | %public% |
+      | resourceType    | folder            |
+      | resource        | folder            |
+      | space           | Personal          |
+      | permissionsRole | <permissionsRole> |
+      | password        | %public%          |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -58,7 +58,7 @@ Feature: Create a share link for a resource
               },
               "type": {
                 "type": "string",
-                "enum": ["<role>"]
+                "enum": ["<permissionsRole>"]
               },
               "webUrl": {
                 "type": "string",
@@ -70,22 +70,22 @@ Feature: Create a share link for a resource
       }
       """
     Examples:
-      | role           |
-      | view           |
-      | edit           |
-      | upload         |
-      | createOnly     |
-      | blocksDownload |
+      | permissionsRole |
+      | view            |
+      | edit            |
+      | upload          |
+      | createOnly      |
+      | blocksDownload  |
 
   @issue-7879
   Scenario Outline: create a link share of a file
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     When user "Alice" creates the following link share using the Graph API:
-      | resourceType | file          |
-      | resource     | textfile1.txt |
-      | space        | Personal      |
-      | role         | <role>        |
-      | password     | %public%      |
+      | resourceType    | file              |
+      | resource        | textfile1.txt     |
+      | space           | Personal          |
+      | permissionsRole | <permissionsRole> |
+      | password        | %public%          |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -129,7 +129,7 @@ Feature: Create a share link for a resource
               },
               "type": {
                 "type": "string",
-                "enum": ["<role>"]
+                "enum": ["<permissionsRole>"]
               },
               "webUrl": {
                 "type": "string",
@@ -141,10 +141,10 @@ Feature: Create a share link for a resource
       }
       """
     Examples:
-      | role           |
-      | view           |
-      | edit           |
-      | blocksDownload |
+      | permissionsRole |
+      | view            |
+      | edit            |
+      | blocksDownload  |
 
   @issue-7879
   Scenario Outline: create a link share of a folder with display name and expiry date
@@ -153,7 +153,7 @@ Feature: Create a share link for a resource
       | resourceType       | folder                   |
       | resource           | folder                   |
       | space              | Personal                 |
-      | role               | <role>                   |
+      | permissionsRole    | <permissionsRole>        |
       | password           | %public%                 |
       | displayName        | Homework                 |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
@@ -205,7 +205,7 @@ Feature: Create a share link for a resource
               },
               "type": {
                 "type": "string",
-                "enum": ["<role>"]
+                "enum": ["<permissionsRole>"]
               },
               "webUrl": {
                 "type": "string",
@@ -217,12 +217,12 @@ Feature: Create a share link for a resource
       }
       """
     Examples:
-      | role           |
-      | view           |
-      | edit           |
-      | upload         |
-      | createOnly     |
-      | blocksDownload |
+      | permissionsRole |
+      | view            |
+      | edit            |
+      | upload          |
+      | createOnly      |
+      | blocksDownload  |
 
   @issue-7879
   Scenario Outline: create a link share of a file with display name and expiry date
@@ -231,7 +231,7 @@ Feature: Create a share link for a resource
       | resourceType       | file                     |
       | resource           | textfile1.txt            |
       | space              | Personal                 |
-      | role               | <role>                   |
+      | permissionsRole    | <permissionsRole>        |
       | password           | %public%                 |
       | displayName        | Homework                 |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
@@ -283,7 +283,7 @@ Feature: Create a share link for a resource
               },
               "type": {
                 "type": "string",
-                "enum": ["<role>"]
+                "enum": ["<permissionsRole>"]
               },
               "webUrl": {
                 "type": "string",
@@ -295,10 +295,10 @@ Feature: Create a share link for a resource
       }
       """
     Examples:
-      | role           |
-      | view           |
-      | edit           |
-      | blocksDownload |
+      | permissionsRole |
+      | view            |
+      | edit            |
+      | blocksDownload  |
 
   @env-config @issue-7879
   Scenario Outline: create a link share of a file without password
@@ -307,10 +307,10 @@ Feature: Create a share link for a resource
       | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
     And user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     When user "Alice" creates the following link share using the Graph API:
-      | resourceType | file          |
-      | resource     | textfile1.txt |
-      | space        | Personal      |
-      | role         | <role>        |
+      | resourceType    | file              |
+      | resource        | textfile1.txt     |
+      | space           | Personal          |
+      | permissionsRole | <permissionsRole> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -354,7 +354,7 @@ Feature: Create a share link for a resource
               },
               "type": {
                 "type": "string",
-                "enum": ["<role>"]
+                "enum": ["<permissionsRole>"]
               },
               "webUrl": {
                 "type": "string",
@@ -366,25 +366,25 @@ Feature: Create a share link for a resource
       }
       """
     Examples:
-      | role           |
-      | view           |
-      | edit           |
-      | blocksDownload |
+      | permissionsRole |
+      | view            |
+      | edit            |
+      | blocksDownload  |
 
   @issue-7879
   Scenario Outline: update role of a file's link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     And user "Alice" has created the following link share:
-      | resourceType | file           |
-      | resource     | textfile1.txt  |
-      | space        | Personal       |
-      | role         | <previousRole> |
-      | password     | %public%       |
+      | resourceType    | file                      |
+      | resource        | textfile1.txt             |
+      | space           | Personal                  |
+      | permissionsRole | <previousPermissionsRole> |
+      | password        | %public%                  |
     When user "Alice" updates the last public link share using the Graph API with
-      | resourceType | file          |
-      | resource     | textfile1.txt |
-      | space        | Personal      |
-      | role         | <newRole>     |
+      | resourceType    | file                 |
+      | resource        | textfile1.txt        |
+      | space           | Personal             |
+      | permissionsRole | <newPermissionsRole> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -428,7 +428,7 @@ Feature: Create a share link for a resource
               },
               "type": {
                 "type": "string",
-                "enum": ["<newRole>"]
+                "enum": ["<newPermissionsRole>"]
               },
               "webUrl": {
                 "type": "string",
@@ -440,13 +440,13 @@ Feature: Create a share link for a resource
       }
       """
     Examples:
-      | previousRole   | newRole        |
-      | view           | edit           |
-      | view           | blocksDownload |
-      | edit           | view           |
-      | edit           | blocksDownload |
-      | blocksDownload | edit           |
-      | blocksDownload | blocksDownload |
+      | previousPermissionsRole | newPermissionsRole |
+      | view                    | edit               |
+      | view                    | blocksDownload     |
+      | edit                    | view               |
+      | edit                    | blocksDownload     |
+      | blocksDownload          | edit               |
+      | blocksDownload          | blocksDownload     |
 
 
   Scenario: update expiration date of a file's link share
@@ -455,7 +455,7 @@ Feature: Create a share link for a resource
       | resourceType       | file                     |
       | resource           | textfile1.txt            |
       | space              | Personal                 |
-      | role               | view                     |
+      | permissionsRole    | view                     |
       | password           | %public%                 |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     When user "Alice" updates the last public link share using the Graph API with
@@ -526,10 +526,10 @@ Feature: Create a share link for a resource
       | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
     And user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     And user "Alice" has created the following link share:
-      | resourceType | file          |
-      | resource     | textfile1.txt |
-      | space        | Personal      |
-      | role         | view          |
+      | resourceType    | file          |
+      | resource        | textfile1.txt |
+      | space           | Personal      |
+      | permissionsRole | view          |
     When user "Alice" sets the following password for the last link share using the Graph API:
       | resourceType | file          |
       | resource     | textfile1.txt |
@@ -556,12 +556,12 @@ Feature: Create a share link for a resource
   Scenario: update password of a file's link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     And user "Alice" has created the following link share:
-      | resourceType | file          |
-      | resource     | textfile1.txt |
-      | space        | Personal      |
-      | role         | view          |
-      | password     | $heLlo*1234*  |
-    When user "Alice" updates the following password for the last link share using the Graph API:
+      | resourceType    | file          |
+      | resource        | textfile1.txt |
+      | space           | Personal      |
+      | permissionsRole | view          |
+      | password        | $heLlo*1234*  |
+    When user "Alice" sets the following password for the last link share using the Graph API:
       | resourceType | file          |
       | resource     | textfile1.txt |
       | space        | Personal      |

--- a/tests/acceptance/features/apiSharingNg/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/shareInvitations.feature
@@ -16,12 +16,12 @@ Feature: Send a sharing invitations
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | <resource-type> |
-      | resource     | <path>          |
-      | space        | Personal        |
-      | sharee       | Brian           |
-      | shareType    | user            |
-      | role         | <role>          |
+      | resourceType    | <resource-type>   |
+      | resource        | <path>            |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | <permissionsRole> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -43,7 +43,7 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "roles": {
                   "type": "array",
@@ -86,16 +86,16 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | role        | resource-type | path           |
-      | Viewer      | file          | /textfile1.txt |
-      | File Editor | file          | /textfile1.txt |
-      | Co Owner    | file          | /textfile1.txt |
-      | Manager     | file          | /textfile1.txt |
-      | Viewer      | folder        | FolderToShare  |
-      | Editor      | folder        | FolderToShare  |
-      | Co Owner    | folder        | FolderToShare  |
-      | Uploader    | folder        | FolderToShare  |
-      | Manager     | folder        | FolderToShare  |
+      | permissionsRole | resource-type | path           |
+      | Viewer          | file          | /textfile1.txt |
+      | File Editor     | file          | /textfile1.txt |
+      | Co Owner        | file          | /textfile1.txt |
+      | Manager         | file          | /textfile1.txt |
+      | Viewer          | folder        | FolderToShare  |
+      | Editor          | folder        | FolderToShare  |
+      | Co Owner        | folder        | FolderToShare  |
+      | Uploader        | folder        | FolderToShare  |
+      | Manager         | folder        | FolderToShare  |
 
 
   Scenario Outline: send share invitation to group with different roles
@@ -108,12 +108,12 @@ Feature: Send a sharing invitations
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | <resource-type> |
-      | resource     | <path>          |
-      | space        | Personal        |
-      | sharee       | grp1            |
-      | shareType    | group           |
-      | role         | <role>          |
+      | resourceType    | <resource-type>   |
+      | resource        | <path>            |
+      | space           | Personal          |
+      | sharee          | grp1              |
+      | shareType       | group             |
+      | permissionsRole | <permissionsRole> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -135,7 +135,7 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "roles": {
                   "type": "array",
@@ -178,27 +178,27 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | role        | resource-type | path           |
-      | Viewer      | file          | /textfile1.txt |
-      | File Editor | file          | /textfile1.txt |
-      | Co Owner    | file          | /textfile1.txt |
-      | Manager     | file          | /textfile1.txt |
-      | Viewer      | folder        | FolderToShare  |
-      | Editor      | folder        | FolderToShare  |
-      | Co Owner    | folder        | FolderToShare  |
-      | Uploader    | folder        | FolderToShare  |
-      | Manager     | folder        | FolderToShare  |
+      | permissionsRole | resource-type | path           |
+      | Viewer          | file          | /textfile1.txt |
+      | File Editor     | file          | /textfile1.txt |
+      | Co Owner        | file          | /textfile1.txt |
+      | Manager         | file          | /textfile1.txt |
+      | Viewer          | folder        | FolderToShare  |
+      | Editor          | folder        | FolderToShare  |
+      | Co Owner        | folder        | FolderToShare  |
+      | Uploader        | folder        | FolderToShare  |
+      | Manager         | folder        | FolderToShare  |
 
 
   Scenario Outline: send share invitation for a file to user with different permissions
     Given user "Alice" has uploaded file with content "to share" to "textfile1.txt"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | file          |
-      | resource     | textfile1.txt |
-      | space        | Personal      |
-      | sharee       | Brian         |
-      | shareType    | user          |
-      | permission   | <permission>  |
+      | resourceType      | file                |
+      | resource          | textfile1.txt       |
+      | space             | Personal            |
+      | sharee            | Brian               |
+      | shareType         | user                |
+      | permissionsAction | <permissionsAction> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -220,13 +220,13 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "@libre.graph.permissions.actions": {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^libre\\.graph\\/driveItem\\/<permission>$"
+                    "pattern": "^libre\\.graph\\/driveItem\\/<permissionsAction>$"
                   }
                 },
                 "grantedToV2": {
@@ -263,7 +263,7 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | permission         |
+      | permissionsAction  |
       | permissions/create |
       | children/create    |
       | upload/create      |
@@ -288,12 +288,12 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation for a folder to user with different permissions
     Given user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | folder        |
-      | resource     | FolderToShare |
-      | space        | Personal      |
-      | sharee       | Brian         |
-      | shareType    | user          |
-      | permission   | <permission>  |
+      | resourceType      | folder              |
+      | resource          | FolderToShare       |
+      | space             | Personal            |
+      | sharee            | Brian               |
+      | shareType         | user                |
+      | permissionsAction | <permissionsAction> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -315,13 +315,13 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "@libre.graph.permissions.actions": {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^libre\\.graph\\/driveItem\\/<permission>$"
+                    "pattern": "^libre\\.graph\\/driveItem\\/<permissionsAction>$"
                   }
                 },
                 "grantedToV2": {
@@ -358,7 +358,7 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | permission         |
+      | permissionsAction  |
       | permissions/create |
       | children/create    |
       | upload/create      |
@@ -389,12 +389,12 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "textfile1.txt"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | file          |
-      | resource     | textfile1.txt |
-      | space        | Personal      |
-      | sharee       | grp1          |
-      | shareType    | group         |
-      | permission   | <permission>  |
+      | resourceType      | file                |
+      | resource          | textfile1.txt       |
+      | space             | Personal            |
+      | sharee            | grp1                |
+      | shareType         | group               |
+      | permissionsAction | <permissionsAction> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -416,13 +416,13 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "@libre.graph.permissions.actions": {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^libre\\.graph\\/driveItem\\/<permission>$"
+                    "pattern": "^libre\\.graph\\/driveItem\\/<permissionsAction>$"
                   }
                 },
                 "grantedToV2": {
@@ -459,7 +459,7 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | permission         |
+      | permissionsAction  |
       | permissions/create |
       | children/create    |
       | upload/create      |
@@ -490,12 +490,12 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | folder        |
-      | resource     | FolderToShare |
-      | space        | Personal      |
-      | sharee       | grp1          |
-      | shareType    | group         |
-      | permission   | <permission>  |
+      | resourceType      | folder              |
+      | resource          | FolderToShare       |
+      | space             | Personal            |
+      | sharee            | grp1                |
+      | shareType         | group               |
+      | permissionsAction | <permissionsAction> |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -517,13 +517,13 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "@libre.graph.permissions.actions": {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^libre\\.graph\\/driveItem\\/<permission>$"
+                    "pattern": "^libre\\.graph\\/driveItem\\/<permissionsAction>$"
                   }
                 },
                 "grantedToV2": {
@@ -560,7 +560,7 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | permission         |
+      | permissionsAction  |
       | permissions/create |
       | children/create    |
       | upload/create      |
@@ -586,13 +586,13 @@ Feature: Send a sharing invitations
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | <resource-type>          |
-      | resource     | <path>                   |
-      | space        | Personal                 |
-      | sharee       | Brian                    |
-      | shareType    | user                     |
-      | role         | <role>                   |
-      | expireDate   | 2043-07-15T14:00:00.000Z |
+      | resourceType    | <resource-type>          |
+      | resource        | <path>                   |
+      | space           | Personal                 |
+      | sharee          | Brian                    |
+      | shareType       | user                     |
+      | permissionsRole | <permissionsRole>        |
+      | expireDate      | 2043-07-15T14:00:00.000Z |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -615,7 +615,7 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "roles": {
                   "type": "array",
@@ -664,16 +664,16 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | role        | resource-type | path           |
-      | Viewer      | file          | /textfile1.txt |
-      | File Editor | file          | /textfile1.txt |
-      | Co Owner    | file          | /textfile1.txt |
-      | Manager     | file          | /textfile1.txt |
-      | Viewer      | folder        | FolderToShare  |
-      | Editor      | folder        | FolderToShare  |
-      | Co Owner    | folder        | FolderToShare  |
-      | Uploader    | folder        | FolderToShare  |
-      | Manager     | folder        | FolderToShare  |
+      | permissionsRole | resource-type | path           |
+      | Viewer          | file          | /textfile1.txt |
+      | File Editor     | file          | /textfile1.txt |
+      | Co Owner        | file          | /textfile1.txt |
+      | Manager         | file          | /textfile1.txt |
+      | Viewer          | folder        | FolderToShare  |
+      | Editor          | folder        | FolderToShare  |
+      | Co Owner        | folder        | FolderToShare  |
+      | Uploader        | folder        | FolderToShare  |
+      | Manager         | folder        | FolderToShare  |
 
 
   Scenario Outline: send share invitation with expiration date to group with different roles
@@ -686,13 +686,13 @@ Feature: Send a sharing invitations
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following share invitation using the Graph API:
-      | resourceType | <resource-type>          |
-      | resource     | <path>                   |
-      | space        | Personal                 |
-      | sharee       | grp1                     |
-      | shareType    | group                    |
-      | role         | <role>                   |
-      | expireDate   | 2043-07-15T14:00:00.000Z |
+      | resourceType    | <resource-type>          |
+      | resource        | <path>                   |
+      | space           | Personal                 |
+      | sharee          | grp1                     |
+      | shareType       | group                    |
+      | permissionsRole | <permissionsRole>        |
+      | expireDate      | 2043-07-15T14:00:00.000Z |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -715,7 +715,7 @@ Feature: Send a sharing invitations
               "properties": {
                 "id": {
                   "type": "string",
-                  "pattern": "^%share_id_pattern%$"
+                  "pattern": "^%permissions_id_pattern%$"
                 },
                 "roles": {
                   "type": "array",
@@ -764,13 +764,13 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | role        | resource-type | path           |
-      | Viewer      | file          | /textfile1.txt |
-      | File Editor | file          | /textfile1.txt |
-      | Co Owner    | file          | /textfile1.txt |
-      | Manager     | file          | /textfile1.txt |
-      | Viewer      | folder        | FolderToShare  |
-      | Editor      | folder        | FolderToShare  |
-      | Co Owner    | folder        | FolderToShare  |
-      | Uploader    | folder        | FolderToShare  |
-      | Manager     | folder        | FolderToShare  |
+      | permissionsRole | resource-type | path           |
+      | Viewer          | file          | /textfile1.txt |
+      | File Editor     | file          | /textfile1.txt |
+      | Co Owner        | file          | /textfile1.txt |
+      | Manager         | file          | /textfile1.txt |
+      | Viewer          | folder        | FolderToShare  |
+      | Editor          | folder        | FolderToShare  |
+      | Co Owner        | folder        | FolderToShare  |
+      | Uploader        | folder        | FolderToShare  |
+      | Manager         | folder        | FolderToShare  |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2793,10 +2793,10 @@ class FeatureContext extends BehatVariablesContext {
 				"parameter" => []
 			],
 			[
-				"code" => "%share_id_pattern%",
+				"code" => "%permissions_id_pattern%",
 				"function" => [
 					__NAMESPACE__ . '\TestHelpers\GraphHelper',
-					"getShareIdRegex"
+					"getPermissionsIdRegex"
 				],
 				"parameter" => []
 			]

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -21,7 +21,6 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\GraphHelper;
 use Behat\Gherkin\Node\TableNode;
@@ -78,7 +77,7 @@ class SharingNgContext implements Context {
 		$bodyRows['expirationDateTime'] = $bodyRows['expirationDateTime'] ?? null;
 		$bodyRows['password'] = $bodyRows['password'] ?? null;
 		$body = [
-			'type' => $bodyRows['role'],
+			'type' => $bodyRows['permissionsRole'],
 			'displayName' => $bodyRows['displayName'],
 			'expirationDateTime' => $bodyRows['expirationDateTime'],
 			'password' => $this->featureContext->getActualPassword($bodyRows['password'])
@@ -147,8 +146,8 @@ class SharingNgContext implements Context {
 			? $this->featureContext->getAttributeOfCreatedUser($rows['sharee'], 'id')
 			: $this->featureContext->getAttributeOfCreatedGroup($rows['sharee'], 'id');
 
-		$role = $rows['role'] ?? null;
-		$permission = $rows['permission'] ?? null;
+		$permissionsRole = $rows['permissionsRole'] ?? null;
+		$permissionsAction = $rows['permissionsAction'] ?? null;
 		$expireDate = $rows["expireDate"] ?? null;
 
 		$this->featureContext->setResponse(
@@ -161,8 +160,8 @@ class SharingNgContext implements Context {
 				$itemId,
 				$shareeId,
 				$rows['shareType'],
-				$role,
-				$permission,
+				$permissionsRole,
+				$permissionsAction,
 				$expireDate
 			)
 		);
@@ -222,13 +221,13 @@ class SharingNgContext implements Context {
 			$body = [
 				"expirationDateTime" => $bodyRows['expirationDateTime'],
 				"link" => [
-					"type" => $bodyRows['role']
+					"type" => $bodyRows['permissionsRole']
 				]
 			];
-		} elseif (\array_key_exists('role', $bodyRows)) {
+		} elseif (\array_key_exists('permissionsRole', $bodyRows)) {
 			$body = [
 				"link" => [
-					"type" => $bodyRows['role']
+					"type" => $bodyRows['permissionsRole']
 				]
 			];
 		} elseif (\array_key_exists('expirationDateTime', $bodyRows)) {
@@ -253,7 +252,7 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user sets/updates the following password for the last link share using the Graph API:
+	 * @When user :user sets the following password for the last link share using the Graph API:
 	 *
 	 * @param string $user
 	 * @param TableNode|null $body


### PR DESCRIPTION
after discution https://github.com/owncloud/ocis/pull/8130#discussion_r1441655159

In our tests, I found some confusion about the names. 
I suggest to define and solve it at an early stage.

example:  <img width="687" alt="image" src="https://github.com/owncloud/ocis/assets/84779829/ba86ff9a-4b3c-4a9a-8c1a-028b707f7dd3">




so I suggest to use: 

<img width="1077" alt="Screenshot 2024-01-05 at 11 37 03" src="https://github.com/owncloud/ocis/assets/84779829/825c1cfd-3909-4316-80f2-213ad604c89f">




| old naming         | new naming in test  | 
|------------|-------|
|role|permissionsRole|
|roleId|permissionsRoleId|
|permission|permissionsAction|
|shareId|permissionsId|


2. Changed` When user "Alice" updates the following password for the last link share using the Graph API:` to `When user "Alice" sets the following password for the last link share using the Graph API:` not to be confused PATCH request with POST setPassword request


