### PR TITLE
graph: Small improvments for filtering users by role

### DIFF
--- a/services/graph/mocks/role_service.go
+++ b/services/graph/mocks/role_service.go
@@ -175,6 +175,80 @@ func (_c *RoleService_ListRoleAssignments_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// ListRoleAssignmentsFiltered provides a mock function with given fields: ctx, in, opts
+func (_m *RoleService) ListRoleAssignmentsFiltered(ctx context.Context, in *v0.ListRoleAssignmentsFilteredRequest, opts ...client.CallOption) (*v0.ListRoleAssignmentsResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRoleAssignmentsFiltered")
+	}
+
+	var r0 *v0.ListRoleAssignmentsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v0.ListRoleAssignmentsFilteredRequest, ...client.CallOption) (*v0.ListRoleAssignmentsResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *v0.ListRoleAssignmentsFilteredRequest, ...client.CallOption) *v0.ListRoleAssignmentsResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v0.ListRoleAssignmentsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *v0.ListRoleAssignmentsFilteredRequest, ...client.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RoleService_ListRoleAssignmentsFiltered_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRoleAssignmentsFiltered'
+type RoleService_ListRoleAssignmentsFiltered_Call struct {
+	*mock.Call
+}
+
+// ListRoleAssignmentsFiltered is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *v0.ListRoleAssignmentsFilteredRequest
+//   - opts ...client.CallOption
+func (_e *RoleService_Expecter) ListRoleAssignmentsFiltered(ctx interface{}, in interface{}, opts ...interface{}) *RoleService_ListRoleAssignmentsFiltered_Call {
+	return &RoleService_ListRoleAssignmentsFiltered_Call{Call: _e.mock.On("ListRoleAssignmentsFiltered",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *RoleService_ListRoleAssignmentsFiltered_Call) Run(run func(ctx context.Context, in *v0.ListRoleAssignmentsFilteredRequest, opts ...client.CallOption)) *RoleService_ListRoleAssignmentsFiltered_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]client.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(client.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*v0.ListRoleAssignmentsFilteredRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *RoleService_ListRoleAssignmentsFiltered_Call) Return(_a0 *v0.ListRoleAssignmentsResponse, _a1 error) *RoleService_ListRoleAssignmentsFiltered_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *RoleService_ListRoleAssignmentsFiltered_Call) RunAndReturn(run func(context.Context, *v0.ListRoleAssignmentsFilteredRequest, ...client.CallOption) (*v0.ListRoleAssignmentsResponse, error)) *RoleService_ListRoleAssignmentsFiltered_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListRoles provides a mock function with given fields: ctx, in, opts
 func (_m *RoleService) ListRoles(ctx context.Context, in *v0.ListBundlesRequest, opts ...client.CallOption) (*v0.ListBundlesResponse, error) {
 	_va := make([]interface{}, len(opts))

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -298,7 +298,7 @@ func (g Graph) GetUsers(w http.ResponseWriter, r *http.Request) {
 	expandAppRoleAssignments := slices.Contains(exp, "appRoleAssignments")
 	expandMemberOf := slices.Contains(exp, "memberOf")
 	for _, u := range users {
-		if expandAppRoleAssignments {
+		if expandAppRoleAssignments && u.AppRoleAssignments == nil {
 			u.AppRoleAssignments, err = g.fetchAppRoleAssignments(r.Context(), u.GetId())
 			if err != nil {
 				// TODO I think we should not continue here, see http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -82,7 +82,7 @@ func (g Graph) GetMe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// expand appRoleAssignments if requested
-	if slices.Contains(exp, "appRoleAssignments") {
+	if slices.Contains(exp, appRoleAssignments) {
 		var err error
 		me.AppRoleAssignments, err = g.fetchAppRoleAssignments(r.Context(), me.GetId())
 		if err != nil {
@@ -295,7 +295,7 @@ func (g Graph) GetUsers(w http.ResponseWriter, r *http.Request) {
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
-	expandAppRoleAssignments := slices.Contains(exp, "appRoleAssignments")
+	expandAppRoleAssignments := slices.Contains(exp, appRoleAssignments)
 	expandMemberOf := slices.Contains(exp, "memberOf")
 	for _, u := range users {
 		if expandAppRoleAssignments && u.AppRoleAssignments == nil {
@@ -539,7 +539,7 @@ func (g Graph) GetUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// expand appRoleAssignments if requested
-	if slices.Contains(exp, "appRoleAssignments") {
+	if slices.Contains(exp, appRoleAssignments) {
 		user.AppRoleAssignments, err = g.fetchAppRoleAssignments(r.Context(), user.GetId())
 		if err != nil {
 			logger.Debug().Err(err).Str("userid", user.GetId()).Msg("could not get appRoleAssignments for user")

--- a/services/graph/pkg/service/v0/users_filter.go
+++ b/services/graph/pkg/service/v0/users_filter.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	appRoleID = "appRoleId"
+	appRoleID          = "appRoleId"
+	appRoleAssignments = "appRoleAssignments"
 )
 
 func invalidFilterError() error {
@@ -237,7 +238,7 @@ func (g Graph) applyFilterLambda(ctx context.Context, req *godata.GoDataRequest,
 	switch nodes[0].Token.Value {
 	case "memberOf":
 		return g.applyLambdaMemberOfAny(ctx, req, nodes[1].Children)
-	case "appRoleAssignments":
+	case appRoleAssignments:
 		return g.applyLambdaAppRoleAssignmentAny(ctx, req, nodes[1].Children)
 	}
 	logger.Debug().Str("Token", nodes[0].Token.Value).Msg("unsupported relation for lambda filter")
@@ -349,7 +350,7 @@ func (g Graph) filterUsersByAppRoleID(ctx context.Context, req *godata.GoDataReq
 	var expand bool
 	if exp := req.Query.GetExpand(); exp != nil {
 		for _, item := range exp.ExpandItems {
-			if item.Path[0].Value == "appRoleAssignments" {
+			if item.Path[0].Value == appRoleAssignments {
 				expand = true
 				break
 			}
@@ -405,7 +406,7 @@ func (g Graph) isAppRoleAssignmentFilter(ctx context.Context, node *godata.Parse
 		return false, "", ""
 	}
 
-	if node.Children[0].Token.Type != godata.ExpressionTokenLiteral || node.Children[0].Token.Value != "appRoleAssignments" {
+	if node.Children[0].Token.Type != godata.ExpressionTokenLiteral || node.Children[0].Token.Value != appRoleAssignments {
 		return false, "", ""
 	}
 

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -517,6 +517,16 @@ var _ = Describe("Users", func() {
 			identityBackend.On("GetGroupMembers", mock.Anything, "25cb7bc0-3168-4a0c-adbe-396f478ad494", mock.Anything).Return(users, nil)
 			identityBackend.On("GetGroupMembers", mock.Anything, "2713f1d5-6822-42bd-ad56-9f6c55a3a8fa", mock.Anything).Return([]*libregraph.User{}, nil)
 			identityBackend.On("GetUsers", mock.Anything, mock.Anything).Return([]*libregraph.User{user}, nil)
+			roleService.On("ListRoleAssignmentsFiltered", mock.Anything, mock.Anything, mock.Anything).
+				Return(func(ctx context.Context, in *settings.ListRoleAssignmentsFilteredRequest, opts ...client.CallOption) *settings.ListRoleAssignmentsResponse {
+					return &settings.ListRoleAssignmentsResponse{Assignments: []*settingsmsg.UserRoleAssignment{
+						{
+							Id:          "some-appRoleAssignment-ID",
+							AccountUuid: user.GetId(),
+							RoleId:      "some-appRole-ID",
+						},
+					}}
+				}, nil)
 			roleService.On("ListRoleAssignments", mock.Anything, mock.Anything, mock.Anything).
 				Return(func(ctx context.Context, in *settings.ListRoleAssignmentsRequest, opts ...client.CallOption) *settings.ListRoleAssignmentsResponse {
 					return &settings.ListRoleAssignmentsResponse{Assignments: []*settingsmsg.UserRoleAssignment{


### PR DESCRIPTION
This addresses some low hanging fruits for improving the GetUsers call when filtering users by role-assignment (and expanding the assignments).

The first commit avoids a lot of extra queries to the settings service when `$expand=appRoleAssignment` is used together with filtering.

The second commit switch the filtering code to use the new ListRoleAssignmentsFiltered request in the settings service. Reducing the number of queries to the settings service to a single request. (Orignally it was one per existing user + one per user that matched the filter).

On my system with 1000 users (external LDAP) assigned to the `User` role and the metadata service using and NFS volume the query time for: `$filter=(appRoleAssignments/any(m:m/appRoleId eq 'd7beeea8-8ff4-406b-8fb6-ab2dd81e6b11'))&$orderby=displayName&$expand=appRoleAssignments` (the query used by web). I get this:

Cold Caches:
master: ~18s
this pr: ~14s

Hot Caches (mainly the settings service's cache and the kernel's buffercache):
master 0.8s
this pr: 0.4s

So the overall improvement isn't all that big yet (mainly because the settings service itself still needs to scan all assignments in the metadata backend in order to apply the filter). Still, there is some improvement.

Related Issue: #8938 
