### PR TITLE
[tests-only][full-ci] added test to check id from shareWithMe and PROPFIND response

### DIFF
--- a/tests/acceptance/features/apiSharingNg/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg/propfindShares.feature
@@ -120,3 +120,22 @@ Feature: propfind a shares
       | oc:fileid      | UUIDof:textfile.txt |
       | oc:name        | textfile.txt        |
       | oc:permissions | S                   |
+
+
+  Scenario Outline: check file-id from PROPFIND with shared-with-me drive-item-id
+    Given using spaces DAV path
+    And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following share invitation:
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    When user "Brian" sends PROPFIND request to space "Shares" with depth "1" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the key "oc:fileid" from PROPFIND response should match with shared-with-me drive-item-id of share "<resource>"
+    Examples:
+      | resource      |
+      | textfile1.txt |
+      | folderToShare |

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3831,6 +3831,38 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * @Then as user :user the key :key from PROPFIND response should match with shared-with-me drive-item-id of share :resource
+	 *
+	 * @param string $user
+	 * @param string $key
+	 * @param string $resource
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function asUserTheKeyFromPropfindResponseShouldMatchWithSharedwithmeDriveitemidOfShare(string $user, string $key, string $resource): void {
+		$xmlResponse = $this->featureContext->getResponseXml();
+		$fileId = $xmlResponse->xpath("//oc:name[text()='$resource']/preceding-sibling::$key")[0]->__toString();
+
+		$jsonResponse = GraphHelper::getSharesSharedWithMe(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user)
+		);
+		$jsonResponseBody = $this->featureContext->getJsonDecodedResponseBodyContent($jsonResponse);
+		foreach ($jsonResponseBody->value as $value) {
+			if ($value->name === "$resource") {
+				$driveItemId = $value->id;
+				break;
+			} else {
+				throw new Error("Response didn't contain a share $resource");
+			}
+		}
+		Assert::assertEquals($fileId, $driveItemId, "File-id '$fileId' doesn't match driveItemId '$driveItemId'");
+	}
+
+	/**
 	 * @When /^public downloads the folder "([^"]*)" from the last created public link using the public files API$/
 	 *
 	 * @param string $resource


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added api test to check the driveItem id with `oc:fileid` from PROPFIND response. The `oc:fileid` should match the driveItem id from the sharedWithMe response, after the fixes in PR https://github.com/owncloud/ocis/pull/8467

Added Scenario:
```feature
Scenario Outline: check ids from sharedWithMe driveItemId with PROPFIND response
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/8493

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
