### PR TITLE
set go version to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/owncloud/ocis/v2
 
-go 1.22
+go 1.22.0
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
## Description
Set go version including the patch release to avoid an [unfixed bug in go.](https://github.com/golang/go/issues/66175)

## Motivation and Context
After cleaning my go cache
```
go clean -modcache
go clean -cache
```
I couldn't build ocis anymore, `make generate` would stop with `ERR unable to parse packages error="err: exit status 1: stderr: go: downloading go1.22 (linux/amd64)\ngo: download go1.22 for linux/amd64: toolchain not available\n" dry-run=false version=v2.40.2`

setting the version in go.mod to `1.22.0` fixes the problem.
alternative workaround `GOTOOLCHAIN=go1.22.0 make generate`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run `make generate` locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
