### PR TITLE
fix: graph JSON error capitalization

### DIFF
--- a/changelog/unreleased/fix-graph-json-error-capitalization.md
+++ b/changelog/unreleased/fix-graph-json-error-capitalization.md
@@ -1,0 +1,6 @@
+Bugfix: Fix graph JSON error capitalization
+
+We fixed the graph service json error messages to be capitalized by default.
+
+https://github.com/owncloud/ocis/issues/8624
+https://github.com/owncloud/ocis/pulls/8732

--- a/services/graph/pkg/errorcode/errorcode.go
+++ b/services/graph/pkg/errorcode/errorcode.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
+	"github.com/huandu/xstrings"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 )
 
@@ -89,18 +90,18 @@ var errorCodes = [...]string{
 func New(e ErrorCode, msg string) Error {
 	return Error{
 		errorCode: e,
-		msg:       msg,
+		msg:       xstrings.FirstRuneToUpper(msg),
 	}
 }
 
 // Render writes an Graph ErrorCode	object to the response writer
 func (e ErrorCode) Render(w http.ResponseWriter, r *http.Request, status int, msg string) {
 	render.Status(r, status)
-	render.JSON(w, r, e.CreateOdataError(r.Context(), msg))
+	render.JSON(w, r, e.createOdataError(r.Context(), xstrings.FirstRuneToUpper(msg)))
 }
 
-// CreateOdataError creates and populates a Graph ErrorCode object
-func (e ErrorCode) CreateOdataError(ctx context.Context, msg string) *libregraph.OdataError {
+// createOdataError creates and populates a Graph ErrorCode object
+func (e ErrorCode) createOdataError(ctx context.Context, msg string) *libregraph.OdataError {
 	innererror := map[string]interface{}{
 		"date": time.Now().UTC().Format(time.RFC3339),
 	}
@@ -115,7 +116,7 @@ func (e ErrorCode) CreateOdataError(ctx context.Context, msg string) *libregraph
 	}
 }
 
-// Render writes an Graph Error object to the response writer
+// Render writes a Graph Error object to the response writer
 func (e Error) Render(w http.ResponseWriter, r *http.Request) {
 	var status int
 	switch e.errorCode {


### PR DESCRIPTION
## Description
change the graph service json error messages to be capitalized by default.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/8624

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
