### PR TITLE
test: check for status codes that are different on oCIS and reva

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -26,6 +26,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Stream\StreamInterface;
+use TestHelpers\OcisHelper;
 use TestHelpers\UploadHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
@@ -2619,14 +2620,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the HTTP status code of responses on each endpoint should be :statusCodes respectively
-	 *
 	 * @param string $statusCodes a comma-separated string of expected HTTP status codes
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBe(string $statusCodes):void {
+	public function checkTheHTTPStatusCodeOfResponsesOnEachEndpoint(string $statusCodes):void {
 		$expectedStatusCodes = \explode(',', $statusCodes);
 		$actualStatusCodes = $this->lastHttpStatusCodesArray;
 		$count = \count($expectedStatusCodes);
@@ -2648,6 +2647,36 @@ trait WebDav {
 			'Expected HTTP status codes: "' . $statusCodes .
 			'". Found HTTP status codes: "' . \implode(',', $actualStatusCodes) . '"'
 		);
+	}
+
+	/**
+	 * @Then the HTTP status code of responses on each endpoint should be :statusCodes respectively
+	 *
+	 * @param string $statusCodes a comma-separated string of expected HTTP status codes
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBe(string $statusCodes):void {
+		$this->checkTheHTTPStatusCodeOfResponsesOnEachEndpoint($statusCodes);
+	}
+
+	/**
+	 * @Then the HTTP status code of responses on each endpoint should be :ocisStatusCodes on oCIS or :revaStatusCodes on reva
+	 *
+	 * @param string $ocisStatusCodes a comma-separated string of expected HTTP status codes when running on oCIS
+	 * @param string $revaStatusCodes a comma-separated string of expected HTTP status codes when running on reva
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBeOcisReva(string $ocisStatusCodes, string $revaStatusCodes):void {
+		if (OcisHelper::isTestingOnReva()) {
+			$expectedStatusCodes = $revaStatusCodes;
+		} else {
+			$expectedStatusCodes = $ocisStatusCodes;
+		}
+		$this->checkTheHTTPStatusCodeOfResponsesOnEachEndpoint($expectedStatusCodes);
 	}
 
 	/**

--- a/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature
+++ b/tests/acceptance/features/coreApiAuth/webDavSpecialURLs.feature
@@ -20,7 +20,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER          |
-    Then the HTTP status code of responses on each endpoint should be "200,200,204,204,200" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,200,204,204,200" on oCIS or "204,204,204,204,204" on reva
 
   @skipOnRevaMaster
   Scenario: send DELETE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -30,7 +30,7 @@ Feature: make webdav request with special urls
       | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
       | /remote.php//dav/spaces/%spaceid%/PARENT             |
       | //remote.php/dav//spaces/%spaceid%//FOLDER           |
-    Then the HTTP status code of responses on each endpoint should be "200,200,204,200" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,200,204,200" on oCIS or "204,204,204,204" on reva
 
 
   Scenario: send GET requests to webDav endpoints with 2 slashes
@@ -84,7 +84,7 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%/PARENT4 |
       | /remote.php/dav/files/%username%//PARENT5  |
       | /remote.php/dav//files/%username%/PARENT6  |
-    Then the HTTP status code of responses on each endpoint should be "200,201,200,200,201,201" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,201,200,200,201,201" on oCIS or "201,201,201,201,201,201" on reva
 
   @skipOnRevaMaster
   Scenario: send MKCOL requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -96,7 +96,7 @@ Feature: make webdav request with special urls
       | //remote.php/dav//spaces/%spaceid%/PARENT4 |
       | /remote.php/dav/spaces/%spaceid%//PARENT5  |
       | /remote.php/dav//spaces/%spaceid%/PARENT6  |
-    Then the HTTP status code of responses on each endpoint should be "200,201,200,200,201,201" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,201,200,200,201,201" on oCIS or "201,201,201,201,201,201" on reva
 
 
   Scenario: send MOVE requests to webDav endpoints with 2 slashes
@@ -107,7 +107,7 @@ Feature: make webdav request with special urls
       | /remote.php/webdav//PARENT                           | /remote.php/webdav/PARENT1                           |
       | //remote.php/dav/files/%username%//PARENT1           | /remote.php/dav/files/%username%/PARENT2             |
       | /remote.php/dav//files/%username%/PARENT2/parent.txt | /remote.php/dav/files/%username%/PARENT2/parent1.txt |
-    Then the HTTP status code of responses on each endpoint should be "200,201,201,200,404" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,201,201,200,404" on oCIS or "201,201,201,201,201" on reva
 
   @skipOnRevaMaster
   Scenario: send MOVE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -117,7 +117,7 @@ Feature: make webdav request with special urls
       | /remote.php/dav//spaces/%spaceid%/PARENT             | /remote.php/dav/spaces/%spaceid%/PARENT1             |
       | //remote.php/dav/spaces/%spaceid%//PARENT1           | /remote.php/dav/spaces/%spaceid%/PARENT2             |
       | //remote.php/dav/spaces/%spaceid%/PARENT2/parent.txt | /remote.php/dav/spaces/%spaceid%/PARENT2/parent1.txt |
-    Then the HTTP status code of responses on each endpoint should be "201,201,200,200" respectively
+    Then the HTTP status code of responses on each endpoint should be "201,201,200,200" on oCIS or "201,201,201,201" on reva
 
 
   Scenario: send POST requests to webDav endpoints with 2 slashes
@@ -149,7 +149,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER          |
-    Then the HTTP status code of responses on each endpoint should be "200,200,207,207,200" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,200,207,207,200" on oCIS or "207,207,207,207,207" on reva
 
   @skipOnRevaMaster
   Scenario: send PROPFIND requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -159,7 +159,7 @@ Feature: make webdav request with special urls
       | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
       | /remote.php//dav/spaces/%spaceid%/PARENT            |
       | //remote.php/dav//spaces/%spaceid%//FOLDER          |
-    Then the HTTP status code of responses on each endpoint should be "200,207,207,200" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,207,207,200" on oCIS or "207,207,207,207" on reva
 
 
   Scenario: send PROPPATCH requests to webDav endpoints with 2 slashes
@@ -191,7 +191,7 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt     |
       | /remote.php/dav/files/%username%/textfile7.txt       |
       | //remote.php/dav/files/%username%/PARENT//parent.txt |
-    Then the HTTP status code of responses on each endpoint should be "200,204,200,201,200" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,204,200,201,200" on oCIS or "204,204,204,201,204" on reva
 
   @skipOnRevaMaster
   Scenario: send PUT requests to webDav endpoints with 2 slashes using the spaces WebDAV API
@@ -202,4 +202,4 @@ Feature: make webdav request with special urls
       | //remote.php//dav/spaces/%spaceid%/textfile1.txt     |
       | /remote.php/dav/spaces/%spaceid%/textfile7.txt       |
       | //remote.php/dav/spaces/%spaceid%/PARENT//parent.txt |
-    Then the HTTP status code of responses on each endpoint should be "200,204,200,201,200" respectively
+    Then the HTTP status code of responses on each endpoint should be "200,204,200,201,200" on oCIS or "204,204,204,201,204" on reva


### PR DESCRIPTION
## Description
These test scenarios in `webDavSpecialURLs.feature` were recently updated to specify the actual HTTP status codes that are returned by oCIS. But when we run these scenarios on reva we get slightly different HTTP status codes.

These are tests for unusual edge-case calls to end-points, using double-slash in unexpected parts of the URL. The main thing is that these unusual cases do not "crash" the server, and they do return "some reasonable response". If oCIS and reva are a little different then it does not really matter.

A new step definition has been added that allows us to specify the HTTP status codes expected on oCIS and on reva as separate/different lists. That step definition is used in the tests to specify what we observe as the current behavior on oCIS and reva.

This problem was noticed when trying to bump the oCIS commit id in reva PR https://github.com/cs3org/reva/pull/4715

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
