### PR TITLE
[tests-only] [full-ci] Use sharing ng in api spaces

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -47,6 +47,7 @@ default:
         - GraphContext:
         - OcisConfigContext:
         - WebDavLockingContext:
+        - SharingNgContext:
 
     apiSpacesShares:
       paths:

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -14,12 +14,16 @@ Feature: Change data of space
       | Bob      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
-    And user "Alice" has shared a space "Project Jupiter" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
-    And user "Alice" has shared a space "Project Jupiter" with settings:
-      | shareWith | Bob    |
-      | role      | viewer |
+    And user "Alice" has sent the following space share invitation:
+      | space           | Project Jupiter |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | Space Editor    |
+    And user "Alice" has sent the following space share invitation:
+      | space           | Project Jupiter |
+      | sharee          | Bob             |
+      | shareType       | user            |
+      | permissionsRole | Space Viewer    |
     And using spaces DAV path
 
 

--- a/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/disableAndDeleteSpaces.feature
@@ -15,12 +15,16 @@ Feature: Disabling and deleting space
       | Carol    |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "Project Moon" with the default quota using the Graph API
-    And user "Alice" has shared a space "Project Moon" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
-    And user "Alice" has shared a space "Project Moon" with settings:
-      | shareWith | Bob    |
-      | role      | viewer |
+    And user "Alice" has sent the following space share invitation:
+      | space           | Project Moon |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Editor |
+    And user "Alice" has sent the following space share invitation:
+      | space           | Project Moon |
+      | sharee          | Bob          |
+      | shareType       | user         |
+      | permissionsRole | Space Viewer |
 
 
   Scenario Outline: user can disable their own space via the Graph API

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -16,12 +16,14 @@ Feature: A manager of the space can edit public link
     And using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "edit space" with the default quota using the Graph API
-    And user "Alice" has created a public link share of the space "edit space" with settings:
-      | permissions | 1                        |
-      | password    | %public%                 |
-      | expireDate  | 2040-01-01T23:59:59+0100 |
-      | name        | someName                 |
+    And user "Alice" has created the following space link share:
+      | space              | edit space               |
+      | permissionsRole    | view                     |
+      | password           | %public%                 |
+      | expirationDateTime | 2040-01-01T23:59:59.000Z |
+      | displayName        | someName                 |
     And user "Alice" has uploaded a file inside space "edit space" with content "some content" to "test.txt"
+    And using SharingNG
 
 
   Scenario Outline: manager of the space can edit public link.
@@ -69,15 +71,17 @@ Feature: A manager of the space can edit public link
 
   Scenario Outline: members of the space try to edit a public link
     Given using OCS API version "2"
-    And user "Alice" has shared a space "edit space" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    And user "Alice" has sent the following space share invitation:
+      | space           | edit space   |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | <space-role> |
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | 15 |
     Then the HTTP status code should be "<http-status-code>"
     And the OCS status code should be "<ocs-status-code>"
     Examples:
-      | space-role | http-status-code | ocs-status-code |
-      | manager    | 200              | 200             |
-      | editor     | 401              | 997             |
-      | viewer     | 401              | 997             |
+      | space-role   | http-status-code | ocs-status-code |
+      | Manager      | 200              | 200             |
+      | Space Editor | 401              | 997             |
+      | Space Viewer | 401              | 997             |

--- a/tests/acceptance/features/apiSpaces/filePreviews.feature
+++ b/tests/acceptance/features/apiSpaces/filePreviews.feature
@@ -46,7 +46,12 @@ Feature: Preview file in project space
   Scenario Outline: download preview of shared file inside project space
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded a file from "<source>" to "<destination>" via TUS inside of the space "previews of the files" using the WebDAV API
-    And user "Alice" has shared resource "<destination>" inside space "previews of the files" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <destination>         |
+      | space           | previews of the files |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
     When user "Brian" downloads the preview of shared resource "/Shares/<destination>" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
@@ -60,7 +65,12 @@ Feature: Preview file in project space
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a folder "folder" in space "previews of the files"
     And user "Alice" has uploaded a file inside space "previews of the files" with content "test" to "/folder/lorem.txt"
-    And user "Alice" has shared resource "/folder" inside space "previews of the files" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        |  /folder              |
+      | space           | previews of the files |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
     When user "Brian" downloads the preview of shared resource "Shares/folder/lorem.txt" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -80,7 +80,12 @@ Feature: List and create spaces
   Scenario: ordinary user can request information about their Space via the Graph API using a filter
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "folder"
-    And user "Brian" has shared folder "folder" with user "Alice" with permissions "15"
+    And user "Brian" has sent the following resource share invitation:
+      | resource        | folder   |
+      | space           | Personal |
+      | sharee          | Alice    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
     When user "Alice" lists all available spaces via the Graph API with query "$filter=driveType eq 'personal'"
     Then the HTTP status code should be "200"
     And the JSON response should contain space called "Alice Hansen" and match
@@ -441,7 +446,12 @@ Feature: List and create spaces
     And user "Alice" has disabled auto-accepting
     And user "Brian" has uploaded file with content "this is a test file." to "test.txt"
     And the administrator has assigned the role "<user-role>" to user "Alice" using the Graph API
-    And user "Brian" has shared file "/test.txt" with user "Alice"
+    And user "Brian" has sent the following resource share invitation:
+      | resource        | test.txt |
+      | space           | Personal |
+      | sharee          | Alice    |
+      | shareType       | user     |
+      | permissionsRole | Viewer   |
     When user "Alice" lists all available spaces via the Graph API
     Then the HTTP status code should be "200"
     And the JSON response should contain space called "Shares" owned by "Alice" and match

--- a/tests/acceptance/features/apiSpaces/publicLink.feature
+++ b/tests/acceptance/features/apiSpaces/publicLink.feature
@@ -9,8 +9,10 @@ Feature: public link for a space
     And using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "public space" with the default quota using the Graph API
-    And user "Alice" has created a public link share of the space "public space" with settings:
-      | permissions | 1 |
+    And user "Alice" has created the following space link share:
+      | space           | public space |
+      | permissionsRole | view         |
+    And using SharingNG
 
 
   Scenario: public tries to upload a file in the public space

--- a/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
+++ b/tests/acceptance/features/apiSpaces/removeSpaceObjects.feature
@@ -19,26 +19,30 @@ Feature: Remove files, folder
 
 
   Scenario Outline: user deletes a folder with some subfolders in a space via the webDav API
-    Given user "Alice" has shared a space "delete objects" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | delete objects |
+      | sharee          | Brian          |
+      | shareType       | user           |
+      | permissionsRole | <space-role>   |
     When user "<user>" removes the folder "folderForDeleting" from space "delete objects"
     Then the HTTP status code should be "<http-status-code>"
     And for user "<user>" the space "delete objects" <should-or-not-be-in-space> contain these entries:
       | folderForDeleting |
     And as "<user>" folder "folderForDeleting" <should-or-not-be-in-trash> exist in the trashbin of the space "delete objects"
     Examples:
-      | user  | space-role | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
-      | Alice | manager    | 204              | should not                | should                    |
-      | Brian | manager    | 204              | should not                | should                    |
-      | Brian | editor     | 204              | should not                | should                    |
-      | Brian | viewer     | 403              | should                    | should not                |
+      | user  | space-role   | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
+      | Alice | Manager      | 204              | should not                | should                    |
+      | Brian | Manager      | 204              | should not                | should                    |
+      | Brian | Space Editor | 204              | should not                | should                    |
+      | Brian | Space Viewer | 403              | should                    | should not                |
 
 
   Scenario Outline: user deletes a subfolder in a space via the webDav API
-    Given user "Alice" has shared a space "delete objects" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | delete objects |
+      | sharee          | Brian          |
+      | shareType       | user           |
+      | permissionsRole | <space-role>   |
     When user "<user>" removes the folder "folderForDeleting/sub1" from space "delete objects"
     Then the HTTP status code should be "<http-status-code>"
     And for user "<user>" the space "delete objects" should contain these entries:
@@ -47,28 +51,30 @@ Feature: Remove files, folder
       | sub1 |
     And as "<user>" folder "sub1" <should-or-not-be-in-trash> exist in the trashbin of the space "delete objects"
     Examples:
-      | user  | space-role | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
-      | Alice | manager    | 204              | should not                | should                    |
-      | Brian | manager    | 204              | should not                | should                    |
-      | Brian | editor     | 204              | should not                | should                    |
-      | Brian | viewer     | 403              | should                    | should not                |
+      | user  | space-role   | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
+      | Alice | Manager      | 204              | should not                | should                    |
+      | Brian | Manager      | 204              | should not                | should                    |
+      | Brian | Space Editor | 204              | should not                | should                    |
+      | Brian | Space Viewer | 403              | should                    | should not                |
 
 
   Scenario Outline: user deletes a file in a space via the webDav API
-    Given user "Alice" has shared a space "delete objects" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | delete objects |
+      | sharee          | Brian          |
+      | shareType       | user           |
+      | permissionsRole | <space-role>   |
     When user "<user>" removes the file "text.txt" from space "delete objects"
     Then the HTTP status code should be "<http-status-code>"
     And for user "<user>" the space "delete objects" <should-or-not-be-in-space> contain these entries:
       | text.txt |
     And as "<user>" file "text.txt" <should-or-not-be-in-trash> exist in the trashbin of the space "delete objects"
     Examples:
-      | user  | space-role | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
-      | Alice | manager    | 204              | should not                | should                    |
-      | Brian | manager    | 204              | should not                | should                    |
-      | Brian | editor     | 204              | should not                | should                    |
-      | Brian | viewer     | 403              | should                    | should not                |
+      | user  | space-role   | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
+      | Alice | Manager      | 204              | should not                | should                    |
+      | Brian | Manager      | 204              | should not                | should                    |
+      | Brian | Space Editor | 204              | should not                | should                    |
+      | Brian | Space Viewer | 403              | should                    | should not                |
 
 
   Scenario: try to delete an empty string folder from a space

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -153,7 +153,7 @@ class PublicWebDavContext implements Context {
 	 * @return ResponseInterface
 	 */
 	public function deleteFileFromPublicShare(string $fileName, string $publicWebDAVAPIVersion, string $password = ""):ResponseInterface {
-		$token = $this->featureContext->getLastCreatedPublicShareToken();
+		$token = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareToken() : $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1610,7 +1610,7 @@ class PublicWebDavContext implements Context {
 		string $destination,
 		string $password
 	):ResponseInterface {
-		$token = $this->featureContext->getLastCreatedPublicShareToken();
+		$token = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareToken() : $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -304,7 +304,8 @@ class PublicWebDavContext implements Context {
 			$path,
 			$password,
 			"",
-			$publicWebDAVAPIVersion
+			$publicWebDAVAPIVersion,
+			$this->featureContext->isUsingSharingNG()
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -577,7 +577,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userHasCreatedTheFollowingLinkShare(string $user, TableNode  $body): void {
 		$rows = $body->getRowsHash();
-		Assert::assertArrayHasKey("resource", $rows, "'resource' should not be provided in the data-table while sharing a space");
+		Assert::assertArrayNotHasKey("resource", $rows, "'resource' should not be provided in the data-table while sharing a space");
 		$response = $this->createDriveLinkShare($user, $body);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "Failed while creating public share link!", $response);
 		$this->featureContext->shareNgAddToCreatedLinkShares($response);

--- a/tests/acceptance/features/bootstrap/SpacesContext.php
+++ b/tests/acceptance/features/bootstrap/SpacesContext.php
@@ -3443,7 +3443,7 @@ class SpacesContext implements Context {
 		if ($should) {
 			Assert::assertNotEmpty($responseArray, __METHOD__ . ' Response should contain a link, but it is empty');
 			foreach ($responseArray as $element) {
-				$expectedLinkId = (string) $this->featureContext->getLastCreatedPublicShare()->id;
+				$expectedLinkId = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareID() : (string) $this->featureContext->getLastCreatedPublicShare()->id;
 				Assert::assertEquals($element["id"], $expectedLinkId, "link IDs are different");
 			}
 		} else {


### PR DESCRIPTION
## Description
Changed `Given` step for sharing using SharingNg in apiSpaces:
- `changeSpaces.feature`
- `disableAndDeleteSpaces.feature`
- `editPublicLinkOfSpace.feature`
- `filePreviews.feature`
- `listSpaces.feature`
- `publicLink.feature`
- `removeSpaceObjects.feature`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/8717

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
