### PR TITLE
[tests-only] make json scheme assertion strict

### DIFF
--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -800,6 +800,8 @@ Feature: an user gets the resources shared to them
                   },
                   "permissions": {
                     "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
                     "items": {
                       "oneOf": [
                         {
@@ -1131,6 +1133,8 @@ Feature: an user gets the resources shared to them
                   },
                   "permissions": {
                     "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
                     "items": {
                       "oneOf": [
                         {
@@ -1491,6 +1495,8 @@ Feature: an user gets the resources shared to them
                   },
                   "permissions": {
                     "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
                     "items": {
                       "oneOf": [
                         {
@@ -1790,6 +1796,8 @@ Feature: an user gets the resources shared to them
                   },
                   "permissions": {
                     "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
                     "items": {
                       "oneOf": [
                         {

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -802,6 +802,7 @@ Feature: an user gets the resources shared to them
                     "type": "array",
                     "minItems": 2,
                     "maxItems": 2,
+                    "uniqueItems": true,
                     "items": {
                       "oneOf": [
                         {
@@ -1135,6 +1136,7 @@ Feature: an user gets the resources shared to them
                     "type": "array",
                     "minItems": 2,
                     "maxItems": 2,
+                    "uniqueItems": true,
                     "items": {
                       "oneOf": [
                         {
@@ -1497,6 +1499,7 @@ Feature: an user gets the resources shared to them
                     "type": "array",
                     "minItems": 2,
                     "maxItems": 2,
+                    "uniqueItems": true,
                     "items": {
                       "oneOf": [
                         {
@@ -1798,6 +1801,7 @@ Feature: an user gets the resources shared to them
                     "type": "array",
                     "minItems": 2,
                     "maxItems": 2,
+                    "uniqueItems": true,
                     "items": {
                       "oneOf": [
                         {
@@ -2959,6 +2963,7 @@ Feature: an user gets the resources shared to them
             "type": "array",
             "minItems": 2,
             "maxItems": 2,
+            "uniqueItems": true,
             "items": {
               "oneOf": [
                 {
@@ -3255,6 +3260,7 @@ Feature: an user gets the resources shared to them
             "type": "array",
             "minItems": 2,
             "maxItems": 2,
+            "uniqueItems": true,
             "items": {
               "oneOf": [
                 {

--- a/tests/acceptance/features/apiSharingNg/sharedWithMeSyncDisabled.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMeSyncDisabled.feature
@@ -1992,6 +1992,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
                       "type": "array",
                       "minItems": 2,
                       "maxItems": 2,
+                      "uniqueItems": true,
                       "items": {
                         "oneOf": [
                           {
@@ -2131,6 +2132,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
                       "type": "array",
                       "minItems": 2,
                       "maxItems": 2,
+                      "uniqueItems": true,
                       "items": {
                         "oneOf": [
                           {
@@ -2228,6 +2230,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
             "type": "array",
             "minItems": 2,
             "maxItems": 2,
+            "uniqueItems": true,
             "items": {
               "oneOf": [
                 {
@@ -2524,6 +2527,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
             "type": "array",
             "minItems": 2,
             "maxItems": 2,
+            "uniqueItems": true,
             "items": {
               "oneOf": [
                 {


### PR DESCRIPTION
## Description
Make array in json schema stricter by adding `minItems` and `maxItems`

## Related Issue
Part of https://github.com/owncloud/ocis/issues/8333

## Motivation and Context

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
