### PR TITLE
autoprovisioning: Manage group memberships

### DIFF
--- a/changelog/unreleased/autoprovsion-groups.md
+++ b/changelog/unreleased/autoprovsion-groups.md
@@ -1,0 +1,7 @@
+Enhancement: Autoprovision group memberships
+
+When PROXY_AUTOPROVISION_ACCOUNTS is enabled it is now possible to automatically
+maintain the group memberships of users via a configurable OIDC claim.
+
+https://github.com/owncloud/ocis/pull/9458
+https://github.com/owncloud/ocis/issues/5538

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -52,22 +52,21 @@ unprotected: false # with false (default), calling the endpoint requires authori
 
 ## Automatic User and Group Provisioning
 
-When using and external OpenID Connect IDP the proxy can be configured to automatically provision
+When using an external OpenID Connect IDP, the proxy can be configured to automatically provision
 users upon their first login.
 
 ### Prequisites
 
 A number of prerequisites must be met for automatic user provisioning to work:
 
-* ownCloud Infinite Scale must be configured to use an external OpenID Connect
-  IDP
+* ownCloud Infinite Scale must be configured to use an external OpenID Connect IDP
 * The `graph` service must be configured to allow updating users and groups
-  (`GRAPH_LDAP_SERVER_WRITE_ENABLED`)
+  (`GRAPH_LDAP_SERVER_WRITE_ENABLED`).
 * The IDP must return a unique value in the user's claims (as part of the
   userinfo response and/or the access tokens) that can be used to identify
   the user. This claim needs to be stable and cannot be changed for the whole
-  lifetime of the user. That means if a claim like `email` or
-  `preferred_username` is used, you must asure that the user's email address or
+  lifetime of the user. That means, if a claim like `email` or
+  `preferred_username` is used, you must ensure that the user's email address or
   username never changes.
 
 ### Configuration
@@ -75,35 +74,37 @@ A number of prerequisites must be met for automatic user provisioning to work:
 To enable automatic user provisioning, the following environment variables must
 be set for the proxy service:
 
-* `PROXY_AUTOPROVISION_ACCOUNTS`: Set to `true` to enable automatic user provisioning.
-* `PROXY_AUTOPROVISION_CLAIM_USERNAME`: The name of an OIDC claim whose value
-  should be used as the username for the autoprovsioned user in ownCloud
-  Infinite Scale. Defaults to `preferred_username`. Can also be set to e.g.
-  `sub` to guarantee a unique and stable username.
-* `PROXY_AUTOPROVISION_CLAIM_EMAIL`: The name of an OIDC claim whose value
-  should be used for the `mail` attribute of the autoprovisioned user in
-  ownCloud Infinite Scale. Defaults to `email`.
-* `PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME`: The name of an OIDC claim whose
-  value should be used for the `displayname` attribute of the autoprovisioned
-  user in ownCloud Infinite Scale. Defaults to `name`.
-* `PROXY_AUTOPROVISION_CLAIM_GROUPS`: The name of an OIDC claim whose value
-  should be used to maintain a user's group membership. The claim value should
-  contain a list of group names the user should be a member of. Defaults to
-  `groups`.
-* `PROXY_USER_OIDC_CLAIM`: When resolving and authenticated OIDC user, the
-  value of this claims is used to lookup the user in the users service. For
-  auto provisioning setups this usually is the same claims as set via
-  `PROXY_AUTOPROVISION_CLAIM_USERNAME`.
-* `PROXY_USER_CS3_CLAIM`: This is the name of the user attribute in ocis that
-  is used to lookup the user by the value of the `PROXY_USER_OIDC_CLAIM`. For
-  auto provisioning setups this usually needs to be set to `username`.
+* `PROXY_AUTOPROVISION_ACCOUNTS`\
+Set to `true` to enable automatic user provisioning.
+* `PROXY_AUTOPROVISION_CLAIM_USERNAME`\
+The name of an OIDC claim whose value should be used as the username for the
+autoprovsioned user in ownCloud Infinite Scale. Defaults to `preferred_username`.
+Can also be set to e.g. `sub` to guarantee a unique and stable username.
+* `PROXY_AUTOPROVISION_CLAIM_EMAIL`\
+The name of an OIDC claim whose value should be used for the `mail` attribute
+of the autoprovisioned user in ownCloud Infinite Scale. Defaults to `email`.
+* `PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME`\
+The name of an OIDC claim whose value should be used for the `displayname`
+attribute of the autoprovisioned user in ownCloud Infinite Scale. Defaults to `name`.
+* `PROXY_AUTOPROVISION_CLAIM_GROUPS`\
+The name of an OIDC claim whose value should be used to maintain a user's group
+membership. The claim value should contain a list of group names the user should
+be a member of. Defaults to `groups`.
+* `PROXY_USER_OIDC_CLAIM`\
+When resolving and authenticated OIDC user, the value of this claims is used to
+lookup the user in the users service. For auto provisioning setups this usually is the
+same claims as set via `PROXY_AUTOPROVISION_CLAIM_USERNAME`.
+* `PROXY_USER_CS3_CLAIM`\
+This is the name of the user attribute in ocis that is used to lookup the user by the
+value of the `PROXY_USER_OIDC_CLAIM`. For auto provisioning setups this usually
+needs to be set to `username`.
 
-### How it works
+### How it Works
 
 When a user logs into ownCloud Infinite Scale for the first time, the proxy
-checks if that user already exists by querying the `users` service for users
+checks if that user already exists. This is done by querying the `users` service for users,
 where the attribute set in `PROXY_USER_CS3_CLAIM` matches the value of the OIDC
-claim configure in `PROXY_USER_OIDC_CLAIM`.
+claim configured in `PROXY_USER_OIDC_CLAIM`.
 
 If the users does not exist, the proxy will create a new user via the `graph`
 service using the claim values configured in
@@ -111,16 +112,16 @@ service using the claim values configured in
 `PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME`.
 
 If the user does already exist, the proxy will check if the user's email or
-displayname has changed and update those accordingly via `graph` service.
+displayname has changed and updates those accordingly via `graph` service.
 
 Next, the proxy will check if the user is a member of the groups configured in
 `PROXY_AUTOPROVISION_CLAIM_GROUPS`. It will add the user to the groups listed
-in there and remove it from all other groups that it is currently a member of.
-Groups that do not exist yet will be created. Note: This can be a somewhat
-costly operation, especially if the user is a member of a large number of
+via the OIDC claim that holds the groups defined in the envvar and removes it from
+all other groups that he is currently a member of.
+Groups that do not exist in the external IDP yet will be created. Note: This can be a
+somewhat costly operation, especially if the user is a member of a large number of
 groups. If the group memberships of a user are changed in the IDP after the
-first login it can take up to 5 minutes until the changes are reflected in
-ownCloud Infinite Scale.
+first login, it can take up to 5 minutes until the changes are reflected in Infinite Scale.
 
 ## Automatic Quota Assignments
 
@@ -149,9 +150,8 @@ is unset.
 When `PROXY_ROLE_ASSIGNMENT_DRIVER` is set to `oidc` the role assignment for a user will happen
 based on the values of an OpenID Connect Claim of that user. The name of the OpenID Connect Claim to
 be used for the role assignment can be configured via the `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`
-environment variable. It is also possible to defe ine a mapping of claim values to role names defined
-in ownCloud Infinite Scale via a `yaml` configuration. See the following `proxy.yaml` snippet for an
-example.
+environment variable. It is also possible to define a mapping of claim values to role names defined
+in Infinite Scale via a `yaml` configuration. See the following `proxy.yaml` snippet for an example.
 
 ```yaml
 role_assignment:

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -160,6 +160,7 @@ type AutoProvisionClaims struct {
 	Username    string `yaml:"username" env:"PROXY_AUTOPROVISION_CLAIM_USERNAME" desc:"The name of the OIDC claim that holds the username." introductionVersion:"6.0.0"`
 	Email       string `yaml:"email" env:"PROXY_AUTOPROVISION_CLAIM_EMAIL" desc:"The name of the OIDC claim that holds the email." introductionVersion:"6.0.0"`
 	DisplayName string `yaml:"display_name" env:"PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME" desc:"The name of the OIDC claim that holds the display name." introductionVersion:"6.0.0"`
+	Groups      string `yaml:"groups" env:"PROXY_AUTOPROVISION_CLAIM_GROUPS" desc:"The name of the OIDC claim that holds the groups." introductionVersion:"6.1.0"`
 }
 
 // PolicySelector is the toplevel-configuration for different selectors

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -88,6 +88,7 @@ func DefaultConfig() *config.Config {
 			Username:    "preferred_username",
 			Email:       "email",
 			DisplayName: "name",
+			Groups:      "groups",
 		},
 		EnableBasicAuth:       false,
 		InsecureBackends:      false,

--- a/services/proxy/pkg/user/backend/backend.go
+++ b/services/proxy/pkg/user/backend/backend.go
@@ -22,4 +22,5 @@ type UserBackend interface {
 	Authenticate(ctx context.Context, username string, password string) (*cs3.User, string, error)
 	CreateUserFromClaims(ctx context.Context, claims map[string]interface{}) (*cs3.User, error)
 	UpdateUserIfNeeded(ctx context.Context, user *cs3.User, claims map[string]interface{}) error
+	SyncGroupMemberships(ctx context.Context, user *cs3.User, claims map[string]interface{}) error
 }


### PR DESCRIPTION
Requires: https://github.com/cs3org/reva/pull/4738 :heavy_check_mark: 

- ~~groupmembership are not deleted yet~~
- ~~config knobs for the group claim are missing~~ 
- ~~The sync process is currently triggered with every single request, we need to limit this to e.g. once per accesstoken lifetime (or once per userinfo cache ttl)~~
- ~~documentation is missing~~

To avoid syncing group memberships with every single incoming request I add a small ttl based cache that keeps track of when group memberships were last updated for a specific user. Currently the ttl is hardcode to 1 minute, I am still pondering whether to turn that into a configuration option.