### PR TITLE
fix: hardcode config for spaces which was not allowed to change

### DIFF
--- a/changelog/unreleased/remove-useless-vars.md
+++ b/changelog/unreleased/remove-useless-vars.md
@@ -1,0 +1,5 @@
+Bugfix: Remove invalid environment variables
+
+We have removed two spaces related environment variables (whether project spaces and the share jail are enabled) and hardcoded the only allowed options. Misusing those variables would have resulted in invalid config.
+
+https://github.com/owncloud/ocis/pull/8303

--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -27,8 +27,6 @@ type Config struct {
 	SkipUserGroupsInToken bool `yaml:"skip_user_groups_in_token" env:"FRONTEND_SKIP_USER_GROUPS_IN_TOKEN" desc:"Disables the loading of user's group memberships from the reva access token."`
 
 	EnableFavorites                bool   `yaml:"enable_favorites" env:"FRONTEND_ENABLE_FAVORITES" desc:"Enables the support for favorites in the clients."`
-	EnableProjectSpaces            bool   `yaml:"enable_project_spaces" env:"FRONTEND_ENABLE_PROJECT_SPACES" desc:"Changing this value is NOT supported. Indicates to clients that project spaces are supposed to be made available."`
-	EnableShareJail                bool   `yaml:"enable_share_jail" env:"FRONTEND_ENABLE_SHARE_JAIL" desc:"Changing this value is NOT supported. Indicates to clients that the share jail is supposed to be used."`
 	MaxQuota                       uint64 `yaml:"max_quota" env:"OCIS_SPACES_MAX_QUOTA;FRONTEND_MAX_QUOTA" desc:"Set the global max quota value in bytes. A value of 0 equals unlimited. The value is provided via capabilities."`
 	UploadMaxChunkSize             int    `yaml:"upload_max_chunk_size" env:"FRONTEND_UPLOAD_MAX_CHUNK_SIZE" desc:"Sets the max chunk sizes in bytes for uploads via the clients."`
 	UploadHTTPMethodOverride       string `yaml:"upload_http_method_override" env:"FRONTEND_UPLOAD_HTTP_METHOD_OVERRIDE" desc:"Advise TUS to replace PATCH requests by POST requests."`

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -81,8 +81,6 @@ func DefaultConfig() *config.Config {
 		Reva:                     shared.DefaultRevaConfig(),
 		PublicURL:                "https://localhost:9200",
 		EnableFavorites:          false,
-		EnableProjectSpaces:      true,
-		EnableShareJail:          true,
 		UploadMaxChunkSize:       1e+7,
 		UploadHTTPMethodOverride: "",
 		DefaultUploadProtocol:    "tus",

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -286,9 +286,9 @@ func FrontendConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string
 							},
 							"spaces": map[string]interface{}{
 								"version":    "1.0.0",
-								"enabled":    cfg.EnableProjectSpaces || cfg.EnableShareJail,
-								"projects":   cfg.EnableProjectSpaces,
-								"share_jail": cfg.EnableShareJail,
+								"enabled":    true,
+								"projects":   true,
+								"share_jail": true,
 								"max_quota":  cfg.MaxQuota,
 							},
 							"search": map[string]interface{}{


### PR DESCRIPTION
## Description
Stumbled over two environment variables for which even the description states that they are not allowed to be changed. This PR has two positive results:
- reduced the risk to misconfigure ocis
- will allow the  web team to remove capability checks in web, because ocis is the only allowed backend. Since other clients are checking those capabilities, we can't remove the capabilities entirely.

I consider this to be a bugfix because the description of the env vars hints towards broken ocis if those config variables are set to other values than those which I now hardcoded.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
