### PR TITLE
route /wopi to collaboration service

### DIFF
--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -33,6 +33,7 @@ import (
 	authmachine "github.com/owncloud/ocis/v2/services/auth-machine/pkg/command"
 	authservice "github.com/owncloud/ocis/v2/services/auth-service/pkg/command"
 	clientlog "github.com/owncloud/ocis/v2/services/clientlog/pkg/command"
+	collaboration "github.com/owncloud/ocis/v2/services/collaboration/pkg/command"
 	eventhistory "github.com/owncloud/ocis/v2/services/eventhistory/pkg/command"
 	frontend "github.com/owncloud/ocis/v2/services/frontend/pkg/command"
 	gateway "github.com/owncloud/ocis/v2/services/gateway/pkg/command"
@@ -322,6 +323,11 @@ func NewService(options ...Option) (*Service, error) {
 		cfg.Audit.Context = ctx
 		cfg.Audit.Commons = cfg.Commons
 		return audit.Execute(cfg.Audit)
+	})
+	areg(opts.Config.Collaboration.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
+		cfg.Collaboration.Context = ctx
+		cfg.Collaboration.Commons = cfg.Commons
+		return collaboration.Execute(cfg.Collaboration)
 	})
 	areg(opts.Config.Policies.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Policies.Context = ctx

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -33,7 +33,6 @@ import (
 	authmachine "github.com/owncloud/ocis/v2/services/auth-machine/pkg/command"
 	authservice "github.com/owncloud/ocis/v2/services/auth-service/pkg/command"
 	clientlog "github.com/owncloud/ocis/v2/services/clientlog/pkg/command"
-	collaboration "github.com/owncloud/ocis/v2/services/collaboration/pkg/command"
 	eventhistory "github.com/owncloud/ocis/v2/services/eventhistory/pkg/command"
 	frontend "github.com/owncloud/ocis/v2/services/frontend/pkg/command"
 	gateway "github.com/owncloud/ocis/v2/services/gateway/pkg/command"
@@ -324,11 +323,14 @@ func NewService(options ...Option) (*Service, error) {
 		cfg.Audit.Commons = cfg.Commons
 		return audit.Execute(cfg.Audit)
 	})
-	areg(opts.Config.Collaboration.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
-		cfg.Collaboration.Context = ctx
-		cfg.Collaboration.Commons = cfg.Commons
-		return collaboration.Execute(cfg.Collaboration)
-	})
+	// cannot be started because the approvider dies if it cannot reach the wopi client service
+	/*
+		areg(opts.Config.Collaboration.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
+			cfg.Collaboration.Context = ctx
+			cfg.Collaboration.Commons = cfg.Commons
+			return collaboration.Execute(cfg.Collaboration)
+		})
+	*/
 	areg(opts.Config.Policies.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Policies.Context = ctx
 		cfg.Policies.Commons = cfg.Commons

--- a/services/collaboration/README.md
+++ b/services/collaboration/README.md
@@ -2,7 +2,11 @@
 
 The collaboration service connects ocis with document servers such as Collabora and ONLYOFFICE using the WOPI protocol.
 
-Since this service requires an external document server, it won't start by default when using `ocis server`. You must start it manually with the `ocis collaboration server` command.
+Since this service requires an external document server, it won't start by default when using `ocis server`. You must start it manually with the `ocis collaboration server` command, or setting `OCIS_ADD_RUN_SERVICES=collaboration`.
+
+oCIS will automatically routes all `/wopi` traffic to the collaboration service if it is running.
+
+For demo purposes, more than one collaboration service can be started by running a dedicated `ocis collaboration server` instance on a different domain configured by setting e.g. `COLLABORATION_WOPIAPP_WOPISRC=https://otheroffice-wopi.example.com`. It does not require a proxy service and can directly handle requests.
 
 ## Requirements
 
@@ -22,11 +26,11 @@ There are a few variables that you need to set:
   The URL of the WOPI app (onlyoffice, collabora, etc).\
   For example: `https://office.example.com`.
 
-* `COLLABORATION_HTTP_ADDR`:\
-  The external address of the collaboration service. The target app (onlyoffice, collabora, etc) will use this address to read and write files from Infinite Scale.\
-  For example: `https://wopiserver.example.com`.
+* `COLLABORATION_WOPIAPP_INSECURE`:\
+  In case you are using a self signed certificate for the WOPI app you can tell the collaboration service to allow an insecure connection.
 
-* `COLLABORATION_HTTP_SCHEME`:\
-  The scheme to be used when accessing the collaboration service. Either `http` or `https`. This will be used to finally build the URL that the WOPI app needs in order to contact the collaboration service.
+* `COLLABORATION_WOPIAPP_WOPISRC`:\
+  The external address of the collaboration service. The target app (onlyoffice, collabora, etc) will use this address to read and write files from Infinite Scale. It defaults to `OCIS_URL` and only needs to be changed when running a dedicated collaboration service to handle requests for a different WOPI app.\
+  For example: `https://otheroffice-wopi.example.com`.
 
 The rest of the configuration options available can be left with the default values.

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -29,12 +29,12 @@ func DefaultConfig() *config.Config {
 		JWTSecret: secret,
 		GRPC: config.GRPC{
 			Addr:      "0.0.0.0:9301",
-			Namespace: "com.owncloud.collaboration",
+			Namespace: "com.owncloud.api",
 		},
 		HTTP: config.HTTP{
 			Addr:      "127.0.0.1:9300",
 			BindAddr:  "0.0.0.0:9300",
-			Namespace: "com.owncloud.collaboration",
+			Namespace: "com.owncloud.web",
 			Scheme:    "https",
 		},
 		Debug: config.Debug{

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -33,9 +33,7 @@ func DefaultConfig() *config.Config {
 		},
 		HTTP: config.HTTP{
 			Addr:      "127.0.0.1:9300",
-			BindAddr:  "0.0.0.0:9300",
 			Namespace: "com.owncloud.web",
-			Scheme:    "https",
 		},
 		Debug: config.Debug{
 			Addr:   "127.0.0.1:9304",
@@ -46,6 +44,7 @@ func DefaultConfig() *config.Config {
 		WopiApp: config.WopiApp{
 			Addr:     "https://127.0.0.1:8080",
 			Insecure: false,
+			WopiSrc:  "https://localhost:9200",
 		},
 		CS3Api: config.CS3Api{
 			Gateway: config.Gateway{

--- a/services/collaboration/pkg/config/http.go
+++ b/services/collaboration/pkg/config/http.go
@@ -6,9 +6,7 @@ import (
 
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string                `yaml:"addr" env:"COLLABORATION_HTTP_ADDR" desc:"The external address of the collaboration service wihout a leading scheme. Either use an IP address or a hostname (127.0.0.1:9301 or wopi.private.prv). The configured 'Scheme' in another envvar will be used to finally build the public URL along with this address." introductionVersion:"5.1"`
-	BindAddr  string                `yaml:"bindaddr" env:"COLLABORATION_HTTP_BINDADDR" desc:"The bind address of the HTTP service. Use '<ip-address>:<port>', for example, '127.0.0.1:9301' or '0.0.0.0:9301'." introductionVersion:"5.1"`
+	Addr      string                `yaml:"addr" env:"COLLABORATION_HTTP_ADDR" desc:"The bind address of the HTTP service." introductionVersion:"5.1"`
 	Namespace string                `yaml:"-"`
-	Scheme    string                `yaml:"scheme" env:"COLLABORATION_HTTP_SCHEME" desc:"The scheme to use for the HTTP address, which is either 'http' or 'https'." introductionVersion:"5.1"`
 	TLS       shared.HTTPServiceTLS `yaml:"tls"`
 }

--- a/services/collaboration/pkg/config/wopiapp.go
+++ b/services/collaboration/pkg/config/wopiapp.go
@@ -4,4 +4,5 @@ package config
 type WopiApp struct {
 	Addr     string `yaml:"addr" env:"COLLABORATION_WOPIAPP_ADDR" desc:"The URL where the WOPI app is located, such as https://127.0.0.1:8080." introductionVersion:"5.1"`
 	Insecure bool   `yaml:"insecure" env:"COLLABORATION_WOPIAPP_INSECURE" desc:"Skip TLS certificate verification when connecting to the WOPI app" introductionVersion:"5.1"`
+	WopiSrc  string `yaml:"wopisrc" env:"OCIS_URL;COLLABORATION_WOPIAPP_WOPISRC" desc:"The WOPISrc base URL containing schema, host and port. Path will be set to /wopi/files/{fileid} if not given. {fileid} will be replaced with the WOPI file id. Set this to the schema and domain where the collaboration service is reachable for the wopi app, such as https://cloud.owncloud.test or, if you need to set up an additional WOPI server https://wopi-other.owncloud.test." introductionVersion:"5.1"`
 }

--- a/services/collaboration/pkg/helpers/registration.go
+++ b/services/collaboration/pkg/helpers/registration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
+	"github.com/owncloud/ocis/v2/ocis-pkg/version"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/config"
 )
 
@@ -18,7 +19,7 @@ import (
 // There are no explicit requirements for the context, and it will be passed
 // without changes to the underlying RegisterService method.
 func RegisterOcisService(ctx context.Context, cfg *config.Config, logger log.Logger) error {
-	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, "0.0.0")
+	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
 	return registry.RegisterService(ctx, svc, logger)
 }
 

--- a/services/collaboration/pkg/server/grpc/server.go
+++ b/services/collaboration/pkg/server/grpc/server.go
@@ -7,7 +7,6 @@ import (
 )
 
 // Server initializes a new grpc service ready to run
-// THIS SERVICE IS REGISTERED AGAINST REVA, NOT GO-MICRO
 func Server(opts ...Option) (*grpc.Server, func(), error) {
 	grpcOpts := []grpc.ServerOption{}
 	options := newOptions(opts...)

--- a/services/collaboration/pkg/server/http/server.go
+++ b/services/collaboration/pkg/server/http/server.go
@@ -27,7 +27,7 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Namespace(options.Config.HTTP.Namespace),
 		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),
-		http.Address(options.Config.HTTP.BindAddr),
+		http.Address(options.Config.HTTP.Addr),
 		http.Context(options.Context),
 		http.TraceProvider(options.TracerProvider),
 	)

--- a/services/collaboration/pkg/service/grpc/v0/service.go
+++ b/services/collaboration/pkg/service/grpc/v0/service.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 
 	appproviderv1beta1 "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -123,10 +124,12 @@ func (s *Service) OpenInApp(
 		viewAppURL = editAppURL
 	}
 
-	wopiSrcURL := url.URL{
-		Scheme: s.config.HTTP.Scheme,
-		Host:   s.config.HTTP.Addr,
-		Path:   path.Join("wopi", "files", fileRef),
+	wopiSrcURL, err := url.Parse(strings.Replace(s.config.WopiApp.WopiSrc, "{fileid}", fileRef, 1))
+	if err != nil {
+		return nil, err
+	}
+	if wopiSrcURL.Path == "" {
+		wopiSrcURL.Path = path.Join("wopi", "files", fileRef)
 	}
 
 	addWopiSrcQueryParam := func(baseURL string) (string, error) {
@@ -184,7 +187,7 @@ func (s *Service) OpenInApp(
 
 	wopiContext := middleware.WopiContext{
 		AccessToken:   cryptedReqAccessToken,
-		ViewOnlyToken: utils.ReadPlainFromOpaque(req.Opaque, "viewOnlyToken"),
+		ViewOnlyToken: utils.ReadPlainFromOpaque(req.GetOpaque(), "viewOnlyToken"),
 		FileReference: providerFileRef,
 		User:          user,
 		ViewMode:      req.GetViewMode(),

--- a/services/collaboration/pkg/service/grpc/v0/service_suite_test.go
+++ b/services/collaboration/pkg/service/grpc/v0/service_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGraph(t *testing.T) {
+func TestService(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Service Suite")
 }

--- a/services/collaboration/pkg/service/grpc/v0/service_test.go
+++ b/services/collaboration/pkg/service/grpc/v0/service_test.go
@@ -103,8 +103,7 @@ var _ = Describe("Discovery", func() {
 		It("Invalid access token", func() {
 			ctx := context.Background()
 
-			cfg.HTTP.Addr = "wopiserver.test.prv"
-			cfg.HTTP.Scheme = "https"
+			cfg.WopiApp.WopiSrc = "https://wopiserver.test.prv"
 
 			req := &appproviderv1beta1.OpenInAppRequest{
 				ResourceInfo: &providerv1beta1.ResourceInfo{
@@ -140,8 +139,7 @@ var _ = Describe("Discovery", func() {
 			ctx := context.Background()
 			nowTime := time.Now()
 
-			cfg.HTTP.Addr = "wopiserver.test.prv"
-			cfg.HTTP.Scheme = "https"
+			cfg.WopiApp.WopiSrc = "https://wopiserver.test.prv"
 			cfg.JWTSecret = "my_supa_secret"
 
 			myself := &userv1beta1.User{

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -237,6 +237,11 @@ func DefaultPolicies() []config.Policy {
 					Service:  "com.owncloud.web.frontend",
 				},
 				{
+					Endpoint:    "/wopi",
+					Service:     "com.owncloud.web.collaboration",
+					Unprotected: true,
+				},
+				{
 					Endpoint: "/graph/v1.0/invitations",
 					Service:  "com.owncloud.graph.invitations",
 				},


### PR DESCRIPTION
I am trying to run the collaboration service as easily as possible, but it does not work as expected when tryin to replace the approvider with it:
```json
	"OCIS_ADD_RUN_SERVICES": "collaboration",
	"OCIS_EXCLUDE_RUN_SERVICES": "app-provider",
	"COLLABORATION_WOPIAPP_ADDR": "https://onlyoffice.ocis.test",
	"COLLABORATION_HTTP_ADDR": "https://cloud.ocis.test",
	"COLLABORATION_HTTP_SCHEME": "https",
```

I had to make the runtime recognize the `collaboration` service and start it, register proper service names and make the proxi route `/wopi` to the collaboration provider.