### PR TITLE
Collaboration proofkeys

### DIFF
--- a/services/collaboration/pkg/config/app.go
+++ b/services/collaboration/pkg/config/app.go
@@ -9,4 +9,11 @@ type App struct {
 
 	Addr     string `yaml:"addr" env:"COLLABORATION_APP_ADDR" desc:"The URL where the WOPI app is located, such as https://127.0.0.1:8080." introductionVersion:"%%NEXT%%"`
 	Insecure bool   `yaml:"insecure" env:"COLLABORATION_APP_INSECURE" desc:"Skip TLS certificate verification when connecting to the WOPI app" introductionVersion:"%%NEXT%%"`
+
+	ProofKeys ProofKeys `yaml:"proofkeys"`
+}
+
+type ProofKeys struct {
+	Disable  bool   `yaml:"disable" env:"COLLABORATION_APP_PROOF_DISABLE" desc:"Disable the proof keys verification" introductionVersion:"%%NEXT%%"`
+	Duration string `yaml:"duration" env:"COLLABORATION_APP_PROOF_DURATION" desc:"Duration for the proof keys to be cached in memory, using time.ParseDuration format. If the duration can't be parsed, we'll use the default 12h as duration" introductionVersion:"%%NEXT%%"`
 }

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -26,6 +26,10 @@ func DefaultConfig() *config.Config {
 			LockName:    "com.github.owncloud.collaboration",
 			Addr:        "https://127.0.0.1:9980",
 			Insecure:    false,
+			ProofKeys: config.ProofKeys{
+				// they'll be enabled by default
+				Duration: "12h",
+			},
 		},
 		GRPC: config.GRPC{
 			Addr:      "127.0.0.1:9301",

--- a/services/collaboration/pkg/middleware/proofkeys.go
+++ b/services/collaboration/pkg/middleware/proofkeys.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/owncloud/ocis/v2/services/collaboration/pkg/config"
+	"github.com/owncloud/ocis/v2/services/collaboration/pkg/proofkeys"
+	"github.com/rs/zerolog"
+)
+
+func ProofKeysMiddleware(cfg *config.Config, next http.Handler) http.Handler {
+	wopiDiscovery := cfg.App.Addr + "/hosting/discovery"
+	insecure := cfg.App.Insecure
+	cacheDuration, err := time.ParseDuration(cfg.App.ProofKeys.Duration)
+	if err != nil {
+		cacheDuration = 12 * time.Hour
+	}
+
+	pkHandler := proofkeys.NewVerifyHandler(wopiDiscovery, insecure, cacheDuration)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := zerolog.Ctx(r.Context())
+
+		// the url we need is the one being requested, but we need the
+		// scheme and host, so we'll get those from the configured WOPISrc
+		wopiSrcURL, _ := url.Parse(cfg.Wopi.WopiSrc)
+		currentURL, _ := url.Parse(r.URL.String())
+		currentURL.Scheme = wopiSrcURL.Scheme
+		currentURL.Host = wopiSrcURL.Host
+
+		accessToken := r.URL.Query().Get("access_token")
+		stamp := r.Header.Get("X-WOPI-TimeStamp")
+
+		err := pkHandler.Verify(
+			accessToken,
+			currentURL.String(),
+			stamp,
+			r.Header.Get("X-WOPI-Proof"),
+			r.Header.Get("X-WOPI-ProofOld"),
+			proofkeys.VerifyWithLogger(logger),
+		)
+		// Need to check that the timestamp was sent within the last 20 minutes
+
+		if err != nil {
+			logger.Error().Err(err).Msg("ProofKeys verification failed")
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		logger.Debug().Msg("ProofKeys verified")
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/services/collaboration/pkg/middleware/proofkeys.go
+++ b/services/collaboration/pkg/middleware/proofkeys.go
@@ -40,7 +40,6 @@ func ProofKeysMiddleware(cfg *config.Config, next http.Handler) http.Handler {
 			r.Header.Get("X-WOPI-ProofOld"),
 			proofkeys.VerifyWithLogger(logger),
 		)
-		// Need to check that the timestamp was sent within the last 20 minutes
 
 		if err != nil {
 			logger.Error().Err(err).Msg("ProofKeys verification failed")

--- a/services/collaboration/pkg/middleware/wopicontext.go
+++ b/services/collaboration/pkg/middleware/wopicontext.go
@@ -90,6 +90,9 @@ func WopiContextAuthMiddleware(jwtSecret string, next http.Handler) http.Handler
 		logger := zerolog.Ctx(ctx)
 		ctx = logger.With().
 			Str("WopiOverride", r.Header.Get("X-WOPI-Override")).
+			Str("WopiProof", r.Header.Get("X-WOPI-Proof")).
+			Str("WopiProofOld", r.Header.Get("X-WOPI-ProofOld")).
+			Str("WopiStamp", r.Header.Get("X-WOPI-TimeStamp")).
 			Str("FileReference", claims.WopiContext.FileReference.String()).
 			Str("ViewMode", claims.WopiContext.ViewMode.String()).
 			Str("Requester", claims.WopiContext.User.GetId().String()).

--- a/services/collaboration/pkg/proofkeys/handler.go
+++ b/services/collaboration/pkg/proofkeys/handler.go
@@ -1,0 +1,216 @@
+package proofkeys
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"github.com/beevik/etree"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+)
+
+type PubKeys struct {
+	Key    *rsa.PublicKey
+	OldKey *rsa.PublicKey
+}
+
+type Verifier interface {
+	Verify(accessToken, url, timestamp, sig64, oldSig64 string) error
+}
+
+type VerifyHandler struct {
+	discoveryURL string
+	insecure     bool
+	logger       log.Logger
+}
+
+func NewVerifyHandler(discoveryURL string, insecure bool, logger log.Logger) Verifier {
+	return &VerifyHandler{
+		discoveryURL: discoveryURL,
+		insecure:     insecure,
+		logger:       logger,
+	}
+}
+
+// Verify the request comes from a trusted source
+// All the provided parameters are strings:
+// * accessToken: The access token used for this request (targeting this collaboration service)
+// * url: The full url for this request, including scheme, host and all query parameters,
+// something like "https://wopiserver.test.private/wopi/file/abcbcbd?access_token=oiuiu" or
+// "http://wopiserver:8888/wopi/file/abcdef?access_token=zzxxyy"
+// * timestamp: The timestamp provided by the WOPI app in the "X-WOPI-TimeStamp" header, as string
+// * sig64: The base64-encoded signature, which should come directly from the "X-WOPI-Proof" header
+// * olSig64: The base64-encoded previous signature, coming from the "X-WOPI-ProofOld" header
+//
+// The public keys will be obtained from the /hosting/discovery path of the target WOPI app.
+// Note that the method will perform the following checks in that order:
+// * current signature with the current key
+// * old signature with the current key
+// * current signature with the old key
+// If all of those checks are wrong, the method will fail, and the request should be rejected.
+//
+// The method will return an error if something fails, or nil if everything is ok
+func (vh *VerifyHandler) Verify(accessToken, url, timestamp, sig64, oldSig64 string) error {
+	// need to decode the signatures
+	signature, err := base64.StdEncoding.DecodeString(sig64)
+	if err != nil {
+		return err
+	}
+
+	var oldSignature []byte
+	if oldSig64 != "" {
+		if oldSig, err := base64.StdEncoding.DecodeString(oldSig64); err != nil {
+			return nil
+		} else {
+			oldSignature = oldSig
+		}
+	}
+
+	// fetch the public keys
+	pubkeys, err := vh.fetchPublicKeys()
+	if err != nil {
+		return err
+	}
+
+	// build and hash the expected proof
+	expectedProof := vh.generateProof(accessToken, url, timestamp)
+	hashedProof := sha256.Sum256(expectedProof)
+
+	// verify
+	if err := rsa.VerifyPKCS1v15(pubkeys.Key, crypto.SHA256, hashedProof[:], signature); err != nil {
+		if err := rsa.VerifyPKCS1v15(pubkeys.Key, crypto.SHA256, hashedProof[:], oldSignature); err != nil {
+			if pubkeys.OldKey != nil {
+				return rsa.VerifyPKCS1v15(pubkeys.OldKey, crypto.SHA256, hashedProof[:], signature)
+			} else {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// generateProof will generated a expected proof to be verified later.
+// The method will return a slice of bytes with the proof (consider it binary
+// data).
+// The bytes will need to be hashed later in order to perform the verification
+func (vh *VerifyHandler) generateProof(accessToken, url, timestamp string) []byte {
+	tokenBytes := []byte(accessToken)
+	tokenLen := len(tokenBytes)
+	tokenLenBytes := big.NewInt(int64(tokenLen)).FillBytes(make([]byte, 4))
+
+	// url needs to be uppercase
+	urlBytes := []byte(strings.ToUpper(url))
+	urlLen := len(urlBytes)
+	urlLenBytes := big.NewInt(int64(urlLen)).FillBytes(make([]byte, 4))
+
+	stampBigInt, _ := new(big.Int).SetString(timestamp, 10)
+	stampBytes := stampBigInt.FillBytes(make([]byte, 8))
+	stampLen := len(stampBytes)
+	stampLenBytes := big.NewInt(int64(stampLen)).FillBytes(make([]byte, 4))
+
+	proof := new(bytes.Buffer)
+	proof.Write(tokenLenBytes)
+	proof.Write(tokenBytes)
+	proof.Write(urlLenBytes)
+	proof.Write(urlBytes)
+	proof.Write(stampLenBytes)
+	proof.Write(stampBytes)
+	return proof.Bytes()
+}
+
+// fetchPublicKeys will fetch the public keys from the /hosting/discovery URL
+// of the provided WOPI app.
+// It will return a PubKeys struct to hold the public keys based on the modulus
+// and exponent found.
+// The PubKeys returned might be either nil (with the non-nil error), or might
+// contain only a PubKeys.Key field (the PubKeys.OldKey might be nil)
+func (vh *VerifyHandler) fetchPublicKeys() (*PubKeys, error) {
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: vh.insecure,
+			},
+		},
+	}
+
+	httpResp, err := httpClient.Get(vh.discoveryURL)
+	if err != nil {
+		vh.logger.Error().
+			Err(err).
+			Str("WopiAppUrl", vh.discoveryURL).
+			Msg("WopiDiscovery: failed to access wopi app url")
+		return nil, err
+	}
+
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		vh.logger.Error().
+			Str("WopiAppUrl", vh.discoveryURL).
+			Int("HttpCode", httpResp.StatusCode).
+			Msg("WopiDiscovery: wopi app url failed with unexpected code")
+		return nil, err
+	}
+
+	doc := etree.NewDocument()
+	if _, err := doc.ReadFrom(httpResp.Body); err != nil {
+		return nil, err
+	}
+
+	root := doc.SelectElement("wopi-discovery")
+	if root == nil {
+		return nil, errors.New("wopi-discovery element not found in the XML body")
+	}
+
+	proofKey := root.SelectElement("proof-key")
+	if proofKey == nil {
+		return nil, errors.New("proof-key element not found in the XML body")
+	}
+
+	mod64 := proofKey.SelectAttrValue("modulus", "")
+	exp64 := proofKey.SelectAttrValue("exponent", "")
+	oldMod64 := proofKey.SelectAttrValue("oldmodulus", "")
+	oldExp64 := proofKey.SelectAttrValue("oldexponent", "")
+
+	if mod64 == "" || exp64 == "" {
+		return nil, errors.New("modulus or exponent not found in the proof-key element")
+	}
+
+	keys := &PubKeys{
+		Key: vh.keyFromBase64(mod64, exp64),
+	}
+
+	if oldMod64 != "" && oldExp64 != "" {
+		keys.OldKey = vh.keyFromBase64(oldMod64, oldExp64)
+	}
+
+	return keys, nil
+}
+
+// keyFromBase64 will create a rsa public key from the provided modulus and
+// exponent, both encoded with base64.
+// If any of the provided strings can't be decoded, nil will be returned.
+func (vh *VerifyHandler) keyFromBase64(mod64, exp64 string) *rsa.PublicKey {
+	dataMod, err := base64.StdEncoding.DecodeString(mod64)
+	if err != nil {
+		return nil
+	}
+
+	dataE, err := base64.StdEncoding.DecodeString(exp64)
+	if err != nil {
+		return nil
+	}
+
+	pub := &rsa.PublicKey{
+		N: new(big.Int).SetBytes(dataMod),
+		E: int(new(big.Int).SetBytes(dataE).Int64()),
+	}
+	return pub
+}

--- a/services/collaboration/pkg/proofkeys/option.go
+++ b/services/collaboration/pkg/proofkeys/option.go
@@ -1,0 +1,35 @@
+package proofkeys
+
+import (
+	"github.com/rs/zerolog"
+)
+
+// VerifyOption defines a single option function.
+type VerifyOption func(o *VerifyOptions)
+
+// VerifyOptions defines the available options for the Verify function.
+type VerifyOptions struct {
+	Logger *zerolog.Logger
+}
+
+// newOptions initializes the available default options.
+func newOptions(opts ...VerifyOption) VerifyOptions {
+	defaultLog := zerolog.Nop()
+	opt := VerifyOptions{
+		//Logger: log.NopLogger(), // use a NopLogger by default
+		Logger: &defaultLog, // use a NopLogger by default
+	}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	return opt
+}
+
+// VerifyWithLogger provides a function to set the Logger option.
+func VerifyWithLogger(val *zerolog.Logger) VerifyOption {
+	return func(o *VerifyOptions) {
+		o.Logger = val
+	}
+}

--- a/services/collaboration/pkg/server/http/server.go
+++ b/services/collaboration/pkg/server/http/server.go
@@ -118,8 +118,14 @@ func prepareRoutes(r *chi.Mux, options Options) {
 			r.Use(func(h stdhttp.Handler) stdhttp.Handler {
 				// authentication and wopi context
 				return colabmiddleware.WopiContextAuthMiddleware(options.Config.Wopi.Secret, h)
-			},
-			)
+			})
+
+			// check whether we should check for proof keys
+			if !options.Config.App.ProofKeys.Disable {
+				r.Use(func(h stdhttp.Handler) stdhttp.Handler {
+					return colabmiddleware.ProofKeysMiddleware(options.Config, h)
+				})
+			}
 
 			r.Get("/", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 				adapter.CheckFileInfo(w, r)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Add support for proof keys. These will be used to ensure that the calls coming to the collaboration service comes from a trusted source.

Most of the technical details can be found on https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/scenarios/proofkeys

The proofkeys verification will be enabled by default. This could cause problems if the WOPI app doesn't support the feature, it doesn't have the keys ready, or there are bugs in our side. In order to not disturb the system too much, this feature can be disabled on our side (collaboration service) so the verification won't happen and all the requests will be allowed. Note that you'll need to restart the collaboration service after changing its configuration.

In addition, the retrieved keys from the discovery (required for the verification) will be cached in memory for 12 hours by default. It's expected that the WOPI app rotates the keys so we'll need to fetch them again periodically. You can adjust the caching period in order to ensure we get updated keys periodically, otherwise the verification could fail.

## Related Issue
No open issue

## Motivation and Context
This should increase the security because all the allowed requests should come from a trusted source.

## How Has This Been Tested?
Manually tested with OnlyOffice

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
