### PR TITLE
always initialize http handler

### DIFF
--- a/changelog/unreleased/fix-well-known-rewrite.md
+++ b/changelog/unreleased/fix-well-known-rewrite.md
@@ -1,0 +1,4 @@
+Bugfix: Fix well-known rewrite endpoint
+
+https://github.com/owncloud/ocis/pull/8946
+https://github.com/owncloud/ocis/issues/8703

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/owncloud/ocis/v2/services/proxy/pkg/staticroutes"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/owncloud/ocis/v2/services/proxy/pkg/staticroutes"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/justinas/alice"
@@ -134,12 +135,13 @@ func Server(cfg *config.Config) *cli.Command {
 			)
 
 			lh := staticroutes.StaticRouteHandler{
-				Prefix:        cfg.HTTP.Root,
-				UserInfoCache: userInfoCache,
-				Logger:        logger,
-				Config:        *cfg,
-				OidcClient:    oidcClient,
-				Proxy:         rp,
+				Prefix:         cfg.HTTP.Root,
+				UserInfoCache:  userInfoCache,
+				Logger:         logger,
+				Config:         *cfg,
+				OidcClient:     oidcClient,
+				OidcHttpClient: oidcHTTPClient,
+				Proxy:          rp,
 			}
 			if err != nil {
 				return fmt.Errorf("failed to initialize reverse proxy: %w", err)

--- a/services/proxy/pkg/staticroutes/oidc_well-known.go
+++ b/services/proxy/pkg/staticroutes/oidc_well-known.go
@@ -3,6 +3,8 @@ package staticroutes
 import (
 	"io"
 	"net/http"
+	"net/url"
+	"path"
 )
 
 var (
@@ -10,29 +12,33 @@ var (
 )
 
 // OIDCWellKnownRewrite is a handler that rewrites the /.well-known/openid-configuration endpoint for external IDPs.
-func (s *StaticRouteHandler) oIDCWellKnownRewrite(w http.ResponseWriter, r *http.Request) {
-	wellKnownRes, err := s.OidcHttpClient.Get(s.oidcURL.String())
-	if err != nil {
-		s.Logger.Error().
-			Err(err).
-			Str("handler", "oidc wellknown rewrite").
-			Str("url", s.oidcURL.String()).
-			Msg("get information from url failed")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+func (s *StaticRouteHandler) oIDCWellKnownRewrite(issuer string) http.HandlerFunc {
+	oidcURL, _ := url.Parse(issuer)
+	oidcURL.Path = path.Join(oidcURL.Path, wellKnownPath)
+	return func(w http.ResponseWriter, r *http.Request) {
+		wellKnownRes, err := s.OidcHttpClient.Get(oidcURL.String())
+		if err != nil {
+			s.Logger.Error().
+				Err(err).
+				Str("handler", "oidc wellknown rewrite").
+				Str("url", oidcURL.String()).
+				Msg("get information from url failed")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
-	defer wellKnownRes.Body.Close()
+		defer wellKnownRes.Body.Close()
 
-	copyHeader(w.Header(), wellKnownRes.Header)
-	w.WriteHeader(wellKnownRes.StatusCode)
-	_, err = io.Copy(w, wellKnownRes.Body)
-	if err != nil {
-		s.Logger.Error().
-			Err(err).
-			Str("handler", "oidc wellknown rewrite").
-			Msg("copying response body failed")
+		copyHeader(w.Header(), wellKnownRes.Header)
+		w.WriteHeader(wellKnownRes.StatusCode)
+		_, err = io.Copy(w, wellKnownRes.Body)
+		if err != nil {
+			s.Logger.Error().
+				Err(err).
+				Str("handler", "oidc wellknown rewrite").
+				Msg("copying response body failed")
 
+		}
 	}
 }
 

--- a/services/proxy/pkg/staticroutes/staticroutes.go
+++ b/services/proxy/pkg/staticroutes/staticroutes.go
@@ -2,8 +2,6 @@ package staticroutes
 
 import (
 	"net/http"
-	"net/url"
-	"path"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
@@ -21,8 +19,6 @@ type StaticRouteHandler struct {
 	Config         config.Config
 	OidcClient     oidc.OIDCClient
 	OidcHttpClient *http.Client
-
-	oidcURL *url.URL
 }
 
 type jse struct {
@@ -31,8 +27,6 @@ type jse struct {
 }
 
 func (s *StaticRouteHandler) Handler() http.Handler {
-	s.oidcURL, _ = url.Parse(s.Config.OIDC.Issuer)
-	s.oidcURL.Path = path.Join(s.oidcURL.Path, wellKnownPath)
 	m := chi.NewMux()
 	m.Route(s.Prefix, func(r chi.Router) {
 
@@ -41,7 +35,7 @@ func (s *StaticRouteHandler) Handler() http.Handler {
 
 		// openid .well-known
 		if s.Config.OIDC.RewriteWellKnown {
-			r.Get("/.well-known/openid-configuration", s.oIDCWellKnownRewrite)
+			r.Get("/.well-known/openid-configuration", s.oIDCWellKnownRewrite(s.Config.OIDC.Issuer))
 		}
 
 		// Send all requests to the proxy handler


### PR DESCRIPTION
fixes https://github.com/owncloud/ocis/issues/8703

I also moved the oidcUrl from a struct property to a parameter of the handler func as it is only used there. By moving the parsing of the url right next to the handler we improve the [Locality of Behavior](https://htmx.org/essays/locality-of-behaviour/).