### PR TITLE
[tests-only] add a Given step to check for the share sync status

### DIFF
--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -1265,6 +1265,7 @@ class SharingNgContext implements Context {
 				break;
 			}
 		}
+		Assert::assertIsBool($syncStatus, "'@client.synchronize' must be a boolean value");
 		return $syncStatus;
 	}
 

--- a/tests/acceptance/features/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/features/bootstrap/SharingNgContext.php
@@ -1265,7 +1265,7 @@ class SharingNgContext implements Context {
 				break;
 			}
 		}
-		return $syncStatus === true;
+		return $syncStatus;
 	}
 
 	/**

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -245,7 +245,8 @@ Feature: sharing
     And user "Brian" has been added to group "grp2"
     And user "Alice" has created folder "/PARENT"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
-    Then user "Brian" should see the following elements
+    Then user "Brian" should have sync enabled for share "PARENT"
+    And user "Brian" should see the following elements
       | /Shares/PARENT/ |
 
 

--- a/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
@@ -180,6 +180,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Carol" has a share "/TMP" synced
     When user "Carol" moves folder "/Shares/TMP" to "/Shares/new" using the WebDAV API
     And the administrator deletes user "Carol" using the provisioning API
     Then the HTTP status code of responses on each endpoint should be "201, 204" respectively


### PR DESCRIPTION
## Description
The test failure in `coreApiShareManagementToShares/moveReceivedShare.feature:172` was mostly due to the share being unavailable to the receiver in time. Since the sharing/accepting-share is an async task, we couldn't come up with the better solution for waiting for the shares to be accepted during the share creation step. So, added a Given step which waits for the share to be synced.

Usage:
```feature
Given user "Alice" has sent the following resource share invitation:
      | resource        | TMP      |
      | space           | Personal |
      | sharee          | grp1     |
      | shareType       | group    |
      | permissionsRole | Viewer   |
And user "Carol" has a share "/TMP" synced
When user "Carol" moves folder "/Shares/TMP" to "/Shares/new" using the WebDAV API
```

## Related Issue
- trying to fix https://github.com/owncloud/ocis/issues/9428

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
