### PR TITLE
[docs-only] Update storage-users README.md

### DIFF
--- a/services/storage-users/README.md
+++ b/services/storage-users/README.md
@@ -45,7 +45,7 @@ When using Infinite Scale as user storage, a directory named `storage/users/uplo
 
 Example cases for expired uploads:
 
-*   In the final step, the upload blob is moved from the upload area to the final blobstore (e.g. S3).
+*   When a user uploads a big file but the file exceeds the user-quota, the upload can't be moved to the target after it has finished. The file stays at the upload location until it is manually cleared.
 
 *   If the bandwidth is limited and the file to transfer can't be transferred completely before the upload expiration time is reached, the file expires and can't be processed.
 


### PR DESCRIPTION
References: #9228 ([docs-only] added the details to the 'Restore Trash-Bins Items' doc section')

Aligning one list item of `Example cases for expired uploads` to the admin docs.
The original sentence was confusing.

