### PR TITLE
[docs-only] Remove EXPERIMENTAL from envvar text

### DIFF
--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -145,7 +145,7 @@ type OCS struct {
 	PublicShareMustHavePassword          bool               `yaml:"public_sharing_share_must_have_password" env:"OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD;FRONTEND_OCS_PUBLIC_SHARE_MUST_HAVE_PASSWORD" desc:"Set this to true if you want to enforce passwords on all public shares." introductionVersion:"5.0"`
 	WriteablePublicShareMustHavePassword bool               `yaml:"public_sharing_writeableshare_must_have_password" env:"OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD;FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" desc:"Set this to true if you want to enforce passwords for writable shares. Only effective if the setting for 'passwords on all public shares' is set to false." introductionVersion:"5.0"`
 	IncludeOCMSharees                    bool               `yaml:"include_ocm_sharees" env:"FRONTEND_OCS_INCLUDE_OCM_SHAREES" desc:"Include OCM sharees when listing sharees." introductionVersion:"5.0"`
-	ShowUserEmailInResults               bool               `yaml:"show_email_in_results" env:"FRONTEND_SHOW_USER_EMAIL_IN_RESULTS;OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses. (EXPERIMENTAL)" introductionVersion:"5.1"`
+	ShowUserEmailInResults               bool               `yaml:"show_email_in_results" env:"FRONTEND_SHOW_USER_EMAIL_IN_RESULTS;OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"5.1"`
 }
 
 type CacheWarmupDrivers struct {


### PR DESCRIPTION
Based on a discussion with @tbsbdr, we can remove the EXPERIMENTAL string from the `OCIS_SHOW_USER_EMAIL_IN_RESULTS` envvar text in the frontend service.

This is already fixed in master.