### PR TITLE
[tests-only][full-ci ] use responsexml from HttpRequestHelper instead of featurecontext in test

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1720,7 +1720,7 @@ trait WebDav {
 		string $entry = "file",
 		?string $path = null,
 		string $type = "files"
-	):ResponseInterface {
+	):void {
 		$user = $this->getActualUsername($user);
 		$path = $this->substituteInLineCodes($path);
 		$response = $this->listFolder(
@@ -1733,7 +1733,7 @@ trait WebDav {
 		$statusCode = $response->getStatusCode();
 		if ($statusCode < 401 || $statusCode > 404) {
 			try {
-				$responseXml = $this->featureContext->getResponseXml(
+				$responseXml = HttpRequestHelper::getResponseXml(
 					$response,
 					__METHOD__
 				);
@@ -1756,7 +1756,6 @@ trait WebDav {
 				"$entry '$path' should not exist. But it does exist and is a $actualResourceType"
 			);
 		}
-		return $response;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Previously we got response from featurecontext and inside trait featurecontext couldn't be accessed. The error did not occur since there was a try-catch. So, getting the response from HttpRequestHelper class
