### PR TITLE
[tests-only] retry if auto-sync is enabled but client.synchronize is false

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -685,4 +685,15 @@ class HttpRequestHelper {
 		$timeout = \getenv("REQUEST_TIMEOUT");
 		return (int)$timeout ?: 60;
 	}
+
+	/**
+	 * returns json decoded body content of a json response as an object
+	 *
+	 * @param ResponseInterface $response
+	 *
+	 * @return mixed
+	 */
+	public static function getJsonDecodedResponseBodyContent(ResponseInterface $response): mixed {
+		return json_decode($response->getBody()->getContents(), null, 512, JSON_THROW_ON_ERROR);
+	}
 }

--- a/tests/TestHelpers/SettingsHelper.php
+++ b/tests/TestHelpers/SettingsHelper.php
@@ -1,0 +1,281 @@
+<?php declare(strict_types=1);
+/**
+ * ownCloud
+ *
+ * @author Sajan Gurung <sajan@jankaritech.com>
+ * @copyright Copyright (c) 2024 Sajan Gurung sajan@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace TestHelpers;
+
+use TestHelpers\HttpRequestHelper;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\Assert;
+
+/**
+ * A helper class for ocis settings
+ */
+class SettingsHelper {
+	private static string $settingsEndpoint = '/api/v0/settings/';
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $path
+	 *
+	 * @return string
+	 */
+	public static function buildFullUrl(string $baseUrl, string $path): string {
+		return $baseUrl . self::$settingsEndpoint . $path;
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $xRequestId
+	 * @param array $headers
+	 *
+	 * @return ResponseInterface
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function getBundlesList(string $baseUrl, string $user, string $password, string $xRequestId, array $headers = []): ResponseInterface {
+		$fullUrl = self::buildFullUrl($baseUrl, "bundles-list");
+		return HttpRequestHelper::post(
+			$fullUrl,
+			$xRequestId,
+			$user,
+			$password,
+			$headers,
+			"{}"
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $bundleName
+	 * @param string $xRequestId
+	 *
+	 * @return array
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function getBundleByName(string $baseUrl, string $user, string $password, string $bundleName, string $xRequestId): array {
+		$response = self::getBundlesList($baseUrl, $user, $password, $xRequestId);
+		Assert::assertEquals(201, $response->getStatusCode(), "Failed to get bundles list");
+
+		$bundlesList = HttpRequestHelper::getJsonDecodedResponseBodyContent($response);
+		foreach ($bundlesList->bundles as $value) {
+			if ($value->displayName === $bundleName) {
+				return json_decode(json_encode($value), true);
+			}
+		}
+		return [];
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $xRequestId
+	 * @param array $headers
+	 *
+	 * @return ResponseInterface
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function getRolesList(string $baseUrl, string $user, string $password, string $xRequestId, array $headers = []): ResponseInterface {
+		$fullUrl = self::buildFullUrl($baseUrl, "roles-list");
+		return HttpRequestHelper::post(
+			$fullUrl,
+			$xRequestId,
+			$user,
+			$password,
+			$headers,
+			"{}"
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $assigneeId
+	 * @param string $roleId
+	 * @param string $xRequestId
+	 * @param array $headers
+	 *
+	 * @return ResponseInterface
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function assignRoleToUser(string $baseUrl, string $user, string $password, string $assigneeId, string $roleId, string $xRequestId, array $headers = []): ResponseInterface {
+		$fullUrl = self::buildFullUrl($baseUrl, "assignments-add");
+		$body = json_encode(["account_uuid" => $assigneeId, "role_id" => $roleId], JSON_THROW_ON_ERROR);
+		return HttpRequestHelper::post(
+			$fullUrl,
+			$xRequestId,
+			$user,
+			$password,
+			$headers,
+			$body
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $userId
+	 * @param string $xRequestId
+	 * @param array $headers
+	 *
+	 * @return ResponseInterface
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function getAssignmentsList(string $baseUrl, string $user, string $password, string $userId, string $xRequestId, array $headers = []): ResponseInterface {
+		$fullUrl = self::buildFullUrl($baseUrl, "assignments-list");
+		$body = json_encode(["account_uuid" => $userId], JSON_THROW_ON_ERROR);
+		return HttpRequestHelper::post(
+			$fullUrl,
+			$xRequestId,
+			$user,
+			$password,
+			$headers,
+			$body
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $xRequestId
+	 * @param array $headers
+	 *
+	 * @return ResponseInterface
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function getValuesList(string $baseUrl, string $user, string $password, string $xRequestId, array $headers = []): ResponseInterface {
+		$fullUrl = self::buildFullUrl($baseUrl, "values-list");
+		$body = json_encode(["account_uuid" => "me"], JSON_THROW_ON_ERROR);
+		return HttpRequestHelper::post(
+			$fullUrl,
+			$xRequestId,
+			$user,
+			$password,
+			$headers,
+			$body
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $xRequestId
+	 *
+	 * @return bool
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function getAutoAcceptSharesSettingValue(string $baseUrl, string $user, string $password, string $xRequestId): bool {
+		$response = self::getValuesList($baseUrl, $user, $password, $xRequestId);
+		Assert::assertEquals(201, $response->getStatusCode(), "Failed to get values list");
+
+		$valuesList = HttpRequestHelper::getJsonDecodedResponseBodyContent($response);
+
+		if (empty($valuesList)) {
+			return true;
+		}
+
+		foreach ($valuesList->values as $value) {
+			if ($value->identifier->setting === "auto-accept-shares") {
+				return $value->value->boolValue;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $xRequestId
+	 *
+	 * @return string
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function getLanguageSettingValue(string $baseUrl, string $user, string $password, string $xRequestId): string {
+		$response = self::getValuesList($baseUrl, $user, $password, $xRequestId);
+		Assert::assertEquals(201, $response->getStatusCode(), "Failed to get values list");
+
+		$valuesList = HttpRequestHelper::getJsonDecodedResponseBodyContent($response);
+
+		// if no language is set, the request body is empty return English as the default language
+		if (empty($valuesList)) {
+			return "en";
+		}
+		foreach ($valuesList->values as $value) {
+			if ($value->identifier->setting === "language") {
+				return $value->value->listValue->values[0]->stringValue;
+			}
+		}
+		// if a language setting was still not found, return English
+		return "en";
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $body
+	 * @param string $xRequestId
+	 * @param array $headers
+	 *
+	 * @return ResponseInterface
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public static function updateSettings(string $baseUrl, string $user, string $password, string $body, string $xRequestId, array $headers = []): ResponseInterface {
+		$fullUrl = self::buildFullUrl($baseUrl, "values-save");
+		return HttpRequestHelper::post(
+			$fullUrl,
+			$xRequestId,
+			$user,
+			$password,
+			$headers,
+			$body
+		);
+	}
+}

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -20,7 +20,7 @@ Feature: an user gets the resources shared to them
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    When user "Brian" lists the shares shared with him after clearing user cache using the Graph API
+    When user "Brian" lists the shares shared with him using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -167,6 +167,39 @@ class FeatureContext extends BehatVariablesContext {
 	private array $lastHttpStatusCodesArray = [];
 	private array $lastOCSStatusCodesArray = [];
 
+	/**
+	 * Store for auto-sync settings for users
+	 */
+	private array $autoSyncSettings = [];
+
+	/**
+	 * @param string $user
+	 *
+	 * @return bool
+	 */
+	public function getUserAutoSyncSetting(string $user): bool {
+		if (\array_key_exists($user, $this->autoSyncSettings)) {
+			return $this->autoSyncSettings[$user];
+		}
+		// auto-sync is enabled by default
+		return true;
+	}
+
+	/**
+	 * @param string $user
+	 * @param bool $value
+	 *
+	 * @return void
+	 */
+	public function rememberUserAutoSyncSetting(string $user, bool $value): void {
+		$this->autoSyncSettings[$user] = $value;
+	}
+
+	/**
+	 * this is set true for db conversion tests
+	 */
+	private bool $dbConversion = false;
+
 	public const SHARES_SPACE_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668';
 	private bool $useSharingNG = false;
 

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -181,8 +181,10 @@ class FeatureContext extends BehatVariablesContext {
 		if (\array_key_exists($user, $this->autoSyncSettings)) {
 			return $this->autoSyncSettings[$user];
 		}
-		// auto-sync is enabled by default
-		return true;
+		$autoSyncSetting = $this->settingsContext->getAutoAcceptSharesSettingValue($user);
+		$this->autoSyncSettings[$user] = $autoSyncSetting;
+
+		return $autoSyncSetting;
 	}
 
 	/**
@@ -1465,15 +1467,12 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @param ResponseInterface|null $response
 	 *
-	 * @return object
+	 * @return mixed
 	 */
-	public function getJsonDecodedResponseBodyContent(ResponseInterface $response = null):?object {
+	public function getJsonDecodedResponseBodyContent(ResponseInterface $response = null): mixed {
 		$response = $response ?? $this->response;
-		if ($response !== null) {
-			$response->getBody()->rewind();
-			return json_decode($response->getBody()->getContents());
-		}
-		return null;
+		$response->getBody()->rewind();
+		return json_decode($response->getBody()->getContents(), null, 512, JSON_THROW_ON_ERROR);
 	}
 
 	/**
@@ -2440,12 +2439,14 @@ class FeatureContext extends BehatVariablesContext {
 		$this->ocsContext = new OCSContext();
 		$this->authContext = new AuthContext();
 		$this->tusContext = new TUSContext();
+		$this->settingsContext = new SettingsContext();
 		$this->ocsContext->before($scope);
 		$this->authContext->setUpScenario($scope);
 		$this->tusContext->setUpScenario($scope);
 		$environment->registerContext($this->ocsContext);
 		$environment->registerContext($this->authContext);
 		$environment->registerContext($this->tusContext);
+		$environment->registerContext($this->settingsContext);
 		$scenarioLine = $scope->getScenario()->getLine();
 		$featureFile = $scope->getFeature()->getFile();
 		$suiteName = $scope->getSuite()->getName();

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -42,6 +42,7 @@ use TestHelpers\HttpLogger;
 use TestHelpers\OcisHelper;
 use TestHelpers\GraphHelper;
 use TestHelpers\WebDavHelper;
+use TestHelpers\SettingsHelper;
 
 require_once 'bootstrap.php';
 
@@ -181,7 +182,12 @@ class FeatureContext extends BehatVariablesContext {
 		if (\array_key_exists($user, $this->autoSyncSettings)) {
 			return $this->autoSyncSettings[$user];
 		}
-		$autoSyncSetting = $this->settingsContext->getAutoAcceptSharesSettingValue($user);
+		$autoSyncSetting = SettingsHelper::getAutoAcceptSharesSettingValue(
+			$this->baseUrl,
+			$user,
+			$this->getPasswordForUser($user),
+			$this->getStepLineRef()
+		);
 		$this->autoSyncSettings[$user] = $autoSyncSetting;
 
 		return $autoSyncSetting;
@@ -196,11 +202,6 @@ class FeatureContext extends BehatVariablesContext {
 	public function rememberUserAutoSyncSetting(string $user, bool $value): void {
 		$this->autoSyncSettings[$user] = $value;
 	}
-
-	/**
-	 * this is set true for db conversion tests
-	 */
-	private bool $dbConversion = false;
 
 	public const SHARES_SPACE_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668';
 	private bool $useSharingNG = false;
@@ -1472,7 +1473,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function getJsonDecodedResponseBodyContent(ResponseInterface $response = null): mixed {
 		$response = $response ?? $this->response;
 		$response->getBody()->rewind();
-		return json_decode($response->getBody()->getContents(), null, 512, JSON_THROW_ON_ERROR);
+		return HttpRequestHelper::getJsonDecodedResponseBodyContent($response);
 	}
 
 	/**
@@ -2439,14 +2440,12 @@ class FeatureContext extends BehatVariablesContext {
 		$this->ocsContext = new OCSContext();
 		$this->authContext = new AuthContext();
 		$this->tusContext = new TUSContext();
-		$this->settingsContext = new SettingsContext();
 		$this->ocsContext->before($scope);
 		$this->authContext->setUpScenario($scope);
 		$this->tusContext->setUpScenario($scope);
 		$environment->registerContext($this->ocsContext);
 		$environment->registerContext($this->authContext);
 		$environment->registerContext($this->tusContext);
-		$environment->registerContext($this->settingsContext);
 		$scenarioLine = $scope->getScenario()->getLine();
 		$featureFile = $scope->getFeature()->getFile();
 		$suiteName = $scope->getSuite()->getName();

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2517,9 +2517,9 @@ class GraphContext implements Context {
 				$credentials['password']
 			);
 
-			$jsonObj = $this->featureContext->getJsonDecodedResponseBodyContent($response);
+			$jsonBody = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 
-			foreach ($jsonObj->value as $share) {
+			foreach ($jsonBody->value as $share) {
 				$autoSync = $this->featureContext->getUserAutoSyncSetting($credentials['username']);
 				$tryAgain = !$share->{'@client.synchronize'} && $autoSync && $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
 

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2503,14 +2503,38 @@ class GraphContext implements Context {
 		}
 
 		$credentials = $this->getAdminOrUserCredentials($user);
-		$this->featureContext->setResponse(
-			GraphHelper::getSharesSharedWithMe(
+
+		// Sometimes listing shares might not return the updated shares list
+		// so try again until @client.synchronize is true for the max. number of retries (i.e. 10)
+		// and do not retry when the share is expected to be not synced
+		$tryAgain = false;
+		$retried = 0;
+		do {
+			$response = GraphHelper::getSharesSharedWithMe(
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getStepLineRef(),
 				$credentials['username'],
 				$credentials['password']
-			)
-		);
+			);
+
+			$jsonObj = $this->featureContext->getJsonDecodedResponseBodyContent($response);
+
+			foreach ($jsonObj->value as $share) {
+				$autoSync = $this->featureContext->getUserAutoSyncSetting($credentials['username']);
+				$tryAgain = !$share->{'@client.synchronize'} && $autoSync && $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
+
+				if ($tryAgain) {
+					$retried += 1;
+					echo "auto-sync share for user '$user' is enabled\n";
+					echo "but share '$share->name' was not auto-synced, retrying ($retried)...\n";
+					// wait 500ms and try again
+					\usleep(500 * 1000);
+					break;
+				}
+			}
+		} while ($tryAgain);
+
+		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastStatusCodesArrays();
 	}
 

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -13,6 +13,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use TestHelpers\EmailHelper;
 use PHPUnit\Framework\Assert;
 use TestHelpers\GraphHelper;
+use TestHelpers\SettingsHelper;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
@@ -109,7 +110,13 @@ class NotificationContext implements Context {
 	 */
 	public function listAllNotifications(string $user):ResponseInterface {
 		$this->setUserRecipient($user);
-		$headers = ["accept-language" => $this->settingsContext->getSettingLanguageValue($user)];
+		$language = SettingsHelper::getLanguageSettingValue(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getActualUsername($user),
+			$this->featureContext->getPasswordForUser($user),
+			$this->featureContext->getStepLineRef()
+		);
+		$headers = ["accept-language" => $language];
 		return OcsApiHelper::sendRequest(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getActualUsername($user),

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -553,7 +553,12 @@ class OCSContext implements Context {
 	 * @throws Exception
 	 */
 	public function getOCSResponseStatusCode(ResponseInterface $response):string {
-		$jsonResponse = $this->featureContext->getJsonDecodedResponseBodyContent($response);
+		try {
+			$jsonResponse = $this->featureContext->getJsonDecodedResponseBodyContent($response);
+		} catch (JsonException $e) {
+			$jsonResponse = null;
+		}
+
 		if (\is_object($jsonResponse) && $jsonResponse->ocs->meta->statuscode) {
 			return (string) $jsonResponse->ocs->meta->statuscode;
 		}

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -360,6 +360,37 @@ class SettingsContext implements Context {
 	}
 
 	/**
+	 * @param string $user
+	 *
+	 * @return bool
+	 *
+	 * @throws GuzzleException
+	 * @throws Exception
+	 */
+	public function getAutoAcceptSharesSettingValue(string $user): bool {
+		$response = $this->sendRequestGetSettingsValuesList($user);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			201,
+			"Expected response status code should be 201",
+			$response
+		);
+
+		$body = $this->featureContext->getJsonDecodedResponseBodyContent($response);
+
+		if (empty($body)) {
+			return true;
+		}
+
+		foreach ($body->values as $value) {
+			if ($value->identifier->setting === "auto-accept-shares") {
+				return $value->value->boolValue;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * @When /^user "([^"]*)" lists values-list with headers using the Settings API$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -541,5 +541,6 @@ class SettingsContext implements Context {
 			"Expected response status code should be 201",
 			$response
 		);
+		$this->featureContext->rememberUserAutoSyncSetting($user, false);
 	}
 }

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -1132,6 +1132,8 @@ class SharingNgContext implements Context {
 		);
 		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastStatusCodesArrays();
+		// disable check for client.synchronize
+		$this->featureContext->rememberUserAutoSyncSetting($user, false);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Implemented retry when listing the shares if auto-sync is enabled but client.synchronize is false. If the auto-sync is disabled then the retry will be skipped.

Scenarios can pass with retry:
```feature
    When user "Brian" lists the shares shared with him using the Graph API
      │ auto-sync share for user 'Brian' is enabled
      │ but share 'textfile0.txt' was not auto-synced, retrying (1)...
      │ 
    Then the HTTP status code should be "200"
```
## Related Issue
- Revert https://github.com/owncloud/ocis/commit/4e66cc730e633cd3ff3dac787e9bd5f92c0b7224
- Fixes #8864, Fixes #8859

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
