### PR TITLE
[full-ci] [tests-only] Use sharing-ng in given steps for sharing

### DIFF
--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -253,7 +253,6 @@ default:
         - FeatureContext: *common_feature_context_params
         - SearchContext:
         - PublicWebDavContext:
-        - SpacesContext:
         - SharingNgContext:
         - WebDavPropertiesContext:
         - TrashbinContext:

--- a/tests/acceptance/config/behat-core.yml
+++ b/tests/acceptance/config/behat-core.yml
@@ -253,6 +253,8 @@ default:
         - FeatureContext: *common_feature_context_params
         - SearchContext:
         - PublicWebDavContext:
+        - SpacesContext:
+        - SharingNgContext:
         - WebDavPropertiesContext:
         - TrashbinContext:
         - OcisConfigContext:

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1871,7 +1871,7 @@ class PublicWebDavContext implements Context {
 		} else {
 			$body = null;
 		}
-		$token = $this->featureContext->getLastCreatedPublicShareToken();
+		$token = ($this->featureContext->isUsingSharingNG()) ? $this->featureContext->shareNgGetLastCreatedLinkShareToken() : $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			null,
 			null,

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5463,16 +5463,12 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldContainTheseNodes(TableNode $table):void {
-		if ($this->isUsingSharingNG()) {
-			$user = $this->shareNgGetLastCreatedLinkShareToken();
-		} else {
-			$user = $this->getLastCreatedPublicShareToken();
-		}
+		$token = ($this->isUsingSharingNG()) ? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
 			$path = $this->substituteInLineCodes($row['name']);
-			$res = $this->findEntryFromPropfindResponse($path, $user, $type);
+			$res = $this->findEntryFromPropfindResponse($path, $token, $type);
 			Assert::assertNotFalse($res, "expected $path to be in DAV response but was not found");
 		}
 	}
@@ -5486,12 +5482,12 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldNotContainTheseNodes(TableNode $table):void {
-		$user = $this->getLastCreatedPublicShareToken();
+		$token = ($this->isUsingSharingNG()) ? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
 			$path = $this->substituteInLineCodes($row['name']);
-			$res = $this->findEntryFromPropfindResponse($path, $user, $type);
+			$res = $this->findEntryFromPropfindResponse($path, $token, $type);
 			Assert::assertFalse($res, "expected $path to not be in DAV response but was found");
 		}
 	}

--- a/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
@@ -132,7 +132,11 @@ Feature: list files
       | path                                                                       |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3/simple-folder4 |
-    And user "Alice" has created a public link share of folder "simple-folder"
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | simple-folder |
+      | space           | Personal      |
+      | permissionsRole | view          |
     When the public lists the resources in the last created public link with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last public link DAV response should not contain these nodes
@@ -156,7 +160,11 @@ Feature: list files
       | path                                                                       |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3/simple-folder4 |
-    And user "Alice" has created a public link share of folder "simple-folder"
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | simple-folder |
+      | space           | Personal      |
+      | permissionsRole | view          |
     When the public lists the resources in the last created public link with depth "1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last public link DAV response should contain these nodes

--- a/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
@@ -48,10 +48,12 @@ Feature: PROPFIND
   Scenario: send PROPFIND request to a public link shared with password
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | read     |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | view     |
+      | password        | %public% |
     When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API with password "%public%"
     Then the HTTP status code should be "207"
     And the value of the item "//d:href" in the response should match "/%base_path%\/remote.php\/dav\/public-files\/%public_token%\/$/"
@@ -61,10 +63,12 @@ Feature: PROPFIND
   Scenario: send PROPFIND request to a public link shared with password (request without password)
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | read     |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | view     |
+      | password        | %public% |
     When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API
     Then the HTTP status code should be "401"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotAuthenticated"
@@ -73,10 +77,12 @@ Feature: PROPFIND
   Scenario: send PROPFIND request to a public link shared with password (request with incorrect password)
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT  |
-      | permissions | read     |
-      | password    | %public% |
+    And using SharingNG
+    And user "Alice" has created the following resource link share:
+      | resource        | PARENT   |
+      | space           | Personal |
+      | permissionsRole | view     |
+      | password        | %public% |
     When the public sends "PROPFIND" request to the last public link share using the new public WebDAV API with password "1234"
     Then the HTTP status code should be "401"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotAuthenticated"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Used sharingNG graph API in the given steps for sharing.

Suites covered:
- `coreApiWebdavOperations/`
  - `listFiles.feature`
  - `propfind.feature`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/8717

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
