### PR TITLE
[tests-only] [full-ci] Use sharingNG in remaining feature file of apiSpaces folder

### DIFF
--- a/tests/acceptance/features/apiSpaces/restoreSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/restoreSpaces.feature
@@ -26,12 +26,16 @@ Feature: Restoring space
   Scenario: participants can see the data after the space is restored
     Given user "Alice" has created a folder "mainFolder" in space "restore a space"
     And user "Alice" has uploaded a file inside space "restore a space" with content "example" to "test.txt"
-    And user "Alice" has shared a space "restore a space" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
-    And user "Alice" has shared a space "restore a space" with settings:
-      | shareWith | Bob    |
-      | role      | viewer |
+    And user "Alice" has sent the following space share invitation:
+      | space           | restore a space |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | Space Editor    |
+    And user "Alice" has sent the following space share invitation:
+      | space           | restore a space |
+      | sharee          | Bob             |
+      | shareType       | user            |
+      | permissionsRole | Space Viewer    |
     And user "Alice" has disabled a space "restore a space"
     When user "Alice" restores a disabled space "restore a space"
     Then for user "Alice" the space "restore a space" should contain these entries:
@@ -46,9 +50,11 @@ Feature: Restoring space
 
 
   Scenario: participant can create data in the space after restoring
-    Given user "Alice" has shared a space "restore a space" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | restore a space |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | Space Editor    |
     And user "Alice" has disabled a space "restore a space"
     And user "Alice" has restored a disabled space "restore a space"
     When user "Brian" creates a folder "mainFolder" in space "restore a space" using the WebDav Api
@@ -59,16 +65,18 @@ Feature: Restoring space
 
 
   Scenario Outline: user without space manager role cannot restore space
-    Given user "Alice" has shared a space "restore a space" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | restore a space |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <space-role>    |
     And user "Alice" has disabled a space "restore a space"
     When user "Brian" tries to restore a disabled space "restore a space" owned by user "Alice"
     Then the HTTP status code should be "404"
     Examples:
-      | space-role |
-      | viewer     |
-      | editor     |
+      | space-role   |
+      | Space Viewer |
+      | Space Editor |
 
 
   Scenario Outline: user with role user and user light cannot restore space

--- a/tests/acceptance/features/apiSpaces/setQuota.feature
+++ b/tests/acceptance/features/apiSpaces/setQuota.feature
@@ -111,19 +111,21 @@ Feature: Set quota
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has created a space "Project Jupiter" of type "project" with quota "20"
-    And user "Alice" has shared a space "Project Jupiter" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    And user "Alice" has sent the following space share invitation:
+      | space           | Project Jupiter |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <space-role>    |
     When user "Brian" changes the quota of the "Project Jupiter" space to "100"
     Then the HTTP status code should be "403"
     Examples:
-      | user-role  | space-role |
-      | User       | viewer     |
-      | User       | editor     |
-      | User       | manager    |
-      | User Light | viewer     |
-      | User Light | editor     |
-      | User Light | manager    |
+      | user-role  | space-role   |
+      | User       | Space Viewer |
+      | User       | Space Editor |
+      | User       | Manager      |
+      | User Light | Space Viewer |
+      | User Light | Space Editor |
+      | User Light | Manager      |
 
 
   Scenario: admin user can set their own personal space quota

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -19,9 +19,11 @@ Feature: Tag
 
 
   Scenario: user creates tags for resources in the project space
-    Given user "Alice" has shared a space "use-tag" with settings:
-      | shareWith | Brian  |
-      | role      | viewer |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | use-tag      |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Viewer |
     When user "Alice" creates the following tags for folder "folderMain" of space "use-tag":
       | tag level#1                    |
       | tag with symbols @^$#^%$@%!_+) |
@@ -84,9 +86,11 @@ Feature: Tag
 
 
   Scenario Outline: member of the space tries to create tag
-    Given user "Alice" has shared a space "use-tag" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | use-tag      |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | <space-role> |
     When user "Brian" creates the following tags for folder "folderMain/insideTheFolder.txt" of space "use-tag":
       | tag level#1                    |
       | tag with symbols @^$#^%$@%!_+) |
@@ -97,10 +101,10 @@ Feature: Tag
       | tag level#1                    |
       | tag with symbols @^$#^%$@%!_+) |
     Examples:
-      | space-role | http-status-code | should-or-not |
-      | viewer     | 403              | should not    |
-      | editor     | 200              | should        |
-      | manager    | 200              | should        |
+      | space-role   | http-status-code | should-or-not |
+      | Space Viewer | 403              | should not    |
+      | Space Editor | 200              | should        |
+      | Manager      | 200              | should        |
 
 
   Scenario: recipient has a created tags if share is accepted
@@ -245,9 +249,11 @@ Feature: Tag
 
 
   Scenario: user creates a comma-separated list of tags for resources in the project space
-    Given user "Alice" has shared a space "use-tag" with settings:
-      | shareWith | Brian  |
-      | role      | viewer |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | use-tag      |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Viewer |
     When user "Alice" creates the following tags for folder "folderMain" of space "use-tag":
       | finance,नेपाल |
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSpaces/trashBin.feature
+++ b/tests/acceptance/features/apiSpaces/trashBin.feature
@@ -19,9 +19,11 @@ Feature: Restore files, folder
 
 
   Scenario Outline: user with different role can see deleted objects in trash bin of the space via the webDav API
-    Given user "Alice" has shared a space "restore objects" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | restore objects |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <space-role>    |
     And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
     And user "Alice" has removed the folder "newFolder" from space "restore objects"
     When user "Brian" lists all deleted files in the trash bin of the space "restore objects"
@@ -29,16 +31,18 @@ Feature: Restore files, folder
     And as "Brian" folder "newFolder" should exist in the trashbin of the space "restore objects"
     And as "Brian" file "file.txt" should exist in the trashbin of the space "restore objects"
     Examples:
-      | space-role |
-      | manager    |
-      | editor     |
-      | viewer     |
+      | space-role   |
+      | Manager      |
+      | Space Editor |
+      | Space Viewer |
 
 
   Scenario Outline: user can restore a folder with some objects from the trash via the webDav API
-    Given user "Alice" has shared a space "restore objects" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | restore objects |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <space-role>    |
     And user "Alice" has removed the folder "newFolder" from space "restore objects"
     When user "<user>" restores the folder "newFolder" from the trash of the space "restore objects" to "/newFolder"
     Then the HTTP status code should be "<http-status-code>"
@@ -46,17 +50,19 @@ Feature: Restore files, folder
       | newFolder |
     And as "<user>" folder "newFolder" <should-or-not-be-in-trash> exist in the trashbin of the space "restore objects"
     Examples:
-      | user  | space-role | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
-      | Alice | manager    | 201              | should                    | should not                |
-      | Brian | manager    | 201              | should                    | should not                |
-      | Brian | editor     | 201              | should                    | should not                |
-      | Brian | viewer     | 403              | should not                | should                    |
+      | user  | space-role   | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
+      | Alice | Manager      | 201              | should                    | should not                |
+      | Brian | Manager      | 201              | should                    | should not                |
+      | Brian | Space Editor | 201              | should                    | should not                |
+      | Brian | Space Viewer | 403              | should not                | should                    |
 
 
   Scenario Outline: user can restore a file from the trash via the webDav API
-    Given user "Alice" has shared a space "restore objects" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | restore objects |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <space-role>    |
     And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
     When user "<user>" restores the file "file.txt" from the trash of the space "restore objects" to "newFolder/file.txt"
     Then the HTTP status code should be "<http-status-code>"
@@ -64,27 +70,29 @@ Feature: Restore files, folder
       | file.txt |
     And as "<user>" file "file.txt" <should-or-not-be-in-trash> exist in the trashbin of the space "restore objects"
     Examples:
-      | user  | space-role | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
-      | Alice | manager    | 201              | should                    | should not                |
-      | Brian | manager    | 201              | should                    | should not                |
-      | Brian | editor     | 201              | should                    | should not                |
-      | Brian | viewer     | 403              | should not                | should                    |
+      | user  | space-role   | http-status-code | should-or-not-be-in-space | should-or-not-be-in-trash |
+      | Alice | Manager      | 201              | should                    | should not                |
+      | Brian | Manager      | 201              | should                    | should not                |
+      | Brian | Space Editor | 201              | should                    | should not                |
+      | Brian | Space Viewer | 403              | should not                | should                    |
 
 
   Scenario Outline: only space manager can purge the trash via the webDav API
-    Given user "Alice" has shared a space "restore objects" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | restore objects |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <space-role>    |
     And the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
     When user "Brian" deletes the file "file.txt" from the trash of the space "restore objects"
     Then the HTTP status code should be "<http-status-code>"
     And as "Brian" file "file.txt" <should-or-not-be-in-trash> exist in the trashbin of the space "restore objects"
     Examples:
-      | space-role | http-status-code | should-or-not-be-in-trash |
-      | manager    | 204              | should not                |
-      | editor     | 403              | should                    |
-      | viewer     | 403              | should                    |
+      | space-role   | http-status-code | should-or-not-be-in-trash |
+      | Manager      | 204              | should not                |
+      | Space Editor | 403              | should                    |
+      | Space Viewer | 403              | should                    |
 
 
   Scenario Outline: admin user who is not a member of space cannot see its trash bin
@@ -99,9 +107,11 @@ Feature: Restore files, folder
 
 
   Scenario Outline: admin user without space-manager role cannot purge the trash
-    Given user "Alice" has shared a space "restore objects" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | restore objects |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | Space Editor    |
     And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has removed the file "newFolder/file.txt" from space "restore objects"
     When user "Brian" tries to delete the file "file.txt" from the trash of the space "restore objects"

--- a/tests/acceptance/features/apiSpaces/tusUpload.feature
+++ b/tests/acceptance/features/apiSpaces/tusUpload.feature
@@ -140,4 +140,3 @@ Feature: upload resources using TUS protocol
     When user "Brian" uploads a file from "filesForUpload/zerobyte.txt" to "textfile.txt" via TUS inside of the space "new-space" using the WebDAV API
     Then for user "Brian" the content of the file "textfile.txt" of the space "new-space" should be ""
     And for user "Alice" the content of the file "textfile.txt" of the space "new-space" should be ""
-

--- a/tests/acceptance/features/apiSpaces/tusUpload.feature
+++ b/tests/acceptance/features/apiSpaces/tusUpload.feature
@@ -45,7 +45,12 @@ Feature: upload resources using TUS protocol
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "testFolder"
-    And user "Alice" has shared folder "testFolder" with user "Brian" with permissions "all"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testFolder |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Editor     |
     When user "Brian" uploads file "filesForUpload/zerobyte.txt" to "Shares/testFolder/textfile.txt" using the TUS protocol on the WebDAV API
     Then the content of file "Shares/testFolder/textfile.txt" for user "Brian" should be ""
     And the content of file "testFolder/textfile.txt" for user "Alice" should be ""
@@ -59,7 +64,12 @@ Feature: upload resources using TUS protocol
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "testFolder"
-    And user "Alice" has shared folder "testFolder" with user "Brian" with permissions "all"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testFolder |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Editor     |
     When user "Brian" uploads a file from "filesForUpload/zerobyte.txt" to "testFolder/textfile.txt" via TUS inside of the space "Shares" using the WebDAV API
     Then for user "Brian" the content of the file "testFolder/textfile.txt" of the space "Shares" should be ""
     And for user "Alice" the content of the file "testFolder/textfile.txt" of the space "Personal" should be ""
@@ -77,7 +87,12 @@ Feature: upload resources using TUS protocol
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "This is TUS upload" to "textfile.txt"
-    And user "Alice" has shared file "textfile.txt" with user "Brian" with permissions "read,update"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | File Editor  |
     When user "Brian" uploads file "filesForUpload/zerobyte.txt" to "Shares/textfile.txt" using the TUS protocol on the WebDAV API
     Then the content of file "Shares/textfile.txt" for user "Brian" should be ""
     And the content of file "textfile.txt" for user "Alice" should be ""
@@ -91,7 +106,12 @@ Feature: upload resources using TUS protocol
     Given using spaces DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "This is TUS upload" to "textfile.txt"
-    And user "Alice" has shared file "textfile.txt" with user "Brian" with permissions "read,update"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | File Editor  |
     When user "Brian" uploads a file from "filesForUpload/zerobyte.txt" to "textfile.txt" via TUS inside of the space "Shares" using the WebDAV API
     Then for user "Brian" the content of the file "textfile.txt" of the space "Shares" should be ""
     And for user "Alice" the content of the file "textfile.txt" of the space "Personal" should be ""
@@ -112,9 +132,12 @@ Feature: upload resources using TUS protocol
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "new-space" with content "This is TUS upload" to "textfile.txt"
-    And user "Alice" has shared a space "new-space" with settings:
-      | shareWith | Brian  |
-      | role      | editor |
+    And user "Alice" has sent the following space share invitation:
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Editor |
     When user "Brian" uploads a file from "filesForUpload/zerobyte.txt" to "textfile.txt" via TUS inside of the space "new-space" using the WebDAV API
     Then for user "Brian" the content of the file "textfile.txt" of the space "new-space" should be ""
     And for user "Alice" the content of the file "textfile.txt" of the space "new-space" should be ""
+

--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -18,33 +18,37 @@ Feature: Upload files into a space
 
 
   Scenario Outline: user creates a folder in the space via the Graph API
-    Given user "Alice" has shared a space "Project Ceres" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | Project Ceres |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | <space-role>  |
     When user "Brian" creates a folder "mainFolder" in space "Project Ceres" using the WebDav Api
     Then the HTTP status code should be "<http-status-code>"
     And for user "Brian" the space "Project Ceres" <should-or-not> contain these entries:
       | mainFolder |
     Examples:
-      | space-role | http-status-code | should-or-not |
-      | manager    | 201              | should        |
-      | editor     | 201              | should        |
-      | viewer     | 403              | should not    |
+      | space-role   | http-status-code | should-or-not |
+      | Manager      | 201              | should        |
+      | Space Editor | 201              | should        |
+      | Space Viewer | 403              | should not    |
 
 
   Scenario Outline: user uploads a file in shared space via the Graph API
-    Given user "Alice" has shared a space "Project Ceres" with settings:
-      | shareWith | Brian        |
-      | role      | <space-role> |
+    Given user "Alice" has sent the following space share invitation:
+      | space           | Project Ceres |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | <space-role>  |
     When user "Brian" uploads a file inside space "Project Ceres" with content "Test" to "test.txt" using the WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And for user "Brian" the space "Project Ceres" <should-or-not> contain these entries:
       | test.txt |
     Examples:
-      | space-role | http-status-code | should-or-not |
-      | manager    | 201              | should        |
-      | editor     | 201              | should        |
-      | viewer     | 403              | should not    |
+      | space-role   | http-status-code | should-or-not |
+      | Manager      | 201              | should        |
+      | Space Editor | 201              | should        |
+      | Space Viewer | 403              | should not    |
 
 
   Scenario: user can create subfolders in a space via the Graph API


### PR DESCRIPTION
## Description
Changed `Given` step for sharing using SharingNg in apiSpaces:
- `restoreSpaces.feature`
- `setQuota.feature`
- `tag.feature`
- `trashBin.feature`
- `tusUpload.feature`
- `uploadSpaces.feature`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/8717

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
