### PR TITLE
[tests-only] separate different SharingNG share steps

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -2178,4 +2178,34 @@ class GraphHelper {
 			$body
 		);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $spaceId
+	 * @param mixed $body
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function createDriveShareLink(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $spaceId,
+		$body
+	): ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/createLink");
+		return HttpRequestHelper::post(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			$body
+		);
+	}
 }

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -148,7 +148,7 @@ Feature: antivirus
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -173,7 +173,7 @@ Feature: antivirus
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -198,7 +198,7 @@ Feature: antivirus
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | group1       |
@@ -225,7 +225,7 @@ Feature: antivirus
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has created folder "uploadFolder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | group1       |
@@ -274,7 +274,7 @@ Feature: antivirus
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -406,7 +406,7 @@ Feature: antivirus
     And user "Brian" has been added to group "group1"
     And user "Alice" has been added to group "group1"
     And user "Alice" has uploaded file with content "hello" to "/test.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | test.txt    |
       | space           | Personal    |
       | sharee          | group1      |
@@ -432,7 +432,7 @@ Feature: antivirus
     And user "Brian" has been added to group "group1"
     And user "Alice" has been added to group "group1"
     And user "Alice" has uploaded file with content "hello" to "/test.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | test.txt    |
       | space           | Personal    |
       | sharee          | group1      |
@@ -452,14 +452,14 @@ Feature: antivirus
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "this is a test file." to "uploadFolder/test.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Editor       |
     And user "Alice" has uploaded file with content "this is a test file." to "/test.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | test.txt    |
       | space           | Personal    |
       | sharee          | Brian       |
@@ -490,14 +490,14 @@ Feature: antivirus
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "this is a test file." to "uploadFolder/test.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Editor       |
     And user "Alice" has uploaded file with content "this is a test file." to "/test.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | test.txt    |
       | space           | Personal    |
       | sharee          | Brian       |
@@ -538,7 +538,7 @@ Feature: antivirus
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -560,7 +560,7 @@ Feature: antivirus
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -97,7 +97,7 @@ Feature: antivirus
     And the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And using SharingNG
     And user "Alice" has created folder "/uploadFolder"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource           | uploadFolder             |
       | space              | Personal                 |
       | permissionsRole    | edit                     |
@@ -122,7 +122,7 @@ Feature: antivirus
     Given using <dav-path-version> DAV path
     And using SharingNG
     And user "Alice" has created folder "/uploadFolder"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource           | uploadFolder             |
       | space              | Personal                 |
       | permissionsRole    | edit                     |
@@ -382,7 +382,7 @@ Feature: antivirus
     And using <dav-path-version> DAV path
     And using SharingNG
     And user "Alice" has uploaded file with content "hello" to "test.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | test.txt |
       | space           | Personal |
       | permissionsRole | edit     |

--- a/tests/acceptance/features/apiArchiver/downloadById.feature
+++ b/tests/acceptance/features/apiArchiver/downloadById.feature
@@ -80,25 +80,25 @@ Feature: download multiple resources bundled into an archive
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile2.txt"
     And user "Alice" has created folder "more_data"
     And user "Alice" has uploaded file with content "more data" to "/more_data/an_other_file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | my_data  |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | more_data |
       | space           | Personal  |
       | sharee          | Brian     |
@@ -126,25 +126,25 @@ Feature: download multiple resources bundled into an archive
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile2.txt"
     And user "Alice" has created folder "more_data"
     And user "Alice" has uploaded file with content "more data" to "/more_data/an_other_file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | my_data  |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | more_data |
       | space           | Personal  |
       | sharee          | Brian     |

--- a/tests/acceptance/features/apiArchiver/downloadByPath.feature
+++ b/tests/acceptance/features/apiArchiver/downloadByPath.feature
@@ -78,25 +78,25 @@ Feature: download multiple resources bundled into an archive
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile2.txt"
     And user "Alice" has created folder "more_data"
     And user "Alice" has uploaded file with content "more data" to "/more_data/an_other_file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | my_data  |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | more_data |
       | space           | Personal  |
       | sharee          | Brian     |
@@ -124,25 +124,25 @@ Feature: download multiple resources bundled into an archive
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile2.txt"
     And user "Alice" has created folder "more_data"
     And user "Alice" has uploaded file with content "more data" to "/more_data/an_other_file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | my_data  |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | more_data |
       | space           | Personal  |
       | sharee          | Brian     |

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -30,7 +30,7 @@ Feature: Propfind test
 
   Scenario Outline: space member with a different role checks the PROPFIND request of a space
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -55,7 +55,7 @@ Feature: Propfind test
 
   Scenario Outline: space member with a different role checks the PROPFIND request of the folder in the space
     Given user "Alice" has created a folder "folderMain" in space "new-space"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -78,7 +78,7 @@ Feature: Propfind test
 
   Scenario Outline: space member with a different role checks the PROPFIND request of the sub-folder in the space
     Given user "Alice" has created a folder "folderMain/subFolder1/subFolder2" in space "new-space"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -101,7 +101,7 @@ Feature: Propfind test
 
   Scenario Outline: space member with a different role checks the PROPFIND request of the file in the space
     Given user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -11,7 +11,7 @@ Feature: REPORT request to Shares space
     And user "Alice" has created folder "/folderMain"
     And user "Alice" has created folder "/folderMain/SubFolder1"
     And user "Alice" has created folder "/folderMain/SubFolder1/subFOLDER2"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | /folderMain |
       | space           | Personal    |
       | sharee          | Brian       |
@@ -65,7 +65,7 @@ Feature: REPORT request to Shares space
     Given user "Brian" has disabled auto-accepting
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "/folderToBrian"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | /folderToBrian |
       | space           | Personal       |
       | sharee          | Brian          |

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -20,7 +20,7 @@ Feature: Report test
 
 
   Scenario: check the response of the found folder
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | find data  |
       | sharee          | Brian      |
@@ -42,7 +42,7 @@ Feature: Report test
 
 
   Scenario: check the response of the found file
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | find data  |
       | sharee          | Brian      |
@@ -65,7 +65,7 @@ Feature: Report test
 
   Scenario: search for the shared folder when the share is not accepted
     Given user "Brian" has disabled auto-accepting
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | find data  |
       | sharee          | Brian      |

--- a/tests/acceptance/features/apiDepthInfinity/propfind.feature
+++ b/tests/acceptance/features/apiDepthInfinity/propfind.feature
@@ -78,7 +78,7 @@ Feature: PROPFIND with depth:infinity
       | config                                       | value |
       | OCDAV_ALLOW_PROPFIND_DEPTH_INFINITY          | true  |
       | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | simple-folder |
       | space           | Personal      |
       | permissionsRole | view          |
@@ -129,7 +129,7 @@ Feature: PROPFIND with depth:infinity
       | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
     And using new DAV path
     And using SharingNG
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | simple-folder |
       | space           | Personal      |
       | permissionsRole | view          |

--- a/tests/acceptance/features/apiDownloads/download.feature
+++ b/tests/acceptance/features/apiDownloads/download.feature
@@ -16,12 +16,12 @@ Feature: Download file in project space
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "download file" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "download file" with content "some content" to "file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | download file |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Space Editor  |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | download file |
       | sharee          | Bob           |
       | shareType       | user          |

--- a/tests/acceptance/features/apiDownloads/spaceDownload.feature
+++ b/tests/acceptance/features/apiDownloads/spaceDownload.feature
@@ -29,7 +29,7 @@ Feature: Download space
 
 
   Scenario Outline: user downloads a shared space (shared by others)
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following space share invitation:
       | space           | Project-space |
       | sharee          | Brian         |
       | shareType       | user          |

--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -61,7 +61,7 @@ Feature: enforce password on public link
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
     And using SharingNG
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
       | permissionsRole | view         |
@@ -153,7 +153,7 @@ Feature: enforce password on public link
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
     And using SharingNG
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
       | permissionsRole | view         |
@@ -186,7 +186,7 @@ Feature: enforce password on public link
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
     And using SharingNG
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
       | permissionsRole | view         |
@@ -261,7 +261,7 @@ Feature: enforce password on public link
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using SharingNG
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
       | permissionsRole | internal     |

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -714,7 +714,7 @@ Feature: user GDPR (General Data Protection Regulation) report
   Scenario: generate a GDPR report and check events when a user creates a public link share
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/folderMain"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | folderMain |
       | space           | Personal   |
       | permissionsRole | view       |

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -586,7 +586,7 @@ Feature: user GDPR (General Data Protection Regulation) report
   Scenario: generate a GDPR report and check events when a user shares a folder
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/folderMain"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -861,7 +861,7 @@ Feature: user GDPR (General Data Protection Regulation) report
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "GDPR Space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | GDPR Space   |
       | sharee          | Brian        |
       | shareType       | user         |

--- a/tests/acceptance/features/apiGraphUserGroup/deleteGroup.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/deleteGroup.feature
@@ -68,13 +68,13 @@ Feature: delete groups
     Given group "grp1" has been created
     And group "grp2" has been created
     And user "Alice" has uploaded file with content "sample text" to "lorem.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | lorem.txt |
       | space           | Personal  |
       | sharee          | grp1      |
       | shareType       | group     |
       | permissionsRole | Viewer    |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | lorem.txt |
       | space           | Personal  |
       | sharee          | grp2      |
@@ -92,7 +92,7 @@ Feature: delete groups
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | lorem.txt |
       | space           | Personal  |
       | sharee          | grp1      |

--- a/tests/acceptance/features/apiGraphUserGroup/deleteUser.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/deleteUser.feature
@@ -157,7 +157,7 @@ Feature: delete user
     Given the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "new"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | new      |
       | space           | Personal |
       | sharee          | Alice    |

--- a/tests/acceptance/features/apiLocks/unlockFiles.feature
+++ b/tests/acceptance/features/apiLocks/unlockFiles.feature
@@ -27,7 +27,7 @@ Feature: unlock locked items
     And using SharingNG
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
       | permissionsRole | edit     |
@@ -311,7 +311,7 @@ Feature: unlock locked items
     And using SharingNG
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/textfile0.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
       | permissionsRole | edit     |

--- a/tests/acceptance/features/apiLocks/unlockFiles.feature
+++ b/tests/acceptance/features/apiLocks/unlockFiles.feature
@@ -97,7 +97,7 @@ Feature: unlock locked items
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT/parent.txt |
       | space           | Personal          |
       | sharee          | Brian             |
@@ -126,7 +126,7 @@ Feature: unlock locked items
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -151,7 +151,7 @@ Feature: unlock locked items
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT/parent.txt |
       | space           | Personal          |
       | sharee          | Brian             |
@@ -178,7 +178,7 @@ Feature: unlock locked items
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT/parent.txt |
       | space           | Personal          |
       | sharee          | Brian             |
@@ -205,7 +205,7 @@ Feature: unlock locked items
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -284,7 +284,7 @@ Feature: unlock locked items
     And using spaces DAV path
     And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |

--- a/tests/acceptance/features/apiSearch1/dateSearch.feature
+++ b/tests/acceptance/features/apiSearch1/dateSearch.feature
@@ -54,7 +54,7 @@ Feature: date search
     And using spaces DAV path
     And user "Alice" has created folder "sharedFolder"
     And user "Alice" uploads a file "filesForUpload/textfile.txt" to "/sharedFolder/yesterday.txt" with mtime "yesterday" via TUS inside of the space "Personal" using the WebDAV API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | sharedFolder |
       | space           | Personal     |
       | sharee          | Brian        |

--- a/tests/acceptance/features/apiSearch1/search.feature
+++ b/tests/acceptance/features/apiSearch1/search.feature
@@ -35,7 +35,7 @@ Feature: Search
 
   Scenario Outline: user can search items from the shares
     Given using <dav-path-version> DAV path
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | project101 |
       | sharee          | Brian      |
@@ -74,7 +74,7 @@ Feature: Search
   Scenario Outline: user cannot search pending share
     Given user "Brian" has disabled auto-accepting
     And using <dav-path-version> DAV path
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | project101 |
       | sharee          | Brian      |
@@ -96,7 +96,7 @@ Feature: Search
 
   Scenario Outline: user cannot search declined share
     Given using <dav-path-version> DAV path
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | project101 |
       | sharee          | Brian      |
@@ -163,7 +163,7 @@ Feature: Search
 
   Scenario Outline: search inside folder in shares
     Given using <dav-path-version> DAV path
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderMain |
       | space           | project101 |
       | sharee          | Brian      |
@@ -246,7 +246,7 @@ Feature: Search
     Given using <dav-path-version> DAV path
     And user "Alice" has created a folder "foo/sharedToBrian" in space "Alice Hansen"
     And user "Alice" has created a folder "sharedToCarol" in space "Alice Hansen"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | foo      |
       | space           | Personal |
       | sharee          | Brian    |

--- a/tests/acceptance/features/apiSearch2/mediaTypeSearch.feature
+++ b/tests/acceptance/features/apiSearch2/mediaTypeSearch.feature
@@ -109,7 +109,7 @@ Feature: media type search
     And user "Alice" has uploaded file "filesForUpload/data.7z" to "/uploadFolder/data.7z"
     And user "Alice" has uploaded file "filesForUpload/data.rar" to "/uploadFolder/data.rar"
     And user "Alice" has uploaded file "filesForUpload/data.tar.bz2" to "/uploadFolder/data.tar.bz2"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -145,7 +145,7 @@ Feature: media type search
     And user "Alice" has uploaded a file "filesForUpload/data.7z" to "/data.7z" in space "project101"
     And user "Alice" has uploaded a file "filesForUpload/data.rar" to "/data.rar" in space "project101"
     And user "Alice" has uploaded a file "filesForUpload/data.tar.bz2" to "/data.tar.bz2" in space "project101"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | project101   |
       | sharee          | Brian        |
       | shareType       | user         |

--- a/tests/acceptance/features/apiSearch2/tagSearch.feature
+++ b/tests/acceptance/features/apiSearch2/tagSearch.feature
@@ -125,7 +125,7 @@ Feature: tag search
     And user "Alice" has uploaded file with content "hello nepal" to "uploadFolder/file3.txt"
     And user "Alice" has created the following tags for file "uploadFolder/file1.txt" of the space "Personal":
       | tag1 |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -154,7 +154,7 @@ Feature: tag search
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "tag-space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | tag-space    |
       | sharee          | Brian        |
       | shareType       | user         |

--- a/tests/acceptance/features/apiSearchContent/contentSearch.feature
+++ b/tests/acceptance/features/apiSearchContent/contentSearch.feature
@@ -92,7 +92,7 @@ Feature: content search
     And user "Alice" has uploaded file with content "saying hello to the world" to "uploadFolder/keywordAtMiddle.txt"
     And user "Alice" has uploaded file with content "nepal want to say hello" to "uploadFolder/keywordAtLast.txt"
     And user "Alice" has uploaded file with content "Namaste nepal" to "uploadFolder/hello.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -191,7 +191,7 @@ Feature: content search
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "project-space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | project-space |
       | sharee          | Brian         |
       | shareType       | user          |

--- a/tests/acceptance/features/apiSharingNg/enableDisableShareSync.feature
+++ b/tests/acceptance/features/apiSharingNg/enableDisableShareSync.feature
@@ -14,7 +14,7 @@ Feature:  enable or disable sync of incoming shares
   Scenario Outline: disable sync of shared resource
     And user "Alice" has created folder "FolderToShare"
     And user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -61,7 +61,7 @@ Feature:  enable or disable sync of incoming shares
     Given user "Brian" has disabled the auto-sync share
     And user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
     And user "Alice" has created folder "folder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -98,7 +98,7 @@ Feature:  enable or disable sync of incoming shares
     And user "Brian" has disabled the auto-sync share
     And user "Carol" has uploaded file with content "hello world" to "/textfile0.txt"
     And user "Carol" has created folder "FolderToShare"
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | grp1       |
@@ -135,7 +135,7 @@ Feature:  enable or disable sync of incoming shares
     And user "Brian" has been added to group "grp1"
     And user "Carol" has created folder "FolderToShare"
     And user "Carol" has uploaded file with content "hello world" to "/textfile0.txt"
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | grp1       |
@@ -157,7 +157,7 @@ Feature:  enable or disable sync of incoming shares
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
     And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "/textfile0.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | NewSpace   |
       | sharee          | Brian      |
@@ -190,7 +190,7 @@ Feature:  enable or disable sync of incoming shares
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
     And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "/textfile0.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | NewSpace   |
       | sharee          | Brian      |
@@ -244,7 +244,7 @@ Feature:  enable or disable sync of incoming shares
     And user "Carol" has created a space "NewSpace" with the default quota using the Graph API
     And user "Carol" has created a folder "FolderToShare" in space "NewSpace"
     And user "Carol" has uploaded a file inside space "NewSpace" with content "hello world" to "/textfile0.txt"
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | NewSpace   |
       | sharee          | grp1       |
@@ -283,7 +283,7 @@ Feature:  enable or disable sync of incoming shares
     And user "Carol" has created a space "NewSpace" with the default quota using the Graph API
     And user "Carol" has created a folder "FolderToShare" in space "NewSpace"
     And user "Carol" has uploaded a file inside space "NewSpace" with content "hello world" to "/textfile0.txt"
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | NewSpace   |
       | sharee          | grp1       |

--- a/tests/acceptance/features/apiSharingNg/linkShare.feature
+++ b/tests/acceptance/features/apiSharingNg/linkShare.feature
@@ -9,7 +9,7 @@ Feature: Create a share link for a resource
   @issue-7879
   Scenario Outline: create a link share of a folder
     Given user "Alice" has created folder "folder"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folder             |
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
@@ -74,7 +74,7 @@ Feature: Create a share link for a resource
   @issue-8619
   Scenario: create an internal link share of a folder
     Given user "Alice" has created folder "folder"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folder   |
       | space           | Personal |
       | permissionsRole | internal |
@@ -131,7 +131,7 @@ Feature: Create a share link for a resource
   @issue-8619
   Scenario: try to create an internal link share of a folder with password
     Given user "Alice" has created folder "folder"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folder   |
       | space           | Personal |
       | permissionsRole | internal |
@@ -141,7 +141,7 @@ Feature: Create a share link for a resource
   @issue-7879
   Scenario Outline: create a link share of a file
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile1.txt      |
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
@@ -204,7 +204,7 @@ Feature: Create a share link for a resource
   @issue-8619
   Scenario: create an internal link share of a file
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | permissionsRole | internal      |
@@ -261,7 +261,7 @@ Feature: Create a share link for a resource
   @issue-8619
   Scenario: try to create an internal link share of a file with password
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | permissionsRole | internal      |
@@ -271,7 +271,7 @@ Feature: Create a share link for a resource
   @issue-7879
   Scenario Outline: create a link share of a folder with display name and expiry date
     Given user "Alice" has created folder "folder"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource           | folder                   |
       | space              | Personal                 |
       | permissionsRole    | <permissions-role>       |
@@ -342,7 +342,7 @@ Feature: Create a share link for a resource
   @issue-7879
   Scenario Outline: create a link share of a file with display name and expiry date
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource           | textfile1.txt            |
       | space              | Personal                 |
       | permissionsRole    | <permissions-role>       |
@@ -414,7 +414,7 @@ Feature: Create a share link for a resource
       | config                                       | value |
       | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
     And user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile1.txt      |
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
@@ -477,7 +477,7 @@ Feature: Create a share link for a resource
   @issue-7879
   Scenario Outline: update role of a file's link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | textfile1.txt      |
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
@@ -547,7 +547,7 @@ Feature: Create a share link for a resource
   @issue-8619
   Scenario Outline: update role of a file's to internal link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | textfile1.txt      |
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
@@ -613,7 +613,7 @@ Feature: Create a share link for a resource
 
   Scenario: update expiration date of a file's link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource           | textfile1.txt            |
       | space              | Personal                 |
       | permissionsRole    | view                     |
@@ -677,7 +677,7 @@ Feature: Create a share link for a resource
   Scenario Outline: remove expiration date of a resource link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
     And user "Alice" has created folder "folder"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource           | <resource>               |
       | space              | Personal                 |
       | permissionsRole    | view                     |
@@ -744,7 +744,7 @@ Feature: Create a share link for a resource
       | config                                       | value |
       | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD | false |
     And user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | permissionsRole | view          |
@@ -771,7 +771,7 @@ Feature: Create a share link for a resource
 
   Scenario: update password of a file's link share
     Given user "Alice" has uploaded file with content "other data" to "textfile1.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | permissionsRole | view          |
@@ -802,7 +802,7 @@ Feature: Create a share link for a resource
   Scenario Outline: create a file's link share with a password that is listed in the Banned-Password-List
     Given the config "OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST" has been set to path "config/drone/banned-password-list.txt"
     And user "Alice" has uploaded file with content "other data" to "text.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | text.txt          |
       | space           | Personal          |
       | permissionsRole | view              |
@@ -845,7 +845,7 @@ Feature: Create a share link for a resource
   Scenario Outline: update a file's link share with a password that is listed in the Banned-Password-List
     Given the config "OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST" has been set to path "config/drone/banned-password-list.txt"
     And user "Alice" has uploaded file with content "other data" to "text.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | text.txt |
       | space           | Personal |
       | permissionsRole | view     |
@@ -895,7 +895,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare      |
       | space           | projectSpace       |
       | permissionsRole | <permissions-role> |
@@ -963,7 +963,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare |
       | space           | projectSpace  |
       | permissionsRole | internal      |
@@ -1022,7 +1022,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare |
       | space           | projectSpace  |
       | permissionsRole | internal      |
@@ -1035,7 +1035,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource           | folderToShare            |
       | space              | projectSpace             |
       | permissionsRole    | <permissions-role>       |
@@ -1110,7 +1110,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare      |
       | space           | projectSpace       |
       | permissionsRole | <permissions-role> |
@@ -1171,7 +1171,7 @@ Feature: Create a share link for a resource
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "folderToShare/textfile.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | folderToShare |
       | space           | projectSpace  |
       | permissionsRole | view          |
@@ -1205,7 +1205,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare      |
       | space           | projectSpace       |
       | permissionsRole | <permissions-role> |
@@ -1272,7 +1272,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt       |
       | space           | projectSpace       |
       | permissionsRole | <permissions-role> |
@@ -1338,7 +1338,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt |
       | space           | projectSpace |
       | permissionsRole | internal     |
@@ -1398,7 +1398,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt |
       | space           | projectSpace |
       | permissionsRole | internal     |
@@ -1411,7 +1411,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource           | textfile.txt             |
       | space              | projectSpace             |
       | permissionsRole    | <permissions-role>       |
@@ -1485,7 +1485,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt       |
       | space           | projectSpace       |
       | permissionsRole | <permissions-role> |
@@ -1552,7 +1552,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    When user "Alice" creates the following link share using the Graph API:
+    When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt       |
       | space           | projectSpace       |
       | permissionsRole | <permissions-role> |
@@ -1606,7 +1606,7 @@ Feature: Create a share link for a resource
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | projectSpace |
       | permissionsRole | view         |

--- a/tests/acceptance/features/apiSharingNg/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg/listPermissions.feature
@@ -352,7 +352,7 @@ Feature: List a sharing permissions
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -1329,7 +1329,7 @@ Feature: List a sharing permissions
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |

--- a/tests/acceptance/features/apiSharingNg/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg/listPermissions.feature
@@ -357,7 +357,7 @@ Feature: List a sharing permissions
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Space Viewer |
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | space           | new-space |
       | permissionsRole | view      |
       | password        | %public%  |

--- a/tests/acceptance/features/apiSharingNg/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg/propfindShares.feature
@@ -17,13 +17,13 @@ Feature: propfind a shares
     And user "Alice" has created folder "folderToShare"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
     And user "Carol" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -54,13 +54,13 @@ Feature: propfind a shares
     And user "Alice" has created folder "folderToShare"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
     And user "Carol" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -96,13 +96,13 @@ Feature: propfind a shares
     And user "Alice" has uploaded file with content "to share" to "folderToShare/textfile.txt"
     And user "Carol" has created folder "folderToShare"
     And user "Carol" has uploaded file with content "to share" to "folderToShare/textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -126,7 +126,7 @@ Feature: propfind a shares
     Given using spaces DAV path
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |

--- a/tests/acceptance/features/apiSharingNg/removeAccessToDrive.feature
+++ b/tests/acceptance/features/apiSharingNg/removeAccessToDrive.feature
@@ -13,7 +13,7 @@ Feature: Remove access to a drive
   Scenario Outline: user removes user member from project space
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -33,7 +33,7 @@ Feature: Remove access to a drive
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | group1             |
       | shareType       | group              |
@@ -53,12 +53,12 @@ Feature: Remove access to a drive
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | group1             |
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace     |
       | sharee          | Carol        |
       | shareType       | user         |
@@ -78,7 +78,7 @@ Feature: Remove access to a drive
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | group1             |
       | shareType       | group              |
@@ -97,7 +97,7 @@ Feature: Remove access to a drive
   Scenario Outline: user removes himself from the project space
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -115,12 +115,12 @@ Feature: Remove access to a drive
   Scenario Outline: user removes another user from project space using permissions endpoint
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace     |
       | sharee          | Carol        |
       | shareType       | user         |
@@ -148,7 +148,7 @@ Feature: Remove access to a drive
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace |
       | sharee          | group1   |
       | shareType       | group    |

--- a/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature
+++ b/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature
@@ -109,7 +109,7 @@ Feature: Remove access to a drive item
 
   Scenario Outline: user removes access to a folder in link share
     Given user "Alice" has created folder "FolderToShare"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | FolderToShare      |
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
@@ -127,7 +127,7 @@ Feature: Remove access to a drive item
 
   Scenario Outline: user removes access to a file in link share
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | textfile.txt       |
       | space           | Personal           |
       | permissionsRole | <permissions-role> |
@@ -145,7 +145,7 @@ Feature: Remove access to a drive item
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | FolderToShare      |
       | space           | NewSpace           |
       | permissionsRole | <permissions-role> |
@@ -165,7 +165,7 @@ Feature: Remove access to a drive item
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "some content" to "textfile.txt"
-    And user "Alice" has created the following link share:
+    And user "Alice" has created the following resource link share:
       | resource        | textfile.txt       |
       | space           | NewSpace           |
       | permissionsRole | <permissions-role> |

--- a/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature
+++ b/tests/acceptance/features/apiSharingNg/removeAccessToDriveItem.feature
@@ -12,7 +12,7 @@ Feature: Remove access to a drive item
   Scenario Outline: user removes access to resource in the user share
     Given user "Alice" has created folder "FolderToShare"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | Brian              |
@@ -36,7 +36,7 @@ Feature: Remove access to a drive item
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
     And user "Alice" has uploaded a file inside space "NewSpace" with content "some content" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>         |
       | space           | NewSpace           |
       | sharee          | Brian              |
@@ -61,7 +61,7 @@ Feature: Remove access to a drive item
     And user "Alice" has been added to group "group1"
     And user "Alice" has created folder "FolderToShare"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | group1             |
@@ -88,7 +88,7 @@ Feature: Remove access to a drive item
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
     And user "Alice" has been added to group "group1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>         |
       | space           | NewSpace           |
       | sharee          | group1             |
@@ -182,7 +182,7 @@ Feature: Remove access to a drive item
   Scenario Outline: user removes user member from project space using permissions endpoint
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -202,7 +202,7 @@ Feature: Remove access to a drive item
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And group "group1" has been created
     And user "Brian" has been added to group "group1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | group1              |
       | shareType       | group               |

--- a/tests/acceptance/features/apiSharingNg/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/shareInvitations.feature
@@ -15,7 +15,7 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation to user with different roles
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | Brian              |
@@ -105,7 +105,7 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | grp1               |
@@ -190,7 +190,7 @@ Feature: Send a sharing invitations
 
   Scenario Outline: send share invitation for a file to user with different permissions
     Given user "Alice" has uploaded file with content "to share" to "textfile1.txt"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource          | textfile1.txt        |
       | space             | Personal             |
       | sharee            | Brian                |
@@ -278,7 +278,7 @@ Feature: Send a sharing invitations
 
   Scenario Outline: send share invitation for a folder to user with different permissions
     Given user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource          | FolderToShare        |
       | space             | Personal             |
       | sharee            | Brian                |
@@ -375,7 +375,7 @@ Feature: Send a sharing invitations
       | Brian    | grp1      |
       | Carol    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "textfile1.txt"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource          | textfile1.txt        |
       | space             | Personal             |
       | sharee            | grp1                 |
@@ -469,7 +469,7 @@ Feature: Send a sharing invitations
       | Brian    | grp1      |
       | Carol    | grp1      |
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource          | FolderToShare        |
       | space             | Personal             |
       | sharee            | grp1                 |
@@ -561,7 +561,7 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation with expiration date to user with different roles
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>               |
       | space           | Personal                 |
       | sharee          | Brian                    |
@@ -657,7 +657,7 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>               |
       | space           | Personal                 |
       | sharee          | grp1                     |
@@ -748,7 +748,7 @@ Feature: Send a sharing invitations
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     And the user "Admin" has disabled user "Brian"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | Brian              |
@@ -837,7 +837,7 @@ Feature: Send a sharing invitations
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     And group "grp1" has been deleted
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | grp1               |
@@ -883,7 +883,7 @@ Feature: Send a sharing invitations
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     And the user "Admin" has deleted a user "Brian"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | Brian              |
@@ -940,7 +940,7 @@ Feature: Send a sharing invitations
       | Bob      | grp2      |
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | grp1, grp2         |
@@ -995,7 +995,7 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | grp1, Bob          |
@@ -1040,7 +1040,7 @@ Feature: Send a sharing invitations
   Scenario Outline: send sharing invitation to non-existing group
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | nonExistentGroup   |
@@ -1091,13 +1091,13 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | grp1               |
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | grp1               |
@@ -1143,7 +1143,7 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation to wrong user id
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" tries to send the following share invitation using the Graph API:
+    When user "Alice" tries to send the following resource share invitation using the Graph API:
       | resource        | <resource>                           |
       | space           | Personal                             |
       | shareeId        | a4c0c83e-ae24-4870-93c3-fcaf2a2228f7 |
@@ -1185,7 +1185,7 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation with empty user id
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" tries to send the following share invitation using the Graph API:
+    When user "Alice" tries to send the following resource share invitation using the Graph API:
       | resource        | <resource> |
       | space           | Personal   |
       | shareeId        |            |
@@ -1227,7 +1227,7 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation to user with wrong recipient type
     Given user "Alice" has uploaded file with content "to share" to "textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" tries to send the following share invitation using the Graph API:
+    When user "Alice" tries to send the following resource share invitation using the Graph API:
       | resource        | <resource>     |
       | space           | Personal       |
       | sharee          | Brian          |
@@ -1275,7 +1275,7 @@ Feature: Send a sharing invitations
       | username | groupname |
       | Brian    | grp1      |
       | Carol    | grp1      |
-    When user "Alice" tries to send the following share invitation using the Graph API:
+    When user "Alice" tries to send the following resource share invitation using the Graph API:
       | resource        | <resource>     |
       | space           | Personal       |
       | sharee          | grp1           |
@@ -1317,7 +1317,7 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation to user with empty recipient type
     Given user "Alice" has uploaded file with content "to share" to "textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" tries to send the following share invitation using the Graph API:
+    When user "Alice" tries to send the following resource share invitation using the Graph API:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -1365,7 +1365,7 @@ Feature: Send a sharing invitations
       | username | groupname |
       | Brian    | grp1      |
       | Carol    | grp1      |
-    When user "Alice" tries to send the following share invitation using the Graph API:
+    When user "Alice" tries to send the following resource share invitation using the Graph API:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | grp1       |
@@ -1407,7 +1407,7 @@ Feature: Send a sharing invitations
   Scenario Outline: try to share a resource with invalid roles
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | Brian              |
@@ -1452,7 +1452,7 @@ Feature: Send a sharing invitations
 
   Scenario Outline: try to share a file with invalid roles
     Given user "Alice" has uploaded file with content "to share" to "textfile1.txt"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile1.txt      |
       | space           | Personal           |
       | sharee          | Brian              |
@@ -1494,13 +1494,13 @@ Feature: Send a sharing invitations
   Scenario Outline: send share invitation to already shared user
     Given user "Alice" has uploaded file with content "to share" to "textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    When user "Alice" tries to send the following share invitation using the Graph API:
+    When user "Alice" tries to send the following resource share invitation using the Graph API:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -1540,11 +1540,11 @@ Feature: Send a sharing invitations
       | FolderToShare  |
 
 
-  Scenario Outline: send share invitation for project space to user with different roles
+  Scenario Outline: send share invitation for project space to user with different roles (permissions endpoint)
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -1615,12 +1615,12 @@ Feature: Send a sharing invitations
       | Manager          |
 
 
-  Scenario Outline: send share invitation for disabled project space to user with different roles
+  Scenario Outline: send share invitation for disabled project space to user with different roles (permissions endpoint)
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Admin" has disabled a space "NewSpace"
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -1660,13 +1660,13 @@ Feature: Send a sharing invitations
       | Manager          |
 
 
-  Scenario Outline: send share invitation for deleted project space to user with different roles
+  Scenario Outline: send share invitation for deleted project space to user with different roles (permissions endpoint)
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Admin" has disabled a space "NewSpace"
     And user "Admin" has deleted a space "NewSpace"
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -1705,7 +1705,7 @@ Feature: Send a sharing invitations
       | Manager          |
 
 
-  Scenario Outline: send share invitation for project space to group with different roles
+  Scenario Outline: send share invitation for project space to group with different roles (permissions endpoint)
     Given using spaces DAV path
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -1715,7 +1715,7 @@ Feature: Send a sharing invitations
       | Carol    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | grp1               |
       | shareType       | group              |
@@ -1791,7 +1791,7 @@ Feature: Send a sharing invitations
       | Manager          |
 
 
-  Scenario Outline: send share invitation for disabled project space to group with different roles
+  Scenario Outline: send share invitation for disabled project space to group with different roles (permissions endpoint)
     Given using spaces DAV path
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -1802,7 +1802,7 @@ Feature: Send a sharing invitations
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Admin" has disabled a space "NewSpace"
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | grp1               |
       | shareType       | group              |
@@ -1842,7 +1842,7 @@ Feature: Send a sharing invitations
       | Manager          |
 
 
-  Scenario Outline: send share invitation for deleted project space to group with different roles
+  Scenario Outline: send share invitation for deleted project space to group with different roles (permissions endpoint)
     Given using spaces DAV path
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -1854,7 +1854,7 @@ Feature: Send a sharing invitations
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Admin" has disabled a space "NewSpace"
     And user "Admin" has deleted a space "NewSpace"
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | grp1               |
       | shareType       | group              |
@@ -1981,13 +1981,13 @@ Feature: Send a sharing invitations
       """
 
 
-  Scenario Outline: send share invitation for project space resource to user with different roles
+  Scenario Outline: send share invitation for project space resource to user with different roles (permissions endpoint)
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "textfile1.txt"
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | NewSpace           |
       | sharee          | Brian              |
@@ -2063,7 +2063,7 @@ Feature: Send a sharing invitations
       | Uploader         | FolderToShare |
 
 
-  Scenario Outline: send share invitation for project space resource to group with different roles
+  Scenario Outline: send share invitation for project space resource to group with different roles (permissions endpoint)
     Given using spaces DAV path
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -2075,7 +2075,7 @@ Feature: Send a sharing invitations
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "textfile1.txt"
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    When user "Alice" sends the following share invitation for space using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | <resource>         |
       | space           | NewSpace           |
       | sharee          | grp1               |
@@ -2158,8 +2158,8 @@ Feature: Send a sharing invitations
       | Uploader         | FolderToShare |
 
   @issue-8494
-  Scenario Outline: try to send share invitation for personal space to user with different roles
-    When user "Alice" sends the following share invitation for space using the Graph API:
+  Scenario Outline: try to send share invitation for personal space to user with different roles (permissions endpoint)
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | Personal           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -2204,8 +2204,8 @@ Feature: Send a sharing invitations
       | Manager          |
 
   @issue-8495
-  Scenario Outline: try to share Shares space with a user
-    When user "Alice" sends the following share invitation for space using the Graph API:
+  Scenario Outline: try to share Shares space with a user (permissions endpoint)
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
       | space           | Shares             |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -2258,14 +2258,14 @@ Feature: Send a sharing invitations
       | username | groupname |
       | Brian    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "textfile1.txt"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource          | textfile1.txt        |
       | space             | Personal             |
       | sharee            | grp1                 |
       | shareType         | group                |
       | permissionsAction | <permissions-action> |
     Then the HTTP status code should be "400"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource          | FolderToShare        |
       | space             | Personal             |
       | sharee            | Brian                |
@@ -2284,7 +2284,7 @@ Feature: Send a sharing invitations
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" sends the following share invitation using root endpoint of the Graph API:
+    When user "Alice" sends the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -2364,7 +2364,7 @@ Feature: Send a sharing invitations
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" sends the following share invitation using root endpoint of the Graph API:
+    When user "Alice" sends the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | grp1               |
       | shareType       | group              |
@@ -2441,7 +2441,7 @@ Feature: Send a sharing invitations
     And user "Carol" has been created with default attributes and without skeleton files
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | Brian, Carol       |
       | shareType       | user, user         |
@@ -2490,7 +2490,7 @@ Feature: Send a sharing invitations
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace            |
       | sharee          | Brian, non-existent |
       | shareType       | user, user          |
@@ -2546,7 +2546,7 @@ Feature: Send a sharing invitations
       | Carol    | grp2      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | grp1, grp2         |
       | shareType       | group, group       |
@@ -2599,7 +2599,7 @@ Feature: Send a sharing invitations
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | grp1, grp2         |
       | shareType       | group, group       |
@@ -2653,7 +2653,7 @@ Feature: Send a sharing invitations
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | Carol, grp2        |
       | shareType       | user, group        |
@@ -2699,7 +2699,7 @@ Feature: Send a sharing invitations
 
 
   Scenario Outline: try to invite user to personal drive with different roles using root endpoint
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | Personal           |
       | sharee          | Brian              |
       | shareType       | user               |
@@ -2751,7 +2751,7 @@ Feature: Send a sharing invitations
     And the following users have been added to the following groups
       | username | groupname |
       | Brian    | grp1      |
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | Personal           |
       | sharee          | grp1               |
       | shareType       | group              |
@@ -2799,7 +2799,7 @@ Feature: Send a sharing invitations
 
 
   Scenario Outline: try to invite user to shares drive with different re-sharing permissions using root endpoint
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space             | Shares               |
       | sharee            | Brian                |
       | shareType         | user                 |
@@ -2850,7 +2850,7 @@ Feature: Send a sharing invitations
     And the following users have been added to the following groups
       | username | groupname |
       | Brian    | grp1      |
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space             | Shares               |
       | sharee            | grp1                 |
       | shareType         | group                |
@@ -2897,7 +2897,7 @@ Feature: Send a sharing invitations
 
 
   Scenario Outline: try to send a sharing invitation for the personal drive to an non-existent sharee using root endpoint
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | Personal           |
       | sharee          | non-existent       |
       | shareType       | <sharee-type>      |
@@ -2950,7 +2950,7 @@ Feature: Send a sharing invitations
 
 
   Scenario Outline: try to send a sharing invitation for the personal drive with an empty sharee using root endpoint
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | Personal           |
       | sharee          |                    |
       | shareType       | <sharee-type>      |
@@ -3006,7 +3006,7 @@ Feature: Send a sharing invitations
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          | non-existent       |
       | shareType       | <sharee-type>      |
@@ -3058,7 +3058,7 @@ Feature: Send a sharing invitations
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    When user "Alice" tries to send the following share invitation using root endpoint of the Graph API:
+    When user "Alice" tries to send the following space share invitation using root endpoint of the Graph API:
       | space           | NewSpace           |
       | sharee          |                    |
       | shareType       | <sharee-type>      |
@@ -3113,7 +3113,7 @@ Feature: Send a sharing invitations
       | username | groupname |
       | Carol    | Brian     |
     And user "Alice" has uploaded file with content "lorem" to "textfile.txt"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -3122,7 +3122,7 @@ Feature: Send a sharing invitations
     Then the HTTP status code should be "200"
     And for user "Brian" the space Shares should contain these entries:
       | textfile.txt |
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -3139,7 +3139,7 @@ Feature: Send a sharing invitations
       | username | groupname |
       | Brian    | ?\?@#%@;  |
     And user "Alice" has uploaded file with content "lorem" to "textfile.txt"
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | ?\?@#%@;     |
@@ -3160,7 +3160,7 @@ Feature: Send a sharing invitations
     And the following users have been added to the following groups
       | username | groupname |
       | Carol    | Brian     |
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | NewSpace     |
       | sharee          | Brian        |
@@ -3169,7 +3169,7 @@ Feature: Send a sharing invitations
     Then the HTTP status code should be "200"
     And for user "Brian" the space Shares should contain these entries:
       | textfile.txt |
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | NewSpace     |
       | sharee          | Brian        |
@@ -3189,7 +3189,7 @@ Feature: Send a sharing invitations
     And the following users have been added to the following groups
       | username | groupname |
       | Brian    | ?\?@#%@;  |
-    When user "Alice" sends the following share invitation using the Graph API:
+    When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | NewSpace     |
       | sharee          | ?\?@#%@;     |

--- a/tests/acceptance/features/apiSharingNg/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedByMe.feature
@@ -14,7 +14,7 @@ Feature: resources shared by user
 
   Scenario: sharer lists the file share (Personal space)
     Given user "Alice" has uploaded file with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -138,7 +138,7 @@ Feature: resources shared by user
   Scenario: sharer lists the file share shared from inside a folder (Personal space)
     Given user "Alice" has created folder "FolderToShare"
     And user "Alice" has uploaded file with content "hello world" to "FolderToShare/textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare/textfile.txt |
       | space           | Personal                   |
       | sharee          | Brian                      |
@@ -261,7 +261,7 @@ Feature: resources shared by user
 
   Scenario: sharer lists the folder share (Personal space)
     Given user "Alice" has created folder "FolderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -378,13 +378,13 @@ Feature: resources shared by user
   Scenario: sharer lists the file and folder shares (Personal space)
     Given user "Alice" has created folder "FolderToShare"
     And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -613,13 +613,13 @@ Feature: resources shared by user
     Given group "grp1" has been created
     And user "Alice" has created folder "FolderToShare"
     And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | Viewer       |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare |
       | space           | Personal      |
       | sharee          | grp1          |
@@ -825,7 +825,7 @@ Feature: resources shared by user
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | NewSpace     |
       | sharee          | Brian        |
@@ -952,7 +952,7 @@ Feature: resources shared by user
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
     And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "FolderToShare/textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare/textfile.txt |
       | space           | NewSpace                   |
       | sharee          | Brian                      |
@@ -1078,7 +1078,7 @@ Feature: resources shared by user
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare |
       | space           | NewSpace      |
       | sharee          | Brian         |
@@ -1198,13 +1198,13 @@ Feature: resources shared by user
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
     And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | NewSpace     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare |
       | space           | NewSpace      |
       | sharee          | Brian         |
@@ -1436,13 +1436,13 @@ Feature: resources shared by user
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
     And user "Alice" has created a folder "FolderToShare" in space "new-space"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | new-space    |
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | Viewer       |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | FolderToShare |
       | space           | new-space     |
       | sharee          | grp1          |
@@ -1647,7 +1647,7 @@ Feature: resources shared by user
     Given the config "GRAPH_SPACES_USERS_CACHE_TTL" has been set to "1"
     And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -1679,7 +1679,7 @@ Feature: resources shared by user
     And group "grp1" has been created
     And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -1710,7 +1710,7 @@ Feature: resources shared by user
     Given the config "GRAPH_SPACES_USERS_CACHE_TTL" has been set to "1"
     And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -1801,7 +1801,7 @@ Feature: resources shared by user
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | new-space    |
       | sharee          | Brian        |
@@ -1835,7 +1835,7 @@ Feature: resources shared by user
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | new-space    |
       | sharee          | grp1         |
@@ -1868,7 +1868,7 @@ Feature: resources shared by user
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | new-space    |
       | sharee          | Brian        |

--- a/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMe.feature
@@ -14,7 +14,7 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the file share (Personal space)
     Given user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -313,7 +313,7 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the folder share (Personal space)
     Given user "Alice" has created folder "folder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -604,7 +604,7 @@ Feature: an user gets the resources shared to them
     And user "Alice" has uploaded file with content "hello" to "textfile0.txt"
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | grp1          |
@@ -897,7 +897,7 @@ Feature: an user gets the resources shared to them
     And  user "Alice" has created folder "folder"
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | grp1     |
@@ -1137,13 +1137,13 @@ Feature: an user gets the resources shared to them
     And user "Alice" has uploaded file with content "hello" to "textfile0.txt"
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | grp1          |
@@ -1508,13 +1508,13 @@ Feature: an user gets the resources shared to them
     And  user "Alice" has created folder "folder"
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | grp1     |
@@ -1850,13 +1850,13 @@ Feature: an user gets the resources shared to them
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "to share" to "textfile.txt"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -2132,13 +2132,13 @@ Feature: an user gets the resources shared to them
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "folderToShare"
     And user "Carol" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -2416,25 +2416,25 @@ Feature: an user gets the resources shared to them
     And user "Brian" has uploaded file with content "hello world" to "/textfile.txt"
     And user "Carol" has created folder "folder"
     And user "Carol" has uploaded file with content "hello world" to "/textfile.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Alice    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Alice    |
@@ -2504,7 +2504,7 @@ Feature: an user gets the resources shared to them
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | testfile.txt |
       | space           | new-space    |
       | sharee          | Brian        |
@@ -2732,7 +2732,7 @@ Feature: an user gets the resources shared to them
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has created a folder "folder" in space "new-space"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder    |
       | space           | new-space |
       | sharee          | Brian     |
@@ -2943,7 +2943,7 @@ Feature: an user gets the resources shared to them
     And user "Alice" has uploaded a file inside space "new-space" with content "hello world" to "textfile0.txt"
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | new-space     |
       | sharee          | grp1          |
@@ -3158,7 +3158,7 @@ Feature: an user gets the resources shared to them
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Alice" has created a folder "folder" in space "new-space"
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder    |
       | space           | new-space |
       | sharee          | grp1      |
@@ -3351,13 +3351,13 @@ Feature: an user gets the resources shared to them
     And user "Alice" has uploaded a file inside space "new-space" with content "hello world" to "textfile0.txt"
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | new-space     |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | new-space     |
       | sharee          | grp1          |
@@ -3643,13 +3643,13 @@ Feature: an user gets the resources shared to them
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Alice" has created a folder "folder" in space "new-space"
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder    |
       | space           | new-space |
       | sharee          | Brian     |
       | shareType       | user      |
       | permissionsRole | Viewer    |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder    |
       | space           | new-space |
       | sharee          | grp1      |
@@ -3917,25 +3917,25 @@ Feature: an user gets the resources shared to them
     And user "Alice" has created a space "space-mars" with the default quota using the Graph API
     And user "Alice" has created a folder "folder" in space "space-mars"
     And user "Alice" has uploaded a file inside space "space-mars" with content "hello world" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | space-moon   |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder     |
       | space           | space-moon |
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | space-mars   |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder     |
       | space           | space-mars |
       | sharee          | Brian      |
@@ -4002,7 +4002,7 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the file share after sharer is deleted (Personal space)
     Given user "Alice" has uploaded file with content "hello" to "textfile0.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -4029,7 +4029,7 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the folder share after sharer is deleted (Personal space)
     Given user "Alice" has created folder "folder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -4058,7 +4058,7 @@ Feature: an user gets the resources shared to them
 
   Scenario: sharee lists the file share after the sharer is disabled (Personal space)
     Given user "Alice" has uploaded file with content "hello" to "textfile0.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -4239,7 +4239,7 @@ Feature: an user gets the resources shared to them
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has created a folder "folder" in space "new-space"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder    |
       | space           | new-space |
       | sharee          | Brian     |
@@ -4450,7 +4450,7 @@ Feature: an user gets the resources shared to them
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "testfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | testfile.txt |
       | space           | new-space    |
       | sharee          | Brian        |
@@ -4685,7 +4685,7 @@ Feature: an user gets the resources shared to them
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has created a folder "folder" in space "new-space"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder    |
       | space           | new-space |
       | sharee          | Brian     |
@@ -4845,7 +4845,7 @@ Feature: an user gets the resources shared to them
   Scenario Outline: sharee hides the shared resource (Personal space)
     Given user "Alice" has created folder "folder"
     And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -4886,7 +4886,7 @@ Feature: an user gets the resources shared to them
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "testfile.txt"
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | NewSpace   |
       | sharee          | Brian      |
@@ -4924,7 +4924,7 @@ Feature: an user gets the resources shared to them
   Scenario Outline: sharee lists the shares after hiding (Personal space)
     Given user "Alice" has created folder "folder"
     And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -4970,7 +4970,7 @@ Feature: an user gets the resources shared to them
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "testfile.txt"
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | NewSpace   |
       | sharee          | Brian      |

--- a/tests/acceptance/features/apiSharingNg/sharedWithMeSyncDisabled.feature
+++ b/tests/acceptance/features/apiSharingNg/sharedWithMeSyncDisabled.feature
@@ -15,7 +15,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
 
   Scenario: user lists the file shared with them
     Given user "Alice" has uploaded file with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -284,7 +284,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
 
   Scenario: user lists the folder shared with them
     Given user "Alice" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -527,7 +527,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
       | username | groupname |
       | Brian    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -800,7 +800,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
       | username | groupname |
       | Brian    | grp1      |
     And user "Alice" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | grp1          |
@@ -1042,7 +1042,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | projectSpace |
       | sharee          | Brian        |
@@ -1285,7 +1285,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | projectSpace  |
       | sharee          | Brian         |
@@ -1507,7 +1507,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | projectSpace |
       | sharee          | grp1         |
@@ -1741,7 +1741,7 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | projectSpace  |
       | sharee          | grp1          |
@@ -1942,13 +1942,13 @@ Feature: listing sharedWithMe when auto-sync is disabled
       | username | groupname |
       | Brian    | grp1      |
     And user "Alice" has uploaded file with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -2086,13 +2086,13 @@ Feature: listing sharedWithMe when auto-sync is disabled
       | username | groupname |
       | Brian    | grp1      |
     And user "Alice" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | grp1          |
@@ -2226,13 +2226,13 @@ Feature: listing sharedWithMe when auto-sync is disabled
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "to share" to "textfile.txt"
     And user "Carol" has uploaded file with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -2523,13 +2523,13 @@ Feature: listing sharedWithMe when auto-sync is disabled
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "folderToShare"
     And user "Carol" has created folder "folderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | Personal      |
       | sharee          | Brian         |
@@ -2825,13 +2825,13 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | projectSpace |
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | File Editor  |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | projectSpace |
       | sharee          | Brian        |
@@ -2999,13 +2999,13 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | projectSpace  |
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | Viewer        |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | projectSpace  |
       | sharee          | Brian         |
@@ -3167,14 +3167,14 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And user "Alice" has created a space "projectSpace1" with the default quota using the Graph API
     And user "Carol" has created a space "projectSpace2" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "projectSpace1" with content "to share" to "textfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt  |
       | space           | projectSpace1 |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
     And user "Carol" has uploaded a file inside space "projectSpace2" with content "to share" to "textfile.txt"
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | textfile.txt  |
       | space           | projectSpace2 |
       | sharee          | Brian         |
@@ -3486,14 +3486,14 @@ Feature: listing sharedWithMe when auto-sync is disabled
     And user "Alice" has created a space "projectSpace1" with the default quota using the Graph API
     And user "Carol" has created a space "projectSpace2" with the default quota using the Graph API
     And user "Alice" has created a folder "folderToShare" in space "projectSpace1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | projectSpace1 |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
     And user "Carol" has created a folder "folderToShare" in space "projectSpace2"
-    And user "Carol" has sent the following share invitation:
+    And user "Carol" has sent the following resource share invitation:
       | resource        | folderToShare |
       | space           | projectSpace2 |
       | sharee          | Brian         |

--- a/tests/acceptance/features/apiSharingNg/updateShareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/updateShareInvitations.feature
@@ -13,14 +13,14 @@ Feature: Update permission of a share
 
   Scenario: user updates expiration date of a share
     Given user "Alice" has uploaded file with content "hello world" to "testfile.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource           | testfile.txt         |
       | space              | Personal             |
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | Viewer               |
       | expirationDateTime | 2025-07-15T14:00:00Z |
-    When user "Alice" updates the last share with the following using the Graph API:
+    When user "Alice" updates the last resource share with the following using the Graph API:
       | space              | Personal             |
       | resource           | testfile.txt         |
       | expirationDateTime | 2200-07-15T14:00:00Z |
@@ -85,14 +85,14 @@ Feature: Update permission of a share
   Scenario Outline: user removes expiration date of a share
     Given user "Alice" has uploaded file with content "hello world" to "testfile.txt"
     And user "Alice" has created folder "folder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource           | <resource>           |
       | space              | Personal             |
       | sharee             | Brian                |
       | shareType          | user                 |
       | permissionsRole    | Viewer               |
       | expirationDateTime | 2025-07-15T14:00:00Z |
-    When user "Alice" updates the last share with the following using the Graph API:
+    When user "Alice" updates the last resource share with the following using the Graph API:
       | space              | Personal   |
       | resource           | <resource> |
       | expirationDateTime |            |
@@ -156,13 +156,13 @@ Feature: Update permission of a share
   Scenario Outline: user updates role of a share
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>         |
       | space           | Personal           |
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    When user "Alice" updates the last share with the following using the Graph API:
+    When user "Alice" updates the last resource share with the following using the Graph API:
       | permissionsRole | <new-permissions-role> |
       | space           | Personal               |
       | resource        | <resource>             |
@@ -233,12 +233,12 @@ Feature: Update permission of a share
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    When user "Alice" updates the last share with the following using the Graph API:
+    When user "Alice" updates the space share for user "Brian" with the following using the Graph API:
       | permissionsRole | <new-permissions-role> |
       | space           | NewSpace               |
     Then the HTTP status code should be "200"
@@ -308,13 +308,13 @@ Feature: Update permission of a share
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "textfile1.txt"
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>         |
       | space           | NewSpace           |
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    When user "Alice" updates the last share with the following using the Graph API:
+    When user "Alice" updates the last resource share with the following using the Graph API:
       | permissionsRole | <new-permissions-role> |
       | space           | NewSpace               |
       | resource        | <resource>             |
@@ -389,7 +389,7 @@ Feature: Update permission of a share
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | grp1                 |
       | shareType          | group                |
@@ -469,7 +469,7 @@ Feature: Update permission of a share
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | grp1                 |
       | shareType          | group                |
@@ -549,7 +549,7 @@ Feature: Update permission of a share
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | grp1                 |
       | shareType          | group                |
@@ -634,7 +634,7 @@ Feature: Update permission of a share
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | grp1                 |
       | shareType          | group                |
@@ -715,7 +715,7 @@ Feature: Update permission of a share
       | Brian    | grp1      |
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | grp1                 |
       | shareType          | group                |
@@ -797,7 +797,7 @@ Feature: Update permission of a share
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | Brian                |
       | shareType          | user                 |
@@ -873,7 +873,7 @@ Feature: Update permission of a share
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | Brian                |
       | shareType          | user                 |
@@ -949,7 +949,7 @@ Feature: Update permission of a share
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | Brian                |
       | shareType          | user                 |
@@ -1031,7 +1031,7 @@ Feature: Update permission of a share
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | Brian                |
       | shareType          | user                 |
@@ -1108,7 +1108,7 @@ Feature: Update permission of a share
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following share invitation using root endpoint of the Graph API:
+    And user "Alice" has sent the following space share invitation:
       | space              | NewSpace             |
       | sharee             | Brian                |
       | shareType          | user                 |

--- a/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
@@ -186,7 +186,7 @@ Feature: copying file using file id
     And user "Alice" has created folder "folder/sub-folder"
     And user "Alice" has uploaded file with content "some data" to "/folder/sub-folder/test.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -211,7 +211,7 @@ Feature: copying file using file id
   Scenario Outline: copy a file from personal to share space
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/folder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -238,7 +238,7 @@ Feature: copying file using file id
     And user "Alice" has created folder "/folder"
     And user "Alice" has uploaded file with content "some data" to "/folder/test.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Brian    |

--- a/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
@@ -17,7 +17,7 @@ Feature: checking file versions using file id
 
 
   Scenario Outline: check the file versions of a file shared from project space
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | text.txt |
       | space           | Project1 |
       | sharee          | Brian    |
@@ -34,7 +34,7 @@ Feature: checking file versions using file id
       | Viewer      |
 
   Scenario Outline: check the versions of a file in a shared space as editor/manager
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following space share invitation:
       | space           | Project1     |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -52,7 +52,7 @@ Feature: checking file versions using file id
 
 
   Scenario: check the versions of a file in a shared space as viewer
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following space share invitation:
       | space           | Project1     |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -63,7 +63,7 @@ Feature: checking file versions using file id
   @issue-7738
   Scenario Outline: check the versions of a file after moving to a shared folder inside a project space as editor/viewer
     Given user "Alice" has created a folder "testFolder" in space "Project1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | text.txt |
       | space           | Project1 |
       | sharee          | Brian    |
@@ -83,13 +83,13 @@ Feature: checking file versions using file id
   @issue-7738
   Scenario: check the versions of a file after moving it to a shared folder inside a project space as manager
     Given user "Alice" has created a folder "testFolder" in space "Project1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | testFolder |
       | space           | Project1   |
       | sharee          | Brian      |
       | shareType       | user       |
       | permissionsRole | Viewer     |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | Project1 |
       | sharee          | Brian    |
       | shareType       | user     |

--- a/tests/acceptance/features/apiSpacesDavOperation/getFileByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/getFileByFileId.feature
@@ -51,7 +51,7 @@ Feature: accessing files using file id
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -71,7 +71,7 @@ Feature: accessing files using file id
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "some data" to "uploadFolder/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -92,7 +92,7 @@ Feature: accessing files using file id
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some data" to "textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -123,7 +123,7 @@ Feature: accessing files using file id
     And user "Brian" has disabled the auto-sync share
     And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -144,7 +144,7 @@ Feature: accessing files using file id
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "some data" to "uploadFolder/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -167,7 +167,7 @@ Feature: accessing files using file id
     And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -191,7 +191,7 @@ Feature: accessing files using file id
     And the administrator has assigned the role "Admin" to user "Alice" using the Graph API
     And user "Alice" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -214,7 +214,7 @@ Feature: accessing files using file id
     And user "Brian" has disabled the auto-sync share
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | new-space    |
       | sharee          | Brian        |
@@ -238,7 +238,7 @@ Feature: accessing files using file id
     And user "Alice" has created a folder "uploadFolder" in space "new-space"
     And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "uploadFolder/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | new-space    |
       | sharee          | Brian        |
@@ -263,7 +263,7 @@ Feature: accessing files using file id
     And we save it into "FILEID"
     And user "Admin" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | new-space    |
       | sharee          | grp1         |
@@ -289,7 +289,7 @@ Feature: accessing files using file id
     And we save it into "FILEID"
     And user "Admin" has created a group "grp1" using the Graph API
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | new-space    |
       | sharee          | grp1         |

--- a/tests/acceptance/features/apiSpacesDavOperation/propfindByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/propfindByFileId.feature
@@ -104,7 +104,7 @@ Feature: propfind a file using file id
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -125,7 +125,7 @@ Feature: propfind a file using file id
   Scenario Outline: sharee sends a PROPFIND request to a file inside of a shared folder
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/folder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | folder   |
       | space           | Personal |
       | sharee          | Brian    |

--- a/tests/acceptance/features/apiSpacesDavOperation/updateFileByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/updateFileByFileId.feature
@@ -51,7 +51,7 @@ Feature: update files using file id
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -72,7 +72,7 @@ Feature: update files using file id
     And user "Alice" has created folder "uploadFolder"
     And user "Alice" has uploaded file with content "some data" to "uploadFolder/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | uploadFolder |
       | space           | Personal     |
       | sharee          | Brian        |
@@ -94,7 +94,7 @@ Feature: update files using file id
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "some data" to "/textfile.txt"
     And we save it into "FILEID"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
       | shareType       | user         |

--- a/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature
+++ b/tests/acceptance/features/apiSpacesShares/changingFilesShare.feature
@@ -17,13 +17,13 @@ Feature: change shared resource
     And user "Alice" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT"
     And user "Alice" has moved file "textfile0.txt" to "PARENT/from_alice.txt" in space "Personal"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Carol    |
       | shareType       | user     |
       | permissionsRole | Editor   |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Carol    |
@@ -41,7 +41,7 @@ Feature: change shared resource
     Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has uploaded file with content "old content version 1" to "/textfile1.txt"
     And user "Alice" has uploaded file with content "old content version 2" to "/textfile1.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | textfile1.txt |
       | space           | Personal      |
       | sharee          | Brian         |

--- a/tests/acceptance/features/apiSpacesShares/checksum.feature
+++ b/tests/acceptance/features/apiSpacesShares/checksum.feature
@@ -11,7 +11,7 @@ Feature: checksums
   @issue-1291
   Scenario: sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | myChecksumFile.txt |
       | space           | Personal           |
       | sharee          | Brian              |
@@ -24,7 +24,7 @@ Feature: checksums
   @issue-1291
   Scenario: modifying a shared file should return correct checksum in the propfind using new DAV path
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | myChecksumFile.txt |
       | space           | Personal           |
       | sharee          | Brian              |

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -16,7 +16,7 @@ Feature: copy file
     And user "Alice" has created a space "Project" with the default quota using the Graph API
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/insideSpace.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -37,7 +37,7 @@ Feature: copy file
     And user "Alice" has created a space "Project" with the default quota using the Graph API
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -53,12 +53,12 @@ Feature: copy file
     And user "Brian" has created a space "Project1" with the default quota using the Graph API
     And user "Brian" has created a space "Project2" with the default quota using the Graph API
     And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "/project1.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project2        |
       | sharee          | Alice           |
       | shareType       | user            |
       | permissionsRole | <to-space-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project1          |
       | sharee          | Alice             |
       | shareType       | user              |
@@ -81,12 +81,12 @@ Feature: copy file
     And user "Brian" has created a space "Project1" with the default quota using the Graph API
     And user "Brian" has created a space "Project2" with the default quota using the Graph API
     And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "/project1.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project2     |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Space Viewer |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project1     |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -105,7 +105,7 @@ Feature: copy file
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -127,12 +127,12 @@ Feature: copy file
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | <space-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare |
       | space           | Personal  |
       | sharee          | Alice     |
@@ -155,7 +155,7 @@ Feature: copy file
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "/project.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -175,7 +175,7 @@ Feature: copy file
   Scenario Outline: user copies a file from personal space to project space with different role
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -195,7 +195,7 @@ Feature: copy file
   Scenario: user copies a file from personal space to project space with role viewer
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -209,7 +209,7 @@ Feature: copy file
 
   Scenario: user copies a file from personal space to share space with role editor
     Given user "Brian" has created folder "/testshare"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare |
       | space           | Personal  |
       | sharee          | Alice     |
@@ -225,7 +225,7 @@ Feature: copy file
 
   Scenario: user copies a file from personal space to share space with role viewer
     Given user "Brian" has created folder "/testshare"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare |
       | space           | Personal  |
       | sharee          | Alice     |
@@ -242,7 +242,7 @@ Feature: copy file
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -262,14 +262,14 @@ Feature: copy file
   Scenario Outline: user copies a file from share space with different role to project space with different role
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | <space-role> |
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -291,14 +291,14 @@ Feature: copy file
   Scenario Outline: user copies a file from share space with different role to project space with role viewer
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Space Viewer |
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -318,13 +318,13 @@ Feature: copy file
     Given user "Brian" has created folder "/testshare1"
     And user "Brian" has created folder "/testshare2"
     And user "Brian" has uploaded file with content "testshare1 content" to "/testshare1/testshare1.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare1         |
       | space           | Personal           |
       | sharee          | Alice              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare2 |
       | space           | Personal   |
       | sharee          | Alice      |
@@ -348,13 +348,13 @@ Feature: copy file
     Given user "Brian" has created folder "/testshare1"
     And user "Brian" has created folder "/testshare2"
     And user "Brian" has uploaded file with content "testshare1 content" to "/testshare1/testshare1.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare1         |
       | space           | Personal           |
       | sharee          | Alice              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare2 |
       | space           | Personal   |
       | sharee          | Alice      |
@@ -378,7 +378,7 @@ Feature: copy file
     And user "Alice" has created a folder "/folder1" in space "Project"
     And user "Alice" has created a folder "/folder2" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/folder2/demo.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Brian        |
       | shareType       | user         |
@@ -400,12 +400,12 @@ Feature: copy file
     And user "Brian" has created a space "Project2" with the default quota using the Graph API
     And user "Brian" has created a folder "/folder1" in space "Project1"
     And user "Brian" has uploaded a file inside space "Project1" with content "some content" to "/folder1/demo.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project2        |
       | sharee          | Alice           |
       | shareType       | user            |
       | permissionsRole | <to-space-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project1          |
       | sharee          | Alice             |
       | shareType       | user              |
@@ -430,7 +430,7 @@ Feature: copy file
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has created a folder "/folder1" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "/folder1/demo.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -452,12 +452,12 @@ Feature: copy file
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a folder "/folder1" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "/folder1/demo.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | <space-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -480,7 +480,7 @@ Feature: copy file
   Scenario Outline: user copies a folder from personal space to project space with different role
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -500,7 +500,7 @@ Feature: copy file
 
   Scenario Outline: user copies a folder from personal space to share space with different permissions
     Given user "Brian" has created folder "/testshare"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -522,7 +522,7 @@ Feature: copy file
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -542,7 +542,7 @@ Feature: copy file
   Scenario Outline: user copies a folder from share space with different role to project space with different role
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -550,7 +550,7 @@ Feature: copy file
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created folder "/testshare/folder1"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/folder1/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -571,7 +571,7 @@ Feature: copy file
   Scenario Outline: user copies a folder from share space with different role to project space with role viewer
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -579,7 +579,7 @@ Feature: copy file
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created folder "/testshare/folder1"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/folder1/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -598,7 +598,7 @@ Feature: copy file
   Scenario: copying a file to a folder with no permissions
     Given using spaces DAV path
     And user "Brian" has created folder "/testshare"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare |
       | space           | Personal  |
       | sharee          | Alice     |
@@ -615,7 +615,7 @@ Feature: copy file
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "ownCloud test text file 1" to "/testshare/overwritethis.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare |
       | space           | Personal  |
       | sharee          | Alice     |
@@ -631,7 +631,7 @@ Feature: copy file
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
     And user "Brian" has created folder "/BRIAN-Folder"
     And user "Brian" has created folder "BRIAN-Folder/sample-folder"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-Folder |
       | space           | Personal     |
       | sharee          | Alice        |
@@ -649,7 +649,7 @@ Feature: copy file
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has created folder "/FOLDER/sample-folder"
     And user "Brian" has uploaded file with content "file to share" to "/sharedfile1.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | sharedfile1.txt |
       | space           | Personal        |
       | sharee          | Alice           |
@@ -669,7 +669,7 @@ Feature: copy file
     And user "Brian" has created folder "/BRIAN-FOLDER"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | Alice        |
@@ -695,7 +695,7 @@ Feature: copy file
     And user "Brian" has created folder "/BRIAN-FOLDER"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | Alice        |
@@ -722,7 +722,7 @@ Feature: copy file
     And using SharingNG
     And user "Brian" has created folder "/BRIAN-FOLDER"
     And user "Brian" has uploaded file with content "file at second level" to "/BRIAN-FOLDER/second-level-file.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | Alice        |
@@ -753,7 +753,7 @@ Feature: copy file
     And user "Brian" has created folder "/BRIAN-FOLDER"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
     And user "Brian" has uploaded file with content "file at third level" to "BRIAN-FOLDER/second-level-folder/third-level-file.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | Alice        |
@@ -778,7 +778,7 @@ Feature: copy file
     And user "Brian" has created folder "/BRIAN-FOLDER"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -805,7 +805,7 @@ Feature: copy file
     And user "Brian" has created folder "/BRIAN-FOLDER"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder/third-level-folder"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -832,7 +832,7 @@ Feature: copy file
     And user "Brian" has been added to group "grp1"
     And user "Brian" has created folder "BRIAN-FOLDER"
     And user "Brian" has uploaded file with content "file at second level" to "/BRIAN-FOLDER/second-level-file.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -862,7 +862,7 @@ Feature: copy file
     And user "Brian" has created folder "/BRIAN-FOLDER"
     And user "Brian" has created folder "/BRIAN-FOLDER/second-level-folder"
     And user "Brian" has uploaded file with content "file at third level" to "/BRIAN-FOLDER/second-level-folder/third-level-file.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | BRIAN-FOLDER |
       | space           | Personal     |
       | sharee          | grp1         |
@@ -922,7 +922,7 @@ Feature: copy file
     And user "Alice" has created a space "Project" with the default quota using the Graph API
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "some content" to "/newfolder/personal.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | newfolder |
       | space           | Project   |
       | sharee          | Brian     |
@@ -946,7 +946,7 @@ Feature: copy file
     And user "Alice" has created a folder "/newfolder" in space "Project"
     And user "Alice" has uploaded a file inside space "Project" with content "old content version 1" to "/newfolder/personal.txt"
     And user "Alice" has uploaded a file inside space "Project" with content "old content version 2" to "/newfolder/personal.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | newfolder |
       | space           | Project   |
       | sharee          | Brian     |

--- a/tests/acceptance/features/apiSpacesShares/etagPropagation.feature
+++ b/tests/acceptance/features/apiSpacesShares/etagPropagation.feature
@@ -14,7 +14,7 @@ Feature: check etag propagation after different file alterations
 
   Scenario: copying a file inside a folder as a share receiver changes its etag for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -46,7 +46,7 @@ Feature: check etag propagation after different file alterations
 
   Scenario: copying a file inside a folder as a sharer changes its etag for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -78,7 +78,7 @@ Feature: check etag propagation after different file alterations
 
   Scenario: share receiver renaming a file inside a folder changes its etag for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -106,7 +106,7 @@ Feature: check etag propagation after different file alterations
 
   Scenario: sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -135,13 +135,13 @@ Feature: check etag propagation after different file alterations
   Scenario: sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Alice" has created folder "/dst"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | dst      |
       | space           | Personal |
       | sharee          | Brian    |
@@ -169,13 +169,13 @@ Feature: check etag propagation after different file alterations
   Scenario: sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Alice" has created folder "/dst"
     And user "Alice" has created folder "/upload/toMove"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | dst      |
       | space           | Personal |
       | sharee          | Brian    |
@@ -200,7 +200,7 @@ Feature: check etag propagation after different file alterations
 
 
   Scenario: share receiver creating a folder inside a folder received as a share changes its etag for all collaborators
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -221,7 +221,7 @@ Feature: check etag propagation after different file alterations
 
 
   Scenario: sharer creating a folder inside a shared folder changes etag for all collaborators
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -242,7 +242,7 @@ Feature: check etag propagation after different file alterations
 
 
   Scenario: share receiver uploading a file inside a folder received as a share changes its etag for all collaborators
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -263,7 +263,7 @@ Feature: check etag propagation after different file alterations
 
 
   Scenario: sharer uploading a file inside a shared folder should update etags for all collaborators
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -285,7 +285,7 @@ Feature: check etag propagation after different file alterations
 
   Scenario: share receiver overwriting a file inside a received shared folder should update etags for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -307,7 +307,7 @@ Feature: check etag propagation after different file alterations
 
   Scenario: sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -330,7 +330,7 @@ Feature: check etag propagation after different file alterations
   Scenario: share receiver deleting (removing) a file changes the etags of all parents for all collaborators
     Given user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -361,7 +361,7 @@ Feature: check etag propagation after different file alterations
   Scenario: sharer deleting (removing) a file changes the etags of all parents for all collaborators
     Given user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -392,7 +392,7 @@ Feature: check etag propagation after different file alterations
   Scenario: share receiver deleting (removing) a folder changes the etags of all parents for all collaborators
     Given user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -423,7 +423,7 @@ Feature: check etag propagation after different file alterations
   Scenario: sharer deleting (removing) a folder changes the etags of all parents for all collaborators
     Given user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | upload   |
       | space           | Personal |
       | sharee          | Brian    |

--- a/tests/acceptance/features/apiSpacesShares/favorite.feature
+++ b/tests/acceptance/features/apiSpacesShares/favorite.feature
@@ -13,7 +13,7 @@ Feature: favorite
 
 
   Scenario: favorite a received share itself
-    Given user "Alice" has sent the following share invitation:
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -26,7 +26,7 @@ Feature: favorite
 
   Scenario: favorite a file inside of a received share
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -39,7 +39,7 @@ Feature: favorite
 
   Scenario: favorite a folder inside of a received share
     Given user "Alice" has created folder "/PARENT/sub-folder"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -52,7 +52,7 @@ Feature: favorite
 
   Scenario: sharee file favorite state should not change the favorite state of sharer
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
-    And user "Alice" has sent the following share invitation:
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT/parent.txt |
       | space           | Personal          |
       | sharee          | Brian             |

--- a/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/moveSpaces.feature
@@ -16,7 +16,7 @@ Feature: move (rename) file
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has created a folder "newfolder" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -38,7 +38,7 @@ Feature: move (rename) file
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has created a folder "newfolder" in space "Project"
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -55,7 +55,7 @@ Feature: move (rename) file
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has uploaded a file inside space "Project" with content "some content" to "insideSpace.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -76,12 +76,12 @@ Feature: move (rename) file
     And user "Brian" has created a space "Project1" with the default quota using the Graph API
     And user "Brian" has created a space "Project2" with the default quota using the Graph API
     And user "Brian" has uploaded a file inside space "Project1" with content "Project1 content" to "project1.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project1        |
       | sharee          | Alice           |
       | shareType       | user            |
       | permissionsRole | <to-space-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project2          |
       | sharee          | Alice             |
       | shareType       | user              |
@@ -109,7 +109,7 @@ Feature: move (rename) file
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "project.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -132,12 +132,12 @@ Feature: move (rename) file
     And user "Brian" has created a space "Project" with the default quota using the Graph API
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded a file inside space "Project" with content "Project content" to "project.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | <space-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -165,7 +165,7 @@ Feature: move (rename) file
   Scenario Outline: user moves a file from space personal to space project with different role
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
@@ -186,7 +186,7 @@ Feature: move (rename) file
 
   Scenario Outline: user moves a file from space personal to space Shares with different role (permission)
     Given user "Brian" has created folder "/testshare"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -209,7 +209,7 @@ Feature: move (rename) file
   Scenario Outline: user moves a file from space Shares with different role (permissions) to space personal
     Given user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -231,14 +231,14 @@ Feature: move (rename) file
   Scenario Outline: user moves a file from space Shares with different role (permissions) to space project with different role
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | <space-role> |
     And user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -267,13 +267,13 @@ Feature: move (rename) file
     Given user "Brian" has created folder "/testshare1"
     And user "Brian" has created folder "/testshare2"
     And user "Brian" has uploaded file with content "testshare1 content" to "/testshare1/testshare1.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare1              |
       | space           | Personal                |
       | sharee          | Alice                   |
       | shareType       | user                    |
       | permissionsRole | <from-permissions-role> |
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare2            |
       | space           | Personal              |
       | sharee          | Alice                 |
@@ -301,7 +301,7 @@ Feature: move (rename) file
   Scenario Outline: moving a file out of a shared folder as a sharer
     Given user "Brian" has created folder "/testshare"
     And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -327,7 +327,7 @@ Feature: move (rename) file
       | /testshare               |
       | /testshare/testsubfolder |
     And user "Brian" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -351,7 +351,7 @@ Feature: move (rename) file
     Given user "Brian" has created folder "testshare"
     Given user "Brian" has created folder "testshare/child"
     And user "Brian" has uploaded file with content "test file content" to "/testshare/testfile.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -372,7 +372,7 @@ Feature: move (rename) file
     Given user "Brian" has created folder "testshare"
     Given user "Brian" has created folder "testshare/child"
     And user "Brian" has uploaded file with content "test file content" to "/testshare/testfile.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare |
       | space           | Personal  |
       | sharee          | Alice     |
@@ -389,7 +389,7 @@ Feature: move (rename) file
   Scenario Outline: sharee tries to move a file into same shared folder with same name
     Given user "Brian" has created folder "testshare"
     And user "Brian" has uploaded file with content "test file content" to "testshare/testfile.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following resource share invitation:
       | resource        | testshare          |
       | space           | Personal           |
       | sharee          | Alice              |
@@ -414,7 +414,7 @@ Feature: move (rename) file
     And user "Brian" has uploaded a file inside space "Project" with content "root file v1" to "testfile.txt"
     And user "Brian" has uploaded a file inside space "Project" with content "root file v2" to "testfile.txt"
     And user "Brian" has uploaded a file inside space "Project" with content "same name file" to "folder/testfile.txt"
-    And user "Brian" has sent the following share invitation:
+    And user "Brian" has sent the following space share invitation:
       | space           | Project      |
       | sharee          | Alice        |
       | shareType       | user         |


### PR DESCRIPTION
## Description
```diff
- has sent the following share invitation:
+ has sent the following resource share invitation:
+ has sent the following space share invitation:    ---> (done using drives.root endpoint)

- sends the following share invitation using the Graph API:
+ sends the following resource share invitation using the Graph API:

- has created the following link share:
+ has created the following resource link share:
+ has created the following space link share:    ---> (done using drives.root endpoint)

- creates the following link share using the Graph API:
+ creates the following resource link share using the Graph API:

Other new steps:
+ updates the space share for (user|group) "<user|group>" with the following using the Graph API:
```

## Related Issue

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
