### PR TITLE
enhancement: allow skipping service listing

### DIFF
--- a/changelog/unreleased/enhancement-skip-version-service-listing
+++ b/changelog/unreleased/enhancement-skip-version-service-listing
@@ -1,0 +1,7 @@
+Enhancement: allow to skip service listing
+
+The ocis version cmd listed all services by default. This is not always intended,
+so we allow to skip the listing of the services by using the --skip-services flag.
+
+https://github.com/owncloud/ocis/pull/8408
+https://github.com/owncloud/ocis/issues/8070


### PR DESCRIPTION
## Description
The ocis version cmd listed all services by default. This is not always intended,
so we allow to skip the listing of the services by using the --skip-services flag.

@kobergj, @dragonchaser and myself had a good time finding out who likes line-breaks before errors in the cli output and who not, worth every second. THX for that, i loved the discussion 🤣 

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/8070