### PR TITLE
added ability to debug the ocis in a docker compose stack via delve

### DIFF
--- a/.make/go.mk
+++ b/.make/go.mk
@@ -107,3 +107,15 @@ $(BIN)/$(EXECUTABLE)-debug: $(SOURCES)
 .PHONY: watch
 watch: $(REFLEX)
 	$(REFLEX) -c reflex.conf
+
+debug-linux-docker-amd64: release-dirs
+	GOOS=linux \
+	GOARCH=amd64 \
+	go build \
+        -gcflags="all=-N -l" \
+		-tags 'netgo $(TAGS)' \
+		-buildmode=exe \
+		-trimpath \
+		-ldflags '-extldflags "-static" $(DEBUG_LDFLAGS) $(DOCKER_LDFLAGS)' \
+		-o '$(DIST)/binaries/$(EXECUTABLE)-linux-amd64' \
+		./cmd/$(NAME)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,13 @@
             "request": "launch"
         },
         {
+            "name": "Debug remote :40000",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "port": 40000
+        },
+        {
             "name": "oCIS server",
             "type": "go",
             "request": "launch",

--- a/ocis/Makefile
+++ b/ocis/Makefile
@@ -31,6 +31,12 @@ dev-docker:
 	$(MAKE) --no-print-directory release-linux-docker-$(GOARCH)
 	docker build -f docker/Dockerfile.linux.$(GOARCH) -t owncloud/ocis:dev .
 
+############ debug-docker ############
+.PHONY: debug-docker
+debug-docker:
+	$(MAKE) --no-print-directory debug-linux-docker-$(GOARCH)
+	docker build -f docker/Dockerfile.linux.debug.$(GOARCH) -t owncloud/ocis:debug .
+
 ############ generate ############
 include ../.make/generate.mk
 

--- a/ocis/docker/Dockerfile.linux.debug.amd64
+++ b/ocis/docker/Dockerfile.linux.debug.amd64
@@ -1,0 +1,41 @@
+FROM amd64/alpine:3.19
+
+ARG VERSION=""
+ARG REVISION=""
+
+RUN apk add --no-cache ca-certificates mailcap tree attr curl libc6-compat delve && \
+	echo 'hosts: files dns' >| /etc/nsswitch.conf
+
+LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
+  org.opencontainers.image.title="ownCloud Infinite Scale" \
+  org.opencontainers.image.vendor="ownCloud GmbH" \
+  org.opencontainers.image.authors="ownCloud GmbH" \
+  org.opencontainers.image.description="oCIS - ownCloud Infinite Scale is a modern file-sync and share platform" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.documentation="https://github.com/owncloud/ocis" \
+  org.opencontainers.image.url="https://hub.docker.com/r/owncloud/ocis" \
+  org.opencontainers.image.source="https://github.com/owncloud/ocis" \
+  org.opencontainers.image.version="${VERSION}" \
+  org.opencontainers.image.revision="${REVISION}"
+
+RUN addgroup -g 1000 -S ocis-group && \
+  adduser -S --ingroup ocis-group --uid 1000 ocis-user --home /var/lib/ocis
+
+RUN mkdir -p /var/lib/ocis && \
+ chown -R ocis-user:ocis-group /var/lib/ocis && \
+ chmod -R 751 /var/lib/ocis && \
+ mkdir -p /etc/ocis && \
+ chown -R ocis-user:ocis-group /etc/ocis && \
+ chmod -R 751 /etc/ocis
+
+VOLUME [ "/var/lib/ocis", "/etc/ocis" ]
+WORKDIR /var/lib/ocis
+
+USER 1000
+
+EXPOSE 9200/tcp
+
+ENTRYPOINT ["/usr/bin/ocis"]
+CMD ["server"]
+
+COPY dist/binaries/ocis-linux-amd64 /usr/bin/ocis


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added ability to debug the ocis binary in a docker compose stack via delve.

### Debugging the ocis in a docker container

Remote debugging is the debug mode commonly used to work with a debugger and target running on a remote machine or a container for example a wopi stack `deployments/examples/ocis_wopi/docker-compose.yml`.
Below we describe the steps how to build the image, run the docker-compose and connect via remote debugger.
1. Build the image:
```bash
cd github.com/owncloud/ocis/ocis
make debug-docker
```
2. Change the tag label:
```bash
export OCIS_DOCKER_TAG=debug
```
3. Change the docker-compose `ocis` or `ocis-appprovider-collabora` or `ocis-appprovider-onlyoffice` depends on what do you want to debug:
For example `deployments/examples/ocis_wopi/docker-compose.yml`
```yaml
  ocis:
    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
    networks:
      ocis-net:
    entrypoint:
      - /bin/sh
# Comment out command
#    command: ["-c", "ocis init || true; ocis server"]
# Add new command and expose the port
    command: [ "-c", "ocis init || true; dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec /usr/bin/ocis server" ]
    ports:
      - 40000:40000
```
4. Run the docker-compose
5. Connect to remote `delve`
* For the VS Code add the configuration to the `.vscode/launch.json` [https://github.com/golang/vscode-go/wiki/debugging#remote-debugging](https://github.com/golang/vscode-go/wiki/debugging#remote-debugging)
```json
 {
  "name": "Debug remote :40000",
  "type": "go",
  "request": "attach",
  "mode": "remote",
  "port": 40000,
  "host": "localhost", // optional
  "trace": "verbose",  // optional
  "showLog": true      // optional
},
```