### PR TITLE
[tests-only][full-ci] backport added test to send share invitation to user and gruop at once

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -300,5 +300,14 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSharingNg/shareInvitations.feature:1046](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1046)
 - [apiSharingNg/shareInvitations.feature:1047](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1047)
 - [apiSharingNg/shareInvitations.feature:1048](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1048)
+- [apiSharingNg/shareInvitations.feature:1105](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1105)
+- [apiSharingNg/shareInvitations.feature:1106](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1106)
+- [apiSharingNg/shareInvitations.feature:1107](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1107)
+- [apiSharingNg/shareInvitations.feature:1108](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1108)
+- [apiSharingNg/shareInvitations.feature:1109](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1109)
+- [apiSharingNg/shareInvitations.feature:1110](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1110)
+- [apiSharingNg/shareInvitations.feature:1111](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1111)
+- [apiSharingNg/shareInvitations.feature:1112](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1112)
+- [apiSharingNg/shareInvitations.feature:1113](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/shareInvitations.feature#L1113)
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSharingNg/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/shareInvitations.feature
@@ -1046,3 +1046,68 @@ Feature: Send a sharing invitations
       | Co Owner         | folder        | FolderToShare  |
       | Uploader         | folder        | FolderToShare  |
       | Manager          | folder        | FolderToShare  |
+
+
+  Scenario Outline: try to send sharing invitation to user and group at once
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Carol    |
+      | Bob      |
+    And group "grp1" has been created
+    And the following users have been added to the following groups
+      | username | groupname |
+      | Brian    | grp1      |
+      | Carol    | grp1      |
+    And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
+    And user "Alice" has created folder "FolderToShare"
+    When user "Alice" sends the following share invitation using the Graph API:
+      | resourceType    | <resource-type>    |
+      | resource        | <path>             |
+      | space           | Personal           |
+      | sharee          | grp1, Bob          |
+      | shareType       | group, user        |
+      | permissionsRole | <permissions-role> |
+    Then the HTTP status code should be "400"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "invalidRequest"
+                ]
+              },
+              "message": {
+                "type": "string",
+                "enum": [
+                  "Key: 'DriveItemInvite.Recipients' Error:Field validation for 'Recipients' failed on the 'len' tag"
+                ]
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | permissions-role | resource-type | path           |
+      | Viewer           | file          | /textfile1.txt |
+      | File Editor      | file          | /textfile1.txt |
+      | Co Owner         | file          | /textfile1.txt |
+      | Manager          | file          | /textfile1.txt |
+      | Viewer           | folder        | FolderToShare  |
+      | Editor           | folder        | FolderToShare  |
+      | Co Owner         | folder        | FolderToShare  |
+      | Uploader         | folder        | FolderToShare  |
+      | Manager          | folder        | FolderToShare  |


### PR DESCRIPTION
Backport of PR: https://github.com/owncloud/ocis/pull/8168