### PR TITLE
[tests-only][full-ci]added test for sharee downloading resource inside project space when auto sync is disabled

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/getFileByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/getFileByFileId.feature
@@ -192,3 +192,50 @@ Feature: accessing files using file id
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
       | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: sharee gets content of a shared file in project space when sync is disabled
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has disabled the auto-sync share
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following share invitation:
+      | resource        | textfile.txt |
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    When user "Brian" sends HTTP method "GET" to URL "<dav-path>"
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "some content"
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: sharee gets content of a file inside a shared folder in project space when sync is disabled
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has disabled the auto-sync share
+    And user "Alice" has created a folder "uploadFolder" in space "new-space"
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "uploadFolder/textfile.txt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following share invitation:
+      | resource        | uploadFolder |
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    When user "Brian" sends HTTP method "GET" to URL "<dav-path>"
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "some content"
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the tests related to sharee downloading the shared resources inside project space.
Added Scenarios:
```feature
Scenario Outline: sharee gets content of a shared file in project space when sync is disabled
Scenario Outline: sharee gets content of a file inside a shared folder in project space when sync is disabled
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/8662

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
