### PR TITLE
chore: report all drone CI results to builds channel

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -152,7 +152,7 @@ config = {
         },
     },
     "rocketchat": {
-        "channel": "infinitescale",
+        "channel": "builds",
         "channel_cron": "builds",
         "from_secret": "rocketchat_talk_webhook",
     },


### PR DESCRIPTION
## Description
Currently only the nightly CI results are reported to the `builds` channel. Other results of merge CI etc. are reported to the `infinitescale` channel on https://talk.owncloud.com/channel/infinitescale

This PR makes all drone CI be reported to the `builds` channel.

That channel is already reviewed every morning, looking for "real" failures of CI for all the repos that report there. So the at-least-daily check of the `builds` channel will pick-up any recurring failures of ocis CI.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
