### PR TITLE
configurable ocm timeouts

### DIFF
--- a/changelog/unreleased/ocm-configurable-timeouts.md
+++ b/changelog/unreleased/ocm-configurable-timeouts.md
@@ -1,0 +1,5 @@
+Enhancement: Configurable OCM timeouts
+
+We added `OCM_OCM_INVITE_MANAGER_TOKEN_EXPIRATION` and `OCM_OCM_INVITE_MANAGER_TIMEOUT` to allow changing the default invite token duration as well as the request timeout for requests made to other instances.
+
+https://github.com/owncloud/ocis/pull/9450

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"go-micro.dev/v4/client"
@@ -90,9 +91,11 @@ type OCMD struct {
 }
 
 type OCMInviteManager struct {
-	Driver   string                  `yaml:"driver" env:"OCM_OCM_INVITE_MANAGER_DRIVER" desc:"Driver to be used to persist OCM invites. Supported value is only 'json'." introductionVersion:"5.0"`
-	Drivers  OCMInviteManagerDrivers `yaml:"drivers"`
-	Insecure bool                    `yaml:"insecure" env:"OCM_OCM_INVITE_MANAGER_INSECURE" desc:"Disable TLS certificate validation for the OCM connections. Do not set this in production environments." introductionVersion:"5.0"`
+	Driver          string                  `yaml:"driver" env:"OCM_OCM_INVITE_MANAGER_DRIVER" desc:"Driver to be used to persist OCM invites. Supported value is only 'json'." introductionVersion:"5.0"`
+	Drivers         OCMInviteManagerDrivers `yaml:"drivers"`
+	TokenExpiration time.Duration           `yaml:"token_expiration" env:"OCM_OCM_INVITE_MANAGER_TOKEN_EXPIRATION" desc:"Expiry duration for invite tokens." introductionVersion:"6.0.1"`
+	Timeout         time.Duration           `yaml:"timeout" env:"OCM_OCM_INVITE_MANAGER_TIMEOUT" desc:"Timeout specifies a time limit for requests made to OCM endpoints." introductionVersion:"6.0.1"`
+	Insecure        bool                    `yaml:"insecure" env:"OCM_OCM_INVITE_MANAGER_INSECURE" desc:"Disable TLS certificate validation for the OCM connections. Do not set this in production environments." introductionVersion:"5.0"`
 }
 
 type OCMInviteManagerDrivers struct {

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"path/filepath"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
@@ -97,7 +98,9 @@ func DefaultConfig() *config.Config {
 					File: filepath.Join(defaults.BaseDataPath(), "storage", "ocm", "ocminvites.json"),
 				},
 			},
-			Insecure: false,
+			TokenExpiration: 24 * time.Hour,
+			Timeout:         30 * time.Second,
+			Insecure:        false,
 		},
 		OCMProviderAuthorizerDriver: "json",
 		OCMProviderAuthorizerDrivers: config.OCMProviderAuthorizerDrivers{

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -1,6 +1,8 @@
 package revaconfig
 
 import (
+	"math"
+
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/ocm/pkg/config"
 )
@@ -98,8 +100,10 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 							"file": cfg.OCMInviteManager.Drivers.JSON.File,
 						},
 					},
-					"provider_domain": cfg.Commons.OcisURL,
-					"ocm_insecure":    cfg.OCMInviteManager.Insecure,
+					"provider_domain":  cfg.Commons.OcisURL,
+					"token_expiration": cfg.OCMInviteManager.TokenExpiration.String(),
+					"ocm_timeout":      int(math.Round(cfg.OCMInviteManager.Timeout.Seconds())),
+					"ocm_insecure":     cfg.OCMInviteManager.Insecure,
 				},
 				"ocmproviderauthorizer": map[string]interface{}{
 					"driver": cfg.OCMProviderAuthorizerDriver,


### PR DESCRIPTION
We added `OCM_OCM_INVITE_MANAGER_TOKEN_EXPIRATION` and `OCM_OCM_INVITE_MANAGER_TIMEOUT` to allow changing the default invite token duration as well as the request timeout for requests made to other instances.
