### PR TITLE
fix(autoprovision): fixup the service name of the graph service

### DIFF
--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -282,7 +282,7 @@ func (c cs3backend) updateLibregraphUser(userid string, user libregraph.User) er
 
 func (c cs3backend) setupLibregraphClient(ctx context.Context, cs3token string) (*libregraph.APIClient, error) {
 	// Use micro registry to resolve next graph service endpoint
-	next, err := c.graphSelector.Select("com.owncloud.graph.graph")
+	next, err := c.graphSelector.Select("com.owncloud.web.graph")
 	if err != nil {
 		c.logger.Debug().Err(err).Msg("setupLibregraphClient: error during Select")
 		return nil, err


### PR DESCRIPTION
This is a fixup for commit 799b12b8dda00d860ad91a7143a8e06b2096d218 adjusting the service name of the graph service to the new value.

Closes: #9258

