### PR TITLE
[docs-only] Backport of #9172 (add staging for letsencrypt in ocis_wopi)

### DIFF
--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -11,6 +11,11 @@ TRAEFIK_DOMAIN=
 TRAEFIK_BASIC_AUTH_USERS=
 # Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
 TRAEFIK_ACME_MAIL=
+# Defaults to "https://acme-v02.api.letsencrypt.org/directory".
+# Set to: "https://acme-staging-v02.api.letsencrypt.org/directory" for testing to check the certificate process.
+# With staging, there will be an SSL error in the browser. When certificates are displayed and are emitted by
+# "Fake LE Intermediate X1", the process went well and the envvar can be reset to empty to get valid certificates.
+TRAEFIK_ACME_CASERVER=
 
 ### oCIS settings ###
 # oCIS version. Defaults to "latest"

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
       - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
       - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+      - "--certificatesresolvers.http.acme.caserver=${TRAEFIK_ACME_CASERVER:-https://acme-v02.api.letsencrypt.org/directory"
       # enable dashboard
       - "--api.dashboard=true"
       # define entrypoints


### PR DESCRIPTION
Backport of #9172 ([docs-only] Update ocis_wopi docker-compose.yml --> add staging for letsencrypt)

The backport is necessary for our easy entry docs.