### PR TITLE
[full-ci] chore: bump web to v8.0.1

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=a4e644056c8ed93d0aa2a3f301c891ef2f49b0b5
+WEB_COMMITID=97a5cf669626ed83acaeb2f7e8aaf542d42100c2
 WEB_BRANCH=stable-8.0

--- a/changelog/unreleased/update-web-8.0.1.md
+++ b/changelog/unreleased/update-web-8.0.1.md
@@ -1,0 +1,12 @@
+Enhancement: Update web to v8.0.1
+
+Tags: web
+
+We updated ownCloud Web to v8.0.1. Please refer to the changelog (linked) for details on the web release.
+
+* Bugfix [owncloud/web#10573](https://github.com/owncloud/web/pull/10573): Add link in right sidebar sharing menu, doesn't copy link to clipboard
+* Bugfix [owncloud/web#10576](https://github.com/owncloud/web/pull/10576): WebDav Url in right sidebar is missing dav in path
+* Bugfix [owncloud/web#10585](https://github.com/owncloud/web/issues/10585): Update translations
+
+https://github.com/owncloud/ocis/pull/8626
+https://github.com/owncloud/web/releases/tag/v8.0.1

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.0
+WEB_ASSETS_VERSION = v8.0.1
 
 include ../../.make/recursion.mk
 

--- a/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
@@ -14,7 +14,3 @@ Other free text and Markdown formatting can be used elsewhere in the document if
 
 - [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
 - [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)
-
-### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
-
-- [webUIUpload/upload.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L36)


### PR DESCRIPTION
Bump web to `v8.0.1` brings 2 bugfixes and a German translation update.