### PR TITLE
feat: add exif panel options to web config struct

### DIFF
--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -127,6 +127,7 @@ func DefaultConfig() *config.Config {
 					},
 					Sidebar: config.Sidebar{
 						Shares: config.SidebarShares{},
+						Exif:   config.SidebarExif{},
 					},
 					Upload:                  &config.Upload{},
 					OpenLinksWithDefaultApp: true,

--- a/services/web/pkg/config/options.go
+++ b/services/web/pkg/config/options.go
@@ -43,11 +43,16 @@ type FeedbackLink struct {
 // Sidebar are the sidebar option
 type Sidebar struct {
 	Shares SidebarShares `json:"shares" yaml:"shares"`
+	Exif   SidebarExif   `json:"exif" yaml:"exif"`
 }
 
 // SidebarShares are the options for the shares sidebar
 type SidebarShares struct {
 	ShowAllOnLoad bool `json:"showAllOnLoad" yaml:"showAllOnLoad" env:"WEB_OPTION_SIDEBAR_SHARES_SHOW_ALL_ON_LOAD" desc:"Sets the list of the (link) shares list in the sidebar to be initially expanded. Default is a collapsed state, only showing the first three shares." introductionVersion:"pre5.0"`
+}
+
+type SidebarExif struct {
+	ShowLocation bool `json:"showLocation" yaml:"showLocation" env:"WEB_OPTION_SIDEBAR_EXIF_SHOW_LOCATION" desc:"Shows the location data in the EXIF sidebar panel. Default is the location data being shown." introductionVersion:"6.0"`
 }
 
 // Routing are the routing options


### PR DESCRIPTION
## Description
There is (will be) a new config option in web for hiding the location in the new image info sidebar panel. Adding the option to the web config struct, so that we disabling the location actually works (vanishes from the exposed config.json otherwise).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
