### PR TITLE
[ci] upload artifacts of production, rolling or daily

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1268,25 +1268,28 @@ def logTracingResults():
 
 def dockerReleases(ctx):
     pipelines = []
+    docker_repos = []
 
     # dockerhub repo
     #  - "owncloud/ocis-rolling"
     repo = ctx.repo.slug + "-rolling"
+    docker_repos.append(repo)
 
     # production release repo
     if ctx.build.event == "tag" and ctx.build.ref.replace("refs/tags/v", "") in PRODUCTION_RELEASE_TAGS:
-        repo = ctx.repo.slug
+        docker_repos.append(ctx.repo.slug)
 
-    for arch in config["dockerReleases"]["architectures"]:
-        pipelines.append(dockerRelease(ctx, arch, repo))
+    for repo in docker_repos:
+        for arch in config["dockerReleases"]["architectures"]:
+            pipelines.append(dockerRelease(ctx, arch, repo))
 
-    manifest = releaseDockerManifest(repo)
-    manifest["depends_on"] = getPipelineNames(pipelines)
-    pipelines.append(manifest)
+        manifest = releaseDockerManifest(repo)
+        manifest["depends_on"] = getPipelineNames(pipelines)
+        pipelines.append(manifest)
 
-    readme = releaseDockerReadme(ctx, repo)
-    readme["depends_on"] = getPipelineNames(pipelines)
-    pipelines.append(readme)
+        readme = releaseDockerReadme(ctx, repo)
+        readme["depends_on"] = getPipelineNames(pipelines)
+        pipelines.append(readme)
 
     return pipelines
 

--- a/.drone.star
+++ b/.drone.star
@@ -1287,19 +1287,22 @@ def dockerReleases(ctx):
                 break
 
     for repo in docker_repos:
+        repo_pipelines = []
         if ctx.build.event == "tag":
             build_type = "rolling" if "rolling" in repo else "production"
 
         for arch in config["dockerReleases"]["architectures"]:
-            pipelines.append(dockerRelease(ctx, arch, repo, build_type))
+            repo_pipelines.append(dockerRelease(ctx, arch, repo, build_type))
 
         manifest = releaseDockerManifest(repo, build_type)
-        manifest["depends_on"] = getPipelineNames(pipelines)
-        pipelines.append(manifest)
+        manifest["depends_on"] = getPipelineNames(repo_pipelines)
+        repo_pipelines.append(manifest)
 
         readme = releaseDockerReadme(ctx, repo, build_type)
-        readme["depends_on"] = getPipelineNames(pipelines)
-        pipelines.append(readme)
+        readme["depends_on"] = getPipelineNames(repo_pipelines)
+        repo_pipelines.append(readme)
+
+        pipelines.extend(repo_pipelines)
 
     return pipelines
 

--- a/.drone.star
+++ b/.drone.star
@@ -1387,13 +1387,14 @@ def binaryRelease(ctx, name):
     target = "/ocis/%s/daily" % (ctx.repo.name.replace("ocis-", ""))
     depends_on = getPipelineNames(testOcisAndUploadResults(ctx) + testPipelines(ctx))
     if ctx.build.event == "tag":
-        # uploads binary to eg. https://download.owncloud.com/ocis/ocis/1.0.0-beta9/
-        folder = "stable"
+        # uploads binary to eg. https://download.owncloud.com/ocis/ocis/testing/1.0.0/
+        folder = "testing"
         buildref = ctx.build.ref.replace("refs/tags/v", "")
-        buildref = buildref.lower()
-        if buildref.find("-") != -1:  # "x.x.x-alpha", "x.x.x-beta", "x.x.x-rc"
-            folder = "testing"
-        target = "/ocis/%s/%s/%s" % (ctx.repo.name.replace("ocis-", ""), folder, buildref)
+        if buildref in PRODUCTION_RELEASE_TAGS:
+            # uploads binary to eg. https://download.owncloud.com/ocis/ocis/stable/2.0.0/
+            folder = "stable"
+
+        target = "/ocis/%s/%s/%s" % (ctx.repo.name.replace("ocis-", ""), folder, buildref.lower())
         depends_on = []
 
     settings = {

--- a/.drone.star
+++ b/.drone.star
@@ -5,7 +5,7 @@
 # NOTE: need to be updated if new production releases are determined
 # - follow semver
 # - omit 'v' prefix
-PRODUCTION_RELEASE_TAGS = ["5.0.0", "5.0.1", "5.0.2", "5.0.3", "7.0.0-rc.1", "7.0.0"]
+PRODUCTION_RELEASE_TAGS = ["5.0", "7.0.0"]
 
 # images
 ALPINE_GIT = "alpine/git:latest"
@@ -1281,8 +1281,10 @@ def dockerReleases(ctx):
     # production release repo
     if ctx.build.event == "tag":
         tag = ctx.build.ref.replace("refs/tags/v", "").lower()
-        if tag in PRODUCTION_RELEASE_TAGS:
-            docker_repos.append(ctx.repo.slug)
+        for prod_tag in PRODUCTION_RELEASE_TAGS:
+            if tag.startswith(prod_tag):
+                docker_repos.append(ctx.repo.slug)
+                break
 
     for repo in docker_repos:
         if ctx.build.event == "tag":
@@ -1412,11 +1414,14 @@ def binaryReleases(ctx):
             target = "%s/%s/%s" % (target_path, folder, buildref)
             targets.append(target)
 
-            if buildref in PRODUCTION_RELEASE_TAGS:
-                # uploads binary to eg. https://download.owncloud.com/ocis/ocis/stable/2.0.0/
-                folder = "stable"
-                target = "%s/%s/%s" % (target_path, folder, buildref)
-                targets.append(target)
+            for prod_tag in PRODUCTION_RELEASE_TAGS:
+                if buildref.startswith(prod_tag):
+                    # uploads binary to eg. https://download.owncloud.com/ocis/ocis/stable/2.0.0/
+                    folder = "stable"
+                    target = "%s/%s/%s" % (target_path, folder, buildref)
+                    targets.append(target)
+                    break
+
     else:
         targets.append(target)
 

--- a/.drone.star
+++ b/.drone.star
@@ -3,7 +3,9 @@
 
 # Production release tags
 # NOTE: need to be updated if new production releases are determined
-PRODUCTION_RELEASE_TAGS = ["5.0.0", "5.0.1", "5.0.2", "5.0.3", "7.0.0"]
+# - follow semver
+# - omit 'v' prefix
+PRODUCTION_RELEASE_TAGS = ["5.0.0", "5.0.1", "5.0.2", "5.0.3", "7.0.0-rc.1", "7.0.0"]
 
 # images
 ALPINE_GIT = "alpine/git:latest"
@@ -1277,8 +1279,10 @@ def dockerReleases(ctx):
     docker_repos.append(repo)
 
     # production release repo
-    if ctx.build.event == "tag" and ctx.build.ref.replace("refs/tags/v", "") in PRODUCTION_RELEASE_TAGS:
-        docker_repos.append(ctx.repo.slug)
+    if ctx.build.event == "tag":
+        tag = ctx.build.ref.replace("refs/tags/v", "").lower()
+        if tag in PRODUCTION_RELEASE_TAGS:
+            docker_repos.append(ctx.repo.slug)
 
     for repo in docker_repos:
         if ctx.build.event == "tag":

--- a/ocis/docker/manifest.production.tmpl
+++ b/ocis/docker/manifest.production.tmpl
@@ -1,0 +1,17 @@
+image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  - image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    platform:
+      architecture: arm64
+      variant: v8
+      os: linux

--- a/ocis/docker/manifest.tmpl
+++ b/ocis/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: owncloud/ocis-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -6,11 +6,11 @@ tags:
 {{/each}}
 {{/if}}
 manifests:
-  - image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+  - image: owncloud/ocis-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: owncloud/ocis:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+  - image: owncloud/ocis-rolling:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       variant: v8


### PR DESCRIPTION
## Description
This is a POC for deploying docker and binary build artifacts according to https://github.com/owncloud/ocis/issues/9264.

**What is known:**
- Production release docker tags: `owncloud/ocis:x.x.x`
- Rolling release docker tags: `owncloud/ocis-rolling:x.x.x` _(including production tags)_
- Production binary builds go to: `stable` subfolder
- Rolling binary builds go to: `rolling` subfolder
- Daily binary builds go to: `daily` subfolder

**Q?:**
- What kind of builds go to `testing` subfolder? Pre-releases - alpha, beta, rc?
- Docker tag for daily builds? `owncloud/ocis-rolling:latest`?
- What should happen to previous docker tags and binary builds? (move to respective docker repo and binary subfolders?) - not related to this PR though


**PR implementation:** tag release type from https://github.com/owncloud/ocis/issues/9264#issue-2318967021
- `commit push`:
  - docker-arm64-daily
  - docker-amd64-daily
  - manifest-daily
  - readme-daily
  - binaries-linux-daily
  - binaries-darwin-daily

- `v6.0.0-rc.1`:
  - docker-arm64-rolling
  - docker-amd64-rolling
  - manifest-rolling
  - readme-rolling
  - binaries-linux-testing
  - binaries-darwin-testing

- `v6.0.0`:
  - docker-arm64-rolling
  - docker-amd64-rolling
  - manifest-rolling
  - readme-rolling
  - binaries-linux-rolling
  - binaries-darwin-rolling

- `v7.0.0-rc.1`:
  - docker-arm64-rolling
  - docker-amd64-rolling
  - manifest-rolling
  - readme-rolling
  - docker-arm64-production
  - docker-amd64-production
  - manifest-production
  - readme-production
  - binaries-linux-testing
  - binaries-darwin-testing

- `v7.0.0`:
  - docker-arm64-rolling
  - docker-amd64-rolling
  - manifest-rolling
  - readme-rolling
  - docker-arm64-production
  - docker-amd64-production
  - manifest-production
  - readme-production
  - binaries-linux-rolling
  - binaries-darwin-rolling
  - binaries-linux-production
  - binaries-darwin-production


## Related Issue
- https://github.com/owncloud/ocis/issues/9264

## Motivation and Context

## How Has This Been Tested?
- :exclamation: END RESULT NOT TESTED

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
