### PR TITLE
[tests-only][full-ci]Added test for hide shared resources (personal and project space) in shares

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -2022,7 +2022,7 @@ class GraphHelper {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public static function hideSharedResource(
+	public static function hideShare(
 		string $baseUrl,
 		string $xRequestId,
 		string $user,

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -2017,6 +2017,39 @@ class GraphHelper {
 	 * @param string $password
 	 * @param string $itemId
 	 * @param string $shareSpaceId
+	 * @param array $body
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function hideSharedResource(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $itemId,
+		string $shareSpaceId,
+		array $body
+	):ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "drives/$shareSpaceId/items/$itemId");
+		return HttpRequestHelper::sendRequest(
+			$url,
+			$xRequestId,
+			'PATCH',
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			\json_encode($body)
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $itemId
+	 * @param string $shareSpaceId
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -4867,7 +4867,6 @@ Feature: an user gets the resources shared to them
           "required": ["path"],
           "properties": {
             "path": {
-              "type": "string",
               "const": "<resource>"
             }
           }
@@ -4883,7 +4882,7 @@ Feature: an user gets the resources shared to them
 
   Scenario Outline: sharee hides the shared resource (Project space)
     Given using spaces DAV path
-    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "testfile.txt"
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
@@ -4909,7 +4908,6 @@ Feature: an user gets the resources shared to them
           "required": ["path"],
           "properties": {
             "path": {
-              "type": "string",
               "const": "<resource>"
             }
           }
@@ -4968,7 +4966,7 @@ Feature: an user gets the resources shared to them
 
   Scenario Outline: sharee lists the shares after hiding (Project space)
     Given using spaces DAV path
-    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "testfile.txt"
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -4842,7 +4842,7 @@ Feature: an user gets the resources shared to them
       """
 
 
-  Scenario Outline: user hide the shared resource from a personal space
+  Scenario Outline: sharee hides the shared resource (Personal space)
     Given user "Alice" has created folder "folder"
     And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
     And user "Alice" has sent the following share invitation:
@@ -4851,7 +4851,7 @@ Feature: an user gets the resources shared to them
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    When user "Brian" hides the resource "<resource>" shared with me using the Graph API
+    When user "Brian" hides the shared resource "<resource>" using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
     """
@@ -4860,8 +4860,7 @@ Feature: an user gets the resources shared to them
       "required": ["hidden", "mount_point"],
       "properties": {
         "hidden": {
-          "type": "boolean",
-          "enum": [true]
+          "const": true
         },
         "mount_point": {
           "type": "object",
@@ -4882,7 +4881,7 @@ Feature: an user gets the resources shared to them
       | folder       |
 
 
-  Scenario Outline: user hide the shared resource from a project space
+  Scenario Outline: sharee hides the shared resource (Project space)
     Given using spaces DAV path
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
@@ -4894,7 +4893,7 @@ Feature: an user gets the resources shared to them
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    When user "Brian" hides the resource "<resource>" shared with me using the Graph API
+    When user "Brian" hides the shared resource "<resource>" using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
     """
@@ -4903,8 +4902,7 @@ Feature: an user gets the resources shared to them
       "required": ["hidden", "mount_point"],
       "properties": {
         "hidden": {
-          "type": "boolean",
-          "enum": [true]
+          "const": true
         },
         "mount_point": {
           "type": "object",
@@ -4925,7 +4923,7 @@ Feature: an user gets the resources shared to them
       | FolderToShare |
 
 
-  Scenario Outline: user hide and list the shared resource from a personal space
+  Scenario Outline: sharee lists the shares after hiding (Personal space)
     Given user "Alice" has created folder "folder"
     And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
     And user "Alice" has sent the following share invitation:
@@ -4934,7 +4932,7 @@ Feature: an user gets the resources shared to them
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    And user "Brian" hidden the resource "<resource>" shared with him
+    And user "Brian" has hidden the share "<resource>"
     When user "Brian" lists the shares shared with him using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -4968,7 +4966,7 @@ Feature: an user gets the resources shared to them
       | folder       |
 
 
-  Scenario Outline: user hide and list the shared resource from a personal
+  Scenario Outline: sharee lists the shares after hiding (Project space)
     Given using spaces DAV path
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
@@ -4980,7 +4978,7 @@ Feature: an user gets the resources shared to them
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    And user "Brian" hidden the resource "<resource>" shared with him
+    And user "Brian" has hidden the share "<resource>"
     When user "Brian" lists the shares shared with him using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -4840,3 +4840,175 @@ Feature: an user gets the resources shared to them
         }
       }
       """
+
+
+  Scenario Outline: user hide the shared resource from a personal space
+    Given user "Alice" has created folder "folder"
+    And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
+    And user "Alice" has sent the following share invitation:
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    When user "Brian" hides the resource "<resource>" shared with me using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["hidden", "mount_point"],
+      "properties": {
+        "hidden": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "mount_point": {
+          "type": "object",
+          "required": ["path"],
+          "properties": {
+            "path": {
+              "type": "string",
+              "const": "<resource>"
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | resource     |
+      | testfile.txt |
+      | folder       |
+
+
+  Scenario Outline: user hide the shared resource from a project space
+    Given using spaces DAV path
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "testfile.txt"
+    And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Alice" has sent the following share invitation:
+      | resource        | <resource> |
+      | space           | NewSpace   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    When user "Brian" hides the resource "<resource>" shared with me using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["hidden", "mount_point"],
+      "properties": {
+        "hidden": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "mount_point": {
+          "type": "object",
+          "required": ["path"],
+          "properties": {
+            "path": {
+              "type": "string",
+              "const": "<resource>"
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | resource      |
+      | testfile.txt  |
+      | FolderToShare |
+
+
+  Scenario Outline: user hide and list the shared resource from a personal space
+    Given user "Alice" has created folder "folder"
+    And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
+    And user "Alice" has sent the following share invitation:
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    And user "Brian" hidden the resource "<resource>" shared with him
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "array",
+          "maxItems": 1,
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "@UI.Hidden"
+            ],
+            "properties": {
+              "@UI.Hidden":{
+                "const": true
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | resource     |
+      | testfile.txt |
+      | folder       |
+
+
+  Scenario Outline: user hide and list the shared resource from a personal
+    Given using spaces DAV path
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "testfile.txt"
+    And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Alice" has sent the following share invitation:
+      | resource        | <resource> |
+      | space           | NewSpace   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    And user "Brian" hidden the resource "<resource>" shared with him
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+    """
+    {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "array",
+          "maxItems": 1,
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "@UI.Hidden"
+            ],
+            "properties": {
+              "@UI.Hidden":{
+                "const": true
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    Examples:
+      | resource      |
+      | testfile.txt  |
+      | FolderToShare |

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -698,6 +698,32 @@ class SharingNgContext implements Context {
 	}
 
 	/**
+	 * @param string $sharee
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 * @throws JsonException
+	 */
+	public function hideSharedResource(
+		string $sharee
+	): ResponseInterface {
+		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
+		$shareSpaceId = FeatureContext::SHARES_SPACE_ID;
+		$itemId = $shareSpaceId . '!' . $shareItemId;
+		$body = [];
+		$body['@UI.Hidden'] = true;
+		return GraphHelper::hideSharedResource(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$this->featureContext->getActualUsername($sharee),
+			$this->featureContext->getPasswordForUser($sharee),
+			$itemId,
+			$shareSpaceId,
+			$body
+		);
+	}
+
+	/**
 	 * @Then /^for user "([^"]*)" the space Shares should (not|)\s?contain these (files|entries):$/
 	 *
 	 * @param string $user
@@ -749,6 +775,34 @@ class SharingNgContext implements Context {
 		);
 		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastStatusCodesArrays();
+	}
+
+	/**
+	 * @When user :user hides the resource :sharedResource shared with me using the Graph API
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws Exception
+	 * @throws GuzzleException
+	 */
+	public function userHidesSharedResourceSharedWithMeUsingTheGraphApi(string $user):void {
+		$response = $this->hideSharedResource($user);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @Given  user :user hidden the resource :sharedResource shared with him/her
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws Exception
+	 * @throws GuzzleException
+	 */
+	public function userHiddenSharedResourceSharedWithHimHerUsingTheGraphApi(string $user):void {
+		$response = $this->hideSharedResource($user);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -699,15 +699,15 @@ class SharingNgContext implements Context {
 
 	/**
 	 * @param string $sharee
+	 * @param string $shareID
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function hideSharedResource(string $sharee): ResponseInterface {
-		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
+	public function hideSharedResource(string $sharee, string $shareID): ResponseInterface {
 		$shareSpaceId = FeatureContext::SHARES_SPACE_ID;
-		$itemId = $shareSpaceId . '!' . $shareItemId;
+		$itemId = $shareSpaceId . '!' . $shareID;
 		$body['@UI.Hidden'] = true;
 		return GraphHelper::hideShare(
 			$this->featureContext->getBaseUrl(),
@@ -784,7 +784,8 @@ class SharingNgContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userHidesTheSharedResourceUsingTheGraphApi(string $user):void {
-		$response = $this->hideSharedResource($user);
+		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
+		$response = $this->hideSharedResource($user, $shareItemId);
 		$this->featureContext->setResponse($response);
 	}
 
@@ -798,7 +799,8 @@ class SharingNgContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userHasHiddenTheShare(string $user):void {
-		$response = $this->hideSharedResource($user);
+		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
+		$response = $this->hideSharedResource($user, $shareItemId);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -704,15 +704,12 @@ class SharingNgContext implements Context {
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function hideSharedResource(
-		string $sharee
-	): ResponseInterface {
+	public function hideSharedResource(string $sharee): ResponseInterface {
 		$shareItemId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
 		$shareSpaceId = FeatureContext::SHARES_SPACE_ID;
 		$itemId = $shareSpaceId . '!' . $shareItemId;
-		$body = [];
 		$body['@UI.Hidden'] = true;
-		return GraphHelper::hideSharedResource(
+		return GraphHelper::hideShare(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
 			$this->featureContext->getActualUsername($sharee),
@@ -778,7 +775,7 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When user :user hides the resource :sharedResource shared with me using the Graph API
+	 * @When user :user hides the shared resource :sharedResource using the Graph API
 	 *
 	 * @param string $user
 	 *
@@ -786,13 +783,13 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
-	public function userHidesSharedResourceSharedWithMeUsingTheGraphApi(string $user):void {
+	public function userHidesTheSharedResourceUsingTheGraphApi(string $user):void {
 		$response = $this->hideSharedResource($user);
 		$this->featureContext->setResponse($response);
 	}
 
 	/**
-	 * @Given  user :user hidden the resource :sharedResource shared with him/her
+	 * @Given  user :user has hidden the share :sharedResource
 	 *
 	 * @param string $user
 	 *
@@ -800,7 +797,7 @@ class SharingNgContext implements Context {
 	 * @throws Exception
 	 * @throws GuzzleException
 	 */
-	public function userHiddenSharedResourceSharedWithHimHerUsingTheGraphApi(string $user):void {
+	public function userHasHiddenTheShare(string $user):void {
 		$response = $this->hideSharedResource($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}


### PR DESCRIPTION
### Description
This PR adds test for sharingNg to hiding the shared resources shared from project and personal space

```feature
Scenario Outline: sharee hides the shared resource (Personal space)
Scenario Outline: sharee hides the shared resource (Project space)
Scenario Outline: sharee lists the shares after hiding (Personal space)
Scenario Outline: sharee lists the shares after hiding (Project space)
```

### Related issue:
https://github.com/owncloud/ocis/issues/8888
