### PR TITLE
Disable Multiparts uploads

### DIFF
--- a/changelog/unreleased/non-default-multipartuploads.md
+++ b/changelog/unreleased/non-default-multipartuploads.md
@@ -1,0 +1,6 @@
+Bugfix: Disable Multipart uploads
+
+Disables multiparts uploads as they lead to high memory consumption
+
+https://github.com/owncloud/ocis/pull/8666
+

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -121,6 +121,7 @@ func DefaultConfig() *config.Config {
 				MaxAcquireLockCycles:       20,
 				MaxConcurrency:             5,
 				LockCycleDurationFactor:    30,
+				DisableMultipart:           true,
 			},
 			OCIS: config.OCISDriver{
 				MetadataBackend:            "messagepack",


### PR DESCRIPTION
Multipart uploads do cause extreme memory consumption