### PR TITLE
[tests-only] do not try to delete already deleted groups

### DIFF
--- a/tests/acceptance/features/apiSharingNg/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/shareInvitations.feature
@@ -863,7 +863,7 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    And the administrator has deleted group "grp1"
+    And group "grp1" has been deleted
     When user "Alice" sends the following share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |

--- a/tests/acceptance/features/apiSharingNg/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedByMe.feature
@@ -1463,7 +1463,7 @@ Feature: resources shared by user
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And the administrator has deleted user "Brian" using the provisioning API
+    And user "Brian" has been deleted
     When user "Alice" lists the shares shared by her after clearing user cache using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -1042,7 +1042,7 @@ class GraphContext implements Context {
 	public function userDeletesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$response = $this->deleteGroupWithId($groupId, $user);
-		if ($response->getStatusCode() === 204){
+		if ($response->getStatusCode() === 204) {
 			$this->featureContext->rememberThatGroupIsNotExpectedToExist($group);
 		}
 		$this->featureContext->setResponse($response);

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -1042,20 +1042,10 @@ class GraphContext implements Context {
 	public function userDeletesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$response = $this->deleteGroupWithId($groupId, $user);
+		if ($response->getStatusCode() === 204){
+			$this->featureContext->rememberThatGroupIsNotExpectedToExist($group);
+		}
 		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @Given the administrator has deleted group :group
-	 *
-	 * @param string $group
-	 *
-	 * @return void
-	 */
-	public function theAdministratorHasDeletedGroup(string $group): void {
-		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
-		$response = $this->deleteGroupWithId($groupId);
-		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -274,7 +274,7 @@ class GraphContext implements Context {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public function userDeletesGroupWithGroupId(
+	public function deleteGroupWithId(
 		string $groupId,
 		?string $user = null
 	): ResponseInterface {
@@ -290,30 +290,17 @@ class GraphContext implements Context {
 	}
 
 	/**
-	 * @param string $groupId
-	 *
-	 * @return void
-	 * @throws GuzzleException
-	 */
-	public function adminDeletesGroupWithGroupId(
-		string $groupId
-	): void {
-		$response = $this->userDeletesGroupWithGroupId($groupId);
-		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
-	}
-
-	/**
 	 * @param string $group
 	 *
-	 * @return void
+	 * @return ResponseInterface
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
-	public function adminDeletesGroupUsingTheGraphApi(
+	public function deleteGroupWithName(
 		string $group
-	): void {
+	): ResponseInterface {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
-		$this->adminDeletesGroupWithGroupId($groupId);
+		return $this->deleteGroupWithId($groupId);
 	}
 
 	/**
@@ -1054,7 +1041,7 @@ class GraphContext implements Context {
 	 */
 	public function userDeletesGroupUsingTheGraphApi(string $group, ?string $user = null): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
-		$response = $this->userDeletesGroupWithGroupId($groupId, $user);
+		$response = $this->deleteGroupWithId($groupId, $user);
 		$this->featureContext->setResponse($response);
 	}
 
@@ -1067,7 +1054,7 @@ class GraphContext implements Context {
 	 */
 	public function theAdministratorHasDeletedGroup(string $group): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
-		$response = $this->userDeletesGroupWithGroupId($groupId);
+		$response = $this->deleteGroupWithId($groupId);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 	}
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -222,18 +222,11 @@ trait Provisioning {
 		$usersList = $this->getCreatedUsers();
 		$normalizedUsername = $this->normalizeUsername($user);
 		if (\array_key_exists($normalizedUsername, $usersList)) {
-			// provide attributes only if the user exists
-			if ($usersList[$normalizedUsername]["shouldExist"]) {
-				if (\array_key_exists($attribute, $usersList[$normalizedUsername])) {
-					return $usersList[$normalizedUsername][$attribute];
-				} else {
-					throw new Exception(
-						__METHOD__ . ": User '$user' has no attribute with name '$attribute'."
-					);
-				}
+			if (\array_key_exists($attribute, $usersList[$normalizedUsername])) {
+				return $usersList[$normalizedUsername][$attribute];
 			} else {
 				throw new Exception(
-					__METHOD__ . ": User '$user' has been deleted."
+					__METHOD__ . ": User '$user' has no attribute with name '$attribute'."
 				);
 			}
 		} else {
@@ -251,18 +244,11 @@ trait Provisioning {
 	public function getAttributeOfCreatedGroup(string $group, string $attribute) {
 		$groupsList = $this->getCreatedGroups();
 		if (\array_key_exists($group, $groupsList)) {
-			// provide attributes only if the group exists
-			if ($groupsList[$group]["shouldExist"]) {
-				if (\array_key_exists($attribute, $groupsList[$group])) {
-					return $groupsList[$group][$attribute];
-				} else {
-					throw new Exception(
-						__METHOD__ . ": Group '$group' has no attribute with name '$attribute'."
-					);
-				}
+			if (\array_key_exists($attribute, $groupsList[$group])) {
+				return $groupsList[$group][$attribute];
 			} else {
 				throw new Exception(
-					__METHOD__ . ": Group '$group' has been deleted."
+					__METHOD__ . ": Group '$group' has no attribute with name '$attribute'."
 				);
 			}
 		} else {
@@ -1362,22 +1348,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^the administrator has deleted user "([^"]*)" using the provisioning API$/
-	 *
-	 * @param string|null $user
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theAdministratorHasDeletedUserUsingTheProvisioningApi(?string $user):void {
-		$user = $this->getActualUsername($user);
-		$response =  $this->deleteUser($user);
-		$this->theHttpStatusCodeShouldBe(204, "", $response);
-		WebDavHelper::removeSpaceIdReferenceForUser($user);
-		$this->userShouldNotExist($user);
-	}
-
-	/**
 	 * @When /^the administrator deletes user "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
@@ -1929,8 +1899,10 @@ trait Provisioning {
 			} else {
 				$response = $this->deleteUser($user);
 				$this->theHTTPStatusCodeShouldBe(204, "", $response);
+				WebDavHelper::removeSpaceIdReferenceForUser($user);
 			}
 		}
+		$this->rememberThatUserIsNotExpectedToExist($user);
 		$this->userShouldNotExist($user);
 	}
 

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -198,7 +198,7 @@ class SharingNgContext implements Context {
 				$shareeId = "";
 				if ($shareType === "user") {
 					$shareeId = $this->featureContext->getAttributeOfCreatedUser($sharee, 'id');
-				} else if ($shareType === "group") {
+				} elseif ($shareType === "group") {
 					$shareeId = $this->featureContext->getAttributeOfCreatedGroup($sharee, 'id');
 				}
 				// for non-exiting group or user, generate random id

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -201,7 +201,7 @@ class SharingNgContext implements Context {
 				} elseif ($shareType === "group") {
 					$shareeId = $this->featureContext->getAttributeOfCreatedGroup($sharee, 'id');
 				}
-				// for non-exiting group or user, generate random id
+				// for non-existing group or user, generate random id
 				$shareeIds[] = $shareeId ?: WebDavHelper::generateUUIDv4();
 			}
 		}

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -193,10 +193,16 @@ class SharingNgContext implements Context {
 			$sharees = array_map('trim', explode(',', $rows['sharee']));
 			$shareTypes = array_map('trim', explode(',', $rows['shareType']));
 
-			foreach ($sharees as $sharee) {
+			foreach ($sharees as $index => $sharee) {
+				$shareType = $shareTypes[$index];
+				$shareeId = "";
+				if ($shareType === "user") {
+					$shareeId = $this->featureContext->getAttributeOfCreatedUser($sharee, 'id');
+				} else if ($shareType === "group") {
+					$shareeId = $this->featureContext->getAttributeOfCreatedGroup($sharee, 'id');
+				}
 				// for non-exiting group or user, generate random id
-				$shareeIds[] = $this->featureContext->getAttributeOfCreatedUser($sharee, 'id')
-					?: ($this->featureContext->getAttributeOfCreatedGroup($sharee, 'id') ?: WebDavHelper::generateUUIDv4());
+				$shareeIds[] = $shareeId ?: WebDavHelper::generateUUIDv4();
 			}
 		}
 

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -533,7 +533,7 @@ Feature: sharing
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile0.txt" with user "Carol"
-    And the administrator has deleted user "Brian" using the provisioning API
+    And user "Brian" has been deleted
     When user "Alice" gets all the shares of the file "textfile0.txt" using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
@@ -206,7 +206,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin102" has deleted file "/textfile0.txt"
     And user "testtrashbin102" has deleted file "/textfile2.txt"
-    And the administrator has deleted user "testtrashbin102" using the provisioning API
+    And user "testtrashbin102" has been deleted
     And user "testtrashbin102" has been created with default attributes and without skeleton files
     And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile3.txt"
     And user "testtrashbin102" has deleted file "/textfile3.txt"


### PR DESCRIPTION
## Description
Do not try to delete already deleted groups

Fixes this error in AfterScenario hooks:
```php
│
  ╳  HTTP status code 404 is not the expected value 204
  ╳  Failed asserting that 404 matches expected 204.
  │
  └─ @AfterScenario # FeatureContext::afterScenario()
```

## Related Issue
https://github.com/owncloud/ocis/issues/8864

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
