### PR TITLE
[tests-only][full-ci]Strictly validate json scheme on tests steps

### DIFF
--- a/tests/acceptance/features/apiSharingNg/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg/listPermissions.feature
@@ -48,6 +48,8 @@ Feature: List a sharing permissions
           },
           "@libre.graph.permissions.roles.allowedValues": {
             "type": "array",
+            "minItems": 4,
+            "maxItems": 4,
             "items": [
               {
                 "type": "object",
@@ -185,76 +187,6 @@ Feature: List a sharing permissions
                     "type": "string",
                     "enum": [
                       "fb6c3e19-e378-47e5-b277-9732f9de6e21"
-                    ]
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "required": [
-                  "@libre.graph.weight",
-                  "description",
-                  "displayName",
-                  "id"
-                ],
-                "properties": {
-                  "@libre.graph.weight": {
-                    "type": "integer",
-                    "enum": [
-                      5
-                    ]
-                  },
-                  "description": {
-                    "type": "string",
-                    "enum": [
-                      "Grants co-owner permissions on a resource"
-                    ]
-                  },
-                  "displayName": {
-                    "type": "string",
-                    "enum": [
-                      "Co Owner"
-                    ]
-                  },
-                  "id": {
-                    "type": "string",
-                    "enum": [
-                      "3a4ba8e9-6a0d-4235-9140-0e7a34007abe"
-                    ]
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "required": [
-                  "@libre.graph.weight",
-                  "description",
-                  "displayName",
-                  "id"
-                ],
-                "properties": {
-                  "@libre.graph.weight": {
-                    "type": "integer",
-                    "enum": [
-                      6
-                    ]
-                  },
-                  "description": {
-                    "type": "string",
-                    "enum": [
-                      "Grants manager permissions on a resource. Semantically equivalent to co-owner"
-                    ]
-                  },
-                  "displayName": {
-                    "type": "string",
-                    "enum": [
-                      "Manager"
-                    ]
-                  },
-                  "id": {
-                    "type": "string",
-                    "enum": [
-                      "312c0871-5ef7-4b3a-85b6-0e4074c64049"
                     ]
                   }
                 }


### PR DESCRIPTION
## Description
This PR implements code to strictly validate json scheme and json response. Upto now using `maxItems` validate the json response only. Json scheme can contain any number of items but json response should contain maxItem number items 

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/8333

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
