### PR TITLE
[full-ci] [tests-only] Used `expirationDateTime` key for graph api sharing steps

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -1688,7 +1688,7 @@ class GraphHelper {
 	 * @param array $shareTypes
 	 * @param string|null $permissionsRole
 	 * @param string|null $permissionsAction
-	 * @param string|null $expireDate
+	 * @param string|null $expirationDateTime
 	 *
 	 * @return array
 	 * @throws \Exception
@@ -1698,7 +1698,7 @@ class GraphHelper {
 		array $shareTypes,
 		?string $permissionsRole,
 		?string $permissionsAction,
-		?string $expireDate
+		?string $expirationDateTime
 	): array {
 		$body = [];
 
@@ -1719,8 +1719,8 @@ class GraphHelper {
 			$body['@libre.graph.permissions.actions'] = ['libre.graph/driveItem/' . $permissionsAction];
 		}
 
-		if ($expireDate !== null) {
-			$body['expirationDateTime'] = $expireDate;
+		if ($expirationDateTime !== null) {
+			$body['expirationDateTime'] = $expirationDateTime;
 		}
 		return $body;
 	}
@@ -1736,7 +1736,7 @@ class GraphHelper {
 	 * @param array $shareTypes
 	 * @param string|null $permissionsRole
 	 * @param string|null $permissionsAction
-	 * @param string|null $expireDate
+	 * @param string|null $expirationDateTime
 	 *
 	 * @return ResponseInterface
 	 * @throws \JsonException
@@ -1753,11 +1753,10 @@ class GraphHelper {
 		array $shareTypes,
 		?string $permissionsRole,
 		?string $permissionsAction,
-		?string $expireDate
+		?string $expirationDateTime
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/invite");
-		$body = self::createShareInviteBody($shareeIds, $shareTypes, $permissionsRole, $permissionsAction, $expireDate);
-
+		$body = self::createShareInviteBody($shareeIds, $shareTypes, $permissionsRole, $permissionsAction, $expirationDateTime);
 		return HttpRequestHelper::post(
 			$url,
 			$xRequestId,
@@ -2115,7 +2114,7 @@ class GraphHelper {
 	 * @param array $shareTypes
 	 * @param string|null $permissionsRole
 	 * @param string|null $permissionsAction
-	 * @param string|null $expireDate
+	 * @param string|null $expirationDateTime
 	 *
 	 * @return ResponseInterface
 	 * @throws \Exception|GuzzleException
@@ -2130,10 +2129,10 @@ class GraphHelper {
 		array $shareTypes,
 		?string $permissionsRole,
 		?string $permissionsAction,
-		?string $expireDate
+		?string $expirationDateTime
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/invite");
-		$body = self::createShareInviteBody($shareeIds, $shareTypes, $permissionsRole, $permissionsAction, $expireDate);
+		$body = self::createShareInviteBody($shareeIds, $shareTypes, $permissionsRole, $permissionsAction, $expirationDateTime);
 
 		return HttpRequestHelper::post(
 			$url,

--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -562,12 +562,12 @@ Feature: Send a sharing invitations
     Given user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following resource share invitation using the Graph API:
-      | resource        | <resource>               |
-      | space           | Personal                 |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | <permissions-role>       |
-      | expireDate      | 2043-07-15T14:00:00.000Z |
+      | resource           | <resource>               |
+      | space              | Personal                 |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | <permissions-role>       |
+      | expirationDateTime | 2043-07-15T14:00:00.000Z |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -658,12 +658,12 @@ Feature: Send a sharing invitations
     And user "Alice" has uploaded file with content "to share" to "/textfile1.txt"
     And user "Alice" has created folder "FolderToShare"
     When user "Alice" sends the following resource share invitation using the Graph API:
-      | resource        | <resource>               |
-      | space           | Personal                 |
-      | sharee          | grp1                     |
-      | shareType       | group                    |
-      | permissionsRole | <permissions-role>       |
-      | expireDate      | 2043-07-15T14:00:00.000Z |
+      | resource           | <resource>               |
+      | space              | Personal                 |
+      | sharee             | grp1                     |
+      | shareType          | group                    |
+      | permissionsRole    | <permissions-role>       |
+      | expirationDateTime | 2043-07-15T14:00:00.000Z |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """

--- a/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpaces.feature
@@ -345,11 +345,11 @@ Feature: Share spaces
 
   Scenario Outline: update the expiration date of a space in user share
     Given user "Alice" has sent the following space share invitation:
-      | space           | share space              |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | <space-role>             |
-      | expireDate      | 2042-03-25T23:59:59.000Z |
+      | space              | share space              |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | <space-role>             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" updates the space "share space" with settings:
       | shareWith  | Brian                         |
       | expireDate | 2044-01-01T23:59:59.999+01:00 |
@@ -367,11 +367,11 @@ Feature: Share spaces
     Given group "sales" has been created
     And the administrator has added a user "Brian" to the group "sales" using the Graph API
     And user "Alice" has sent the following space share invitation:
-      | space           | share space              |
-      | sharee          | sales                    |
-      | shareType       | group                    |
-      | permissionsRole | <space-role>             |
-      | expireDate      | 2042-03-25T23:59:59.000Z |
+      | space              | share space              |
+      | sharee             | sales                    |
+      | shareType          | group                    |
+      | permissionsRole    | <space-role>             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" updates the space "share space" with settings:
       | shareWith  | sales                         |
       | shareType  | 8                             |
@@ -388,11 +388,11 @@ Feature: Share spaces
 
   Scenario Outline: delete the expiration date of a space in user share
     Given user "Alice" has sent the following space share invitation:
-      | space           | share space              |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | <space-role>             |
-      | expireDate      | 2042-03-25T23:59:59.000Z |
+      | space              | share space              |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | <space-role>             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" updates the space "share space" with settings:
       | shareWith  | Brian              |
       | expireDate |                    |
@@ -410,11 +410,11 @@ Feature: Share spaces
     Given group "sales" has been created
     And the administrator has added a user "Brian" to the group "sales" using the Graph API
     And user "Alice" has sent the following space share invitation:
-      | space           | share space              |
-      | sharee          | sales                    |
-      | shareType       | group                    |
-      | permissionsRole | <space-role>             |
-      | expireDate      | 2042-03-25T23:59:59.000Z |
+      | space              | share space              |
+      | sharee             | sales                    |
+      | shareType          | group                    |
+      | permissionsRole    | <space-role>             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" updates the space "share space" with settings:
       | shareWith  | sales              |
       | shareType  | 8                  |
@@ -431,11 +431,11 @@ Feature: Share spaces
 
   Scenario Outline: check the end of expiration of a space in user share
     Given user "Alice" has sent the following space share invitation:
-      | space           | share space              |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | <space-role>             |
-      | expireDate      | 2042-03-25T23:59:59.000Z |
+      | space              | share space              |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | <space-role>             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" expires the user share of space "share space" for user "Brian"
     Then the HTTP status code should be "200"
     And the user "Brian" should not have a space called "share space"
@@ -450,11 +450,11 @@ Feature: Share spaces
     Given group "sales" has been created
     And the administrator has added a user "Brian" to the group "sales" using the Graph API
     And user "Alice" has sent the following space share invitation:
-      | space           | share space              |
-      | sharee          | sales                    |
-      | shareType       | group                    |
-      | permissionsRole | <space-role>             |
-      | expireDate      | 2042-03-25T23:59:59.000Z |
+      | space              | share space              |
+      | sharee             | sales                    |
+      | shareType          | group                    |
+      | permissionsRole    | <space-role>             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" expires the group share of space "share space" for group "sales"
     Then the HTTP status code should be "200"
     And the user "Brian" should not have a space called "share space"

--- a/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSubItemOfSpace.feature
@@ -125,12 +125,12 @@ Feature: Share a file or folder that is inside a space
   Scenario: user changes the expiration date
     Given using SharingNG
     And user "Alice" has sent the following resource share invitation:
-      | resource        | folder                   |
-      | space           | share sub-item           |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | Viewer                   |
-      | expireDate      | 2042-01-01T23:59:59.000Z |
+      | resource           | folder                   |
+      | space              | share sub-item           |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | Viewer                   |
+      | expirationDateTime | 2042-01-01T23:59:59.000Z |
     When user "Alice" changes the last share with settings:
       | expireDate | 2044-01-01T23:59:59.999+01:00 |
       | role       | viewer                        |
@@ -142,12 +142,12 @@ Feature: Share a file or folder that is inside a space
   Scenario: user deletes the expiration date
     Given using SharingNG
     And user "Alice" has sent the following resource share invitation:
-      | resource        | folder                   |
-      | space           | share sub-item           |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | Viewer                   |
-      | expireDate      | 2042-01-01T23:59:59.000Z |
+      | resource           | folder                   |
+      | space              | share sub-item           |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | Viewer                   |
+      | expirationDateTime | 2042-01-01T23:59:59.000Z |
     When user "Alice" changes the last share with settings:
       | expireDate |        |
       | role       | viewer |
@@ -160,12 +160,12 @@ Feature: Share a file or folder that is inside a space
     Given using OCS API version "<ocs_api_version>"
     And using SharingNG
     And user "Alice" has sent the following resource share invitation:
-      | resource        | folder                   |
-      | space           | share sub-item           |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | Viewer                   |
-      | expireDate      | 2042-01-01T23:59:59.000Z |
+      | resource           | folder                   |
+      | space              | share sub-item           |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | Viewer                   |
+      | expirationDateTime | 2042-01-01T23:59:59.000Z |
     When user "Alice" changes the last share with settings:
       | role |  |
     Then the HTTP status code should be "400"
@@ -174,12 +174,12 @@ Feature: Share a file or folder that is inside a space
   Scenario: check the end of expiration date in user share
     Given using SharingNG
     And user "Alice" has sent the following resource share invitation:
-      | resource        | folder                   |
-      | space           | share sub-item           |
-      | sharee          | Brian                    |
-      | shareType       | user                     |
-      | permissionsRole | Viewer                   |
-      | expireDate      | 2042-01-01T23:59:59.000Z |
+      | resource           | folder                   |
+      | space              | share sub-item           |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | Viewer                   |
+      | expirationDateTime | 2042-01-01T23:59:59.000Z |
     When user "Alice" expires the last share of resource "folder" inside of the space "share sub-item"
     Then the HTTP status code should be "200"
     And as "Brian" folder "Shares/folder" should not exist
@@ -190,12 +190,12 @@ Feature: Share a file or folder that is inside a space
     And using SharingNG
     And the administrator has added a user "Brian" to the group "sales" using the Graph API
     And user "Alice" has sent the following resource share invitation:
-      | resource        | folder                   |
-      | space           | share sub-item           |
-      | sharee          | sales                    |
-      | shareType       | group                    |
-      | permissionsRole | Viewer                   |
-      | expireDate      | 2042-01-01T23:59:59.000Z |
+      | resource           | folder                   |
+      | space              | share sub-item           |
+      | sharee             | sales                    |
+      | shareType          | group                    |
+      | permissionsRole    | Viewer                   |
+      | expirationDateTime | 2042-01-01T23:59:59.000Z |
     When user "Alice" expires the last share of resource "folder" inside of the space "share sub-item"
     Then the HTTP status code should be "200"
     And as "Brian" folder "Shares/folder" should not exist

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -289,7 +289,7 @@ class SharingNgContext implements Context {
 
 		$permissionsRole = $rows['permissionsRole'] ?? null;
 		$permissionsAction = $rows['permissionsAction'] ?? null;
-		$expireDate = $rows["expireDate"] ?? null;
+		$expirationDateTime = $rows["expirationDateTime"] ?? null;
 
 		$response = GraphHelper::sendSharingInvitation(
 			$this->featureContext->getBaseUrl(),
@@ -302,7 +302,7 @@ class SharingNgContext implements Context {
 			$shareTypes,
 			$permissionsRole,
 			$permissionsAction,
-			$expireDate
+			$expirationDateTime
 		);
 		if ($response->getStatusCode() === 200) {
 			$this->featureContext->shareNgAddToCreatedUserGroupShares($response);
@@ -354,7 +354,7 @@ class SharingNgContext implements Context {
 
 		$permissionsRole = $rows['permissionsRole'] ?? null;
 		$permissionsAction = $rows['permissionsAction'] ?? null;
-		$expireDate = $rows["expireDate"] ?? null;
+		$expirationDateTime = $rows["expirationDateTime"] ?? null;
 
 		return GraphHelper::sendSharingInvitationForDrive(
 			$this->featureContext->getBaseUrl(),
@@ -366,7 +366,7 @@ class SharingNgContext implements Context {
 			$shareTypes,
 			$permissionsRole,
 			$permissionsAction,
-			$expireDate
+			$expirationDateTime
 		);
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The key for an expiration date for creating a share invitation using a graph was `expireDate` and `expirationDateTime` in the feature file but the implementation was done for `expireDate`. So I refactored the step implementation and feature file and used the `expirationDateTime` everywhere for graph API.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/9124


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
