### PR TITLE
[tests-only] extend share invite json response assertion

### DIFF
--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -69,7 +69,7 @@ Feature: an user gets the resources shared to them
               },
               "eTag": {
                 "type": "string",
-                "pattern": "%eTag%"
+                "pattern": "%etag_pattern%"
               },
               "file": {
                 "type": "object",
@@ -151,7 +151,7 @@ Feature: an user gets the resources shared to them
                   },
                   "eTag": {
                     "type": "string",
-                    "pattern": "%eTag%"
+                    "pattern": "%etag_pattern%"
                   },
                   "file": {
                     "type": "object",
@@ -336,7 +336,7 @@ Feature: an user gets the resources shared to them
               },
               "eTag": {
                 "type": "string",
-                "pattern": "%eTag%"
+                "pattern": "%etag_pattern%"
               },
               "folder": {
                 "type": "object",
@@ -412,7 +412,7 @@ Feature: an user gets the resources shared to them
                   },
                   "eTag": {
                     "type": "string",
-                    "pattern": "%eTag%"
+                    "pattern": "%etag_pattern%"
                   },
                   "file": {
                     "type": "object",

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -35,6 +35,8 @@ Feature: an user gets the resources shared to them
           "items": {
             "type": "object",
             "required": [
+              "@UI.Hidden",
+              "@client.synchronize",
               "createdBy",
               "eTag",
               "file",
@@ -42,9 +44,18 @@ Feature: an user gets the resources shared to them
               "lastModifiedDateTime",
               "name",
               "parentReference",
-              "remoteItem"
+              "remoteItem",
+              "size"
             ],
             "properties": {
+              "@UI.Hidden": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "@client.synchronize": {
+                "type": "boolean",
+                "enum": [true]
+              },
               "createdBy": {
                 "type": "object",
                 "required": [
@@ -95,16 +106,21 @@ Feature: an user gets the resources shared to them
                 "type": "object",
                 "required": [
                   "driveId",
-                  "driveType"
+                  "driveType",
+                  "id"
                 ],
                 "properties": {
                   "driveId": {
                     "type": "string",
                     "pattern": "^%space_id_pattern%$"
                   },
-                  "driveType" : {
+                  "driveType": {
                     "type": "string",
                     "enum": ["virtual"]
+                  },
+                  "id": {
+                    "type": "string",
+                    "pattern": "^%file_id_pattern%$"
                   }
                 }
               },
@@ -175,107 +191,121 @@ Feature: an user gets the resources shared to them
                       "textfile0.txt"
                     ]
                   },
+                  "parentReference": {
+                    "type": "object",
+                    "required": [
+                      "driveId",
+                      "driveType"
+                    ],
+                    "properties": {
+                      "driveId": {
+                        "type": "string",
+                        "pattern": "^%file_id_pattern%$"
+                      },
+                      "driveType": {
+                        "type": "string",
+                        "enum": ["personal"]
+                      }
+                    }
+                  },
                   "permissions": {
                     "type": "array",
                     "items": [
                       {
                         "type": "object",
                         "required": [
-                           "grantedToV2",
-                           "id",
-                           "invitation"
-                         ],
-                         "properties": {
-                           "id": {
-                             "type": "string"
-                           },
-                           "grantedToV2": {
-                             "type": "object",
-                             "required": [
-                               "user"
-                             ],
-                             "properties": {
-                               "user": {
-                                 "type": "object",
-                                 "properties": {
-                                   "displayName": {
-                                     "type": "string"
-                                   },
-                                   "id": {
-                                     "type": "string"
-                                   }
-                                 },
-                                 "required": [
-                                   "displayName",
-                                   "id"
-                                 ]
-                               }
-                             }
-                           },
-                           "invitation": {
-                             "type": "object",
-                             "properties": {
-                               "invitedBy": {
-                                 "type": "object",
-                                 "properties": {
-                                   "user": {
-                                     "type": "object",
-                                     "properties": {
-                                       "displayName": {
-                                         "type": "string"
-                                       },
-                                       "id": {
-                                         "type": "string"
-                                       }
-                                     },
-                                     "required": [
-                                       "displayName",
-                                       "id"
-                                     ]
-                                   }
-                                 },
-                                 "required": [
-                                   "user"
-                                 ]
-                               }
-                             },
-                             "required": [
-                               "invitedBy"
-                             ]
-                           },
-                           "@libre.graph.permissions.actions": {
-                             "type": "array",
-                             "items": [
-                               {
-                                 "type": "string"
-                               }
-                             ]
-                           },
-                           "roles": {
-                             "type": "array",
-                             "items": [
-                               {
-                                 "type": "string"
-                               }
-                             ]
-                           }
-                         }
-                       }
-                     ]
-                   },
-                   "size": {
-                     "type": "number",
-                     "enum": [
-                       11
-                     ]
-                   }
-                 }
-               }
-             }
-           }
-         }
-       }
-     }
+                          "grantedToV2",
+                          "id",
+                          "invitation",
+                          "roles"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "pattern": "^%permissions_id_pattern%$"
+                          },
+                          "grantedToV2": {
+                            "type": "object",
+                            "required": [
+                              "user"
+                            ],
+                            "properties": {
+                              "user": {
+                                "type": "object",
+                                "required": [
+                                  "displayName",
+                                  "id"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": "string",
+                                    "enum": ["Brian Murphy"]
+                                  },
+                                  "id": {
+                                    "type": "string",
+                                    "pattern": "^%user_id_pattern%$"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "invitation": {
+                            "type": "object",
+                            "properties": {
+                              "invitedBy": {
+                                "type": "object",
+                                "properties": {
+                                  "user": {
+                                    "type": "object",
+                                    "properties": {
+                                      "displayName": {
+                                        "type": "string",
+                                        "enum": ["Alice Hansen"]
+                                      },
+                                      "id": {
+                                        "type": "string",
+                                        "pattern": "^%user_id_pattern%$"
+                                      }
+                                    },
+                                    "required": [
+                                      "displayName",
+                                      "id"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "user"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "invitedBy"
+                            ]
+                          },
+                          "roles": {
+                            "type": "array",
+                            "items": [
+                              {
+                                "type": "string",
+                                "pattern": "^%role_id_pattern%$"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "size": {
+                "type": "number",
+                "enum": [11]
+              }
+            }
+          }
+        }
+      }
+    }
     """
 
 
@@ -302,6 +332,8 @@ Feature: an user gets the resources shared to them
           "items": {
             "type": "object",
             "required": [
+              "@UI.Hidden",
+              "@client.synchronize",
               "createdBy",
               "eTag",
               "folder",
@@ -312,6 +344,14 @@ Feature: an user gets the resources shared to them
               "remoteItem"
             ],
             "properties": {
+              "@UI.Hidden": {
+                "type": "boolean",
+                "enum": [false]
+              },
+              "@client.synchronize": {
+                "type": "boolean",
+                "enum": [true]
+              },
               "createdBy": {
                 "type": "object",
                 "required": [
@@ -357,16 +397,21 @@ Feature: an user gets the resources shared to them
                 "type": "object",
                 "required": [
                   "driveId",
-                  "driveType"
+                  "driveType",
+                  "id"
                 ],
                 "properties": {
                   "driveId": {
                     "type": "string",
                     "pattern": "^%space_id_pattern%$"
                   },
-                  "driveType" : {
+                  "driveType": {
                     "type": "string",
                     "enum": ["virtual"]
+                  },
+                  "id": {
+                    "type": "string",
+                    "pattern": "^%file_id_pattern%$"
                   }
                 }
               },
@@ -422,7 +467,7 @@ Feature: an user gets the resources shared to them
                     "properties": {
                       "mimeType": {
                         "type": "string",
-                        "pattern": "text/plain"
+                        "enum": ["text/plain"]
                       }
                     }
                   },
@@ -436,99 +481,115 @@ Feature: an user gets the resources shared to them
                       "folder"
                     ]
                   },
+                  "parentReference": {
+                    "type": "object",
+                    "required": [
+                      "driveId",
+                      "driveType"
+                    ],
+                    "properties": {
+                      "driveId": {
+                        "type": "string",
+                        "pattern": "^%file_id_pattern%$"
+                      },
+                      "driveType": {
+                        "type": "string",
+                        "enum": ["personal"]
+                      }
+                    }
+                  },
                   "permissions": {
                     "type": "array",
                     "items": [
                       {
                         "type": "object",
                         "required": [
-                           "grantedToV2",
-                           "id",
-                           "invitation"
-                         ],
-                         "properties": {
-                           "id": {
-                             "type": "string"
-                           },
-                           "grantedToV2": {
-                             "type": "object",
-                             "required": [
-                               "user"
-                             ],
-                             "properties": {
-                               "user": {
-                                 "type": "object",
-                                 "properties": {
-                                   "displayName": {
-                                     "type": "string"
-                                   },
-                                   "id": {
-                                     "type": "string"
-                                   }
-                                 },
-                                 "required": [
-                                   "displayName",
-                                   "id"
-                                 ]
-                               }
-                             }
-                           },
-                           "invitation": {
-                             "type": "object",
-                             "properties": {
-                               "invitedBy": {
-                                 "type": "object",
-                                 "properties": {
-                                   "user": {
-                                     "type": "object",
-                                     "properties": {
-                                       "displayName": {
-                                         "type": "string"
-                                       },
-                                       "id": {
-                                         "type": "string"
-                                       }
-                                     },
-                                     "required": [
-                                       "displayName",
-                                       "id"
-                                     ]
-                                   }
-                                 },
-                                 "required": [
-                                   "user"
-                                 ]
-                               }
-                             },
-                             "required": [
-                               "invitedBy"
-                             ]
-                           },
-                           "@libre.graph.permissions.actions": {
-                             "type": "array",
-                             "items": [
-                               {
-                                 "type": "string"
-                               }
-                             ]
-                           },
-                           "roles": {
-                             "type": "array",
-                             "items": [
-                               {
-                                 "type": "string"
-                               }
-                             ]
-                           }
-                         }
-                       }
-                     ]
-                   }
-                 }
-               }
-             }
-           }
-         }
-       }
-     }
+                          "grantedToV2",
+                          "id",
+                          "invitation",
+                          "roles"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "pattern": "^%permissions_id_pattern%$"
+                          },
+                          "grantedToV2": {
+                            "type": "object",
+                            "required": [
+                              "user"
+                            ],
+                            "properties": {
+                              "user": {
+                                "type": "object",
+                                "properties": {
+                                  "displayName": {
+                                    "type": "string",
+                                    "enum": ["Brian Murphy"]
+                                  },
+                                  "id": {
+                                    "type": "string",
+                                    "pattern": "^%user_id_pattern%$"
+                                  }
+                                },
+                                "required": [
+                                  "displayName",
+                                  "id"
+                                ]
+                              }
+                            }
+                          },
+                          "invitation": {
+                            "type": "object",
+                            "properties": {
+                              "invitedBy": {
+                                "type": "object",
+                                "properties": {
+                                  "user": {
+                                    "type": "object",
+                                    "properties": {
+                                      "displayName": {
+                                        "type": "string",
+                                        "enum": ["Alice Hansen"]
+                                      },
+                                      "id": {
+                                        "type": "string",
+                                        "pattern": "^%user_id_pattern%$"
+                                      }
+                                    },
+                                    "required": [
+                                      "displayName",
+                                      "id"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "user"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "invitedBy"
+                            ]
+                          },
+                          "roles": {
+                            "type": "array",
+                            "items": [
+                              {
+                                "type": "string",
+                                "pattern": "^%role_id_pattern%$"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     """

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1451,7 +1451,6 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function theDataOfTheResponseShouldMatch(PyStringNode $schemaString, ResponseInterface $response=null): void {
 		$responseBody = $this->getJsonDecodedResponseBodyContent($response);
-		print_r($schemaString);
 		$this->assertJsonDocumentMatchesSchema(
 			$responseBody,
 			$this->getJSONSchema($schemaString)
@@ -2748,30 +2747,6 @@ class FeatureContext extends BehatVariablesContext {
 				"parameter" => []
 			],
 			[
-				"code" => "%group_id_pattern%",
-				"function" => [
-					__NAMESPACE__ . '\TestHelpers\GraphHelper',
-					"getUUIDv4Regex"
-				],
-				"parameter" => []
-			],
-			[
-				"code" => "%space_id_pattern%",
-				"function" => [
-					__NAMESPACE__ . '\TestHelpers\GraphHelper',
-					"getSpaceIdRegex"
-				],
-				"parameter" => []
-			],
-			[
-				"code" => "%user_id_pattern%",
-				"function" => [
-					__NAMESPACE__ . '\TestHelpers\GraphHelper',
-					"getUUIDv4Regex"
-				],
-				"parameter" => []
-			],
-			[
 				"code" => "%user_id%",
 				"function" => [
 					$this, "getUserIdByUserName"
@@ -2784,6 +2759,22 @@ class FeatureContext extends BehatVariablesContext {
 					$this, "getGroupIdByGroupName"
 				],
 				"parameter" => [$group]
+			],
+			[
+				"code" => "%user_id_pattern%",
+				"function" => [
+					__NAMESPACE__ . '\TestHelpers\GraphHelper',
+					"getUUIDv4Regex"
+				],
+				"parameter" => []
+			],
+			[
+				"code" => "%group_id_pattern%",
+				"function" => [
+					__NAMESPACE__ . '\TestHelpers\GraphHelper',
+					"getUUIDv4Regex"
+				],
+				"parameter" => []
 			],
 			[
 				"code" => "%role_id_pattern%",
@@ -2806,6 +2797,14 @@ class FeatureContext extends BehatVariablesContext {
 				"function" => [
 					__NAMESPACE__ . '\TestHelpers\GraphHelper',
 					"getFileIdRegex"
+				],
+				"parameter" => []
+			],
+			[
+				"code" => "%space_id_pattern%",
+				"function" => [
+					__NAMESPACE__ . '\TestHelpers\GraphHelper',
+					"getSpaceIdRegex"
 				],
 				"parameter" => []
 			],

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1451,6 +1451,7 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function theDataOfTheResponseShouldMatch(PyStringNode $schemaString, ResponseInterface $response=null): void {
 		$responseBody = $this->getJsonDecodedResponseBodyContent($response);
+		print_r($schemaString);
 		$this->assertJsonDocumentMatchesSchema(
 			$responseBody,
 			$this->getJSONSchema($schemaString)
@@ -2817,7 +2818,7 @@ class FeatureContext extends BehatVariablesContext {
 				"parameter" => []
 			],
 			[
-				"code" => "%eTag%",
+				"code" => "%etag_pattern%",
 				"function" => [
 					__NAMESPACE__ . '\TestHelpers\GraphHelper',
 					"getEtagRegex"


### PR DESCRIPTION
## Description
extend `sharedWithMe` json response assertion for newly added properties:
```
- "@UI.Hidden"
- "@client.synchronize"
```

## Related Issue
- coverage for https://github.com/owncloud/ocis/pull/8322

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
