### PR TITLE
[tests-only] increase e2e pipeline by 1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -142,7 +142,7 @@ config = {
     "e2eTests": {
         "basic": {
             "skip": False,
-            "totalParts": 3,  # divide and run all suites in parts (divide pipelines)
+            "totalParts": 4,  # divide and run all suites in parts (divide pipelines)
             "xsuites": ["search", "app-provider"],  # suites to skip
         },
         "search": {


### PR DESCRIPTION
## Description
One of the e2e pipelines has ~20 mins of execution time. increasing the pipeline so that it balances out

Before:
![Screenshot from 2024-03-27 10-08-04](https://github.com/owncloud/ocis/assets/52366632/e811a6eb-d98b-413f-811b-043edcf8fb30)

Now:
![Screenshot from 2024-03-27 11-12-46](https://github.com/owncloud/ocis/assets/52366632/40218242-3eed-4eaf-ac46-dd47d04893ac)


## Related Issue


## Motivation and Context

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
