### PR TITLE
fix: token refresh in single binary and wopi deployment example

### DIFF
--- a/changelog/unreleased/csp.md
+++ b/changelog/unreleased/csp.md
@@ -3,3 +3,6 @@ Enhancement: Add CSP and other security related headers to oCIS
 General hardening of oCIS
 
 https://github.com/owncloud/ocis/pull/8777
+https://github.com/owncloud/ocis/pull/9025
+https://github.com/owncloud/ocis/pull/9167
+

--- a/deployments/examples/ocis_wopi/config/ocis/csp.yaml
+++ b/deployments/examples/ocis_wopi/config/ocis/csp.yaml
@@ -8,7 +8,7 @@ directives:
   font-src:
     - '''self'''
   frame-ancestors:
-    - '''none'''
+    - '''self'''
   frame-src:
     - '''self'''
     - 'https://embed.diagrams.net/'

--- a/services/proxy/pkg/config/csp.yaml
+++ b/services/proxy/pkg/config/csp.yaml
@@ -8,7 +8,7 @@ directives:
   font-src:
     - '''self'''
   frame-ancestors:
-    - '''none'''
+    - '''self'''
   frame-src:
     - '''self'''
     - 'https://embed.diagrams.net/'

--- a/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature
@@ -271,7 +271,7 @@ Feature: download file
     And the following headers should be set
       | header                            | value                                                              |
       | Content-Disposition               | attachment; filename*=UTF-8''"<file-name>"; filename="<file-name>" |
-      | Content-Security-Policy           | child-src 'self'; connect-src 'self'; default-src 'none'; font-src 'self'; frame-ancestors 'none'; frame-src 'self' https://embed.diagrams.net/; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'self' blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'                                                |
+      | Content-Security-Policy           | child-src 'self'; connect-src 'self'; default-src 'none'; font-src 'self'; frame-ancestors 'self'; frame-src 'self' https://embed.diagrams.net/; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'self' blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'                                                |
       | X-Content-Type-Options            | nosniff                                                            |
       | X-Download-Options                | noopen                                                             |
       | X-Frame-Options                   | SAMEORIGIN                                                         |
@@ -300,7 +300,7 @@ Feature: download file
     And the following headers should be set
       | header                            | value                                                                            |
       | Content-Disposition               | attachment; filename*=UTF-8''""quote"double".txt"; filename=""quote"double".txt" |
-      | Content-Security-Policy           | child-src 'self'; connect-src 'self'; default-src 'none'; font-src 'self'; frame-ancestors 'none'; frame-src 'self' https://embed.diagrams.net/; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'self' blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'                                                              |
+      | Content-Security-Policy           | child-src 'self'; connect-src 'self'; default-src 'none'; font-src 'self'; frame-ancestors 'self'; frame-src 'self' https://embed.diagrams.net/; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'self' blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'                                                              |
       | X-Content-Type-Options            | nosniff                                                                          |
       | X-Download-Options                | noopen                                                                           |
       | X-Frame-Options                   | SAMEORIGIN                                                                       |

--- a/tests/parallelDeployAcceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/parallelDeployAcceptance/features/apiWebdavOperations/downloadFile.feature
@@ -132,7 +132,7 @@ Feature: download file
     Then the following headers should be set
       | header                            | value                                                              |
       | Content-Disposition               | attachment; filename*=UTF-8''textfile.txt; filename="textfile.txt" |
-      | Content-Security-Policy           | child-src 'self'; connect-src 'self'; default-src 'none'; font-src 'self'; frame-ancestors 'none'; frame-src 'self' https://embed.diagrams.net/; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'self' blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'                                                |
+      | Content-Security-Policy           | child-src 'self'; connect-src 'self'; default-src 'none'; font-src 'self'; frame-ancestors 'self'; frame-src 'self' https://embed.diagrams.net/; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; object-src 'self' blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'                                                |
       | X-Content-Type-Options            | nosniff                                                            |
       | X-Download-Options                | noopen                                                             |
       | X-Frame-Options                   | SAMEORIGIN                                                         |


### PR DESCRIPTION
## Description
When refreshing the oidc client loads ocis in an iframe - which was disallowed until this fix.

## Related Issue
- Fixes #9163 

## How Has This Been Tested?
- cd deployment/example/ocis_wopi
- docker compose up
- xdg-open https://ocis.owncloud.test/
- login
- open developer console in browser
- wait 5m
- see token expiring and being refreshed
- observe to stay logged in

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
