### PR TITLE
fix: forward COLLABORA_DOMAIN and ONLYOFFICE_DOMAIN to the ocis conta…

### DIFF
--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -89,6 +89,8 @@ services:
       NATS_NATS_HOST: 0.0.0.0
       NATS_NATS_PORT: 9233
       PROXY_CSP_CONFIG_FILE_LOCATION: /etc/ocis/csp.yaml
+      COLLABORA_DOMAIN: ${COLLABORA_DOMAIN:-collabora.owncloud.test}
+      ONLYOFFICE_DOMAIN: ${ONLYOFFICE_DOMAIN:-onlyoffice.owncloud.test}
     volumes:
       - ./config/ocis/app-registry.yaml:/etc/ocis/app-registry.yaml
       - ./config/ocis/csp.yaml:/etc/ocis/csp.yaml


### PR DESCRIPTION
…iner to allow substitution in csp.yaml


## Description
Environment variables need to be set in the ocis container to allow proper substitution in csp.yaml-

## Related Issue
refs https://github.com/owncloud/ocis/pull/8777#discussion_r1581052693

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
