### PR TITLE
[Draft] Expose posix fs settings

### DIFF
--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -102,6 +102,7 @@ type Drivers struct {
 	OCIS        OCISDriver        `yaml:"ocis"`
 	S3NG        S3NGDriver        `yaml:"s3ng"`
 	OwnCloudSQL OwnCloudSQLDriver `yaml:"owncloudsql"`
+	Posix       PosixDriver       `yaml:"posix"`
 
 	S3    S3Driver    `yaml:",omitempty"` // not supported by the oCIS product, therefore not part of docs
 	EOS   EOSDriver   `yaml:",omitempty"` // not supported by the oCIS product, therefore not part of docs
@@ -184,6 +185,14 @@ type OwnCloudSQLDriver struct {
 	DBPort                int    `yaml:"db_port" env:"STORAGE_USERS_OWNCLOUDSQL_DB_PORT" desc:"Port that the database server is listening on." introductionVersion:"pre5.0"`
 	DBName                string `yaml:"db_name" env:"STORAGE_USERS_OWNCLOUDSQL_DB_NAME" desc:"Name of the database to be used." introductionVersion:"pre5.0"`
 	UsersProviderEndpoint string `yaml:"users_provider_endpoint" env:"STORAGE_USERS_OWNCLOUDSQL_USERS_PROVIDER_ENDPOINT" desc:"Endpoint of the users provider." introductionVersion:"pre5.0"`
+}
+
+// PosixDriver is the storage driver configuration when using 'posix' storage driver
+type PosixDriver struct {
+	// Root is the absolute path to the location of the data
+	Root                string `yaml:"root" env:"STORAGE_USERS_POSIX_ROOT" desc:"The directory where the filesystem storage will store its data. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/storage/owncloud."`
+	UserLayout          string `yaml:"user_layout" env:"STORAGE_USERS_POSIX_USER_LAYOUT" desc:"Template string for the user storage layout in the user directory."`
+	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_POSIX_PERMISSIONS_ENDPOINT" desc:"Endpoint of the permissions service. The endpoints can differ for 'ocis', 'posix' and 's3ng'."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -192,6 +192,7 @@ type PosixDriver struct {
 	// Root is the absolute path to the location of the data
 	Root                string `yaml:"root" env:"STORAGE_USERS_POSIX_ROOT" desc:"The directory where the filesystem storage will store its data. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/storage/owncloud."`
 	UserLayout          string `yaml:"user_layout" env:"STORAGE_USERS_POSIX_USER_LAYOUT" desc:"Template string for the user storage layout in the user directory."`
+	ProjectLayout       string `yaml:"project_layout" env:"STORAGE_USERS_POSIX_PROJECT_LAYOUT" desc:"Template string for the project spaces storage layout."`
 	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_POSIX_PERMISSIONS_ENDPOINT" desc:"Endpoint of the permissions service. The endpoints can differ for 'ocis', 'posix' and 's3ng'."`
 }
 

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -194,6 +194,9 @@ type PosixDriver struct {
 	UserLayout          string `yaml:"user_layout" env:"STORAGE_USERS_POSIX_USER_LAYOUT" desc:"Template string for the user storage layout in the user directory."`
 	ProjectLayout       string `yaml:"project_layout" env:"STORAGE_USERS_POSIX_PROJECT_LAYOUT" desc:"Template string for the project spaces storage layout."`
 	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_POSIX_PERMISSIONS_ENDPOINT" desc:"Endpoint of the permissions service. The endpoints can differ for 'ocis', 'posix' and 's3ng'."`
+
+	WatchType string `yaml:"watch_type" env:"STORAGE_USERS_POSIX_WATCH_TYPE" desc:"Type of the watcher to use for getting notified about changes to the filesystem. Currently available options are 'inotifywait' (default) and 'gpfsfileauditlogging'."`
+	WatchPath string `yaml:"watch_path" env:"STORAGE_USERS_POSIX_WATCH_PATH" desc:"Path to the watch directory/file. Only applies to the 'gpfsfileauditlogling' watcher, in which case it is the path of the file audit log file."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -195,8 +195,9 @@ type PosixDriver struct {
 	ProjectLayout       string `yaml:"project_layout" env:"STORAGE_USERS_POSIX_PROJECT_LAYOUT" desc:"Template string for the project spaces storage layout."`
 	PermissionsEndpoint string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_POSIX_PERMISSIONS_ENDPOINT" desc:"Endpoint of the permissions service. The endpoints can differ for 'ocis', 'posix' and 's3ng'."`
 
-	WatchType string `yaml:"watch_type" env:"STORAGE_USERS_POSIX_WATCH_TYPE" desc:"Type of the watcher to use for getting notified about changes to the filesystem. Currently available options are 'inotifywait' (default) and 'gpfsfileauditlogging'."`
-	WatchPath string `yaml:"watch_path" env:"STORAGE_USERS_POSIX_WATCH_PATH" desc:"Path to the watch directory/file. Only applies to the 'gpfsfileauditlogling' watcher, in which case it is the path of the file audit log file."`
+	WatchType               string `yaml:"watch_type" env:"STORAGE_USERS_POSIX_WATCH_TYPE" desc:"Type of the watcher to use for getting notified about changes to the filesystem. Currently available options are 'inotifywait' (default) and 'gpfsfileauditlogging'."`
+	WatchPath               string `yaml:"watch_path" env:"STORAGE_USERS_POSIX_WATCH_PATH" desc:"Path to the watch directory/file. Only applies to the 'gpfsfileauditlogling' watcher, in which case it is the path of the file audit log file."`
+	WatchFolderKafkaBrokers string `yaml:"watch_folder_kafka_hosts" env:"STORAGE_USERS_POSIX_WATCH_FOLDER_KAFKA_BROKERS" desc:"Comma-separate list of kafka brokers to connect to to read the watchfolder events from."`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -138,6 +138,7 @@ func DefaultConfig() *config.Config {
 			},
 			Posix: config.PosixDriver{
 				UserLayout:          "users/{{.User.Username}}",
+				ProjectLayout:       "projects/{{.SpaceId}}",
 				PermissionsEndpoint: "com.owncloud.api.settings",
 			},
 		},

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -136,6 +136,10 @@ func DefaultConfig() *config.Config {
 				LockCycleDurationFactor:    30,
 				AsyncUploads:               true,
 			},
+			Posix: config.PosixDriver{
+				UserLayout:          "users/{{.User.Username}}",
+				PermissionsEndpoint: "com.owncloud.api.settings",
+			},
 		},
 		Events: config.Events{
 			Addr:      "127.0.0.1:9233",

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -89,6 +89,7 @@ func Posix(cfg *config.Config) map[string]interface{} {
 	return map[string]interface{}{
 		"root":                    cfg.Drivers.Posix.Root,
 		"user_layout":             cfg.Drivers.Posix.UserLayout,
+		"project_layout":          cfg.Drivers.Posix.ProjectLayout,
 		"permissionssvc":          cfg.Drivers.Posix.PermissionsEndpoint,
 		"permissionssvc_tls_mode": cfg.Commons.GRPCClientTLS.Mode,
 		"treetime_accounting":     true,

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -94,6 +94,9 @@ func Posix(cfg *config.Config) map[string]interface{} {
 		"permissionssvc_tls_mode": cfg.Commons.GRPCClientTLS.Mode,
 		"treetime_accounting":     true,
 		"treesize_accounting":     true,
+
+		"watch_type": cfg.Drivers.Posix.WatchType,
+		"watch_path": cfg.Drivers.Posix.WatchPath,
 	}
 }
 

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -84,6 +84,16 @@ func Local(cfg *config.Config) map[string]interface{} {
 	}
 }
 
+// Posix is the config mapping for the Posix storage driver
+func Posix(cfg *config.Config) map[string]interface{} {
+	return map[string]interface{}{
+		"root":                    cfg.Drivers.Posix.Root,
+		"user_layout":             cfg.Drivers.Posix.UserLayout,
+		"permissionssvc":          cfg.Drivers.Posix.PermissionsEndpoint,
+		"permissionssvc_tls_mode": cfg.Commons.GRPCClientTLS.Mode,
+	}
+}
+
 // LocalHome is the config mapping for the LocalHome storage driver
 func LocalHome(cfg *config.Config) map[string]interface{} {
 	return map[string]interface{}{

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -94,6 +94,16 @@ func Posix(cfg *config.Config) map[string]interface{} {
 		"permissionssvc_tls_mode": cfg.Commons.GRPCClientTLS.Mode,
 		"treetime_accounting":     true,
 		"treesize_accounting":     true,
+		"idcache": map[string]interface{}{
+			"cache_store":               cfg.IDCache.Store,
+			"cache_nodes":               cfg.IDCache.Nodes,
+			"cache_database":            cfg.IDCache.Database,
+			"cache_ttl":                 cfg.IDCache.TTL,
+			"cache_size":                cfg.IDCache.Size,
+			"cache_disable_persistence": cfg.IDCache.DisablePersistence,
+			"cache_auth_username":       cfg.IDCache.AuthUsername,
+			"cache_auth_password":       cfg.IDCache.AuthPassword,
+		},
 
 		"watch_type": cfg.Drivers.Posix.WatchType,
 		"watch_path": cfg.Drivers.Posix.WatchPath,

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -105,8 +105,9 @@ func Posix(cfg *config.Config) map[string]interface{} {
 			"cache_auth_password":       cfg.IDCache.AuthPassword,
 		},
 
-		"watch_type": cfg.Drivers.Posix.WatchType,
-		"watch_path": cfg.Drivers.Posix.WatchPath,
+		"watch_type":                 cfg.Drivers.Posix.WatchType,
+		"watch_path":                 cfg.Drivers.Posix.WatchPath,
+		"watch_folder_kafka_brokers": cfg.Drivers.Posix.WatchFolderKafkaBrokers,
 	}
 }
 

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -91,6 +91,8 @@ func Posix(cfg *config.Config) map[string]interface{} {
 		"user_layout":             cfg.Drivers.Posix.UserLayout,
 		"permissionssvc":          cfg.Drivers.Posix.PermissionsEndpoint,
 		"permissionssvc_tls_mode": cfg.Commons.GRPCClientTLS.Mode,
+		"treetime_accounting":     true,
+		"treesize_accounting":     true,
 	}
 }
 

--- a/services/storage-users/pkg/revaconfig/user.go
+++ b/services/storage-users/pkg/revaconfig/user.go
@@ -14,6 +14,7 @@ func StorageProviderDrivers(cfg *config.Config) map[string]interface{} {
 		"ocis":        OcisNoEvents(cfg),
 		"s3":          S3(cfg),
 		"s3ng":        S3NGNoEvents(cfg),
+		"posix":       Posix(cfg),
 	}
 }
 
@@ -29,5 +30,6 @@ func DataProviderDrivers(cfg *config.Config) map[string]interface{} {
 		"ocis":        Ocis(cfg),
 		"s3":          S3(cfg),
 		"s3ng":        S3NG(cfg),
+		"posix":       Posix(cfg),
 	}
 }


### PR DESCRIPTION
ocis companion PR for https://github.com/cs3org/reva/pull/4562

Example settings for gpfs with the `gpfswatchfolder` watcher: 

```
"STORAGE_USERS_DRIVER": "posix",
"STORAGE_USERS_POSIX_ROOT": "/ibm/fs1/storage-users",
"STORAGE_USERS_POSIX_WATCH_TYPE": "gpfswatchfolder",
"STORAGE_USERS_POSIX_WATCH_PATH": "fs1_audit", // the kafka topic to watch
"STORAGE_USERS_POSIX_WATCH_FOLDER_KAFKA_BROKERS": "192.168.1.180:29092",
"STORAGE_USERS_ID_CACHE_STORE": "redis",
"STORAGE_USERS_ID_CACHE_STORE_NODES": "127.0.0.1:6379",
```