### PR TITLE
[full-ci] More work on spaces support for sharing-ng

### DIFF
--- a/services/graph/pkg/service/v0/driveitems.go
+++ b/services/graph/pkg/service/v0/driveitems.go
@@ -599,6 +599,10 @@ func (g Graph) Invite(w http.ResponseWriter, r *http.Request) {
 
 	if id := createShareResponse.GetShare().GetId().GetOpaqueId(); id != "" {
 		permission.Id = conversions.ToPointer(id)
+	} else if IsSpaceRoot(statResponse.GetInfo().GetId()) {
+		// permissions on a space root are not handled by a share manager so
+		// they don't get a shareid
+		permission.SetId(identitySetToSpacePermissionID(permission.GetGrantedToV2()))
 	}
 
 	if expiration := createShareResponse.GetShare().GetExpiration(); expiration != nil {

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -734,7 +734,7 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 	}
 	spaceID := storagespace.FormatResourceID(spaceRid)
 
-	permissions := g.cs3PermissionsToLibreGraph(ctx, space, apiVersion)
+	permissions := g.cs3SpacePermissionsToLibreGraph(ctx, space, apiVersion)
 
 	drive := &libregraph.Drive{
 		Id:   libregraph.PtrString(spaceID),
@@ -830,7 +830,7 @@ func (g Graph) cs3StorageSpaceToDrive(ctx context.Context, baseURL *url.URL, spa
 	return drive, nil
 }
 
-func (g Graph) cs3PermissionsToLibreGraph(ctx context.Context, space *storageprovider.StorageSpace, apiVersion APIVersion) []libregraph.Permission {
+func (g Graph) cs3SpacePermissionsToLibreGraph(ctx context.Context, space *storageprovider.StorageSpace, apiVersion APIVersion) []libregraph.Permission {
 	if space.Opaque == nil {
 		return nil
 	}


### PR DESCRIPTION
To add a space member:

```
curl --request POST \
  --url 'https://localhost:9200/graph/v1beta1/drives/0ec6cef0-9cd6-46a5-83ae-d4085a5f8a07$ae158e91-cb8b-45e0-ac9a-44ff5f6887d3/items/0ec6cef0-9cd6-46a5-83ae-d4085a5f8a07$ae158e91-cb8b-45e0-ac9a-44ff5f6887d3!ae158e91-cb8b-45e0-ac9a-44ff5f6887d3/invite' \
  --data '{
  "recipients": [
    {
      "@libre.graph.recipient.type": "user",
      "objectId": "4c510ada-c86b-4815-8820-42cdf82c3d51"
    }
  ],
  "roles": [ <roleid> ]
}'
```

gives the response:
```
{
  "value": [
    {
      "grantedToV2": {
        "user": {
          "displayName": "Albert Einstein",
          "id": "4c510ada-c86b-4815-8820-42cdf82c3d51"
        }
      },
      "id": "u:4c510ada-c86b-4815-8820-42cdf82c3d51",
      "roles": [
        "a8d5fe5e-96e3-418d-825b-534dbdf22b99"
      ]
    }
  ]
}
```

To remove a permission:
```
curl --request DELETE \
  --url 'https://localhost:9200/graph/v1beta1/drives/0ec6cef0-9cd6-46a5-83ae-d4085a5f8a07$ae158e91-cb8b-45e0-ac9a-44ff5f6887d3/items/0ec6cef0-9cd6-46a5-83ae-d4085a5f8a07$ae158e91-cb8b-45e0-ac9a-44ff5f6887d3!ae158e91-cb8b-45e0-ac9a-44ff5f6887d3/permissions/u:4c510ada-c86b-4815-8820-42cdf82c3d51'
```

The permission-id (last part of the URL) can be taken from the `GET https://localhost:9200/graph/v1beta1/drives/{{driveid}}/items/{{itemid}}/permissions` response.

This needs: https://github.com/cs3org/reva/pull/4585