### PR TITLE
fix the resource name

### DIFF
--- a/changelog/unreleased/fix-resource-name.md
+++ b/changelog/unreleased/fix-resource-name.md
@@ -1,0 +1,7 @@
+Bugfix: Fix the resource name
+
+We fixed a problem where after renaming resource as sharer the receiver see a new name.
+
+https://github.com/owncloud/ocis/pull/8246  
+https://github.com/cs3org/reva/pull/4463  
+https://github.com/owncloud/ocis/issues/8242  


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
After the sharer changed the name of a shared resource, the receiver can see the new name, but cannot access it by using the new name.
We fixed a problem where after renaming the resource as sharer the receiver saw a new name.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [https://github.com/owncloud/ocis/issues/8242](https://github.com/owncloud/ocis/issues/8242)
- Related changes [https://github.com/cs3org/reva/pull/4463/files](https://github.com/cs3org/reva/pull/4463/files)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
1. create a folder
2. share the folder
3. as sharer rename the folder
4. as receiver do a propfind on the share-jail `curl -XPROPFIND -uuu1:uu1 'https://localhost:9200/dav/spaces/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668' -k | xmllint --format  -`

## Expected behavior
`d:href` element and `oc:name` should correlate

## Actual behavior
`d:href`, `d:displayname` and `oc:name` shows the old name for receiver

response (shortened)
```
 <d:response>
    <d:href>/dav/spaces/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668/folder/</d:href>
    <d:propstat>
      <d:prop>
        <oc:name>folder</oc:name>
        <d:displayname>folder</d:displayname>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
