### PR TITLE
[tests-only][full-ci]added test for enable disable share shared by project space to group

### DIFF
--- a/tests/acceptance/features/apiSharingNg/enableDisableShareSync.feature
+++ b/tests/acceptance/features/apiSharingNg/enableDisableShareSync.feature
@@ -229,3 +229,69 @@ Feature:  enable or disable sync of incoming shares
       | resource      |
       | textfile0.txt |
       | FolderToShare |
+
+
+  Scenario Outline: enable a group share sync shared from Project Space by only one user in a group
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Space Admin" to user "Carol" using the Graph API
+    And group "grp1" has been created
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has disabled the auto-sync share
+    And user "Brian" has disabled the auto-sync share
+    And user "Carol" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Carol" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Carol" has uploaded a file inside space "NewSpace" with content "hello world" to "/textfile0.txt"
+    And user "Carol" has sent the following share invitation:
+      | resource        | <resource> |
+      | space           | NewSpace   |
+      | sharee          | grp1       |
+      | shareType       | group      |
+      | permissionsRole | Viewer     |
+    When user "Alice" enables sync of share "<resource>" offered by "Carol" from "NewSpace" space using the Graph API
+    Then the HTTP status code should be "201"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "@client.synchronize"
+        ],
+        "properties": {
+          "@client.synchronize": {
+            "const": true
+          }
+        }
+      }
+      """
+    And user "Alice" should have sync enabled for share "<resource>"
+    And user "Brian" should have sync disabled for share "<resource>"
+    Examples:
+      | resource      |
+      | textfile0.txt |
+      | FolderToShare |
+
+
+  Scenario Outline: disable group share sync shared from Project space by only one user in a group
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Space Admin" to user "Carol" using the Graph API
+    And group "grp1" has been created
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Carol" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Carol" has uploaded a file inside space "NewSpace" with content "hello world" to "/textfile0.txt"
+    And user "Carol" has sent the following share invitation:
+      | resource        | <resource> |
+      | space           | NewSpace   |
+      | sharee          | grp1       |
+      | shareType       | group      |
+      | permissionsRole | Viewer     |
+    When user "Alice" disables sync of share "<resource>" using the Graph API
+    Then the HTTP status code should be "200"
+    And user "Alice" should have sync disabled for share "<resource>"
+    And user "Brian" should have sync enabled for share "<resource>"
+    Examples:
+      | resource      |
+      | textfile0.txt |
+      | FolderToShare |


### PR DESCRIPTION
## Description
Adding test feature file that covers test for enabling and disabling sync of share shared from Project space to group

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/8486

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- tlocally
- CI
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
