### PR TITLE
graph/sharedWitMe: fix response for shares from project space

### DIFF
--- a/changelog/unreleased/sharing-ng-empty-owner.md
+++ b/changelog/unreleased/sharing-ng-empty-owner.md
@@ -1,0 +1,11 @@
+Bugfix: graph/sharedWithMe works for shares from project spaces now
+
+We fixed a bug in the 'graph/v1beta1/me/drive/sharedWithMe' endpoint that
+caused an error response when the user received shares from project spaces.
+Additionally the endpoint now behaves more graceful in cases where the
+displayname of the owner or creator of a share or shared resource couldn't be
+resolved.
+
+https://github.com/owncloud/ocis/pull/8233
+https://github.com/owncloud/ocis/issues/8027
+https://github.com/owncloud/ocis/issues/8215


### PR DESCRIPTION
Resources on project space do not have a real owner assigned. A special
of the type USER_TYPE_SPACE_OWNER is returned as the owner. This type of
user can't be looked up via a GetUser request. So we skip that call for
this usertype.

This also fixes the behavior of 'sharedWithMe' for case when the owner
or creator of a share or shared resource can't be looked up in the 'users'
service. Previously cause the complete request to fail with an error message.
So a single share with an unresolvable owner caused 'sharedWithMe' to fail.
Now we log a warning but return all shares. Those where the owner or creator
couldn't be resolved will have the 'displayName' field of the user in the
'remoteItem.shared.owner' or 'remoteItem.shared.sharedBy' property left
empty.

Fixes: #8215
Fixes: #8027
