### PR TITLE
feat: web server compression

### DIFF
--- a/changelog/unreleased/enhancement-web-server-compression.md
+++ b/changelog/unreleased/enhancement-web-server-compression.md
@@ -1,0 +1,6 @@
+Enhancement: Web server compression
+
+We've added a compression middleware to the web server to reduce the request size when delivering static files. This speeds up loading times in web clients.
+
+https://github.com/owncloud/ocis/pull/9287
+https://github.com/owncloud/web/issues/7964

--- a/services/web/pkg/server/http/server.go
+++ b/services/web/pkg/server/http/server.go
@@ -99,6 +99,7 @@ func Server(opts ...Option) (http.Service, error) {
 		svc.Middleware(
 			chimiddleware.RealIP,
 			chimiddleware.RequestID,
+			chimiddleware.Compress(5),
 			middleware.NoCache,
 			webmid.SilentRefresh,
 			middleware.Version(


### PR DESCRIPTION
## Description
Adds a compression middleware to the web server to reduce the request size when delivering static files. This speeds up loading times in web clients.

The chi middleware we're using for this currently supports `gzip` as compression algorithm. We might want to extend this to support `br` (Brotli) in the future, since it's a newer and more performant algorithm. But for now, any compression is a big step up.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/7964

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
