### PR TITLE
feat: return Retry-After header in case of 429/Too Many Requests on thumbnail WebDAV endpoint

### DIFF
--- a/changelog/unreleased/thumbnail-request-limit.md
+++ b/changelog/unreleased/thumbnail-request-limit.md
@@ -4,3 +4,4 @@ The number of concurrent requests to the thumbnail service can be limited now
 to have more control over the consumed system resources.
 
 https://github.com/owncloud/ocis/pull/9199
+https://github.com/owncloud/ocis/pull/9240

--- a/ocis-pkg/middleware/throttle.go
+++ b/ocis-pkg/middleware/throttle.go
@@ -2,14 +2,28 @@ package middleware
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
 )
 
+func retryAfterFn(ctxDone bool) time.Duration {
+	if ctxDone {
+		return time.Minute
+	}
+	return time.Minute * 5
+}
+
 // Throttle limits the number of concurrent requests.
 func Throttle(limit int) func(http.Handler) http.Handler {
 	if limit > 0 {
-		return middleware.Throttle(limit)
+		opts := middleware.ThrottleOpts{
+			RetryAfterFn:   retryAfterFn,
+			Limit:          limit,
+			BacklogLimit:   0,
+			BacklogTimeout: time.Minute,
+		}
+		return middleware.ThrottleWithOpts(opts)
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description
https://github.com/owncloud/ocis/pull/9199#discussion_r1608337168

## Related Issue
https://github.com/owncloud/ocis/pull/9199#discussion_r1608337168

## Motivation and Context
https://github.com/owncloud/ocis/pull/9199#discussion_r1608337168

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
