### PR TITLE
fix: bulky error message for invalid search request

### DIFF
--- a/changelog/unreleased/fix-search-error-message.md
+++ b/changelog/unreleased/fix-search-error-message.md
@@ -1,0 +1,6 @@
+Bugfix: Fix search error message
+
+We fixed an error message returned when the search request is invalid
+
+https://github.com/owncloud/ocis/pull/8444
+https://github.com/owncloud/ocis/issues/8442

--- a/services/webdav/pkg/service/v0/search.go
+++ b/services/webdav/pkg/service/v0/search.go
@@ -78,7 +78,7 @@ func (g Webdav) Search(w http.ResponseWriter, r *http.Request) {
 		e := merrors.Parse(err.Error())
 		switch e.Code {
 		case http.StatusBadRequest:
-			renderError(w, r, errBadRequest(err.Error()))
+			renderError(w, r, errBadRequest(e.Detail))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}


### PR DESCRIPTION
## Description
Fixed the error message returned by the invalid search request. now, the message only includes the necessary info

Current:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<d:error xmlns:d="DAV" xmlns:s="http://sabredav.org/ns">
    <s:exception>Sabre\DAV\Exception\BadRequest</s:exception>
    <!-- BAD -->
    <s:message>
        {&#34;id&#34;:&#34;com.owncloud.api.search&#34;,&#34;code&#34;:400,&#34;detail&#34;:&#34;error: bad request: the expression can&#39;t begin from a binary operator: &#39;AND&#39;&#34;,&#34;status&#34;:&#34;Bad Request&#34;}
    </s:message>
</d:error>
```

With Fix:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<d:error xmlns:d="DAV" xmlns:s="http://sabredav.org/ns">
    <s:exception>Sabre\DAV\Exception\BadRequest</s:exception>
    <!-- FIXED -->
    <s:message>
        error: bad request: the expression can&#39;t begin from a binary operator: &#39;AND&#39;
    </s:message>
</d:error>
```

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/8442

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
