### PR TITLE
Fix a typo

### DIFF
--- a/services/_includes/adoc/storage-users_configvars.adoc
+++ b/services/_includes/adoc/storage-users_configvars.adoc
@@ -373,7 +373,6 @@ a| [subs=-attributes]
 Maximum number of concurrent go-routines. Higher values can potentially get work done faster but will also cause more load on the system. Values of 0 or below will be ignored and the default value of 100 will be used.
 
 a|`OCIS_ASYNC_UPLOADS` +
-`` +
 
 a| [subs=-attributes]
 ++bool ++


### PR DESCRIPTION
Removing a not necessary line item in the adoc table, else this renders as:

```
OCIS_ASYNC_UPLOADS
``
```
See  the two not necessary ticks in the second line.
Note that this only does the change in the docs-stable-4.0 branch.
Master is clean.