### PR TITLE
test: fix linter tagalign to respect oCIS custom order + migrate skip-dirs to exclude-dirs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,8 +44,16 @@ linters:
     - depguard # disabled for now. Needs configuration
 
 linters-settings:
+  tagalign:
+    align: false
+    sort: true
+    order:
+      - yaml
+      - env
+      - desc
+      - introductionVersion
   gocyclo:
-    min-complexity: 35 # there are some func unforuntately who need this - should we refactor them?
+    min-complexity: 35 # there are some func unfortunately who need this - should we refactor them?
   gomoddirectives:
     replace-allow-list:
       - github.com/studio-b12/gowebdav
@@ -56,12 +64,6 @@ linters-settings:
 
 severity:
   default-severity: error
-
-skip-dirs:
-  - protogen/gen
-  - docs
-  - deployments
-  - changelog
 
 issues:
   exclude-use-default: true
@@ -75,6 +77,12 @@ issues:
     - EXC0013
     - EXC0014
     - EXC0015
+
+  exclude-dirs:
+    - protogen/gen
+    - docs
+    - deployments
+    - changelog
 
 # Enabled by default linters:
 # deadcode: Finds unused code [fast: false, auto-fix: false]


### PR DESCRIPTION
## Description
- migrate setting skip-dirs to exclude-dirs - see https://github.com/golangci/golangci-lint/pull/4509
- tagalign linter sorts now according to our used order: yaml, env, desc, introductionVersion

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
