### PR TITLE
[WIP] feat: use runners to startup the services

### DIFF
--- a/ocis-pkg/runner/factory.go
+++ b/ocis-pkg/runner/factory.go
@@ -1,0 +1,134 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
+	ohttp "github.com/owncloud/ocis/v2/ocis-pkg/service/http"
+	"google.golang.org/grpc"
+)
+
+// NewGoMicroGrpcServerRunner creates a new runner based on the provided go-micro's
+// GRPC service. The service is expected to be created via
+// "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc".NewService(...) function
+//
+// The runner will behave as described:
+// * The task is to start a server and listen for connections. If the server
+// can't start, the task will finish with that error.
+// * The stopper will call the server's stop method and send the result to
+// the task.
+// * The stopper will run asynchronously because the stop method could take a
+// while and we don't want to block
+func NewGoMicroGrpcServerRunner(name string, server ogrpc.Service, opts ...Option) *Runner {
+	httpCh := make(chan error, 1)
+	r := New(name, func() error {
+		// start the server and return if it fails
+		if err := server.Server().Start(); err != nil {
+			return err
+		}
+		return <-httpCh // wait for the result
+	}, func() {
+		// stop implies deregistering and waiting for request to finish,
+		// so don't block
+		go func() {
+			httpCh <- server.Server().Stop() // stop and send result through channel
+			close(httpCh)
+		}()
+	}, opts...)
+	return r
+}
+
+// NewGoMicroHttpServerRunner creates a new runner based on the provided go-micro's
+// HTTP service. The service is expected to be created via
+// "github.com/owncloud/ocis/v2/ocis-pkg/service/http".NewService(...) function
+//
+// The runner will behave as described:
+// * The task is to start a server and listen for connections. If the server
+// can't start, the task will finish with that error.
+// * The stopper will call the server's stop method and send the result to
+// the task.
+// * The stopper will run asynchronously because the stop method could take a
+// while and we don't want to block
+func NewGoMicroHttpServerRunner(name string, server ohttp.Service, opts ...Option) *Runner {
+	httpCh := make(chan error, 1)
+	r := New(name, func() error {
+		// start the server and return if it fails
+		if err := server.Server().Start(); err != nil {
+			return err
+		}
+		return <-httpCh // wait for the result
+	}, func() {
+		// stop implies deregistering and waiting for request to finish,
+		// so don't block
+		go func() {
+			httpCh <- server.Server().Stop() // stop and send result through channel
+			close(httpCh)
+		}()
+	}, opts...)
+	return r
+}
+
+// NewGolangHttpServerRunner creates a new runner based on the provided HTTP server.
+// The HTTP server is expected to be created via
+// "github.com/owncloud/ocis/v2/ocis-pkg/service/debug".NewService(...) function
+// and it's expected to be a regular golang HTTP server
+//
+// The runner will behave as described:
+// * The task starts a server and listen for connections. If the server
+// can't start, the task will finish with that error. If the server is shutdown
+// the task will wait for the shutdown to return that result (task won't finish
+// immediately, but wait until shutdown returns)
+// * The stopper will call the server's shutdown method and send the result to
+// the task. The stopper will wait up to 5 secs for the shutdown.
+// * The stopper will run asynchronously because the shutdown could take a
+// while and we don't want to block
+func NewGolangHttpServerRunner(name string, server *http.Server, opts ...Option) *Runner {
+	debugCh := make(chan error, 1)
+	r := New(name, func() error {
+		// start listening and return if the error is NOT ErrServerClosed.
+		// ListenAndServe will always return a non-nil error.
+		// We need to wait and get the result of the Shutdown call.
+		// App shouldn't exit until Shutdown has returned.
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		// wait for the shutdown and return the result
+		return <-debugCh
+	}, func() {
+		// Since Shutdown might take some time, don't block
+		go func() {
+			// give 5 secs for the shutdown to finish
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			debugCh <- server.Shutdown(shutdownCtx)
+			close(debugCh)
+		}()
+	}, opts...)
+
+	return r
+}
+
+// NewGolangGrpcServerRunner creates a new runner based on the provided GRPC
+// server. The GRPC server is expected to be a regular golang GRPC server,
+// created via "google.golang.org/grpc".NewServer(...)
+// A listener also needs to be provided for the server to listen there.
+//
+// The runner will just start the GRPC server in the listener, and the server
+// will be gracefully stopped when interrupted
+func NewGolangGrpcServerRunner(name string, server *grpc.Server, listener net.Listener, opts ...Option) *Runner {
+	r := New(name, func() error {
+		return server.Serve(listener)
+	}, func() {
+		// Since GracefulStop might take some time, don't block
+		go func() {
+			server.GracefulStop()
+		}()
+	}, opts...)
+
+	return r
+}

--- a/ocis-pkg/runner/types.go
+++ b/ocis-pkg/runner/types.go
@@ -1,8 +1,14 @@
 package runner
 
 import (
+	"os"
 	"strings"
+	"syscall"
 	"time"
+)
+
+var (
+	StopSignals = []os.Signal{syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT}
 )
 
 // Runable represent a task that can be executed by the Runner.

--- a/services/antivirus/pkg/command/server.go
+++ b/services/antivirus/pkg/command/server.go
@@ -3,12 +3,13 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 
-	"github.com/oklog/run"
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/services/antivirus/pkg/config"
 	"github.com/owncloud/ocis/v2/services/antivirus/pkg/config/parser"
@@ -26,31 +27,38 @@ func Server(cfg *config.Config) *cli.Command {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
 		Action: func(c *cli.Context) error {
-			var (
-				gr          = run.Group{}
-				ctx, cancel = context.WithCancel(c.Context)
-				logger      = log.NewLogger(
-					log.Name(cfg.Service.Name),
-					log.Level(cfg.Log.Level),
-					log.Pretty(cfg.Log.Pretty),
-					log.Color(cfg.Log.Color),
-					log.File(cfg.Log.File),
-				)
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
+
+			logger := log.NewLogger(
+				log.Name(cfg.Service.Name),
+				log.Level(cfg.Log.Level),
+				log.Pretty(cfg.Log.Pretty),
+				log.Color(cfg.Log.Color),
+				log.File(cfg.Log.File),
 			)
-			defer cancel()
+
 			traceProvider, err := tracing.GetServiceTraceProvider(cfg.Tracing, cfg.Service.Name)
 			if err != nil {
 				return err
 			}
+
+			gr := runner.NewGroup()
 			{
 				svc, err := service.NewAntivirus(cfg, logger, traceProvider)
 				if err != nil {
 					return err
 				}
 
-				gr.Add(svc.Run, func(_ error) {
-					cancel()
-				})
+				gr.Add(runner.New("antivirus_svc", func() error {
+					return svc.Run()
+				}, func() {
+					svc.Close()
+				}))
 			}
 
 			{
@@ -64,13 +72,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(_ error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("antivirus_debug", debugServer))
 			}
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/antivirus/pkg/service/service.go
+++ b/services/antivirus/pkg/service/service.go
@@ -131,7 +131,7 @@ func (av Antivirus) Run() error {
 	}
 
 	wg := sync.WaitGroup{}
-	for i := 0; i < av.c.Workers; i++ {
+	for range av.c.Workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/services/antivirus/pkg/service/service.go
+++ b/services/antivirus/pkg/service/service.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/owncloud/reva/v2/pkg/bytesize"
@@ -54,7 +55,15 @@ func NewAntivirus(c *config.Config, l log.Logger, tp trace.TracerProvider) (Anti
 		return Antivirus{}, err
 	}
 
-	av := Antivirus{c: c, l: l, tp: tp, s: scanner, client: rhttp.GetHTTPClient(rhttp.Insecure(true))}
+	av := Antivirus{
+		c:       c,
+		l:       l,
+		tp:      tp,
+		s:       scanner,
+		client:  rhttp.GetHTTPClient(rhttp.Insecure(true)),
+		stopCh:  make(chan struct{}, 1),
+		stopped: new(atomic.Bool),
+	}
 
 	switch o := events.PostprocessingOutcome(c.InfectedFileHandling); o {
 	case events.PPOutcomeContinue, events.PPOutcomeAbort, events.PPOutcomeDelete:
@@ -84,7 +93,9 @@ type Antivirus struct {
 	m  uint64
 	tp trace.TracerProvider
 
-	client *http.Client
+	client  *http.Client
+	stopCh  chan struct{}
+	stopped *atomic.Bool
 }
 
 // Run runs the service
@@ -124,24 +135,46 @@ func (av Antivirus) Run() error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for e := range ch {
-				err := av.processEvent(e, natsStream)
-				if err != nil {
-					switch {
-					case errors.Is(err, ErrFatal):
-						av.l.Fatal().Err(err).Msg("fatal error - exiting")
-					case errors.Is(err, ErrEvent):
-						av.l.Error().Err(err).Msg("continuing")
-					default:
-						av.l.Fatal().Err(err).Msg("unknown error - exiting")
+
+		EventLoop:
+			for {
+				select {
+				case e, ok := <-ch:
+					if !ok {
+						break EventLoop
 					}
+
+					err := av.processEvent(e, natsStream)
+					if err != nil {
+						switch {
+						case errors.Is(err, ErrFatal):
+							av.l.Fatal().Err(err).Msg("fatal error - exiting")
+						case errors.Is(err, ErrEvent):
+							av.l.Error().Err(err).Msg("continuing")
+						default:
+							av.l.Fatal().Err(err).Msg("unknown error - exiting")
+						}
+					}
+
+					if av.stopped.Load() {
+						break EventLoop
+					}
+				case <-av.stopCh:
+					break EventLoop
 				}
 			}
 		}()
 	}
+
 	wg.Wait()
 
 	return nil
+}
+
+func (av Antivirus) Close() {
+	if av.stopped.CompareAndSwap(false, true) {
+		close(av.stopCh)
+	}
 }
 
 func (av Antivirus) processEvent(e events.Event, s events.Publisher) error {

--- a/services/clientlog/pkg/command/server.go
+++ b/services/clientlog/pkg/command/server.go
@@ -3,8 +3,8 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 
-	"github.com/oklog/run"
 	"github.com/owncloud/reva/v2/pkg/events"
 	"github.com/owncloud/reva/v2/pkg/events/stream"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
@@ -13,6 +13,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"github.com/owncloud/ocis/v2/services/clientlog/pkg/config"
@@ -61,13 +62,15 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			gr := run.Group{}
-			ctx, cancel := context.WithCancel(c.Context)
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
 
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)
-
-			defer cancel()
 
 			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			s, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
@@ -90,6 +93,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return fmt.Errorf("could not get reva client selector: %s", err)
 			}
 
+			gr := runner.NewGroup()
 			{
 				svc, err := service.NewClientlogService(
 					service.Logger(logger),
@@ -105,23 +109,11 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(func() error {
+				gr.Add(runner.New("clientlog_svc", func() error {
 					return svc.Run()
-				}, func(err error) {
-					if err != nil {
-						logger.Info().
-							Str("transport", "stream").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					} else {
-						logger.Error().Err(err).
-							Str("transport", "stream").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					}
-
-					cancel()
-				})
+				}, func() {
+					svc.Close()
+				}))
 			}
 
 			{
@@ -135,13 +127,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(_ error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("clientlog_debug", debugServer))
 			}
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -7,18 +7,19 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"os/signal"
 	"strings"
 
 	"github.com/go-ldap/ldif"
 	"github.com/libregraph/idm/pkg/ldappassword"
 	"github.com/libregraph/idm/pkg/ldbbolt"
 	"github.com/libregraph/idm/server"
-	"github.com/oklog/run"
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	pkgcrypto "github.com/owncloud/ocis/v2/ocis-pkg/crypto"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	"github.com/owncloud/ocis/v2/services/idm"
 	"github.com/owncloud/ocis/v2/services/idm/pkg/config"
 	"github.com/owncloud/ocis/v2/services/idm/pkg/config/parser"
@@ -36,14 +37,16 @@ func Server(cfg *config.Config) *cli.Command {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
 		Action: func(c *cli.Context) error {
-			var (
-				gr          = run.Group{}
-				logger      = logging.Configure(cfg.Service.Name, cfg.Log)
-				ctx, cancel = context.WithCancel(c.Context)
-			)
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
 
-			defer cancel()
+			logger := logging.Configure(cfg.Service.Name, cfg.Log)
 
+			gr := runner.NewGroup()
 			{
 				servercfg := server.Config{
 					Logger:          log.LogrusWrap(logger.Logger),
@@ -75,30 +78,16 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(func() error {
-					err := make(chan error, 1)
-					select {
-					case <-ctx.Done():
-						return nil
+				// we need an additional context for the idm server in order to
+				// cancel it anytime
+				svcCtx, svcCancel := context.WithCancel(ctx)
+				defer svcCancel()
 
-					case err <- svc.Serve(ctx):
-						return <-err
-					}
-				}, func(err error) {
-					if err == nil {
-						logger.Info().
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					} else {
-						logger.Error().Err(err).
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					}
-
-					cancel()
-				})
+				gr.Add(runner.New("idm_svc", func() error {
+					return svc.Serve(svcCtx)
+				}, func() {
+					svcCancel()
+				}))
 			}
 
 			{
@@ -112,14 +101,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(_ error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("idm_debug", debugServer))
 			}
 
-			return gr.Run()
-			//return start(ctx, logger, cfg)
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/invitations/pkg/command/server.go
+++ b/services/invitations/pkg/command/server.go
@@ -3,9 +3,10 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 
-	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"github.com/owncloud/ocis/v2/services/invitations/pkg/config"
@@ -34,16 +35,17 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			var (
-				gr          = run.Group{}
-				ctx, cancel = context.WithCancel(c.Context)
-				metrics     = metrics.New(metrics.Logger(logger))
-			)
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
 
-			defer cancel()
-
+			metrics := metrics.New(metrics.Logger(logger))
 			metrics.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
+			gr := runner.NewGroup()
 			{
 
 				svc, err := service.New(
@@ -74,23 +76,7 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(func() error {
-					return server.Run()
-				}, func(err error) {
-					if err != nil {
-						logger.Info().
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					} else {
-						logger.Error().Err(err).
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					}
-
-					cancel()
-				})
+				gr.Add(runner.NewGoMicroHttpServerRunner("invitations_http", server))
 			}
 
 			{
@@ -104,13 +90,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(_ error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("invitations_debug", debugServer))
 			}
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/nats/pkg/server/nats/nats.go
+++ b/services/nats/pkg/server/nats/nats.go
@@ -1,7 +1,6 @@
 package nats
 
 import (
-	"context"
 	"time"
 
 	nserver "github.com/nats-io/nats-server/v2/server"
@@ -10,12 +9,11 @@ import (
 var NATSListenAndServeLoopTimer = 1 * time.Second
 
 type NATSServer struct {
-	ctx    context.Context
 	server *nserver.Server
 }
 
 // NatsOption configures the new NATSServer instance
-func NewNATSServer(ctx context.Context, logger nserver.Logger, opts ...NatsOption) (*NATSServer, error) {
+func NewNATSServer(logger nserver.Logger, opts ...NatsOption) (*NATSServer, error) {
 	natsOpts := &nserver.Options{}
 
 	for _, o := range opts {
@@ -35,15 +33,14 @@ func NewNATSServer(ctx context.Context, logger nserver.Logger, opts ...NatsOptio
 	server.SetLoggerV2(logger, true, true, false)
 
 	return &NATSServer{
-		ctx:    ctx,
 		server: server,
 	}, nil
 }
 
 // ListenAndServe runs the NATSServer in a blocking way until the server is shutdown or an error occurs
 func (n *NATSServer) ListenAndServe() (err error) {
-	go n.server.Start()
-	<-n.ctx.Done()
+	n.server.Start()           // it won't block
+	n.server.WaitForShutdown() // block until the server is fully shutdown
 	return nil
 }
 

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -3,13 +3,13 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 	"reflect"
 
 	ehsvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/eventhistory/v0"
 	"github.com/owncloud/reva/v2/pkg/store"
 	microstore "go-micro.dev/v4/store"
 
-	"github.com/oklog/run"
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/reva/v2/pkg/events"
@@ -19,6 +19,7 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	settingssvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/settings/v0"
@@ -57,11 +58,14 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			gr := run.Group{}
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
 
-			ctx, cancel := context.WithCancel(c.Context)
-			defer cancel()
-
+			gr := runner.NewGroup()
 			{
 				debugServer, err := debug.Server(
 					debug.Logger(logger),
@@ -73,10 +77,7 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(_ error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("notifications_debug", debugServer))
 			}
 
 			// evs defines a list of events to subscribe to
@@ -140,11 +141,21 @@ func Server(cfg *config.Config) *cli.Command {
 				cfg.Notifications.EmailTemplatePath, cfg.Notifications.DefaultLanguage, cfg.WebUIURL,
 				cfg.Notifications.TranslationPath, cfg.Notifications.SMTP.Sender, notificationStore, historyClient, registeredEvents)
 
-			gr.Add(svc.Run, func(error) {
-				cancel()
-			})
+			gr.Add(runner.New("notifications_svc", func() error {
+				return svc.Run()
+			}, func() {
+				svc.Close()
+			}))
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/ocs/pkg/command/server.go
+++ b/services/ocs/pkg/command/server.go
@@ -3,9 +3,10 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 
-	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -39,16 +40,17 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			var (
-				gr          = run.Group{}
-				ctx, cancel = context.WithCancel(c.Context)
-				metrics     = metrics.New()
-			)
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
 
-			defer cancel()
-
+			metrics := metrics.New()
 			metrics.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
+			gr := runner.NewGroup()
 			{
 				server, err := http.Server(
 					http.Logger(logger),
@@ -67,27 +69,11 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(func() error {
-					return server.Run()
-				}, func(err error) {
-					if err == nil {
-						logger.Info().
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					} else {
-						logger.Error().Err(err).
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					}
-
-					cancel()
-				})
+				gr.Add(runner.NewGoMicroHttpServerRunner("ocs_http", server))
 			}
 
 			{
-				server, err := debug.Server(
+				debugServer, err := debug.Server(
 					debug.Logger(logger),
 					debug.Context(ctx),
 					debug.Config(cfg),
@@ -98,13 +84,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(server.ListenAndServe, func(_ error) {
-					_ = server.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("ocs_debug", debugServer))
 			}
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/policies/pkg/command/server.go
+++ b/services/policies/pkg/command/server.go
@@ -3,14 +3,15 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 
-	"github.com/oklog/run"
 	"github.com/owncloud/reva/v2/pkg/events/stream"
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -33,18 +34,20 @@ func Server(cfg *config.Config) *cli.Command {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
 		Action: func(c *cli.Context) error {
-			var (
-				gr          = run.Group{}
-				ctx, cancel = context.WithCancel(c.Context)
-				logger      = log.NewLogger(
-					log.Name(cfg.Service.Name),
-					log.Level(cfg.Log.Level),
-					log.Pretty(cfg.Log.Pretty),
-					log.Color(cfg.Log.Color),
-					log.File(cfg.Log.File),
-				).SubloggerWithRequestID(ctx)
-			)
-			defer cancel()
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
+
+			logger := log.NewLogger(
+				log.Name(cfg.Service.Name),
+				log.Level(cfg.Log.Level),
+				log.Pretty(cfg.Log.Pretty),
+				log.Color(cfg.Log.Color),
+				log.File(cfg.Log.File),
+			).SubloggerWithRequestID(ctx)
 
 			traceProvider, err := tracing.GetServiceTraceProvider(cfg.Tracing, cfg.Service.Name)
 			if err != nil {
@@ -56,6 +59,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
+			gr := runner.NewGroup()
 			{
 				grpcClient, err := grpc.NewClient(
 					append(
@@ -98,9 +102,7 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(svc.Run, func(_ error) {
-					cancel()
-				})
+				gr.Add(runner.NewGoMicroGrpcServerRunner("policies_grpc", svc))
 			}
 
 			{
@@ -116,9 +118,11 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(eventSvc.Run, func(_ error) {
-					cancel()
-				})
+				gr.Add(runner.New("policies_svc", func() error {
+					return eventSvc.Run()
+				}, func() {
+					eventSvc.Close()
+				}))
 			}
 
 			{
@@ -132,13 +136,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(_ error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("policies_debug", debugServer))
 			}
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
@@ -20,14 +21,16 @@ import (
 
 // PostprocessingService is an instance of the service handling postprocessing of files
 type PostprocessingService struct {
-	ctx    context.Context
-	log    log.Logger
-	events <-chan events.Event
-	pub    events.Publisher
-	steps  []events.Postprocessingstep
-	store  store.Store
-	c      config.Postprocessing
-	tp     trace.TracerProvider
+	ctx     context.Context
+	log     log.Logger
+	events  <-chan events.Event
+	pub     events.Publisher
+	steps   []events.Postprocessingstep
+	store   store.Store
+	c       config.Postprocessing
+	tp      trace.TracerProvider
+	stopCh  chan struct{}
+	stopped atomic.Bool
 }
 
 var (
@@ -61,6 +64,7 @@ func NewPostprocessingService(ctx context.Context, stream events.Stream, logger 
 		store:  sto,
 		c:      c,
 		tp:     tp,
+		stopCh: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -72,23 +76,61 @@ func (pps *PostprocessingService) Run() error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for e := range pps.events {
-				if err := pps.processEvent(e); err != nil {
-					switch {
-					case errors.Is(err, ErrFatal):
-						pps.log.Fatal().Err(err).Msg("fatal error - exiting")
-					case errors.Is(err, ErrEvent):
-						pps.log.Error().Err(err).Msg("continuing")
-					default:
-						pps.log.Fatal().Err(err).Msg("unknown error - exiting")
+
+		EventLoop:
+			for {
+				select {
+				case <-pps.stopCh:
+					// stop requested
+					// TODO: we might need a way to unsubscribe from the event channel, otherwise
+					// we'll be leaking a goroutine in reva that will be stuck waiting for
+					// someone to read from the event channel.
+					// Note: redis implementation seems to have a timeout, so the goroutine
+					// will exit if there is nobody processing the events and the timeout
+					// is reached. The behavior is unclear with natsjs
+					break EventLoop
+				case e, ok := <-pps.events:
+					if !ok {
+						// event channel is closed, so nothing more to do
+						break EventLoop
+					}
+
+					err := pps.processEvent(e)
+					if err != nil {
+						switch {
+						case errors.Is(err, ErrFatal):
+							pps.log.Fatal().Err(err).Msg("fatal error - exiting")
+						case errors.Is(err, ErrEvent):
+							pps.log.Error().Err(err).Msg("continuing")
+						default:
+							pps.log.Fatal().Err(err).Msg("unknown error - exiting")
+						}
+					}
+
+					if pps.stopped.Load() {
+						// if stopped, don't process any more events
+						break EventLoop
 					}
 				}
 			}
 		}()
 	}
+
 	wg.Wait()
 
 	return nil
+}
+
+// Close will make the postprocessing service to stop processing, so the `Run`
+// method can finish.
+// TODO: Underlying services can't be stopped. This means that some goroutines
+// will get stuck trying to push events through a channel nobody is reading
+// from, so resources won't be freed and there will be memory leaks. For now,
+// if the service is stopped, you should close the app soon after.
+func (pps *PostprocessingService) Close() {
+	if pps.stopped.CompareAndSwap(false, true) {
+		close(pps.stopCh)
+	}
 }
 
 func (pps *PostprocessingService) processEvent(e events.Event) error {

--- a/services/postprocessing/pkg/service/service.go
+++ b/services/postprocessing/pkg/service/service.go
@@ -72,7 +72,7 @@ func NewPostprocessingService(ctx context.Context, stream events.Stream, logger 
 func (pps *PostprocessingService) Run() error {
 	wg := sync.WaitGroup{}
 
-	for i := 0; i < pps.c.Workers; i++ {
+	for range pps.c.Workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/services/webdav/pkg/command/server.go
+++ b/services/webdav/pkg/command/server.go
@@ -3,9 +3,10 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 
-	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -41,16 +42,17 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			var (
-				gr          = run.Group{}
-				ctx, cancel = context.WithCancel(c.Context)
-				metrics     = metrics.New()
-			)
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
 
-			defer cancel()
-
+			metrics := metrics.New()
 			metrics.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
+			gr := runner.NewGroup()
 			{
 				server, err := http.Server(
 					http.Logger(logger),
@@ -69,23 +71,7 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(func() error {
-					return server.Run()
-				}, func(err error) {
-					if err == nil {
-						logger.Info().
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					} else {
-						logger.Error().Err(err).
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					}
-
-					cancel()
-				})
+				gr.Add(runner.NewGoMicroHttpServerRunner("webdav_http", server))
 			}
 
 			{
@@ -100,13 +86,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(err error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("webdav_debug", debugServer))
 			}
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/services/webfinger/pkg/command/server.go
+++ b/services/webfinger/pkg/command/server.go
@@ -3,9 +3,10 @@ package command
 import (
 	"context"
 	"fmt"
+	"os/signal"
 
-	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"github.com/owncloud/ocis/v2/services/webfinger/pkg/config"
@@ -35,16 +36,17 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 
-			var (
-				gr          = run.Group{}
-				ctx, cancel = context.WithCancel(c.Context)
-				m           = metrics.New(metrics.Logger(logger))
-			)
+			var cancel context.CancelFunc
+			ctx := cfg.Context
+			if ctx == nil {
+				ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
+				defer cancel()
+			}
 
-			defer cancel()
-
+			m := metrics.New(metrics.Logger(logger))
 			m.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
+			gr := runner.NewGroup()
 			{
 				relationProviders, err := getRelationProviders(cfg)
 				if err != nil {
@@ -82,23 +84,7 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(func() error {
-					return server.Run()
-				}, func(err error) {
-					if err == nil {
-						logger.Info().
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					} else {
-						logger.Error().Err(err).
-							Str("transport", "http").
-							Str("server", cfg.Service.Name).
-							Msg("Shutting down server")
-					}
-
-					cancel()
-				})
+				gr.Add(runner.NewGoMicroHttpServerRunner("webfinger_http", server))
 			}
 
 			{
@@ -113,13 +99,18 @@ func Server(cfg *config.Config) *cli.Command {
 					return err
 				}
 
-				gr.Add(debugServer.ListenAndServe, func(err error) {
-					_ = debugServer.Shutdown(ctx)
-					cancel()
-				})
+				gr.Add(runner.NewGolangHttpServerRunner("webfinger_debug", debugServer))
 			}
 
-			return gr.Run()
+			grResults := gr.Run(ctx)
+
+			// return the first non-nil error found in the results
+			for _, grResult := range grResults {
+				if grResult.RunnerError != nil {
+					return grResult.RunnerError
+				}
+			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Replace oklog library with customized runners. This is intended to simplify and homogenize command's behavior.
Some of the `os.Exit` calls will also be removed.

**Note**: It's expected that all the services will follow the same approach. The only notable exception (for now) is the antivirus service, which can't be stopped. This will need further analysis.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
Runner's behaviour is expected to be the same across all the commands. The code is also simplified because the behavior is set within the `runner` package, so the commands just need to provide the parameters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
