### PR TITLE
[full-ci] chore: bump ownCloud Web to v8.0.3

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=f07b211627e9a6c9f31d398712c3ce919ce62429
+WEB_COMMITID=813436ccbb1cadefcf927e19272f7987d3850dcb
 WEB_BRANCH=stable-8.0

--- a/changelog/unreleased/update-web-8.0.3.md
+++ b/changelog/unreleased/update-web-8.0.3.md
@@ -1,0 +1,14 @@
+Enhancement: Update web to v8.0.3
+
+Tags: web
+
+We updated ownCloud Web to v8.0.3. Please refer to the changelog (linked) for details on the web release.
+
+- Bugfix [owncloud/web#10814](https://github.com/owncloud/web/issues/10814): Vertical scroll for OcModal on small screens
+- Bugfix [owncloud/web#10918](https://github.com/owncloud/web/issues/10918): Resource deselection on right-click
+- Bugfix [owncloud/web#10920](https://github.com/owncloud/web/pull/10920): Resources with name consist of number won't show up in trash bin
+- Bugfix [owncloud/web#10941](https://github.com/owncloud/web/issues/10941): Space not updating on navigation
+- Bugfix [owncloud/web#11063](https://github.com/owncloud/web/issues/11063): Enforce shortcut URL protocol
+
+https://github.com/owncloud/ocis/pull/9429
+https://github.com/owncloud/web/releases/tag/v8.0.3

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.2
+WEB_ASSETS_VERSION = v8.0.3
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
This is a bugfix release, please see the changelog for more details:

- Bugfix [owncloud/web#10814](https://github.com/owncloud/web/issues/10814): Vertical scroll for OcModal on small screens
- Bugfix [owncloud/web#10918](https://github.com/owncloud/web/issues/10918): Resource deselection on right-click
- Bugfix [owncloud/web#10920](https://github.com/owncloud/web/pull/10920): Resources with name consist of number won't show up in trash bin
- Bugfix [owncloud/web#10941](https://github.com/owncloud/web/issues/10941): Space not updating on navigation
- Bugfix [owncloud/web#11063](https://github.com/owncloud/web/issues/11063): Enforce shortcut URL protocol