### PR TITLE
filter user e-mail in graph/user requests

### DIFF
--- a/changelog/unreleased/mask-user-email-in-output.md
+++ b/changelog/unreleased/mask-user-email-in-output.md
@@ -5,3 +5,4 @@ the sharee search. This is the ocis side which adds an suiting config option to 
 
 https://github.com/owncloud/ocis/issues/8726
 https://github.com/cs3org/reva/pull/4603
+https://github.com/owncloud/ocis/pull/8764

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -114,6 +114,7 @@ type API struct {
 	UsernameMatch           string `yaml:"graph_username_match" env:"GRAPH_USERNAME_MATCH" desc:"Apply restrictions to usernames. Supported values are 'default' and 'none'. When set to 'default', user names must not start with a number and are restricted to ASCII characters. When set to 'none', no restrictions are applied. The default value is 'default'." introductionVersion:"pre5.0"`
 	AssignDefaultUserRole   bool   `yaml:"graph_assign_default_user_role" env:"GRAPH_ASSIGN_DEFAULT_USER_ROLE" desc:"Whether to assign newly created users the default role 'User'. Set this to 'false' if you want to assign roles manually, or if the role assignment should happen at first login. Set this to 'true' (the default) to assign the role 'User' when creating a new user." introductionVersion:"pre5.0"`
 	IdentitySearchMinLength int    `yaml:"graph_identity_search_min_length" env:"GRAPH_IDENTITY_SEARCH_MIN_LENGTH" desc:"The minimum length the search term needs to have for unprivileged users when searching for users or groups." introductionVersion:"5.0"`
+	ShowUserEmailInResults  bool   `yaml:"show_email_in_results" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
 }
 
 // Events combines the configuration options for the event bus.

--- a/services/graph/pkg/config/reva.go
+++ b/services/graph/pkg/config/reva.go
@@ -2,5 +2,6 @@ package config
 
 // TokenManager is the config for using the reva token manager
 type TokenManager struct {
-	JWTSecret string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;GRAPH_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
+	JWTSecret              string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;GRAPH_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
+	ShowUserEmailInResults bool   `yaml:"mask_user_email" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
 }

--- a/services/graph/pkg/config/reva.go
+++ b/services/graph/pkg/config/reva.go
@@ -2,6 +2,5 @@ package config
 
 // TokenManager is the config for using the reva token manager
 type TokenManager struct {
-	JWTSecret              string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;GRAPH_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
-	ShowUserEmailInResults bool   `yaml:"mask_user_email" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
+	JWTSecret string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;GRAPH_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
 }

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -282,7 +282,7 @@ func (g Graph) GetUsers(w http.ResponseWriter, r *http.Request) {
 				UserType:    u.UserType,
 			}
 
-			if g.config.TokenManager.ShowUserEmailInResults {
+			if g.config.API.ShowUserEmailInResults {
 				finalUsers[i].Mail = u.Mail
 			}
 		}
@@ -548,7 +548,7 @@ func (g Graph) GetUser(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if !g.config.TokenManager.ShowUserEmailInResults {
+	if !g.config.API.ShowUserEmailInResults {
 		user.Mail = nil
 	}
 

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -279,8 +279,11 @@ func (g Graph) GetUsers(w http.ResponseWriter, r *http.Request) {
 			finalUsers[i] = &libregraph.User{
 				Id:          u.Id,
 				DisplayName: u.DisplayName,
-				Mail:        u.Mail,
 				UserType:    u.UserType,
+			}
+
+			if g.config.TokenManager.ShowUserEmailInResults {
+				finalUsers[i].Mail = u.Mail
 			}
 		}
 		users = finalUsers
@@ -543,6 +546,10 @@ func (g Graph) GetUser(w http.ResponseWriter, r *http.Request) {
 			errorcode.RenderError(w, r, err)
 			return
 		}
+	}
+
+	if !g.config.TokenManager.ShowUserEmailInResults {
+		user.Mail = nil
 	}
 
 	render.Status(r, http.StatusOK)

--- a/services/ocs/pkg/config/config.go
+++ b/services/ocs/pkg/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Debug   Debug    `yaml:"debug"`
 
 	HTTP HTTP `yaml:"http"`
+	API  API  `yaml:"api"`
 
 	GRPCClientTLS *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 	GrpcClient    client.Client         `yaml:"-"`
@@ -37,4 +38,8 @@ type SigningKeys struct {
 	TTL          time.Duration `yaml:"ttl" env:"OCIS_CACHE_TTL;OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_TTL" desc:"Default time to live for signing keys. See the Environment Variable Types description for more details." introductionVersion:"5.0"`
 	AuthUsername string        `yaml:"username" env:"OCIS_CACHE_AUTH_USERNAME;OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_AUTH_USERNAME" desc:"The username to authenticate with the store. Only applies when store type 'nats-js-kv' is configured." introductionVersion:"5.0"`
 	AuthPassword string        `yaml:"password" env:"OCIS_CACHE_AUTH_PASSWORD;OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_AUTH_PASSWORD" desc:"The password to authenticate with the store. Only applies when store type 'nats-js-kv' is configured." introductionVersion:"5.0"`
+}
+
+type API struct {
+	ShowUserEmailInResults bool `yaml:"show_email_in_results" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
 }

--- a/services/ocs/pkg/config/reva.go
+++ b/services/ocs/pkg/config/reva.go
@@ -2,6 +2,5 @@ package config
 
 // TokenManager is the config for using the reva token manager
 type TokenManager struct {
-	JWTSecret              string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;OCS_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
-	ShowUserEmailInResults bool   `yaml:"mask_user_email" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
+	JWTSecret string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;OCS_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
 }

--- a/services/ocs/pkg/config/reva.go
+++ b/services/ocs/pkg/config/reva.go
@@ -3,5 +3,5 @@ package config
 // TokenManager is the config for using the reva token manager
 type TokenManager struct {
 	JWTSecret              string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;OCS_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
-	ShowUserEmailInResults bool   `yaml:"mask_user_email" env:"OCS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
+	ShowUserEmailInResults bool   `yaml:"mask_user_email" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
 }

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -47,6 +47,11 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [A User can get information of another user with Graph API](https://github.com/owncloud/ocis/issues/5125)
 
+- [apiGraphUserGroup/getUser.feature:84](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L84)
+- [apiGraphUserGroup/getUser.feature:85](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L85)
+- [apiGraphUserGroup/getUser.feature:86](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L86)
+- [apiGraphUserGroup/getUser.feature:87](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L87)
+- [apiGraphUserGroup/getUser.feature:88](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L88)
 - [apiGraphUserGroup/getUser.feature:89](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L89)
 - [apiGraphUserGroup/getUser.feature:90](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L90)
 - [apiGraphUserGroup/getUser.feature:91](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L91)
@@ -54,23 +59,18 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraphUserGroup/getUser.feature:93](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L93)
 - [apiGraphUserGroup/getUser.feature:94](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L94)
 - [apiGraphUserGroup/getUser.feature:95](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L95)
-- [apiGraphUserGroup/getUser.feature:96](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L96)
-- [apiGraphUserGroup/getUser.feature:97](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L97)
-- [apiGraphUserGroup/getUser.feature:98](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L98)
-- [apiGraphUserGroup/getUser.feature:99](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L99)
-- [apiGraphUserGroup/getUser.feature:100](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L100)
-- [apiGraphUserGroup/getUser.feature:657](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L657)
-- [apiGraphUserGroup/getUser.feature:658](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L658)
-- [apiGraphUserGroup/getUser.feature:659](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L659)
-- [apiGraphUserGroup/getUser.feature:660](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L660)
-- [apiGraphUserGroup/getUser.feature:661](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L661)
-- [apiGraphUserGroup/getUser.feature:662](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L662)
-- [apiGraphUserGroup/getUser.feature:663](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L663)
-- [apiGraphUserGroup/getUser.feature:664](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L664)
-- [apiGraphUserGroup/getUser.feature:665](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L665)
-- [apiGraphUserGroup/getUser.feature:666](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L666)
-- [apiGraphUserGroup/getUser.feature:667](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L667)
-- [apiGraphUserGroup/getUser.feature:668](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L668)
+- [apiGraphUserGroup/getUser.feature:637](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L637)
+- [apiGraphUserGroup/getUser.feature:638](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L638)
+- [apiGraphUserGroup/getUser.feature:639](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L639)
+- [apiGraphUserGroup/getUser.feature:640](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L640)
+- [apiGraphUserGroup/getUser.feature:641](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L641)
+- [apiGraphUserGroup/getUser.feature:642](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L642)
+- [apiGraphUserGroup/getUser.feature:643](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L643)
+- [apiGraphUserGroup/getUser.feature:644](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L644)
+- [apiGraphUserGroup/getUser.feature:645](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L645)
+- [apiGraphUserGroup/getUser.feature:646](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L646)
+- [apiGraphUserGroup/getUser.feature:647](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L647)
+- [apiGraphUserGroup/getUser.feature:648](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUserGroup/getUser.feature#L648)
 
 #### [Normal user can get expanded members information of a group](https://github.com/owncloud/ocis/issues/5604)
 
@@ -286,6 +286,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSpacesDavOperation/moveByFileId.feature:465](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesDavOperation/moveByFileId.feature#L465)
 
 ### [500 when deleting share role](https://github.com/owncloud/ocis/issues/8747)
+
 - [apiSpacesShares/shareSubItemOfSpace.feature:147](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature#L147)
 
 - Note: always have an empty line at the end of this file.

--- a/tests/acceptance/features/apiGraphUserGroup/editUser.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/editUser.feature
@@ -15,33 +15,6 @@ Feature: edit user
       | email       | brian@example.com |
       | password    | 1234              |
 
-
-  Scenario Outline: admin user can edit another user's email
-    When the user "Alice" changes the email of user "Brian" to "<new-email>" using the Graph API
-    Then the HTTP status code should be "<http-status-code>"
-    And the user information of "Brian" should match this JSON schema
-    """
-    {
-      "type": "object",
-      "required": [
-        "mail"
-      ],
-      "properties": {
-        "mail": {
-          "type": "string",
-          "enum": ["<expected-email>"]
-        }
-      }
-    }
-    """
-    Examples:
-      | action description        | new-email            | http-status-code | expected-email       |
-      | change to a valid email   | newemail@example.com | 200              | newemail@example.com |
-      | override existing mail    | brian@example.com    | 200              | brian@example.com    |
-      | two users with same mail  | alice@example.org    | 200              | alice@example.org    |
-      | empty mail                |                      | 400              | brian@example.com    |
-      | change to a invalid email | invalidEmail         | 400              | brian@example.com    |
-
   @issue-7044
   Scenario Outline: admin user can edit another user's name
     Given user "Carol" has been created with default attributes and without skeleton files
@@ -119,73 +92,6 @@ Feature: edit user
       }
     }
     """
-
-
-  Scenario Outline: normal user should not be able to change their email address
-    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
-    When the user "Brian" tries to change the email of user "Brian" to "newemail@example.com" using the Graph API
-    Then the HTTP status code should be "401"
-    And the user information of "Brian" should match this JSON schema
-    """
-    {
-      "type": "object",
-      "required": [
-        "mail"
-      ],
-      "properties": {
-        "mail": {
-          "type": "string",
-          "enum": ["brian@example.com"]
-        }
-      }
-    }
-    """
-    Examples:
-      | user-role   |
-      | Space Admin |
-      | User        |
-      | User Light  |
-
-
-  Scenario Outline: normal user should not be able to edit another user's email
-    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
-    And the user "Alice" has created a new user with the following attributes:
-      | userName    | Carol             |
-      | displayName | Carol King        |
-      | email       | carol@example.com |
-      | password    | 1234              |
-    And the administrator has assigned the role "<user-role-2>" to user "Carol" using the Graph API
-    When the user "Brian" tries to change the email of user "Carol" to "newemail@example.com" using the Graph API
-    Then the HTTP status code should be "401"
-    And the user information of "Carol" should match this JSON schema
-    """
-    {
-      "type": "object",
-      "required": [
-        "mail"
-      ],
-      "properties": {
-        "mail": {
-          "type": "string",
-          "enum": ["carol@example.com"]
-        }
-      }
-    }
-    """
-    Examples:
-      | user-role   | user-role-2 |
-      | Space Admin | Space Admin |
-      | Space Admin | User        |
-      | Space Admin | User Light  |
-      | Space Admin | Admin       |
-      | User        | Space Admin |
-      | User        | User        |
-      | User        | User Light  |
-      | User        | Admin       |
-      | User Light  | Space Admin |
-      | User Light  | User        |
-      | User Light  | User Light  |
-      | User Light  | Admin       |
 
 
   Scenario Outline: admin user can edit another user display name
@@ -329,7 +235,6 @@ Feature: edit user
       "required": [
         "displayName",
         "id",
-        "mail",
         "onPremisesSamAccountName",
         "accountEnabled"
       ],
@@ -341,10 +246,6 @@ Feature: edit user
         "id" : {
           "type": "string",
           "pattern": "^%user_id_pattern%$"
-        },
-        "mail": {
-          "type": "string",
-          "enum": ["brian@example.com"]
         },
         "onPremisesSamAccountName": {
           "type": "string",
@@ -373,7 +274,6 @@ Feature: edit user
       "required": [
         "displayName",
         "id",
-        "mail",
         "onPremisesSamAccountName",
         "accountEnabled"
       ],
@@ -385,10 +285,6 @@ Feature: edit user
         "id" : {
           "type": "string",
           "pattern": "^%user_id_pattern%$"
-        },
-        "mail": {
-          "type": "string",
-          "enum": ["carol@example.org"]
         },
         "onPremisesSamAccountName": {
           "type": "string",
@@ -421,7 +317,6 @@ Feature: edit user
       "required": [
         "displayName",
         "id",
-        "mail",
         "onPremisesSamAccountName",
         "accountEnabled"
       ],
@@ -433,10 +328,6 @@ Feature: edit user
         "id" : {
           "type": "string",
           "pattern": "^%user_id_pattern%$"
-        },
-        "mail": {
-          "type": "string",
-          "enum": ["brian@example.com"]
         },
         "onPremisesSamAccountName": {
           "type": "string",
@@ -466,7 +357,6 @@ Feature: edit user
       "required": [
         "displayName",
         "id",
-        "mail",
         "onPremisesSamAccountName",
         "accountEnabled"
       ],
@@ -478,10 +368,6 @@ Feature: edit user
         "id" : {
           "type": "string",
           "pattern": "^%user_id_pattern%$"
-        },
-        "mail": {
-          "type": "string",
-          "enum": ["carol@example.org"]
         },
         "onPremisesSamAccountName": {
           "type": "string",

--- a/tests/acceptance/features/apiGraphUserGroup/getUser.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/getUser.feature
@@ -21,7 +21,6 @@ Feature: get users
       "required": [
         "displayName",
         "id",
-        "mail",
         "onPremisesSamAccountName",
         "accountEnabled",
         "userType"
@@ -34,10 +33,6 @@ Feature: get users
         "id" : {
           "type": "string",
           "pattern": "^%user_id_pattern%$"
-        },
-        "mail": {
-          "type": "string",
-          "enum": ["brian@example.org"]
         },
         "onPremisesSamAccountName": {
           "type": "string",
@@ -298,7 +293,6 @@ Feature: get users
         "required": [
           "displayName",
           "id",
-          "mail",
           "onPremisesSamAccountName",
           "drive",
           "accountEnabled",
@@ -312,10 +306,6 @@ Feature: get users
           "id" : {
             "type": "string",
             "pattern": "^%user_id_pattern%$"
-          },
-          "mail": {
-            "type": "string",
-            "enum": ["brian@example.org"]
           },
           "onPremisesSamAccountName": {
             "type": "string",
@@ -428,7 +418,6 @@ Feature: get users
         "required": [
           "displayName",
           "id",
-          "mail",
           "onPremisesSamAccountName",
           "drive",
           "accountEnabled",
@@ -442,10 +431,6 @@ Feature: get users
           "id" : {
             "type": "string",
             "pattern": "^%user_id_pattern%$"
-          },
-          "mail": {
-            "type": "string",
-            "enum": ["brian@example.org"]
           },
           "onPremisesSamAccountName": {
             "type": "string",
@@ -567,17 +552,12 @@ Feature: get users
       "type": "object",
       "required": [
         "id",
-        "mail",
         "onPremisesSamAccountName"
       ],
       "properties": {
         "id" : {
           "type": "string",
           "pattern": "^%user_id_pattern%$"
-        },
-        "mail": {
-          "type": "string",
-          "enum": ["brian@example.org"]
         },
         "onPremisesSamAccountName": {
           "type": "string",
@@ -1371,7 +1351,6 @@ Feature: get users
             "required": [
               "displayName",
               "id",
-              "mail",
               "userType"
             ],
             "properties": {
@@ -1383,10 +1362,6 @@ Feature: get users
                 "type": "string",
                 "pattern": "^%user_id_pattern%$"
               },
-              "mail": {
-                "type": "string",
-                "enum": ["alice@example.org"]
-              },
               "userType": {
                 "type": "string",
                 "enum": ["Member"]
@@ -1397,7 +1372,6 @@ Feature: get users
       }
     }
     """
-
 
   Scenario: non-admin user tries to search for a user by display name with less than 3 characters
     When user "Brian" tries to search for user "al" using Graph API
@@ -1480,7 +1454,6 @@ Feature: get users
             "required": [
               "displayName",
               "id",
-              "mail",
               "userType"
             ],
             "properties": {
@@ -1491,10 +1464,6 @@ Feature: get users
               "id": {
                 "type": "string",
                 "pattern": "^%user_id_pattern%$"
-              },
-              "mail": {
-                "type": "string",
-                "enum": ["alice@example.org"]
               },
               "userType": {
                 "type": "string",
@@ -1529,7 +1498,6 @@ Feature: get users
             "required": [
               "displayName",
               "id",
-              "mail",
               "userType"
             ],
             "properties": {
@@ -1540,10 +1508,6 @@ Feature: get users
               "id": {
                 "type": "string",
                 "pattern": "^%user_id_pattern%$"
-              },
-              "mail": {
-                "type": "string",
-                "enum": ["alice@example.org"]
               },
               "userType": {
                 "type": "string",
@@ -1560,10 +1524,9 @@ Feature: get users
   Scenario: non-admin user searches for multiple users having same displayname
     Given the user "Admin" has created a new user with the following attributes:
       | userName    | another-alice                |
-      | displayName | Alice Hansen                 |
+      | displayName | Alice Murphy                 |
       | email       | another-alice@example.org    |
       | password    | containsCharacters(*:!;_+-&) |
-
     When user "Brian" searches for user "alice" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -1586,7 +1549,6 @@ Feature: get users
                 "required": [
                   "displayName",
                   "id",
-                  "mail",
                   "userType"
                 ],
                 "properties": {
@@ -1597,10 +1559,6 @@ Feature: get users
                   "id": {
                     "type": "string",
                     "pattern": "^%user_id_pattern%$"
-                  },
-                  "mail": {
-                    "type": "string",
-                    "enum": ["alice@example.org"]
                   },
                   "userType": {
                     "type": "string",
@@ -1613,21 +1571,16 @@ Feature: get users
                 "required": [
                   "displayName",
                   "id",
-                  "mail",
                   "userType"
                 ],
                 "properties": {
                   "displayName": {
                     "type": "string",
-                    "enum": ["Alice Hansen"]
+                    "enum": ["Alice Murphy"]
                   },
                   "id": {
                     "type": "string",
                     "pattern": "^%user_id_pattern%$"
-                  },
-                  "mail": {
-                    "type": "string",
-                    "enum": ["another-alice@example.org"]
                   },
                   "userType": {
                     "type": "string",

--- a/tests/acceptance/features/apiGraphUserGroup/searchUserIncludingEmail.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/searchUserIncludingEmail.feature
@@ -1,0 +1,462 @@
+@env-config
+Feature: edit/search user including email
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    And the user "Alice" has created a new user with the following attributes:
+      | userName    | Brian             |
+      | displayName | Brian Murphy      |
+      | email       | brian@example.com |
+      | password    | 1234              |
+    And the config "OCIS_SHOW_USER_EMAIL_IN_RESULTS" has been set to "true"
+
+
+  Scenario Outline: admin user can edit another user's email
+    When the user "Alice" changes the email of user "Brian" to "<new-email>" using the Graph API
+    Then the HTTP status code should be "<http-status-code>"
+    And the user information of "Brian" should match this JSON schema
+    """
+    {
+      "type": "object",
+      "required": ["mail"],
+      "properties": {
+        "mail": {
+          "const": "<expected-email>"
+        }
+      }
+    }
+    """
+    Examples:
+      | action description        | new-email            | http-status-code | expected-email       |
+      | change to a valid email   | newemail@example.com | 200              | newemail@example.com |
+      | override existing mail    | brian@example.com    | 200              | brian@example.com    |
+      | two users with same mail  | alice@example.org    | 200              | alice@example.org    |
+      | empty mail                |                      | 400              | brian@example.com    |
+      | change to a invalid email | invalidEmail         | 400              | brian@example.com    |
+
+
+  Scenario Outline: normal user should not be able to change their email address
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    When the user "Brian" tries to change the email of user "Brian" to "newemail@example.com" using the Graph API
+    Then the HTTP status code should be "401"
+    And the user information of "Brian" should match this JSON schema
+    """
+    {
+      "type": "object",
+      "required": ["mail"],
+      "properties": {
+        "mail": {
+          "const": "brian@example.com"
+        }
+      }
+    }
+    """
+    Examples:
+      | user-role   |
+      | Space Admin |
+      | User        |
+      | User Light  |
+
+
+  Scenario Outline: normal user should not be able to edit another user's email
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    And the user "Alice" has created a new user with the following attributes:
+      | userName    | Carol             |
+      | displayName | Carol King        |
+      | email       | carol@example.com |
+      | password    | 1234              |
+    And the administrator has assigned the role "<user-role-2>" to user "Carol" using the Graph API
+    When the user "Brian" tries to change the email of user "Carol" to "newemail@example.com" using the Graph API
+    Then the HTTP status code should be "401"
+    And the user information of "Carol" should match this JSON schema
+    """
+    {
+      "type": "object",
+      "required": ["mail"],
+      "properties": {
+        "mail": {
+          "const": "carol@example.com"
+        }
+      }
+    }
+    """
+    Examples:
+      | user-role   | user-role-2 |
+      | Space Admin | Space Admin |
+      | Space Admin | User        |
+      | Space Admin | User Light  |
+      | Space Admin | Admin       |
+      | User        | Space Admin |
+      | User        | User        |
+      | User        | User Light  |
+      | User        | Admin       |
+      | User Light  | Space Admin |
+      | User Light  | User        |
+      | User Light  | User Light  |
+      | User Light  | Admin       |
+
+
+  Scenario: admin user gets the information of a user
+    Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
+    When user "Alice" gets information of user "Brian" using Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": [
+        "displayName",
+        "id",
+        "mail",
+        "onPremisesSamAccountName",
+        "accountEnabled",
+        "userType"
+      ],
+      "properties": {
+        "displayName": {
+          "const": "Brian Murphy"
+        },
+        "id" : {
+          "type": "string",
+          "pattern": "^%user_id_pattern%$"
+        },
+        "mail": {
+          "const": "brian@example.com"
+        },
+        "onPremisesSamAccountName": {
+          "const": "Brian"
+        },
+        "accountEnabled": {
+          "const": true
+        },
+        "userType": {
+          "const": "Member"
+        }
+      }
+    }
+    """
+
+
+  Scenario Outline: user gets his/her own information along with drive information
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    When the user "Brian" gets his drive information using Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+      {
+        "type": "object",
+        "required": [
+          "displayName",
+          "id",
+          "mail",
+          "onPremisesSamAccountName",
+          "drive",
+          "accountEnabled",
+          "userType"
+        ],
+        "properties": {
+          "displayName": {
+            "const": "Brian Murphy"
+          },
+          "id" : {
+            "type": "string",
+            "pattern": "^%user_id_pattern%$"
+          },
+          "mail": {
+            "const": "brian@example.com"
+          },
+          "onPremisesSamAccountName": {
+            "const": "Brian"
+          },
+          "accountEnabled": {
+            "const": true
+          },
+          "userType": {
+            "const": "Member"
+          },
+          "drive": {
+            "type": "object",
+            "required": [
+              "driveAlias",
+              "id",
+              "name",
+              "owner",
+              "quota",
+              "root",
+              "webUrl"
+            ],
+            "properties": {
+              "driveType" : {
+                "const": "personal"
+              },
+              "driveAlias" : {
+                "const": "personal/brian"
+              },
+              "id" : {
+                "type": "string",
+                "pattern": "^%space_id_pattern%$"
+              },
+              "name": {
+                "const": "Brian Murphy"
+              },
+              "owner": {
+                "type": "object",
+                "required": ["user"],
+                "properties": {
+                  "user": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "pattern": "%user_id_pattern%"
+                      }
+                    }
+                  }
+                }
+              },
+              "quota": {
+                "type": "object",
+                "required": ["state"],
+                "properties": {
+                  "state": {
+                    "const": "normal"
+                  }
+                }
+              },
+              "root": {
+                "type": "object",
+                "required": ["id", "webDavUrl"],
+                "properties": {
+                  "state": {
+                    "const": "normal"
+                  },
+                  "webDavUrl": {
+                    "type": "string",
+                    "pattern": "^%base_url%/dav/spaces/%space_id_pattern%$"
+                  }
+                }
+              },
+              "webUrl": {
+                "type": "string",
+                "pattern": "^%base_url%/f/%space_id_pattern%$"
+              }
+            }
+          }
+        }
+      }
+    """
+    Examples:
+      | user-role   |
+      | Admin       |
+      | Space Admin |
+      | User        |
+      | User Light  |
+
+
+  Scenario: non-admin user searches other users by display name
+    When user "Brian" searches for user "ali" using Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "displayName",
+              "id",
+              "mail",
+              "userType"
+            ],
+            "properties": {
+              "displayName": {
+                "const": "Alice Hansen"
+              },
+              "id": {
+                "type": "string",
+                "pattern": "^%user_id_pattern%$"
+              },
+              "mail": {
+                "const": "alice@example.org"
+              },
+              "userType": {
+                "const": "Member"
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+  @issue-7990
+  Scenario: non-admin user searches other users by e-mail
+    When user "Brian" searches for user "%22alice@example.org%22" using Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "displayName",
+              "id",
+              "mail",
+              "userType"
+            ],
+            "properties": {
+              "displayName": {
+                "const": "Alice Hansen"
+              },
+              "id": {
+                "type": "string",
+                "pattern": "^%user_id_pattern%$"
+              },
+              "mail": {
+                "const": "alice@example.org"
+              },
+              "userType": {
+                "const": "Member"
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+
+  Scenario: non-admin user searches for a disabled users
+    Given the user "Admin" has disabled user "Alice"
+    When user "Brian" searches for user "alice" using Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "displayName",
+              "id",
+              "mail",
+              "userType"
+            ],
+            "properties": {
+              "displayName": {
+                "const": "Alice Hansen"
+              },
+              "id": {
+                "type": "string",
+                "pattern": "^%user_id_pattern%$"
+              },
+              "mail": {
+                "const": "alice@example.org"
+              },
+              "userType": {
+                "const": "Member"
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+
+  Scenario: non-admin user searches for multiple users having same displayname
+    Given the user "Admin" has created a new user with the following attributes:
+      | userName    | another-alice                |
+      | displayName | Alice Murphy                 |
+      | email       | another-alice@example.org    |
+      | password    | containsCharacters(*:!;_+-&) |
+    When user "Brian" searches for user "alice" using Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "displayName",
+                  "id",
+                  "mail",
+                  "userType"
+                ],
+                "properties": {
+                  "displayName": {
+                    "const": "Alice Hansen"
+                  },
+                  "id": {
+                    "type": "string",
+                    "pattern": "^%user_id_pattern%$"
+                  },
+                  "mail": {
+                    "const": "alice@example.org"
+                  },
+                  "userType": {
+                    "const": "Member"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "displayName",
+                  "id",
+                  "mail",
+                  "userType"
+                ],
+                "properties": {
+                  "displayName": {
+                    "const": "Alice Murphy"
+                  },
+                  "id": {
+                    "type": "string",
+                    "pattern": "^%user_id_pattern%$"
+                  },
+                  "mail": {
+                    "const": "another-alice@example.org"
+                  },
+                  "userType": {
+                    "const": "Member"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+    """


### PR DESCRIPTION
Bugfix: Mask user email in output

We have fixed a bug where the user email was not masked in the output and the user emails could be enumerated through
the sharee search. This is the ocis side which adds an suiting config option to mask user emails in the output.

refs #8726 