### PR TITLE
[tests-only] Added API test coverage for checking file versions after multiple restores

### DIFF
--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -418,3 +418,31 @@ Feature: dav-versions
     When user "Brian" tries to get versions of file "textfile0.txt" from "Alice"
     Then the HTTP status code should be "403"
     And the value of the item "//s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\Forbidden"
+
+  @issue-enterprise-6249
+  Scenario: upload empty content file and check versions after multiple restores
+    Given user "Alice" has uploaded file with content "" to "textfile.txt"
+    And user "Alice" has uploaded file with content "test content" to "textfile.txt"
+    And the version folder of file "textfile.txt" for user "Alice" should contain "1" element
+    When user "Alice" restores version index "1" of file "textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "textfile.txt" for user "Alice" should be ""
+    And the version folder of file "textfile.txt" for user "Alice" should contain "1" elements
+    When user "Alice" restores version index "1" of file "textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "textfile.txt" for user "Alice" should be "test content"
+    And the version folder of file "textfile.txt" for user "Alice" should contain "1" elements
+
+
+  Scenario: update with empty content and check versions after multiple restores
+    Given user "Alice" has uploaded file with content "test content" to "textfile.txt"
+    And user "Alice" has uploaded file with content "" to "textfile.txt"
+    And the version folder of file "textfile.txt" for user "Alice" should contain "1" element
+    When user "Alice" restores version index "1" of file "textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "textfile.txt" for user "Alice" should be "test content"
+    And the version folder of file "textfile.txt" for user "Alice" should contain "1" elements
+    When user "Alice" restores version index "1" of file "textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "textfile.txt" for user "Alice" should be ""
+    And the version folder of file "textfile.txt" for user "Alice" should contain "1" elements


### PR DESCRIPTION
## Description
Added API test coverage for checking file versions after multiple restores.

**NOTE: file MUST be uploaded with empty content first**

Steps to reproduce bug (webUI):
1. create a new file with some content
2. check the version with 0 byte
3. restore the 0 byte version - OK
4. restore the <x> bytes versions - OK
5. content is empty - BAD
6. there is no versions - BAD

## Related Issue
- test coverage for https://github.com/owncloud/enterprise/issues/6249
- waiting for https://github.com/cs3org/reva/pull/4456 in ocis

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
