### PR TITLE
[tests-only][full-ci] adding skip-on-reva tag for test related to sharing link

### DIFF
--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -141,7 +141,6 @@ default:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
         - TrashbinContext:
-        - SpacesContext:
         - SharingNgContext:
         - WebDavPropertiesContext:
         - OcisConfigContext:

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\GraphHelper;
+use TestHelpers\OcisHelper;
 use TestHelpers\WebDavHelper;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
@@ -48,6 +49,9 @@ class SharingNgContext implements Context {
 	 * @return void
 	 */
 	public function before(BeforeScenarioScope $scope): void {
+		if (OcisHelper::isTestingOnReva()) {
+			return;
+		}
 		// Get the environment
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context from here

--- a/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/accessToPublicLinkShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: accessing a public link share
   As a person who knows a public link
   I want be able to access the preview of a public link file

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -1,5 +1,4 @@
-@issue-1276 @issue-1269
-
+@skipOnReva @issue-1276 @issue-1269
 Feature: changing a public link share
   As a user
   I want to set the permissions of a public link share
@@ -154,7 +153,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-  @skipOnReva
+
   Scenario Outline: normal user tries to remove password of a public link share (change/create permission)
     Given using OCS API version "<ocs-api-version>"
     And using SharingNG
@@ -177,7 +176,7 @@ Feature: changing a public link share
       | 1               | create      | createOnly       | 200              |
       | 2               | create      | createOnly       | 400              |
 
-  @issue-7821 @skipOnReva
+  @issue-7821
   Scenario Outline: normal user tries to remove password of a public link (update without sending permissions)
     Given using OCS API version "<ocs-api-version>"
     And using SharingNG
@@ -197,7 +196,7 @@ Feature: changing a public link share
       | 1               | 200              |
       | 2               | 403              |
 
-  @skipOnReva # reva doesn't have a pre-created admin user
+
   Scenario Outline: administrator removes password of a read-only public link
     Given using OCS API version "<ocs-api-version>"
     And admin has created folder "/PARENT"
@@ -220,7 +219,7 @@ Feature: changing a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnReva # reva doesn't have a pre-created admin user
+
   Scenario Outline: administrator tries to remove password of a public link share (change/create permission)
     Given using OCS API version "<ocs-api-version>"
     And admin has created folder "/PARENT"

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -273,7 +273,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-1293
+  @issue-1293 @skipOnReva
   Scenario: delete a folder that has been publicly shared and try to access using the public WebDAV API
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
@@ -286,7 +286,7 @@ Feature: create a public link share
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
     Then the public download of file "/parent.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" should fail with HTTP status code "404"
 
-  @issue-1269 @issue-1293
+  @issue-1269 @issue-1293 @skipOnReva
   Scenario: try to download from a public share that has upload only permissions using the public webdav api
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
@@ -300,7 +300,7 @@ Feature: create a public link share
     Then the value of the item "//s:message" in the response should be "File not found: parent.txt"
     And the HTTP status code should be "404"
 
-  @env-config
+  @env-config @skipOnReva
   Scenario: get the size of a file shared by public link
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
@@ -344,7 +344,7 @@ Feature: create a public link share
       | old              |
       | new              |
 
-  @env-config
+  @env-config @skipOnReva
   Scenario: get the mtime of a file inside a folder shared by public link using new webDAV version
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And user "Alice" has created folder "testFolder"
@@ -373,7 +373,7 @@ Feature: create a public link share
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-  @env-config
+  @env-config @skipOnReva
   Scenario: check the href of a public link file
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And using new DAV path
@@ -392,7 +392,7 @@ Feature: create a public link share
     Then the HTTP status code should be "207"
     And the value of the item "//d:href" in the response should match "/%base_path%\/remote.php\/dav\/public-files\/%public_token%\/file.txt$/"
 
-  @issue-6929 @skipOnRevaMaster
+  @issue-6929 @@skipOnReva
   Scenario Outline: create a password-protected public link on a file with the name same to the previously deleted one
     Given using OCS API version "<ocs-api-version>"
     And user "Alice" has uploaded file with content "test data 1" to "/test.txt"

--- a/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: delete a public link share
   As a user
   I want to delete a public link

--- a/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: multi-link sharing
   As a user
   I want to create multiple public links for a single resource

--- a/tests/acceptance/features/coreApiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/updatePublicLinkShare.feature
@@ -1,3 +1,4 @@
+@skipOnReva
 Feature: update a public link share
   As a user
   I want to update a public link

--- a/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@issue-1276
+@issue-1276 @skipOnReva
 
 Feature: upload to a public link share
   As a user

--- a/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
@@ -59,7 +59,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: deleting a file in a shared folder moves it to the trashbin root
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -85,7 +85,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: deleting a shared folder moves it to trashbin
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -423,7 +423,7 @@ Feature: dav-versions
       | new              | Uploader         |
       | new              | Editor           |
 
-
+  @skipOnReva
   Scenario: sharee tries to get file versions of file not shared by the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -223,7 +223,7 @@ Feature: propagation of etags when deleting a file or folder
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: deleting a file in a publicly shared folder changes its etag for the sharer
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
@@ -251,7 +251,7 @@ Feature: propagation of etags when deleting a file or folder
       | dav-path-version |
       | spaces           |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: deleting a folder in a publicly shared folder changes its etag for the sharer
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload/sub"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
@@ -302,7 +302,7 @@ Feature: propagation of etags when moving files or folders
       | old              |
       | new              |
 
-
+  @skipOnReva
   Scenario Outline: renaming a file in a publicly shared folder changes its etag for the sharer
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"
@@ -331,7 +331,7 @@ Feature: propagation of etags when moving files or folders
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: renaming a folder in a publicly shared folder changes its etag for the sharer
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/upload"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
@@ -170,7 +170,7 @@ Feature: propagation of etags when uploading data
       | old              |
       | new              |
 
-  @issue-4251
+  @issue-4251 @skipOnReva
   Scenario Outline: uploading a file into a publicly shared folder changes its etag for the sharer
     Given using <dav-path-version> DAV path
     And using SharingNG

--- a/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
@@ -44,7 +44,7 @@ Feature: PROPFIND
       | /remote.php/webdav          | infinity | 400              |
       | /remote.php/dav/files/alice | infinity | 400              |
 
-
+  @skipOnReva
   Scenario: send PROPFIND request to a public link shared with password
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
@@ -59,7 +59,7 @@ Feature: PROPFIND
     And the value of the item "//d:href" in the response should match "/%base_path%\/remote.php\/dav\/public-files\/%public_token%\/$/"
     And the value of the item "//oc:public-link-share-owner" in the response should be "Alice"
 
-
+  @skipOnReva
   Scenario: send PROPFIND request to a public link shared with password (request without password)
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
@@ -73,7 +73,7 @@ Feature: PROPFIND
     Then the HTTP status code should be "401"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotAuthenticated"
 
-
+  @skipOnReva
   Scenario: send PROPFIND request to a public link shared with password (request with incorrect password)
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"

--- a/tests/acceptance/features/coreApiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/getFileProperties.feature
@@ -167,7 +167,7 @@ Feature: get file properties
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: file that is shared to a user has a share-types property
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -194,7 +194,7 @@ Feature: get file properties
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: file that is shared to a group has a share-types property
     Given using <dav-path-version> DAV path
     And group "grp1" has been created
@@ -221,7 +221,7 @@ Feature: get file properties
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: file that is shared by link has a share-types property
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/test"
@@ -246,7 +246,7 @@ Feature: get file properties
       | dav-path-version |
       | spaces           |
 
-
+  @skipOnReva
   Scenario Outline: file that is shared by user,group and link has a share-types property
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
skipping test on reva related to created link share as graph is not implemented in Reva edge.

Reva edge bump: https://github.com/cs3org/reva/pull/4682


## How Has This Been Tested?
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
