### PR TITLE
[full-ci] chore: bump web to v9.0.0-alpha.5

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=9b9616b8429432002d06c4a2c8f252cbe08fb735
-WEB_BRANCH=changeResponseCodeDelete
+WEB_COMMITID=70cea7ca54a2d279a1f4c5aec070fb82850aca8e
+WEB_BRANCH=master

--- a/changelog/unreleased/update-web-9.0.0.md
+++ b/changelog/unreleased/update-web-9.0.0.md
@@ -1,8 +1,8 @@
-Enhancement: Update web to v9.0.0-alpha.4
+Enhancement: Update web to v9.0.0-alpha.5
 
 Tags: web
 
-We updated ownCloud Web to v9.0.0-alpha.4. Please refer to the changelog (linked) for details on the web release.
+We updated ownCloud Web to v9.0.0-alpha.5. Please refer to the changelog (linked) for details on the web release.
 
 ## Summary
 * Bugfix [owncloud/web#10377](https://github.com/owncloud/web/pull/10377): User data not updated while altering own user
@@ -11,6 +11,8 @@ We updated ownCloud Web to v9.0.0-alpha.4. Please refer to the changelog (linked
 * Bugfix [owncloud/web#10551](https://github.com/owncloud/web/pull/10551): Share sidebar icons
 * Bugfix [owncloud/web#10702](https://github.com/owncloud/web/pull/10702): Apply sandbox attribute to iframe in draw-io extension
 * Bugfix [owncloud/web#10706](https://github.com/owncloud/web/pull/10706): Apply sandbox attribute to iframe in app-external extension
+* Bugfix [owncloud/web#10760](https://github.com/owncloud/web/pull/10760): Incoming notifications broken while notification center is open
+* Bugfix [owncloud/web#10746](https://github.com/owncloud/web/pull/10746): Versions loaded multiple times when opening sidebar
 * Change [owncloud/web#7338](https://github.com/owncloud/web/issues/7338): Remove deprecated code
 * Change [owncloud/web#9892](https://github.com/owncloud/web/issues/9892): Remove skeleton app
 * Change [owncloud/web#10102](https://github.com/owncloud/web/pull/10102): Remove deprecated extension point for adding quick actions
@@ -37,6 +39,7 @@ We updated ownCloud Web to v9.0.0-alpha.4. Please refer to the changelog (linked
 * Enhancement [owncloud/web#10709](https://github.com/owncloud/web/pull/10709): Implement Server-Sent Events (SSE) for File Creation
 * Enhancement [owncloud/web#10443](https://github.com/owncloud/web/pull/10443): Custom component extension type
 * Enhancement [owncloud/web#10443](https://github.com/owncloud/web/pull/10443): Add extensionPoint concept
+* Enhancement [owncloud/web#10782](https://github.com/owncloud/web/pull/10782): Implement Server-Sent Events (SSE) for file updates
 
-https://github.com/owncloud/ocis/pull/8812
-https://github.com/owncloud/web/releases/tag/v9.0.0-alpha.4
+https://github.com/owncloud/ocis/pull/8868
+https://github.com/owncloud/web/releases/tag/v9.0.0-alpha.5

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v9.0.0-alpha.4
+WEB_ASSETS_VERSION = v9.0.0-alpha.5
 
 include ../../.make/recursion.mk
 

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -19,8 +19,8 @@ Feature: an user gets the resources shared to them
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
-      | permissionsRole | Viewer        |
-    When user "Brian" lists the shares shared with him using the Graph API
+      | permissionsRole | Viewer        | 
+    When user "Brian" lists the shares shared with him after clearing user cache using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
     """


### PR DESCRIPTION
Bumps Web to `v9.0.0-alpha.5`.