### PR TITLE
always select the next clients when autoaccepting shares

### DIFF
--- a/changelog/unreleased/select-next-clients-for-autoaccept.md
+++ b/changelog/unreleased/select-next-clients-for-autoaccept.md
@@ -1,0 +1,3 @@
+Bugfix: we now always select the next clients when autoaccepting shares
+
+https://github.com/owncloud/ocis/pull/8570


### PR DESCRIPTION
fixes autoaccepting shares when k8s decided to move the gateway pod

We need to pass down a selector and get a new client with Next(), right before the call.

Don't worry abouit the the Next() call itself. It stays in memory, as the registry uses a cache that is actively invalidated.