### PR TITLE
Unbonk rename logic

### DIFF
--- a/changelog/unreleased/sharing-sse.md
+++ b/changelog/unreleased/sharing-sse.md
@@ -3,3 +3,4 @@ Enhancement: Sharing SSEs
 Added server side events for item moved, share created/updated/removed, space membership created/removed.
 
 https://github.com/owncloud/ocis/pull/8854
+https://github.com/owncloud/ocis/pull/8875


### PR DESCRIPTION
Logic to decide what is a `rename` and what is a `move` was bonked. Should be working now.

Fixes https://github.com/owncloud/ocis/issues/8854