### PR TITLE
[tests-only] [full-ci] Use sharingNg in coreApiShareOperationsToShares1

### DIFF
--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -114,6 +114,7 @@ default:
         - TrashbinContext:
         - WebDavPropertiesContext:
         - SettingsContext:
+        - SharingNgContext:
 
     coreApiShareOperationsToShares2:
       paths:

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1783,7 +1783,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function userGetsInfoOfLastShareUsingTheSharingApi(string $user, ?string $language = null):void {
-		$shareId = $this->getLastCreatedUserGroupShareId();
+		$shareId = $this->isUsingSharingNg() ? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
 		$language = TranslationHelper::getLanguage($language);
 		$this->setResponse($this->getShareData($user, $shareId, $language));
 		$this->pushToLastStatusCodesArrays();

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2254,7 +2254,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function checkingLastShareIDIsIncluded():void {
-		$shareId = $this->getLastCreatedUserGroupShareId();
+		$shareId = ($this->isUsingSharingNG()) ? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
 		if (!$this->isFieldInResponse('id', $shareId)) {
 			Assert::fail(
 				"Share id $shareId not found in response"
@@ -2269,7 +2269,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function checkLastShareIDIsNotIncluded():void {
-		$shareId = $this->getLastCreatedUserGroupShareId();
+		$shareId = $this->isUsingSharingNG() ? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
 		if ($this->isFieldInResponse('id', $shareId, false)) {
 			Assert::fail(
 				"Share id $shareId has been found in response"

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/accessToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/accessToShare.feature
@@ -14,7 +14,13 @@ Feature: sharing
   @smokeTest
   Scenario Outline: sharee can see the share
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And using SharingNG
     When user "Brian" gets all the shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -28,8 +34,19 @@ Feature: sharing
   Scenario Outline: sharee can see the filtered share
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has shared file "textfile1.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile1.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And using SharingNG
     When user "Brian" gets all the shares shared with him that are received as file "/Shares/textfile1.txt" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -43,8 +60,19 @@ Feature: sharing
   Scenario Outline: sharee can't see the share that is filtered out
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has shared file "textfile1.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile1.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And using SharingNG
     When user "Brian" gets all the shares shared with him that are received as file "/Shares/textfile0.txt" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -59,7 +87,13 @@ Feature: sharing
     Given using OCS API version "<ocs-api-version>"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | grp1          |
+      | shareType       | group         |
+      | permissionsRole | Viewer        |
+    And using SharingNG
     When user "Brian" gets all the shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
@@ -17,8 +17,18 @@ Feature: sharing
     And user "Alice" has created folder "share2"
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has moved file "textfile0.txt" to "share1/textfile0.txt"
-    And user "Alice" has shared folder "/share1" with user "Brian"
-    And user "Alice" has shared folder "/share2" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | /share1  |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Editor   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | /share2  |
+      | space           | Personal |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | Editor   |
     When user "Brian" moves file "/Shares/share1/textfile0.txt" to "/Shares/share2/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "502"
     And as "Brian" file "/Shares/share1/textfile0.txt" should exist
@@ -34,7 +44,12 @@ Feature: sharing
   Scenario Outline: overwrite a received file share
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "this is the old content" to "/textfile1.txt"
-    And user "Alice" has shared file "/textfile1.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile1.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | File Editor   |
     When user "Brian" uploads file with content "this is a new content" to "/Shares/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Brian" file "Shares/textfile1.txt" should exist

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
@@ -14,7 +14,12 @@ Feature: sharing
   Scenario Outline: getting all shares from a user
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "some data" to "/file_to_share.txt"
-    And user "Alice" has shared file "file_to_share.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | file_to_share.txt |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | Viewer            |
     When user "Alice" gets all shares shared by her using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -28,7 +33,12 @@ Feature: sharing
   Scenario Outline: getting all shares of a user using another user
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
     When the administrator gets all shares shared by him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -46,8 +56,18 @@ Feature: sharing
       | Carol    |
       | David    |
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has shared file "textfile0.txt" with user "Carol"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Carol         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
     When user "Alice" gets all the shares of the file "textfile0.txt" using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -63,7 +83,13 @@ Feature: sharing
   Scenario Outline: getting share info of a share
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "some data" to "/file_to_share.txt"
-    And user "Alice" has shared file "file_to_share.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | file_to_share.txt |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | File Editor       |
+    And using SharingNG
     When user "Alice" gets the info of the last share using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -94,7 +120,13 @@ Feature: sharing
     Given using OCS API version "<ocs-api-version>"
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile0.txt |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And using SharingNG
     When user "Carol" gets the info of the last share using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
@@ -112,7 +144,12 @@ Feature: sharing
     And user "Carol" has been added to group "group0"
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
-    And user "Alice" has shared folder "/PARENT" with group "group0"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | /PARENT  |
+      | space           | Personal |
+      | sharee          | group0   |
+      | shareType       | group    |
+      | permissionsRole | Viewer   |
     When the administrator removes user "Carol" from group "group0" using the provisioning API
     Then the HTTP status code should be "204"
     And user "Brian" should see the following elements
@@ -127,7 +164,12 @@ Feature: sharing
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/file_to_share.txt"
-    And user "Alice" has shared file "/PARENT/file_to_share.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | /PARENT/file_to_share.txt |
+      | space           | Personal                  |
+      | sharee          | Brian                     |
+      | shareType       | user                      |
+      | permissionsRole | File Editor               |
     When user "Alice" gets all shares shared by her using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
@@ -18,20 +18,42 @@ Feature: get the pending shares filtered by type (user, group etc)
     And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
     And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
     And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithUser |
+      | space           | Personal              |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithGroup |
+      | space           | Personal               |
+      | sharee          | grp1                   |
+      | shareType       | group                  |
+      | permissionsRole | Viewer                 |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithUser.txt |
+      | space           | Personal                |
+      | sharee          | Brian                   |
+      | shareType       | user                    |
+      | permissionsRole | Viewer                  |
     And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | /fileToShareWithGroup.txt |
+      | space           | Personal                  |
+      | sharee          | grp1                      |
+      | shareType       | group                     |
+      | permissionsRole | Viewer                    |
     And user "Brian" has accepted share "/fileToShareWithGroup.txt" offered by user "Alice"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
 
 
   Scenario Outline: getting pending shares received from users

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
@@ -17,18 +17,40 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
     And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
     And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithUser |
+      | space           | Personal              |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithGroup |
+      | space           | Personal               |
+      | sharee          | grp1                   |
+      | shareType       | group                  |
+      | permissionsRole | Viewer                 |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithUser.txt |
+      | space           | Personal                |
+      | sharee          | Brian                   |
+      | shareType       | user                    |
+      | permissionsRole | Viewer                  |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithGroup.txt |
+      | space           | Personal                 |
+      | sharee          | grp1                     |
+      | shareType       | group                    |
+      | permissionsRole | Viewer                   |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
 
 
   Scenario Outline: getting shares received from users

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
@@ -21,16 +21,28 @@ Feature: get the received shares filtered by type (user, group etc)
 
   Scenario Outline: getting shares received from users when there are none
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithGroup |
+      | space           | Personal               |
+      | sharee          | grp1                   |
+      | shareType       | group                  |
+      | permissionsRole | Viewer                 |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithGroup.txt |
+      | space           | Personal                 |
+      | sharee          | grp1                     |
+      | shareType       | group                    |
+      | permissionsRole | Viewer                   |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
     When user "Brian" gets the user shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -43,16 +55,28 @@ Feature: get the received shares filtered by type (user, group etc)
 
   Scenario Outline: getting shares received from groups when there are none
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithUser |
+      | space           | Personal              |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithUser.txt |
+      | space           | Personal                |
+      | sharee          | Brian                   |
+      | shareType       | user                    |
+      | permissionsRole | Viewer                  |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
     When user "Brian" gets the group shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -68,18 +92,40 @@ Feature: get the received shares filtered by type (user, group etc)
     #       users do not receive public links, so asking for a list of public links
     #       that are "shared with me" should always return an empty list.
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithUser |
+      | space           | Personal              |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithGroup |
+      | space           | Personal               |
+      | sharee          | grp1                   |
+      | shareType       | group                  |
+      | permissionsRole | Viewer                 |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithUser.txt |
+      | space           | Personal                |
+      | sharee          | Brian                   |
+      | shareType       | user                    |
+      | permissionsRole | Viewer                  |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithGroup.txt |
+      | space           | Personal                 |
+      | sharee          | grp1                     |
+      | shareType       | group                    |
+      | permissionsRole | Viewer                   |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
     When user "Brian" gets the public link shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
@@ -17,18 +17,40 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
     And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
     And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithUser |
+      | space           | Personal              |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithGroup |
+      | space           | Personal               |
+      | sharee          | grp1                   |
+      | shareType       | group                  |
+      | permissionsRole | Viewer                 |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithUser.txt |
+      | space           | Personal                |
+      | sharee          | Brian                   |
+      | shareType       | user                    |
+      | permissionsRole | Viewer                  |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithGroup.txt |
+      | space           | Personal                 |
+      | sharee          | grp1                     |
+      | shareType       | group                    |
+      | permissionsRole | Viewer                   |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
 
 
   Scenario Outline: getting shares shared to users

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
@@ -21,16 +21,28 @@ Feature: get shares filtered by type (user, group etc)
 
   Scenario Outline: getting shares shared to users when there are none
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithGroup |
+      | space           | Personal               |
+      | sharee          | grp1                   |
+      | shareType       | group                  |
+      | permissionsRole | Viewer                 |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithGroup.txt |
+      | space           | Personal                 |
+      | sharee          | grp1                     |
+      | shareType       | group                    |
+      | permissionsRole | Viewer                   |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
     When user "Alice" gets the user shares shared by her using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -43,16 +55,28 @@ Feature: get shares filtered by type (user, group etc)
 
   Scenario Outline: getting shares shared to groups when there are none
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Alice" has created a public link share with settings
-      | path        | /folderToShareWithPublic |
-      | permissions | read                     |
-      | password    | %public%                 |
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
-    And user "Alice" has created a public link share with settings
-      | path        | /fileToShareWithPublic.txt |
-      | permissions | read                       |
-      | password    | %public%                   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithUser |
+      | space           | Personal              |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
+    And user "Alice" has created the following resource link share:
+      | resource        | folderToShareWithPublic |
+      | space           | Personal                |
+      | permissionsRole | view                    |
+      | password        | %public%                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithUser.txt |
+      | space           | Personal                |
+      | sharee          | Brian                   |
+      | shareType       | user                    |
+      | permissionsRole | Viewer                  |
+    And user "Alice" has created the following resource link share:
+      | resource        | fileToShareWithPublic.txt |
+      | space           | Personal                  |
+      | permissionsRole | view                      |
+      | password        | %public%                  |
     When user "Alice" gets the group shares shared by her using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -65,10 +89,30 @@ Feature: get shares filtered by type (user, group etc)
 
   Scenario Outline: getting shares shared to public links when there are none
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithUser |
+      | space           | Personal              |
+      | sharee          | Brian                 |
+      | shareType       | user                  |
+      | permissionsRole | Viewer                |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShareWithGroup |
+      | space           | Personal               |
+      | sharee          | grp1                   |
+      | shareType       | group                  |
+      | permissionsRole | Viewer                 |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithUser.txt |
+      | space           | Personal                |
+      | sharee          | Brian                   |
+      | shareType       | user                    |
+      | permissionsRole | Viewer                  |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | fileToShareWithGroup.txt |
+      | space           | Personal                 |
+      | sharee          | grp1                     |
+      | shareType       | group                    |
+      | permissionsRole | Viewer                   |
     When user "Alice" gets the public link shares shared by her using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"


### PR DESCRIPTION

## Description
Changed `Given` step for sharing using SharingNg in `coreApiShareOperationsToShares1`:

1. `accessToShare.feature`
2. `changingFilesShare.feature`
3. `gettingShares.feature`
4. `gettingSharesPendingFiltered.feature`
5. `gettingSharesReceivedFiltered.feature`
6. `gettingSharesReceivedFilteredEmpty.feature`
7. `gettingSharesSharedFiltered.feature`
8. `gettingSharesSharedFilteredEmpty.feature`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/8717

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
