### PR TITLE
change ocis basepath from home to

### DIFF
--- a/docs/helpers/configenvextractor.go
+++ b/docs/helpers/configenvextractor.go
@@ -63,7 +63,7 @@ func generateIntermediateCode(templatePath string, intermediateCodePath string, 
 
 func runIntermediateCode(intermediateCodePath string) {
 	fmt.Println("Running intermediate go code for " + intermediateCodePath)
-	defaultPath := "~/.ocis"
+	defaultPath := "/etc/ocis"
 	os.Setenv("OCIS_BASE_DATA_PATH", defaultPath)
 	os.Setenv("OCIS_CONFIG_DIR", path.Join(defaultPath, "config"))
 	out, err := exec.Command("go", "run", intermediateCodePath).Output()

--- a/docs/helpers/configenvextractor.go
+++ b/docs/helpers/configenvextractor.go
@@ -63,9 +63,10 @@ func generateIntermediateCode(templatePath string, intermediateCodePath string, 
 
 func runIntermediateCode(intermediateCodePath string) {
 	fmt.Println("Running intermediate go code for " + intermediateCodePath)
-	defaultPath := "/etc/ocis"
-	os.Setenv("OCIS_BASE_DATA_PATH", defaultPath)
-	os.Setenv("OCIS_CONFIG_DIR", path.Join(defaultPath, "config"))
+	defaultConfigPath := "/etc/ocis"
+	defaultDataPath := "/var/lib/ocis"
+	os.Setenv("OCIS_BASE_DATA_PATH", defaultDataPath)
+	os.Setenv("OCIS_CONFIG_DIR", defaultConfigPath)
 	out, err := exec.Command("go", "run", intermediateCodePath).Output()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This PR changes the basepath for the docs helper from `~` (HOME) to `/etc`

refs #7972 