### PR TITLE
[tests-only] add API test coverage for file MOVE to space-id as destination

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
@@ -706,3 +706,37 @@ Feature: moving/renaming file using file id
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
       | /dav/spaces/<<FILEID>>            |
+
+  @issue-6739
+  Scenario Outline: try to move a file to space using its id as the destination
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "myspace" with the default quota using the Graph API
+    And user "Alice" has uploaded file with content "some data" to "textfile.txt"
+    When user "Alice" tries to move a file "textfile.txt" to space "<space>" using its id in destination path "<dav-path>"
+    Then the HTTP status code should be "400"
+    And for user "Alice" the space "Personal" should contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path               | space    |
+      | /remote.php/dav/spaces | Personal |
+      | /dav/spaces            | Personal |
+      | /remote.php/dav/spaces | myspace  |
+      | /dav/spaces            | myspace  |
+
+  @issue-6739
+  Scenario Outline: move a file to folder using its id as the destination
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "myspace" with the default quota using the Graph API
+    And user "Alice" has uploaded file with content "some data" to "textfile.txt"
+    And user "Alice" has created folder "docs"
+    And user "Alice" has uploaded file with content "readme file" to "docs/readme.txt"
+    When user "Alice" moves a file "textfile.txt" to folder "docs" using its id in destination path "<dav-path>"
+    Then the HTTP status code should be "204"
+    And the content of file "docs" for user "Alice" should be "some data"
+    And as "Alice" file "textfile.txt" should not exist
+    And as "Alice" folder "docs" should not exist
+    And as "Alice" folder "docs" should exist in the trashbin of the space "Personal"
+    Examples:
+      | dav-path               |
+      | /remote.php/dav/spaces |
+      | /dav/spaces            |

--- a/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature
@@ -708,11 +708,11 @@ Feature: moving/renaming file using file id
       | /dav/spaces/<<FILEID>>            |
 
   @issue-6739
-  Scenario Outline: try to move a file to space using its id as the destination
+  Scenario Outline: try to move personal file to other spaces using its id as the destination
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "myspace" with the default quota using the Graph API
     And user "Alice" has uploaded file with content "some data" to "textfile.txt"
-    When user "Alice" tries to move a file "textfile.txt" to space "<space>" using its id in destination path "<dav-path>"
+    When user "Alice" tries to move file "textfile.txt" of space "Personal" to space "<space>" using its id in destination path "<dav-path>"
     Then the HTTP status code should be "400"
     And for user "Alice" the space "Personal" should contain these entries:
       | textfile.txt |
@@ -724,18 +724,48 @@ Feature: moving/renaming file using file id
       | /dav/spaces            | myspace  |
 
   @issue-6739
-  Scenario Outline: move a file to folder using its id as the destination
+  Scenario Outline: try to move project file to other spaces using its id as the destination
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "myspace" with the default quota using the Graph API
-    And user "Alice" has uploaded file with content "some data" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "myspace" with content "some data" to "textfile.txt"
+    When user "Alice" tries to move file "textfile.txt" of space "myspace" to space "<space>" using its id in destination path "<dav-path>"
+    Then the HTTP status code should be "400"
+    And for user "Alice" the space "myspace" should contain these entries:
+      | textfile.txt |
+    Examples:
+      | dav-path               | space    |
+      | /remote.php/dav/spaces | Personal |
+      | /dav/spaces            | Personal |
+      | /remote.php/dav/spaces | myspace  |
+      | /dav/spaces            | myspace  |
+
+  @issue-6739
+  Scenario Outline: move a file to folder using its id as the destination (Personal space)
+    Given user "Alice" has uploaded file with content "some data" to "textfile.txt"
     And user "Alice" has created folder "docs"
-    And user "Alice" has uploaded file with content "readme file" to "docs/readme.txt"
-    When user "Alice" moves a file "textfile.txt" to folder "docs" using its id in destination path "<dav-path>"
+    When user "Alice" moves file "textfile.txt" of space "Personal" to folder "docs" using its id in destination path "<dav-path>"
     Then the HTTP status code should be "204"
     And the content of file "docs" for user "Alice" should be "some data"
     And as "Alice" file "textfile.txt" should not exist
     And as "Alice" folder "docs" should not exist
     And as "Alice" folder "docs" should exist in the trashbin of the space "Personal"
+    Examples:
+      | dav-path               |
+      | /remote.php/dav/spaces |
+      | /dav/spaces            |
+
+  @issue-6739
+  Scenario Outline: move a file to folder using its id as the destination (Project space)
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "myspace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "myspace" with content "some data" to "textfile.txt"
+    And user "Alice" has created a folder "docs" in space "myspace"
+    When user "Alice" moves file "textfile.txt" of space "myspace" to folder "docs" using its id in destination path "<dav-path>"
+    Then the HTTP status code should be "204"
+    And for user "Alice" the content of the file "docs" of the space "myspace" should be "some data"
+    And as "Alice" folder "docs" should exist in the trashbin of the space "myspace"
+    And for user "Alice" folder "/" of the space "myspace" should not contain these files:
+      | textfile.txt |
     Examples:
       | dav-path               |
       | /remote.php/dav/spaces |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2061,6 +2061,46 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" tries to move a (?:file|folder) "([^"]*)" to (space|folder) "([^"]*)" using its id in destination path "([^"]*)"$/
+	 * @When /^user "([^"]*)" moves a (?:file|folder) "([^"]*)" to (folder) "([^"]*)" using its id in destination path "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destinationType
+	 * @param string $destinationName
+	 * @param string $destinationPath
+	 *
+	 * @throws GuzzleException
+	 * @return void
+	 */
+	public function userMovesFileToResourceUsingItsIdAsDestinationPath(
+		string $user,
+		string $source,
+		string $destinationType,
+		string $destinationName,
+		string $destinationPath
+	): void {
+		$source = \trim($source, "/");
+		$baseUrl = $this->featureContext->getBaseUrl();
+		$suffix = "";
+		if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
+			$suffix = $this->getSpaceIdByName($user, "Personal") . "/";
+		}
+		$fullUrl = $baseUrl . \rtrim($destinationPath, "/") . "/{$suffix}{$source}";
+
+		$destinationId = "";
+		if ($destinationType === "space") {
+			$destinationId = $this->getSpaceIdByName($user, $destinationName);
+		} else {
+			$destinationId = $this->getResourceId($user, "Personal", $destinationName);
+		}
+		$headers['Destination'] = $baseUrl . \rtrim($destinationPath, "/") . "/$destinationId";
+
+		$response = $this->moveFilesAndFoldersRequest($user, $fullUrl, $headers);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has uploaded a file inside space "([^"]*)" with content "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2061,11 +2061,12 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" tries to move a (?:file|folder) "([^"]*)" to (space|folder) "([^"]*)" using its id in destination path "([^"]*)"$/
-	 * @When /^user "([^"]*)" moves a (?:file|folder) "([^"]*)" to (folder) "([^"]*)" using its id in destination path "([^"]*)"$/
+	 * @When /^user "([^"]*)" tries to move (?:file|folder) "([^"]*)" of space "([^"]*)" to (space|folder) "([^"]*)" using its id in destination path "([^"]*)"$/
+	 * @When /^user "([^"]*)" moves (?:file|folder) "([^"]*)" of space "([^"]*)" to (folder) "([^"]*)" using its id in destination path "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $source
+	 * @param string $sourceSpace
 	 * @param string $destinationType
 	 * @param string $destinationName
 	 * @param string $destinationPath
@@ -2076,6 +2077,7 @@ class SpacesContext implements Context {
 	public function userMovesFileToResourceUsingItsIdAsDestinationPath(
 		string $user,
 		string $source,
+		string $sourceSpace,
 		string $destinationType,
 		string $destinationName,
 		string $destinationPath
@@ -2084,7 +2086,7 @@ class SpacesContext implements Context {
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$suffix = "";
 		if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
-			$suffix = $this->getSpaceIdByName($user, "Personal") . "/";
+			$suffix = $this->getSpaceIdByName($user, $sourceSpace) . "/";
 		}
 		$fullUrl = $baseUrl . \rtrim($destinationPath, "/") . "/{$suffix}{$source}";
 
@@ -2092,7 +2094,7 @@ class SpacesContext implements Context {
 		if ($destinationType === "space") {
 			$destinationId = $this->getSpaceIdByName($user, $destinationName);
 		} else {
-			$destinationId = $this->getResourceId($user, "Personal", $destinationName);
+			$destinationId = $this->getResourceId($user, $sourceSpace, $destinationName);
 		}
 		$headers['Destination'] = $baseUrl . \rtrim($destinationPath, "/") . "/$destinationId";
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1752,9 +1752,12 @@ trait WebDav {
 			} else {
 				$actualResourceType = "folder";
 			}
-			Assert::fail(
-				"$entry '$path' should not exist. But it does exist and is a $actualResourceType"
-			);
+
+			if ($entry === $actualResourceType) {
+				Assert::fail(
+					"$entry '$path' should not exist. But it does."
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Added API test coverage for these scenarios:
- try to MOVE file to space-id as its detination
- MOVE file to folder-id as its detination

## Related Issue
Part of https://github.com/owncloud/ocis/issues/8440
Coverage for:
- https://github.com/owncloud/ocis/issues/6739

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
