### PR TITLE
[full-ci] [tests-only] Use `sharing-ng` in given steps for sharing

### DIFF
--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -136,6 +136,7 @@ default:
         - TrashbinContext:
         - WebDavPropertiesContext:
         - OcisConfigContext:
+        - SpacesContext:
         - SharingNgContext:
 
     coreApiSharePublicLink2:

--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -134,10 +134,10 @@ default:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
         - TrashbinContext:
-        - WebDavPropertiesContext:
-        - OcisConfigContext:
         - SpacesContext:
         - SharingNgContext:
+        - WebDavPropertiesContext:
+        - OcisConfigContext:
 
     coreApiSharePublicLink2:
       paths:

--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -136,6 +136,7 @@ default:
         - TrashbinContext:
         - WebDavPropertiesContext:
         - OcisConfigContext:
+        - SharingNgContext:
 
     coreApiSharePublicLink2:
       paths:

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -90,7 +90,7 @@ cannot share a folder with create permission
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
-- [coreApiSharePublicLink1/createPublicLinkShare.feature:288](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L288)
+- [coreApiSharePublicLink1/createPublicLinkShare.feature:290](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature#L290)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -332,17 +332,12 @@ class PublicWebDavContext implements Context {
 	/**
 	 * @param string $path
 	 * @param string $user
-	 * @param bool $shareNg
 	 *
 	 * @return ResponseInterface
 	 */
-	public function downloadFromPublicLinkAsUser(string $path, string $user, bool $shareNg = false): ResponseInterface {
+	public function downloadFromPublicLinkAsUser(string $path, string $user): ResponseInterface {
 		$path = \ltrim($path, "/");
-		if ($shareNg) {
-			$token = $this->featureContext->shareNgGetLastCreatedLinkShareToken();
-		} else {
-			$token = $this->featureContext->getLastCreatedPublicShareToken();
-		}
+		$token = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareToken() : $this->featureContext->getLastCreatedPublicShareToken();
 
 		$davPath = WebDavHelper::getDavPath(
 			$token,

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1696,7 +1696,7 @@ class PublicWebDavContext implements Context {
 		string $fileName,
 		string $mtime
 	):void {
-		$token = $this->featureContext->getLastCreatedPublicShareToken();
+		$token = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareToken() : $this->featureContext->getLastCreatedPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$mtime = \explode(" ", $mtime);
 		\array_pop($mtime);

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -224,7 +224,7 @@ class PublicWebDavContext implements Context {
 	 * @return ResponseInterface
 	 */
 	public function renameFileFromPublicShare(string $fileName, string $toFileName, string $publicWebDAVAPIVersion, ?string $password = ""):ResponseInterface {
-		$token = $this->featureContext->getLastCreatedPublicShareToken();
+		$token = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareToken() : $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3245,7 +3245,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function thePublicAccessesThePreviewOfTheSharedFileUsingTheSharingApi(string $path):void {
-		$token = $this->getLastCreatedPublicShareToken();
+		$token = ($this->isUsingSharingNG()) ? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
 		$this->getPublicPreviewOfFile($path, $token);
 		$this->pushToLastStatusCodesArrays();
 	}
@@ -3266,7 +3266,7 @@ trait Sharing {
 		$this->emptyLastHTTPStatusCodesArray();
 		$this->emptyLastOCSStatusCodesArray();
 		foreach ($paths as $path) {
-			$token = $this->getLastCreatedPublicShareToken();
+			$token = ($this->isUsingSharingNG()) ? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
 			$this->getPublicPreviewOfFile($path["path"], $token);
 			$this->pushToLastStatusCodesArrays();
 		}

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5505,13 +5505,9 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function thePublicListsTheResourcesInTheLastCreatedPublicLinkWithDepthUsingTheWebdavApi(string $depth):void {
-		if ($this->isUsingSharingNG()) {
-			$user = $this->shareNgGetLastCreatedLinkShareToken();
-		} else {
-			$user = $this->getLastCreatedPublicShareToken();
-		}
+		$token = ($this->isUsingSharingNG()) ? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
 		$response = $this->listFolder(
-			$user,
+			$token,
 			'/',
 			$depth,
 			null,

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1473,8 +1473,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function publicGetsSizeOfLastSharedPublicLinkUsingTheWebdavApi():void {
-		$tokenArray = $this->getLastCreatedPublicShare()->token;
-		$token = (string)$tokenArray[0];
+		$token = ($this->isUsingSharingNG()) ? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
 		$url = $this->getBaseUrl() . "/remote.php/dav/public-files/$token";
 		$this->response = HttpRequestHelper::sendRequest(
 			$url,

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -227,13 +227,13 @@ class WebDavPropertiesContext implements Context {
 	 * @throws Exception
 	 */
 	public function getPropertiesOfEntryFromLastLinkShare(string $path, TableNode $propertiesTable): ResponseInterface {
-		$user = $this->featureContext->getLastCreatedPublicShareToken();
+		$token = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareToken() : $this->featureContext->getLastCreatedPublicShareToken();
 		$properties = null;
 		foreach ($propertiesTable->getRows() as $row) {
 			$properties[] = $row[0];
 		}
 		return $this->featureContext->listFolder(
-			$user,
+			$token,
 			$path,
 			'0',
 			$properties,
@@ -824,6 +824,7 @@ class WebDavPropertiesContext implements Context {
 		);
 		$user = $this->featureContext->getActualUsername($user);
 		$value = $xmlPart[0]->__toString();
+		$callback = ($this->featureContext->isUsingSharingNG()) ? "shareNgGetLastCreatedLinkShareToken" : "getLastCreatedPublicShareToken";
 		$pattern = $this->featureContext->substituteInLineCodes(
 			$pattern,
 			$user,
@@ -832,7 +833,7 @@ class WebDavPropertiesContext implements Context {
 				[
 					"code" => "%public_token%",
 					"function" =>
-					[$this->featureContext, "getLastCreatedPublicShareToken"],
+					[$this->featureContext, $callback],
 					"parameter" => []
 				],
 			]

--- a/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
@@ -11,10 +11,12 @@ Feature: accessing a public link share
 
   Scenario: access to the preview of password protected public link without providing the password is not allowed
     Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
-    And user "Alice" has created a public link share with settings
-      | path        | /testavatar.jpg |
-      | permissions | change          |
-      | password    | %public%        |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | testavatar.jpg |
+      | space           | Personal       |
+      | permissionsRole | edit           |
+      | password        | %public%       |
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "404"
 
@@ -22,9 +24,11 @@ Feature: accessing a public link share
   Scenario: access to the preview of public shared file without password
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
-    And user "Alice" has created a public link share with settings
-      | path        | /testavatar.jpg |
-      | permissions | change          |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | testavatar.jpg |
+      | space           | Personal       |
+      | permissionsRole | edit           |
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "200"
 
@@ -33,10 +37,12 @@ Feature: accessing a public link share
     Given user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile0.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /FOLDER  |
-      | permissions | change   |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | FOLDER   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public accesses the preview of the following files from the last shared public link using the sharing API
       | path           |
       | testavatar.jpg |
@@ -49,9 +55,11 @@ Feature: accessing a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile0.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /FOLDER |
-      | permissions | change  |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | FOLDER   |
+      | space           | Personal |
+      | permissionsRole | edit     |
     When the public accesses the preview of the following files from the last shared public link using the sharing API
       | path           |
       | testavatar.jpg |
@@ -62,9 +70,11 @@ Feature: accessing a public link share
   Scenario: user tries to download public link file using own basic auth
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | FOLDER   |
-      | permissions | change   |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | FOLDER   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When user "Alice" tries to download file "textfile.txt" from the last public link using own basic auth and new public WebDAV API
     Then the HTTP status code should be "401"

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -14,67 +14,79 @@ Feature: changing a public link share
 
 
   Scenario Outline: public can or cannot delete file through publicly shared link depending on having delete permissions using the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT       |
-      | permissions | <permissions> |
-      | password    | %public%      |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT             |
+      | space           | Personal           |
+      | permissionsRole | <permissions-role> |
+      | password        | %public%           |
     When the public deletes file "parent.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
     Examples:
-      | permissions               | http-status-code | should-or-not |
-      | read                      | 403              | should        |
-      | read,create               | 403              | should        |
-      | create                    | 403              | should        |
-      | read,update,create,delete | 204              | should not    |
+      | permissions-role | http-status-code | should-or-not |
+      | view             | 403              | should        |
+      | upload           | 403              | should        |
+      | createOnly       | 403              | should        |
+      | edit             | 204              | should not    |
 
 
-  Scenario: public link share permissions work correctly for renaming and share permissions read,update,create,delete using the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-      | password    | %public%                  |
+  Scenario: public link share permissions work correctly for renaming and share permissions edit using the public WebDAV API
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
 
 
-  Scenario: public link share permissions work correctly for upload with share permissions read,update,create,delete with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-      | password    | %public%                  |
+  Scenario: public link share permissions work correctly for upload with share permissions edit with the public WebDAV API
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public uploads file "lorem.txt" with password "%public%" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
 
 
   Scenario: public cannot delete file through publicly shared link with password using an invalid password with public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | change   |
-      | password    | %public% |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public deletes file "parent.txt" from the last public link share using the password "invalid" and new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
 
 
   Scenario: public can delete file through publicly shared link with password using the valid password with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | change   |
-      | password    | %public% |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public deletes file "parent.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
 
   Scenario: public tries to rename a file in a password protected share using an invalid password with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | change   |
-      | password    | %public% |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "invalid" and the new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/newparent.txt" should not exist
@@ -82,10 +94,12 @@ Feature: changing a public link share
 
 
   Scenario: public tries to rename a file in a password protected share using the valid password with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | change   |
-      | password    | %public% |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/newparent.txt" should exist
@@ -93,30 +107,36 @@ Feature: changing a public link share
 
 
   Scenario: public tries to upload to a password protected public share using an invalid password with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | change   |
-      | password    | %public% |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public uploads file "lorem.txt" with password "invalid" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
 
   Scenario: public tries to upload to a password protected public share using the valid password with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | change   |
-      | password    | %public% |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When the public uploads file "lorem.txt" with password "%public%" and content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
 
   Scenario: public cannot rename a file in upload-write-only public link share with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT         |
-      | permissions | uploadwriteonly |
-      | password    | %public%        |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT     |
+      | space           | Personal   |
+      | permissionsRole | createOnly |
+      | password        | %public%   |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the new public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
@@ -124,10 +144,12 @@ Feature: changing a public link share
 
 
   Scenario: public cannot delete a file in upload-write-only public link share with the public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT         |
-      | permissions | uploadwriteonly |
-      | password    | %public%        |
+    Given using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT     |
+      | space           | Personal   |
+      | permissionsRole | createOnly |
+      | password        | %public%   |
     When the public deletes file "parent.txt" from the last public link share using the password "%public%" and new public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
@@ -135,10 +157,12 @@ Feature: changing a public link share
   @skipOnReva
   Scenario Outline: normal user tries to remove password of a public link share (change/create permission)
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT       |
-      | permissions | <permissions> |
-      | password    | %public%      |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT             |
+      | space           | Personal           |
+      | permissionsRole | <permissions-role> |
+      | password        | %public%           |
     When user "Alice" updates the last public link share using the sharing API with
       | path        | /PARENT       |
       | permissions | <permissions> |
@@ -147,19 +171,21 @@ Feature: changing a public link share
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
-      | ocs-api-version | permissions | http-status-code |
-      | 1               | change      | 200              |
-      | 2               | change      | 400              |
-      | 1               | create      | 200              |
-      | 2               | create      | 400              |
+      | ocs-api-version | permissions | permissions-role | http-status-code |
+      | 1               | change      | edit             | 200              |
+      | 2               | change      | edit             | 400              |
+      | 1               | create      | createOnly       | 200              |
+      | 2               | create      | createOnly       | 400              |
 
   @issue-7821 @skipOnReva
   Scenario Outline: normal user tries to remove password of a public link (update without sending permissions)
     Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | change   |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | edit     |
+      | password        | %public% |
     When user "Alice" updates the last public link share using the sharing API with
       | path     | /PARENT |
       | password |         |
@@ -171,36 +197,18 @@ Feature: changing a public link share
       | 1               | 200              |
       | 2               | 403              |
 
-
-  Scenario Outline: normal user removes password of a public link (invite only public link)
-    Given using OCS API version "<ocs-api-version>"
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | invite   |
-      | password    | %public% |
-    When user "Alice" updates the last public link share using the sharing API with
-      | path        | /PARENT |
-      | password    |         |
-      | permissions | invite  |
-    Then the HTTP status code should be "200"
-    And the OCS status code should be "<ocs-status-code>"
-    And the OCS status message should be "OK"
-    Examples:
-      | ocs-api-version | ocs-status-code |
-      | 1               | 100             |
-      | 2               | 200             |
-
   @skipOnReva # reva doesn't have a pre-created admin user
   Scenario Outline: administrator removes password of a read-only public link
     Given using OCS API version "<ocs-api-version>"
     And admin has created folder "/PARENT"
-    And user "admin" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
-    And user "admin" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | read     |
-      | password    | %public% |
-    When user "admin" updates the last public link share using the sharing API with
+    And user "Admin" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And using SharingNG
+    And user "Admin" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | view     |
+      | password        | %public% |
+    When user "Admin" updates the last public link share using the sharing API with
       | path        | /PARENT |
       | permissions | read    |
       | password    |         |
@@ -216,10 +224,12 @@ Feature: changing a public link share
   Scenario Outline: administrator tries to remove password of a public link share (change/create permission)
     Given using OCS API version "<ocs-api-version>"
     And admin has created folder "/PARENT"
-    And user "admin" has created a public link share with settings
-      | path        | /PARENT       |
-      | permissions | <permissions> |
-      | password    | %public%      |
+    And using SharingNG
+    And user "Admin" has created the following resource link share:
+      | resource        | PARENT             |
+      | space           | Personal           |
+      | permissionsRole | <permissions-role> |
+      | password        | %public%           |
     When user "admin" updates the last public link share using the sharing API with
       | path        | /PARENT       |
       | permissions | <permissions> |
@@ -228,8 +238,8 @@ Feature: changing a public link share
     And the OCS status code should be "400"
     And the OCS status message should be "missing required password"
     Examples:
-      | ocs-api-version | permissions | http-status-code |
-      | 1               | change      | 200              |
-      | 2               | change      | 400              |
-      | 1               | create      | 200              |
-      | 2               | create      | 400              |
+      | ocs-api-version | permissions | permissions-role | http-status-code |
+      | 1               | change      | edit             | 200              |
+      | 2               | change      | edit             | 400              |
+      | 1               | create      | createOnly       | 200              |
+      | 2               | create      | createOnly       | 400              |

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -277,10 +277,12 @@ Feature: create a public link share
   Scenario: delete a folder that has been publicly shared and try to access using the public WebDAV API
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | PARENT   |
-      | permissions | read     |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | view     |
+      | password        | %public% |
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
     Then the public download of file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" should fail with HTTP status code "404"
 
@@ -288,10 +290,12 @@ Feature: create a public link share
   Scenario: try to download from a public share that has upload only permissions using the public webdav api
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | PARENT          |
-      | permissions | uploadwriteonly |
-      | password    | %public%        |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT     |
+      | space           | Personal   |
+      | permissionsRole | createOnly |
+      | password        | %public%   |
     When the public downloads file "parent.txt" from inside the last public link shared folder using the new public WebDAV API
     Then the value of the item "//s:message" in the response should be "File not found: parent.txt"
     And the HTTP status code should be "404"
@@ -300,9 +304,11 @@ Feature: create a public link share
   Scenario: get the size of a file shared by public link
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | test-file.txt |
-      | permissions | read          |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | test-file.txt |
+      | space           | Personal      |
+      | permissionsRole | view          |
     When the public gets the size of the last shared public link using the WebDAV API
     Then the HTTP status code should be "207"
     And the size of the file should be "19"
@@ -342,9 +348,11 @@ Feature: create a public link share
   Scenario: get the mtime of a file inside a folder shared by public link using new webDAV version
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has created folder "testFolder"
-    And user "Alice" has created a public link share with settings
-      | path        | /testFolder               |
-      | permissions | read,update,create,delete |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | testFolder |
+      | space           | Personal   |
+      | permissionsRole | edit       |
     When the public uploads file "file.txt" to the last public link shared folder with password "%public%" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "testFolder/file.txt" should exist
@@ -370,9 +378,11 @@ Feature: create a public link share
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And using new DAV path
     And user "Alice" has uploaded file with content "Random data" to "/file.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | file.txt |
-      | permissions | read     |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | file.txt |
+      | space           | Personal |
+      | permissionsRole | view     |
     When the public lists the resources in the last created public link with depth "1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the value of the item "//d:response[2]//d:href" in the response should match "/%base_path%\/remote.php\/dav\/public-files\/%public_token%\/file.txt$/"
@@ -386,10 +396,12 @@ Feature: create a public link share
   Scenario Outline: create a password-protected public link on a file with the name same to the previously deleted one
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "test data 1" to "/test.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | test.txt |
-      | permissions | read     |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | test.txt |
+      | space           | Personal |
+      | permissionsRole | view     |
+      | password        | %public% |
     And user "Alice" has deleted file "test.txt"
     When user "Alice" updates the last public link share using the sharing API with
       | password | Test:123345 |

--- a/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
@@ -10,10 +10,12 @@ Feature: delete a public link share
   Scenario Outline: deleting a public link of a file
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
-    And user "Alice" has created a public link share with settings
-      | path     | test-file.txt |
-      | name     | sharedlink    |
-      | password | %public%      |
+    And user "Alice" has created the following resource link share:
+      | resource        | test-file.txt |
+      | space           | Personal      |
+      | permissionsRole | edit          |
+      | password        | %public%      |
+      | displayName     | sharedlink    |
     When user "Alice" deletes public link share named "sharedlink" in file "test-file.txt" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status-code>"
@@ -27,12 +29,14 @@ Feature: delete a public link share
   Scenario Outline: deleting a public link after renaming a file
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
-    And user "Alice" has created a public link share with settings
-      | path     | test-file.txt |
-      | name     | sharedlink    |
-      | password | %public%      |
-    When user "Alice" moves file "/test-file.txt" to "/renamed-test-file.txt" using the WebDAV API
-    And user "Alice" deletes public link share named "sharedlink" in file "renamed-test-file.txt" using the sharing API
+    And user "Alice" has created the following resource link share:
+      | resource        | test-file.txt |
+      | space           | Personal      |
+      | permissionsRole | edit          |
+      | password        | %public%      |
+      | displayName     | sharedlink    |
+    And user "Alice" has moved file "/test-file.txt" to "/renamed-test-file.txt"
+    When user "Alice" deletes public link share named "sharedlink" in file "renamed-test-file.txt" using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
     And as user "Alice" the file "renamed-test-file.txt" should not have any shares
@@ -45,10 +49,12 @@ Feature: delete a public link share
   Scenario Outline: deleting a public link of a folder
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has created folder "test-folder"
-    And user "Alice" has created a public link share with settings
-      | path     | /test-folder |
-      | name     | sharedlink   |
-      | password | %public%     |
+    And user "Alice" has created the following resource link share:
+      | resource        | test-folder |
+      | space           | Personal    |
+      | permissionsRole | edit        |
+      | password        | %public%    |
+      | displayName     | sharedlink  |
     When user "Alice" deletes public link share named "sharedlink" in folder "test-folder" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status-code>"
@@ -63,10 +69,12 @@ Feature: delete a public link share
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has created folder "test-folder"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/test-folder/testfile.txt" using the WebDAV API
-    And user "Alice" has created a public link share with settings
-      | path     | /test-folder/testfile.txt |
-      | name     | sharedlink                |
-      | password | %public%                  |
+    And user "Alice" has created the following resource link share:
+      | resource        | test-folder/testfile.txt |
+      | space           | Personal                 |
+      | permissionsRole | edit                     |
+      | password        | %public%                 |
+      | displayName     | sharedlink               |
     And user "Alice" deletes public link share named "sharedlink" in file "/test-folder/testfile.txt" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status-code>"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Used sharingNG graph API in the given steps for sharing.

Suites covered:
- `coreApiSharePublicLink1/`
  - `accessToPublicLinkShare.feature`
  - `changingPublicLinkShare.feature`
  - `createPublicLinkShare.feature`
  - `deletePublicLinkShare.feature`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/8717

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
