### PR TITLE
ci: do not build "latest" docker tag on prerelease

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1309,7 +1309,7 @@ def dockerReleases(ctx):
 def dockerRelease(ctx, arch, repo, build_type):
     build_args = [
         "REVISION=%s" % (ctx.build.commit),
-        "VERSION=%s" % (ctx.build.ref.replace("refs/tags/", "") if ctx.build.event == "tag" else "latest"),
+        "VERSION=%s" % (ctx.build.ref.replace("refs/tags/", "") if ctx.build.event == "tag" else "master"),
     ]
     depends_on = getPipelineNames(testOcisAndUploadResults(ctx) + testPipelines(ctx))
 


### PR DESCRIPTION
## Description
improvement of #9400 to avoid building `latest` tag on pre-releases 

## Related Issue


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`drone starlark --build.ref "refs/tags/v5.0.0" --repo.slug "owncloud/ocis" --build.event "tag" --max-execution-steps=10000000000 --format`

`drone starlark --build.ref "refs/tags/v5.0.0-alpha.1" --repo.slug "owncloud/ocis" --build.event "tag" --max-execution-steps=10000000000 --format`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
