### PR TITLE
[tests-only] [full-ci] Use sharingNG in given step for sharing in `sharesReport.feature` file

### DIFF
--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -11,7 +11,12 @@ Feature: REPORT request to Shares space
     And user "Alice" has created folder "/folderMain"
     And user "Alice" has created folder "/folderMain/SubFolder1"
     And user "Alice" has created folder "/folderMain/SubFolder1/subFOLDER2"
-    And user "Alice" has shared entry "/folderMain" with user "Brian" with permissions "1"
+    And user "Alice" has sent the following share invitation:
+      | resource        | /folderMain |
+      | space           | Personal    |
+      | sharee          | Brian       |
+      | shareType       | user        |
+      | permissionsRole | Viewer      |
 
 
   Scenario Outline: check the REPORT response of the found folder
@@ -60,7 +65,12 @@ Feature: REPORT request to Shares space
     Given user "Brian" has disabled auto-accepting
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "/folderToBrian"
-    And user "Alice" has shared entry "/folderToBrian" with user "Brian" with permissions "1"
+    And user "Alice" has sent the following share invitation:
+      | resource        | /folderToBrian |
+      | space           | Personal       |
+      | sharee          | Brian          |
+      | shareType       | user           |
+      | permissionsRole | Viewer         |
     When user "Brian" searches for "folderToBrian" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions


### PR DESCRIPTION


## Description
Changed `Given` step for share using SharingNg in `apiContract/sharesReport.feature` file.

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/8717

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
