### PR TITLE
[full-ci] split e2e tests in ocis CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1161,11 +1161,15 @@ def uiTestPipeline(ctx, filterTags, runPart = 1, numberOfParts = 1, storage = "o
 def e2eTests(ctx):
     test_suites = {
         "suite1": {
-            "path": "tests/e2e/cucumber/features/*/*[!.oc10].feature",
+            "path": "tests/e2e/cucumber/features/{smoke,journeys}/*.feature",
             "tikaNeeded": False,
         },
         "suite2": {
-            "path": "tests/e2e/cucumber/features/smoke/*[!app-provider]/*[!.oc10].feature",
+            "path": "tests/e2e/cucumber/features/smoke/{spaces,admin-settings}/*.feature",
+            "tikaNeeded": False,
+        },
+        "suite3": {
+            "path": "tests/e2e/cucumber/features/smoke/{search,shares}/*.feature",
             "tikaNeeded": True,
         },
     }


### PR DESCRIPTION
old: 
<img width="785" alt="Screenshot 2024-02-26 at 12 37 54" src="https://github.com/owncloud/ocis/assets/84779829/e5c1346d-144a-475b-9d2d-1a90575de4fb">

new: 
<img width="393" alt="image" src="https://github.com/owncloud/ocis/assets/84779829/ae4bdef7-52b5-40b8-bcad-569c8fd7491d">
