### PR TITLE
[docs-only] fix: changelog contributer mention

### DIFF
--- a/changelog/5.0.0-rc.1_2023-12-27/enhancement-sse-messaging.md
+++ b/changelog/5.0.0-rc.1_2023-12-27/enhancement-sse-messaging.md
@@ -5,6 +5,5 @@ In order to be able to send more content to the client, we have moved the endpoi
 
 * notify postprocessing state changes.
 * notify file locking and unlocking.
-* ... @toDo
 
 https://github.com/owncloud/ocis/pull/6992


### PR DESCRIPTION
## Description
An error crept into the changelog and accidentally mentioned a user

![Screenshot 2024-02-12 at 10 59 15](https://github.com/owncloud/ocis/assets/49308105/ffaf74aa-c73d-49d8-bc10-c3a4b58fb126)
