### PR TITLE
enhancement(sharing): Return space permissions when looking up space root

### DIFF
--- a/changelog/unreleased/sharing-ng-spacepermissions.md
+++ b/changelog/unreleased/sharing-ng-spacepermissions.md
@@ -1,0 +1,7 @@
+Enhancement: The graph endpoints for listing permission works for spaces now
+
+We enhanced the 'graph/v1beta1/drives/{{driveid}}/items/{{itemid}}/permissions' endpoint
+to list permission of the space when the 'itemid' refers to a space root.
+
+https://github.com/owncloud/ocis/pull/8642
+https://github.com/owncloud/ocis/issues/8352

--- a/services/graph/pkg/service/v0/driveitems_test.go
+++ b/services/graph/pkg/service/v0/driveitems_test.go
@@ -1027,7 +1027,7 @@ var _ = Describe("Driveitems", func() {
 		})
 
 		It("fails with wrong role", func() {
-			driveItemInvite.Roles = []string{unifiedrole.NewCoownerUnifiedRole().GetId()}
+			driveItemInvite.Roles = []string{unifiedrole.NewManagerUnifiedRole().GetId()}
 			svc.Invite(
 				rr,
 				httptest.NewRequest(http.MethodPost, "/", toJSONReader(driveItemInvite)).

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -916,6 +916,7 @@ func (g Graph) cs3PermissionsToLibreGraph(ctx context.Context, space *storagepro
 			} else {
 				identitySet.SetUser(identity)
 			}
+			p.SetId(identitySetToSpacePermissionID(identitySet))
 			p.SetGrantedToV2(identitySet)
 		}
 

--- a/services/graph/pkg/service/v0/graph_test.go
+++ b/services/graph/pkg/service/v0/graph_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tidwall/gjson"
 	"google.golang.org/grpc"
 
+	"github.com/cs3org/reva/v2/pkg/conversions"
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
@@ -520,16 +521,17 @@ var _ = Describe("Graph", func() {
 
 				check(jsonData)
 			},
-			Entry("injects grantedToV2", func(jsonData gjson.Result) {}, provider.ResourcePermissions{RemoveGrant: true}),
+			Entry("injects grantedToV2", func(jsonData gjson.Result) {},
+				*conversions.NewSpaceViewerRole().CS3ResourcePermissions()),
 			Entry("remaps manager role to the unified counterpart", func(jsonData gjson.Result) {
 				Expect(jsonData.Get("0.root.permissions.0.roles.0").Str).To(Equal(unifiedrole.UnifiedRoleManagerID))
-			}, provider.ResourcePermissions{RemoveGrant: true}),
+			}, *conversions.NewManagerRole().CS3ResourcePermissions()),
 			Entry("remaps editor role to the unified counterpart", func(jsonData gjson.Result) {
 				Expect(jsonData.Get("0.root.permissions.0.roles.0").Str).To(Equal(unifiedrole.UnifiedRoleSpaceEditorID))
-			}, provider.ResourcePermissions{InitiateFileUpload: true}),
+			}, *conversions.NewSpaceEditorRole().CS3ResourcePermissions()),
 			Entry("remaps viewer role to the unified counterpart", func(jsonData gjson.Result) {
 				Expect(jsonData.Get("0.root.permissions.0.roles.0").Str).To(Equal(unifiedrole.UnifiedRoleSpaceViewerID))
-			}, provider.ResourcePermissions{Stat: true}),
+			}, *conversions.NewSpaceViewerRole().CS3ResourcePermissions()),
 		)
 		Describe("Create Drive", func() {
 			It("cannot create a space without valid user in context", func() {

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -174,7 +174,7 @@ func (g Graph) GetUserDrive(w http.ResponseWriter, r *http.Request) {
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
-	spaces, err := g.formatDrives(ctx, webDavBaseURL, res.StorageSpaces)
+	spaces, err := g.formatDrives(ctx, webDavBaseURL, res.StorageSpaces, APIVersion_1)
 	if err != nil {
 		logger.Debug().Err(err).Msg("could not get personal drive: error parsing grpc response")
 		errorcode.GeneralException.Render(w, r, http.StatusInternalServerError, err.Error())
@@ -513,7 +513,7 @@ func (g Graph) GetUser(w http.ResponseWriter, r *http.Request) {
 			user.Drive = &libregraph.Drive{}
 		}
 		for _, sp := range lspr.GetStorageSpaces() {
-			d, err := g.cs3StorageSpaceToDrive(r.Context(), wdu, sp)
+			d, err := g.cs3StorageSpaceToDrive(r.Context(), wdu, sp, APIVersion_1)
 			if err != nil {
 				logger.Debug().Err(err).Interface("id", sp.Id).Msg("error converting space to drive")
 				continue

--- a/services/graph/pkg/service/v0/utils.go
+++ b/services/graph/pkg/service/v0/utils.go
@@ -131,6 +131,21 @@ func groupIdToIdentity(ctx context.Context, cache identity.IdentityCache, groupI
 	return identity, err
 }
 
+// identitySetToSpacePermissionID generates an Id for a permission from an identitySet. In libregraph
+// permissions need to have an id. For user share permission we just use the cs3 share id as the permission-id
+// As permissions on space to not map to a cs3 share we need something else of the ids. So we just
+// construct the id for the id of the user or group that the permission applies to and prefix that
+// with a "u:" for userids and "g:" for group ids.
+func identitySetToSpacePermissionID(identitySet libregraph.SharePointIdentitySet) (id string) {
+	switch {
+	case identitySet.HasUser():
+		id = "u:" + identitySet.User.GetId()
+	case identitySet.HasGroup():
+		id = "g:" + identitySet.Group.GetId()
+	}
+	return id
+}
+
 func cs3ReceivedSharesToDriveItems(ctx context.Context,
 	logger *log.Logger,
 	gatewayClient gateway.GatewayAPIClient,

--- a/services/graph/pkg/service/v0/utils.go
+++ b/services/graph/pkg/service/v0/utils.go
@@ -153,25 +153,6 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 	resharing bool,
 	receivedShares []*collaboration.ReceivedShare) ([]libregraph.DriveItem, error) {
 
-	// doStat is a helper function that stat a resource.
-	doStat := func(resourceId *storageprovider.ResourceId) (*storageprovider.StatResponse, error) {
-		shareStat, err := gatewayClient.Stat(ctx, &storageprovider.StatRequest{
-			Ref: &storageprovider.Reference{ResourceId: resourceId},
-		})
-		switch errCode := errorcode.FromCS3Status(shareStat.GetStatus(), err); {
-		case errCode == nil:
-			break
-		// skip ItemNotFound shares, they might have been deleted in the meantime or orphans.
-		case errCode.GetCode() == errorcode.ItemNotFound:
-			return nil, nil
-		default:
-			logger.Error().Err(errCode).Msg("could not stat")
-			return nil, errCode
-		}
-
-		return shareStat, nil
-	}
-
 	ch := make(chan libregraph.DriveItem)
 	group := new(errgroup.Group)
 	// Set max concurrency
@@ -188,79 +169,28 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 
 		group.Go(func() error {
 			var err error // redeclare
-			shareStat, err := doStat(receivedShares[0].GetShare().GetResourceId())
-			if shareStat == nil || err != nil {
+			shareStat, err := gatewayClient.Stat(ctx, &storageprovider.StatRequest{
+				Ref: &storageprovider.Reference{
+					ResourceId: receivedShares[0].GetShare().GetResourceId(),
+				},
+			})
+
+			switch errCode := errorcode.FromCS3Status(shareStat.GetStatus(), err); {
+			case errCode == nil:
+				break
+			// skip ItemNotFound shares, they might have been deleted in the meantime or orphans.
+			case errCode.GetCode() == errorcode.ItemNotFound:
+				return nil
+			default:
+				logger.Error().Err(errCode).Msg("could not stat")
+				return errCode
+			}
+
+			driveItem, err := fillDriveItemPropertiesFromReceivedShare(ctx, logger, identityCache,
+				resharing, receivedShares)
+			if err != nil {
 				return err
 			}
-
-			driveItem := libregraph.NewDriveItem()
-
-			permissions := make([]libregraph.Permission, 0, len(receivedShares))
-
-			var oldestReceivedShare *collaboration.ReceivedShare
-			for _, receivedShare := range receivedShares {
-				switch {
-				case oldestReceivedShare == nil:
-					fallthrough
-				case utils.TSToTime(receivedShare.GetShare().GetCtime()).Before(utils.TSToTime(oldestReceivedShare.GetShare().GetCtime())):
-					oldestReceivedShare = receivedShare
-				}
-
-				permission, err := cs3ReceivedShareToLibreGraphPermissions(ctx, logger, identityCache, resharing, receivedShare)
-				if err != nil {
-					return err
-				}
-
-				// If at least one of the shares was accepted, we consider the driveItem's synchronized
-				// flag enabled.
-				// Also we use the Mountpoint name of the first accepted mountpoint as the name of
-				// of the driveItem
-				if receivedShare.GetState() == collaboration.ShareState_SHARE_STATE_ACCEPTED {
-					driveItem.SetClientSynchronize(true)
-					if name := receivedShare.GetMountPoint().GetPath(); name != "" && driveItem.GetName() == "" {
-						driveItem.SetName(receivedShare.GetMountPoint().GetPath())
-					}
-				}
-
-				// if at least one share is marked as hidden, consider the whole driveItem to be hidden
-				if receivedShare.GetHidden() {
-					driveItem.SetUIHidden(true)
-				}
-
-				if userID := receivedShare.GetShare().GetCreator(); userID != nil {
-					identity, err := cs3UserIdToIdentity(ctx, identityCache, userID)
-					if err != nil {
-						logger.Warn().Err(err).Str("userid", userID.String()).Msg("could not get creator of the share")
-					}
-
-					permission.SetInvitation(
-						libregraph.SharingInvitation{
-							InvitedBy: &libregraph.IdentitySet{
-								User: &identity,
-							},
-						},
-					)
-				}
-				permissions = append(permissions, *permission)
-
-			}
-
-			// To stay compatible with the usershareprovider and the webdav
-			// service the id of the driveItem is composed of the StorageID and
-			// SpaceID of the sharestorage appended with the opaque ID of
-			// the oldest share for the resource:
-			// '<sharestorageid>$<sharespaceid>!<share-opaque-id>
-			// Note: This means that the driveitem ID will change when the oldest
-			//   share is removed. It would be good to have are more stable ID here (e.g.
-			//   derived from the shared resource's ID. But as we need to use the same
-			//   ID across all services this means we needed to make similar adjustments
-			//   to the sharejail (usershareprovider, webdav). Which we can't currently do
-			//   as some clients rely on the IDs used there having a special format.
-			driveItem.SetId(storagespace.FormatResourceID(storageprovider.ResourceId{
-				StorageId: utils.ShareStorageProviderID,
-				OpaqueId:  oldestReceivedShare.GetShare().GetId().GetOpaqueId(),
-				SpaceId:   utils.ShareStorageSpaceID,
-			}))
 
 			if !driveItem.HasUIHidden() {
 				driveItem.SetUIHidden(false)
@@ -272,7 +202,7 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 				}
 			}
 
-			remoteItem := libregraph.NewRemoteItem()
+			remoteItem := driveItem.RemoteItem
 			{
 				if id := shareStat.GetInfo().GetId(); id != nil {
 					remoteItem.SetId(storagespace.FormatResourceID(*id))
@@ -369,14 +299,6 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 					remoteItem.File = file
 					driveItem.File = file
 				}
-
-				if len(permissions) > 0 {
-					remoteItem.Permissions = permissions
-				}
-
-				if !reflect.ValueOf(*remoteItem).IsZero() {
-					driveItem.RemoteItem = remoteItem
-				}
 			}
 
 			ch <- *driveItem
@@ -398,6 +320,81 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 	}
 
 	return driveItems, err
+}
+
+func fillDriveItemPropertiesFromReceivedShare(ctx context.Context, logger *log.Logger,
+	identityCache identity.IdentityCache, resharing bool,
+	receivedShares []*collaboration.ReceivedShare) (*libregraph.DriveItem, error) {
+
+	driveItem := libregraph.NewDriveItem()
+	permissions := make([]libregraph.Permission, 0, len(receivedShares))
+
+	var oldestReceivedShare *collaboration.ReceivedShare
+	for _, receivedShare := range receivedShares {
+		switch {
+		case oldestReceivedShare == nil:
+			fallthrough
+		case utils.TSToTime(receivedShare.GetShare().GetCtime()).Before(utils.TSToTime(oldestReceivedShare.GetShare().GetCtime())):
+			oldestReceivedShare = receivedShare
+		}
+
+		permission, err := cs3ReceivedShareToLibreGraphPermissions(ctx, logger, identityCache, resharing, receivedShare)
+		if err != nil {
+			return driveItem, err
+		}
+
+		// If at least one of the shares was accepted, we consider the driveItem's synchronized
+		// flag enabled.
+		// Also we use the Mountpoint name of the first accepted mountpoint as the name for
+		// the driveItem
+		if receivedShare.GetState() == collaboration.ShareState_SHARE_STATE_ACCEPTED {
+			driveItem.SetClientSynchronize(true)
+			if name := receivedShare.GetMountPoint().GetPath(); name != "" && driveItem.GetName() == "" {
+				driveItem.SetName(receivedShare.GetMountPoint().GetPath())
+			}
+		}
+
+		// if at least one share is marked as hidden, consider the whole driveItem to be hidden
+		if receivedShare.GetHidden() {
+			driveItem.SetUIHidden(true)
+		}
+
+		if userID := receivedShare.GetShare().GetCreator(); userID != nil {
+			identity, err := cs3UserIdToIdentity(ctx, identityCache, userID)
+			if err != nil {
+				logger.Warn().Err(err).Str("userid", userID.String()).Msg("could not get creator of the share")
+			}
+
+			permission.SetInvitation(
+				libregraph.SharingInvitation{
+					InvitedBy: &libregraph.IdentitySet{
+						User: &identity,
+					},
+				},
+			)
+		}
+		permissions = append(permissions, *permission)
+		// To stay compatible with the usershareprovider and the webdav
+		// service the id of the driveItem is composed of the StorageID and
+		// SpaceID of the sharestorage appended with the opaque ID of
+		// the oldest share for the resource:
+		// '<sharestorageid>$<sharespaceid>!<share-opaque-id>
+		// Note: This means that the driveitem ID will change when the oldest
+		//   share is removed. It would be good to have are more stable ID here (e.g.
+		//   derived from the shared resource's ID. But as we need to use the same
+		//   ID across all services this means we needed to make similar adjustments
+		//   to the sharejail (usershareprovider, webdav). Which we can't currently do
+		//   as some clients rely on the IDs used there having a special format.
+		driveItem.SetId(storagespace.FormatResourceID(storageprovider.ResourceId{
+			StorageId: utils.ShareStorageProviderID,
+			OpaqueId:  oldestReceivedShare.GetShare().GetId().GetOpaqueId(),
+			SpaceId:   utils.ShareStorageSpaceID,
+		}))
+
+	}
+	driveItem.RemoteItem = libregraph.NewRemoteItem()
+	driveItem.RemoteItem.Permissions = permissions
+	return driveItem, nil
 }
 
 func cs3ReceivedShareToLibreGraphPermissions(ctx context.Context, logger *log.Logger,

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -23,8 +23,6 @@ const (
 	UnifiedRoleSpaceEditorID = "58c63c02-1d89-4572-916a-870abc5a1b7d"
 	// UnifiedRoleFileEditorID Unified role file editor id.
 	UnifiedRoleFileEditorID = "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
-	// UnifiedRoleCoownerID Unified role coowner id.
-	UnifiedRoleCoownerID = "3a4ba8e9-6a0d-4235-9140-0e7a34007abe"
 	// UnifiedRoleUploaderID Unified role uploader id.
 	UnifiedRoleUploaderID = "1c996275-f1c9-4e71-abdf-a42f6495e960"
 	// UnifiedRoleManagerID Unified role manager id.
@@ -143,23 +141,6 @@ func NewFileEditorUnifiedRole(sharing bool) *libregraph.UnifiedRoleDefinition {
 	}
 }
 
-// NewCoownerUnifiedRole creates a coowner role.
-func NewCoownerUnifiedRole() *libregraph.UnifiedRoleDefinition {
-	r := conversions.NewCoownerRole()
-	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleCoownerID),
-		Description: proto.String("Grants co-owner permissions on a resource"),
-		DisplayName: displayName(r),
-		RolePermissions: []libregraph.UnifiedRolePermission{
-			{
-				AllowedResourceActions: convert(r),
-				Condition:              proto.String(UnifiedRoleConditionOwner),
-			},
-		},
-		LibreGraphWeight: proto.Int32(0),
-	}
-}
-
 // NewUploaderUnifiedRole creates an uploader role
 func NewUploaderUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := conversions.NewUploaderRole()
@@ -214,7 +195,6 @@ func GetBuiltinRoleDefinitionList(resharing bool) []*libregraph.UnifiedRoleDefin
 		NewEditorUnifiedRole(resharing),
 		NewSpaceEditorUnifiedRole(),
 		NewFileEditorUnifiedRole(resharing),
-		NewCoownerUnifiedRole(),
 		NewUploaderUnifiedRole(),
 		NewManagerUnifiedRole(),
 	}
@@ -463,8 +443,6 @@ func displayName(role *conversions.Role) *string {
 		displayName = "Space Editor"
 	case conversions.RoleFileEditor:
 		displayName = "File Editor"
-	case conversions.RoleCoowner:
-		displayName = "Co Owner"
 	case conversions.RoleUploader:
 		displayName = "Uploader"
 	case conversions.RoleManager:

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -215,9 +215,10 @@ func GetBuiltinRoleDefinitionList(resharing bool) []*libregraph.UnifiedRoleDefin
 // GetApplicableRoleDefinitionsForActions returns a list of role definitions
 // that match the provided actions and constraints
 func GetApplicableRoleDefinitionsForActions(actions []string, constraints string, resharing, descending bool) []*libregraph.UnifiedRoleDefinition {
-	var definitions []*libregraph.UnifiedRoleDefinition
+	builtin := GetBuiltinRoleDefinitionList(resharing)
+	definitions := make([]*libregraph.UnifiedRoleDefinition, 0, len(builtin))
 
-	for _, definition := range GetBuiltinRoleDefinitionList(resharing) {
+	for _, definition := range builtin {
 		definitionMatch := true
 
 		for _, permission := range definition.GetRolePermissions() {

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -56,6 +56,18 @@ const (
 	DriveItemPermissionsDeny   = "libre.graph/driveItem/permissions/deny"
 )
 
+var legacyNames map[string]string = map[string]string{
+	UnifiedRoleViewerID: conversions.RoleViewer,
+	// one V1 api the "spaceviewer" role was call "viewer" and the "spaceeditor" was "editor",
+	// we need to stay compatible with that
+	UnifiedRoleSpaceViewerID: "viewer",
+	UnifiedRoleSpaceEditorID: "editor",
+	UnifiedRoleEditorID:      conversions.RoleEditor,
+	UnifiedRoleFileEditorID:  conversions.RoleFileEditor,
+	UnifiedRoleUploaderID:    conversions.RoleUploader,
+	UnifiedRoleManagerID:     conversions.RoleManager,
+}
+
 // NewViewerUnifiedRole creates a viewer role. `sharing` indicates if sharing permission should be added
 func NewViewerUnifiedRole(sharing bool) *libregraph.UnifiedRoleDefinition {
 	r := conversions.NewViewerRole(sharing)
@@ -381,6 +393,10 @@ func CS3ResourcePermissionsToLibregraphActions(p provider.ResourcePermissions) (
 		actions = append(actions, DriveItemPermissionsDeny)
 	}
 	return actions
+}
+
+func GetLegacyName(role libregraph.UnifiedRoleDefinition) string {
+	return legacyNames[role.GetId()]
 }
 
 // CS3ResourcePermissionsToUnifiedRole tries to find the UnifiedRoleDefinition that matches the supplied

--- a/services/graph/pkg/unifiedrole/unifiedrole_test.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole_test.go
@@ -27,7 +27,6 @@ var _ = Describe("unifiedroles", func() {
 		Entry(rConversions.RoleViewer, rConversions.NewViewerRole(true), unifiedrole.NewViewerUnifiedRole(true), unifiedrole.UnifiedRoleConditionGrantee),
 		Entry(rConversions.RoleEditor, rConversions.NewEditorRole(true), unifiedrole.NewEditorUnifiedRole(true), unifiedrole.UnifiedRoleConditionGrantee),
 		Entry(rConversions.RoleFileEditor, rConversions.NewFileEditorRole(true), unifiedrole.NewFileEditorUnifiedRole(true), unifiedrole.UnifiedRoleConditionGrantee),
-		Entry(rConversions.RoleCoowner, rConversions.NewCoownerRole(), unifiedrole.NewCoownerUnifiedRole(), unifiedrole.UnifiedRoleConditionOwner),
 		Entry(rConversions.RoleManager, rConversions.NewManagerRole(), unifiedrole.NewManagerUnifiedRole(), unifiedrole.UnifiedRoleConditionOwner),
 		Entry(rConversions.RoleSpaceViewer, rConversions.NewSpaceViewerRole(), unifiedrole.NewSpaceViewerUnifiedRole(), unifiedrole.UnifiedRoleConditionOwner),
 		Entry(rConversions.RoleSpaceEditor, rConversions.NewSpaceEditorRole(), unifiedrole.NewSpaceEditorUnifiedRole(), unifiedrole.UnifiedRoleConditionOwner),
@@ -53,7 +52,6 @@ var _ = Describe("unifiedroles", func() {
 		Entry(rConversions.RoleViewer, rConversions.NewViewerRole(true), unifiedrole.NewViewerUnifiedRole(true), true),
 		Entry(rConversions.RoleEditor, rConversions.NewEditorRole(true), unifiedrole.NewEditorUnifiedRole(true), true),
 		Entry(rConversions.RoleFileEditor, rConversions.NewFileEditorRole(true), unifiedrole.NewFileEditorUnifiedRole(true), true),
-		Entry(rConversions.RoleCoowner, rConversions.NewCoownerRole(), unifiedrole.NewCoownerUnifiedRole(), true),
 		Entry(rConversions.RoleManager, rConversions.NewManagerRole(), unifiedrole.NewManagerUnifiedRole(), true),
 		Entry("no match", rConversions.NewFileEditorRole(true), unifiedrole.NewManagerUnifiedRole(), false),
 	)
@@ -218,7 +216,6 @@ var _ = Describe("unifiedroles", func() {
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSpaceViewerUnifiedRole(),
 					unifiedrole.NewSpaceEditorUnifiedRole(),
-					unifiedrole.NewCoownerUnifiedRole(),
 					unifiedrole.NewManagerUnifiedRole(),
 				},
 			),

--- a/tests/acceptance/features/apiSharingNg/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg/listPermissions.feature
@@ -242,8 +242,8 @@ Feature: List a sharing permissions
         },
         "@libre.graph.permissions.roles.allowedValues": {
           "type": "array",
-          "minItems": 4,
-          "maxItems": 4,
+          "minItems": 3,
+          "maxItems": 3,
           "uniqueItems": true,
           "items": {
             "oneOf":  [
@@ -304,29 +304,6 @@ Feature: List a sharing permissions
                 "properties": {
                   "@libre.graph.weight": {
                     "const": 3
-                  },
-                  "description": {
-                    "const": "Grants co-owner permissions on a resource"
-                  },
-                  "displayName": {
-                    "const": "Co Owner"
-                  },
-                  "id": {
-                    "const": "3a4ba8e9-6a0d-4235-9140-0e7a34007abe"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "required": [
-                  "@libre.graph.weight",
-                  "description",
-                  "displayName",
-                  "id"
-                ],
-                "properties": {
-                  "@libre.graph.weight": {
-                    "const": 4
                   },
                   "description": {
                     "const": "Grants manager permissions on a resource. Semantically equivalent to co-owner"

--- a/tests/acceptance/features/apiSharingNg/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/shareInvitations.feature
@@ -1037,7 +1037,6 @@ Feature: Send a sharing invitations
       | File Editor      | /textfile1.txt |
       | Viewer           | FolderToShare  |
       | Editor           | FolderToShare  |
-      | Co Owner         | FolderToShare  |
       | Uploader         | FolderToShare  |
       | Manager          | FolderToShare  |
 
@@ -1546,11 +1545,9 @@ Feature: Send a sharing invitations
       """
     Examples:
       | permissions-role | path           |
-      | Co Owner         | /textfile1.txt |
       | Manager          | /textfile1.txt |
       | Space Viewer     | /textfile1.txt |
       | Space Editor     | /textfile1.txt |
-      | Co Owner         | FolderToShare  |
       | Manager          | FolderToShare  |
       | Space Viewer     | FolderToShare  |
       | Space Editor     | FolderToShare  |
@@ -1728,7 +1725,6 @@ Feature: Send a sharing invitations
       | permissions-role |
       | Space Viewer     |
       | Space Editor     |
-      | Co Owner         |
       | Manager          |
 
 
@@ -1775,7 +1771,6 @@ Feature: Send a sharing invitations
       | permissions-role |
       | Space Viewer     |
       | Space Editor     |
-      | Co Owner         |
       | Manager          |
 
 
@@ -1823,7 +1818,6 @@ Feature: Send a sharing invitations
       | permissions-role |
       | Space Viewer     |
       | Space Editor     |
-      | Co Owner         |
       | Manager          |
 
 
@@ -1908,7 +1902,6 @@ Feature: Send a sharing invitations
       | permissions-role |
       | Space Viewer     |
       | Space Editor     |
-      | Co Owner         |
       | Manager          |
 
 
@@ -1961,7 +1954,6 @@ Feature: Send a sharing invitations
       | permissions-role |
       | Space Viewer     |
       | Space Editor     |
-      | Co Owner         |
       | Manager          |
 
 
@@ -2015,7 +2007,6 @@ Feature: Send a sharing invitations
       | permissions-role |
       | Space Viewer     |
       | Space Editor     |
-      | Co Owner         |
       | Manager          |
 
 


### PR DESCRIPTION
Make `GET https://localhost:9200/graph/v1beta1/drives/{{driveid}}/items/{{itemid}}/permissions` work for spaceroots

This is still missing link permission on the space root. 