### PR TITLE
Fix nats reconnects

### DIFF
--- a/changelog/unreleased/nats-reconnects.md
+++ b/changelog/unreleased/nats-reconnects.md
@@ -1,5 +1,5 @@
 Bugfix: Nats reconnects
 
-Natsjs kv registry could not handle reconnects correctly. This fixes it.
+We fixed the reconnect handling of the natjs kv registry.
 
 https://github.com/owncloud/ocis/pull/8880

--- a/changelog/unreleased/nats-reconnects.md
+++ b/changelog/unreleased/nats-reconnects.md
@@ -1,0 +1,5 @@
+Bugfix: Nats reconnects
+
+Natsjs kv registry could not handle reconnects correctly. This fixes it.
+
+https://github.com/owncloud/ocis/pull/8880


### PR DESCRIPTION
Repairs reconnects on the natsjs kv registry

New behaviour:
- when nats gets disconnected -> no change
- when nats gets reconnected -> registry reconnects correctly
- when nats connection is closed -> os.Exit as there is no way to recover without initializing everything

Fixes https://github.com/owncloud/ocis/issues/8783