### PR TITLE
enhancement: add parent name and path to shared the shared by me endpoint

### DIFF
--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -1010,6 +1010,8 @@ func cs3ResourceToDriveItem(logger *log.Logger, res *storageprovider.ResourceInf
 		parentRef.SetDriveType(res.GetSpace().GetSpaceType())
 		parentRef.SetDriveId(storagespace.FormatStorageID(res.GetParentId().GetStorageId(), res.GetParentId().GetSpaceId()))
 		parentRef.SetId(storagespace.FormatResourceID(*res.GetParentId()))
+		parentRef.SetName(res.GetName())
+		parentRef.SetPath(res.GetPath())
 		driveItem.ParentReference = parentRef
 	}
 	if res.GetType() == storageprovider.ResourceType_RESOURCE_TYPE_FILE && res.GetMimeType() != "" {


### PR DESCRIPTION
## Description
/graph/v1beta1/me/drive/sharedByMe parent reference missed name and path

## Related Issue
- Needed by https://github.com/owncloud/web/pull/10392

## Motivation and Context
provide more information to api consumers

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
