### PR TITLE
refactor(oidc): Use jmespath to extract roles from claims

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/jellydator/ttlcache/v3 v3.2.0
 	github.com/jinzhu/now v1.1.5
+	github.com/jmespath/go-jmespath v0.4.0
 	github.com/justinas/alice v1.2.0
 	github.com/kovidgoyal/imaging v1.6.3
 	github.com/leonelquinteros/gotext v1.6.0
@@ -250,7 +251,6 @@ require (
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/juliangruber/go-intersect v1.1.0 // indirect

--- a/ocis-pkg/oidc/claims.go
+++ b/ocis-pkg/oidc/claims.go
@@ -1,7 +1,6 @@
 package oidc
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -30,47 +29,4 @@ func SplitWithEscaping(s string, separator string, escapeString string) []string
 		}
 	}
 	return a
-}
-
-// WalkSegments uses the given array of segments to walk the claims and return whatever interface was found
-func WalkSegments(segments []string, claims map[string]interface{}) (interface{}, error) {
-	i := 0
-	for ; i < len(segments)-1; i++ {
-		switch castedClaims := claims[segments[i]].(type) {
-		case map[string]interface{}:
-			claims = castedClaims
-		case map[interface{}]interface{}:
-			claims = make(map[string]interface{}, len(castedClaims))
-			for k, v := range castedClaims {
-				if s, ok := k.(string); ok {
-					claims[s] = v
-				} else {
-					return nil, fmt.Errorf("could not walk claims path, key '%v' is not a string", k)
-				}
-			}
-		default:
-			return nil, fmt.Errorf("unsupported type '%v'", castedClaims)
-		}
-	}
-	return claims[segments[i]], nil
-}
-
-// ReadStringClaim returns the string obtained by following the . seperated path in the claims
-func ReadStringClaim(path string, claims map[string]interface{}) (string, error) {
-	// check the simple case first
-	value, _ := claims[path].(string)
-	if value != "" {
-		return value, nil
-	}
-
-	claim, err := WalkSegments(SplitWithEscaping(path, ".", "\\"), claims)
-	if err != nil {
-		return "", err
-	}
-
-	if value, _ = claim.(string); value != "" {
-		return value, nil
-	}
-
-	return value, fmt.Errorf("claim path '%s' not set or empty", path)
 }

--- a/ocis-pkg/oidc/claims_test.go
+++ b/ocis-pkg/oidc/claims_test.go
@@ -1,8 +1,6 @@
 package oidc_test
 
 import (
-	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
@@ -72,108 +70,6 @@ func TestSplitWithEscaping(t *testing.T) {
 			seperator:     ".",
 			escape:        "\\",
 			expectedParts: []string{"my", "other.roles"},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, test.run)
-	}
-}
-
-type walkSegmentsTest struct {
-	// Name of the subtest.
-	name string
-
-	// path segments to walk
-	segments []string
-
-	// seperator to use
-	claims map[string]interface{}
-
-	expected interface{}
-
-	wantErr bool
-}
-
-func (wst walkSegmentsTest) run(t *testing.T) {
-	v, err := oidc.WalkSegments(wst.segments, wst.claims)
-	if err != nil && !wst.wantErr {
-		t.Errorf("%v", err)
-	}
-	if err == nil && wst.wantErr {
-		t.Errorf("expected error")
-	}
-	if !reflect.DeepEqual(v, wst.expected) {
-		t.Errorf("expected %v got %v", wst.expected, v)
-	}
-}
-
-func TestWalkSegments(t *testing.T) {
-	byt := []byte(`{"first":{"second":{"third":["value1","value2"]},"foo":"bar"},"fizz":"buzz"}`)
-	var dat map[string]interface{}
-	if err := json.Unmarshal(byt, &dat); err != nil {
-		t.Errorf("%v", err)
-	}
-
-	tests := []walkSegmentsTest{
-		{
-			name:     "one segment, single value",
-			segments: []string{"first"},
-			claims: map[string]interface{}{
-				"first": "value",
-			},
-			expected: "value",
-			wantErr:  false,
-		},
-		{
-			name:     "one segment, array value",
-			segments: []string{"first"},
-			claims: map[string]interface{}{
-				"first": []string{"value1", "value2"},
-			},
-			expected: []string{"value1", "value2"},
-			wantErr:  false,
-		},
-		{
-			name:     "two segments, single value",
-			segments: []string{"first", "second"},
-			claims: map[string]interface{}{
-				"first": map[string]interface{}{
-					"second": "value",
-				},
-			},
-			expected: "value",
-			wantErr:  false,
-		},
-		{
-			name:     "two segments, array value",
-			segments: []string{"first", "second"},
-			claims: map[string]interface{}{
-				"first": map[string]interface{}{
-					"second": []string{"value1", "value2"},
-				},
-			},
-			expected: []string{"value1", "value2"},
-			wantErr:  false,
-		},
-		{
-			name:     "three segments, array value from json",
-			segments: []string{"first", "second", "third"},
-			claims:   dat,
-			expected: []interface{}{"value1", "value2"},
-			wantErr:  false,
-		},
-		{
-			name:     "three segments, array value with interface key",
-			segments: []string{"first", "second", "third"},
-			claims: map[string]interface{}{
-				"first": map[interface{}]interface{}{
-					"second": map[interface{}]interface{}{
-						"third": []string{"value1", "value2"},
-					},
-				},
-			},
-			expected: []string{"value1", "value2"},
-			wantErr:  false,
 		},
 	}
 	for _, test := range tests {

--- a/services/proxy/pkg/userroles/oidcroles_test.go
+++ b/services/proxy/pkg/userroles/oidcroles_test.go
@@ -92,7 +92,7 @@ func TestExtractEscapedRolesPathString(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	roles, err := extractRoles("sub\\.roles", claims)
+	roles, err := extractRoles("\"sub.roles\"", claims)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Instead of using our own custom implementation for walking the claims, we now use jmespath query language to extract roles from the claims. This allows a more flexible specification of how to map claims to roles. The drawback being that the way that escaping rules for claim name containing dots (`.`) will change.

This is a bit of a test balloon to get some feedback. Ideally would also allow jmespath queries for the other OIDC claims that we allow to be configured (basically the autoprovisioning attributes and PROXY_USER_OIDC_CLAIM value)

Would also raise the question with jmespath implemenation we should use there is https://github.com/jmespath/go-jmespath and https://github.com/jmespath-community/go-jmespath. I picked the first because we already had it vendored via some other dependency. (The latter one seems to be more uptodate though)