### PR TITLE
[tests-only][full-ci]Add tests for setting password on share link

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -2208,4 +2208,37 @@ class GraphHelper {
 			$body
 		);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $spaceId
+	 * @param mixed $body
+	 * @param string $permissionsId
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 *
+	 */
+	public static function setDriveLinkSharePassword(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $spaceId,
+		$body,
+		string $permissionsId
+	): ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/permissions/$permissionsId/setPassword");
+		return HttpRequestHelper::post(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			$body
+		);
+	}
 }

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -2237,3 +2237,66 @@ Feature: Create a share link for a resource
       | upload           |
       | createOnly       |
       | blocksDownload   |
+
+  @env-config
+  Scenario: set password on a existing link share of a project-space drive using root endpoint
+    Given the following configs have been set:
+      | config                                       | value |
+      | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
+    And user "Alice" has created the following space link share:
+      | space           | projectSpace |
+      | permissionsRole | view         |
+    When user "Alice" sets the following password for the last space link share using root endpoint of the Graph API:
+      | space    | projectSpace |
+      | password | %public%     |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "hasPassword"
+        ],
+        "properties": {
+          "hasPassword": {
+            "const": true
+          }
+        }
+      }
+      """
+    And the public should be able to download file "textfile.txt" from the last link share with password "%public%" and the content should be "to share"
+
+
+  Scenario: update password on a existing link share of a project-space drive using root endpoint
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
+    And user "Alice" has created the following space link share:
+      | space           | projectSpace |
+      | permissionsRole | view         |
+      | password        | $heLlo*1234* |
+    When user "Alice" sets the following password for the last space link share using root endpoint of the Graph API:
+      | space    | projectSpace |
+      | password | %public%     |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "hasPassword"
+        ],
+        "properties": {
+          "hasPassword": {
+            "const": true
+          }
+        }
+      }
+      """
+    And the public should be able to download file "textfile.txt" from the last link share with password "%public%" and the content should be "to share"
+    And the public download of file "textfile.txt" from the last link share with password "$heLlo*1234*" should fail with HTTP status code "401" using shareNg

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -1283,4 +1283,37 @@ class SharingNgContext implements Context {
 
 		$this->featureContext->setResponse($response);
 	}
+
+	/**
+	 * @When user :user sets the following password for the last space link share using root endpoint of the Graph API:
+	 *
+	 * @param string $user
+	 * @param TableNode $body
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userSetsTheFollowingPasswordForTheLastSpaceLinkShareUsingRootEndpointOfTheGraphAPI(string $user, TableNode $body): void {
+		$rows = $body->getRowsHash();
+		Assert::assertArrayNotHasKey("resource", $rows, "'resource' should not be provided in the data-table while setting password in space shared link");
+
+		Assert::assertArrayHasKey("password", $rows, "'password' is missing in the data-table");
+		$body = [
+			"password" => $this->featureContext->getActualPassword($rows['password']),
+		];
+
+		$space = $rows['space'];
+		$spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
+
+		$response = GraphHelper::setDriveLinkSharePassword(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$spaceId,
+			\json_encode($body),
+			$this->featureContext->shareNgGetLastCreatedLinkShareID()
+		);
+		$this->featureContext->setResponse($response);
+	}
 }


### PR DESCRIPTION
## Description
This PR adds tests for setting password on share link

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/8810

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: <link> 
