### PR TITLE
[docs-only] fix NATS configuration in wopi example

### DIFF
--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -84,7 +84,9 @@ services:
       NOTIFICATIONS_SMTP_USERNAME: notifications@${OCIS_DOMAIN:-ocis.owncloud.test}
       NOTIFICATIONS_SMTP_INSECURE: "true" # the mail catcher uses self signed certificates
       # make the registry available to the app provider containers
-      MICRO_REGISTRY: "mdns"
+      MICRO_REGISTRY_ADDRESS: 127.0.0.1:9233
+      NATS_NATS_HOST: 0.0.0.0
+      NATS_NATS_PORT: 9233
     volumes:
       - ./config/ocis/app-registry.yaml:/etc/ocis/app-registry.yaml
       - ocis-config:/etc/ocis
@@ -121,7 +123,7 @@ services:
       APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL: https://${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
       APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       # share the registry with the ocis container
-      MICRO_REGISTRY: "mdns"
+      MICRO_REGISTRY_ADDRESS: ocis:9233
     volumes:
       - ocis-config:/etc/ocis
     logging:
@@ -153,7 +155,7 @@ services:
       APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL: https://${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
       APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       # share the registry with the ocis container
-      MICRO_REGISTRY: "mdns"
+      MICRO_REGISTRY_ADDRESS: ocis:9233
     volumes:
       - ./config/ocis-appprovider-onlyoffice/entrypoint-override.sh:/entrypoint-override.sh
       - ocis-config:/etc/ocis


### PR DESCRIPTION
## Description
The example did not work for me, I believe the NATS settings need to be adjusted.
Wit this change, both collabora and onlyoffice work fine

## Related Issue
- Fixes #8100

## Motivation and Context
NATS seems not to work with mdns

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run collabora & onlyoffice on private ocis instance
- run the example locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
