### PR TITLE
feat: enable draw-io extension by default

### DIFF
--- a/changelog/unreleased/add-spaceid-to-sse.md
+++ b/changelog/unreleased/add-spaceid-to-sse.md
@@ -1,6 +1,6 @@
- Enhancement: Add the spaceID to sse
+Enhancement: Add the spaceID to sse
 
- Adds the spaceID to all clientlog sse messages
+Adds the spaceID to all clientlog sse messages
 
- https://github.com/owncloud/ocis/pull/8614
- https://github.com/owncloud/ocis/pull/8624
+https://github.com/owncloud/ocis/pull/8614
+https://github.com/owncloud/ocis/pull/8624

--- a/changelog/unreleased/enable-drawio-by-default.md
+++ b/changelog/unreleased/enable-drawio-by-default.md
@@ -1,0 +1,5 @@
+Enhancement: Enable web extension drawio by default
+
+Enable web extension drawio by default
+
+https://github.com/owncloud/ocis/pull/8760

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -97,7 +97,7 @@ func DefaultConfig() *config.Config {
 					ResponseType: "code",
 					Scope:        "openid profile email",
 				},
-				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader"},
+				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader", "draw-io"},
 				ExternalApps: []config.ExternalApp{
 					{
 						ID:   "preview",


### PR DESCRIPTION
## Description
I guess it would be nice to have draw-io enabled by default - in addition I could not find any other way to enable it. :shrug: 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
