### PR TITLE
Add `--fail` flag to consistency command

### DIFF
--- a/changelog/unreleased/consistency-fail-flag.md
+++ b/changelog/unreleased/consistency-fail-flag.md
@@ -1,0 +1,5 @@
+Enhancement: Add fail flag to consistency check
+
+We added a `--fail` flag to the `ocis backup consistency` command. If set to true, the command will return a non-zero exit code if any inconsistencies are found. This allows you to use the command in scripts and CI/CD pipelines to ensure that backups are consistent.
+
+https://github.com/owncloud/ocis/pull/9447

--- a/ocis/pkg/backup/backup.go
+++ b/ocis/pkg/backup/backup.go
@@ -60,7 +60,7 @@ func NewConsistency() *Consistency {
 }
 
 // CheckProviderConsistency checks the consistency of a space
-func CheckProviderConsistency(storagepath string, lbs ListBlobstore) error {
+func CheckProviderConsistency(storagepath string, lbs ListBlobstore, fail bool) error {
 	fsys := os.DirFS(storagepath)
 
 	p := NewProvider(fsys, storagepath, lbs)
@@ -71,7 +71,7 @@ func CheckProviderConsistency(storagepath string, lbs ListBlobstore) error {
 	c := NewConsistency()
 	c.GatherData(p.Events)
 
-	return c.PrintResults(storagepath)
+	return c.PrintResults(storagepath, fail)
 }
 
 // GatherData gathers and evaluates data produced by the DataProvider
@@ -134,7 +134,7 @@ func (c *Consistency) GatherData(events <-chan interface{}) {
 }
 
 // PrintResults prints the results of the evaluation
-func (c *Consistency) PrintResults(discpath string) error {
+func (c *Consistency) PrintResults(discpath string, fail bool) error {
 	if len(c.Nodes) != 0 {
 		fmt.Println("\n🚨 Inconsistent Nodes:")
 	}
@@ -161,6 +161,8 @@ func (c *Consistency) PrintResults(discpath string) error {
 	}
 	if len(c.Nodes) == 0 && len(c.LinkedNodes) == 0 && len(c.Blobs) == 0 && len(c.BlobReferences) == 0 {
 		fmt.Printf("💚 No inconsistency found. The backup in '%s' seems to be valid.\n", discpath)
+	} else if fail {
+		os.Exit(1)
 	}
 	return nil
 

--- a/ocis/pkg/command/backup.go
+++ b/ocis/pkg/command/backup.go
@@ -50,6 +50,10 @@ func ConsistencyCommand(cfg *config.Config) *cli.Command {
 				Usage:   "the blobstore type. Can be (none, ocis, s3ng). Default ocis",
 				Value:   "ocis",
 			},
+			&cli.BoolFlag{
+				Name:  "fail",
+				Usage: "exit with non-zero status if consistency check fails",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			basePath := c.String("basepath")
@@ -83,7 +87,7 @@ func ConsistencyCommand(cfg *config.Config) *cli.Command {
 				fmt.Println(err)
 				return err
 			}
-			if err := backup.CheckProviderConsistency(basePath, bs); err != nil {
+			if err := backup.CheckProviderConsistency(basePath, bs, c.Bool("fail")); err != nil {
 				fmt.Println(err)
 				return err
 			}


### PR DESCRIPTION
Adds a `--fail` flag to the ocis consistency command. If set to true, the command will return a non-zero exit code if any inconsistencies are found.

Fixes https://github.com/owncloud/ocis/issues/9411