### PR TITLE
deprecate store env vars

### DIFF
--- a/services/store/pkg/config/config.go
+++ b/services/store/pkg/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 	GrpcClient    client.Client         `yaml:"-"`
 
-	Datapath string `yaml:"data_path" env:"STORE_DATA_PATH" desc:"The directory where the filesystem storage will store ocis settings. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/store."`
+	Datapath string `yaml:"data_path" env:"STORE_DATA_PATH" desc:"The directory where the filesystem storage will store ocis settings. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/store." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
 
 	Context context.Context `yaml:"-"`
 }

--- a/services/store/pkg/config/debug.go
+++ b/services/store/pkg/config/debug.go
@@ -2,8 +2,8 @@ package config
 
 // Debug defines the available debug configuration.
 type Debug struct {
-	Addr   string `yaml:"addr" env:"STORE_DEBUG_ADDR" desc:"Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed."`
-	Token  string `yaml:"token" env:"STORE_DEBUG_TOKEN" desc:"Token to secure the metrics endpoint."`
-	Pprof  bool   `yaml:"pprof" env:"STORE_DEBUG_PPROF" desc:"Enables pprof, which can be used for profiling."`
-	Zpages bool   `yaml:"zpages" env:"STORE_DEBUG_ZPAGES" desc:"Enables zpages, which can be used for collecting and viewing in-memory traces."`
+	Addr   string `yaml:"addr" env:"STORE_DEBUG_ADDR" desc:"Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Token  string `yaml:"token" env:"STORE_DEBUG_TOKEN" desc:"Token to secure the metrics endpoint." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Pprof  bool   `yaml:"pprof" env:"STORE_DEBUG_PPROF" desc:"Enables pprof, which can be used for profiling." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Zpages bool   `yaml:"zpages" env:"STORE_DEBUG_ZPAGES" desc:"Enables zpages, which can be used for collecting and viewing in-memory traces." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
 }

--- a/services/store/pkg/config/grpc.go
+++ b/services/store/pkg/config/grpc.go
@@ -4,7 +4,7 @@ import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
 
 // GRPCConfig defines the available grpc configuration.
 type GRPCConfig struct {
-	Addr      string                 `yaml:"addr" env:"STORE_GRPC_ADDR" desc:"The bind address of the GRPC service."`
+	Addr      string                 `yaml:"addr" env:"STORE_GRPC_ADDR" desc:"The bind address of the GRPC service." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
 	Namespace string                 `yaml:"-"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 }

--- a/services/store/pkg/config/log.go
+++ b/services/store/pkg/config/log.go
@@ -2,8 +2,8 @@ package config
 
 // Log defines the available log configuration.
 type Log struct {
-	Level  string `mapstructure:"level" env:"OCIS_LOG_LEVEL;STORE_LOG_LEVEL" desc:"The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'."`
-	Pretty bool   `mapstructure:"pretty" env:"OCIS_LOG_PRETTY;STORE_LOG_PRETTY" desc:"Activates pretty log output."`
-	Color  bool   `mapstructure:"color" env:"OCIS_LOG_COLOR;STORE_LOG_COLOR" desc:"Activates colorized log output."`
-	File   string `mapstructure:"file" env:"OCIS_LOG_FILE;STORE_LOG_FILE" desc:"The path to the log file. Activates logging to this file if set."`
+	Level  string `mapstructure:"level" env:"OCIS_LOG_LEVEL;STORE_LOG_LEVEL" desc:"The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Pretty bool   `mapstructure:"pretty" env:"OCIS_LOG_PRETTY;STORE_LOG_PRETTY" desc:"Activates pretty log output." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Color  bool   `mapstructure:"color" env:"OCIS_LOG_COLOR;STORE_LOG_COLOR" desc:"Activates colorized log output." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	File   string `mapstructure:"file" env:"OCIS_LOG_FILE;STORE_LOG_FILE" desc:"The path to the log file. Activates logging to this file if set." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
 }

--- a/services/store/pkg/config/tracing.go
+++ b/services/store/pkg/config/tracing.go
@@ -4,10 +4,10 @@ import "github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 
 // Tracing defines the available tracing configuration.
 type Tracing struct {
-	Enabled   bool   `yaml:"enabled" env:"OCIS_TRACING_ENABLED;STORE_TRACING_ENABLED" desc:"Activates tracing."`
-	Type      string `yaml:"type" env:"OCIS_TRACING_TYPE;STORE_TRACING_TYPE" desc:"The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now."`
-	Endpoint  string `yaml:"endpoint" env:"OCIS_TRACING_ENDPOINT;STORE_TRACING_ENDPOINT" desc:"The endpoint of the tracing agent."`
-	Collector string `yaml:"collector" env:"OCIS_TRACING_COLLECTOR;STORE_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset."`
+	Enabled   bool   `yaml:"enabled" env:"OCIS_TRACING_ENABLED;STORE_TRACING_ENABLED" desc:"Activates tracing." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Type      string `yaml:"type" env:"OCIS_TRACING_TYPE;STORE_TRACING_TYPE" desc:"The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Endpoint  string `yaml:"endpoint" env:"OCIS_TRACING_ENDPOINT;STORE_TRACING_ENDPOINT" desc:"The endpoint of the tracing agent." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
+	Collector string `yaml:"collector" env:"OCIS_TRACING_COLLECTOR;STORE_TRACING_COLLECTOR" desc:"The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset." deprecationVersion:"5.0" removalVersion:"6.0.0" deprecationInfo:"The store service is optional and will be removed."`
 }
 
 // Convert Tracing to the tracing package's Config struct.


### PR DESCRIPTION
follow up to https://github.com/owncloud/ocis/pull/8555

also needs to be backported to stable 5