### PR TITLE
feat: add maximum image file size to be processed by the thumbnailer

### DIFF
--- a/changelog/unreleased/max-input-image.md
+++ b/changelog/unreleased/max-input-image.md
@@ -1,5 +1,6 @@
-Change: Define maximum input image dimensions when generating previews
+Change: Define maximum input image dimensions and size when generating previews
 
 This is a general hardening change to limit processing time and resources of the thumbnailer.
 
 https://github.com/owncloud/ocis/pull/9035
+https://github.com/owncloud/ocis/pull/9069

--- a/services/antivirus/pkg/config/config.go
+++ b/services/antivirus/pkg/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	InfectedFileHandling string `yaml:"infected-file-handling" env:"ANTIVIRUS_INFECTED_FILE_HANDLING" desc:"Defines the behaviour when a virus has been found. Supported options are: 'delete', 'continue' and 'abort '. Delete will delete the file. Continue will mark the file as infected but continues further processing. Abort will keep the file in the uploads folder for further admin inspection and will not move it to its final destination." introductionVersion:"pre5.0"`
 	Events               Events
 	Scanner              Scanner
-	MaxScanSize          string `yaml:"max-scan-size" env:"ANTIVIRUS_MAX_SCAN_SIZE" desc:"The maximum scan size the virus scanner can handle. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. Usable common abbreviations: [KB, KiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB." introductionVersion:"pre5.0"`
+	MaxScanSize          string `yaml:"max-scan-size" env:"ANTIVIRUS_MAX_SCAN_SIZE" desc:"The maximum scan size the virus scanner can handle. Only this many bytes of a file will be scanned. 0 means unlimited and is the default. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB." introductionVersion:"pre5.0"`
 
 	Context context.Context `yaml:"-" json:"-"`
 

--- a/services/thumbnails/pkg/config/config.go
+++ b/services/thumbnails/pkg/config/config.go
@@ -36,14 +36,15 @@ type FileSystemStorage struct {
 
 // Thumbnail defines the available thumbnail related configuration.
 type Thumbnail struct {
-	Resolutions         []string          `yaml:"resolutions" env:"THUMBNAILS_RESOLUTIONS" desc:"The supported list of target resolutions in the format WidthxHeight like 32x32. You can define any resolution as required. See the Environment Variable Types description for more details." introductionVersion:"pre5.0"`
-	FileSystemStorage   FileSystemStorage `yaml:"filesystem_storage"`
-	WebdavAllowInsecure bool              `yaml:"webdav_allow_insecure" env:"OCIS_INSECURE;THUMBNAILS_WEBDAVSOURCE_INSECURE" desc:"Ignore untrusted SSL certificates when connecting to the webdav source." introductionVersion:"pre5.0"`
-	CS3AllowInsecure    bool              `yaml:"cs3_allow_insecure" env:"OCIS_INSECURE;THUMBNAILS_CS3SOURCE_INSECURE" desc:"Ignore untrusted SSL certificates when connecting to the CS3 source." introductionVersion:"pre5.0"`
-	RevaGateway         string            `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata" introductionVersion:"pre5.0"`
-	FontMapFile         string            `yaml:"font_map_file" env:"THUMBNAILS_TXT_FONTMAP_FILE" desc:"The path to a font file for txt thumbnails." introductionVersion:"pre5.0"`
-	TransferSecret      string            `yaml:"transfer_secret" env:"THUMBNAILS_TRANSFER_TOKEN" desc:"The secret to sign JWT to download the actual thumbnail file." introductionVersion:"pre5.0"`
-	DataEndpoint        string            `yaml:"data_endpoint" env:"THUMBNAILS_DATA_ENDPOINT" desc:"The HTTP endpoint where the actual thumbnail file can be downloaded." introductionVersion:"pre5.0"`
-	MaxInputWidth       int               `yaml:"max_input_width" env:"THUMBNAILS_MAX_INPUT_WIDTH" desc:"The maximum width of an input image which is being processed." introductionVersion:"6.0"`
-	MaxInputHeight      int               `yaml:"max_input_height" env:"THUMBNAILS_MAX_INPUT_HEIGHT" desc:"The maximum height of an input image which is being processed." introductionVersion:"6.0"`
+	Resolutions           []string          `yaml:"resolutions" env:"THUMBNAILS_RESOLUTIONS" desc:"The supported list of target resolutions in the format WidthxHeight like 32x32. You can define any resolution as required. See the Environment Variable Types description for more details." introductionVersion:"pre5.0"`
+	FileSystemStorage     FileSystemStorage `yaml:"filesystem_storage"`
+	WebdavAllowInsecure   bool              `yaml:"webdav_allow_insecure" env:"OCIS_INSECURE;THUMBNAILS_WEBDAVSOURCE_INSECURE" desc:"Ignore untrusted SSL certificates when connecting to the webdav source." introductionVersion:"pre5.0"`
+	CS3AllowInsecure      bool              `yaml:"cs3_allow_insecure" env:"OCIS_INSECURE;THUMBNAILS_CS3SOURCE_INSECURE" desc:"Ignore untrusted SSL certificates when connecting to the CS3 source." introductionVersion:"pre5.0"`
+	RevaGateway           string            `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata" introductionVersion:"pre5.0"`
+	FontMapFile           string            `yaml:"font_map_file" env:"THUMBNAILS_TXT_FONTMAP_FILE" desc:"The path to a font file for txt thumbnails." introductionVersion:"pre5.0"`
+	TransferSecret        string            `yaml:"transfer_secret" env:"THUMBNAILS_TRANSFER_TOKEN" desc:"The secret to sign JWT to download the actual thumbnail file." introductionVersion:"pre5.0"`
+	DataEndpoint          string            `yaml:"data_endpoint" env:"THUMBNAILS_DATA_ENDPOINT" desc:"The HTTP endpoint where the actual thumbnail file can be downloaded." introductionVersion:"pre5.0"`
+	MaxInputWidth         int               `yaml:"max_input_width" env:"THUMBNAILS_MAX_INPUT_WIDTH" desc:"The maximum width of an input image which is being processed." introductionVersion:"6.0"`
+	MaxInputHeight        int               `yaml:"max_input_height" env:"THUMBNAILS_MAX_INPUT_HEIGHT" desc:"The maximum height of an input image which is being processed." introductionVersion:"6.0"`
+	MaxInputImageFileSize string            `yaml:"max_input_image_file_size" env:"THUMBNAILS_MAX_INPUT_IMAGE_FILE_SIZE" desc:"The maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB." introductionVersion:"6.0"`
 }

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -44,12 +44,13 @@ func DefaultConfig() *config.Config {
 			FileSystemStorage: config.FileSystemStorage{
 				RootDirectory: path.Join(defaults.BaseDataPath(), "thumbnails"),
 			},
-			WebdavAllowInsecure: false,
-			RevaGateway:         shared.DefaultRevaConfig().Address,
-			CS3AllowInsecure:    false,
-			DataEndpoint:        "http://127.0.0.1:9186/thumbnails/data",
-			MaxInputWidth:       7680,
-			MaxInputHeight:      4320,
+			WebdavAllowInsecure:   false,
+			RevaGateway:           shared.DefaultRevaConfig().Address,
+			CS3AllowInsecure:      false,
+			DataEndpoint:          "http://127.0.0.1:9186/thumbnails/data",
+			MaxInputWidth:         7680,
+			MaxInputHeight:        4320,
+			MaxInputImageFileSize: "50MB",
 		},
 	}
 }

--- a/services/thumbnails/pkg/server/grpc/server.go
+++ b/services/thumbnails/pkg/server/grpc/server.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"github.com/cs3org/reva/v2/pkg/bytesize"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
@@ -54,19 +55,25 @@ func NewService(opts ...Option) grpc.Service {
 		options.Logger.Error().Err(err).Msg("could not get gateway selector")
 		return grpc.Service{}
 	}
+	b, err := bytesize.Parse(tconf.MaxInputImageFileSize)
+	if err != nil {
+		options.Logger.Error().Err(err).Msg("could not parse MaxInputImageFileSize")
+		return grpc.Service{}
+	}
+
 	var thumbnail decorators.DecoratedService
 	{
 		thumbnail = svc.NewService(
 			svc.Config(options.Config),
 			svc.Logger(options.Logger),
-			svc.ThumbnailSource(imgsource.NewWebDavSource(tconf)),
+			svc.ThumbnailSource(imgsource.NewWebDavSource(tconf, b)),
 			svc.ThumbnailStorage(
 				storage.NewFileSystemStorage(
 					tconf.FileSystemStorage,
 					options.Logger,
 				),
 			),
-			svc.CS3Source(imgsource.NewCS3Source(tconf, gatewaySelector)),
+			svc.CS3Source(imgsource.NewCS3Source(tconf, gatewaySelector, b)),
 			svc.GatewaySelector(gatewaySelector),
 		)
 		thumbnail = decorators.NewInstrument(thumbnail, options.Metrics)

--- a/services/thumbnails/pkg/thumbnail/imgsource/webdav.go
+++ b/services/thumbnails/pkg/thumbnail/imgsource/webdav.go
@@ -9,21 +9,26 @@ import (
 	_ "image/png"  // Import the png package so that image.Decode can understand pngs
 	"io"
 	"net/http"
+	"strconv"
 
+	"github.com/cs3org/reva/v2/pkg/bytesize"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/config"
+	thumbnailerErrors "github.com/owncloud/ocis/v2/services/thumbnails/pkg/errors"
 	"github.com/pkg/errors"
 )
 
 // NewWebDavSource creates a new webdav instance.
-func NewWebDavSource(cfg config.Thumbnail) WebDav {
+func NewWebDavSource(cfg config.Thumbnail, b bytesize.ByteSize) WebDav {
 	return WebDav{
-		insecure: cfg.WebdavAllowInsecure,
+		insecure:         cfg.WebdavAllowInsecure,
+		maxImageFileSize: b.Bytes(),
 	}
 }
 
 // WebDav implements the Source interface for webdav services
 type WebDav struct {
-	insecure bool
+	insecure         bool
+	maxImageFileSize uint64
 }
 
 // Get downloads the file from a webdav service
@@ -51,6 +56,19 @@ func (s WebDav) Get(ctx context.Context, url string) (io.ReadCloser, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("could not get the image \"%s\". Request returned with statuscode %d ", url, resp.StatusCode)
+	}
+
+	contentLength := resp.Header.Get("Content-Length")
+	if contentLength == "" {
+		// no size information - let's assume it is too big
+		return nil, thumbnailerErrors.ErrImageTooLarge
+	}
+	c, err := strconv.ParseUint(contentLength, 10, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err, `could not parse content length of webdav response "%s"`, url)
+	}
+	if c > s.maxImageFileSize {
+		return nil, thumbnailerErrors.ErrImageTooLarge
 	}
 
 	return resp.Body, nil


### PR DESCRIPTION
## Description
Yet another hardening around the thumbnail service.

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
