### PR TITLE
make storage users service name configurable

### DIFF
--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -59,7 +59,7 @@ type Log struct {
 
 // Service holds general service configuration
 type Service struct {
-	Name string `yaml:"-"`
+	Name string `yaml:"-" env:"STORAGE_USERS_SERVICE_NAME" desc:"Service name to use. Change this when starting an additional storage provider to prevent it from colliding with the default 'storage-users' service."`
 }
 
 // Debug is the configuration for the debug server


### PR DESCRIPTION
Currently, there is no way to start an additional storage provider with a custom configuration, eg. to test a new storage driver like [hellofs](https://github.com/cs3org/reva/pull/4478)

With this change I can run hellofs by setting a few env vars and then running `ocis storage-users server`:
```
					"STORAGE_USERS_SERVICE_NAME":"storage-hello",
					"STORAGE_USERS_DRIVER": "hello",
					"STORAGE_USERS_HTTP_ADDR":"127.0.0.1:9301",
					"STORAGE_USERS_DEBUG_ADDR":"127.0.0.1:9302",
					"STORAGE_USERS_GRPC_ADDR":"127.0.0.1:9303",
					"STORAGE_USERS_DATA_SERVER_URL":"http://127.0.0.1:9301/data",
```

Furthermore, it is really cumbersome to add an additional storage driver to the storage registry in the gateway. Quickest for development is this diff:
```diff
diff --git a/services/gateway/pkg/revaconfig/config.go b/services/gateway/pkg/revaconfig/config.go
index c13688aee9..7c5d992b42 100644
--- a/services/gateway/pkg/revaconfig/config.go
+++ b/services/gateway/pkg/revaconfig/config.go
@@ -203,6 +203,15 @@ func spacesProviders(cfg *config.Config, logger log.Logger) map[string]map[strin
                                },
                        },
                },
+               "com.owncloud.api.storage-hello": {
+                       "providerid": "hello-storage-id",
+                       "spaces": map[string]interface{}{
+                               "project": map[string]interface{}{
+                                       "mount_point":   "/hello",
+                                       "path_template": "/hello/{{.Space.Name}}",
+                               },
+                       },
+               },
                // medatada storage not part of the global namespace
        }
 }
```