### PR TITLE
set correct default external service address

### DIFF
--- a/services/app-provider/pkg/config/defaults/defaultconfig.go
+++ b/services/app-provider/pkg/config/defaults/defaultconfig.go
@@ -31,8 +31,9 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "app-provider",
 		},
-		Reva:   shared.DefaultRevaConfig(),
-		Driver: "",
+		Reva:         shared.DefaultRevaConfig(),
+		ExternalAddr: "com.owncloud.api.app-provider",
+		Driver:       "",
 		Drivers: config.Drivers{
 			WOPI: config.WOPIDriver{
 				WopiFolderURLBaseURL:      "https://localhost:9200/",


### PR DESCRIPTION
The external service address is used to look up the service in the registry. So we can set this to a better default than emptystring.

