### PR TITLE
[tests-only] add API tests to search user/group with special chars

### DIFF
--- a/tests/acceptance/features/apiGraphUserGroup/getGroup.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/getGroup.feature
@@ -464,7 +464,7 @@ Feature: get groups and their members
     Then the HTTP status code should be "404"
 
 
-  Scenario Outline: non-admin user search for a group by group name
+  Scenario Outline: non-admin user searches for a group by group name
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -546,7 +546,7 @@ Feature: get groups and their members
     """
 
   @issue-7990
-  Scenario Outline: non-admin user tries to search for a group by group name with invalid characters/token
+  Scenario Outline: user tries to search for groups with invalid characters/token (search term without quotation)
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -580,3 +580,48 @@ Feature: get groups and their members
       | group      | token   |
       | tea-lovers | -lovers |
       | tea@lovers | @lovers |
+
+  @issue-7990
+  Scenario Outline: user searches for groups with special characters (search term with quotation)
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+    And group "<group>" has been created
+    When user "Brian" tries to search for group '"<group>"' using Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "maxItems": 1,
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["displayName", "id", "groupTypes"],
+              "properties": {
+                "displayName": {
+                  "const": "<group>"
+                },
+                "id": {
+                  "type": "string",
+                  "pattern": "%group_id_pattern%"
+                },
+                "groupTypes": {
+                  "const": []
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | group      | token   |
+      | tea-lovers | -lovers |
+      | tea@lovers | @lovers |
+      | -_.ocgrp   | -_.     |
+      | _ocgrp@    | _oc     |


### PR DESCRIPTION
## Description
Added the following user/group search scenarios:

```feature
Scenario Outline: user searches for groups with special characters (search term with quotation)
      | tea-lovers | -lovers |
      | tea@lovers | @lovers |
      | -_.ocgrp   | -_.     |
      | _ocgrp@    | _oc     |
Scenario: user searches for a non-existent user/group
Scenario Outline: user searches for other users having special characters in displayname (search term with quotation)
      | -_.ocusr         | -_.         |
      | _ocusr@          | _oc         |
      | Alice-Wonderland | -Wonderland |
      | Alice@Wonderland | @Wonderland |
```

Taken from https://github.com/owncloud/web/pull/10858

## Related Issue
- https://github.com/owncloud/web/issues/10259

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
