### PR TITLE
Remove unused ownCloudQuota attribute from LDAP Schema

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/config/ldap/ldif/10_owncloud_schema.ldif
+++ b/deployments/examples/oc10_ocis_parallel/config/ldap/ldif/10_owncloud_schema.ldif
@@ -1,10 +1,32 @@
-# This LDIF files describes the ownCloud schema and can be used to
-# add two optional attributes: ownCloudQuota and ownCloudUUID
-# The ownCloudUUID is used to store a unique, non-reassignable, persistent identifier for users and groups
+# This LDIF files describes the ownCloud schema
 dn: cn=owncloud,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: owncloud
-olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.1 NAME 'ownCloudQuota' DESC 'User Quota (e.g. 2 GB)' EQUALITY caseExactMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
-olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.2 NAME 'ownCloudUUID' DESC 'A non-reassignable and persistent account ID)' EQUALITY uuidMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE )
-olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.3 NAME 'ownCloudSelector' DESC 'A selector attribute for a route in the ownCloud Infinite Scale proxy)' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
-olcObjectClasses: ( 1.3.6.1.4.1.39430.1.2.1 NAME 'ownCloud' DESC 'ownCloud LDAP Schema' AUXILIARY MAY ( ownCloudQuota $ ownCloudUUID $ ownCloudSelector ) )
+olcObjectIdentifier: ownCloudOid 1.3.6.1.4.1.39430
+olcAttributeTypes: ( ownCloudOid:1.1.2 NAME 'ownCloudUUID'
+  DESC 'A non-reassignable and persistent account ID)'
+  EQUALITY uuidMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE )
+olcAttributeTypes: ( ownCloudOid:1.1.3 NAME 'oCExternalIdentity'
+  DESC 'A triple separated by "$" representing the objectIdentity resource type of the Graph API ( signInType $ issuer $ issuerAssignedId )'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( ownCloudOid:1.1.4 NAME 'ownCloudUserEnabled'
+  DESC 'A boolean value indicating if ownCloudUser is enabled'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE)
+olcAttributeTypes: ( ownCloudOid:1.1.5 NAME 'ownCloudUserType'
+  DESC 'User type (e.g. Member or Guest)'
+  EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcObjectClasses: ( ownCloudOid:1.2.1 NAME 'ownCloud'
+  DESC 'ownCloud LDAP Schema'
+  AUXILIARY
+  MAY ( ownCloudUUID ) )
+olcObjectClasses: ( ownCloudOid:1.2.2 NAME 'ownCloudUser'
+  DESC 'ownCloud User LDAP Schema'
+  SUP ownCloud
+  AUXILIARY
+  MAY ( ocExternalIdentity $ ownCloudUserEnabled $ ownCloudUserType ) )

--- a/deployments/examples/ocis_ldap/config/ldap/schemas/10_owncloud_schema.ldif
+++ b/deployments/examples/ocis_ldap/config/ldap/schemas/10_owncloud_schema.ldif
@@ -1,15 +1,8 @@
-# This LDIF files describes the ownCloud schema and can be used to
-# add three optional attributes: ownCloudQuota, ownCloudUUID and ownCloudUserEnabled
-# The ownCloudUUID is used to store a unique, non-reassignable, persistent identifier for users and groups
+# This LDIF files describes the ownCloud schema
 dn: cn=owncloud,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: owncloud
 olcObjectIdentifier: ownCloudOid 1.3.6.1.4.1.39430
-olcAttributeTypes: ( ownCloudOid:1.1.1 NAME 'ownCloudQuota'
-  DESC 'User Quota (e.g. 2 GB)'
-  EQUALITY caseExactMatch
-  SUBSTR caseIgnoreSubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: ( ownCloudOid:1.1.2 NAME 'ownCloudUUID'
   DESC 'A non-reassignable and persistent account ID)'
   EQUALITY uuidMatch
@@ -31,7 +24,7 @@ olcAttributeTypes: ( ownCloudOid:1.1.5 NAME 'ownCloudUserType'
 olcObjectClasses: ( ownCloudOid:1.2.1 NAME 'ownCloud'
   DESC 'ownCloud LDAP Schema'
   AUXILIARY
-  MAY ( ownCloudQuota $ ownCloudUUID ) )
+  MAY ( ownCloudUUID ) )
 olcObjectClasses: ( ownCloudOid:1.2.2 NAME 'ownCloudUser'
   DESC 'ownCloud User LDAP Schema'
   SUP ownCloud

--- a/tests/parallelDeployAcceptance/drone/ldap/ldif/10_owncloud_schema.ldif
+++ b/tests/parallelDeployAcceptance/drone/ldap/ldif/10_owncloud_schema.ldif
@@ -1,10 +1,32 @@
-# This LDIF files describes the ownCloud schema and can be used to
-# add two optional attributes: ownCloudQuota and ownCloudUUID
-# The ownCloudUUID is used to store a unique, non-reassignable, persistent identifier for users and groups
+# This LDIF files describes the ownCloud schema
 dn: cn=owncloud,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: owncloud
-olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.1 NAME 'ownCloudQuota' DESC 'User Quota (e.g. 2 GB)' EQUALITY caseExactMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
-olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.2 NAME 'ownCloudUUID' DESC 'A non-reassignable and persistent account ID)' EQUALITY uuidMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE )
-olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.3 NAME 'ownCloudSelector' DESC 'A selector attribute for a route in the ownCloud Infinite Scale proxy)' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
-olcObjectClasses: ( 1.3.6.1.4.1.39430.1.2.1 NAME 'ownCloud' DESC 'ownCloud LDAP Schema' AUXILIARY MAY ( ownCloudQuota $ ownCloudUUID $ ownCloudSelector ) )
+olcObjectIdentifier: ownCloudOid 1.3.6.1.4.1.39430
+olcAttributeTypes: ( ownCloudOid:1.1.2 NAME 'ownCloudUUID'
+  DESC 'A non-reassignable and persistent account ID)'
+  EQUALITY uuidMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE )
+olcAttributeTypes: ( ownCloudOid:1.1.3 NAME 'oCExternalIdentity'
+  DESC 'A triple separated by "$" representing the objectIdentity resource type of the Graph API ( signInType $ issuer $ issuerAssignedId )'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( ownCloudOid:1.1.4 NAME 'ownCloudUserEnabled'
+  DESC 'A boolean value indicating if ownCloudUser is enabled'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE)
+olcAttributeTypes: ( ownCloudOid:1.1.5 NAME 'ownCloudUserType'
+  DESC 'User type (e.g. Member or Guest)'
+  EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcObjectClasses: ( ownCloudOid:1.2.1 NAME 'ownCloud'
+  DESC 'ownCloud LDAP Schema'
+  AUXILIARY
+  MAY ( ownCloudUUID ) )
+olcObjectClasses: ( ownCloudOid:1.2.2 NAME 'ownCloudUser'
+  DESC 'ownCloud User LDAP Schema'
+  SUP ownCloud
+  AUXILIARY
+  MAY ( ocExternalIdentity $ ownCloudUserEnabled $ ownCloudUserType ) )


### PR DESCRIPTION
In oCIS the quota is a setting of the personal or project spaces. We never stored quotas in LDAP for ocis nor are there plans to do so.

Fixes: #8059