### PR TITLE
 [tests-only] Added test for sharingNg for endpoint sharedByMe from personal space

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1868,4 +1868,29 @@ class GraphHelper {
 			self::getRequestHeaders()
 		);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function getSharesSharedByAUser(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password
+	): ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "me/drive/sharedByMe");
+		return HttpRequestHelper::get(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders()
+		);
+	}
 }

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1878,7 +1878,7 @@ class GraphHelper {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public static function getSharesSharedByAUser(
+	public static function getSharesSharedByMe(
 		string $baseUrl,
 		string $xRequestId,
 		string $user,

--- a/tests/acceptance/features/apiSharingNg/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedByMe.feature
@@ -1,0 +1,614 @@
+Feature: resources shared by user
+  As a user
+  I want to get resources shared by me
+  So that I can know about what resources are shared with others
+
+  https://owncloud.dev/libre-graph-api/#/me.drive/ListSharedByMe
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+
+  Scenario: user lists the shared file from personal space
+    Given user "Alice" has uploaded file with content "hello world" to "textfile.txt"
+    And user "Alice" has sent the following share invitation:
+      | resourceType    | file         |
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    When user "Alice" lists the resources shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain file name "textfile.txt" with the following data:
+    """
+    {
+      "type": "object",
+      "required": [
+        "parentReference",
+        "permissions",
+        "name",
+        "size"
+      ],
+      "properties": {
+        "parentReference": {
+          "type": "object",
+          "required": [
+            "driveId",
+            "driveType",
+            "path",
+            "name",
+            "id"
+          ],
+          "properties": {
+            "driveId": {
+              "type": "string",
+              "pattern": "^%space_id_pattern%$"
+            },
+            "driveType": {
+              "type": "string",
+              "enum": ["personal"]
+            },
+            "path": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "name": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "id": {
+              "type": "string",
+              "pattern": "^%file_id_pattern%$"
+            }
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "required": [
+                "grantedToV2",
+                "id",
+                "roles"
+              ],
+              "properties": {
+                "grantedToV2": {
+                  "type": "object",
+                  "required": [
+                    "user"
+                  ],
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "required": [
+                        "displayName",
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "pattern": "^%user_id_pattern%$"
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "enum": [
+                            "Brian Murphy"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "id": {
+                  "type": "string",
+                  "pattern": "^%permissions_id_pattern%$"
+                },
+                "roles": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string",
+                      "pattern": "^%role_id_pattern%$"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": ["textfile.txt"]
+        },
+        "size": {
+          "type": "number",
+          "enum": [
+            11
+          ]
+        }
+      }
+    }
+    """
+
+
+  Scenario: user lists the shared file inside of a folder from personal space
+    Given user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "hello world" to "FolderToShare/textfile.txt"
+    And user "Alice" has sent the following share invitation:
+      | resourceType    | file                       |
+      | resource        | FolderToShare/textfile.txt |
+      | space           | Personal                   |
+      | sharee          | Brian                      |
+      | shareType       | user                       |
+      | permissionsRole | Viewer                     |
+    When user "Alice" lists the resources shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain file name "textfile.txt" with the following data:
+    """
+    {
+      "type": "object",
+      "required": [
+        "parentReference",
+        "permissions",
+        "name",
+        "size"
+      ],
+      "properties": {
+        "parentReference": {
+          "type": "object",
+          "required": [
+            "driveId",
+            "driveType",
+            "path",
+            "name",
+            "id"
+          ],
+          "properties": {
+            "driveId": {
+              "type": "string",
+              "pattern": "^%space_id_pattern%$"
+            },
+            "driveType": {
+              "type": "string",
+              "enum": ["personal"]
+            },
+            "path": {
+              "type": "string",
+              "enum": ["/FolderToShare"]
+            },
+            "name": {
+              "type": "string",
+              "enum": ["FolderToShare"]
+            },
+            "id": {
+              "type": "string",
+              "pattern": "^%file_id_pattern%$"
+            }
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "required": [
+                "grantedToV2",
+                "id",
+                "roles"
+              ],
+              "properties": {
+                "grantedToV2": {
+                  "type": "object",
+                  "required": [
+                    "user"
+                  ],
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "required": [
+                        "displayName",
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "pattern": "^%user_id_pattern%$"
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "enum": [
+                            "Brian Murphy"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "id": {
+                  "type": "string",
+                  "pattern": "^%permissions_id_pattern%$"
+                },
+                "roles": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string",
+                      "pattern": "^%role_id_pattern%$"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": ["textfile.txt"]
+        },
+        "size": {
+          "type": "number",
+          "enum": [
+            11
+          ]
+        }
+      }
+    }
+    """
+
+
+  Scenario: user lists the shared folder from personal space
+    Given user "Alice" has created folder "FolderToShare"
+    And user "Alice" has sent the following share invitation:
+      | resourceType    | folder        |
+      | resource        | FolderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    When user "Alice" lists the resources shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain file name "FolderToShare" with the following data:
+    """
+    {
+      "type": "object",
+      "required": [
+        "parentReference",
+        "permissions",
+        "name"
+      ],
+      "properties": {
+        "parentReference": {
+          "type": "object",
+          "required": [
+            "driveId",
+            "driveType",
+            "path",
+            "name",
+            "id"
+          ],
+          "properties": {
+            "driveId": {
+              "type": "string",
+              "pattern": "^%space_id_pattern%$"
+            },
+            "driveType": {
+              "type": "string",
+              "enum": ["personal"]
+            },
+            "path": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "name": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "id": {
+              "type": "string",
+              "pattern": "^%file_id_pattern%$"
+            }
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "required": [
+                "grantedToV2",
+                "id",
+                "roles"
+              ],
+              "properties": {
+                "grantedToV2": {
+                  "type": "object",
+                  "required": [
+                    "user"
+                  ],
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "required": [
+                        "displayName",
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "pattern": "^%user_id_pattern%$"
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "enum": [
+                            "Brian Murphy"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "id": {
+                  "type": "string",
+                  "pattern": "^%permissions_id_pattern%$"
+                },
+                "roles": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string",
+                      "pattern": "^%role_id_pattern%$"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": ["FolderToShare"]
+        }
+      }
+    }
+    """
+
+
+  Scenario: user lists shared resources from personal space
+    Given user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
+    And user "Alice" has sent the following share invitation:
+      | resourceType    | file         |
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    And user "Alice" has sent the following share invitation:
+      | resourceType    | folder        |
+      | resource        | FolderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    When user "Alice" lists the resources shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain file name "textfile.txt" with the following data:
+    """
+    {
+      "type": "object",
+      "required": [
+        "parentReference",
+        "permissions",
+        "name",
+        "size"
+      ],
+      "properties": {
+        "parentReference": {
+          "type": "object",
+          "required": [
+            "driveId",
+            "driveType",
+            "path",
+            "name",
+            "id"
+          ],
+          "properties": {
+            "driveId": {
+              "type": "string",
+              "pattern": "^%space_id_pattern%$"
+            },
+            "driveType": {
+              "type": "string",
+              "enum": ["personal"]
+            },
+            "path": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "name": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "id": {
+              "type": "string",
+              "pattern": "^%file_id_pattern%$"
+            }
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "required": [
+                "grantedToV2",
+                "id",
+                "roles"
+              ],
+              "properties": {
+                "grantedToV2": {
+                  "type": "object",
+                  "required": [
+                    "user"
+                  ],
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "required": [
+                        "displayName",
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "pattern": "^%user_id_pattern%$"
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "enum": [
+                            "Brian Murphy"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "id": {
+                  "type": "string",
+                  "pattern": "^%permissions_id_pattern%$"
+                },
+                "roles": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string",
+                      "pattern": "^%role_id_pattern%$"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": ["textfile.txt"]
+        },
+        "size": {
+          "type": "number",
+          "enum": [
+            11
+          ]
+        }
+      }
+    }
+    """
+    And the JSON data of the response should contain file name "FolderToShare" with the following data:
+    """
+    {
+      "type": "object",
+      "required": [
+        "parentReference",
+        "permissions",
+        "name"
+      ],
+      "properties": {
+        "parentReference": {
+          "type": "object",
+          "required": [
+            "driveId",
+            "driveType",
+            "path",
+            "name",
+            "id"
+          ],
+          "properties": {
+            "driveId": {
+              "type": "string",
+              "pattern": "^%space_id_pattern%$"
+            },
+            "driveType": {
+              "type": "string",
+              "enum": ["personal"]
+            },
+            "path": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "name": {
+              "type": "string",
+              "enum": ["/"]
+            },
+            "id": {
+              "type": "string",
+              "pattern": "^%file_id_pattern%$"
+            }
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "required": [
+                "grantedToV2",
+                "id",
+                "roles"
+              ],
+              "properties": {
+                "grantedToV2": {
+                  "type": "object",
+                  "required": [
+                    "user"
+                  ],
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "required": [
+                        "displayName",
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "pattern": "^%user_id_pattern%$"
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "enum": [
+                            "Brian Murphy"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "id": {
+                  "type": "string",
+                  "pattern": "^%permissions_id_pattern%$"
+                },
+                "roles": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string",
+                      "pattern": "^%role_id_pattern%$"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": ["FolderToShare"]
+        }
+      }
+    }
+    """

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2537,7 +2537,7 @@ class GraphContext implements Context {
 	public function userListsTheResourcesSharedByAUserUsingGraphApi(string $user): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$this->featureContext->setResponse(
-			GraphHelper::getSharesSharedByAUser(
+			GraphHelper::getSharesSharedByMe(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getStepLineRef(),
 				$credentials['username'],
@@ -2551,7 +2551,7 @@ class GraphContext implements Context {
 	 *
 	 * @param string $shouldOrNot (not| )
 	 * @param string $fileName
-	 * @param PyStringNode|null $schemaString
+	 * @param PyStringNode $schemaString
 	 *
 	 * @return void
 	 * @throws Exception
@@ -2559,7 +2559,7 @@ class GraphContext implements Context {
 	public function theJsonDataResponseShouldOrNotContainSharedByMeDetails(
 		string $shouldOrNot,
 		string $fileName,
-		?PyStringNode $schemaString = null
+		PyStringNode $schemaString
 	): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->value;
 		$fileOrFolderFound = false;
@@ -2576,7 +2576,7 @@ class GraphContext implements Context {
 		}
 		Assert::assertFalse(
 			!$shouldContain && $fileOrFolderFound,
-			'Response contains file "' . $fileName . '" but should not have.'
+			'Response contains file "' . $fileName . '" but should.'
 		);
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$responseBody,


### PR DESCRIPTION
### Description
This PR adds tests for listing shared by me resource shared from personal space for `sharingNG`.
Added scenarios: 
```feature
Scenario: user lists the file shared from personal space
Scenario: user lists the folder shared from personal space
Scenario: user lists resources shared from personal space
Scenario: user lists the shared file inside of a folder from personal space
```

### Related Issue: 
https://github.com/owncloud/ocis/issues/8111