### PR TITLE
fix: thumbnail max input height

### DIFF
--- a/changelog/unreleased/max-input-image.md
+++ b/changelog/unreleased/max-input-image.md
@@ -2,5 +2,6 @@ Change: Define maximum input image dimensions and size when generating previews
 
 This is a general hardening change to limit processing time and resources of the thumbnailer.
 
+https://github.com/owncloud/ocis/pull/9360
 https://github.com/owncloud/ocis/pull/9035
 https://github.com/owncloud/ocis/pull/9069

--- a/services/thumbnails/pkg/config/defaults/defaultconfig.go
+++ b/services/thumbnails/pkg/config/defaults/defaultconfig.go
@@ -50,7 +50,7 @@ func DefaultConfig() *config.Config {
 			CS3AllowInsecure:      false,
 			DataEndpoint:          "http://127.0.0.1:9186/thumbnails/data",
 			MaxInputWidth:         7680,
-			MaxInputHeight:        4320,
+			MaxInputHeight:        7680,
 			MaxInputImageFileSize: "50MB",
 		},
 	}


### PR DESCRIPTION
## Description
Thumbnail max input width and height need to be the same, because images can be portrait or landscape.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/9234

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
