### PR TITLE
[tests-only][full-ci]extend list permission tests coverage for root endpoint

### DIFF
--- a/tests/acceptance/features/apiSharingNg/updateShareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNg/updateShareInvitations.feature
@@ -619,10 +619,7 @@ Feature: Update permission of a share
     Examples:
       | permissions-role |
       | Space Viewer     |
-      | Space Viewer     |
       | Space Editor     |
-      | Space Editor     |
-      | Manager          |
       | Manager          |
 
 


### PR DESCRIPTION
## Description
This PR has added tests for listing permission using `/drives/{driveID}/root/permissions` api endpoint. 

## Related Issue
- https://github.com/owncloud/ocis/issues/8810

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
