### PR TITLE
[full-ci] adapt cors headers

### DIFF
--- a/changelog/unreleased/improve-cors.md
+++ b/changelog/unreleased/improve-cors.md
@@ -1,0 +1,7 @@
+Enhancement: Change Cors default settings
+
+We have changed the default CORS settings to set `Access-Control-Allow-Origin` to the `OCIS_URL` if not explicitely set
+and `Access-Control-Allow-Credentials` to `false` if not explicitely set.
+
+https://github.com/owncloud/ocis/pull/8518
+https://github.com/owncloud/ocis/issues/8514

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 
 	Mode    Mode // DEPRECATED
 	File    string
-	OcisURL string `yaml:"ocis_url" desc:"URL, where oCIS is reachable for users."`
+	OcisURL string `yaml:"ocis_url" env:"OCIS_URL" desc:"URL, where oCIS is reachable for users."`
 
 	Registry          string               `yaml:"registry"`
 	TokenManager      *shared.TokenManager `yaml:"token_manager"`

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 
 	Mode    Mode // DEPRECATED
 	File    string
-	OcisURL string `yaml:"ocis_url" env:"OCIS_URL" desc:"URL, where oCIS is reachable for users."`
+	OcisURL string `yaml:"ocis_url" env:"OCIS_URL" desc:"URL, where oCIS is reachable for users." introductionVersion:"pre5.0"`
 
 	Registry          string               `yaml:"registry"`
 	TokenManager      *shared.TokenManager `yaml:"token_manager"`

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -185,8 +185,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") &&
+		(cfg.HTTP.CORS.AllowedOrigins == nil ||
+			len(cfg.HTTP.CORS.AllowedOrigins) == 1 &&
+				cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -31,7 +31,7 @@ func DefaultConfig() *config.Config {
 			Protocol:  "tcp",
 			Prefix:    "",
 			CORS: config.CORS{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins: []string{"https://localhost:9200"},
 				AllowedMethods: []string{
 					"OPTIONS",
 					"HEAD",
@@ -73,7 +73,7 @@ func DefaultConfig() *config.Config {
 					"X-HTTP-Method-Override",
 					"Cache-Control",
 				},
-				AllowCredentials: true,
+				AllowCredentials: false,
 			},
 		},
 		Service: config.Service{
@@ -185,6 +185,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
+	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
+	}
 }
 
 // Sanitize sanitized the configuration

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -185,8 +185,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/invitations/pkg/config/defaults/defaultconfig.go
+++ b/services/invitations/pkg/config/defaults/defaultconfig.go
@@ -26,7 +26,7 @@ func DefaultConfig() *config.Config {
 			Root:      "/graph/v1.0",
 			Namespace: "com.owncloud.graph",
 			CORS: config.CORS{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins: []string{"https://localhost:9200"},
 			},
 		},
 		Service: config.Service{
@@ -76,6 +76,11 @@ func EnsureDefaults(cfg *config.Config) {
 		}
 	} else if cfg.TokenManager == nil {
 		cfg.TokenManager = &config.TokenManager{}
+	}
+
+	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }
 

--- a/services/invitations/pkg/config/defaults/defaultconfig.go
+++ b/services/invitations/pkg/config/defaults/defaultconfig.go
@@ -78,8 +78,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") &&
+		(cfg.HTTP.CORS.AllowedOrigins == nil ||
+			len(cfg.HTTP.CORS.AllowedOrigins) == 1 &&
+				cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/invitations/pkg/config/defaults/defaultconfig.go
+++ b/services/invitations/pkg/config/defaults/defaultconfig.go
@@ -78,8 +78,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.TokenManager = &config.TokenManager{}
 	}
 
-	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/ocdav/pkg/config/defaults/defaultconfig.go
+++ b/services/ocdav/pkg/config/defaults/defaultconfig.go
@@ -138,8 +138,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/ocdav/pkg/config/defaults/defaultconfig.go
+++ b/services/ocdav/pkg/config/defaults/defaultconfig.go
@@ -138,8 +138,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
 	}
 
-	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") &&
+		(cfg.HTTP.CORS.AllowedOrigins == nil ||
+			len(cfg.HTTP.CORS.AllowedOrigins) == 1 &&
+				cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/ocdav/pkg/config/defaults/defaultconfig.go
+++ b/services/ocdav/pkg/config/defaults/defaultconfig.go
@@ -30,7 +30,7 @@ func DefaultConfig() *config.Config {
 			Protocol:  "tcp",
 			Prefix:    "",
 			CORS: config.CORS{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins: []string{"https://localhost:9200"},
 				AllowedMethods: []string{
 					"OPTIONS",
 					"HEAD",
@@ -71,7 +71,7 @@ func DefaultConfig() *config.Config {
 					"X-HTTP-Method-Override",
 					"Cache-Control",
 				},
-				AllowCredentials: true,
+				AllowCredentials: false,
 			},
 		},
 		Service: config.Service{
@@ -136,6 +136,11 @@ func EnsureDefaults(cfg *config.Config) {
 
 	if cfg.MachineAuthAPIKey == "" && cfg.Commons != nil && cfg.Commons.MachineAuthAPIKey != "" {
 		cfg.MachineAuthAPIKey = cfg.Commons.MachineAuthAPIKey
+	}
+
+	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }
 

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -32,7 +32,7 @@ func DefaultConfig() *config.Config {
 			Protocol:  "tcp",
 			Prefix:    "",
 			CORS: config.CORS{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins: []string{"https://localhost:9200"},
 				AllowedMethods: []string{
 					"OPTIONS",
 					"HEAD",
@@ -73,7 +73,7 @@ func DefaultConfig() *config.Config {
 					"X-HTTP-Method-Override",
 					"Cache-Control",
 				},
-				AllowCredentials: true,
+				AllowCredentials: false,
 			},
 		},
 		GRPC: config.GRPCConfig{
@@ -164,6 +164,11 @@ func EnsureDefaults(cfg *config.Config) {
 
 	if cfg.GRPC.TLS == nil && cfg.Commons != nil {
 		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
+	}
+
+	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }
 

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -166,8 +166,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 
-	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -166,8 +166,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.GRPC.TLS = structs.CopyOrZeroValue(cfg.Commons.GRPCServiceTLS)
 	}
 
-	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") &&
+		(cfg.HTTP.CORS.AllowedOrigins == nil ||
+			len(cfg.HTTP.CORS.AllowedOrigins) == 1 &&
+				cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -209,8 +209,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tasks.PurgeTrashBin.UserID = cfg.Commons.AdminUserID
 	}
 
-	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") &&
+		(cfg.HTTP.CORS.AllowedOrigins == nil ||
+			len(cfg.HTTP.CORS.AllowedOrigins) == 1 &&
+				cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -209,8 +209,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Tasks.PurgeTrashBin.UserID = cfg.Commons.AdminUserID
 	}
 
-	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -38,7 +38,7 @@ func DefaultConfig() *config.Config {
 			Protocol:  "tcp",
 			Prefix:    "data",
 			CORS: config.CORS{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins: []string{"https://localhost:9200"},
 				AllowedMethods: []string{
 					"POST",
 					"HEAD",
@@ -63,7 +63,7 @@ func DefaultConfig() *config.Config {
 					"Upload-Incomplete",
 					"Upload-Draft-Interop-Version",
 				},
-				AllowCredentials: true,
+				AllowCredentials: false,
 				ExposedHeaders: []string{
 					"Upload-Offset",
 					"Location",
@@ -207,6 +207,11 @@ func EnsureDefaults(cfg *config.Config) {
 
 	if cfg.Tasks.PurgeTrashBin.UserID == "" && cfg.Commons != nil {
 		cfg.Tasks.PurgeTrashBin.UserID = cfg.Commons.AdminUserID
+	}
+
+	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }
 

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -32,7 +32,7 @@ func DefaultConfig() *config.Config {
 			CacheTTL:  604800, // 7 days
 
 			CORS: config.CORS{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins: []string{"https://localhost:9200"},
 				AllowedMethods: []string{
 					"OPTIONS",
 					"HEAD",
@@ -73,7 +73,7 @@ func DefaultConfig() *config.Config {
 					"Upload-Offset",
 					"X-HTTP-Method-Override",
 				},
-				AllowCredentials: true,
+				AllowCredentials: false,
 			},
 		},
 		Service: config.Service{
@@ -172,6 +172,11 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 	if cfg.Commons != nil {
 		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
+
+	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }
 

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -174,8 +174,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
 	}
 
-	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -174,8 +174,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
 	}
 
-	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") &&
+		(cfg.HTTP.CORS.AllowedOrigins == nil ||
+			len(cfg.HTTP.CORS.AllowedOrigins) == 1 &&
+				cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/webfinger/pkg/config/defaults/defaultconfig.go
+++ b/services/webfinger/pkg/config/defaults/defaultconfig.go
@@ -29,7 +29,8 @@ func DefaultConfig() *config.Config {
 			Root:      "/",
 			Namespace: "com.owncloud.web",
 			CORS: config.CORS{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins:   []string{"https://localhost:9200"},
+				AllowCredentials: false,
 			},
 		},
 		Service: config.Service{
@@ -80,6 +81,11 @@ func EnsureDefaults(cfg *config.Config) {
 
 	if cfg.Commons != nil {
 		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
+	}
+
+	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }
 

--- a/services/webfinger/pkg/config/defaults/defaultconfig.go
+++ b/services/webfinger/pkg/config/defaults/defaultconfig.go
@@ -83,8 +83,10 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
 	}
 
-	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") &&
+		(cfg.HTTP.CORS.AllowedOrigins == nil ||
+			len(cfg.HTTP.CORS.AllowedOrigins) == 1 &&
+				cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/services/webfinger/pkg/config/defaults/defaultconfig.go
+++ b/services/webfinger/pkg/config/defaults/defaultconfig.go
@@ -83,8 +83,8 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.HTTP.TLS = cfg.Commons.HTTPServiceTLS
 	}
 
-	if cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
-		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200" {
+	if (cfg.Commons != nil && cfg.Commons.OcisURL != "") && (cfg.HTTP.CORS.AllowedOrigins == nil && cfg.Commons != nil && cfg.Commons.OcisURL != "" ||
+		len(cfg.HTTP.CORS.AllowedOrigins) == 1 && cfg.HTTP.CORS.AllowedOrigins[0] == "https://localhost:9200") {
 		cfg.HTTP.CORS.AllowedOrigins = []string{cfg.Commons.OcisURL}
 	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -35,7 +35,7 @@ sonar.go.golangci-lint.reportPaths=cache/checkstyle/checkstyle.xml
 # Exclude files
 sonar.exclusions=**/third_party,docs/**,changelog/**,**/package.json,**/rollup.config.js,CHANGELOG.md,deployments/**,tests/**,vendor/**,vendor-bin/**,README.md,**/mocks/**,/protogen/**,**/*_gen.go
 sonar.coverage.exclusions=**/*_test.go,**mocks/**,/protogen/**,**/*_gen.go
-sonar.cpd.exclusions=**/*_test.go,**/revaconfig/**,services/settings/pkg/store/defaults/defaults.go
+sonar.cpd.exclusions=**/defaultconfig.go,**/*_test.go,**/revaconfig/**,services/settings/pkg/store/defaults/defaults.go
 
 # Rule exclusions
 sonar.issue.ignore.multicriteria=g1,g2

--- a/tests/acceptance/features/apiContract/copy.feature
+++ b/tests/acceptance/features/apiContract/copy.feature
@@ -22,6 +22,6 @@ Feature: Copy test
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | Oc-Fileid                   | /^[a-f0-9!\$\-]{110}$/                       |
-      | Access-Control-Allow-Origin | /^[*]{1}$/                                   |
+      | Access-Control-Allow-Origin | /^%base_url%$/                               |
       | X-Request-Id                | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
 

--- a/tests/acceptance/features/apiCors/cors.feature
+++ b/tests/acceptance/features/apiCors/cors.feature
@@ -21,7 +21,6 @@ Feature: CORS headers
       | header                           | value               |
       | Access-Control-Expose-Headers    | Location            |
       | Access-Control-Allow-Origin      | https://aphno.badal |
-      | Access-Control-Allow-Credentials | true                |
     Examples:
       | ocs-api-version | endpoint                          | ocs-status-code | http-status-code |
       | 1               | /config                           | 100             | 200              |


### PR DESCRIPTION
Enhencement: Change Cors default settings

We have changed the default CORS settings to set `Access-Control-Allow-Origin` to the `OCIS_URL` if not explicitely set
and `Access-Control-Allow-Credentials` to `false` if not explicitely set.

refs https://github.com/owncloud/ocis/issues/8514
