### PR TITLE
[docs-only] Update ocis_wopi docker-compose.yml --> add staging for letsencrypt

### DIFF
--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -11,6 +11,11 @@ TRAEFIK_DOMAIN=
 TRAEFIK_BASIC_AUTH_USERS=
 # Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
 TRAEFIK_ACME_MAIL=
+# Defaults to "https://acme-v02.api.letsencrypt.org/directory".
+# Set to: "https://acme-staging-v02.api.letsencrypt.org/directory" for testing to check the certificate process.
+# With staging, there will be an SSL error in the browser. When certificates are displayed and are emitted by
+# "Fake LE Intermediate X1", the process went well and the envvar can be reset to empty to get valid certificates.
+TRAEFIK_ACME_CASERVER=
 
 ### oCIS settings ###
 # oCIS version. Defaults to "latest"

--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -31,7 +31,7 @@ DEMO_USERS=
 OCIS_LOG_LEVEL=
 
 ### Wopi server settings ###
-# cs3org wopi server version. Defaults to "v8.3.3"
+# cs3org wopi server version. Defaults to "v10.3.0"
 WOPISERVER_DOCKER_TAG=
 # cs3org wopi server domain. Defaults to "wopiserver.owncloud.test"
 WOPISERVER_DOMAIN=

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -18,13 +18,7 @@ services:
       - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
       - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
       - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
-
-      # Uncomment the command for testing when using real certificates:
-      # You will get an SSL error in the browser, but if you display the certificate and see it was emitted by
-      # "Fake LE Intermediate X1", it means all is good. It is the staging environment intermediate certificate used by Let's Encrypt.
-      # Re-comment to create real certificates.
-      #- "--certificatesresolvers.http.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
-
+      - "--certificatesresolvers.http.acme.caserver=${TRAEFIK_ACME_CASERVER:-https://acme-v02.api.letsencrypt.org/directory"
       # enable dashboard
       - "--api.dashboard=true"
       # define entrypoints

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -18,6 +18,13 @@ services:
       - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
       - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
       - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+
+      # Uncomment the command for testing when using real certificates:
+      # You will get an SSL error in the browser, but if you display the certificate and see it was emitted by
+      # "Fake LE Intermediate X1", it means all is good. It is the staging environment intermediate certificate used by Let's Encrypt.
+      # Re-comment to create real certificates.
+      #- "--certificatesresolvers.http.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+
       # enable dashboard
       - "--api.dashboard=true"
       # define entrypoints


### PR DESCRIPTION
Adding a command plus comments in the ocis_wopi traefik section how to deal with the Letsencrypt staging environment.

This is important if we will create real certificates based on external resolvable URL's.

One needs to test the setup upfront obtaining real certificates as Letsencrypt has a narrow rate limit that last 1 week !!

Staging needs to be set actively, so we do not have any issues.

Such a setting is important for the easy entry docs for proper customer satisfaction.

Backport to 5.0 necessary

@tbsbdr fyi
 
(References: https://doc.traefik.io/traefik/user-guides/docker-compose/acme-dns/ this staging entry was found on many docs)