### PR TITLE
[tests-only][full-ci]Added tests to lists shared by me after sharee is deleted

### DIFF
--- a/tests/acceptance/features/apiSharingNg/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedByMe.feature
@@ -1451,3 +1451,34 @@ Feature: resources shared by user
       }
     }
     """
+
+  @env-config
+  Scenario: user lists shared resources for deleted sharee
+    Given the config "GRAPH_SPACES_USERS_CACHE_TTL" has been set to "1"
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
+    And user "Alice" has sent the following share invitation:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    And the administrator has deleted user "Brian" using the provisioning API
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "array",
+          "minItems":0,
+          "maxItems":0
+        }
+      }
+    }
+    """

--- a/tests/acceptance/features/apiSharingNg/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedByMe.feature
@@ -1464,7 +1464,39 @@ Feature: resources shared by user
       | shareType       | user         |
       | permissionsRole | Viewer       |
     And the administrator has deleted user "Brian" using the provisioning API
-    When user "Alice" lists the shares shared by her using the Graph API
+    When user "Alice" lists the shares shared by her after clearing user cache using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "array",
+          "minItems":0,
+          "maxItems":0
+        }
+      }
+    }
+    """
+
+  @env-config
+  Scenario: user lists shared resources for deleted group
+    Given the config "GRAPH_SPACES_GROUPS_CACHE_TTL" has been set to "1"
+    And group "grp1" has been created
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
+    And user "Alice" has sent the following share invitation:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | grp1         |
+      | shareType       | group        |
+      | permissionsRole | Viewer       |
+    And group "grp1" has been deleted
+    When user "Alice" lists the shares shared by her after clearing group cache using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
     """

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2527,6 +2527,27 @@ class GraphContext implements Context {
 	}
 
 	/**
+	 *
+	 * @param string $user
+	 * @param bool $isCacheClear
+	 *
+	 * @return void
+	 */
+	public function userListsResourcesSharedByHimOrHer(string $user, bool $isCacheClear = false) {
+		$credentials = $this->getAdminOrUserCredentials($user);
+		if ($isCacheClear) {
+			sleep(1);
+		}
+		$response = GraphHelper::getSharesSharedByMe(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$credentials['username'],
+			$credentials['password']
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @When user :user lists the shares shared by him/her using the Graph API
 	 *
 	 * @param string $user
@@ -2535,18 +2556,19 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userListsTheResourcesSharedByAUserUsingGraphApi(string $user): void {
-		$credentials = $this->getAdminOrUserCredentials($user);
-		//TODO
-		// look over wait this
-		sleep(1);
-		$this->featureContext->setResponse(
-			GraphHelper::getSharesSharedByMe(
-				$this->featureContext->getBaseUrl(),
-				$this->featureContext->getStepLineRef(),
-				$credentials['username'],
-				$credentials['password']
-			)
-		);
+		$this->userListsResourcesSharedByHimOrHer($user);
+	}
+
+	/**
+	 * @When user :user lists the shares shared by him/her after clearing user/group cache using the Graph API
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userListsTheResourcesSharedByAUserAfterClearingUserSpaceUsingGraphApi(string $user): void {
+		$this->userListsResourcesSharedByHimOrHer($user, true);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2536,6 +2536,9 @@ class GraphContext implements Context {
 	 */
 	public function userListsTheResourcesSharedByAUserUsingGraphApi(string $user): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
+		//TODO
+		// look over wait this
+		sleep(1);
 		$this->featureContext->setResponse(
 			GraphHelper::getSharesSharedByMe(
 				$this->featureContext->getBaseUrl(),

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2567,7 +2567,7 @@ class GraphContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function userListsTheResourcesSharedByAUserAfterClearingUserSpaceUsingGraphApi(string $user): void {
+	public function userListsTheResourcesSharedByAUserAfterClearingUserOrGroupSpaceUsingGraphApi(string $user): void {
 		$this->userListsResourcesSharedByHimOrHer($user, true);
 	}
 

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2529,13 +2529,16 @@ class GraphContext implements Context {
 	/**
 	 *
 	 * @param string $user
-	 * @param bool $isCacheClear
+	 * @param bool $waitForCacheExpiry
 	 *
 	 * @return void
 	 */
-	public function userListsResourcesSharedByHimOrHer(string $user, bool $isCacheClear = false) {
+	public function listSharesSharedByMe(string $user, bool $waitForCacheExpiry = false) {
 		$credentials = $this->getAdminOrUserCredentials($user);
-		if ($isCacheClear) {
+		if ($waitForCacheExpiry) {
+			// ENV (GRAPH_SPACES_GROUPS_CACHE_TTL | GRAPH_SPACES_USERS_CACHE_TTL) is set default to 60 sec
+			// which means 60 sec is required to clean up all the user|group cache once they are deleted
+			// for tests we have set the above ENV's to minimum which is 1 sec as we check the details for the deleted users
 			sleep(1);
 		}
 		$response = GraphHelper::getSharesSharedByMe(
@@ -2556,7 +2559,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userListsTheResourcesSharedByAUserUsingGraphApi(string $user): void {
-		$this->userListsResourcesSharedByHimOrHer($user);
+		$this->listSharesSharedByMe($user);
 	}
 
 	/**
@@ -2568,7 +2571,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userListsTheResourcesSharedByAUserAfterClearingUserOrGroupSpaceUsingGraphApi(string $user): void {
-		$this->userListsResourcesSharedByHimOrHer($user, true);
+		$this->listSharesSharedByMe($user, true);
 	}
 
 	/**


### PR DESCRIPTION
### Description
This PR adds test coverage for `sharedByMe` after sharee gets deleted with clearing up the user cache and the group cache for the deleted sharee and the group respectively.

```feature
Scenario: user lists shared resources for deleted sharee
Scenario: user lists shared resources for deleted group
```
### Related Issue:
https://github.com/owncloud/ocis/issues/8111