### PR TITLE
[tests-only] add test to try to download public link using basic auth

### DIFF
--- a/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
@@ -57,3 +57,14 @@ Feature: accessing a public link share
       | testavatar.jpg |
       | textfile0.txt  |
     Then the HTTP status code of responses on all endpoints should be "200"
+
+  @issue-web-10473
+  Scenario: user tries to download public link file using own basic auth
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | FOLDER   |
+      | permissions | change   |
+      | password    | %public% |
+    When user "Alice" tries to download file "textfile.txt" from the last public link using own basic auth and new public WebDAV API
+    Then the HTTP status code should be "401"


### PR DESCRIPTION
## Description
Added API test coverage for a scenarios where user tries to access public link using own basic auth

## Related Issue
Coverage: https://github.com/owncloud/web/issues/10473

## Motivation and Context

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
