### PR TITLE
[tests-only][full-ci] downloading file shared via secure view role

### DIFF
--- a/tests/acceptance/features/apiSpaces/filePreviews.feature
+++ b/tests/acceptance/features/apiSpaces/filePreviews.feature
@@ -61,6 +61,23 @@ Feature: Preview file in project space
       | filesForUpload/lorem.txt      | lorem.txt      |
 
 
+  Scenario Outline: download preview of shared file shared via Secure viewer permission role
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded a file from "<source>" to "<destination>" via TUS inside of the space "Alice Hansen" using the WebDAV API
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <destination> |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure viewer |
+    When user "Brian" downloads the preview of shared resource "/Shares/<destination>" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "403"
+    Examples:
+      | source                        | destination    |
+      | filesForUpload/testavatar.png | testavatar.png |
+      | filesForUpload/lorem.txt      | lorem.txt      |
+
+
   Scenario: download preview of file inside shared folder in project space
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a folder "folder" in space "previews of the files"

--- a/tests/acceptance/features/apiSpacesShares/shareOperations.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareOperations.feature
@@ -382,6 +382,33 @@ Feature: sharing
       | Uploader         |
 
 
+  Scenario: sharee cannot download file shared with Secure viewer permission by sharee
+    Given using old DAV path
+    And user "Alice" has uploaded file with content "hello world" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile.txt  |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure viewer |
+    And user "Brian" downloads file "/Shares/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+
+
+  Scenario: sharee cannot download file inside folder shared with Secure viewer permission by sharee
+    Given using old DAV path
+    And user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "hello world" to "FolderToShare/textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | FolderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure viewer |
+    And user "Brian" downloads file "/Shares/FolderToShare/textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+
+
   Scenario Outline: space admin tries to remove password of a public link share (change/create permission)
     Given using spaces DAV path
     And using OCS API version "<ocs-api-version>"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds scenario to download files shared via secure viewer role.
```feature
Scenario Outline: download preview of shared file shared via Secure viewer permission role
Scenario: sharee cannot download file shared with Secure viewer permission by share
Scenario: sharee cannot download file inside folder shared with Secure viewer permission by sharee
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/9334


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally and CI


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
