### PR TITLE
Fix extended Envvar parsing

### DIFF
--- a/changelog/unreleased/fix-extended-env-parser.md
+++ b/changelog/unreleased/fix-extended-env-parser.md
@@ -1,0 +1,6 @@
+Bugfix: Fix extended env parser
+
+The extended envvar parser would be angry if there are two `os.Getenv` in the same line.
+We fixed this.
+
+https://github.com/owncloud/ocis/pull/8409

--- a/docs/helpers/extendedEnv.go
+++ b/docs/helpers/extendedEnv.go
@@ -85,18 +85,20 @@ func GetRogueEnvs() {
 		}
 
 		res := re.FindAllSubmatch([]byte(r[1]), -1)
-		if len(res) != 1 || len(res[0]) < 2 {
+		if len(res) < 1 {
 			fmt.Printf("Error envvar not matching pattern: %s", r[1])
 			continue
 		}
 
-		path := r[0]
-		name := strings.Trim(string(res[0][1]), "\"")
-		currentVars[path+name] = Variable{
-			RawName:     name,
-			Path:        path,
-			FoundInCode: true,
-			Name:        name,
+		for _, m := range res {
+			path := r[0]
+			name := strings.Trim(string(m[1]), "\"")
+			currentVars[path+name] = Variable{
+				RawName:     name,
+				Path:        path,
+				FoundInCode: true,
+				Name:        name,
+			}
 		}
 	}
 

--- a/docs/helpers/extended_vars.yaml
+++ b/docs/helpers/extended_vars.yaml
@@ -34,7 +34,7 @@ variables:
   do_ignore: true
 - rawname: registryEnv
   path: ocis-pkg/registry/registry.go:118
-  foundincode: true
+  foundincode: false
   name: MICRO_REGISTRY
   type: string
   default_value: ""
@@ -45,7 +45,7 @@ variables:
   do_ignore: false
 - rawname: registryAddressEnv
   path: ocis-pkg/registry/registry.go:122
-  foundincode: true
+  foundincode: false
   name: MICRO_REGISTRY_ADDRESS
   type: string
   default_value: 127.0.0.1:9233
@@ -54,7 +54,7 @@ variables:
   do_ignore: false
 - rawname: registryPasswordEnv
   path: ocis-pkg/registry/registry.go:115
-  foundincode: true
+  foundincode: false
   name: MICRO_REGISTRY_AUTH_PASSWORD
   type: ""
   default_value: ""
@@ -62,7 +62,7 @@ variables:
   do_ignore: false
 - rawname: registryUsernameEnv
   path: ocis-pkg/registry/registry.go:114
-  foundincode: true
+  foundincode: false
   name: MICRO_REGISTRY_AUTH_USERNAME
   type: ""
   default_value: ""
@@ -88,6 +88,46 @@ variables:
   description: The default directory location for config files. Predefined to '/etc/ocis'
     for container images (inside the container) or '$HOME/.ocis/config' for binary
     releases.
+  do_ignore: false
+- rawname: _registryAddressEnv
+  path: ocis-pkg/natsjsregistry/registry.go:145
+  foundincode: true
+  name: _registryAddressEnv
+  type: ""
+  default_value: ""
+  description: ""
+  do_ignore: false
+- rawname: _registryAddressEnv
+  path: ocis-pkg/registry/registry.go:118
+  foundincode: true
+  name: _registryAddressEnv
+  type: ""
+  default_value: ""
+  description: ""
+  do_ignore: false
+- rawname: _registryEnv
+  path: ocis-pkg/registry/registry.go:114
+  foundincode: true
+  name: _registryEnv
+  type: ""
+  default_value: ""
+  description: ""
+  do_ignore: false
+- rawname: _registryPasswordEnv
+  path: ocis-pkg/natsjsregistry/registry.go:163
+  foundincode: true
+  name: _registryPasswordEnv
+  type: ""
+  default_value: ""
+  description: ""
+  do_ignore: false
+- rawname: _registryUsernameEnv
+  path: ocis-pkg/natsjsregistry/registry.go:163
+  foundincode: true
+  name: _registryUsernameEnv
+  type: ""
+  default_value: ""
+  description: ""
   do_ignore: false
 - rawname: parts[0]
   path: ocis-pkg/config/envdecode/envdecode.go:382


### PR DESCRIPTION
The extended envvar parser would be angry if there are two `os.Getenv` in the same line.
We fixed this.