### PR TITLE
fix: service startup appprovider onlyoffice

### DIFF
--- a/changelog/unreleased/fix-wopi-example.md
+++ b/changelog/unreleased/fix-wopi-example.md
@@ -1,0 +1,5 @@
+Bugfix: Service startup of WOPI example
+
+We fixed a bug in the service startup of the appprovider-onlyoffice in the ocis_wopi deployment example.
+
+https://github.com/owncloud/ocis/pull/9127

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -146,7 +146,7 @@ services:
     image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
     networks:
       ocis-net:
-    #command: app-provider server
+    command: app-provider server
     environment:
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-info}
       # use the internal service name of the gateway


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Fix the ocis wopi example after it was broken since https://github.com/owncloud/ocis/pull/8984

@DeepDiver1975 The appprovider-onlyoffice was starting a second ocis fullstack service and the service registry was used from the ocis container. This broke a lot of service registrations. The services from the app-provider were registered after the ones from the ocis container but the requests were routed to the ocis container while the "real services" were running in the app-provider container.

@wkloucek @d7oc Interesting. First accidental use of two full stack ocis servers side by side 😄 

Fixes: #3826 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
