### PR TITLE
[test-only] Port #8528 to stable

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1167,11 +1167,15 @@ def uiTestPipeline(ctx, filterTags, runPart = 1, numberOfParts = 1, storage = "o
 def e2eTests(ctx):
     test_suites = {
         "suite1": {
-            "path": "tests/e2e/cucumber/features/*/*[!.oc10].feature",
+            "path": "tests/e2e/cucumber/features/{smoke,journeys}/*.feature",
             "tikaNeeded": False,
         },
         "suite2": {
-            "path": "tests/e2e/cucumber/features/smoke/*[!app-provider]/*[!.oc10].feature",
+            "path": "tests/e2e/cucumber/features/smoke/{spaces,admin-settings}/*.feature",
+            "tikaNeeded": False,
+        },
+        "suite3": {
+            "path": "tests/e2e/cucumber/features/smoke/{search,shares}/*.feature",
             "tikaNeeded": True,
         },
     }


### PR DESCRIPTION
split e2e tests. port #8528

<img width="469" alt="Screenshot 2024-03-12 at 21 13 54" src="https://github.com/owncloud/ocis/assets/84779829/3ce9b87e-e336-4db5-bc63-6421555b749c">

