### PR TITLE
[docs-only] fix two services readme to be inline with admin docs

### DIFF
--- a/services/postprocessing/README.md
+++ b/services/postprocessing/README.md
@@ -79,27 +79,27 @@ See the [cs3 org](https://github.com/cs3org/reva/blob/edge/pkg/events/postproces
 
 ### Resume Postprocessing
 
-If postprocessing fails in one step due to an unforseen error, current uploads will not be retried automatically. A system admin can instead run a CLI command to retry the failed upload which is a two step process:
+If postprocessing fails in one step due to an unforseen error, current uploads will not be retried automatically. A system admin can instead run a CLI command to retry the failed upload which is a two step process. For details on the `storage-users` command see the **Manage Unfinished Uploads** documentation in the `storage-users` service documentation:
 
 -   First list ongoing upload sessions
-```bash
-ocis storage-users uploads sessions
-```
+    ```bash
+    ocis storage-users uploads sessions
+    ```
 
 -   If you want to restart all uploads just rerun the command with the `--restart` flag
-```bash
-ocis storage-users uploads sessions --restart
-```
+    ```bash
+    ocis storage-users uploads sessions --restart
+    ```
 
 -   If you want to restart only one upload use the postprocessing restart command
-```bash
-ocis postprocessing restart -u <uploadID>
-```
+    ```bash
+    ocis postprocessing restart -u <uploadID>
+    ```
 
 Instead of starting one specific upload, a system admin can also restart all uploads that are currently in a specific step.
 Examples:
 ```
-ocis postprocessing restart # Restarts all uploads where postprocessing is finished, but upload is not finished
-ocis postprocessing restart -s "finished" # Equivalent to the above
+ocis postprocessing restart                # Restarts all uploads where postprocessing is finished, but upload is not finished
+ocis postprocessing restart -s "finished"  # Equivalent to the above
 ocis postprocessing restart -s "virusscan" # Restart all uploads currently in virusscan step
 ```

--- a/services/storage-users/README.md
+++ b/services/storage-users/README.md
@@ -43,15 +43,15 @@ When using Infinite Scale as user storage, a directory named `storage/users/uplo
 
 *   **In the rare case of a failure**, after the upload succeeded but the file was not moved to its target location, which can happen when postprocessing fails, the situation is the same as with expired uploads.
 
-Example cases for expired uploads
+Example cases for expired uploads:
 
 *   In the final step the upload blob is moved from the upload area to the final blobstore (e.g. S3). 
 
 *   If the bandwidth is limited and the file to transfer can't be transferred completely before the upload expiration time is reached, the file expires and can't be processed.
 
-The admin can restart the postprocessing for this with the postprocessing cli.
+*   If the upload was technically successful, but the postprocessing step failed due to an internal error, it will not get further processed. See the procedure **Resume Post-Processing** in the `postprocessing` service documentation for details how to solve this.
 
-The storage users service can only list and clean upload sessions:
+The following commands are available to manage unfinished uploads:
 
 ```bash
 ocis storage-users uploads <command>


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-ocis/pull/773 (Update of the restart postprocessing process)

When writing the above PR based on changes in ocis, I identified that readmes in ocis also need a fix to make things complete and inline.