### PR TITLE
[full-ci] [tests-only] Added tests for PROPFIND as sharee for folder

### DIFF
--- a/tests/acceptance/features/apiSharingNg/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg/propfindShares.feature
@@ -11,7 +11,7 @@ Feature: propfind a shares
       | Carol    |
 
   @issue-4421
-  Scenario Outline: sharee PROPFIND a shares when multiple users share resource with same name
+  Scenario Outline: sharee PROPFIND same name shares shared by multiple users
     Given user "Alice" has uploaded file with content "to share" to "textfile.txt"
     And user "Alice" has created folder "folderToShare"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"

--- a/tests/acceptance/features/apiSharingNg/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg/propfindShares.feature
@@ -11,35 +11,37 @@ Feature: propfind a shares
       | Carol    |
 
   @issue-4421
-  Scenario: sharee PROPFIND a shares when multiple user shares resources with same name
+  Scenario Outline: sharee PROPFIND a shares when multiple users share resource with same name
     Given user "Alice" has uploaded file with content "to share" to "textfile.txt"
+    And user "Alice" has created folder "folderToShare"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
+    And user "Carol" has created folder "folderToShare"
     And user "Alice" has sent the following share invitation:
-      | resource        | textfile.txt |
-      | space           | Personal     |
-      | sharee          | Brian        |
-      | shareType       | user         |
-      | permissionsRole | Viewer       |
+      | resource        | <path>   |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
     And user "Carol" has sent the following share invitation:
-      | resource        | textfile.txt |
-      | space           | Personal     |
-      | sharee          | Brian        |
-      | shareType       | user         |
-      | permissionsRole | Viewer       |
+      | resource        | <path>   |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
     When user "Brian" sends PROPFIND request to space "Shares" using the WebDAV API
     Then the HTTP status code should be "207"
     And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
       | key       | value         |
       | oc:fileid | UUIDof:Shares |
     And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key              | value        |
-      | oc:name          | textfile.txt |
-      | oc:permissions   | SR           |
-      | oc:size          | 8            |
-      | d:getcontenttype | text/plain   |
+      | key            | value  |
+      | oc:name        | <path> |
+      | oc:permissions | SR     |
     And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key              | value            |
-      | oc:name          | textfile (1).txt |
-      | oc:permissions   | SR               |
-      | oc:size          | 8                |
-      | d:getcontenttype | text/plain       |
+      | key            | value   |
+      | oc:name        | <path2> |
+      | oc:permissions | SR      |
+    Examples:
+      | path          | path2             |
+      | textfile.txt  | textfile (1).txt  |
+      | folderToShare | folderToShare (1) |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
As sharee, PROPFIND the shares, when two users share resources with the same name using graph API.

Restructured the scenario so that it will cover the folder as well.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/8493
- Coverage for https://github.com/owncloud/ocis/issues/4421

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
