### PR TITLE
[tests-only] extend delete API tests

### DIFF
--- a/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
@@ -376,12 +376,24 @@ Feature: files and folders exist in the trashbin after being deleted
       | !@tester$^.txt   |
       | %file *?2.txt    |
       | # %ab ab?=ed.txt |
+      | fo.              |
+      | fo.1             |
+      | fo...1..         |
+      | ...              |
+      | ..fo             |
+      | fo.xyz           |
     When user "Alice" deletes the following files
       | path             |
       | qa&dev.txt       |
       | !@tester$^.txt   |
       | %file *?2.txt    |
       | # %ab ab?=ed.txt |
+      | fo.              |
+      | fo.1             |
+      | fo...1..         |
+      | ...              |
+      | ..fo             |
+      | fo.xyz           |
     Then the HTTP status code of responses on all endpoints should be "204"
     And as "Alice" the following files should not exist
       | path             |
@@ -389,12 +401,24 @@ Feature: files and folders exist in the trashbin after being deleted
       | !@tester$^.txt   |
       | %file *?2.txt    |
       | # %ab ab?=ed.txt |
+      | fo.              |
+      | fo.1             |
+      | fo...1..         |
+      | ...              |
+      | ..fo             |
+      | fo.xyz           |
     But as "Alice" the files with following original paths should exist in the trashbin
       | path             |
       | qa&dev.txt       |
       | !@tester$^.txt   |
       | %file *?2.txt    |
       | # %ab ab?=ed.txt |
+      | fo.              |
+      | fo.1             |
+      | fo...1..         |
+      | ...              |
+      | ..fo             |
+      | fo.xyz           |
     Examples:
       | dav-path-version |
       | new              |
@@ -413,12 +437,24 @@ Feature: files and folders exist in the trashbin after being deleted
       | !@tester$^   |
       | %file *?2    |
       | # %ab ab?=ed |
+      | fo.          |
+      | fo.1         |
+      | fo...1..     |
+      | ...          |
+      | ..fo         |
+      | fo.xyz       |
     When user "Alice" deletes the following folders
       | path         |
       | qa&dev       |
       | !@tester$^   |
       | %file *?2    |
       | # %ab ab?=ed |
+      | fo.          |
+      | fo.1         |
+      | fo...1..     |
+      | ...          |
+      | ..fo         |
+      | fo.xyz       |
     Then the HTTP status code of responses on all endpoints should be "204"
     But as "Alice" the following folders should not exist
       | path         |
@@ -426,12 +462,24 @@ Feature: files and folders exist in the trashbin after being deleted
       | !@tester$^   |
       | %file *?2    |
       | # %ab ab?=ed |
+      | fo.          |
+      | fo.1         |
+      | fo...1..     |
+      | ...          |
+      | ..fo         |
+      | fo.xyz       |
     And as "Alice" the folders with following original paths should exist in the trashbin
       | path         |
       | qa&dev       |
       | !@tester$^   |
       | %file *?2    |
       | # %ab ab?=ed |
+      | fo.          |
+      | fo.1         |
+      | fo...1..     |
+      | ...          |
+      | ..fo         |
+      | fo.xyz       |
     Examples:
       | dav-path-version |
       | new              |

--- a/tests/acceptance/features/coreApiWebdavDelete/deleteFile.feature
+++ b/tests/acceptance/features/coreApiWebdavDelete/deleteFile.feature
@@ -103,6 +103,32 @@ Feature: delete file
       | spaces           | ",,,.,"        |
 
 
+  Scenario Outline: delete a file with special characters in the filename
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "special file" to <file-name>
+    When user "Alice" deletes file <file-name> using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file <file-name> should not exist
+    Examples:
+      | dav-path-version | file-name      |
+      | old              | "'single'.txt" |
+      | old              | '"double".txt' |
+      | old              | "question?"    |
+      | old              | "&and#hash"    |
+      | new              | "'single'.txt" |
+      | new              | '"double".txt' |
+      | new              | "question?"    |
+      | new              | "&and#hash"    |
+
+    @skipOnRevaMaster
+    Examples:
+      | dav-path-version | file-name      |
+      | spaces           | "'single'.txt" |
+      | spaces           | '"double".txt' |
+      | spaces           | "question?"    |
+      | spaces           | "&and#hash"    |
+
+
   Scenario Outline: delete a hidden file
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/FOLDER"


### PR DESCRIPTION
## Description
Added more delete API tests for special character files

Taken from https://github.com/owncloud/web/pull/10889

## Related Issue
- https://github.com/owncloud/web/issues/10259

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
