### PR TITLE
always select next before making calls

### DIFF
--- a/changelog/unreleased/next-before-making-calls.md
+++ b/changelog/unreleased/next-before-making-calls.md
@@ -1,0 +1,5 @@
+Bugfix: always select next before making calls
+
+We now select the next client more often to spread out load
+
+https://github.com/owncloud/ocis/pull/8578

--- a/services/clientlog/pkg/service/service.go
+++ b/services/clientlog/pkg/service/service.go
@@ -134,7 +134,7 @@ func (cl *ClientlogService) processEvent(event events.Event) {
 					InitiatorID: event.InitiatorID,
 				}
 
-				gwc, err := cl.gatewaySelector.Next()
+				gwc, err = cl.gatewaySelector.Next()
 				if err != nil {
 					cl.log.Error().Err(err).Interface("event", event).Msg("error getting gateway client")
 					return

--- a/services/clientlog/pkg/service/service.go
+++ b/services/clientlog/pkg/service/service.go
@@ -90,6 +90,11 @@ func (cl *ClientlogService) processEvent(event events.Event) {
 		return
 	}
 
+	gwc, err = cl.gatewaySelector.Next()
+	if err != nil {
+		cl.log.Error().Err(err).Interface("event", event).Msg("error getting gateway client")
+		return
+	}
 	var (
 		users  []string
 		evType string
@@ -129,6 +134,11 @@ func (cl *ClientlogService) processEvent(event events.Event) {
 					InitiatorID: event.InitiatorID,
 				}
 
+				gwc, err := cl.gatewaySelector.Next()
+				if err != nil {
+					cl.log.Error().Err(err).Interface("event", event).Msg("error getting gateway client")
+					return
+				}
 				users, err = utils.GetSpaceMembers(ctx, e.ID.GetSpaceId(), gwc, utils.ViewerRole)
 				break
 			}

--- a/services/graph/pkg/service/v0/api_drives_drive_item.go
+++ b/services/graph/pkg/service/v0/api_drives_drive_item.go
@@ -79,6 +79,10 @@ func (s DrivesDriveItemService) UnmountShare(ctx context.Context, resourceID sto
 	}
 
 	// Find all accepted shares for this resource
+	gatewayClient, err = s.gatewaySelector.Next()
+	if err != nil {
+		return err
+	}
 	receivedSharesResponse, err := gatewayClient.ListReceivedShares(ctx, &collaboration.ListReceivedSharesRequest{
 		Filters: []*collaboration.Filter{
 			{
@@ -188,6 +192,10 @@ func (s DrivesDriveItemService) MountShare(ctx context.Context, resourceID stora
 			UpdateMask: updateMask,
 		}
 
+		gatewayClient, err = s.gatewaySelector.Next()
+		if err != nil {
+			return libregraph.DriveItem{}, err
+		}
 		updateReceivedShareResponse, err := gatewayClient.UpdateReceivedShare(ctx, updateReceivedShareRequest)
 		switch errCode := errorcode.FromCS3Status(updateReceivedShareResponse.GetStatus(), err); {
 		case errCode == nil:

--- a/services/graph/pkg/service/v0/api_drives_drive_item.go
+++ b/services/graph/pkg/service/v0/api_drives_drive_item.go
@@ -221,7 +221,7 @@ func (s DrivesDriveItemService) MountShare(ctx context.Context, resourceID stora
 	items, err := cs3ReceivedSharesToDriveItems(ctx, &s.logger, gatewayClient, s.identityCache, acceptedShares)
 	switch {
 	case err != nil:
-		return libregraph.DriveItem{}, nil
+		return libregraph.DriveItem{}, err
 	case len(items) != 1:
 		return libregraph.DriveItem{}, errorcode.New(errorcode.GeneralException, "failed to convert accepted shares into drive-item")
 	}

--- a/services/storage-users/pkg/task/trash_bin.go
+++ b/services/storage-users/pkg/task/trash_bin.go
@@ -26,6 +26,10 @@ func PurgeTrashBin(serviceAccountID string, deleteBefore time.Time, spaceType Sp
 		return err
 	}
 
+	gatewayClient, err = gatewaySelector.Next()
+	if err != nil {
+		return err
+	}
 	listStorageSpacesResponse, err := gatewayClient.ListStorageSpaces(ctx, &apiProvider.ListStorageSpacesRequest{
 		Filters: []*apiProvider.ListStorageSpacesRequest_Filter{
 			{
@@ -49,6 +53,10 @@ func PurgeTrashBin(serviceAccountID string, deleteBefore time.Time, spaceType Sp
 			ResourceId: storageSpace.GetRoot(),
 		}
 
+		gatewayClient, err = gatewaySelector.Next()
+		if err != nil {
+			return err
+		}
 		listRecycleResponse, err := gatewayClient.ListRecycle(ctx, &apiProvider.ListRecycleRequest{Ref: storageSpaceReference})
 		if err != nil {
 			return err
@@ -60,6 +68,10 @@ func PurgeTrashBin(serviceAccountID string, deleteBefore time.Time, spaceType Sp
 				continue
 			}
 
+			gatewayClient, err = gatewaySelector.Next()
+			if err != nil {
+				return err
+			}
 			purgeRecycleResponse, err := gatewayClient.PurgeRecycle(ctx, &apiProvider.PurgeRecycleRequest{
 				Ref: storageSpaceReference,
 				Key: recycleItem.Key,

--- a/services/userlog/pkg/service/http.go
+++ b/services/userlog/pkg/service/http.go
@@ -51,7 +51,6 @@ func (ul *UserlogService) HandleGetEvents(w http.ResponseWriter, r *http.Request
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-
 	ctx, err = utils.GetServiceUserContext(ul.cfg.ServiceAccount.ServiceAccountID, gwc, ul.cfg.ServiceAccount.ServiceAccountSecret)
 	if err != nil {
 		ul.log.Error().Err(err).Msg("cant get service account")
@@ -59,7 +58,7 @@ func (ul *UserlogService) HandleGetEvents(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	conv := NewConverter(ctx, r.Header.Get(HeaderAcceptLanguage), gwc, ul.cfg.Service.Name, ul.cfg.TranslationPath, ul.cfg.DefaultLanguage)
+	conv := NewConverter(ctx, r.Header.Get(HeaderAcceptLanguage), ul.gatewaySelector, ul.cfg.Service.Name, ul.cfg.TranslationPath, ul.cfg.DefaultLanguage)
 
 	var outdatedEvents []string
 	resp := GetEventResponseOC10{}


### PR DESCRIPTION
Following https://github.com/owncloud/ocis/pull/8570 I went over other places in ocis that use the selector and client. We now select the next client more often to spread out load.

I don't expect a huge impact from this PR.

