### PR TITLE
Thumbnailer respect secure view

### DIFF
--- a/changelog/unreleased/prevent-thumbnailer-from-showing-secureview-previews.md
+++ b/changelog/unreleased/prevent-thumbnailer-from-showing-secureview-previews.md
@@ -1,0 +1,6 @@
+Bugfix: Don't show thumbnails for secureview shares
+
+We have fixed a bug where thumbnails were shown for secureview shares.
+
+https://github.com/owncloud/ocis/pull/9299
+https://github.com/owncloud/ocis/issues/9249

--- a/services/thumbnails/pkg/service/grpc/v0/service.go
+++ b/services/thumbnails/pkg/service/grpc/v0/service.go
@@ -123,6 +123,10 @@ func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetTh
 		return "", err
 	}
 
+	if !sRes.GetInfo().GetPermissionSet().GetInitiateFileDownload() {
+		return "", merrors.Forbidden(g.serviceID, "no download permission")
+	}
+
 	tType := thumbnail.GetExtForMime(sRes.GetInfo().GetMimeType())
 	if tType == "" {
 		tType = req.GetThumbnailType().String()
@@ -204,6 +208,10 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *thumbnailssvc.Ge
 	sRes, err := g.stat(statPath, auth)
 	if err != nil {
 		return "", err
+	}
+
+	if !sRes.GetInfo().GetPermissionSet().GetInitiateFileDownload() {
+		return "", merrors.Forbidden(g.serviceID, "no download permission")
 	}
 
 	tType := thumbnail.GetExtForMime(sRes.GetInfo().GetMimeType())

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -33,11 +33,6 @@ import (
 	"github.com/owncloud/ocis/v2/services/webdav/pkg/dav/requests"
 )
 
-func init() {
-	// register method with chi before any routing is set up
-	chi.RegisterMethod("REPORT")
-}
-
 var (
 	codesEnum = map[int]string{
 		http.StatusBadRequest:       "Sabre\\DAV\\Exception\\BadRequest",
@@ -94,6 +89,10 @@ func NewService(opts ...Option) (Service, error) {
 	if svc.config.DisablePreviews {
 		svc.thumbnailsClient = nil
 	}
+
+	// register method with chi before any routing is set up
+	chi.RegisterMethod("REPORT")
+
 	m.Route(options.Config.HTTP.Root, func(r chi.Router) {
 
 		if !svc.config.DisablePreviews {

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -261,6 +261,8 @@ func (g Webdav) SpacesThumbnail(w http.ResponseWriter, r *http.Request) {
 			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(e.Detail))
+		case http.StatusForbidden:
+			renderError(w, r, errPermissionDenied(e.Detail))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -354,6 +354,8 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 			return
 		case http.StatusBadRequest:
 			renderError(w, r, errBadRequest(e.Detail))
+		case http.StatusForbidden:
+			renderError(w, r, errPermissionDenied(e.Detail))
 		default:
 			renderError(w, r, errInternalError(err.Error()))
 		}
@@ -529,6 +531,10 @@ func errInternalError(msg string) *errResponse {
 
 func errBadRequest(msg string) *errResponse {
 	return newErrResponse(http.StatusBadRequest, msg)
+}
+
+func errPermissionDenied(msg string) *errResponse {
+	return newErrResponse(http.StatusForbidden, msg)
 }
 
 func errNotFound(msg string) *errResponse {


### PR DESCRIPTION
Bugfix: Don't show thumbnails for secureview shares.

We have fixed a bug where thumbnails were shown for secureview shares.

refs https://github.com/owncloud/ocis/issues/9249
