### PR TITLE
[tests-only] [full-ci] Change given step for sharing space in apiDownloads

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -231,6 +231,7 @@ default:
         - OcisConfigContext:
         - PublicWebDavContext:
         - ArchiverContext:
+        - SharingNgContext:
 
     apiSearch1:
       paths:

--- a/tests/acceptance/features/apiDownloads/download.feature
+++ b/tests/acceptance/features/apiDownloads/download.feature
@@ -16,13 +16,16 @@ Feature: Download file in project space
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "download file" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "download file" with content "some content" to "file.txt"
-    And user "Alice" has shared a space "download file" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
-    And user "Alice" has shared a space "download file" with settings:
-      | shareWith | Bob    |
-      | role      | viewer |
-
+    And user "Alice" has sent the following share invitation:
+      | space           | download file |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Space Editor  |
+    And user "Alice" has sent the following share invitation:
+      | space           | download file |
+      | sharee          | Bob           |
+      | shareType       | user          |
+      | permissionsRole | Space Viewer  |
 
   Scenario Outline: user downloads a file in the project space
     When user "<user>" downloads the file "file.txt" of the space "download file" using the WebDAV API

--- a/tests/acceptance/features/apiDownloads/spaceDownload.feature
+++ b/tests/acceptance/features/apiDownloads/spaceDownload.feature
@@ -29,9 +29,11 @@ Feature: Download space
 
 
   Scenario Outline: user downloads a shared space (shared by others)
-    Given user "Alice" has shared a space "Project-space" with settings:
-      | shareWith | Brian  |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following share invitation:
+      | space           | Project-space |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | <space-role>  |
     When user "Brian" downloads the space "Project-space" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded "tar" archive should contain these files:
@@ -39,10 +41,10 @@ Feature: Download space
       | file1.txt        | some data         |
       | .space/readme.md | space description |
     Examples:
-      | space-role    |
-      | manager |
-      | editor  |
-      | viewer  |
+      | space-role   |
+      | Manager      |
+      | Space Editor |
+      | Space Viewer |
 
 
   Scenario Outline: admin/space-admin tries to download a space that they do not have access to


### PR DESCRIPTION
## Description
Changed `Given` step for sharing space using SharingNg in 

- `apiDownloads/download.feature`
- `apiDownloads/spaceDownload.feature`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/8717

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
