### PR TITLE
[tests-only] Added test coverage for checking file versions after MOVE

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -728,18 +728,22 @@ class WebDavHelper {
 		?string $spaceId = null
 	):string {
 		$newTrashbinDavPath = "remote.php/dav/trash-bin/$user/";
-		if ($type === "public-files" || $type === "public-files-old") {
-			return "public.php/webdav/";
+
+		switch ($type) {
+			case 'public-files':
+			case 'public-files-old':
+				return "public.php/webdav/";
+			case 'public-files-new':
+				return "remote.php/dav/public-files/$user/";
+			case 'archive':
+				return "remote.php/dav/archive/$user/files";
+			case 'versions':
+			case 'customgroups':
+				return "remote.php/dav/";
+			default:
+				break;
 		}
-		if ($type === "public-files-new") {
-			return "remote.php/dav/public-files/$user/";
-		}
-		if ($type === "archive") {
-			return "remote.php/dav/archive/$user/files";
-		}
-		if ($type === "customgroups") {
-			return "remote.php/dav/";
-		}
+
 		if ($davPathVersionToUse === self::DAV_VERSION_SPACES) {
 			// return spaces root path if spaceid is null
 			// REPORT request uses spaces root path

--- a/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
@@ -21,7 +21,6 @@ Feature: checking file versions using file id
       | path      | text.txt |
       | shareWith | Brian    |
       | role      | <role>   |
-    And using new DAV path
     When user "Alice" gets the number of versions of file "/text.txt" using file-id path "/meta/<<FILEID>>/v"
     Then the HTTP status code should be "207"
     And the number of versions should be "1"
@@ -38,7 +37,6 @@ Feature: checking file versions using file id
     Given user "Alice" has shared a space "Project1" with settings:
       | shareWith | Brian  |
       | role      | <role> |
-    And using new DAV path
     When user "Alice" gets the number of versions of file "/text.txt" using file-id path "/meta/<<FILEID>>/v"
     Then the HTTP status code should be "207"
     And the number of versions should be "1"
@@ -55,11 +53,10 @@ Feature: checking file versions using file id
     Given user "Alice" has shared a space "Project1" with settings:
       | shareWith | Brian  |
       | role      | viewer |
-    And using new DAV path
     When user "Brian" tries to get the number of versions of file "/text.txt" using file-id path "/meta/<<FILEID>>/v"
     Then the HTTP status code should be "403"
 
-
+  @issue-7738
   Scenario Outline: check the versions of a file after moving to a shared folder inside a project space as editor/viewer
     Given user "Alice" has created a folder "testFolder" in space "Project1"
     And user "Alice" has created a share inside of space "Project1" with settings:
@@ -67,7 +64,6 @@ Feature: checking file versions using file id
       | shareWith | Brian      |
       | role      | <role>     |
     And user "Alice" has moved file "text.txt" to "/testFolder/movedText.txt" in space "Project1"
-    And using new DAV path
     When user "Alice" gets the number of versions of file "/testFolder/movedText.txt" using file-id path "/meta/<<FILEID>>/v"
     Then the HTTP status code should be "207"
     And the number of versions should be "1"
@@ -78,7 +74,7 @@ Feature: checking file versions using file id
       | editor |
       | viewer |
 
-
+  @issue-7738
   Scenario: check the versions of a file after moving it to a shared folder of a project space shared with all permissions
     Given user "Alice" has created a folder "testFolder" in space "Project1"
     And user "Alice" has created a share inside of space "Project1" with settings:
@@ -86,7 +82,68 @@ Feature: checking file versions using file id
       | shareWith | Brian      |
       | role      | all        |
     And user "Alice" has moved file "text.txt" to "/testFolder/movedText.txt" in space "Project1"
-    And using new DAV path
     When user "Brian" gets the number of versions of file "/text.txt" using file-id path "/meta/<<FILEID>>/v"
     Then the HTTP status code should be "207"
     And the number of versions should be "1"
+
+  @issue-777
+  Scenario Outline: check file versions after moving to-and-fro folder in personal space
+    Given user "Alice" has created folder "folder"
+    And user "Alice" has uploaded file with content "some data" to "<from>textfile.txt"
+    And user "Alice" has uploaded file with content "some data - edited" to "<from>textfile.txt"
+    And we save it into "FILEID"
+    And user "Alice" has moved file "<from>textfile.txt" to "<to>textfile.txt" in space "Personal"
+    When user "Alice" gets the number of versions of file "<to>textfile.txt" using file-id path "/meta/<<FILEID>>/v"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "1"
+    Examples:
+      | from    | to      |
+      | /       | folder/ |
+      | folder/ | /       |
+
+  @issue-777
+  Scenario Outline: check file versions after moving to-and-fro folder in personal space (MOVE using file-id)
+    Given user "Alice" has created folder "folder"
+    And user "Alice" has uploaded file with content "some data" to "<from>textfile.txt"
+    And user "Alice" has uploaded file with content "some data - edited" to "<from>textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "<from>textfile.txt" into "<to>" inside space "Personal" using file-id path "/dav/spaces/<<FILEID>>"
+    Then the HTTP status code should be "201"
+    When user "Alice" gets the number of versions of file "<to>textfile.txt" using file-id path "/meta/<<FILEID>>/v"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "1"
+    Examples:
+      | from    | to      |
+      | /       | folder/ |
+      | folder/ | /       |
+
+  @issue-777
+  Scenario Outline: check file versions after moving to-and-fro folder in project space
+    Given user "Alice" has created a folder "folder" in space "Project1"
+    And user "Alice" has uploaded a file inside space "Project1" with content "some data" to "<from>textfile.txt"
+    And user "Alice" has uploaded a file inside space "Project1" with content "some data - edited" to "<from>textfile.txt"
+    And we save it into "FILEID"
+    And user "Alice" has moved file "<from>textfile.txt" to "<to>textfile.txt" in space "Project1"
+    When user "Alice" gets the number of versions of file "<from>textfile.txt" using file-id path "/meta/<<FILEID>>/v"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "1"
+    Examples:
+      | from    | to      |
+      | /       | folder/ |
+      | folder/ | /       |
+
+  @issue-777
+  Scenario Outline: check file versions after moving to-and-fro folder in project space (MOVE using file-id)
+    And user "Alice" has created a folder "folder" in space "Project1"
+    And user "Alice" has uploaded a file inside space "Project1" with content "some data" to "<from>textfile.txt"
+    And user "Alice" has uploaded a file inside space "Project1" with content "some data - edited" to "<from>textfile.txt"
+    And we save it into "FILEID"
+    When user "Alice" moves a file "<from>textfile.txt" into "<to>" inside space "Project1" using file-id path "/dav/spaces/<<FILEID>>"
+    Then the HTTP status code should be "201"
+    When user "Alice" gets the number of versions of file "<to>textfile.txt" using file-id path "/meta/<<FILEID>>/v"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "1"
+    Examples:
+      | from    | to      |
+      | /       | folder/ |
+      | folder/ | /       |

--- a/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
@@ -87,7 +87,7 @@ Feature: checking file versions using file id
     And the number of versions should be "1"
 
   @issue-777
-  Scenario Outline: check file versions after moving to-and-fro folder in personal space
+  Scenario Outline: check file versions after moving to-and-from folder in personal space
     Given user "Alice" has created folder "folder"
     And user "Alice" has uploaded file with content "some data" to "<from>textfile.txt"
     And user "Alice" has uploaded file with content "some data - edited" to "<from>textfile.txt"
@@ -102,7 +102,7 @@ Feature: checking file versions using file id
       | folder/ | /       |
 
   @issue-777
-  Scenario Outline: check file versions after moving to-and-fro folder in personal space (MOVE using file-id)
+  Scenario Outline: check file versions after moving to-and-from folder in personal space (MOVE using file-id)
     Given user "Alice" has created folder "folder"
     And user "Alice" has uploaded file with content "some data" to "<from>textfile.txt"
     And user "Alice" has uploaded file with content "some data - edited" to "<from>textfile.txt"
@@ -118,7 +118,7 @@ Feature: checking file versions using file id
       | folder/ | /       |
 
   @issue-777
-  Scenario Outline: check file versions after moving to-and-fro folder in project space
+  Scenario Outline: check file versions after moving to-and-from folder in project space
     Given user "Alice" has created a folder "folder" in space "Project1"
     And user "Alice" has uploaded a file inside space "Project1" with content "some data" to "<from>textfile.txt"
     And user "Alice" has uploaded a file inside space "Project1" with content "some data - edited" to "<from>textfile.txt"
@@ -133,7 +133,7 @@ Feature: checking file versions using file id
       | folder/ | /       |
 
   @issue-777
-  Scenario Outline: check file versions after moving to-and-fro folder in project space (MOVE using file-id)
+  Scenario Outline: check file versions after moving to-and-from folder in project space (MOVE using file-id)
     And user "Alice" has created a folder "folder" in space "Project1"
     And user "Alice" has uploaded a file inside space "Project1" with content "some data" to "<from>textfile.txt"
     And user "Alice" has uploaded a file inside space "Project1" with content "some data - edited" to "<from>textfile.txt"

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -222,6 +222,7 @@ class FilesVersionsContext implements Context {
 	 * @param string $fileId
 	 * @param int $expectedCount
 	 *
+	 * @return void
 	 * @throws Exception
 	 */
 	public function assertFileVersionsCount(string $user, string $fileId, int $expectedCount):void {
@@ -233,7 +234,7 @@ class FilesVersionsContext implements Context {
 		Assert::assertEquals(
 			$expectedCount,
 			$actualCount,
-			"Expected $count versions but found $actualCount in \n" . $responseXml->asXML()
+			"Expected $expectedCount versions but found $actualCount in \n" . $responseXml->asXML()
 		);
 	}
 

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -359,50 +359,33 @@ Feature: dav-versions
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Carol" should be "First content"
 
   @skipOnReva
-  Scenario: moving a file (with versions) into a shared folder as the sharee and as the sharer
-    Given using new DAV path
+  Scenario Outline: moving a file (with versions) into a shared folder as the sharer
+    Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
+      | path        | testshare     |
+      | shareType   | user          |
+      | permissions | <permissions> |
+      | shareWith   | Alice         |
     And user "Brian" has uploaded file with content "test data 1" to "/testfile.txt"
-    And we save it into "FILEID"
     And user "Brian" has uploaded file with content "test data 2" to "/testfile.txt"
     And user "Brian" has uploaded file with content "test data 3" to "/testfile.txt"
     When user "Brian" moves file "/testfile.txt" to "/testshare/testfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And as "Brian" file "/testfile.txt" should not exist
     And the content of file "/Shares/testshare/testfile.txt" for user "Alice" should be "test data 3"
     And the content of file "/testshare/testfile.txt" for user "Brian" should be "test data 3"
-    And as "Brian" file "/testfile.txt" should not exist
-    When user "Alice" tries to get the number of versions of file "/Shares/testshare/testfile.txt" using file-id path "/meta/<<FILEID>>/v"
-    Then the HTTP status code should be "403"
-
-
-  Scenario Outline: moving a file (with versions) out of a shared folder as the sharee and as the sharer
-    Given using <dav-path-version> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "/testshare"
-    And user "Brian" has uploaded file with content "test data 1" to "/testshare/testfile.txt"
-    And user "Brian" has uploaded file with content "test data 2" to "/testshare/testfile.txt"
-    And user "Brian" has uploaded file with content "test data 3" to "/testshare/testfile.txt"
-    And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
-    When user "Brian" moves file "/testshare/testfile.txt" to "/testfile.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the content of file "/testfile.txt" for user "Brian" should be "test data 3"
-    And as "Alice" file "/Shares/testshare/testfile.txt" should not exist
-    And as "Brian" file "/testshare/testfile.txt" should not exist
-    And the version folder of file "/testfile.txt" for user "Brian" should contain "2" elements
+    And the version folder of file "Shares/testshare/testfile.txt" for user "Alice" should contain "0" elements
+    And the version folder of file "testshare/testfile.txt" for user "Brian" should contain "2" elements
     Examples:
-      | dav-path-version |
-      | old              |
-      | new              |
+      | dav-path-version | permissions |
+      | old              | read        |
+      | old              | change      |
+      | old              | all         |
+      | new              | read        |
+      | new              | change      |
+      | new              | all         |
 
 
   Scenario: sharee tries to get file versions of file not shared by the sharer


### PR DESCRIPTION
## Description
Add API test coverage for https://github.com/owncloud/ocis/issues/777 and https://github.com/owncloud/ocis/issues/7738

## Related Issue
- coverage for https://github.com/owncloud/ocis/issues/777 and https://github.com/owncloud/ocis/issues/7738

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
