### PR TITLE
[full-ci] chore: bump web to v8.0.0-rc.5

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=6fca4f4f12aa58d21c73d299b47bda2a9407eb4e
+WEB_COMMITID=98f771cb1424a864805bffd9084ddfc3eea01e49
 WEB_BRANCH=stable-8.0

--- a/changelog/unreleased/update-web-8.0.0.md
+++ b/changelog/unreleased/update-web-8.0.0.md
@@ -1,6 +1,11 @@
-Enhancement: Update web to v8.0.0-rc.4
+Enhancement: Update web to v8.0.0-rc.5
 
 Tags: web
+
+We updated ownCloud Web to v8.0.0-rc.5. Please refer to the changelog (linked) for details on the web release.
+
+## Summary
+* Bugfix [owncloud/web#10473](https://github.com/owncloud/web/issues/10473): Public link file download
 
 We updated ownCloud Web to v8.0.0-rc.4. Please refer to the changelog (linked) for details on the web release.
 
@@ -141,6 +146,10 @@ We updated ownCloud Web to v8.0.0-alpha.12. Please refer to the changelog (linke
 * Enhancement [owncloud/web#10099](https://github.com/owncloud/web/pull/10099): Support mandatory filter while listing users
 * Enhancement [owncloud/web#10102](https://github.com/owncloud/web/pull/10102): Registering quick actions as extension
 
+https://github.com/owncloud/ocis/pull/8491
+https://github.com/owncloud/web/releases/tag/v8.0.0-rc.5
+https://github.com/owncloud/ocis/pull/8468
+https://github.com/owncloud/web/releases/tag/v8.0.0-rc.4
 https://github.com/owncloud/ocis/pull/8342
 https://github.com/owncloud/web/releases/tag/v8.0.0-rc.3
 https://github.com/owncloud/ocis/pull/8154

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.0-rc.4
+WEB_ASSETS_VERSION = v8.0.0-rc.5
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
bump web to `v8.0.0-rc.5`