### PR TITLE
adapt docs-generate step to pick up env var delta tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,10 +168,13 @@ clean:
 docs-generate:
 	# empty the folders first to only have files that are generated without remnants
 	find docs/services/_includes/ -type f \( -name "*" ! -name ".git*" ! -name "_*" \) -delete || exit 1
+
 	@for mod in $(OCIS_MODULES); do \
         $(MAKE) --no-print-directory -C $$mod docs-generate || exit 1; \
     done
 	$(MAKE) --no-print-directory -C docs docs-generate || exit 1
+	mkdir -p docs/services/_includes/env-var-deltas
+	cp docs/env-var-deltas/*.adoc docs/services/_includes/env-var-deltas/
 
 .PHONY: ci-go-generate
 ci-go-generate:

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,7 @@ docs-generate:
         $(MAKE) --no-print-directory -C $$mod docs-generate || exit 1; \
     done
 	$(MAKE) --no-print-directory -C docs docs-generate || exit 1
-	mkdir -p docs/services/_includes/env-var-deltas
-	cp docs/env-var-deltas/*.adoc docs/services/_includes/env-var-deltas/
+	cp docs/env-var-deltas/*.adoc docs/services/_includes/adoc/env-var-deltas/
 
 .PHONY: ci-go-generate
 ci-go-generate:

--- a/docs/services/_includes/.gitignore
+++ b/docs/services/_includes/.gitignore
@@ -1,3 +1,4 @@
 *_configvars.md
 *-example.yaml
 adoc/*adoc
+adoc/env-var-deltas/*adoc

--- a/docs/services/_includes/adoc/env-var-deltas/_index.md
+++ b/docs/services/_includes/adoc/env-var-deltas/_index.md
@@ -1,0 +1,3 @@
+---
+GeekdocHidden: true
+---


### PR DESCRIPTION
This PR extends the make `docs-generate` step to pick up the adoc tables with the variable deltas.