### PR TITLE
fix(public-share-auth): allow to create new documents in public share folder

### DIFF
--- a/changelog/unreleased/fix-adding-wopi-doc-on-public-share.md
+++ b/changelog/unreleased/fix-adding-wopi-doc-on-public-share.md
@@ -1,0 +1,7 @@
+Bugfix: Fix creating new WOPI documents on public shares
+
+Creating a new Office document in a publicly shared folder is now possible.
+
+https://github.com/owncloud/ocis/pull/8828
+https://github.com/owncloud/ocis/issues/8691
+

--- a/services/proxy/pkg/middleware/public_share_auth.go
+++ b/services/proxy/pkg/middleware/public_share_auth.go
@@ -44,7 +44,7 @@ func isPublicShareArchive(r *http.Request) bool {
 // The app open requests can also be made in authenticated context. In these cases the PublicShareAuthenticator
 // needs to ignore the request.
 func isPublicShareAppOpen(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, "/app/open") &&
+	return (strings.HasPrefix(r.URL.Path, "/app/open") || strings.HasPrefix(r.URL.Path, "/app/new")) &&
 		(r.URL.Query().Get(headerShareToken) != "" || r.Header.Get(headerShareToken) != "")
 }
 


### PR DESCRIPTION
The public share authentication middleware only allowed to open existing documents the /app/new route was missing.

Fixes #8691
