### PR TITLE
fix(sharing-ng): Fix setPassword call for spaceroot

### DIFF
--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -242,7 +242,7 @@ func NewService(opts ...Option) (Graph, error) {
 							r.Route("/{permissionID}", func(r chi.Router) {
 								r.Delete("/", driveItemPermissionsApi.DeleteSpaceRootPermission)
 								r.Patch("/", driveItemPermissionsApi.UpdateSpaceRootPermission)
-								r.Post("/setPassword", driveItemPermissionsApi.SetLinkPassword)
+								r.Post("/setPassword", driveItemPermissionsApi.SetSpaceRootLinkPassword)
 							})
 						})
 					})


### PR DESCRIPTION
Requests to /raph/v1beta1/drives/{driveid}/root/permissions/{permissionid}setPassword were rooted to the wrong method.