### PR TITLE
Deprecate sharing cs3 backends

### DIFF
--- a/changelog/unreleased/deprecate-sharing-cs3-backends.md
+++ b/changelog/unreleased/deprecate-sharing-cs3-backends.md
@@ -1,0 +1,5 @@
+Change: Deprecate sharing cs3 backends
+
+The `cs3` user and public sharing drivers have already been replaced by `jsoncs3`. We now mark them as deprecated in preparation to kill a lot of unused code in reva.
+
+https://github.com/owncloud/ocis/pull/8478

--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -308,7 +308,7 @@ func MigrateShares(cfg *config.Config) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "to",
-				Value: "cs3",
+				Value: "jsoncs3",
 				Usage: "Share manager to import the data into",
 			},
 		},
@@ -403,7 +403,7 @@ func MigratePublicShares(cfg *config.Config) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "to",
-				Value: "cs3",
+				Value: "jsoncs3",
 				Usage: "Public share manager to import the data into",
 			},
 		},

--- a/services/sharing/pkg/config/config.go
+++ b/services/sharing/pkg/config/config.go
@@ -21,9 +21,9 @@ type Config struct {
 
 	SkipUserGroupsInToken bool `yaml:"skip_user_groups_in_token" env:"SHARING_SKIP_USER_GROUPS_IN_TOKEN" desc:"Disables the loading of user's group memberships from the reva access token."`
 
-	UserSharingDriver              string               `yaml:"user_sharing_driver" env:"SHARING_USER_DRIVER" desc:"Driver to be used to persist shares. Supported values are 'jsoncs3', 'json', 'cs3' and 'owncloudsql'."`
+	UserSharingDriver              string               `yaml:"user_sharing_driver" env:"SHARING_USER_DRIVER" desc:"Driver to be used to persist shares. Supported values are 'jsoncs3', 'json', 'cs3' (deprecated) and 'owncloudsql'."`
 	UserSharingDrivers             UserSharingDrivers   `yaml:"user_sharing_drivers"`
-	PublicSharingDriver            string               `yaml:"public_sharing_driver" env:"SHARING_PUBLIC_DRIVER" desc:"Driver to be used to persist public shares. Supported values are 'jsoncs3', 'json' and 'cs3'."`
+	PublicSharingDriver            string               `yaml:"public_sharing_driver" env:"SHARING_PUBLIC_DRIVER" desc:"Driver to be used to persist public shares. Supported values are 'jsoncs3', 'json' and 'cs3' (deprecated)."`
 	PublicSharingDrivers           PublicSharingDrivers `yaml:"public_sharing_drivers"`
 	WriteableShareMustHavePassword bool                 `yaml:"public_sharing_writeableshare_must_have_password" env:"OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD;SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" desc:"Set this to true if you want to enforce passwords on Uploader, Editor or Contributor shares. If not using the global OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD, you must define the FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD in the frontend service."`
 	PublicShareMustHavePassword    bool                 `yaml:"public_sharing_share_must_have_password" env:"OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD;SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" desc:"Set this to true if you want to enforce passwords on all public shares."`


### PR DESCRIPTION
The `cs3` user and public sharing drivers have already been replaced by `jsoncs3`. We now mark them as deprecated in preparation to kill a lot of unused code in reva.

We do have a migration cli to dump and load data from driver implementations. cs3 supports dump and jsoncs3 supports load, so a migration is possible.
