### PR TITLE
[tests-only] [full-ci] Change given step using SharingNG for share in apiArchiver/downloadByPath.feature file

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -10,8 +10,8 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiArchiver/downloadByPath.feature:44](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadByPath.feature#L44)
 - [apiArchiver/downloadByPath.feature:47](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadByPath.feature#L47)
 - [apiArchiver/downloadByPath.feature:73](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadByPath.feature#L73)
-- [apiArchiver/downloadByPath.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadByPath.feature#L123)
-- [apiArchiver/downloadByPath.feature:124](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadByPath.feature#L124)
+- [apiArchiver/downloadByPath.feature:163](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadByPath.feature#L163)
+- [apiArchiver/downloadByPath.feature:164](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiArchiver/downloadByPath.feature#L164)
 
 ### [Downloaded /Shares tar contains resource (files|folder) with leading / in Response](https://github.com/owncloud/ocis/issues/4636)
 

--- a/tests/acceptance/features/apiArchiver/downloadByPath.feature
+++ b/tests/acceptance/features/apiArchiver/downloadByPath.feature
@@ -78,10 +78,30 @@ Feature: download multiple resources bundled into an archive
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile2.txt"
     And user "Alice" has created folder "more_data"
     And user "Alice" has uploaded file with content "more data" to "/more_data/an_other_file.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has shared file "textfile1.txt" with user "Brian"
-    And user "Alice" has shared folder "my_data" with user "Brian"
-    And user "Alice" has shared folder "more_data" with user "Brian"
+    And user "Alice" has sent the following share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Alice" has sent the following share invitation:
+      | resource        | textfile1.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Alice" has sent the following share invitation:
+      | resource        | my_data  |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
+    And user "Alice" has sent the following share invitation:
+      | resource        | more_data |
+      | space           | Personal  |
+      | sharee          | Brian     |
+      | shareType       | user      |
+      | permissionsRole | Viewer    |
     When user "Brian" downloads the archive of these items using the resource path
       | /home/Shares/textfile0.txt |
       | /home/Shares/textfile1.txt |
@@ -104,10 +124,30 @@ Feature: download multiple resources bundled into an archive
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile2.txt"
     And user "Alice" has created folder "more_data"
     And user "Alice" has uploaded file with content "more data" to "/more_data/an_other_file.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has shared file "textfile1.txt" with user "Brian"
-    And user "Alice" has shared folder "my_data" with user "Brian"
-    And user "Alice" has shared folder "more_data" with user "Brian"
+    And user "Alice" has sent the following share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Alice" has sent the following share invitation:
+      | resource        | textfile1.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Alice" has sent the following share invitation:
+      | resource        | my_data  |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
+    And user "Alice" has sent the following share invitation:
+      | resource        | more_data |
+      | space           | Personal  |
+      | sharee          | Brian     |
+      | shareType       | user      |
+      | permissionsRole | Viewer    |
     When user "Brian" downloads the archive of "/home/Shares" using the resource path and setting these headers
       | header     | value        |
       | User-Agent | <user-agent> |


### PR DESCRIPTION
## Description
Changed `Given` step for share using SharingNg in `apiArchiver/downloadByPath.feature` file.

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/8717

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
