### PR TITLE
feat: allow bash like syntax to substitute environment variables in a…

### DIFF
--- a/changelog/unreleased/envvar-subst.md
+++ b/changelog/unreleased/envvar-subst.md
@@ -1,0 +1,5 @@
+Enhancement: ENV var substitution in config files
+
+Allow bash like env var substitution in config files.
+
+https://github.com/owncloud/ocis/pull/9020

--- a/docs/ocis/config.md
+++ b/docs/ocis/config.md
@@ -44,7 +44,7 @@ Let's explore with examples this approach.
 - docker images: `/etc/ocis/`
 - binary releases: `$HOME/.ocis/config/`
 
-followed by the `<extension name>.yaml`, eg `proxy.yaml` for the extension configuration. You also can put an `ocis.yaml` config file to the expected loading location to use a single config file.
+followed by the `<extension name>.yaml`, e.g. `proxy.yaml` for the extension configuration. You also can put an `ocis.yaml` config file to the expected loading location to use a single config file.
 
 You can set another directory as config path in the environment variable `OCIS_CONFIG_DIR`. It will then pick the same file names, but from the folder you configured.
 
@@ -98,6 +98,20 @@ log:
   color: true
   level: info
 ```
+#### Substitute ENV variables in configuration files
+
+Environment variables can be used in the configurations files and will be replaced by oCIS when loading these.
+
+```yaml
+proxy:
+  http:
+    addr: ${PROXY_HTTP_ADDR:-localhost:4321}
+log:
+  pretty: true
+  color: true
+  level: info
+```
+
 
 ### Workflows
 

--- a/ocis-pkg/config/defaults/paths.go
+++ b/ocis-pkg/config/defaults/paths.go
@@ -6,12 +6,10 @@ import (
 	"path"
 )
 
-const ()
-
 var (
-	// switch between modes
+	// BaseDataPathType switch between modes
 	BaseDataPathType = "homedir" // or "path"
-	// default data path
+	// BaseDataPathValue default data path
 	BaseDataPathValue = "/var/lib/ocis"
 )
 
@@ -42,9 +40,9 @@ func BaseDataPath() string {
 }
 
 var (
-	// switch between modes
+	// BaseConfigPathType switch between modes
 	BaseConfigPathType = "homedir" // or "path"
-	// default config path
+	// BaseConfigPathValue default config path
 	BaseConfigPathValue = "/etc/ocis"
 )
 

--- a/ocis-pkg/config/helpers.go
+++ b/ocis-pkg/config/helpers.go
@@ -1,16 +1,18 @@
 package config
 
 import (
-	"path"
-
+	"github.com/a8m/envsubst/parse"
 	gofig "github.com/gookit/config/v2"
 	gooyaml "github.com/gookit/config/v2/yaml"
-
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
 )
 
 var (
-	// decoderConfigTagname sets the tag name to be used from the config structs
+	// decoderConfigTagName sets the tag name to be used from the config structs
 	// currently we only support "yaml" because we only support config loading
 	// from yaml files and the yaml parser has no simple way to set a custom tag name to use
 	decoderConfigTagName = "yaml"
@@ -19,19 +21,48 @@ var (
 // BindSourcesToStructs assigns any config value from a config file / env variable to struct `dst`. Its only purpose
 // is to solely modify `dst`, not dealing with the config structs; and do so in a thread safe manner.
 func BindSourcesToStructs(service string, dst interface{}) (*gofig.Config, error) {
+	fileSystem := os.DirFS("/")
+	filePath := strings.TrimLeft(path.Join(defaults.BaseConfigPath(), service+".yaml"), "/")
+	return bindSourcesToStructs(fileSystem, filePath, service, os.Environ(), dst)
+}
+
+func bindSourcesToStructs(fileSystem fs.FS, filePath, service string, env []string, dst interface{}) (*gofig.Config, error) {
 	cnf := gofig.NewWithOptions(service)
 	cnf.WithOptions(func(options *gofig.Options) {
-		options.ParseEnv = true
+		options.ParseEnv = false
 		options.DecoderConfig.TagName = decoderConfigTagName
 	})
 	cnf.AddDriver(gooyaml.Driver)
 
-	_ = cnf.LoadFiles(path.Join(defaults.BaseConfigPath(), service+".yaml"))
+	yamlContent, err := fs.ReadFile(fileSystem, filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cnf, nil
+		}
 
-	err := cnf.BindStruct("", &dst)
+		return nil, err
+	}
+	// replace env vars ..
+	yamlContent, err = substitute(yamlContent, env)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = cnf.LoadSources("yaml", yamlContent)
+
+	err = cnf.BindStruct("", &dst)
 	if err != nil {
 		return nil, err
 	}
 
 	return cnf, nil
+}
+
+func substitute(b []byte, env []string) ([]byte, error) {
+	s, err := parse.New("bytes", env,
+		&parse.Restrictions{}).Parse(string(b))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(s), nil
 }

--- a/ocis-pkg/config/helpers_test.go
+++ b/ocis-pkg/config/helpers_test.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"gotest.tools/v3/assert"
+	"testing"
+	"testing/fstest"
+)
+
+type TestConfig struct {
+	A string `yaml:"a"`
+	B string `yaml:"b"`
+	C string `yaml:"c"`
+}
+
+func TestBindSourcesToStructs(t *testing.T) {
+	// setup test env
+	yaml := `
+a: "${FOO_VAR:-no-foo}"
+b: "${BAR_VAR:-no-bar}"
+c: "${CODE_VAR:-code}"
+`
+	env := []string{"FOO_VAR=foo", "BAR_VAR=bar"}
+	filePath := "etc/ocis/foo.yaml"
+	fs := fstest.MapFS{
+		filePath: {Data: []byte(yaml)},
+	}
+	// perform test
+	c := TestConfig{}
+	_, err := bindSourcesToStructs(fs, filePath, "foo", env, &c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, c.A, "foo")
+	assert.Equal(t, c.B, "bar")
+	assert.Equal(t, c.C, "code")
+}
+
+func TestBindSourcesToStructs_UnknownFile(t *testing.T) {
+	// setup test env
+	var env []string
+	filePath := "etc/ocis/foo.yaml"
+	fs := fstest.MapFS{}
+	// perform test
+	c := TestConfig{}
+	_, err := bindSourcesToStructs(fs, filePath, "foo", env, &c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, c.A, "")
+	assert.Equal(t, c.B, "")
+	assert.Equal(t, c.C, "")
+}
+
+func TestBindSourcesToStructs_NoEnvVar(t *testing.T) {
+	// setup test env
+	yaml := `
+token_manager:
+  jwt_secret: f%LovwC6xnKkHhc.!.Lp4ZYpQDIO7=d@
+machine_auth_api_key: jG&%ZCmCSYqT#Yi$9y28o5u84ZMo2UBf
+system_user_api_key: wqxH7FZHv5gifuLIzxqdyaZOCo2s^yl1
+transfer_secret: $1^2xspR1WHussV16knaJ$x@X*XLPL%y
+system_user_id: 4d0bf32c-83ee-4703-bd43-5e0d6b78215b
+admin_user_id: e2fca2b3-992b-47d5-8ecd-3312418ed3d7
+graph:
+  application:
+    id: 4fdff90c-d13c-47ab-8227-bbd3e6dbee3c
+  events:
+    tls_insecure: true
+  spaces:
+    insecure: true
+  identity:
+    ldap:
+      bind_password: $ZZ8fSJR&YA02jBBPx6IRCzW0kVZ#cBO
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+idp:
+  ldap:
+    bind_password: kWJGC6WRY1wQ+e8Bmt--=-3r6gp0CNVS
+idm:
+  service_user_passwords:
+    admin_password: admin
+    idm_password: $ZZ8fSJR&YA02jBBPx6IRCzW0kVZ#cBO
+    reva_password: c68JL=V$c@0GHs!%eSb8r&Ps3rgzKnXJ
+    idp_password: kWJGC6WRY1wQ+e8Bmt--=-3r6gp0CNVS
+proxy:
+  oidc:
+    insecure: true
+  insecure_backends: true
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+frontend:
+  app_handler:
+    insecure: true
+  archiver:
+    insecure: true
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+auth_basic:
+  auth_providers:
+    ldap:
+      bind_password: c68JL=V$c@0GHs!%eSb8r&Ps3rgzKnXJ
+auth_bearer:
+  auth_providers:
+    oidc:
+      insecure: true
+users:
+  drivers:
+    ldap:
+      bind_password: c68JL=V$c@0GHs!%eSb8r&Ps3rgzKnXJ
+groups:
+  drivers:
+    ldap:
+      bind_password: c68JL=V$c@0GHs!%eSb8r&Ps3rgzKnXJ
+ocdav:
+  insecure: true
+ocm:
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+thumbnails:
+  thumbnail:
+    transfer_secret: 0N05@YXB.h3e@lsVfksL4YxwQC9aE5A.
+    webdav_allow_insecure: true
+    cs3_allow_insecure: true
+search:
+  events:
+    tls_insecure: true
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+audit:
+  events:
+    tls_insecure: true
+settings:
+  service_account_ids:
+  - c05389b2-d94c-4d01-a9b5-a2f97952cc14
+sharing:
+  events:
+    tls_insecure: true
+storage_users:
+  events:
+    tls_insecure: true
+  mount_id: 64fdfb03-22ff-4788-be4d-d7731a475683
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+notifications:
+  notifications:
+    events:
+      tls_insecure: true
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+nats:
+  nats:
+    tls_skip_verify_client_cert: true
+gateway:
+  storage_registry:
+    storage_users_mount_id: 64fdfb03-22ff-4788-be4d-d7731a475683
+userlog:
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+auth_service:
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+clientlog:
+  service_account:
+    service_account_id: c05389b2-d94c-4d01-a9b5-a2f97952cc14
+    service_account_secret: GW5.x1vDM&+NPRi++eV@.P7Tms4vj!=s
+`
+	env := []string{}
+	filePath := "etc/ocis/foo.yaml"
+	fs := fstest.MapFS{
+		filePath: {Data: []byte(yaml)},
+	}
+	// perform test
+	c := Config{}
+	_, err := bindSourcesToStructs(fs, filePath, "foo", env, &c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, c.Graph.Identity.LDAP.BindPassword, "$ZZ8fSJR&YA02jBBPx6IRCzW0kVZ#cBO")
+}


### PR DESCRIPTION
…ny oCIS config file

## Description
Allows bask like env var handling in any oCIS config file.

## Motivation and Context
Originally introduces with #8777 - we wanted to have one mechanism.

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
