### PR TITLE
enable multiple collaboration services for different apps by appending the appname to the collaboration service name

### DIFF
--- a/services/collaboration/pkg/command/version.go
+++ b/services/collaboration/pkg/command/version.go
@@ -24,14 +24,14 @@ func Version(cfg *config.Config) *cli.Command {
 			fmt.Println("")
 
 			reg := registry.GetRegistry()
-			services, err := reg.GetService(cfg.HTTP.Namespace + "." + cfg.Service.Name)
+			services, err := reg.GetService(cfg.HTTP.Namespace + "." + cfg.Service.Name + "-" + cfg.App.Name)
 			if err != nil {
-				fmt.Println(fmt.Errorf("could not get %s services from the registry: %v", cfg.Service.Name, err))
+				fmt.Println(fmt.Errorf("could not get %s services from the registry: %v", cfg.Service.Name+"-"+cfg.App.Name, err))
 				return err
 			}
 
 			if len(services) == 0 {
-				fmt.Println("No running " + cfg.Service.Name + " service found.")
+				fmt.Println("No running " + cfg.Service.Name + "-" + cfg.App.Name + " service found.")
 				return nil
 			}
 

--- a/services/collaboration/pkg/helpers/registration.go
+++ b/services/collaboration/pkg/helpers/registration.go
@@ -19,7 +19,7 @@ import (
 // There are no explicit requirements for the context, and it will be passed
 // without changes to the underlying RegisterService method.
 func RegisterOcisService(ctx context.Context, cfg *config.Config, logger log.Logger) error {
-	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name+"-"+cfg.App.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
 	return registry.RegisterService(ctx, svc, logger)
 }
 
@@ -62,7 +62,7 @@ func RegisterAppProvider(
 			Name:        cfg.App.Name,
 			Description: cfg.App.Description,
 			Icon:        cfg.App.Icon,
-			Address:     cfg.GRPC.Namespace + "." + cfg.Service.Name,
+			Address:     cfg.GRPC.Namespace + "." + cfg.Service.Name + "-" + cfg.App.Name,
 			MimeTypes:   mimeTypes,
 		},
 	}

--- a/services/collaboration/pkg/service/grpc/v0/service.go
+++ b/services/collaboration/pkg/service/grpc/v0/service.go
@@ -38,7 +38,7 @@ func NewHandler(opts ...Option) (*Service, func(), error) {
 	}
 
 	return &Service{
-		id:      options.Config.GRPC.Namespace + "." + options.Config.Service.Name,
+		id:      options.Config.GRPC.Namespace + "." + options.Config.Service.Name + "-" + options.Config.App.Name,
 		appURLs: options.AppURLs,
 		logger:  options.Logger,
 		config:  options.Config,


### PR DESCRIPTION
## Description

In https://github.com/owncloud/ocis-charts/pull/567 I was tring to start a collaboration service for each OnlyOffice and Collabora.

Therefore I found out that both are registering with the same service name and coulnd't be distinuished.

## Related Issue
- Having multiple collaboration apps on one instance

## Motivation and Context
- Having multiple collaboration apps on one instance

## How Has This Been Tested?
- run in Minikube with https://github.com/owncloud/ocis-charts/pull/567

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
