### PR TITLE
[full-ci] chore: bump ownCloud Web to v8.0.2

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=97a5cf669626ed83acaeb2f7e8aaf542d42100c2
+WEB_COMMITID=c5c982a37f90024a6ac7e292ab06687477c0f84e
 WEB_BRANCH=stable-8.0

--- a/changelog/unreleased/update-web-8.0.2.md
+++ b/changelog/unreleased/update-web-8.0.2.md
@@ -1,0 +1,16 @@
+Enhancement: Update web to v8.0.2
+
+Tags: web
+
+We updated ownCloud Web to v8.0.2. Please refer to the changelog (linked) for details on the web release.
+
+* Bugfix [owncloud/web#10515](https://github.com/owncloud/web/issues/10515): Folder replace
+* Bugfix [owncloud/web#10598](https://github.com/owncloud/web/issues/10598): Hidden right sidebar on small screens
+* Bugfix [owncloud/web#10634](https://github.com/owncloud/web/issues/10634): Scope loss when showing search results
+* Bugfix [owncloud/web#10657](https://github.com/owncloud/web/issues/10657): Theme loading without matching theme
+* Bugfix [owncloud/web#10763](https://github.com/owncloud/web/pull/10763): Flickering loading indicator
+* Bugfix [owncloud/web#10810](https://github.com/owncloud/web/issues/10810): Download files with special chars in name
+* Bugfix [owncloud/web#10881](https://github.com/owncloud/web/pull/10881): IDP logout issues
+
+https://github.com/owncloud/ocis/pull/9153
+https://github.com/owncloud/web/releases/tag/v8.0.2

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.1
+WEB_ASSETS_VERSION = v8.0.2
 
 include ../../.make/recursion.mk
 

--- a/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-webUI-on-OCIS-storage.md
@@ -9,8 +9,3 @@ Please follow this format for the actual expected failures.
 Level-3 headings should be used for the references to the relevant issues. Include the issue title with a link to the issue in GitHub.
 
 Other free text and Markdown formatting can be used elsewhere in the document if needed. But if you want to explain something about the issue, then please post that in the issue itself.
-
-### [Exit page re-appears in loop when logged in user is deleted](https://github.com/owncloud/web/issues/4677)
-
-- [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
-- [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)


### PR DESCRIPTION
chore: bump ownCloud Web to v8.0.2

This is a bugfix release, most importantly fixing issues with the IDP logout page being shown.