### PR TITLE
[tests-only][full-ci] extend test for trying to move file/folder within shared folder with secure view role

### DIFF
--- a/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
@@ -201,15 +201,16 @@ Feature: sharing
     But as "Alice" file "/folderToShare/fileInside" should not exist
 
 
-  Scenario: receiver tries to rename a received share with read permissions inside the Shares folder
+  Scenario Outline: receiver tries to rename a received share with read permissions inside the Shares folder
     Given user "Alice" has created folder "folderToShare"
+    And user "Alice" has created folder "folderToShare/folderInside"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
     And user "Alice" has sent the following resource share invitation:
-      | resource        | folderToShare |
-      | space           | Personal      |
-      | sharee          | Brian         |
-      | shareType       | user          |
-      | permissionsRole | Viewer        |
+      | resource        | folderToShare      |
+      | space           | Personal           |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
     When user "Brian" moves folder "/Shares/folderToShare" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "/Shares/myFolder" should exist
@@ -218,6 +219,14 @@ Feature: sharing
     Then the HTTP status code should be "403"
     And as "Brian" file "/Shares/myFolder/renamedFile" should not exist
     But as "Brian" file "Shares/myFolder/fileInside" should exist
+    When user "Brian" moves folder "/Shares/myFolder/folderInside" to "/Shares/myFolder/renamedFolder" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Brian" folder "/Shares/myFolder/renamedFolder" should not exist
+    But as "Brian" folder "Shares/myFolder/folderInside" should exist
+    Examples:
+      | permissions-role |
+      | Viewer           |
+      | Secure viewer    |
 
 
   Scenario: receiver renames a received folder share to a different name on the same folder


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR updates the previous scenarios regarding sharee trying to move file/folder within the shared folder with permission secure view too.
Scenario Updated:
```feature
Scenario: receiver tries to rename a received share with read permissions inside the Shares folder
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/9334

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
