### PR TITLE
[tests-only][full-ci] changed given statement of sharing link in api antivirus feature file

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -208,6 +208,7 @@ default:
         - SettingsContext:
         - OcisConfigContext:
         - PublicWebDavContext:
+        - SharingNgContext:
 
     apiDownloads:
       paths:

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -86,16 +86,17 @@ Feature: antivirus
       | spaces           |
 
 
-  Scenario Outline: upload a file with the virus to a public share
+  Scenario Outline: public uploads a file with the virus to a public share
     Given using <dav-path-version> DAV path
+    And the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
+    And using SharingNG
     And user "Alice" has created folder "/uploadFolder"
     And user "Alice" has created the following link share:
       | resource           | uploadFolder             |
       | space              | Personal                 |
       | permissionsRole    | edit                     |
-      | password           | %public%                 |
       | expirationDateTime | 2040-01-01T23:59:59.000Z |
-    When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/uploadFolder/<new-file-name>" using the WebDAV API
+    When the public uploads file "filesForUpload/filesWithVirus/<file-name>" to "<new-file-name>" inside last link shared folder using the new WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                          |
@@ -111,8 +112,9 @@ Feature: antivirus
       | spaces           | eicar_com.zip | virusFile2.zip |
 
 
-  Scenario Outline: upload a file with the virus to a password-protected public share
+  Scenario Outline: public uploads a file with the virus to a password-protected public share
     Given using <dav-path-version> DAV path
+    And using SharingNG
     And user "Alice" has created folder "/uploadFolder"
     And user "Alice" has created the following link share:
       | resource           | uploadFolder             |
@@ -120,7 +122,7 @@ Feature: antivirus
       | permissionsRole    | edit                     |
       | password           | %public%                 |
       | expirationDateTime | 2040-01-01T23:59:59.000Z |
-    When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/uploadFolder/<new-file-name>" using the WebDAV API
+    When the public uploads file "filesForUpload/filesWithVirus/<file-name>" to "<new-file-name>" inside last link shared folder with password "%public%" using the new WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                          |

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -89,12 +89,12 @@ Feature: antivirus
   Scenario Outline: upload a file with the virus to a public share
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/uploadFolder"
-    And user "Alice" has created a public link share with settings
-      | path        | /uploadFolder            |
-      | name        | sharedlink               |
-      | permissions | change                   |
-      | expireDate  | 2040-01-01T23:59:59+0100 |
-      | password    | %public%                 |
+    And user "Alice" has created the following link share:
+      | resource           | uploadFolder             |
+      | space              | Personal                 |
+      | permissionsRole    | edit                     |
+      | password           | %public%                 |
+      | expirationDateTime | 2040-01-01T23:59:59.000Z |
     When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/<new-file-name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
@@ -114,13 +114,12 @@ Feature: antivirus
   Scenario Outline: upload a file with the virus to a password-protected public share
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/uploadFolder"
-    And user "Alice" has created a public link share with settings
-      | path        | /uploadFolder            |
-      | name        | sharedlink               |
-      | permissions | change                   |
-      | password    | newpasswd                |
-      | expireDate  | 2040-01-01T23:59:59+0100 |
-      | password    | %public%                 |
+    And user "Alice" has created the following link share:
+      | resource           | uploadFolder             |
+      | space              | Personal                 |
+      | permissionsRole    | edit                     |
+      | password           | %public%                 |
+      | expirationDateTime | 2040-01-01T23:59:59.000Z |
     When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/<new-file-name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
@@ -141,7 +140,12 @@ Feature: antivirus
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Alice" has sent the following share invitation:
+      | resource        | uploadFolder |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Editor       |
     When user "Brian" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/Shares/uploadFolder/<new-file-name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
@@ -161,7 +165,12 @@ Feature: antivirus
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Alice" has sent the following share invitation:
+      | resource        | uploadFolder |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Editor       |
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/<file-name>" to "/uploadFolder/<new-file-name>" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
@@ -181,7 +190,12 @@ Feature: antivirus
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has shared folder "uploadFolder" with group "group1"
+    And user "Alice" has sent the following share invitation:
+      | resource        | uploadFolder |
+      | space           | Personal     |
+      | sharee          | group1       |
+      | shareType       | group        |
+      | permissionsRole | Editor       |
     When user "Brian" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/Shares/uploadFolder/<new-file-name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
@@ -203,7 +217,12 @@ Feature: antivirus
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has shared folder "uploadFolder" with group "group1"
+    And user "Alice" has sent the following share invitation:
+      | resource        | uploadFolder |
+      | space           | Personal     |
+      | sharee          | group1       |
+      | shareType       | group        |
+      | permissionsRole | Editor       |
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/<file-name>" to "/uploadFolder/<new-file-name>" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
@@ -247,9 +266,11 @@ Feature: antivirus
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has shared a space "new-space" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
+    And user "Alice" has sent the following share invitation:
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Editor |
     When user "Brian" uploads a file "/filesForUpload/filesWithVirus/<file-name>" to "/<new-file-name>" in space "new-space" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
@@ -351,12 +372,14 @@ Feature: antivirus
   Scenario Outline: try to overwrite a file with the virus content in a public link share
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And using <dav-path-version> DAV path
+    And using sharingNg
     And user "Alice" has uploaded file with content "hello" to "test.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /test.txt  |
-      | name        | sharedlink |
-      | permissions | change     |
-    When the public overwrites file "test.txt" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" using the new WebDAV API
+    And user "Alice" has created the following link share:
+      | resource        | test.txt |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
+    When the public overwrites file "test.txt" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" using the "new" WebDAV API
     Then the HTTP status code should be "204"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                   |
@@ -376,7 +399,12 @@ Feature: antivirus
     And user "Brian" has been added to group "group1"
     And user "Alice" has been added to group "group1"
     And user "Alice" has uploaded file with content "hello" to "/test.txt"
-    And user "Alice" has shared file "test.txt" with group "group1"
+    And user "Alice" has sent the following share invitation:
+      | resource        | test.txt    |
+      | space           | Personal    |
+      | sharee          | group1      |
+      | shareType       | group       |
+      | permissionsRole | File Editor |
     When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Brian" should get a notification with subject "Virus found" and message:
@@ -397,7 +425,12 @@ Feature: antivirus
     And user "Brian" has been added to group "group1"
     And user "Alice" has been added to group "group1"
     And user "Alice" has uploaded file with content "hello" to "/test.txt"
-    And user "Alice" has shared file "test.txt" with group "group1"
+    And user "Alice" has sent the following share invitation:
+      | resource        | test.txt    |
+      | space           | Personal    |
+      | sharee          | group1      |
+      | shareType       | group       |
+      | permissionsRole | File Editor |
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "/test.txt" in space "Shares" using the WebDAV API
     Then the HTTP status code should be "204"
     And user "Brian" should get a notification with subject "Virus found" and message:
@@ -412,9 +445,19 @@ Feature: antivirus
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "this is a test file." to "uploadFolder/test.txt"
-    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Alice" has sent the following share invitation:
+      | resource        | uploadFolder |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Editor       |
     And user "Alice" has uploaded file with content "this is a test file." to "/test.txt"
-    And user "Alice" has shared file "/test.txt" with user "Brian"
+    And user "Alice" has sent the following share invitation:
+      | resource        | test.txt    |
+      | space           | Personal    |
+      | sharee          | Brian       |
+      | shareType       | user        |
+      | permissionsRole | File Editor |
     When user "Brian" uploads file with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" to "Shares/uploadFolder/test.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And user "Brian" should get a notification for resource "test.txt" with subject "Virus found" and message:
@@ -440,7 +483,12 @@ Feature: antivirus
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "this is a test file." to "uploadFolder/test.txt"
-    And user "Alice" has shared folder "uploadFolder" with user "Brian" with permissions "all"
+    And user "Alice" has sent the following share invitation:
+      | resource        | uploadFolder |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Editor       |
     And user "Alice" has uploaded file with content "this is a test file." to "/test.txt"
     And user "Alice" has shared file "/test.txt" with user "Brian"
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "/uploadFolder/test.txt" in space "Shares" using the WebDAV API
@@ -478,9 +526,11 @@ Feature: antivirus
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has shared a space "new-space" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
+    And user "Alice" has sent the following share invitation:
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Editor |
     And user "Alice" has created a folder ".space" in space "new-space"
     And user "Alice" has uploaded a file inside space "new-space" with content "Here you can add a description for this Space." to ".space/readme.md"
     And user "Alice" has set the file ".space/readme.md" as a description in a special section of the "new-space" space
@@ -498,9 +548,11 @@ Feature: antivirus
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has shared a space "new-space" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
+    And user "Alice" has sent the following share invitation:
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Editor |
     And user "Alice" has uploaded a file inside space "new-space" with content "hello world" to "text.txt"
     When user "Brian" uploads a file "filesForUpload/filesWithVirus/eicar.com" to "text.txt" in space "new-space" using the WebDAV API
     Then the HTTP status code should be "204"

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -95,7 +95,7 @@ Feature: antivirus
       | permissionsRole    | edit                     |
       | password           | %public%                 |
       | expirationDateTime | 2040-01-01T23:59:59.000Z |
-    When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/<new-file-name>" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/uploadFolder/<new-file-name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                          |
@@ -120,7 +120,7 @@ Feature: antivirus
       | permissionsRole    | edit                     |
       | password           | %public%                 |
       | expirationDateTime | 2040-01-01T23:59:59.000Z |
-    When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/<new-file-name>" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/filesWithVirus/<file-name>" to "/uploadFolder/<new-file-name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                          |
@@ -372,14 +372,13 @@ Feature: antivirus
   Scenario Outline: try to overwrite a file with the virus content in a public link share
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And using <dav-path-version> DAV path
-    And using sharingNg
+    And using SharingNG
     And user "Alice" has uploaded file with content "hello" to "test.txt"
     And user "Alice" has created the following link share:
       | resource        | test.txt |
       | space           | Personal |
       | permissionsRole | edit     |
-      | password        | %public% |
-    When the public overwrites file "test.txt" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" using the "new" WebDAV API
+    When the public overwrites file "test.txt" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" using the new WebDAV API
     Then the HTTP status code should be "204"
     And user "Alice" should get a notification with subject "Virus found" and message:
       | message                                                                   |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -185,13 +185,13 @@ class FeatureContext extends BehatVariablesContext {
 	private bool $dbConversion = false;
 
 	public const SHARES_SPACE_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668';
-	private bool $sharingNg;
+	private bool $useSharingNG = false;
 
 	/**
 	 * @return bool
 	 */
-	public function getSharingNgValue(): bool {
-		return $this->sharingNg;
+	public function isUsingSharingNG(): bool {
+		return $this->useSharingNG;
 	}
 
 	/**
@@ -1019,10 +1019,12 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Given using sharingNg
+	 * @Given using SharingNG
+	 *
+	 * @return void
 	 */
-	public function usingSharingng(): void {
-		$this->sharingNg = true;
+	public function usingSharingNG(): void {
+		$this->useSharingNG = true;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -185,6 +185,15 @@ class FeatureContext extends BehatVariablesContext {
 	private bool $dbConversion = false;
 
 	public const SHARES_SPACE_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668';
+	private bool $sharingNg;
+
+	/**
+	 * @return bool
+	 */
+	public function getSharingNgValue(): bool {
+		return $this->sharingNg;
+	}
+
 	/**
 	 * @param bool $value
 	 *
@@ -1007,6 +1016,13 @@ class FeatureContext extends BehatVariablesContext {
 			$this->guzzleClientHeaders,
 			$guzzleClientHeaders
 		);
+	}
+
+	/**
+	 * @Given using sharingNg
+	 */
+	public function usingSharingng(): void {
+		$this->sharingNg = true;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1689,7 +1689,6 @@ class PublicWebDavContext implements Context {
 	 * @param bool $autoRename
 	 * @param array $additionalHeaders
 	 * @param string $publicWebDAVAPIVersion
-	 * @param bool $shareNg
 	 *
 	 * @return ResponseInterface|null
 	 */
@@ -1700,14 +1699,12 @@ class PublicWebDavContext implements Context {
 		bool $autoRename = false,
 		array $additionalHeaders = [],
 		string $publicWebDAVAPIVersion = "old",
-		bool $shareNg = false
 	):?ResponseInterface {
 		if ($publicWebDAVAPIVersion === "old") {
 			return null;
 		}
 		$password = $this->featureContext->getActualPassword($password);
-		$shareNg = $this->featureContext->getSharingNgValue();
-		if ($shareNg) {
+		if ($this->featureContext->isUsingSharingNG()) {
 			$token = $this->featureContext->shareNgGetLastCreatedLinkShareToken();
 		} else {
 			$token = $this->featureContext->getLastCreatedPublicShareToken();

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1507,6 +1507,65 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @When the public uploads file :source to :destination inside last link shared folder using the :new WebDAV API
+	 *
+	 * @param string $source
+	 * @param string $destination
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicUploadsFileToInsideLastLinkSharedFolderUsingTheNewWebdavApi(
+		string $source,
+		string $destination,
+		string $publicWebDAVAPIVersion
+	):void {
+		$content = \file_get_contents(
+			$this->featureContext->acceptanceTestsDirLocation() . $source
+		);
+		$response = $this->publicUploadContent(
+			$destination,
+			'',
+			$content,
+			false,
+			[],
+			$publicWebDAVAPIVersion
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 *
+	 * @When the public uploads file :source to :destination inside last link shared folder with password :password using the :new WebDAV API
+	 *
+	 * @param string $source
+	 * @param string $destination
+	 * @param string $password
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicUploadsFileToInsideLastLinkSharedFolderWithPasswordUsingTheNewWebdavApi(
+		string $source,
+		string $destination,
+		string $password,
+		string $publicWebDAVAPIVersion
+	):void {
+		$content = \file_get_contents(
+			$this->featureContext->acceptanceTestsDirLocation() . $source
+		);
+		$response = $this->publicUploadContent(
+			$destination,
+			$password,
+			$content,
+			false,
+			[],
+			$publicWebDAVAPIVersion
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @When the public uploads file :fileName to the last public link shared folder with password :password with mtime :mtime using the :davVersion public WebDAV API
 	 *
 	 * @param String $fileName
@@ -1698,7 +1757,7 @@ class PublicWebDavContext implements Context {
 		string $body = 'test',
 		bool $autoRename = false,
 		array $additionalHeaders = [],
-		string $publicWebDAVAPIVersion = "old",
+		string $publicWebDAVAPIVersion = "old"
 	):?ResponseInterface {
 		if ($publicWebDAVAPIVersion === "old") {
 			return null;

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1689,6 +1689,7 @@ class PublicWebDavContext implements Context {
 	 * @param bool $autoRename
 	 * @param array $additionalHeaders
 	 * @param string $publicWebDAVAPIVersion
+	 * @param bool $shareNg
 	 *
 	 * @return ResponseInterface|null
 	 */
@@ -1698,13 +1699,19 @@ class PublicWebDavContext implements Context {
 		string $body = 'test',
 		bool $autoRename = false,
 		array $additionalHeaders = [],
-		string $publicWebDAVAPIVersion = "old"
+		string $publicWebDAVAPIVersion = "old",
+		bool $shareNg = false
 	):?ResponseInterface {
 		if ($publicWebDAVAPIVersion === "old") {
 			return null;
 		}
 		$password = $this->featureContext->getActualPassword($password);
-		$token = $this->featureContext->getLastCreatedPublicShareToken();
+		$shareNg = $this->featureContext->getSharingNgValue();
+		if ($shareNg) {
+			$token = $this->featureContext->shareNgGetLastCreatedLinkShareToken();
+		} else {
+			$token = $this->featureContext->getLastCreatedPublicShareToken();
+		}
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,


### PR DESCRIPTION
## Description
Changing `Given` statement of apiantivirus feature file to use graph api

## Related Issue
- Part of  https://github.com/owncloud/ocis/issues/8717#event-12535134605

## How Has This Been Tested?
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
