### PR TITLE
verify all system accounts are set

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,11 @@
                 "GATEWAY_STORAGE_USERS_MOUNT_ID": "storage-users-1",
                 "STORAGE_USERS_MOUNT_ID": "storage-users-1",
                 // graph application ID
-                "GRAPH_APPLICATION_ID": "application-1"
+                "GRAPH_APPLICATION_ID": "application-1",
+
+                // service accounts
+                "OCIS_SERVICE_ACCOUNT_ID": "service-account-id",
+                "OCIS_SERVICE_ACCOUNT_SECRET": "service-account-secret"
             }
         }
     ]

--- a/ocis-pkg/shared/errors.go
+++ b/ocis-pkg/shared/errors.go
@@ -69,3 +69,19 @@ func MissingAdminUserID(service string) error {
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
+
+func MissingServiceAccountID(service string) error {
+	return fmt.Errorf("The service account id has not been configured for %s. "+
+		"Make sure your %s config contains the proper values "+
+		"(e.g. by running ocis init or setting it manually in "+
+		"the config/corresponding environment variable).",
+		service, defaults.BaseConfigPath())
+}
+
+func MissingServiceAccountSecret(service string) error {
+	return fmt.Errorf("The service account secret has not been configured for %s. "+
+		"Make sure your %s config contains the proper values "+
+		"(e.g. by running ocis init or setting it manually in "+
+		"the config/corresponding environment variable).",
+		service, defaults.BaseConfigPath())
+}

--- a/ocis/pkg/init/init.go
+++ b/ocis/pkg/init/init.go
@@ -83,6 +83,10 @@ type FrontendService struct {
 	ServiceAccount ServiceAccount `yaml:"service_account"`
 }
 
+type OcmService struct {
+	ServiceAccount ServiceAccount `yaml:"service_account"`
+}
+
 type AuthbasicService struct {
 	AuthProviders LdapBasedService `yaml:"auth_providers"`
 }
@@ -194,6 +198,7 @@ type OcisConfig struct {
 	Users             UsersAndGroupsService
 	Groups            UsersAndGroupsService
 	Ocdav             InsecureService
+	Ocm               OcmService
 	Thumbnails        ThumbnailService
 	Search            Search
 	Audit             Audit
@@ -391,6 +396,9 @@ func CreateConfig(insecure, forceOverwrite bool, configPath, adminPassword strin
 			ServiceAccount: serviceAccount,
 		},
 		Frontend: FrontendService{
+			ServiceAccount: serviceAccount,
+		},
+		Ocm: OcmService{
 			ServiceAccount: serviceAccount,
 		},
 		Clientlog: Clientlog{

--- a/services/auth-service/pkg/config/parser/parse.go
+++ b/services/auth-service/pkg/config/parser/parse.go
@@ -38,5 +38,12 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingJWTTokenError(cfg.Service.Name)
 	}
 
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/services/clientlog/pkg/config/parser/parse.go
+++ b/services/clientlog/pkg/config/parser/parse.go
@@ -39,5 +39,12 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingJWTTokenError(cfg.Service.Name)
 	}
 
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/services/frontend/pkg/config/parser/parse.go
+++ b/services/frontend/pkg/config/parser/parse.go
@@ -56,5 +56,12 @@ func Validate(cfg *config.Config) error {
 		cfg.OCS.WriteablePublicShareMustHavePassword = true
 	}
 
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/services/graph/pkg/config/parser/parse.go
+++ b/services/graph/pkg/config/parser/parse.go
@@ -65,6 +65,13 @@ func Validate(cfg *config.Config) error {
 			"graph", defaults2.BaseConfigPath())
 	}
 
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }
 

--- a/services/notifications/pkg/config/parser/parse.go
+++ b/services/notifications/pkg/config/parser/parse.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/logging"
@@ -52,5 +53,13 @@ func Validate(cfg *config.Config) error {
 			)
 		}
 	}
+
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/services/ocm/pkg/config/parser/parse.go
+++ b/services/ocm/pkg/config/parser/parse.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	ociscfg "github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"github.com/owncloud/ocis/v2/ocis-pkg/structs"
 	"github.com/owncloud/ocis/v2/services/ocm/pkg/config"
 	"github.com/owncloud/ocis/v2/services/ocm/pkg/config/defaults"
@@ -37,6 +38,13 @@ func ParseConfig(cfg *config.Config) error {
 func Validate(cfg *config.Config) error {
 	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
 		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
+	}
+
+	if cfg.ServiceAccount.ID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.Secret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
 	}
 
 	return nil

--- a/services/proxy/pkg/config/parser/parse.go
+++ b/services/proxy/pkg/config/parser/parse.go
@@ -53,5 +53,12 @@ func Validate(cfg *config.Config) error {
 		)
 	}
 
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/services/search/pkg/config/parser/parse.go
+++ b/services/search/pkg/config/parser/parse.go
@@ -37,5 +37,13 @@ func Validate(cfg *config.Config) error {
 	if cfg.TokenManager.JWTSecret == "" {
 		return shared.MissingJWTTokenError(cfg.Service.Name)
 	}
+
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/services/settings/pkg/config/parser/parse.go
+++ b/services/settings/pkg/config/parser/parse.go
@@ -49,5 +49,9 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingAdminUserID(cfg.Service.Name)
 	}
 
+	if len(cfg.ServiceAccountIDs) == 0 {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+
 	return nil
 }

--- a/services/storage-users/pkg/config/parser/parse.go
+++ b/services/storage-users/pkg/config/parser/parse.go
@@ -47,5 +47,12 @@ func Validate(cfg *config.Config) error {
 			"the config/corresponding environment variable).",
 			"storage-users", defaults2.BaseConfigPath())
 	}
+
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
 	return nil
 }

--- a/services/userlog/pkg/config/parser/parse.go
+++ b/services/userlog/pkg/config/parser/parse.go
@@ -39,5 +39,12 @@ func Validate(cfg *config.Config) error {
 		return shared.MissingJWTTokenError(cfg.Service.Name)
 	}
 
+	if cfg.ServiceAccount.ServiceAccountID == "" {
+		return shared.MissingServiceAccountID(cfg.Service.Name)
+	}
+	if cfg.ServiceAccount.ServiceAccountSecret == "" {
+		return shared.MissingServiceAccountSecret(cfg.Service.Name)
+	}
+
 	return nil
 }


### PR DESCRIPTION
while we are configuring them in ocis init, we are not verifying if they are set. This allows the service to start with a broken configuration that leads to failing requests.