### PR TITLE
chore: bump icap client which fixes defer error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/pl
 
 replace github.com/studio-b12/gowebdav => github.com/aduffeck/gowebdav v0.0.0-20231215102054-212d4a4374f6
 
-replace github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240105150744-9c2d8aff3ef2
+replace github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a
 
 // exclude the v2 line of go-sqlite3 which was released accidentally and prevents pulling in newer versions of go-sqlite3
 // see https://github.com/mattn/go-sqlite3/issues/965 for more details

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/pl
 
 replace github.com/studio-b12/gowebdav => github.com/aduffeck/gowebdav v0.0.0-20231215102054-212d4a4374f6
 
-replace github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a
+replace github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240123094924-5af178158eaf
 
 // exclude the v2 line of go-sqlite3 which was released accidentally and prevents pulling in newer versions of go-sqlite3
 // see https://github.com/mattn/go-sqlite3/issues/965 for more details

--- a/go.sum
+++ b/go.sum
@@ -1113,8 +1113,8 @@ github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6
 github.com/foxcpp/go-mockdns v1.0.0/go.mod h1:lgRN6+KxQBawyIghpnl5CezHFGS9VLzvtVlwxvzXTQ4=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
-github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a h1:id4FzJEvDsNtLxIdux6iT9qHuWhCAwto9MgqA8kik+o=
-github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a/go.mod h1:Curjbe9P7SKWAtoXuu/huL8VnqzuBzetEpEPt9TLToE=
+github.com/fschade/icap-client v0.0.0-20240123094924-5af178158eaf h1:3IzYXRblwIxeis+EtLLWTK0QitcefZT7YfpF7jfTFYA=
+github.com/fschade/icap-client v0.0.0-20240123094924-5af178158eaf/go.mod h1:Curjbe9P7SKWAtoXuu/huL8VnqzuBzetEpEPt9TLToE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/go.sum
+++ b/go.sum
@@ -1113,8 +1113,8 @@ github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6
 github.com/foxcpp/go-mockdns v1.0.0/go.mod h1:lgRN6+KxQBawyIghpnl5CezHFGS9VLzvtVlwxvzXTQ4=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
-github.com/fschade/icap-client v0.0.0-20240105150744-9c2d8aff3ef2 h1:PJERPsceXsS4uTJuDvHy/4rgrZyZWttbKesaacKmXiI=
-github.com/fschade/icap-client v0.0.0-20240105150744-9c2d8aff3ef2/go.mod h1:Curjbe9P7SKWAtoXuu/huL8VnqzuBzetEpEPt9TLToE=
+github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a h1:id4FzJEvDsNtLxIdux6iT9qHuWhCAwto9MgqA8kik+o=
+github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a/go.mod h1:Curjbe9P7SKWAtoXuu/huL8VnqzuBzetEpEPt9TLToE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/vendor/github.com/egirna/icap-client/client.go
+++ b/vendor/github.com/egirna/icap-client/client.go
@@ -31,9 +31,7 @@ func NewClient(options ...ConfigOption) (Client, error) {
 }
 
 // Do is the main function of the client that makes the ICAP request
-func (c *Client) Do(req Request) (Response, error) {
-	var err error
-
+func (c *Client) Do(req Request) (res Response, err error) {
 	// establish connection to the icap server
 	err = c.conn.Connect(req.ctx, req.URL.Host)
 	if err != nil {
@@ -57,15 +55,15 @@ func (c *Client) Do(req Request) (Response, error) {
 		return Response{}, err
 	}
 
-	resp, err := toClientResponse(bufio.NewReader(strings.NewReader(string(dataRes))))
+	res, err = toClientResponse(bufio.NewReader(strings.NewReader(string(dataRes))))
 	if err != nil {
 		return Response{}, err
 	}
 
 	// check if the message is fully done scanning or if it needs to be sent another chunk
-	done := !(resp.StatusCode == http.StatusContinue && !req.bodyFittedInPreview && req.previewSet)
+	done := !(res.StatusCode == http.StatusContinue && !req.bodyFittedInPreview && req.previewSet)
 	if done {
-		return resp, nil
+		return res, nil
 	}
 
 	// get the remaining body bytes

--- a/vendor/github.com/egirna/icap-client/request.go
+++ b/vendor/github.com/egirna/icap-client/request.go
@@ -55,10 +55,9 @@ func NewRequest(ctx context.Context, method, urlStr string, httpReq *http.Reques
 
 // SetPreview sets the preview bytes in the icap header
 // todo: defer close error
-func (r *Request) SetPreview(maxBytes int) error {
+func (r *Request) SetPreview(maxBytes int) (err error) {
 	var bodyBytes []byte
 	var previewBytes int
-	var err error
 
 	// receiving the body bites to determine the preview bytes depending on the request ICAP method
 	if r.Method == MethodREQMOD {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -763,7 +763,7 @@ github.com/dutchcoders/go-clamd
 # github.com/egirna/icap v0.0.0-20181108071049-d5ee18bd70bc
 ## explicit
 github.com/egirna/icap
-# github.com/egirna/icap-client v0.1.1 => github.com/fschade/icap-client v0.0.0-20240105150744-9c2d8aff3ef2
+# github.com/egirna/icap-client v0.1.1 => github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a
 ## explicit; go 1.21
 github.com/egirna/icap-client
 # github.com/emirpasic/gods v1.18.1
@@ -2320,4 +2320,4 @@ stash.kopano.io/kgol/oidc-go
 stash.kopano.io/kgol/rndm
 # github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20231207143248-4d424e3ae348
 # github.com/studio-b12/gowebdav => github.com/aduffeck/gowebdav v0.0.0-20231215102054-212d4a4374f6
-# github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240105150744-9c2d8aff3ef2
+# github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -763,7 +763,7 @@ github.com/dutchcoders/go-clamd
 # github.com/egirna/icap v0.0.0-20181108071049-d5ee18bd70bc
 ## explicit
 github.com/egirna/icap
-# github.com/egirna/icap-client v0.1.1 => github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a
+# github.com/egirna/icap-client v0.1.1 => github.com/fschade/icap-client v0.0.0-20240123094924-5af178158eaf
 ## explicit; go 1.21
 github.com/egirna/icap-client
 # github.com/emirpasic/gods v1.18.1
@@ -2320,4 +2320,4 @@ stash.kopano.io/kgol/oidc-go
 stash.kopano.io/kgol/rndm
 # github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20231207143248-4d424e3ae348
 # github.com/studio-b12/gowebdav => github.com/aduffeck/gowebdav v0.0.0-20231215102054-212d4a4374f6
-# github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240117145045-466b8532173a
+# github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240123094924-5af178158eaf


### PR DESCRIPTION
## Description
In certain cases, icap-client errors were concealed, which has now been fixed

## Related Issue
- Fixes https://github.com/fschade/icap-client/pull/5#issue-2086377837

## Motivation and Context
in my home-lab i found out that In certain cases errors are not displayed... this can lead to unnecessary leaks.

## How Has This Been Tested?
- local installation

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)