### PR TITLE
enhancement: add Graph API Token Information Endpoint

### DIFF
--- a/services/graph/pkg/middleware/auth.go
+++ b/services/graph/pkg/middleware/auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	opkgm "github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/errorcode"
+	"github.com/owncloud/ocis/v2/services/proxy/pkg/middleware"
 )
 
 // authOptions initializes the available default options.
@@ -41,6 +42,12 @@ func Auth(opts ...account.Option) func(http.Handler) http.Handler {
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			if middleware.IsPublicPath(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			ctx := r.Context()
 			t := r.Header.Get("x-access-token")
 			if t == "" {

--- a/services/graph/pkg/service/v0/api_drives_drive_item.go
+++ b/services/graph/pkg/service/v0/api_drives_drive_item.go
@@ -270,7 +270,7 @@ func (api DrivesDriveItemApi) CreateDriveItem(w http.ResponseWriter, r *http.Req
 	ctx := r.Context()
 	driveID, err := parseIDParam(r, "driveID")
 	if err != nil {
-		api.logger.Debug().Err(err).Msg("invlid driveID")
+		api.logger.Debug().Err(err).Msg("invalid driveID")
 		errorcode.InvalidRequest.Render(w, r, http.StatusUnprocessableEntity, "invalid driveID")
 		return
 	}

--- a/services/graph/pkg/service/v0/api_extensions_org_libregraph_info.go
+++ b/services/graph/pkg/service/v0/api_extensions_org_libregraph_info.go
@@ -1,0 +1,126 @@
+package svc
+
+import (
+	"context"
+	"net/http"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/cs3org/reva/v2/pkg/conversions"
+	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/errorcode"
+)
+
+// TemporaryTokenInfoResponse is a response struct for the TokenInfo method,
+// it will go away once its part of the libregraph API
+type TemporaryTokenInfoResponse struct {
+	ID          string `json:"id"`
+	HasPassword bool   `json:"has_password"`
+	IsInternal  bool   `json:"is_internal"`
+}
+
+// ExtensionsOrgLibregraphInfoProvider is the interface that defines all methods that are needed to provide the information
+type ExtensionsOrgLibregraphInfoProvider interface {
+	TokenInfo(ctx context.Context, token, password string) (TemporaryTokenInfoResponse, error)
+}
+
+// ExtensionsOrgLibregraphInfoService implements the libregraph API
+type ExtensionsOrgLibregraphInfoService struct {
+	logger          log.Logger
+	gatewaySelector pool.Selectable[gateway.GatewayAPIClient]
+}
+
+// NewExtensionsOrgLibregraphInfoService initializes a new libregraph service
+func NewExtensionsOrgLibregraphInfoService(logger log.Logger, gatewaySelector pool.Selectable[gateway.GatewayAPIClient]) (ExtensionsOrgLibregraphInfoService, error) {
+	return ExtensionsOrgLibregraphInfoService{
+		logger:          log.Logger{Logger: logger.With().Str("graph api", "ExtensionsOrgLibregraphInfoService").Logger()},
+		gatewaySelector: gatewaySelector,
+	}, nil
+}
+
+// TokenInfo returns information about a token
+func (s ExtensionsOrgLibregraphInfoService) TokenInfo(ctx context.Context, token, password string) (TemporaryTokenInfoResponse, error) {
+	gatewayClient, err := s.gatewaySelector.Next()
+	if err != nil {
+		return TemporaryTokenInfoResponse{}, err
+	}
+
+	authenticateResponse, err := gatewayClient.Authenticate(ctx, &gateway.AuthenticateRequest{
+		Type:         "publicshares",
+		ClientId:     token,
+		ClientSecret: "password|" + password,
+	})
+	// could authenticateResponse be a nil?
+	if errCode := errorcode.FromCS3Status(authenticateResponse.GetStatus(), err); errCode != nil {
+		return TemporaryTokenInfoResponse{}, errCode
+	}
+
+	ctx = ctxpkg.ContextSetToken(ctx, authenticateResponse.GetToken())
+	ctx = ctxpkg.ContextSetUser(ctx, authenticateResponse.GetUser())
+	ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, authenticateResponse.GetToken())
+
+	getPublicShareResponse, err := gatewayClient.GetPublicShare(
+		ctx,
+		&link.GetPublicShareRequest{
+			Ref: &link.PublicShareReference{
+				Spec: &link.PublicShareReference_Token{
+					Token: token,
+				},
+			},
+		},
+	)
+	if errCode := errorcode.FromCS3Status(getPublicShareResponse.GetStatus(), err); errCode != nil {
+		return TemporaryTokenInfoResponse{}, errCode
+	}
+
+	return TemporaryTokenInfoResponse{
+		ID:          storagespace.FormatResourceID(*getPublicShareResponse.Share.GetResourceId()),
+		HasPassword: getPublicShareResponse.GetShare().GetPasswordProtected(),
+		IsInternal: func() bool {
+			return conversions.RoleFromResourcePermissions(getPublicShareResponse.Share.Permissions.GetPermissions(), true).OCSPermissions() == 0
+		}(),
+	}, nil
+}
+
+// ExtensionsOrgLibregraphInfoApi is the API that exposes the extensions libregraph info API
+type ExtensionsOrgLibregraphInfoApi struct {
+	logger                              log.Logger
+	extensionsOrgLibregraphInfoProvider ExtensionsOrgLibregraphInfoProvider
+}
+
+// NewExtensionsOrgLibregraphInfoApi initializes a new libregraph info API
+func NewExtensionsOrgLibregraphInfoApi(extensionsOrgLibregraphInfoProvider ExtensionsOrgLibregraphInfoProvider, logger log.Logger) (ExtensionsOrgLibregraphInfoApi, error) {
+	return ExtensionsOrgLibregraphInfoApi{
+		logger:                              log.Logger{Logger: logger.With().Str("graph api", "ExtensionsOrgLibregraphInfoApi").Logger()},
+		extensionsOrgLibregraphInfoProvider: extensionsOrgLibregraphInfoProvider,
+	}, nil
+}
+
+// TokenInfo returns information about a token
+func (api ExtensionsOrgLibregraphInfoApi) TokenInfo(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		api.logger.Debug().Msg("no token provided")
+		errorcode.InvalidRequest.Render(w, r, http.StatusUnprocessableEntity, "no token provided")
+		return
+	}
+
+	_, pw, _ := r.BasicAuth()
+	tokenInfo, err := api.extensionsOrgLibregraphInfoProvider.TokenInfo(r.Context(), token, pw)
+	if err != nil {
+		msg := "could not get token info"
+		api.logger.Debug().Err(err).Msg(msg)
+		errorcode.InvalidRequest.Render(w, r, http.StatusFailedDependency, msg)
+		return
+	}
+
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, tokenInfo)
+}

--- a/services/graph/pkg/service/v0/api_extensions_org_libregraph_info.go
+++ b/services/graph/pkg/service/v0/api_extensions_org_libregraph_info.go
@@ -6,6 +6,7 @@ import (
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"google.golang.org/grpc/metadata"
@@ -21,14 +22,37 @@ import (
 // TemporaryTokenInfoResponse is a response struct for the TokenInfo method,
 // it will go away once its part of the libregraph API
 type TemporaryTokenInfoResponse struct {
-	ID          string `json:"id"`
-	HasPassword bool   `json:"has_password"`
-	IsInternal  bool   `json:"is_internal"`
+	ID          string `json:"id,omitempty"`
+	HasPassword bool   `json:"hasPassword"`
+	IsInternal  bool   `json:"isInternal"`
 }
 
 // ExtensionsOrgLibregraphInfoProvider is the interface that defines all methods that are needed to provide the information
 type ExtensionsOrgLibregraphInfoProvider interface {
-	TokenInfo(ctx context.Context, token, password string) (TemporaryTokenInfoResponse, error)
+	TokenInfo(ctx context.Context, infoToken, password string) (TemporaryTokenInfoResponse, error)
+}
+
+// ExtensionsOrgLibregraphInfoServiceOptions defines the required parameters to create a new libregraph info service
+type ExtensionsOrgLibregraphInfoServiceOptions struct {
+	logger          log.Logger
+	gatewaySelector pool.Selectable[gateway.GatewayAPIClient]
+}
+
+// validate checks if the required parameters are set
+func (o ExtensionsOrgLibregraphInfoServiceOptions) validate() error {
+	return nil
+}
+
+// WithLogger sets the logger option
+func (o ExtensionsOrgLibregraphInfoServiceOptions) WithLogger(logger log.Logger) ExtensionsOrgLibregraphInfoServiceOptions {
+	o.logger = log.Logger{Logger: logger.With().Str("graph api", "ExtensionsOrgLibregraphInfoService").Logger()}
+	return o
+}
+
+// WithGatewaySelector sets the gatewaySelector option
+func (o ExtensionsOrgLibregraphInfoServiceOptions) WithGatewaySelector(gatewaySelector pool.Selectable[gateway.GatewayAPIClient]) ExtensionsOrgLibregraphInfoServiceOptions {
+	o.gatewaySelector = gatewaySelector
+	return o
 }
 
 // ExtensionsOrgLibregraphInfoService implements the libregraph API
@@ -38,15 +62,15 @@ type ExtensionsOrgLibregraphInfoService struct {
 }
 
 // NewExtensionsOrgLibregraphInfoService initializes a new libregraph service
-func NewExtensionsOrgLibregraphInfoService(logger log.Logger, gatewaySelector pool.Selectable[gateway.GatewayAPIClient]) (ExtensionsOrgLibregraphInfoService, error) {
+func NewExtensionsOrgLibregraphInfoService(options ExtensionsOrgLibregraphInfoServiceOptions) (ExtensionsOrgLibregraphInfoService, error) {
 	return ExtensionsOrgLibregraphInfoService{
-		logger:          log.Logger{Logger: logger.With().Str("graph api", "ExtensionsOrgLibregraphInfoService").Logger()},
-		gatewaySelector: gatewaySelector,
-	}, nil
+		logger:          options.logger,
+		gatewaySelector: options.gatewaySelector,
+	}, options.validate()
 }
 
 // TokenInfo returns information about a token
-func (s ExtensionsOrgLibregraphInfoService) TokenInfo(ctx context.Context, token, password string) (TemporaryTokenInfoResponse, error) {
+func (s ExtensionsOrgLibregraphInfoService) TokenInfo(ctx context.Context, infoToken, password string) (TemporaryTokenInfoResponse, error) {
 	gatewayClient, err := s.gatewaySelector.Next()
 	if err != nil {
 		return TemporaryTokenInfoResponse{}, err
@@ -54,24 +78,29 @@ func (s ExtensionsOrgLibregraphInfoService) TokenInfo(ctx context.Context, token
 
 	authenticateResponse, err := gatewayClient.Authenticate(ctx, &gateway.AuthenticateRequest{
 		Type:         "publicshares",
-		ClientId:     token,
+		ClientId:     infoToken,
 		ClientSecret: "password|" + password,
 	})
-	// could authenticateResponse be a nil?
-	if errCode := errorcode.FromCS3Status(authenticateResponse.GetStatus(), err); errCode != nil {
+	switch errCode := errorcode.FromCS3Status(authenticateResponse.GetStatus(), err); {
+	case errCode == nil:
+		break
+	// AccessDenied is a special case, we need to return the password-protected status
+	case errCode.GetCode() == errorcode.AccessDenied:
+		return TemporaryTokenInfoResponse{HasPassword: true}, nil
+	default:
 		return TemporaryTokenInfoResponse{}, errCode
 	}
 
-	ctx = ctxpkg.ContextSetToken(ctx, authenticateResponse.GetToken())
-	ctx = ctxpkg.ContextSetUser(ctx, authenticateResponse.GetUser())
-	ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, authenticateResponse.GetToken())
+	createdCTX := ctxpkg.ContextSetToken(context.Background(), authenticateResponse.GetToken())
+	createdCTX = ctxpkg.ContextSetUser(createdCTX, authenticateResponse.GetUser())
+	createdCTX = metadata.AppendToOutgoingContext(createdCTX, ctxpkg.TokenHeader, authenticateResponse.GetToken())
 
 	getPublicShareResponse, err := gatewayClient.GetPublicShare(
-		ctx,
+		createdCTX,
 		&link.GetPublicShareRequest{
 			Ref: &link.PublicShareReference{
 				Spec: &link.PublicShareReference_Token{
-					Token: token,
+					Token: infoToken,
 				},
 			},
 		},
@@ -80,13 +109,60 @@ func (s ExtensionsOrgLibregraphInfoService) TokenInfo(ctx context.Context, token
 		return TemporaryTokenInfoResponse{}, errCode
 	}
 
-	return TemporaryTokenInfoResponse{
+	temporaryTokenInfoResponse := TemporaryTokenInfoResponse{
 		ID:          storagespace.FormatResourceID(*getPublicShareResponse.Share.GetResourceId()),
 		HasPassword: getPublicShareResponse.GetShare().GetPasswordProtected(),
 		IsInternal: func() bool {
 			return conversions.RoleFromResourcePermissions(getPublicShareResponse.Share.Permissions.GetPermissions(), true).OCSPermissions() == 0
 		}(),
-	}, nil
+	}
+
+	if !temporaryTokenInfoResponse.IsInternal {
+		return temporaryTokenInfoResponse, nil
+	}
+
+	statResponse, err := gatewayClient.Stat(
+		ctx,
+		&storageprovider.StatRequest{
+			Ref: &storageprovider.Reference{
+				ResourceId: getPublicShareResponse.GetShare().GetResourceId(),
+			},
+		},
+	)
+	switch errCode := errorcode.FromCS3Status(statResponse.GetStatus(), err); {
+	case errCode == nil:
+		break
+	case errCode.GetCode() == errorcode.ItemNotFound:
+		temporaryTokenInfoResponse.ID = ""
+		return temporaryTokenInfoResponse, nil
+	default:
+		return TemporaryTokenInfoResponse{}, errCode
+	}
+
+	return temporaryTokenInfoResponse, err
+}
+
+// ExtensionsOrgLibregraphInfoApiOptions defines the required parameters to create a new libregraph info API
+type ExtensionsOrgLibregraphInfoApiOptions struct {
+	logger                              log.Logger
+	extensionsOrgLibregraphInfoProvider ExtensionsOrgLibregraphInfoProvider
+}
+
+// validate checks if the required parameters are set
+func (o ExtensionsOrgLibregraphInfoApiOptions) validate() error {
+	return nil
+}
+
+// WithLogger sets the logger option
+func (o ExtensionsOrgLibregraphInfoApiOptions) WithLogger(logger log.Logger) ExtensionsOrgLibregraphInfoApiOptions {
+	o.logger = log.Logger{Logger: logger.With().Str("graph api", "ExtensionsOrgLibregraphInfoApi").Logger()}
+	return o
+}
+
+// WithExtensionsOrgLibregraphInfoProvider sets the extensionsOrgLibregraphInfoProvider option
+func (o ExtensionsOrgLibregraphInfoApiOptions) WithExtensionsOrgLibregraphInfoProvider(extensionsOrgLibregraphInfoProvider ExtensionsOrgLibregraphInfoProvider) ExtensionsOrgLibregraphInfoApiOptions {
+	o.extensionsOrgLibregraphInfoProvider = extensionsOrgLibregraphInfoProvider
+	return o
 }
 
 // ExtensionsOrgLibregraphInfoApi is the API that exposes the extensions libregraph info API
@@ -96,24 +172,24 @@ type ExtensionsOrgLibregraphInfoApi struct {
 }
 
 // NewExtensionsOrgLibregraphInfoApi initializes a new libregraph info API
-func NewExtensionsOrgLibregraphInfoApi(extensionsOrgLibregraphInfoProvider ExtensionsOrgLibregraphInfoProvider, logger log.Logger) (ExtensionsOrgLibregraphInfoApi, error) {
+func NewExtensionsOrgLibregraphInfoApi(options ExtensionsOrgLibregraphInfoApiOptions) (ExtensionsOrgLibregraphInfoApi, error) {
 	return ExtensionsOrgLibregraphInfoApi{
-		logger:                              log.Logger{Logger: logger.With().Str("graph api", "ExtensionsOrgLibregraphInfoApi").Logger()},
-		extensionsOrgLibregraphInfoProvider: extensionsOrgLibregraphInfoProvider,
-	}, nil
+		logger:                              options.logger,
+		extensionsOrgLibregraphInfoProvider: options.extensionsOrgLibregraphInfoProvider,
+	}, options.validate()
 }
 
 // TokenInfo returns information about a token
 func (api ExtensionsOrgLibregraphInfoApi) TokenInfo(w http.ResponseWriter, r *http.Request) {
-	token := chi.URLParam(r, "token")
-	if token == "" {
+	infoToken := chi.URLParam(r, "token")
+	if infoToken == "" {
 		api.logger.Debug().Msg("no token provided")
 		errorcode.InvalidRequest.Render(w, r, http.StatusUnprocessableEntity, "no token provided")
 		return
 	}
 
 	_, pw, _ := r.BasicAuth()
-	tokenInfo, err := api.extensionsOrgLibregraphInfoProvider.TokenInfo(r.Context(), token, pw)
+	tokenInfo, err := api.extensionsOrgLibregraphInfoProvider.TokenInfo(r.Context(), infoToken, pw)
 	if err != nil {
 		msg := "could not get token info"
 		api.logger.Debug().Err(err).Msg(msg)

--- a/services/graph/pkg/service/v0/api_extensions_org_libregraph_info_test.go
+++ b/services/graph/pkg/service/v0/api_extensions_org_libregraph_info_test.go
@@ -1,0 +1,129 @@
+package svc_test
+
+import (
+	"context"
+	"errors"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	linkv1beta1 "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc"
+
+	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+
+	"github.com/owncloud/ocis/v2/services/graph/pkg/errorcode"
+
+	cs3mocks "github.com/cs3org/reva/v2/tests/cs3mocks/mocks"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/graph/mocks"
+	svc "github.com/owncloud/ocis/v2/services/graph/pkg/service/v0"
+)
+
+var _ = Describe("ExtensionsOrgLibregraphInfoService", func() {
+	var (
+		service         svc.ExtensionsOrgLibregraphInfoService
+		gatewayClient   *cs3mocks.GatewayAPIClient
+		gatewaySelector *mocks.Selectable[gateway.GatewayAPIClient]
+	)
+	BeforeEach(func() {
+		logger := log.NewLogger()
+		gatewayClient = cs3mocks.NewGatewayAPIClient(GinkgoT())
+
+		gatewaySelector = mocks.NewSelectable[gateway.GatewayAPIClient](GinkgoT())
+		gatewaySelector.On("Next").Return(gatewayClient, nil)
+
+		extensionsOrgLibregraphInfoService, err := svc.NewExtensionsOrgLibregraphInfoService(
+			svc.ExtensionsOrgLibregraphInfoServiceOptions{}.
+				WithLogger(logger).
+				WithGatewaySelector(gatewaySelector),
+		)
+		Expect(err).ToNot(HaveOccurred())
+		service = extensionsOrgLibregraphInfoService
+	})
+
+	Describe("TokenInfo", func() {
+		It("exits if the next gatewayClient cannot be obtained", func() {
+			gatewaySelector.ExpectedCalls = nil
+
+			expectedError := errors.New("obtaining next gatewayClient failed")
+			gatewaySelector.On("Next").Return(gatewayClient, expectedError)
+
+			_, err := service.TokenInfo(context.Background(), "", "")
+			Expect(err).To(MatchError(expectedError))
+		})
+		It("authorizes the request with correct parameters", func() {
+			gatewayClient.
+				On("Authenticate", mock.Anything, mock.Anything).
+				Return(func(ctx context.Context, r *gateway.AuthenticateRequest, _ ...grpc.CallOption) (*gateway.AuthenticateResponse, error) {
+					Expect(r.Type).To(Equal("publicshares"))
+					Expect(r.ClientId).To(Equal("123"))
+					Expect(r.ClientSecret).To(Equal("password|456"))
+					return nil, nil
+				})
+
+			_, _ = service.TokenInfo(context.Background(), "123", "456")
+		})
+		It("exits the Authorization fails", func() {
+			expectedError := errorcode.New(errorcode.GeneralException, "authorization failed")
+			gatewayClient.
+				On("Authenticate", mock.Anything, mock.Anything).
+				Return(&gateway.AuthenticateResponse{}, errors.New("authorization failed"))
+
+			r, err := service.TokenInfo(context.Background(), "", "")
+			Expect(err).To(MatchError(&expectedError))
+			Expect(r.ID).To(Equal(""))
+			Expect(r.IsInternal).To(BeFalse())
+			Expect(r.HasPassword).To(BeFalse())
+		})
+		It("reports an info response with required password if the permission is denied", func() {
+			gatewayClient.
+				On("Authenticate", mock.Anything, mock.Anything).
+				Return(&gateway.AuthenticateResponse{
+					Status: &rpcv1beta1.Status{
+						Code: rpcv1beta1.Code_CODE_PERMISSION_DENIED,
+					},
+				}, nil)
+
+			r, err := service.TokenInfo(context.Background(), "", "")
+			Expect(err).To(BeNil())
+			Expect(r.ID).To(Equal(""))
+			Expect(r.IsInternal).To(BeFalse())
+			Expect(r.HasPassword).To(BeTrue())
+		})
+		It("uses proper authentication for the share lookup", func() {
+			gatewayClient.
+				On("Authenticate", mock.Anything, mock.Anything).
+				Return(&gateway.AuthenticateResponse{
+					Status: &rpcv1beta1.Status{
+						Code: rpcv1beta1.Code_CODE_OK,
+					},
+					Token: "token",
+					User: &userv1beta1.User{
+						Username: "username",
+					},
+				}, nil)
+
+			gatewayClient.
+				On("GetPublicShare", mock.Anything, mock.Anything).
+				Return(func(ctx context.Context, r *linkv1beta1.GetPublicShareRequest, opts ...grpc.CallOption) (*linkv1beta1.GetPublicShareResponse, error) {
+					u, _ := ctxpkg.ContextGetUser(ctx)
+					Expect(u.GetUsername()).To(Equal("username"))
+					t, _ := ctxpkg.ContextGetToken(ctx)
+					Expect(t).To(Equal("token"))
+					Expect(r.GetRef().GetToken()).To(Equal("token"))
+					return nil, nil
+				})
+
+			_, _ = service.TokenInfo(context.Background(), "", "")
+		})
+		It("exits if the share lookup fails", func() {})
+		It("returns the information for non internal shares", func() {})
+		It("exits if the stat for internal shares fails", func() {})
+		It("removes the info id field if the requested share is not found", func() {})
+		It("retruns all the information for internal shares", func() {})
+	})
+})

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/store"
-
 	ocisldap "github.com/owncloud/ocis/v2/ocis-pkg/ldap"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/ocis-pkg/roles"
@@ -219,12 +218,20 @@ func NewService(opts ...Option) (Graph, error) {
 
 	var extensionsOrgLibregraphInfoApi ExtensionsOrgLibregraphInfoApi
 	{
-		extensionsOrgLibregraphInfoService, err := NewExtensionsOrgLibregraphInfoService(options.Logger, options.GatewaySelector)
+		extensionsOrgLibregraphInfoService, err := NewExtensionsOrgLibregraphInfoService(
+			ExtensionsOrgLibregraphInfoServiceOptions{}.
+				WithLogger(options.Logger).
+				WithGatewaySelector(options.GatewaySelector),
+		)
 		if err != nil {
 			return svc, err
 		}
 
-		extensionsOrgLibregraphInfoApi, err = NewExtensionsOrgLibregraphInfoApi(extensionsOrgLibregraphInfoService, options.Logger)
+		extensionsOrgLibregraphInfoApi, err = NewExtensionsOrgLibregraphInfoApi(
+			ExtensionsOrgLibregraphInfoApiOptions{}.
+				WithLogger(options.Logger).
+				WithExtensionsOrgLibregraphInfoProvider(extensionsOrgLibregraphInfoService),
+		)
 		if err != nil {
 			return svc, err
 		}
@@ -236,7 +243,8 @@ func NewService(opts ...Option) (Graph, error) {
 		r.Route("/v1beta1", func(r chi.Router) {
 			r.Route("/extensions/org.libregraph", func(r chi.Router) {
 				r.Route("/info", func(r chi.Router) {
-					r.Get("/token/{token}", extensionsOrgLibregraphInfoApi.TokenInfo)
+					r.Get("/token/protected/{token}", extensionsOrgLibregraphInfoApi.TokenInfo)
+					r.Get("/token/unprotected/{token}", extensionsOrgLibregraphInfoApi.TokenInfo)
 				})
 			})
 			r.Route("/me", func(r chi.Router) {

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -7,11 +7,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/owncloud/ocis/v2/services/proxy/pkg/router"
-	"github.com/owncloud/ocis/v2/services/proxy/pkg/webdav"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	"github.com/owncloud/ocis/v2/services/proxy/pkg/router"
+	"github.com/owncloud/ocis/v2/services/proxy/pkg/webdav"
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 		"/remote.php/dav/public-files/",
 		"/ocs/v1.php/apps/files_sharing/api/v1/tokeninfo/unprotected",
 		"/ocs/v2.php/apps/files_sharing/api/v1/tokeninfo/unprotected",
+		"/graph/v1beta1/extensions/org.libregraph/info/token",
 		"/ocs/v1.php/cloud/capabilities",
 	}
 )
@@ -78,7 +80,7 @@ func Authentication(auths []Authenticator, opts ...Option) func(next http.Handle
 					return
 				}
 			}
-			if !isPublicPath(r.URL.Path) {
+			if !IsPublicPath(r.URL.Path) {
 				// Failed basic authentication attempts receive the Www-Authenticate header in the response
 				var touch bool
 				caser := cases.Title(language.Und)
@@ -131,7 +133,8 @@ func isOIDCTokenAuth(req *http.Request) bool {
 	return req.URL.Path == "/konnect/v1/token"
 }
 
-func isPublicPath(p string) bool {
+// IsPublicPath checks if a given path is public.
+func IsPublicPath(p string) bool {
 	for _, pp := range _publicPaths {
 		if strings.HasPrefix(p, pp) {
 			return true

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -32,7 +32,7 @@ var (
 		"/remote.php/dav/public-files/",
 		"/ocs/v1.php/apps/files_sharing/api/v1/tokeninfo/unprotected",
 		"/ocs/v2.php/apps/files_sharing/api/v1/tokeninfo/unprotected",
-		"/graph/v1beta1/extensions/org.libregraph/info/token",
+		"/graph/v1beta1/extensions/org.libregraph/info/token/unprotected",
 		"/ocs/v1.php/cloud/capabilities",
 	}
 )

--- a/services/proxy/pkg/middleware/authentication_test.go
+++ b/services/proxy/pkg/middleware/authentication_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 var _ = Describe("authentication helpers", func() {
-	DescribeTable("isPublicPath should recognize public paths",
+	DescribeTable("IsPublicPath should recognize public paths",
 		func(input string, expected bool) {
-			isPublic := isPublicPath(input)
+			isPublic := IsPublicPath(input)
 			Expect(isPublic).To(Equal(expected))
 		},
 		Entry("public files path", "/remote.php/dav/public-files/", true),

--- a/services/proxy/pkg/middleware/basic_auth.go
+++ b/services/proxy/pkg/middleware/basic_auth.go
@@ -18,7 +18,7 @@ type BasicAuthenticator struct {
 
 // Authenticate implements the authenticator interface to authenticate requests via basic auth.
 func (m BasicAuthenticator) Authenticate(r *http.Request) (*http.Request, bool) {
-	if isPublicPath(r.URL.Path) {
+	if IsPublicPath(r.URL.Path) {
 		// The authentication of public path requests is handled by another authenticator.
 		// Since we can't guarantee the order of execution of the authenticators, we better
 		// implement an early return here for paths we can't authenticate in this authenticator.

--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 	"github.com/pkg/errors"
 	"github.com/shamaton/msgpack/v2"
-	store "go-micro.dev/v4/store"
+	"go-micro.dev/v4/store"
 	"golang.org/x/crypto/sha3"
 	"golang.org/x/oauth2"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 )
 
 const (
@@ -168,7 +169,7 @@ func (m OIDCAuthenticator) shouldServe(req *http.Request) bool {
 // Authenticate implements the authenticator interface to authenticate requests via oidc auth.
 func (m *OIDCAuthenticator) Authenticate(r *http.Request) (*http.Request, bool) {
 	// there is no bearer token on the request,
-	if !m.shouldServe(r) || isPublicPath(r.URL.Path) {
+	if !m.shouldServe(r) || IsPublicPath(r.URL.Path) {
 		// The authentication of public path requests is handled by another authenticator.
 		// Since we can't guarantee the order of execution of the authenticators, we better
 		// implement an early return here for paths we can't authenticate in this authenticator.

--- a/services/proxy/pkg/middleware/public_share_auth.go
+++ b/services/proxy/pkg/middleware/public_share_auth.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 )
@@ -29,7 +30,7 @@ type PublicShareAuthenticator struct {
 // The archiver is able to create archives from public shares in which case it needs to use the
 // PublicShareAuthenticator. It might however also be called using "normal" authentication or
 // using signed url, which are handled by other middleware. For this reason we can't just
-// handle `/archiver` with the `isPublicPath()` check.
+// handle `/archiver` with the `IsPublicPath()` check.
 func isPublicShareArchive(r *http.Request) bool {
 	if strings.HasPrefix(r.URL.Path, "/archiver") {
 		if r.URL.Query().Get(headerShareToken) != "" || r.Header.Get(headerShareToken) != "" {
@@ -50,7 +51,7 @@ func isPublicShareAppOpen(r *http.Request) bool {
 
 // Authenticate implements the authenticator interface to authenticate requests via public share auth.
 func (a PublicShareAuthenticator) Authenticate(r *http.Request) (*http.Request, bool) {
-	if !isPublicPath(r.URL.Path) && !isPublicShareArchive(r) && !isPublicShareAppOpen(r) {
+	if !IsPublicPath(r.URL.Path) && !isPublicShareArchive(r) && !isPublicShareAppOpen(r) {
 		return nil, false
 	}
 


### PR DESCRIPTION


## Description
We have introduced a new endpoint to the Graph API that allows users to retrieve information about a token.

This endpoint serves as the Graph API's counterpart to the `GET /ocs/v1.php/apps/files_sharing/api/v1/tokeninfo/unprotected/TOKEN_ID`
endpoint in the OCS API, providing users with more comprehensive access to token information.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/8617

## Motivation and Context
Decision pending, we have to decide whether to proceed with this implementation or see if we find a cleaner solution without that endpoint.

## How Has This Been Tested?
- ...

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## ToDo:
- [x] decide if we need it that way
- [ ] Unit tests
- [ ] Acceptance tests
- [ ] Add to libregraph spec
