### PR TITLE
[full-ci] [tests-only] sharee PROPFINDs same name shares shared by multiple users

### DIFF
--- a/tests/acceptance/features/apiCors/cors.feature
+++ b/tests/acceptance/features/apiCors/cors.feature
@@ -83,6 +83,7 @@ Feature: CORS headers
 
   @issue-8231
   Scenario: CORS headers should be returned when setting CORS domain sending origin header in the Webdav api
+    Given using spaces DAV path
     When user "Alice" sends PROPFIND request to space "Alice Hansen" with headers using the WebDAV API
       | header | value               |
       | Origin | https://aphno.badal |

--- a/tests/acceptance/features/apiSharingNg/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg/propfindShares.feature
@@ -12,7 +12,8 @@ Feature: propfind a shares
 
   @issue-4421
   Scenario Outline: sharee PROPFIND same name shares shared by multiple users
-    Given user "Alice" has uploaded file with content "to share" to "textfile.txt"
+    Given using spaces DAV path
+    And user "Alice" has uploaded file with content "to share" to "textfile.txt"
     And user "Alice" has created folder "folderToShare"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
     And user "Carol" has created folder "folderToShare"
@@ -41,6 +42,46 @@ Feature: propfind a shares
       | key            | value   |
       | oc:name        | <path2> |
       | oc:permissions | SR      |
+    Examples:
+      | path          | path2             |
+      | textfile.txt  | textfile (1).txt  |
+      | folderToShare | folderToShare (1) |
+
+  @issue-4421
+  Scenario Outline: sharee PROPFIND same name shares shared by multiple users using new dav path
+    Given using new DAV path
+    And user "Alice" has uploaded file with content "to share" to "textfile.txt"
+    And user "Alice" has created folder "folderToShare"
+    And user "Carol" has uploaded file with content "to share" to "textfile.txt"
+    And user "Carol" has created folder "folderToShare"
+    And user "Alice" has sent the following share invitation:
+      | resource        | <path>   |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
+    And user "Carol" has sent the following share invitation:
+      | resource        | <path>   |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
+    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "Shares" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
+      | key       | value         |
+      | oc:fileid | UUIDof:Shares |
+      | oc:name   | Shares        |
+    And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
+      | key            | value         |
+      | oc:fileid      | UUIDof:<path> |
+      | oc:name        | <path>        |
+      | oc:permissions | SR            |
+    And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
+      | key            | value          |
+      | oc:fileid      | UUIDof:<path2> |
+      | oc:name        | <path2>        |
+      | oc:permissions | SR             |
     Examples:
       | path          | path2             |
       | textfile.txt  | textfile (1).txt  |

--- a/tests/acceptance/features/apiSharingNg/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg/propfindShares.feature
@@ -18,54 +18,54 @@ Feature: propfind a shares
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
     And user "Carol" has created folder "folderToShare"
     And user "Alice" has sent the following share invitation:
-      | resource        | <path>   |
-      | space           | Personal |
-      | sharee          | Brian    |
-      | shareType       | user     |
-      | permissionsRole | Viewer   |
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
     And user "Carol" has sent the following share invitation:
-      | resource        | <path>   |
-      | space           | Personal |
-      | sharee          | Brian    |
-      | shareType       | user     |
-      | permissionsRole | Viewer   |
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
     When user "Brian" sends PROPFIND request to space "Shares" using the WebDAV API
     Then the HTTP status code should be "207"
     And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
       | key       | value         |
       | oc:fileid | UUIDof:Shares |
     And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key            | value  |
-      | oc:name        | <path> |
-      | oc:permissions | SR     |
+      | key            | value      |
+      | oc:name        | <resource> |
+      | oc:permissions | SR         |
     And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key            | value   |
-      | oc:name        | <path2> |
-      | oc:permissions | SR      |
+      | key            | value        |
+      | oc:name        | <resource-2> |
+      | oc:permissions | SR           |
     Examples:
-      | path          | path2             |
+      | resource      | resource-2        |
       | textfile.txt  | textfile (1).txt  |
       | folderToShare | folderToShare (1) |
 
   @issue-4421
   Scenario Outline: sharee PROPFIND same name shares shared by multiple users using new dav path
-    Given using new DAV path
+    Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "to share" to "textfile.txt"
     And user "Alice" has created folder "folderToShare"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
     And user "Carol" has created folder "folderToShare"
     And user "Alice" has sent the following share invitation:
-      | resource        | <path>   |
-      | space           | Personal |
-      | sharee          | Brian    |
-      | shareType       | user     |
-      | permissionsRole | Viewer   |
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
     And user "Carol" has sent the following share invitation:
-      | resource        | <path>   |
-      | space           | Personal |
-      | sharee          | Brian    |
-      | shareType       | user     |
-      | permissionsRole | Viewer   |
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
     When user "Brian" sends PROPFIND request from the space "Shares" to the resource "Shares" using the WebDAV API
     Then the HTTP status code should be "207"
     And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
@@ -73,16 +73,18 @@ Feature: propfind a shares
       | oc:fileid | UUIDof:Shares |
       | oc:name   | Shares        |
     And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key            | value         |
-      | oc:fileid      | UUIDof:<path> |
-      | oc:name        | <path>        |
-      | oc:permissions | SR            |
+      | key            | value             |
+      | oc:fileid      | UUIDof:<resource> |
+      | oc:name        | <resource>        |
+      | oc:permissions | SR                |
     And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key            | value          |
-      | oc:fileid      | UUIDof:<path2> |
-      | oc:name        | <path2>        |
-      | oc:permissions | SR             |
+      | key            | value               |
+      | oc:fileid      | UUIDof:<resource-2> |
+      | oc:name        | <resource-2>        |
+      | oc:permissions | SR                  |
     Examples:
-      | path          | path2             |
-      | textfile.txt  | textfile (1).txt  |
-      | folderToShare | folderToShare (1) |
+      | dav-path-version | resource      | resource-2        |
+      | old              | textfile.txt  | textfile (1).txt  |
+      | old              | folderToShare | folderToShare (1) |
+      | new              | textfile.txt  | textfile (1).txt  |
+      | new              | folderToShare | folderToShare (1) |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3617,11 +3617,12 @@ class SpacesContext implements Context {
 
 	/**
 	 * @When /^user "([^"]*)" sends PROPFIND request from the space "([^"]*)" to the resource "([^"]*)" with depth "([^"]*)" using the WebDAV API$/
+	 * @When user :user sends PROPFIND request from the space :spaceName to the resource :resource using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $spaceName
 	 * @param string $resource
-	 * @param string $folderDepth
+	 * @param string|null $folderDepth
 	 *
 	 * @return void
 	 *
@@ -3629,7 +3630,7 @@ class SpacesContext implements Context {
 	 *
 	 * @throws GuzzleException
 	 */
-	public function userSendsPropfindRequestFromTheSpaceToTheResourceWithDepthUsingTheWebdavApi(string $user, string $spaceName, string $resource, string $folderDepth): void {
+	public function userSendsPropfindRequestFromTheSpaceToTheResourceWithDepthUsingTheWebdavApi(string $user, string $spaceName, string $resource, ?string $folderDepth = "1"): void {
 		$this->featureContext->setResponse(
 			$this->sendPropfindRequestToSpace($user, $spaceName, $resource, null, $folderDepth)
 		);
@@ -3705,7 +3706,7 @@ class SpacesContext implements Context {
 			$this->featureContext->getStepLineRef(),
 			$folderDepth,
 			"files",
-			WebDavHelper::DAV_VERSION_SPACES,
+			$this->featureContext->getDavPathVersion(),
 			null,
 			$headers
 		);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
As sharee, PROPFIND the shares using the `new` dav path, when two users share resources with the same name using graph API.

Added Scenario:
- `Scenario Outline: sharee PROPFIND same name shares shared by multiple users using new dav path`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/8493

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
