### PR TITLE
fix: setting config for concurrent share requests

### DIFF
--- a/changelog/unreleased/fix-concurrent-shares-config.md
+++ b/changelog/unreleased/fix-concurrent-shares-config.md
@@ -1,0 +1,5 @@
+Bugfix: Fix concurrent shares config
+
+We fixed setting the config for concurrent web requests, which did not work as expected before.
+
+https://github.com/owncloud/ocis/pull/8317

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -118,7 +118,9 @@ func DefaultConfig() *config.Config {
 					Editor:                   &config.Editor{},
 					FeedbackLink:             &config.FeedbackLink{},
 					Embed:                    &config.Embed{},
-					ConcurrentRequests:       &config.ConcurrentRequests{},
+					ConcurrentRequests: &config.ConcurrentRequests{
+						Shares: &config.ConcurrentRequestsShares{},
+					},
 					Routing: config.Routing{
 						IDBased: true,
 					},


### PR DESCRIPTION
## Description
Fixes an issue where setting the config for concurrent share requests did not work.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/ocis-charts/issues/473

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
