### PR TITLE
Use a selector instead of a client to fulfill the selector interface

### DIFF
--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -106,11 +106,11 @@ func RebuildJSONCS3Indexes(cfg *config.Config) *cli.Command {
 			if err != nil {
 				return err
 			}
-			gc, err := pool.GetGatewayServiceClient(conf.GatewayAddr)
+			gs, err := pool.GatewaySelector(conf.GatewayAddr)
 			if err != nil {
 				return err
 			}
-			mgr, err := jsoncs3.New(s, gc, 0, nil, 1)
+			mgr, err := jsoncs3.New(s, gs, 0, nil, 1)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This adapts ocis to the changed signature from https://github.com/cs3org/reva/commit/1a424f0f9f9810bce77267077dd23d47a47fd685