### PR TITLE
[full-ci] chore: bump web to v9.0.0-alpha.2

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=f0ecc835614411bdad7ef4ad5624f175634944d9
+WEB_COMMITID=4210a0817386127d3345eaf5fd70a2e0d1ef9f99
 WEB_BRANCH=master

--- a/changelog/unreleased/update-web-9.0.0.md
+++ b/changelog/unreleased/update-web-9.0.0.md
@@ -1,0 +1,31 @@
+Enhancement: Update web to v9.0.0-alpha.2
+
+Tags: web
+
+We updated ownCloud Web to v9.0.0-alpha.2. Please refer to the changelog (linked) for details on the web release.
+
+## Summary
+* Bugfix [owncloud/web#10377](https://github.com/owncloud/web/pull/10377): User data not updated while altering own user
+* Bugfix [owncloud/web#10417](https://github.com/owncloud/web/pull/10417): Admin settings keyboard navigation
+* Bugfix [owncloud/web#10517](https://github.com/owncloud/web/pull/10517): Load thumbnail when postprocessing is finished
+* Bugfix [owncloud/web#10551](https://github.com/owncloud/web/pull/10551): Share sidebar icons
+* Change [owncloud/web#7338](https://github.com/owncloud/web/issues/7338): Remove deprecated code
+* Change [owncloud/web#9892](https://github.com/owncloud/web/issues/9892): Remove skeleton app
+* Change [owncloud/web#10102](https://github.com/owncloud/web/pull/10102): Remove deprecated extension point for adding quick actions
+* Change [owncloud/web#10122](https://github.com/owncloud/web/pull/10122): Remove homeFolder option
+* Change [owncloud/web#10210](https://github.com/owncloud/web/issues/10210): Vuex store removed
+* Change [owncloud/web#10240](https://github.com/owncloud/web/pull/10240): Remove ocs user
+* Change [owncloud/web#10330](https://github.com/owncloud/web/pull/10330): Registering app file editors
+* Enhancement [owncloud/web#9215](https://github.com/owncloud/web/issues/9215): Icon for .dcm files
+* Enhancement [owncloud/web#10207](https://github.com/owncloud/web/pull/10207): Enable user preferences in public links
+* Enhancement [owncloud/web#10334](https://github.com/owncloud/web/pull/10334): Move ThemeSwitcher into Account Settings
+* Enhancement [owncloud/web#10383](https://github.com/owncloud/web/issues/10383): Top loading bar increase visibility
+* Enhancement [owncloud/web#10390](https://github.com/owncloud/web/pull/10390): Integrate ToastUI editor in the text editor app
+* Enhancement [owncloud/web#10448](https://github.com/owncloud/web/pull/10448): Epub reader app
+* Enhancement [owncloud/web#10485](https://github.com/owncloud/web/pull/10485): Highlight search term in sharing autosuggest list
+* Enhancement [owncloud/web#10519](https://github.com/owncloud/web/pull/10519): Warn user before closing browser when upload is in progress
+* Enhancement [owncloud/web#10544](https://github.com/owncloud/web/pull/10544): Show locked and processing next to other status indicators
+* Enhancement [owncloud/web#10546](https://github.com/owncloud/web/pull/10546): Set emoji as space icon
+
+https://github.com/owncloud/ocis/pull/8634
+https://github.com/owncloud/web/releases/tag/v9.0.0-alpha.2

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v9.0.0-alpha.1
+WEB_ASSETS_VERSION = v9.0.0-alpha.2
 
 include ../../.make/recursion.mk
 

--- a/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
@@ -9,16 +9,3 @@ Please follow this format for the actual expected failures.
 Level-3 headings should be used for the references to the relevant issues. Include the issue title with a link to the issue in GitHub.
 
 Other free text and Markdown formatting can be used elsewhere in the document if needed. But if you want to explain something about the issue, then please post that in the issue itself.
-
-### [Exit page re-appears in loop when logged in user is deleted](https://github.com/owncloud/web/issues/4677)
-
-- [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
-- [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)
-
-### [restoring a file deleted from a received shared folder is not possible](https://github.com/owncloud/ocis/issues/1124)
-
-- [webUITrashbinRestore/trashbinRestore.feature:176](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature#L176)
-
-### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
-
-- [webUIUpload/upload.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L36)


### PR DESCRIPTION
Bumping web to `v9.0.0-alpha.2`