### PR TITLE
fix: graph api sharing parentReference path

### DIFF
--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -1010,8 +1010,7 @@ func cs3ResourceToDriveItem(logger *log.Logger, res *storageprovider.ResourceInf
 		parentRef.SetDriveType(res.GetSpace().GetSpaceType())
 		parentRef.SetDriveId(storagespace.FormatStorageID(res.GetParentId().GetStorageId(), res.GetParentId().GetSpaceId()))
 		parentRef.SetId(storagespace.FormatResourceID(*res.GetParentId()))
-		parentRef.SetName(res.GetName())
-		parentRef.SetPath(res.GetPath())
+		parentRef.SetPath(path.Dir(res.GetPath()))
 		driveItem.ParentReference = parentRef
 	}
 	if res.GetType() == storageprovider.ResourceType_RESOURCE_TYPE_FILE && res.GetMimeType() != "" {

--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -1010,6 +1010,7 @@ func cs3ResourceToDriveItem(logger *log.Logger, res *storageprovider.ResourceInf
 		parentRef.SetDriveType(res.GetSpace().GetSpaceType())
 		parentRef.SetDriveId(storagespace.FormatStorageID(res.GetParentId().GetStorageId(), res.GetParentId().GetSpaceId()))
 		parentRef.SetId(storagespace.FormatResourceID(*res.GetParentId()))
+		parentRef.SetName(path.Base(path.Dir(res.GetPath())))
 		parentRef.SetPath(path.Dir(res.GetPath()))
 		driveItem.ParentReference = parentRef
 	}


### PR DESCRIPTION
## Description
use parent path in the parentReference graphApi property

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/pull/10392