### PR TITLE
[full-ci]first api test for ocm

### DIFF
--- a/tests/TestHelpers/OcmHelper.php
+++ b/tests/TestHelpers/OcmHelper.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+/**
+ * ownCloud
+ *
+ * @author Viktor Scharf <scharf.vi@gmail.com>
+ * @copyright Copyright (c) 2024 Viktor Scharf <scharf.vi@gmail.com>
+ */
+
+namespace TestHelpers;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A helper class for managing federation server requests
+ */
+class OcmHelper {
+	/**
+	 * @return string[]
+	 */
+	private static function getRequestHeaders(): array {
+		return [
+			'Content-Type' => 'application/json',
+		];
+	}
+  
+	/**
+	 * @param string $baseUrl
+	 * @param string $path
+	 *
+	 * @return string
+	 */
+	public static function getFullUrl(string $baseUrl, string $path): string {
+		$fullUrl = $baseUrl;
+		if (\substr($fullUrl, -1) !== '/') {
+			$fullUrl .= '/';
+		}
+		$fullUrl .= 'sciencemesh/' . $path;
+		return $fullUrl;
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string|null $email
+	 * @param string|null $description
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function createInvitation(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		?string $email = null,
+		?string $description = null
+	): ResponseInterface {
+		$body['params'] = [
+		  "description" => $description,
+		  "recipient" => $email
+		];
+		$url = self::getFullUrl($baseUrl, 'generate-invite');
+		return HttpRequestHelper::post(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			\json_encode($body)
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $token
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function acceptInvitation(
+		string $baseUrl,
+		string $xRequestId,
+		string $user,
+		string $password,
+		string $token
+	): ResponseInterface {
+		$body = [
+		  "token" => $token,
+		  "providerDomain" => 'ocis-server'
+		];
+		$url = self::getFullUrl($baseUrl, 'accept-invite');
+		return HttpRequestHelper::post(
+			$url,
+			$xRequestId,
+			$user,
+			$password,
+			self::getRequestHeaders(),
+			\json_encode($body)
+		);
+	}
+}

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -357,6 +357,14 @@ default:
         - PublicWebDavContext:
         - OcisConfigContext:
 
+    apiOcm:
+      paths:
+        - "%paths.base%/../features/apiOcm"
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - OcmContext:
+
   extensions:
     rdx\behatvars\BehatVariablesExtension: ~
 

--- a/tests/acceptance/features/apiOcm/ocm.feature
+++ b/tests/acceptance/features/apiOcm/ocm.feature
@@ -1,0 +1,20 @@
+Feature: an user shares resources usin ScienceMesh application
+  As a user
+  I want to share resources between different ocis instances
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And using server "REMOTE"
+    And user "Brian" has been created with default attributes and without skeleton files
+
+
+  Scenario: user generates invitation 
+    Given using server "LOCAL"
+    When "Alice" generates invitation
+    Then the HTTP status code should be "200"
+    When using server "REMOTE"
+    And "Brian" accepts invitation
+    Then the HTTP status code should be "200"
+  

--- a/tests/acceptance/features/bootstrap/OcmContext.php
+++ b/tests/acceptance/features/bootstrap/OcmContext.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+/**
+ * @author Viktor Scharf <scharf.vi@gmail.com>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use GuzzleHttp\Exception\GuzzleException;
+use TestHelpers\OcisHelper;
+use TestHelpers\OcmHelper;
+
+/**
+ * Acceptance test steps related to testing sharing ng features
+ */
+class OcmContext implements Context {
+	private FeatureContext $featureContext;
+	private string $invitationToken;
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope): void {
+		if (OcisHelper::isTestingOnReva()) {
+			return;
+		}
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context from here
+		$this->featureContext = $environment->getContext('FeatureContext');
+	}
+
+	/**
+	 * @When :user generates invitation
+	 * @When :user generates invitation with email :email and description :description
+	 *
+	 * @param string $user
+	 * @param string $email
+	 * @param string $description
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userGeneratesInvitation(string $user, $email = null, $description = null): void {
+		$response = OcmHelper::createInvitation(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$email,
+			$description
+		);
+		$this->featureContext->setResponse($response);
+		$this->invitationToken = $this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())['token'];
+	}
+
+	/**
+	 * @When :user accepts invitation
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userAcceptsInvitation(string $user): void {
+		$response = OcmHelper::acceptInvitation(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$this->invitationToken
+		);
+		$this->featureContext->setResponse($response);
+	}
+}

--- a/tests/config/drone/providers.json
+++ b/tests/config/drone/providers.json
@@ -1,0 +1,46 @@
+[
+  {
+          "name": "ocis-server:9200",
+          "full_name": "first-ocis-instance",
+          "organization": "Owncloud",
+          "domain": "ocis-server",
+          "homepage": "https://owncloud.com",
+          "services": [
+                  {
+                          "endpoint": {
+                                  "type": {
+                                          "name": "OCM",
+                                          "description": "CERNBox Open Cloud Mesh API"
+                                  },
+                                  "name": "CERNBox - OCM API",
+                                  "path": "https://ocis-server:9200/ocm/",
+                                  "is_monitored": true
+                          },
+                          "api_version": "0.0.1",
+                          "host": "ocis-server:9200"
+                  }
+          ]
+  },
+  {
+          "name": "federation-ocis-server:9200",
+          "full_name": "Federation ocis",
+          "organization": "Owncloud",
+          "domain": "federation-ocis-server",
+          "homepage": "https://owncloud.com",
+          "services": [
+                  {
+                          "endpoint": {
+                                  "type": {
+                                          "name": "OCM",
+                                          "description": "CERNBox Open Cloud Mesh API"
+                                  },
+                                  "name": "CERNBox - OCM API",
+                                  "path": "https:federation-ocis-server:9200/ocm/",
+                                  "is_monitored": true
+                          },
+                          "api_version": "0.0.1",
+                          "host": "federation-ocis-server:9200"
+                  }
+          ]
+  }
+]


### PR DESCRIPTION
related #1329

how to start two ocis instances:

- create providers.json file:

<details>
<summary>  providers.json </summary>

```
[
        {
                "name": "localhost:9200",
                "full_name": "Local",
                "organization": "Owncloud",
                "domain": "localhost",
                "homepage": "https://owncloud.com",
                "services": [
                        {
                                "endpoint": {
                                        "type": {
                                                "name": "OCM",
                                                "description": "CERNBox Open Cloud Mesh API"
                                        },
                                        "name": "CERNBox - OCM API",
                                        "path": "https://localhost:9200/ocm/",
                                        "is_monitored": true
                                },
                                "api_version": "0.0.1",
                                "host": "localhost:9200"
                        }
                ]
        },
        {
                "name": "anotherlocalhost:10200",
                "full_name": "Local 10200",
                "organization": "Owncloud",
                "domain": "anotherlocalhost",
                "homepage": "https://owncloud.com",
                "services": [
                        {
                                "endpoint": {
                                        "type": {
                                                "name": "OCM",
                                                "description": "CERNBox Open Cloud Mesh API"
                                        },
                                        "name": "CERNBox - OCM API",
                                        "path": "https://anotherlocalhost:10200/ocm/",
                                        "is_monitored": true
                                },
                                "api_version": "0.0.1",
                                "host": "anotherlocalhost:10200"
                        }
                ]
        }
]
```

</details>

- put `127.0.0.1       anotherlocalhost` to `/etc/hosts`
- put `ocm` to https://github.com/owncloud/ocis/blob/master/services/web/pkg/config/defaults/defaultconfig.go#L101
- build ocis `make -C ocis clean generate build`
- start first instance https://localhost:9200: `PROXY_ENABLE_BASIC_AUTH=true OCIS_LOG_PRETTY=true IDM_CREATE_DEMO_USERS=true ADMIN_PASSWORD=admin FRONTEND_OCS_INCLUDE_OCM_SHAREES=true FRONTEND_OCS_LIST_OCM_SHARES=true FRONTEND_ENABLE_FEDERATED_SHARING_INCOMING=true FRONTEND_ENABLE_FEDERATED_SHARING_OUTGOING=true OCIS_ADD_RUN_SERVICES=ocm GRAPH_INCLUDE_OCM_SHAREES=true OCM_OCM_INVITE_MANAGER_INSECURE=true OCM_OCM_SHARE_PROVIDER_INSECURE=true OCM_OCM_STORAGE_PROVIDER_INSECURE=true OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE=providers.json ocis/bin/ocis server
`
- start second ocis instance https://anotherlocalhost:9200
using launch.json vscode: 


<details>
<summary> launch.json </summary>

```
{
          "name": "10200",
          "type": "go",
          "request": "launch",
          "mode": "debug",
          "program": "${workspaceFolder}/ocis/cmd/ocis/main.go",
          "args": ["server"],
          "env": {
              "OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE": "/Users/scharfviktor/Work/ocis/providers.json",
              "OCM_OCM_INVITE_MANAGER_INSECURE": "true",
              "OCM_OCM_SHARE_PROVIDER_INSECURE": "true",
              "OCM_OCM_STORAGE_PROVIDER_INSECURE": "true",
              "FRONTEND_OCS_INCLUDE_OCM_SHAREES": "true",
              "OCIS_BASE_DATA_PATH": "/Users/scharfviktor/.ocis-10200",
              "OCIS_CONFIG_DIR": "/Users/scharfviktor/.ocis-10200/config",
              "OCIS_EVENTS_ENDPOINT": "127.0.0.1:10233",
              "OCIS_LDAP_URI": "ldaps://localhost:10235",
              "OCIS_RUNTIME_PORT": "10250",
              "OCIS_URL": "https://anotherlocalhost:10200",
              // "OCIS_OIDC_ISSUER": "anotherlocalhost",
              "FRONTEND_OCS_LIST_OCM_SHARES": "true",
              "FRONTEND_ENABLE_FEDERATED_SHARING_INCOMING": "true",
              "FRONTEND_ENABLE_FEDERATED_SHARING_OUTGOING":"true",
              "OCIS_ADD_RUN_SERVICES": "ocm",
              "GRAPH_INCLUDE_OCM_SHAREES": "true",
              "APP_PROVIDER_DEBUG_ADDR": "127.0.0.1:10165",
              "APP_PROVIDER_GRPC_ADDR": "127.0.0.1:10164",
              "APP_REGISTRY_DEBUG_ADDR": "127.0.0.1:10243",
              "APP_REGISTRY_GRPC_ADDR": "127.0.0.1:10242",
              "AUTH_BASIC_DEBUG_ADDR": "127.0.0.1:10147",
              "AUTH_BASIC_GRPC_ADDR": "127.0.0.1:10146",
              "AUTH_MACHINE_DEBUG_ADDR": "127.0.0.1:10167",
              "AUTH_MACHINE_GRPC_ADDR": "127.0.0.1:10166",
              "AUTH_SERVICE_DEBUG_ADDR": "127.0.0.1:10169",
              "AUTH_SERVICE_GRPC_ADDR": "127.0.0.1:10199",
              "CLIENTLOG_DEBUG_ADDR": "127.0.0.1:10260",
              "EVENTHISTORY_DEBUG_ADDR": "127.0.0.1:10270",
              "FRONTEND_DEBUG_ADDR": "127.0.0.1:10141",
              "FRONTEND_HTTP_ADDR": "127.0.0.1:10140",
              "GATEWAY_DEBUG_ADDR": "127.0.0.1:10143",
              "GATEWAY_GRPC_ADDR": "127.0.0.1:10142",
              "GRAPH_DEBUG_ADDR": "127.0.0.1:10124",
              "GRAPH_HTTP_ADDR": "127.0.0.1:10120",
              "GROUPS_DEBUG_ADDR": "127.0.0.1:10161",
              "GROUPS_GRPC_ADDR": "127.0.0.1:10160",
              "IDM_DEBUG_ADDR": "127.0.0.1:10239",
              "IDM_LDAPS_ADDR": "127.0.0.1:10235",
              "IDP_DEBUG_ADDR": "127.0.0.1:10134",
              "IDP_HTTP_ADDR": "127.0.0.1:10130",
              "NATS_DEBUG_ADDR": "127.0.0.1:10234",
              "NATS_NATS_PORT": "10233",
              "OCDAV_DEBUG_ADDR": "127.0.0.1:10163",
              "OCM_DEBUG_ADDR": "127.0.0.1:10281",
              "OCM_HTTP_ADDR": "127.0.0.1:10280",
              "OCM_GRPC_ADDR": "127.0.0.1:10282",
              "OCS_DEBUG_ADDR": "127.0.0.1:10114",
              "OCS_HTTP_ADDR": "127.0.0.1:10110",
              "POSTPROCESSING_DEBUG_ADDR": "127.0.0.1:10255",
              "POSTPROCESSING_SERVICE_DEBUG_ADDR": "127.0.0.1:10255",
              "PROXY_DEBUG_ADDR": "127.0.0.1:10205",
              "PROXY_HTTP_ADDR": "127.0.0.1:10200",
              "SEARCH_DEBUG_ADDR": "127.0.0.1:10224",
              "SEARCH_GRPC_ADDR": "127.0.0.1:10220",
              "SETTINGS_DEBUG_ADDR": "127.0.0.1:10189",
              "SETTINGS_GRPC_ADDR": "127.0.0.1:10185",
              "SETTINGS_HTTP_ADDR": "127.0.0.1:10186",
              "SHARING_DEBUG_ADDR": "127.0.0.1:10151",
              "SHARING_GRPC_ADDR": "127.0.0.1:10150",
              "SSE_DEBUG_ADDR": "127.0.0.1:10135",
              "STORAGE_PUBLICLINK_DEBUG_ADDR": "127.0.0.1:10179",
              "STORAGE_PUBLICLINK_GRPC_ADDR": "127.0.0.1:10178",
              "STORAGE_SHARES_DEBUG_ADDR": "127.0.0.1:10156",
              "STORAGE_SHARES_GRPC_ADDR": "127.0.0.1:10154",
              "STORAGE_SYSTEM_DATA_SERVER_URL": "http://localhost:10216/data",
              "STORAGE_SYSTEM_DEBUG_ADDR": "127.0.0.1:10217",
              "STORAGE_SYSTEM_GRPC_ADDR": "127.0.0.1:10215",
              "STORAGE_SYSTEM_HTTP_ADDR": "127.0.0.1:10216",
              "STORAGE_USERS_DEBUG_ADDR": "127.0.0.1:10159",
              "STORAGE_USERS_GRPC_ADDR": "127.0.0.1:10157",
              "STORAGE_USERS_HTTP_ADDR": "127.0.0.1:10158",
              "STORAGE_USERS_DATA_SERVER_URL": "http://localhost:10158/data",
              "STORE_DEBUG_ADDR": "127.0.0.1:10464",
              "STORE_GRPC_ADDR": "127.0.0.1:10460",
              "THUMBNAILS_DEBUG_ADDR": "127.0.0.1:10194",
              "THUMBNAILS_GRPC_ADDR": "127.0.0.1:10191",
              "THUMBNAILS_HTTP_ADDR": "127.0.0.1:10190",
              "USERLOG_DEBUG_ADDR": "127.0.0.1:10210",
              "USERS_DEBUG_ADDR": "127.0.0.1:10145",
              "USERS_GRPC_ADDR": "127.0.0.1:10144",
              "WEB_DEBUG_ADDR": "localhost:10104",
              "WEB_HTTP_ADDR": "localhost:10100",
              "WEBDAV_DEBUG_ADDR": "127.0.0.1:10119",
              "WEBDAV_HTTP_ADDR": "127.0.0.1:10115",
              "OCIS_SERVICE_ACCOUNT_ID": "serviceaccount",
              "OCIS_SERVICE_ACCOUNT_SECRET": "serviceaccountsecret",
              "OCIS_DECOMPOSEDFS_PROPAGATOR": "async",
              "STORAGE_USERS_ASYNC_PROPAGATOR_PROPAGATION_DELAY": "10s",
              "TLS_INSECURE": "true",
              "OCIS_INSECURE": "true",
              "IDP_ACCESS_TOKEN_EXPIRATION": "9000",
              "GATEWAY_STORAGE_USERS_MOUNT_ID": "storage-users-1",
              "STORAGE_USERS_MOUNT_ID": "storage-users-1",
              "MICRO_REGISTRY": "memory",
              "SHARING_PUBLIC_DRIVER": "jsoncs3",
              "FRONTEND_OCS_RESOURCE_INFO_CACHE_TTL": "0",
              "OCIS_LOG_LEVEL": "info",
              "OCIS_LOG_PRETTY": "true",
              "OCIS_LOG_COLOR": "true",
              "PROXY_ENABLE_BASIC_AUTH": "true",
              "IDM_CREATE_DEMO_USERS": "true",
              "OCIS_ADMIN_USER_ID": "some-admin-user-id-0000-000000000000", // FIXME currently must have the length of a UUID, see reva/pkg/storage/utils/decomposedfs/spaces.go:228
              "IDM_ADMIN_PASSWORD": "admin",
              "OCIS_SYSTEM_USER_ID": "some-system-user-id-000-000000000000", // FIXME currently must have the length of a UUID, see reva/pkg/storage/utils/decomposedfs/spaces.go:228
              "OCIS_SYSTEM_USER_API_KEY": "some-system-user-machine-auth-api-key",
              "OCIS_JWT_SECRET": "some-ocis-jwt-secret",
              "OCIS_MACHINE_AUTH_API_KEY": "some-ocis-machine-auth-api-key",
              "OCIS_TRANSFER_SECRET": "some-ocis-transfer-secret",
              "IDM_SVC_PASSWORD": "some-ldap-idm-password",
              "GRAPH_LDAP_BIND_PASSWORD": "some-ldap-idm-password",
              "IDM_REVASVC_PASSWORD": "some-ldap-reva-password",
              "GROUPS_LDAP_BIND_PASSWORD": "some-ldap-reva-password",
              "USERS_LDAP_BIND_PASSWORD": "some-ldap-reva-password",
              "AUTH_BASIC_LDAP_BIND_PASSWORD": "some-ldap-reva-password",
              "IDM_IDPSVC_PASSWORD": "some-ldap-idp-password",
              "IDP_LDAP_BIND_PASSWORD": "some-ldap-idp-password",
              "GRAPH_APPLICATION_ID": "application-1"
          }
      },
```

</details>

- open ocis. go to 
<img width="285" alt="image" src="https://github.com/owncloud/ocis/assets/84779829/56c1a7dd-70f6-49ec-9b6e-3f9dccc353db">

