### PR TITLE
[docs-only] Create new 'ocis_wopi_community' deployment example

### DIFF
--- a/deployments/examples/ocis_wopi_community/.env
+++ b/deployments/examples/ocis_wopi_community/.env
@@ -1,0 +1,125 @@
+# Define the docker compose log driver used.
+# Do not change until you know what you are doing.
+LOG_DRIVER=
+
+# If you're on an internet facing server. comment out following line.
+# It skips certificate validation for various parts of Infinite Scale and is
+# needed when self signed certificates are used.
+INSECURE=true
+
+
+### Traefik Settings ###
+
+# Serve Traefik dashboard.
+# Defaults to "false".
+TRAEFIK_DASHBOARD=
+
+# Domain of Traefik, where you can find the dashboard.
+# Defaults to "traefik.owncloud.test"
+TRAEFIK_DOMAIN=
+
+# Basic authentication for the traefik dashboard.
+# Defaults to user "admin" and password "admin" (written as: "admin:admin").
+TRAEFIK_BASIC_AUTH_USERS=
+
+# Email address for obtaining LetsEncrypt certificates.
+# Needs only be changed if this is a public facing server.
+TRAEFIK_ACME_MAIL=
+
+# Defaults to "https://acme-v02.api.letsencrypt.org/directory".
+# Set to the following for testing to check the certificate process:
+# "https://acme-staging-v02.api.letsencrypt.org/directory" 
+# With staging configured, there will be an SSL error in the browser.
+# When certificates are displayed and are emitted by # "Fake LE Intermediate X1",
+# the process went well and the envvar can be reset to empty to get valid certificates.
+TRAEFIK_ACME_CASERVER=
+
+
+### Infinite Scale Settings ###
+
+# The oCIS container version.
+# Defaults to "latest". It is recommended to use a stable version like 5.0.5.
+OCIS_DOCKER_TAG=
+
+# Domain of oCIS, where you can find the frontend.
+# Defaults to "ocis.owncloud.test"
+OCIS_DOMAIN=
+
+# oCIS admin user password. Defaults to "admin".
+ADMIN_PASSWORD=
+
+# Demo users should not be created on a production instance,
+# because their passwords are public. Defaults to "false".
+# Also see: https://doc.owncloud.com/ocis/latest/deployment/general/general-info.html#demo-users-and-groups
+DEMO_USERS=
+
+# Define the loglevel used.
+# For more details see:
+# https://doc.owncloud.com/ocis/latest/deployment/services/env-vars-special-scope.html
+LOG_LEVEL=
+
+# Define SMPT settings if you would like to send Infinite Scale email notifications.
+# For more details see:
+# https://doc.owncloud.com/ocis/latest/deployment/services/s-list/notifications.html
+
+# SMTP host to connect to.
+SMTP_HOST=
+
+# Port of the SMTP host to connect to.
+SMTP_PORT=
+
+# An eMail address that is used for sending Infinite Scale notification eMails
+# like "ocis notifications <noreply@yourdomain.com>".
+SMTP_SENDER=
+
+# Username for the SMTP host to connect to.
+SMTP_USERNAME=
+
+# Password for the SMTP host to connect to.
+SMTP_PASSWORD=
+
+# Authentication method for the SMTP communication.
+SMTP_AUTHENTICATION=
+
+# Allow insecure connections to the SMTP server. Defaults to false.
+SMTP_INSECURE=
+
+
+### Wopi Server Settings ###
+
+# cs3org WOPI Server Version.
+# Defaults to "v10.5.0"
+WOPISERVER_DOCKER_TAG=
+
+# cs3org WOPI Server Domain. Defaults to "wopiserver.owncloud.test"
+WOPISERVER_DOMAIN=
+
+# JWT secret which is used for the documents to be request by the WOPI client
+# from the cs3org WOPI server. Must be changed in order to have a secure WOPI server.
+# Defaults to "LoremIpsum567"
+WOPI_JWT_SECRET=
+
+
+### Collabora Settings ###
+
+# Domain of Collabora, where you can find the frontend.
+# Defaults to "collabora.owncloud.test"
+COLLABORA_DOMAIN=
+
+# Admin user for Collabora.
+# Defaults to blank. Provide one to enable access.
+# Collabora Admin Panel URL:
+# https://{COLLABORA_DOMAIN}/browser/dist/admin/admin.html
+COLLABORA_ADMIN_USER=
+
+# Admin password for Collabora.
+# Defaults to blank, provide one to enable access
+COLLABORA_ADMIN_PASSWORD=
+
+
+### Apache Tika Content Analysis Toolkit ###
+
+# Set the desired docker image tag or digest.
+# Defaults to "latest"
+TIKA_IMAGE=
+

--- a/deployments/examples/ocis_wopi_community/README.md
+++ b/deployments/examples/ocis_wopi_community/README.md
@@ -1,0 +1,2 @@
+Please refer to our [admin documentation](https://doc.owncloud.com/ocis/latest/depl-examples/ubuntu-compose/ubuntu-compose-eval.html#start-the-compose-setup)
+for instructions on how to deploy this community focused scenario.

--- a/deployments/examples/ocis_wopi_community/config/ocis/app-registry.yaml
+++ b/deployments/examples/ocis_wopi_community/config/ocis/app-registry.yaml
@@ -1,0 +1,65 @@
+app_registry:
+  mimetypes:
+  - mime_type: application/pdf
+    extension: pdf
+    name: PDF
+    description: PDF document
+    icon: ''
+    default_app: ''
+    allow_creation: false
+  - mime_type: application/vnd.oasis.opendocument.text
+    extension: odt
+    name: OpenDocument
+    description: OpenDocument text document
+    icon: ''
+    default_app: Collabora
+    allow_creation: true
+  - mime_type: application/vnd.oasis.opendocument.spreadsheet
+    extension: ods
+    name: OpenSpreadsheet
+    description: OpenDocument spreadsheet document
+    icon: ''
+    default_app: Collabora
+    allow_creation: true
+  - mime_type: application/vnd.oasis.opendocument.presentation
+    extension: odp
+    name: OpenPresentation
+    description: OpenDocument presentation document
+    icon: ''
+    default_app: Collabora
+    allow_creation: true
+  - mime_type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    extension: docx
+    name: Microsoft Word
+    description: Microsoft Word document
+    icon: ''
+    default_app: OnlyOffice
+    allow_creation: true
+  - mime_type: application/vnd.openxmlformats-officedocument.wordprocessingml.form
+    extension: docxf
+    name: Form Document
+    description: Form Document
+    icon: ''
+    default_app: OnlyOffice
+    allow_creation: true
+  - mime_type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+    extension: xlsx
+    name: Microsoft Excel
+    description: Microsoft Excel document
+    icon: ''
+    default_app: OnlyOffice
+    allow_creation: true
+  - mime_type: application/vnd.openxmlformats-officedocument.presentationml.presentation
+    extension: pptx
+    name: Microsoft PowerPoint
+    description: Microsoft PowerPoint document
+    icon: ''
+    default_app: OnlyOffice
+    allow_creation: true
+  - mime_type: application/vnd.jupyter
+    extension: ipynb
+    name: Jupyter Notebook
+    description: Jupyter Notebook
+    icon: ''
+    default_app: ''
+    allow_creation: true

--- a/deployments/examples/ocis_wopi_community/config/ocis/banned-password-list.txt
+++ b/deployments/examples/ocis_wopi_community/config/ocis/banned-password-list.txt
@@ -1,0 +1,5 @@
+password
+12345678
+123
+ownCloud
+ownCloud-1

--- a/deployments/examples/ocis_wopi_community/config/ocis/web.yaml
+++ b/deployments/examples/ocis_wopi_community/config/ocis/web.yaml
@@ -1,0 +1,11 @@
+web:
+  config:
+    external_apps:
+      - id: preview
+        path: web-app-preview
+        config:
+          mimeTypes:
+            - image/tiff
+            - image/bmp
+            - image/x-ms-bmp
+

--- a/deployments/examples/ocis_wopi_community/config/wopiserver/entrypoint-override.sh
+++ b/deployments/examples/ocis_wopi_community/config/wopiserver/entrypoint-override.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+echo "${WOPISECRET}" > /etc/wopi/wopisecret
+
+cp /etc/wopi/wopiserver.conf.dist /etc/wopi/wopiserver.conf
+sed -i 's/wopiserver.owncloud.test/'${WOPISERVER_DOMAIN}'/g' /etc/wopi/wopiserver.conf
+
+if [ "$WOPISERVER_INSECURE" = "true" ]; then
+    sed -i 's/sslverify\s=\sTrue/sslverify = False/g' /etc/wopi/wopiserver.conf
+fi
+
+/app/wopiserver.py

--- a/deployments/examples/ocis_wopi_community/config/wopiserver/wopiserver.conf.dist
+++ b/deployments/examples/ocis_wopi_community/config/wopiserver/wopiserver.conf.dist
@@ -1,0 +1,128 @@
+#
+# This config is based on https://github.com/cs3org/wopiserver/blob/master/wopiserver.conf
+#
+# wopiserver.conf
+#
+# Default configuration file for the WOPI server for oCIS
+#
+##############################################################
+
+[general]
+# Storage access layer to be loaded in order to operate this WOPI server
+# only "cs3" is supported with oCIS
+storagetype = cs3
+
+# Port where to listen for WOPI requests
+port = 8880
+
+# Logging level. Debug enables the Flask debug mode as well.
+# Valid values are: Debug, Info, Warning, Error.
+loglevel = Error
+loghandler = stream
+logdest = stdout
+
+# URL of your WOPI server or your HA proxy in front of it
+wopiurl = https://wopiserver.owncloud.test
+
+# URL for direct download of files. The complete URL that is sent
+# to clients will include the access_token argument
+downloadurl = https://wopiserver.owncloud.test/wopi/iop/download
+
+# The internal server engine to use (defaults to flask).
+# Set to waitress for production installations.
+internalserver = waitress
+
+# List of file extensions deemed incompatible with LibreOffice:
+# interoperable locking will be disabled for such files
+nonofficetypes = .md .zmd .txt .epd
+
+# List of file extensions to be supported by Collabora (deprecated)
+codeofficetypes = .odt .ott .ods .ots .odp .otp .odg .otg .doc .dot .xls .xlt .xlm .ppt .pot .pps .vsd .dxf .wmf .cdr .pages .number .key
+
+# WOPI access token expiration time [seconds]
+tokenvalidity = 86400
+
+# WOPI lock expiration time [seconds]
+wopilockexpiration = 3600
+
+# WOPI lock strict check: if True (default), WOPI locks will be compared according to specs,
+# that is their representation must match. False allows for a more relaxed comparison,
+# which compensates incorrect lock requests from Microsoft Office Online 2016-2018
+# on-premise setups.
+#wopilockstrictcheck = True
+
+# Enable support of rename operations from WOPI apps. This is currently
+# disabled by default as it has been observed that both MS Office and Collabora
+# Online do not play well with this feature.
+# Not supported with oCIS, must always be set to "False"
+enablerename = False
+
+# Detection of external Microsoft Office or LibreOffice locks. By default, lock files
+# compatible with Office for Desktop applications are detected, assuming that the
+# underlying storage can be mounted as a remote filesystem: in this case, WOPI GetLock
+# and SetLock operations return such locks and prevent online apps from entering edit mode.
+# This feature can be disabled in order to operate a pure WOPI server for online apps.
+# Not supported with oCIS, must always be set to "False"
+detectexternallocks = False
+
+# Location of the webconflict files. By default, such files are stored in the same path
+# as the original file. If that fails (e.g. because of missing permissions),
+# an attempt is made to store such files in this path if specified, otherwise
+# the system falls back to the recovery space (cf. io|recoverypath).
+# The keywords <user_initial> and <username> are replaced with the actual username's
+# initial letter and the actual username, respectively, so you can use e.g.
+# /your_storage/home/user_initial/username
+#conflictpath = /
+
+# ownCloud's WOPI proxy configuration. Disabled by default.
+#wopiproxy = https://external-wopi-proxy.com
+#wopiproxysecretfile = /path/to/your/shared-key-file
+#proxiedappname = Name of your proxied app
+
+[security]
+# Location of the secret files. Requires a restart of the
+# WOPI server when either the files or their content change.
+wopisecretfile = /etc/wopi/wopisecret
+# iop secret is not used for cs3 storage type
+#iopsecretfile = /etc/wopi/iopsecret
+
+# Use https as opposed to http (requires certificate)
+usehttps = no
+
+# Certificate and key for https. Requires a restart
+# to apply a change.
+wopicert = /etc/grid-security/host.crt
+wopikey = /etc/grid-security/host.key
+
+[bridge]
+# SSL certificate check for the connected apps
+sslverify = True
+
+# Minimal time interval between two consecutive save operations [seconds]
+#saveinterval = 200
+
+# Minimal time interval before a closed file is WOPI-unlocked [seconds]
+#unlockinterval = 90
+
+# CodiMD: disable creating zipped bundles when files contain pictures
+#disablezip = False
+
+[io]
+# Size used for buffered reads [bytes]
+chunksize = 4194304
+
+# Path to a recovery space in case of I/O errors when reaching to the remote storage.
+# This is expected to be a local path, and it is provided in order to ease user support.
+# Defaults to the indicated spool folder.
+recoverypath = /var/spool/wopirecovery
+
+[cs3]
+# Host and port of the Reva(-like) CS3-compliant GRPC gateway endpoint
+revagateway = ocis:9142
+
+# Reva/gRPC authentication token expiration time [seconds]
+# The default value matches Reva's default
+authtokenvalidity = 3600
+
+# SSL certificate check for Reva
+sslverify = True

--- a/deployments/examples/ocis_wopi_community/docker-compose.yml
+++ b/deployments/examples/ocis_wopi_community/docker-compose.yml
@@ -1,0 +1,206 @@
+---
+version: "3.7"
+
+services:
+  traefik:
+    image: traefik:v3.0.2
+    networks:
+      ocis-net:
+        aliases:
+          - ${OCIS_DOMAIN:-ocis.owncloud.test}
+          - ${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
+          - ${COLLABORA_DOMAIN:-collabora.owncloud.test}
+    command:
+      - "--log.level=${TRAEFIK_LOG_LEVEL:-ERROR}"
+      # letsencrypt configuration
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
+      - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
+      - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+      - "--certificatesresolvers.http.acme.caserver=${TRAEFIK_ACME_CASERVER:-https://acme-v02.api.letsencrypt.org/directory}"
+      # enable dashboard
+      - "--api.dashboard=true"
+      # define entrypoints
+      - "--entryPoints.http.address=:80"
+      - "--entryPoints.http.http.redirections.entryPoint.to=https"
+      - "--entryPoints.http.http.redirections.entryPoint.scheme=https"
+      - "--entryPoints.https.address=:443"
+      # docker provider (get configuration from container labels)
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+      - "--providers.docker.exposedByDefault=false"
+      # access log
+      - "--accessLog=true"
+      - "--accessLog.format=json"
+      - "--accessLog.fields.headers.names.X-Request-Id=keep"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock:ro"
+      - "certs:/certs"
+    labels:
+      - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
+      # basic authentication for the traefik dashboard, defaults to admin:admin
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$$apr1$$4vqie50r$$YQAmQdtmz5n9rEALhxJ4l.}"
+      - "traefik.http.routers.traefik.entrypoints=https"
+      - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.routers.traefik.middlewares=traefik-auth"
+      - "traefik.http.routers.traefik.tls.certresolver=http"
+      - "traefik.http.routers.traefik.service=api@internal"
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+
+  ocis:
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
+    networks:
+      ocis-net:
+    entrypoint:
+      - /bin/sh
+    # run ocis init to initialize a configuration file with random secrets
+    # it will fail on subsequent runs, because the config file already exists
+    # therefore we ignore the error and then start the ocis server
+    command: ["-c", "ocis init || true; ocis server"]
+    environment:
+      OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      OCIS_LOG_LEVEL: ${LOG_LEVEL:-info}
+      # do not use SSL between Traefik and oCIS
+      PROXY_TLS: "false"
+      # make the REVA gateway accessible to the app drivers
+      GATEWAY_GRPC_ADDR: 0.0.0.0:9142
+      # INSECURE: needed if oCIS / Traefik is using self generated certificates
+      OCIS_INSECURE: "${INSECURE:-false}"
+      # admin user password
+      # use the admin password from the configuration file if defined
+      IDM_ADMIN_PASSWORD: "${ADMIN_PASSWORD:-admin}"
+      # demo users
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
+      # fulltext search
+      SEARCH_EXTRACTOR_TYPE: tika
+      SEARCH_EXTRACTOR_TIKA_TIKA_URL: http://tika:9998
+      FRONTEND_FULL_TEXT_SEARCH_ENABLED: "true"
+      # email server (if configured)
+      NOTIFICATIONS_SMTP_HOST: "${SMTP_HOST}"
+      NOTIFICATIONS_SMTP_PORT: "${SMTP_PORT}"
+      NOTIFICATIONS_SMTP_SENDER: "${SMTP_SENDER}"
+      NOTIFICATIONS_SMTP_USERNAME: "${SMTP_USERNAME}"
+      NOTIFICATIONS_SMTP_INSECURE: "${SMTP_INSECURE}"
+      # other required configurations
+      MICRO_REGISTRY_ADDRESS: 127.0.0.1:9233
+      NATS_NATS_HOST: 0.0.0.0
+      NATS_NATS_PORT: 9233
+    volumes:
+      - ./config/ocis/app-registry.yaml:/etc/ocis/app-registry.yaml
+      - ./config/ocis/web.yaml:/etc/ocis/web.yaml
+      - ocis-config:/etc/ocis
+      - ocis-data:/var/lib/ocis
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ocis.entrypoints=https"
+      - "traefik.http.routers.ocis.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.routers.ocis.tls.certresolver=http"
+      - "traefik.http.routers.ocis.service=ocis"
+      - "traefik.http.services.ocis.loadbalancer.server.port=9200"
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+
+  ocis-appprovider-collabora:
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
+    networks:
+      ocis-net:
+    command: app-provider server
+    environment:
+      OCIS_LOG_LEVEL: ${LOG_LEVEL:-info}
+      APP_PROVIDER_GRPC_ADDR: 0.0.0.0:9164
+      # configure the service name to avoid collision with other app providers 
+      APP_PROVIDER_SERVICE_NAME: app-provider-collabora
+      # use the internal service name
+      APP_PROVIDER_EXTERNAL_ADDR: com.owncloud.api.app-provider-collabora
+      APP_PROVIDER_DRIVER: wopi
+      APP_PROVIDER_WOPI_APP_NAME: Collabora
+      APP_PROVIDER_WOPI_APP_ICON_URI: https://${COLLABORA_DOMAIN:-collabora.owncloud.test}/favicon.ico
+      APP_PROVIDER_WOPI_APP_URL: https://${COLLABORA_DOMAIN:-collabora.owncloud.test}
+      APP_PROVIDER_WOPI_INSECURE: "${INSECURE:-false}"
+      APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL: https://${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
+      APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      # share the registry with the ocis container
+      MICRO_REGISTRY_ADDRESS: ocis:9233
+    volumes:
+      - ocis-config:/etc/ocis
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+    depends_on:
+      ocis:
+        condition: service_started
+      collabora:
+        condition: service_healthy
+
+  wopiserver:
+    image: cs3org/wopiserver:${WOPISERVER_DOCKER_TAG:-v10.5.0}
+    networks:
+      ocis-net:
+    entrypoint:
+      - /bin/sh
+      - /entrypoint-override.sh
+    environment:
+      WOPISERVER_INSECURE: "${INSECURE:-false}"
+      WOPISECRET: ${WOPI_JWT_SECRET:-LoremIpsum567}
+      WOPISERVER_DOMAIN: ${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}
+    volumes:
+      - ./config/wopiserver/entrypoint-override.sh:/entrypoint-override.sh
+      - ./config/wopiserver/wopiserver.conf.dist:/etc/wopi/wopiserver.conf.dist
+      - wopi-recovery:/var/spool/wopirecovery
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wopiserver.entrypoints=https"
+      - "traefik.http.routers.wopiserver.rule=Host(`${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}`)"
+      - "traefik.http.routers.wopiserver.tls.certresolver=http"
+      - "traefik.http.routers.wopiserver.service=wopiserver"
+      - "traefik.http.services.wopiserver.loadbalancer.server.port=8880"
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+
+  collabora:
+    # this is the latest tested and functional collabora version
+    # other versions may be working but need pass testing first
+    image: collabora/code:23.05.10.1.1
+    networks:
+      ocis-net:
+    environment:
+      aliasgroup1: https://${WOPISERVER_DOMAIN:-wopiserver.owncloud.test}:443
+      DONT_GEN_SSL_CERT: "YES"
+      extra_params: --o:ssl.enable=false --o:ssl.termination=true --o:welcome.enable=false --o:net.frame_ancestors=${OCIS_DOMAIN:-ocis.owncloud.test}
+      username: ${COLLABORA_ADMIN_USER}
+      password: ${COLLABORA_ADMIN_PASSWORD}
+    cap_add:
+      - MKNOD
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.collabora.entrypoints=https"
+      - "traefik.http.routers.collabora.rule=Host(`${COLLABORA_DOMAIN:-collabora.owncloud.test}`)"
+      - "traefik.http.routers.collabora.tls.certresolver=http"
+      - "traefik.http.routers.collabora.service=collabora"
+      - "traefik.http.services.collabora.loadbalancer.server.port=9980"
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9980/hosting/discovery"]
+
+  tika:
+    image: ${TIKA_IMAGE:-apache/tika:latest-full}
+    networks:
+      ocis-net:
+    restart: always
+
+volumes:
+  certs:
+  ocis-config:
+  ocis-data:
+  wopi-recovery:
+
+networks:
+  ocis-net:
+


### PR DESCRIPTION
Fixes: #9388 (New community ready deployment example using WOPI necessary)

This PR adds a new deployment example that focuses on community use. It derives from the `ocis_wopi` example and contains the following changes:

* Removal of the following containers and their configuration:
   * Inbucket
   * Companion
   * Onlyoffice
* Removal of:
   * Supplemental monitoring
* Updating the following containers:
   * traefik: 2.9.1 --> 3.0.2
   * collabora: 23.05.5.2.1 --> 23.05.10.1.1
   Note that the latest version 24.x is not working as it cant update a file but you need to create a copy.
   * wopiserver: 10.4.0 --> 10.5.0
* Adding the possibility to configure ocis notifications (email)
* The `.env` file has been updated accordingly and readability improved
* The `compose` file has been updated accordingly and readability improved (only minor changes)
   * Note that "dead" envvars from the original example like `REVA_GATEWAY` have been removed as they were no longer available and therefore senseless.

Comments:
* This example is now much smaller compared to `ocis_wopi` 6.1GB --> 2.7GB.
* Only a few changes necessary in the prepared admin docs currently visible on staging (just working on it).
* This example is **only compatible** with ocis v5.0.5 but not with `latest`. Redirection to login hangs.

Tests:
- [x] Locally tested successfully using the `*.owncloud.test` domain (self signed certificates)
- [ ] A test using an own domain with Letsencrypt and SMTP settings is open

Imho, a double test check should be made @ScharfViktor 

Backport to `stable-5.0` necessary.

@tbsbdr @micbar 
