### PR TITLE
[tests-only] check for invalid schema validators

### DIFF
--- a/tests/acceptance/features/apiNotification/notification.feature
+++ b/tests/acceptance/features/apiNotification/notification.feature
@@ -85,7 +85,7 @@ Feature: Notification
                 },
                 "id": {
                   "type": "string",
-                  "enim": ["%user_id%"]
+                  "pattern": "^%user_id_pattern%$"
                 },
                 "name": {
                   "type": "string",

--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -97,9 +97,7 @@ Feature: Notification
                   },
                   "id": {
                     "type": "string",
-                    "enim": [
-                      "%user_id%"
-                    ]
+                    "pattern": "^%user_id_pattern%$"
                   },
                   "name": {
                     "type": "string",
@@ -232,9 +230,7 @@ Feature: Notification
                   },
                   "id": {
                     "type": "string",
-                    "enim": [
-                      "%user_id%"
-                    ]
+                    "pattern": "^%user_id_pattern%$"
                   },
                   "name": {
                     "type": "string",
@@ -368,9 +364,7 @@ Feature: Notification
                   },
                   "id": {
                     "type": "string",
-                    "enim": [
-                      "%user_id%"
-                    ]
+                    "pattern": "^%user_id_pattern%$"
                   },
                   "name": {
                     "type": "string",

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -553,8 +553,6 @@ Feature: Create a share link for a resource
           },
           "link": {
             "type": "object",
-            "minItems": 5,
-            "maxItems": 5,
             "required": [
               "@libre.graph.displayName",
               "@libre.graph.quickLink",

--- a/tests/acceptance/features/apiSharingNg/updateShareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/updateShareInvitations.feature
@@ -102,8 +102,6 @@ Feature: Update permission of a share
     """
     {
       "type": "object",
-      "minItems": 3,
-      "maxItems": 3,
       "required": [
         "grantedToV2",
         "id",

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1238,7 +1238,9 @@ class FeatureContext extends BehatVariablesContext {
 	public function validateSchemaObject(JsonSchema $schemaObj): void {
 		$this->checkInvalidValidator($schemaObj);
 
-		if ($schemaObj->type && $schemaObj->type !== "object") return;
+		if ($schemaObj->type && $schemaObj->type !== "object") {
+			return;
+		}
 
 		$notAllowedValidators = ["items", "maxItems", "minItems", "uniqueItems"];
 
@@ -1273,7 +1275,9 @@ class FeatureContext extends BehatVariablesContext {
 	private function validateSchemaArray(JsonSchema $schemaObj): void {
 		$this->checkInvalidValidator($schemaObj);
 
-		if ($schemaObj->type && $schemaObj->type !== "array") return;
+		if ($schemaObj->type && $schemaObj->type !== "array") {
+			return;
+		}
 
 		$hasTwoElementValidator = ($schemaObj->enum && $schemaObj->const) || ($schemaObj->enum && $schemaObj->items) || ($schemaObj->const && $schemaObj->items);
 		Assert::assertFalse($hasTwoElementValidator, "'items', 'enum' and 'const' should not be used together");


### PR DESCRIPTION
## Description
More schema validation:
- report if there are invalid schema validators
  ```yml
  "type": "object",
  # ❌ Invalid validator: 'key101'
  "key101": "value1"
  ```
- do not allow validators used for array in object and vice versa
  ```yml
  "type": "object",
  # ❌ 'items' not allowed with object type
  "items": {}
  ```

**NOTE:** For object and array types, we have to specify `type` validator. Currently, we haven't made `type` as the required validator.

## Related Issue

## Motivation and Context

## How Has This Been Tested?
Found these problems:
https://drone.owncloud.com/owncloud/ocis/32443/28/6, https://drone.owncloud.com/owncloud/ocis/32446/30/8
```
apiSharingNg/linkShare.feature:589
apiSharingNg/linkShare.feature:590
apiSharingNg/updateShareInvitations.feature:156
apiSharingNg/updateShareInvitations.feature:157
apiNotification/notification.feature:125
apiNotification/notification.feature:126
apiNotification/spaceNotification.feature:16
apiNotification/spaceNotification.feature:150
apiNotification/spaceNotification.feature:285
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
