### PR TITLE
[tests-only] fix MOVE with another user dav path scenarios

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -729,19 +729,19 @@ class WebDavHelper {
 		?string $type = "files",
 		?string $spaceId = null
 	):string {
-		$newTrashbinDavPath = "remote.php/dav/trash-bin/$user/";
+		$newTrashbinDavPath = "/remote.php/dav/trash-bin/$user/";
 
 		switch ($type) {
 			case 'public-files':
 			case 'public-files-old':
-				return "public.php/webdav/";
+				return "/public.php/webdav/";
 			case 'public-files-new':
-				return "remote.php/dav/public-files/$user/";
+				return "/remote.php/dav/public-files/$user/";
 			case 'archive':
-				return "remote.php/dav/archive/$user/files";
+				return "/remote.php/dav/archive/$user/files";
 			case 'versions':
 			case 'customgroups':
-				return "remote.php/dav/";
+				return "/remote.php/dav/";
 			default:
 				break;
 		}
@@ -765,12 +765,12 @@ class WebDavHelper {
 				return "remote.php/webdav/";
 			} elseif ($davPathVersionToUse === self::DAV_VERSION_NEW) {
 				if ($type === "files") {
-					$path = 'remote.php/dav/files/';
+					$path = '/remote.php/dav/files/';
 					return $path . $user . '/';
 				} elseif ($type === "trash-bin") {
 					return $newTrashbinDavPath;
 				} else {
-					return "remote.php/dav";
+					return "/remote.php/dav";
 				}
 			} else {
 				throw new InvalidArgumentException(

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -661,7 +661,7 @@ class WebDavHelper {
 			$urlParameter = \http_build_query($urlParameter, '', '&');
 			$path .= '?' . $urlParameter;
 		}
-		$fullUrl = self::sanitizeUrl($baseUrl . $davPath . $path);
+		$fullUrl = self::sanitizeUrl($baseUrl . "/$davPath" . $path);
 
 		if ($authType === 'bearer') {
 			$headers['Authorization'] = 'Bearer ' . $password;
@@ -729,19 +729,19 @@ class WebDavHelper {
 		?string $type = "files",
 		?string $spaceId = null
 	):string {
-		$newTrashbinDavPath = "/remote.php/dav/trash-bin/$user/";
+		$newTrashbinDavPath = "remote.php/dav/trash-bin/$user/";
 
 		switch ($type) {
 			case 'public-files':
 			case 'public-files-old':
-				return "/public.php/webdav/";
+				return "public.php/webdav/";
 			case 'public-files-new':
-				return "/remote.php/dav/public-files/$user/";
+				return "remote.php/dav/public-files/$user/";
 			case 'archive':
-				return "/remote.php/dav/archive/$user/files";
+				return "remote.php/dav/archive/$user/files";
 			case 'versions':
 			case 'customgroups':
-				return "/remote.php/dav/";
+				return "remote.php/dav/";
 			default:
 				break;
 		}
@@ -750,12 +750,12 @@ class WebDavHelper {
 			// return spaces root path if spaceid is null
 			// REPORT request uses spaces root path
 			if ($spaceId === null) {
-				return "/remote.php/dav/spaces/";
+				return "remote.php/dav/spaces/";
 			}
 			if ($type === "trash-bin") {
-				return "/remote.php/dav/spaces/trash-bin/" . $spaceId . '/';
+				return "remote.php/dav/spaces/trash-bin/" . $spaceId . '/';
 			}
-			return "/remote.php/dav/spaces/" . $spaceId . '/';
+			return "remote.php/dav/spaces/" . $spaceId . '/';
 		} else {
 			if ($davPathVersionToUse === self::DAV_VERSION_OLD) {
 				if ($type === "trash-bin") {
@@ -765,12 +765,12 @@ class WebDavHelper {
 				return "remote.php/webdav/";
 			} elseif ($davPathVersionToUse === self::DAV_VERSION_NEW) {
 				if ($type === "files") {
-					$path = '/remote.php/dav/files/';
+					$path = 'remote.php/dav/files/';
 					return $path . $user . '/';
 				} elseif ($type === "trash-bin") {
 					return $newTrashbinDavPath;
 				} else {
-					return "/remote.php/dav";
+					return "remote.php/dav";
 				}
 			} else {
 				throw new InvalidArgumentException(

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -227,15 +227,6 @@ _ocdav: api compatibility, return correct status code_
 - [coreApiAuth/webDavLOCKAuth.feature:46](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavLOCKAuth.feature#L46)
 - [coreApiAuth/webDavLOCKAuth.feature:58](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavLOCKAuth.feature#L58)
 
-#### [send (MOVE,COPY) requests to another user's webDav endpoints as normal user gives 400 instead of 403](https://github.com/owncloud/ocis/issues/3882)
-
-_ocdav: api compatibility, return correct status code_
-
-- [coreApiAuth/webDavMOVEAuth.feature:45](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavMOVEAuth.feature#L45)
-- [coreApiAuth/webDavMOVEAuth.feature:54](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavMOVEAuth.feature#L54)
-- [coreApiAuth/webDavCOPYAuth.feature:45](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavCOPYAuth.feature#L45)
-- [coreApiAuth/webDavCOPYAuth.feature:54](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavCOPYAuth.feature#L54)
-
 #### [send POST requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis/issues/1287)
 
 _ocdav: api compatibility, return correct status code_

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -25,6 +25,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
 use TestHelpers\SetupHelper;
 use \Psr\Http\Message\ResponseInterface;
+use TestHelpers\WebDavHelper;
 
 /**
  * Authentication functions
@@ -592,7 +593,13 @@ class AuthContext implements Context {
 	public function userRequestsTheseEndpointsAboutUser(string $user, string $method, string $ofUser, TableNode $table):void {
 		$headers = [];
 		if ($method === 'MOVE' || $method === 'COPY') {
-			$headers['Destination'] = '/path/to/destination';
+			$baseUrl = $this->featureContext->getBaseUrl();
+			$suffix = "";
+			if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES){
+				$suffix = $this->featureContext->spacesContext->getSpaceIdByName($user, "Personal") . "/";
+			}
+			$davPath = WebDavHelper::getDavPath($user, $this->featureContext->getDavPathVersion());
+			$headers['Destination'] = "{$baseUrl}{$davPath}{$suffix}moved";
 		}
 
 		foreach ($table->getHash() as $row) {

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -595,7 +595,7 @@ class AuthContext implements Context {
 		if ($method === 'MOVE' || $method === 'COPY') {
 			$baseUrl = $this->featureContext->getBaseUrl();
 			$suffix = "";
-			if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES){
+			if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
 				$suffix = $this->featureContext->spacesContext->getSpaceIdByName($user, "Personal") . "/";
 			}
 			$davPath = WebDavHelper::getDavPath($user, $this->featureContext->getDavPathVersion());

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -599,7 +599,7 @@ class AuthContext implements Context {
 				$suffix = $this->featureContext->spacesContext->getSpaceIdByName($user, "Personal") . "/";
 			}
 			$davPath = WebDavHelper::getDavPath($user, $this->featureContext->getDavPathVersion());
-			$headers['Destination'] = "{$baseUrl}{$davPath}{$suffix}moved";
+			$headers['Destination'] = "{$baseUrl}/{$davPath}{$suffix}moved";
 		}
 
 		foreach ($table->getHash() as $row) {

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -2048,7 +2048,7 @@ class SpacesContext implements Context {
 		if ($toSpaceName === 'Shares') {
 			$sharesPath = $this->featureContext->getSharesMountPath($user, $fileDestination);
 			$davPath = WebDavHelper::getDavPath($user, $this->featureContext->getDavPathVersion());
-			$headers['Destination'] = $baseUrl . $davPath . $sharesPath;
+			$headers['Destination'] = $baseUrl . "/$davPath" . $sharesPath;
 		} else {
 			$headers['Destination'] = $this->destinationHeaderValueWithSpaceName($user, $fileDestination, $toSpaceName, $url);
 		}

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5000,7 +5000,7 @@ trait WebDav {
 		$sharesPath = $this->getSharesMountPath($user, $path) . '/?' . $urlParameter;
 
 		$davPath = WebDavHelper::getDavPath($user, $this->getDavPathVersion());
-		$fullUrl = $this->getBaseUrl() . $davPath . $sharesPath;
+		$fullUrl = $this->getBaseUrl() . "/$davPath" . $sharesPath;
 
 		return HttpRequestHelper::sendRequest(
 			$fullUrl,
@@ -5027,7 +5027,7 @@ trait WebDav {
 		$sharesPath = $this->getSharesMountPath($user, $destination);
 
 		$davPath = WebDavHelper::getDavPath($user, $this->getDavPathVersion());
-		$fullUrl = $this->getBaseUrl() . $davPath . $sharesPath;
+		$fullUrl = $this->getBaseUrl() . "/$davPath" . $sharesPath;
 
 		return HttpRequestHelper::sendRequest(
 			$fullUrl,

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5766,7 +5766,7 @@ trait WebDav {
 		if ($entryNameToSearch !== null) {
 			$entryNameToSearch = \trim($entryNameToSearch, "/");
 		}
-		$spacesBaseUrl = webDavHelper::getDavPath(null, webDavHelper::DAV_VERSION_SPACES);
+		$spacesBaseUrl = "/" . webDavHelper::getDavPath(null, webDavHelper::DAV_VERSION_SPACES);
 		$searchResults = $this->getResponseXml()->xpath("//d:multistatus/d:response");
 		$results = [];
 		foreach ($searchResults as $item) {

--- a/tests/acceptance/features/coreApiAuth/webDavCOPYAuth.feature
+++ b/tests/acceptance/features/coreApiAuth/webDavCOPYAuth.feature
@@ -12,6 +12,7 @@ Feature: COPY file/folder
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+    And using new DAV path
 
   @smokeTest
   Scenario: send COPY requests to webDav endpoints as normal user with wrong password
@@ -41,23 +42,24 @@ Feature: COPY file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-
+  @issue-3882
   Scenario: send COPY requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "COPY" about user "Alice"
       | endpoint                                           |
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "403"
+    Then the HTTP status code of responses on all endpoints should be "404"
 
-  @skipOnRevaMaster
+  @skipOnRevaMaster @issue-3882
   Scenario: send COPY requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    Given using spaces DAV path
     When user "Brian" requests these endpoints with "COPY" about user "Alice"
       | endpoint                                           |
       | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "403"
+    Then the HTTP status code of responses on all endpoints should be "404"
 
 
   Scenario: send COPY requests to webDav endpoints using invalid username but correct password
@@ -101,7 +103,7 @@ Feature: COPY file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-
+  @issue-4332 @issue-3882
   Scenario: send COPY requests to webDav endpoints with body as normal user
     When user "Alice" requests these endpoints with "COPY" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |
@@ -113,7 +115,7 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "415"
 
-  @skipOnRevaMaster
+  @skipOnRevaMaster @issue-4332 @issue-3882
   Scenario: send COPY requests to webDav endpoints with body as normal user using the spaces WebDAV API
     When user "Alice" requests these endpoints with "COPY" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/coreApiAuth/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/coreApiAuth/webDavDELETEAuth.feature
@@ -104,7 +104,7 @@ Feature: delete file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-
+  @issue-4332
   Scenario: send DELETE requests to webDav endpoints with body as normal user
     When user "Alice" requests these endpoints with "DELETE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |
@@ -115,7 +115,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/FOLDER            |
     Then the HTTP status code of responses on all endpoints should be "415"
 
-  @skipOnRevaMaster
+  @skipOnRevaMaster @issue-4332
   Scenario: send DELETE requests to webDav endpoints with body as normal user using the spaces WebDAV API
     When user "Alice" requests these endpoints with "DELETE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/coreApiAuth/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/coreApiAuth/webDavMOVEAuth.feature
@@ -12,6 +12,7 @@ Feature: MOVE file/folder
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+    And using new DAV path
 
   @smokeTest
   Scenario: send MOVE requests to webDav endpoints as normal user with wrong password
@@ -41,23 +42,24 @@ Feature: MOVE file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-
+  @issue-3882
   Scenario: send MOVE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MOVE" about user "Alice"
       | endpoint                                           |
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "403"
+    Then the HTTP status code of responses on all endpoints should be "404"
 
-  @skipOnRevaMaster
+  @skipOnRevaMaster @issue-3882
   Scenario: send MOVE requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    Given using spaces DAV path
     When user "Brian" requests these endpoints with "MOVE" about user "Alice"
       | endpoint                                           |
       | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "403"
+    Then the HTTP status code of responses on all endpoints should be "404"
 
 
   Scenario: send MOVE requests to webDav endpoints using invalid username but correct password
@@ -101,7 +103,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-
+  @issue-4332 @issue-3882
   Scenario: send MOVE requests to webDav endpoints with body as normal user
     When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |
@@ -113,7 +115,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "415"
 
-  @skipOnRevaMaster
+  @skipOnRevaMaster @issue-4332 @issue-3882
   Scenario: send MOVE requests to webDav endpoints with body as normal user using the spaces WebDAV API
     When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |


### PR DESCRIPTION
## Description
Tests fixed according to https://github.com/owncloud/ocis/issues/3882#issuecomment-1156408457
>So I just tested this and requests to another users resources now always return 404.
I also opened a PR for the request body check: https://github.com/cs3org/reva/pull/2974

## Related Issue
Part of https://github.com/owncloud/ocis/issues/8440
Tests fix for https://github.com/owncloud/ocis/issues/3882

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
