### PR TITLE
fix service names for userlog, graph, invitations, sse and web

### DIFF
--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -28,7 +28,7 @@ func DefaultConfig() *config.Config {
 		},
 		HTTP: config.HTTP{
 			Addr:      "127.0.0.1:9120",
-			Namespace: "com.owncloud.graph",
+			Namespace: "com.owncloud.web",
 			Root:      "/graph",
 			CORS: config.CORS{
 				AllowedOrigins:   []string{"*"},

--- a/services/graph/pkg/server/http/server.go
+++ b/services/graph/pkg/server/http/server.go
@@ -35,7 +35,7 @@ func Server(opts ...Option) (http.Service, error) {
 		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
 		http.Namespace(options.Config.HTTP.Namespace),
-		http.Name("graph"),
+		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),
 		http.Address(options.Config.HTTP.Addr),
 		http.Context(options.Context),
@@ -66,7 +66,7 @@ func Server(opts ...Option) (http.Service, error) {
 		middleware.TraceContext,
 		chimiddleware.RequestID,
 		middleware.Version(
-			"graph",
+			options.Config.Service.Name,
 			version.GetString(),
 		),
 		middleware.Logger(

--- a/services/invitations/pkg/config/defaults/defaultconfig.go
+++ b/services/invitations/pkg/config/defaults/defaultconfig.go
@@ -24,7 +24,7 @@ func DefaultConfig() *config.Config {
 		HTTP: config.HTTP{
 			Addr:      "127.0.0.1:0", // :0 to pick any free local port
 			Root:      "/graph/v1.0",
-			Namespace: "com.owncloud.graph",
+			Namespace: "com.owncloud.web",
 			CORS: config.CORS{
 				AllowedOrigins: []string{"https://localhost:9200"},
 			},

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -142,7 +142,7 @@ func DefaultPolicies() []config.Policy {
 				{
 					// reroute oc10 notifications endpoint to userlog service
 					Endpoint: "/ocs/v2.php/apps/notifications/api/v1/notifications",
-					Service:  "com.owncloud.userlog.userlog",
+					Service:  "com.owncloud.web.userlog",
 				},
 				{
 					Type:     config.RegexRoute,
@@ -238,11 +238,11 @@ func DefaultPolicies() []config.Policy {
 				},
 				{
 					Endpoint: "/graph/v1.0/invitations",
-					Service:  "com.owncloud.graph.invitations",
+					Service:  "com.owncloud.web.invitations",
 				},
 				{
 					Endpoint: "/graph/",
-					Service:  "com.owncloud.graph.graph",
+					Service:  "com.owncloud.web.graph",
 				},
 				{
 					Endpoint: "/api/v0/settings",

--- a/services/sse/pkg/server/http/server.go
+++ b/services/sse/pkg/server/http/server.go
@@ -47,7 +47,7 @@ func Server(opts ...Option) (http.Service, error) {
 	middlewares := []func(stdhttp.Handler) stdhttp.Handler{
 		chimiddleware.RequestID,
 		middleware.Version(
-			"userlog",
+			options.Config.Service.Name,
 			version.GetString(),
 		),
 		middleware.Logger(

--- a/services/userlog/pkg/config/defaults/defaultconfig.go
+++ b/services/userlog/pkg/config/defaults/defaultconfig.go
@@ -44,7 +44,7 @@ func DefaultConfig() *config.Config {
 		HTTP: config.HTTP{
 			Addr:      "127.0.0.1:0",
 			Root:      "/",
-			Namespace: "com.owncloud.userlog",
+			Namespace: "com.owncloud.web",
 			CORS: config.CORS{
 				AllowedOrigins:   []string{"*"},
 				AllowedMethods:   []string{"GET"},

--- a/services/userlog/pkg/server/http/server.go
+++ b/services/userlog/pkg/server/http/server.go
@@ -29,7 +29,7 @@ func Server(opts ...Option) (http.Service, error) {
 		http.TLSConfig(options.Config.HTTP.TLS),
 		http.Logger(options.Logger),
 		http.Namespace(options.Config.HTTP.Namespace),
-		http.Name("userlog"),
+		http.Name(options.Config.Service.Name),
 		http.Version(version.GetString()),
 		http.Address(options.Config.HTTP.Addr),
 		http.Context(options.Context),
@@ -46,7 +46,7 @@ func Server(opts ...Option) (http.Service, error) {
 	middlewares := []func(stdhttp.Handler) stdhttp.Handler{
 		chimiddleware.RequestID,
 		middleware.Version(
-			"userlog",
+			options.Config.Service.Name,
 			version.GetString(),
 		),
 		middleware.Logger(

--- a/services/web/pkg/server/http/server.go
+++ b/services/web/pkg/server/http/server.go
@@ -86,7 +86,7 @@ func Server(opts ...Option) (http.Service, error) {
 			middleware.NoCache,
 			webmid.SilentRefresh,
 			middleware.Version(
-				"web",
+				options.Config.Service.Name,
 				version.GetString(),
 			),
 			middleware.Logger(


### PR DESCRIPTION
we did not always stick to the correct service name pattern:
* http services should live in the `com.owncloud.web` namespace
* grpc services should live in the `com.owncloud.api` namespace
* we could add a `com.owncloud.debug` namespace for all the debug ports ... (not part of this pr)

it seems the userlog code got copy pasted into several services ...

We need to add a changelog for this and maybe add the env vars to the helmchart in case someone intends to mix versions ...