### PR TITLE
Backport to stable 5: Update wopi tag to 10.4.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -946,7 +946,7 @@ def wopiValidatorTests(ctx, storage, accounts_hash_difficulty = 4):
                  [
                      {
                          "name": "wopiserver",
-                         "image": "cs3org/wopiserver:v10.3.0",
+                         "image": "cs3org/wopiserver:v10.4.0",
                          "detach": True,
                          "commands": [
                              "cp %s/tests/config/drone/wopiserver.conf /etc/wopi/wopiserver.conf" % (dirs["base"]),

--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -29,7 +29,7 @@ ADMIN_PASSWORD=
 DEMO_USERS=
 
 ### Wopi server settings ###
-# cs3org wopi server version. Defaults to "v8.3.3"
+# cs3org wopi server version. Defaults to "v10.4.0"
 WOPISERVER_DOCKER_TAG=
 # cs3org wopi server domain. Defaults to "wopiserver.owncloud.test"
 WOPISERVER_DOMAIN=

--- a/deployments/examples/ocis_wopi/docker-compose.yml
+++ b/deployments/examples/ocis_wopi/docker-compose.yml
@@ -174,7 +174,7 @@ services:
         condition: service_healthy
 
   wopiserver:
-    image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-v10.3.0}
+    image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-v10.4.0}
     networks:
       ocis-net:
     entrypoint:


### PR DESCRIPTION
Backport of #9182 (bump cs3org wopi server to 10.4.0)

I have tested this locally using 5.0.4 and no issues occurred. Creating and changing office documents worked.