### PR TITLE
[docs-only] Fix envvar description

### DIFF
--- a/services/clientlog/pkg/config/config.go
+++ b/services/clientlog/pkg/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 
 	TokenManager *TokenManager `yaml:"token_manager"`
 
-	RevaGateway string `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY;CLIENTLOG_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata" introductionVersion:"5.0" deprecationVersion:"6.0" removalVersion:"%%NEXT%%" deprecationInfo:"CLIENTLOG_REVA_GATEWAY removed from simplicity."`
+	RevaGateway string `yaml:"reva_gateway" env:"OCIS_REVA_GATEWAY;CLIENTLOG_REVA_GATEWAY" desc:"CS3 gateway used to look up user metadata" introductionVersion:"5.0" deprecationVersion:"6.0" removalVersion:"%%NEXT%%" deprecationInfo:"CLIENTLOG_REVA_GATEWAY removed for simplicity."`
 	Events      Events `yaml:"events"`
 
 	ServiceAccount ServiceAccount `yaml:"service_account"`

--- a/services/collaboration/pkg/config/cs3api.go
+++ b/services/collaboration/pkg/config/cs3api.go
@@ -8,7 +8,7 @@ type CS3Api struct {
 
 // Gateway defines the available configuration for the CS3 API gateway
 type Gateway struct {
-	Name string `yaml:"name" env:"OCIS_REVA_GATEWAY;COLLABORATION_CS3API_GATEWAY_NAME" desc:"The service name of the CS3API gateway." introductionVersion:"6.0.0" deprecationVersion:"6.0" removalVersion:"%%NEXT%%" deprecationInfo:"COLLABORATION_CS3API_GATEWAY_NAME removed from simplicity."`
+	Name string `yaml:"name" env:"OCIS_REVA_GATEWAY;COLLABORATION_CS3API_GATEWAY_NAME" desc:"CS3 gateway used to look up user metadata." introductionVersion:"6.0.0" deprecationVersion:"6.0" removalVersion:"%%NEXT%%" deprecationInfo:"COLLABORATION_CS3API_GATEWAY_NAME removed for simplicity."`
 }
 
 // DataGateway defines the available configuration for the CS3 API data gateway


### PR DESCRIPTION
References: #9452 ([docs-only] Deprecate gateway envvars)

1. There was a typo in the deprecation note
2. Harmonizing the envvar text in the collaboration service to align with the others.