### PR TITLE
fix(deployment): keycloak blocked due to security violation in ocis_keycloak example

### DIFF
--- a/deployments/examples/ocis_keycloak/config/ocis/csp.yaml
+++ b/deployments/examples/ocis_keycloak/config/ocis/csp.yaml
@@ -1,0 +1,32 @@
+directives:
+  child-src:
+    - '''self'''
+  connect-src:
+    - '''self'''
+    - 'https://${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}/'
+  default-src:
+    - '''none'''
+  font-src:
+    - '''self'''
+  frame-ancestors:
+    - '''none'''
+  frame-src:
+    - '''self'''
+    - 'https://embed.diagrams.net/'
+  img-src:
+    - '''self'''
+    - 'data:'
+    - 'blob:'
+  manifest-src:
+    - '''self'''
+  media-src:
+    - '''self'''
+  object-src:
+    - '''self'''
+    - 'blob:'
+  script-src:
+    - '''self'''
+    - '''unsafe-inline'''
+  style-src:
+    - '''self'''
+    - '''unsafe-inline'''

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -79,8 +79,11 @@ services:
       GRAPH_USERNAME_MATCH: "none"
       # password policies
       OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST: "banned-password-list.txt"
+      PROXY_CSP_CONFIG_FILE_LOCATION: /etc/ocis/csp.yaml
+      KEYCLOAK_DOMAIN: ${KEYCLOAK_DOMAIN:-keycloak.owncloud.test}
     volumes:
       - ./config/ocis/banned-password-list.txt:/etc/ocis/banned-password-list.txt
+      - ./config/ocis/csp.yaml:/etc/ocis/csp.yaml
       - ocis-config:/etc/ocis
       - ocis-data:/var/lib/ocis
     labels:


### PR DESCRIPTION
## Description
ocis_keycloak deployment example doesn't work with current latest ocis because the PR #8777 has hardened some security.
This PR fixes the problem by adding custom `csp.yaml` file in the deployment example 

## Related Issue
- https://github.com/owncloud/ocis/pull/8777

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
