### PR TITLE
[tests-only] test: adjust tests related to issue 1667

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -186,23 +186,6 @@ _ocdav: api compatibility, return correct status code_
 - [coreApiAuth/webDavPUTAuth.feature:46](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavPUTAuth.feature#L46)
 - [coreApiAuth/webDavPUTAuth.feature:58](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavPUTAuth.feature#L58)
 
-#### [Using double slash in URL to access a folder gives 501 and other status codes](https://github.com/owncloud/ocis/issues/1667)
-
-- [coreApiAuth/webDavSpecialURLs.feature:15](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L15)
-- [coreApiAuth/webDavSpecialURLs.feature:26](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L26)
-- [coreApiAuth/webDavSpecialURLs.feature:78](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L78)
-- [coreApiAuth/webDavSpecialURLs.feature:90](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L90)
-- [coreApiAuth/webDavSpecialURLs.feature:102](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L102)
-- [coreApiAuth/webDavSpecialURLs.feature:113](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L113)
-- [coreApiAuth/webDavSpecialURLs.feature:123](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L123)
-- [coreApiAuth/webDavSpecialURLs.feature:134](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L134)
-- [coreApiAuth/webDavSpecialURLs.feature:144](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L144)
-- [coreApiAuth/webDavSpecialURLs.feature:155](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L155)
-- [coreApiAuth/webDavSpecialURLs.feature:165](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L165)
-- [coreApiAuth/webDavSpecialURLs.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L176)
-- [coreApiAuth/webDavSpecialURLs.feature:186](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L186)
-- [coreApiAuth/webDavSpecialURLs.feature:197](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature#L197)
-
 #### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis/issues/1286)
 
 - [coreApiCapabilities/capabilitiesWithNormalUser.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiCapabilities/capabilitiesWithNormalUser.feature#L13)

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2619,31 +2619,35 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the HTTP status code of responses on each endpoint should be :statusCode respectively
+	 * @Then the HTTP status code of responses on each endpoint should be :statusCodes respectively
 	 *
-	 * @param string $statusCodes
+	 * @param string $statusCodes a comma-separated string of expected HTTP status codes
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBe(string $statusCodes):void {
-		$statusCodes = \explode(',', $statusCodes);
-		$count = \count($statusCodes);
-		if ($count === \count($this->lastHttpStatusCodesArray)) {
+		$expectedStatusCodes = \explode(',', $statusCodes);
+		$actualStatusCodes = $this->lastHttpStatusCodesArray;
+		$count = \count($expectedStatusCodes);
+		$statusCodesAreAllOk = true;
+		if ($count === \count($actualStatusCodes)) {
 			for ($i = 0; $i < $count; $i++) {
-				Assert::assertSame(
-					(int)\trim($statusCodes[$i]),
-					(int)$this->lastHttpStatusCodesArray[$i],
-					'Responses did not return expected HTTP status code'
-				);
+				$expectedCode = (int)\trim($expectedStatusCodes[$i]);
+				$actualCode = (int)$actualStatusCodes[$i];
+				if ($expectedCode !== $actualCode) {
+					$statusCodesAreAllOk = false;
+				}
 			}
-			$this->emptyLastHTTPStatusCodesArray();
 		} else {
-			throw new Exception(
-				'Expected HTTP status codes: "' . \implode(',', $statusCodes) .
-				'". Found HTTP status codes: "' . \implode(',', $this->lastHttpStatusCodesArray) . '"'
-			);
+			$statusCodesAreAllOk = false;
 		}
+		$this->emptyLastHTTPStatusCodesArray();
+		Assert::assertTrue(
+			$statusCodesAreAllOk,
+			'Expected HTTP status codes: "' . $statusCodes .
+			'". Found HTTP status codes: "' . \implode(',', $actualStatusCodes) . '"'
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature
+++ b/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature
@@ -20,7 +20,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "204"
+    Then the HTTP status code of responses on each endpoint should be "200,200,204,204,200" respectively
 
   @skipOnRevaMaster
   Scenario: send DELETE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -30,7 +30,7 @@ Feature: make webdav request with special urls
       | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
       | /remote.php//dav/spaces/%spaceid%/PARENT             |
       | //remote.php/dav//spaces/%spaceid%//FOLDER           |
-    Then the HTTP status code of responses on all endpoints should be "204"
+    Then the HTTP status code of responses on each endpoint should be "200,200,204,200" respectively
 
 
   Scenario: send GET requests to webDav endpoints with 2 slashes
@@ -84,7 +84,7 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%/PARENT4 |
       | /remote.php/dav/files/%username%//PARENT5  |
       | /remote.php/dav//files/%username%/PARENT6  |
-    Then the HTTP status code of responses on all endpoints should be "201"
+    Then the HTTP status code of responses on each endpoint should be "200,201,200,200,201,201" respectively
 
   @skipOnRevaMaster
   Scenario: send MKCOL requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -96,7 +96,7 @@ Feature: make webdav request with special urls
       | //remote.php/dav//spaces/%spaceid%/PARENT4 |
       | /remote.php/dav/spaces/%spaceid%//PARENT5  |
       | /remote.php/dav//spaces/%spaceid%/PARENT6  |
-    Then the HTTP status code of responses on all endpoints should be "201"
+    Then the HTTP status code of responses on each endpoint should be "200,201,200,200,201,201" respectively
 
 
   Scenario: send MOVE requests to webDav endpoints with 2 slashes
@@ -107,7 +107,7 @@ Feature: make webdav request with special urls
       | /remote.php/webdav//PARENT                           | /remote.php/webdav/PARENT1                           |
       | //remote.php/dav/files/%username%//PARENT1           | /remote.php/dav/files/%username%/PARENT2             |
       | /remote.php/dav//files/%username%/PARENT2/parent.txt | /remote.php/dav/files/%username%/PARENT2/parent1.txt |
-    Then the HTTP status code of responses on all endpoints should be "201"
+    Then the HTTP status code of responses on each endpoint should be "200,201,201,200,404" respectively
 
   @skipOnRevaMaster
   Scenario: send MOVE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -117,7 +117,7 @@ Feature: make webdav request with special urls
       | /remote.php/dav//spaces/%spaceid%/PARENT             | /remote.php/dav/spaces/%spaceid%/PARENT1             |
       | //remote.php/dav/spaces/%spaceid%//PARENT1           | /remote.php/dav/spaces/%spaceid%/PARENT2             |
       | //remote.php/dav/spaces/%spaceid%/PARENT2/parent.txt | /remote.php/dav/spaces/%spaceid%/PARENT2/parent1.txt |
-    Then the HTTP status code of responses on all endpoints should be "201"
+    Then the HTTP status code of responses on each endpoint should be "201,201,200,200" respectively
 
 
   Scenario: send POST requests to webDav endpoints with 2 slashes
@@ -128,7 +128,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "500" or "501"
+    Then the HTTP status code of responses on each endpoint should be "200,200,412,412,200" respectively
 
   @skipOnRevaMaster
   Scenario: send POST requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -138,7 +138,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
       | /remote.php//dav/spaces/%spaceid%/PARENT            |
       | //remote.php/dav//spaces/%spaceid%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "500" or "501"
+    Then the HTTP status code of responses on each endpoint should be "200,412,412,200" respectively
 
 
   Scenario: send PROPFIND requests to webDav endpoints with 2 slashes
@@ -149,7 +149,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "207"
+    Then the HTTP status code of responses on each endpoint should be "200,200,207,207,200" respectively
 
   @skipOnRevaMaster
   Scenario: send PROPFIND requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -159,7 +159,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
       | /remote.php//dav/spaces/%spaceid%/PARENT            |
       | //remote.php/dav//spaces/%spaceid%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "207"
+    Then the HTTP status code of responses on each endpoint should be "200,207,207,200" respectively
 
 
   Scenario: send PROPPATCH requests to webDav endpoints with 2 slashes
@@ -170,7 +170,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "207"
+    Then the HTTP status code of responses on each endpoint should be "200,200,400,400,200" respectively
 
   @skipOnRevaMaster
   Scenario: send PROPPATCH requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -180,7 +180,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
       | /remote.php//dav/spaces/%spaceid%/PARENT            |
       | //remote.php/dav//spaces/%spaceid%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "207"
+    Then the HTTP status code of responses on each endpoint should be "200,400,400,200" respectively
 
 
   Scenario: send PUT requests to webDav endpoints with 2 slashes
@@ -191,7 +191,7 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt     |
       | /remote.php/dav/files/%username%/textfile7.txt       |
       | //remote.php/dav/files/%username%/PARENT//parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "204" or "201"
+    Then the HTTP status code of responses on each endpoint should be "200,204,200,201,200" respectively
 
   @skipOnRevaMaster
   Scenario: send PUT requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -202,4 +202,4 @@ Feature: make webdav request with special urls
       | //remote.php//dav/spaces/%spaceid%/textfile1.txt     |
       | /remote.php/dav/spaces/%spaceid%/textfile7.txt       |
       | //remote.php/dav/spaces/%spaceid%/PARENT//parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "204" or "201"
+    Then the HTTP status code of responses on each endpoint should be "200,204,200,201,200" respectively


### PR DESCRIPTION
## Description
The issue was about test scenarios that send various unusual combinations of paths in the URL that have multiple `/` characters together - sending paths like `/remote.php//dav/spacessomeSpaceId/textfile1.txt`

Previously some of these were "crashing" the server and returning 5xx HTTP status codes. But that has been fixed "some time ago". The test scenarios had expectations for various 2xx and 4xx status codes, but the actual exact codes that are returned are a bit different from what was put in the tests. This PR adjusts the expected codes so that they match what really happens.

There are different codes like 200, 201, 204, 400, 404, 412 etc. because these kind of requests are, in a sense, all invalid. But it is also easy for a human to see what is intended by each request, and some server code paths are actually parsing and processing these requests fine, resulting in `2xx` codes and the file action being done. Others are rejected, quite rightly, by the server code - the "invalid" format of the path might mean that the server cannot find the resource (404), or rejects the request (412, precondition failed etc.). I think that it is OK that the server responds in slightly different ways to these "bad" things. A least it does not give a 500 response any more.

So this PR makes the test scenarios pass and "document" the current behavior. This way, we will know if some server code change causes a change in any of this behavior - the test scenario(s) will start failing.

I refactored test step `theHTTPStatusCodeOfResponsesOnEachEndpointShouldBe` so that it better reports what the expected and actual status codes were when there is a problem. That was helpful to me when changing the test scenasrio expectations, and should be helpful to future developers.

## Related Issue
- Fixes #1667 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
