### PR TITLE
[test-only] remove access to drive tests

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1851,7 +1851,7 @@ class GraphHelper {
 	 *
 	 * @throws GuzzleException
 	 */
-	public static function deleteSharePermission(
+	public static function removeAccessToSpaceItem(
 		string $baseUrl,
 		string $xRequestId,
 		string $user,
@@ -1861,6 +1861,36 @@ class GraphHelper {
 		string $permissionId
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permissionId");
+		return HttpRequestHelper::delete(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders()
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $spaceId
+	 * @param string $permissionId
+	 *
+	 * @return ResponseInterface
+	 *
+	 * @throws GuzzleException
+	 */
+	public static function removeAccessToSpace(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $spaceId,
+		string $permissionId
+	): ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/permissions/$permissionId");
 		return HttpRequestHelper::delete(
 			$url,
 			$xRequestId,

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -250,10 +250,10 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSharingNg/linkShare.feature:586](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/linkShare.feature#L586)
 - [apiSharingNg/linkShare.feature:587](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/linkShare.feature#L587)
 - [apiSharingNg/linkShare.feature:659](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/linkShare.feature#L659)
-- [apiSharingNg/deletePermissions.feature:125](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/deletePermissions.feature#L125)
-- [apiSharingNg/deletePermissions.feature:141](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/deletePermissions.feature#L141)
-- [apiSharingNg/deletePermissions.feature:161](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/deletePermissions.feature#L161)
-- [apiSharingNg/deletePermissions.feature:179](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/deletePermissions.feature#L179)
+- [apiSharingNg/removeAccessToDriveItem.feature:125](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature#L125)
+- [apiSharingNg/removeAccessToDriveItem.feature:141](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature#L141)
+- [apiSharingNg/removeAccessToDriveItem.feature:161](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature#L161)
+- [apiSharingNg/removeAccessToDriveItem.feature:179](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature#L179)
 
 ### [sharee (editor role) MOVE a file by file-id into same shared folder returns 403](https://github.com/owncloud/ocis/issues/7617)
 

--- a/tests/acceptance/features/apiSharingNg/removeAccessToDrive.feature
+++ b/tests/acceptance/features/apiSharingNg/removeAccessToDrive.feature
@@ -1,0 +1,47 @@
+Feature: Remove access to a drive
+  https://owncloud.dev/libre-graph-api/#/drives.root/DeletePermissionSpaceRoot
+  
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And using spaces DAV path
+
+
+  Scenario Outline: user removes user member from project space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has sent the following share invitation:
+      | space           | NewSpace           |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+    When user "Alice" removes the access of user "Brian" from space "NewSpace" using root endpoint of the Graph API
+    Then the HTTP status code should be "204"
+    And the user "Brian" should not have a space called "NewSpace"
+    Examples:
+      | permissions-role |
+      | Space Viewer     |
+      | Space Editor     |
+      | Manager          |
+
+  @issue-8768
+  Scenario Outline: user removes group from project space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has sent the following share invitation:
+      | space           | NewSpace           |
+      | sharee          | group1             |
+      | shareType       | group              |
+      | permissionsRole | <permissions-role> |
+    When user "Alice" removes the access of group "group1" from space "NewSpace" using root endpoint of the Graph API
+    Then the HTTP status code should be "204"
+    And the user "Brian" should not have a space called "NewSpace"
+    Examples:
+      | permissions-role |
+      | Space Viewer     |
+      | Space Editor     |
+      | Manager          |

--- a/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature
+++ b/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature
@@ -18,7 +18,7 @@ Feature: Remove access to a drive item
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    When user "Alice" removes the share permission of user "Brian" from resource "<resource>" of space "Personal" using the Graph API
+    When user "Alice" removes the access of user "Brian" from resource "<resource>" of space "Personal" using the Graph API
     Then the HTTP status code should be "204"
     And for user "Brian" the space "Shares" should not contain these entries:
       | <resource> |
@@ -42,7 +42,7 @@ Feature: Remove access to a drive item
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    When user "Alice" removes the share permission of user "Brian" from resource "<resource>" of space "NewSpace" using the Graph API
+    When user "Alice" removes the access of user "Brian" from resource "<resource>" of space "NewSpace" using the Graph API
     Then the HTTP status code should be "204"
     And for user "Brian" the space "Shares" should not contain these entries:
       | <resource> |
@@ -67,7 +67,7 @@ Feature: Remove access to a drive item
       | sharee          | group1             |
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
-    When user "Alice" removes the share permission of group "group1" from resource "<resource>" of space "Personal" using the Graph API
+    When user "Alice" removes the access of group "group1" from resource "<resource>" of space "Personal" using the Graph API
     Then the HTTP status code should be "204"
     And for user "Brian" the space "Shares" should not contain these entries:
       | <resource> |
@@ -94,7 +94,7 @@ Feature: Remove access to a drive item
       | sharee          | group1             |
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
-    When user "Alice" removes the share permission of group "group1" from resource "<resource>" of space "NewSpace" using the Graph API
+    When user "Alice" removes the access of group "group1" from resource "<resource>" of space "NewSpace" using the Graph API
     Then the HTTP status code should be "204"
     And for user "Brian" the space "Shares" should not contain these entries:
       | <resource> |
@@ -114,7 +114,7 @@ Feature: Remove access to a drive item
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
       | password        | %public%           |
-    When user "Alice" removes the share permission of link from folder "FolderToShare" of space "Personal" using the Graph API
+    When user "Alice" removes the link of folder "FolderToShare" from space "Personal" using the Graph API
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
@@ -132,7 +132,7 @@ Feature: Remove access to a drive item
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
       | password        | %public%           |
-    When user "Alice" removes the share permission of link from file "textfile.txt" of space "Personal" using the Graph API
+    When user "Alice" removes the link of file "textfile.txt" from space "Personal" using the Graph API
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
@@ -150,7 +150,7 @@ Feature: Remove access to a drive item
       | space           | NewSpace           |
       | permissionsRole | <permissions-role> |
       | password        | %public%           |
-    When user "Alice" removes the share permission of link from folder "FolderToShare" of space "NewSpace" using the Graph API
+    When user "Alice" removes the link of folder "FolderToShare" from space "NewSpace" using the Graph API
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
@@ -170,7 +170,7 @@ Feature: Remove access to a drive item
       | space           | NewSpace           |
       | permissionsRole | <permissions-role> |
       | password        | %public%           |
-    When user "Alice" removes the share permission of link from file "textfile.txt" of space "NewSpace" using the Graph API
+    When user "Alice" removes the link of file "textfile.txt" from space "NewSpace" using the Graph API
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
@@ -178,8 +178,8 @@ Feature: Remove access to a drive item
       | edit             |
       | blocksDownload   |
 
-  
-  Scenario Outline: user removes user member from project space
+
+  Scenario Outline: user removes user member from project space using permissions endpoint
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has sent the following share invitation:
@@ -187,7 +187,7 @@ Feature: Remove access to a drive item
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    When user "Alice" removes the share permission of user "Brian" from space "NewSpace" using the Graph API
+    When user "Alice" removes the access of user "Brian" from space "NewSpace" using permissions endpoint of the Graph API
     Then the HTTP status code should be "204"
     And the user "Brian" should not have a space called "NewSpace"
     Examples:
@@ -196,8 +196,8 @@ Feature: Remove access to a drive item
       | Space Editor     |
       | Manager          |
 
-  @issue-8768
-  Scenario Outline: user removes group from project space
+
+  Scenario Outline: user removes group from project space using permissions endpoint
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And group "group1" has been created
@@ -207,11 +207,11 @@ Feature: Remove access to a drive item
       | sharee          | group1              |
       | shareType       | group               |
       | permissionsRole | <permissions-role> |
-    When user "Alice" removes the share permission of group "group1" from space "NewSpace" using the Graph API
+    When user "Alice" removes the access of group "group1" from space "NewSpace" using permissions endpoint of the Graph API
     Then the HTTP status code should be "204"
     And the user "Brian" should not have a space called "NewSpace"
     Examples:
       | permissions-role |
       | Space Viewer     |
       | Space Editor     |
-      | Manager          |    
+      | Manager          |  

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -459,7 +459,7 @@ class SharingNgContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function removeSharePermission(
+	public function removeAccessToSpaceItem(
 		string $sharer,
 		string $shareType,
 		string $space,
@@ -473,7 +473,7 @@ class SharingNgContext implements Context {
 			? $this->featureContext->shareNgGetLastCreatedLinkShareID()
 			: $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		return
-			GraphHelper::deleteSharePermission(
+			GraphHelper::removeAccessToSpaceItem(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getStepLineRef(),
 				$sharer,
@@ -485,7 +485,39 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the share permission of (user|group) "([^"]*)" from (?:file|folder|resource) "([^"]*)" of space "([^"]*)" using the Graph API$/
+	 * @param string $sharer
+	 * @param string $shareType (user|group|link)
+	 * @param string $space
+	 * @param string|null $recipient
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function removeAccessToSpace(
+		string $sharer,
+		string $shareType,
+		string $space,
+		?string $recipient = null
+	): ResponseInterface {
+		$spaceId = ($this->spacesContext->getSpaceByName($sharer, $space))["id"];
+
+		$permId = ($shareType === 'link')
+			? $this->featureContext->shareNgGetLastCreatedLinkShareID()
+			: $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
+		return
+			GraphHelper::removeAccessToSpace(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getStepLineRef(),
+				$sharer,
+				$this->featureContext->getPasswordForUser($sharer),
+				$spaceId,
+				$permId
+			);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" removes the access of (user|group) "([^"]*)" from (?:file|folder|resource) "([^"]*)" of space "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $recipientType (user|group)
@@ -497,7 +529,7 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function userRemovesSharePermissionOfUserFromResourceOfSpaceUsingGraphAPI(
+	public function userRemovesAccessOfUserOrGroupFromResourceOfSpaceUsingGraphAPI(
 		string $sharer,
 		string $recipientType,
 		string $recipient,
@@ -505,12 +537,12 @@ class SharingNgContext implements Context {
 		string $space
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeSharePermission($sharer, $recipientType, $space, $resource)
+			$this->removeAccessToSpaceItem($sharer, $recipientType, $space, $resource)
 		);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the share permission of (user|group) "([^"]*)" from space "([^"]*)" using the Graph API$/
+	 * @When /^user "([^"]*)" removes the access of (user|group) "([^"]*)" from space "([^"]*)" using permissions endpoint of the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $recipientType (user|group)
@@ -521,19 +553,19 @@ class SharingNgContext implements Context {
 	 * @throws JsonException
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function userRemovesSharePermissionOfUserFromSpaceUsingGraphAPI(
+	public function userRemovesAccessOfUserOrGroupFromSpaceUsingPermissionsEndpointOfGraphAPI(
 		string $sharer,
 		string $recipientType,
 		string $recipient,
 		string $space
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeSharePermission($sharer, $recipientType, $space)
+			$this->removeAccessToSpaceItem($sharer, $recipientType, $space)
 		);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" removes the share permission of link from (?:file|folder) "([^"]*)" of space "([^"]*)" using the Graph API$/
+	 * @When /^user "([^"]*)" removes the link of (?:file|folder) "([^"]*)" from space "([^"]*)" using the Graph API$/
 	 *
 	 * @param string $sharer
 	 * @param string $resource
@@ -549,7 +581,49 @@ class SharingNgContext implements Context {
 		string $space
 	):void {
 		$this->featureContext->setResponse(
-			$this->removeSharePermission($sharer, 'link', $space, $resource)
+			$this->removeAccessToSpaceItem($sharer, 'link', $space, $resource)
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" removes the access of (user|group) "([^"]*)" from space "([^"]*)" using root endpoint of the Graph API$/
+	 *
+	 * @param string $sharer
+	 * @param string $recipientType (user|group)
+	 * @param string $recipient can be both user or group
+	 * @param string $space
+	 *
+	 * @return void
+	 * @throws JsonException
+	 * @throws \GuzzleHttp\Exception\GuzzleException
+	 */
+	public function userRemovesAccessOfUserOrGroupFromSpaceUsingGraphAPI(
+		string $sharer,
+		string $recipientType,
+		string $recipient,
+		string $space
+	): void {
+		$this->featureContext->setResponse(
+			$this->removeAccessToSpace($sharer, $recipientType, $space)
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" removes the link from space "([^"]*)" using root endpoint of the Graph API$/
+	 *
+	 * @param string $sharer
+	 * @param string $space
+	 *
+	 * @return void
+	 * @throws JsonException
+	 * @throws GuzzleException
+	 */
+	public function userRemovesLinkFromSpaceUsingRootEndpointOfGraphAPI(
+		string $sharer,
+		string $space
+	):void {
+		$this->featureContext->setResponse(
+			$this->removeAccessToSpace($sharer, 'link', $space)
 		);
 	}
 
@@ -705,7 +779,7 @@ class SharingNgContext implements Context {
 			$httpsStatusCode = $responseSendInvitation->getStatusCode();
 			if ($httpsStatusCode === 200 && !empty($jsonResponseSendInvitation->value)) {
 				// remove the share so that the same user can be share for the next allowed roles
-				$removePermissionsResponse = $this->removeSharePermission($user, $shareType, $space, $resource);
+				$removePermissionsResponse = $this->removeAccessToSpaceItem($user, $shareType, $space, $resource);
 				Assert::assertEquals(204, $removePermissionsResponse->getStatusCode());
 			} else {
 				$areAllSendInvitationSuccessFullForAllowedRoles = false;


### PR DESCRIPTION
https://owncloud.dev/libre-graph-api/#/drives.root/DeletePermissionSpaceRoot

- [x] split `deletePermitions.feature` to `removeAccessToDrive.feature` and `removeAccessToDriveItem.feature` using same naming https://owncloud.dev/libre-graph-api
- [x] fix naming in the swagger https://github.com/owncloud/libre-graph-api/pull/173
- [x] remove access to space uses `DELETE` `/drives/{drive-id}/root/permissions/{permissionID}` instead of `DELETE` `/drives/{drive-id}/items/{item-id}permissions/{permissionID}` 

- [x] added tests deleting space access using `DELETE` `/drives/{drive-id}/items/{item-id}permissions/{permissionID}` Not sure that we need tests for that

- [ ] ToDo I added step when we delete space link but we don't have tests where we create space link so deleting space link will be implement later