### PR TITLE
feat: limit concurrent processing of thumbnail requests

### DIFF
--- a/changelog/unreleased/thumbnail-request-limit.md
+++ b/changelog/unreleased/thumbnail-request-limit.md
@@ -1,0 +1,6 @@
+Enhancement: Limit concurrent thumbnail requests
+
+The number of concurrent requests to the thumbnail service can be limited now
+to have more control over the consumed system resources.
+
+https://github.com/owncloud/ocis/pull/9199

--- a/ocis-pkg/middleware/throttle.go
+++ b/ocis-pkg/middleware/throttle.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// Throttle limits the number of concurrent requests.
+func Throttle(limit int) func(http.Handler) http.Handler {
+	if limit > 0 {
+		return middleware.Throttle(limit)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/services/thumbnails/README.md
+++ b/services/thumbnails/README.md
@@ -41,19 +41,19 @@ Thumbnails can either be generated as `png`, `jpg` or `gif` files. These types a
 
 ## Thumbnail Query String Parameters
 
-Clients can request thumbnail previews for files by adding `?preview=1` to the file URL. Requests for files with thumbnail availabe respond with HTTP status `404`.
+Clients can request thumbnail previews for files by adding `?preview=1` to the file URL. Requests for files with thumbnail available respond with HTTP status `404`.
 
 The following query parameters are supported:
 
 | Parameter | Required | Default Value                                        | Description                                                                     |
-| --------- | -------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+|-----------|----------|------------------------------------------------------|---------------------------------------------------------------------------------|
 | preview   | YES      | 1                                                    | generates preview                                                               |
 | x         | YES      | first x-value configured in `THUMBNAILS_RESOLUTIONS` | horizontal target size                                                          |
 | y         | YES      | first y-value configured in `THUMBNAILS_RESOLUTIONS` | vertical target size                                                            |
-| scalingup | NO       | 0                                                    | prevents upscaling of small images                                              |
+| scalingup | NO       | 0                                                    | prevents up-scaling of small images                                             |
 | a         | NO       | 1                                                    | aspect ratio                                                                    |
 | c         | NO       | Caching string                                       | Clients should send the etag, so they get a fresh thumbnail after a file change |
-| processor | NO       | `resize` for gif's and `thumbnail` for all others    | preferred thumbnail processor                                                   |
+| processor | NO       | `resize` for gifs and `thumbnail` for all others     | preferred thumbnail processor                                                   |
 
 ## Thumbnail Resolution
 
@@ -61,21 +61,21 @@ Various resolutions can be defined via `THUMBNAILS_RESOLUTIONS`. A requestor can
 
 Example:
 
-Requested: 18x12  
-Available: 30x20, 15x10, 9x6  
-Returned: 15x10  
+Requested: 18x12
+Available: 30x20, 15x10, 9x6
+Returned: 15x10
 
 ## Thumbnail Processors
 
-Normally, an image might get cropped when creating a preview, depending on the aspect ratio of the original image. This can have negative 
+Normally, an image might get cropped when creating a preview, depending on the aspect ratio of the original image. This can have negative
 impacts on previews as only a part of the image will be shown. When using an _optional_ processor in the request, cropping can be avoided by defining on how the preview image generation will be done. The following processors are available:
 
 *   `resize` resizes the image to the specified width and height and returns the transformed image. If one of width or height is 0, the image aspect ratio is preserved.
 *   `fit` scales down the image to fit the specified maximum width and height and returns the transformed image.
 *   `fill`: creates an image with the specified dimensions and fills it with the scaled source image. To achieve the correct aspect ratio without stretching, the source image will be cropped.
-*   `thumbnail` scales the image up or down, crops it to the specified width and hight and returns the transformed image.
+*   `thumbnail` scales the image up or down, crops it to the specified width and height and returns the transformed image.
 
-To apply one of those, a query parameter has to be added to the request, like `?processor=fit`. If no query parameter or processor is added, the default behaviour applies which is `resize` for gif's and `thumbnail` for all others.
+To apply one of those, a query parameter has to be added to the request, like `?processor=fit`. If no query parameter or processor is added, the default behaviour applies which is `resize` for gifs and `thumbnail` for all others.
 
 ## Deleting Thumbnails
 
@@ -84,3 +84,4 @@ As of now, there is no automated thumbnail deletion. This is especially true whe
 ## Memory Considerations
 
 Since source files need to be loaded into memory when generating thumbnails, large source files could potentially crash this service if there is insufficient memory available. For bigger instances when using container orchestration deployment methods, this service can be dedicated to its own server(s) with more memory.
+To have more control over memory (and CPU) consumption the maximum number of concurrent requests can be limited by setting the environment variable `THUMBNAILS_MAX_CONCURRENT_REQUESTS`. The default value is 0 which does not apply any restrictions to the number of concurrent requests. As soon as the number of concurrent requests is reached any further request will be responded with `429/Too Many Requests` and the client can retry at a later point in time.

--- a/services/thumbnails/pkg/command/server.go
+++ b/services/thumbnails/pkg/command/server.go
@@ -98,6 +98,7 @@ func Server(cfg *config.Config) *cli.Command {
 				http.Metrics(m),
 				http.Namespace(cfg.HTTP.Namespace),
 				http.TraceProvider(traceProvider),
+				http.MaxConcurrentRequests(cfg.HTTP.MaxConcurrentRequests),
 			)
 			if err != nil {
 				logger.Info().

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -32,9 +32,10 @@ func DefaultConfig() *config.Config {
 			Namespace: "com.owncloud.api",
 		},
 		HTTP: config.HTTP{
-			Addr:      "127.0.0.1:9186",
-			Root:      "/thumbnails",
-			Namespace: "com.owncloud.web",
+			Addr:                  "127.0.0.1:9186",
+			Root:                  "/thumbnails",
+			Namespace:             "com.owncloud.web",
+			MaxConcurrentRequests: 0,
 		},
 		Service: config.Service{
 			Name: "thumbnails",

--- a/services/thumbnails/pkg/config/http.go
+++ b/services/thumbnails/pkg/config/http.go
@@ -4,8 +4,9 @@ import "github.com/owncloud/ocis/v2/ocis-pkg/shared"
 
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr      string                `yaml:"addr" env:"THUMBNAILS_HTTP_ADDR" desc:"The bind address of the HTTP service." introductionVersion:"pre5.0"`
-	TLS       shared.HTTPServiceTLS `yaml:"tls"`
-	Root      string                `yaml:"root" env:"THUMBNAILS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service." introductionVersion:"pre5.0"`
-	Namespace string                `yaml:"-"`
+	Addr                  string                `yaml:"addr" env:"THUMBNAILS_HTTP_ADDR" desc:"The bind address of the HTTP service." introductionVersion:"pre5.0"`
+	TLS                   shared.HTTPServiceTLS `yaml:"tls"`
+	Root                  string                `yaml:"root" env:"THUMBNAILS_HTTP_ROOT" desc:"Subdirectory that serves as the root for this HTTP service." introductionVersion:"pre5.0"`
+	Namespace             string                `yaml:"-"`
+	MaxConcurrentRequests int                   `yaml:"max_concurrent_requests" env:"THUMBNAILS_MAX_CONCURRENT_REQUESTS" desc:"Number of maximum concurrent thumbnail requests. Default is 0 which is unlimited." introductionVersion:"6.0"`
 }

--- a/services/thumbnails/pkg/server/http/option.go
+++ b/services/thumbnails/pkg/server/http/option.go
@@ -16,13 +16,14 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Namespace     string
-	Logger        log.Logger
-	Context       context.Context
-	Config        *config.Config
-	Metrics       *metrics.Metrics
-	Flags         []cli.Flag
-	TraceProvider trace.TracerProvider
+	Namespace             string
+	Logger                log.Logger
+	Context               context.Context
+	Config                *config.Config
+	Metrics               *metrics.Metrics
+	Flags                 []cli.Flag
+	TraceProvider         trace.TracerProvider
+	MaxConcurrentRequests int
 }
 
 // newOptions initializes the available default options.
@@ -79,5 +80,12 @@ func TraceProvider(traceProvider trace.TracerProvider) Option {
 		} else {
 			o.TraceProvider = noop.NewTracerProvider()
 		}
+	}
+}
+
+// MaxConcurrentRequests provides a function to set the MaxConcurrentRequests option.
+func MaxConcurrentRequests(val int) Option {
+	return func(o *Options) {
+		o.MaxConcurrentRequests = val
 	}
 }

--- a/services/thumbnails/pkg/server/http/server.go
+++ b/services/thumbnails/pkg/server/http/server.go
@@ -39,6 +39,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.Middleware(
 			middleware.RealIP,
 			middleware.RequestID,
+			ocismiddleware.Throttle(options.MaxConcurrentRequests),
 			ocismiddleware.Version(
 				options.Config.Service.Name,
 				version.GetString(),

--- a/services/thumbnails/pkg/service/http/v0/service.go
+++ b/services/thumbnails/pkg/service/http/v0/service.go
@@ -3,12 +3,11 @@ package svc
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"strconv"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/riandyrn/otelchi"
+	"net/http"
+	"strconv"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"

--- a/services/webdav/pkg/service/v0/search.go
+++ b/services/webdav/pkg/service/v0/search.go
@@ -47,7 +47,7 @@ func (g Webdav) Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t := r.Header.Get(TokenHeader)
+	t := r.Header.Get(revactx.TokenHeader)
 	ctx := revactx.ContextSetToken(r.Context(), t)
 	ctx = metadata.Set(ctx, revactx.TokenHeader, t)
 


### PR DESCRIPTION
## Description
Creating thumbnails can be quite intensive with respect to memory and cpu consumption.
Limiting the number of concurrent requests can help to relax this situation.

In case a request is rejected `429/Too Many Requests` will be returned and clients can retry later.

## Motivation and Context
Make OCIS/ByCS robust ...

## How Has This Been Tested?
- set `THUMBNAILS_MAX_CONCURRENT_REQUESTS` to 1
- upload a lot of pictures
- see 429 on some of the thumbnail requests
- to fully enforce this: place a sleep in https://github.com/owncloud/ocis/pull/9199/files#diff-a9a24a55f3b593d160f93b1d5488f9328ecb4beae99f60ecd098807bcf9e707aR94

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
