### PR TITLE
[test-only] fix test: secret file drop

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -115,10 +115,6 @@ cannot share a folder with create permission
 - [coreApiSharePublicLink2/copyFromPublicLink.feature:193](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L193)
 - [coreApiSharePublicLink2/copyFromPublicLink.feature:194](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature#L194)
 
-#### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
-
-- [coreApiSharePublicLink2/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature#L13)
-
 #### [d:quota-available-bytes in dprop of PROPFIND give wrong response value](https://github.com/owncloud/ocis/issues/8197)
 
 - [coreApiWebdavProperties/getQuota.feature:55](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L55)

--- a/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -17,13 +17,14 @@ Feature: upload to a public link share
       | permissions | create   |
       | password    | %public% |
     When the public uploads file "test.txt" with password "%public%" and content "test" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the new public WebDAV API
-    Then the HTTP status code of responses on all endpoints should be "201"
+    Then the HTTP status code should be "201"
+    And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
-    And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
-
+             
 
   Scenario Outline: uploading file to a public upload-only share using public API that was deleted does not work
     Given using <dav-path-version> DAV path


### PR DESCRIPTION
fix test coreApiSharePublicLink2/uploadToPublicLinkShare.feature:13 after https://github.com/owncloud/ocis/pull/8340

closed bugs: 
- https://github.com/owncloud/ocis/issues/1267
- https://github.com/owncloud/ocis/issues/5074