### PR TITLE
Fix posixfs events

### DIFF
--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -198,6 +198,7 @@ type PosixDriver struct {
 	PersonalSpacePathTemplate string `yaml:"personalspacepath_template" env:"STORAGE_USERS_POSIX_PERSONAL_SPACE_PATH_TEMPLATE" desc:"Template string to construct the paths of the personal space roots." introductionVersion:"6.0.0"`
 	GeneralSpacePathTemplate  string `yaml:"generalspacepath_template" env:"STORAGE_USERS_POSIX_GENERAL_SPACE_PATH_TEMPLATE" desc:"Template string to construct the paths of the projects space roots." introductionVersion:"6.0.0"`
 	PermissionsEndpoint       string `yaml:"permissions_endpoint" env:"STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_POSIX_PERMISSIONS_ENDPOINT" desc:"Endpoint of the permissions service. The endpoints can differ for 'ocis', 'posix' and 's3ng'." introductionVersion:"6.0.0"`
+	AsyncUploads              bool   `yaml:"async_uploads" env:"OCIS_ASYNC_UPLOADS" desc:"Enable asynchronous file uploads." introductionVersion:"pre5.0"`
 
 	UseSpaceGroups bool `yaml:"use_space_groups" env:"STORAGE_USERS_POSIX_USE_SPACE_GROUPS" desc:"Use space groups to manage permissions on spaces." introductionVersion:"6.0.0"`
 

--- a/services/storage-users/pkg/config/defaults/defaultconfig.go
+++ b/services/storage-users/pkg/config/defaults/defaultconfig.go
@@ -146,6 +146,7 @@ func DefaultConfig() *config.Config {
 				PersonalSpacePathTemplate: "users/{{.User.Username}}",
 				GeneralSpacePathTemplate:  "projects/{{.SpaceId}}",
 				PermissionsEndpoint:       "com.owncloud.api.settings",
+				AsyncUploads:              true,
 			},
 		},
 		Events: config.Events{

--- a/services/storage-users/pkg/revaconfig/config.go
+++ b/services/storage-users/pkg/revaconfig/config.go
@@ -37,6 +37,15 @@ func StorageUsersConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					"expose_data_server": cfg.ExposeDataServer,
 					"data_server_url":    cfg.DataServerURL,
 					"upload_expiration":  cfg.UploadExpiration,
+					"events": map[string]interface{}{
+						"nats_address":     cfg.Events.Addr,
+						"nats_clusterid":   cfg.Events.ClusterID,
+						"tls_insecure":     cfg.Events.TLSInsecure,
+						"tls_root_ca_cert": cfg.Events.TLSRootCaCertPath,
+						"nats_enable_tls":  cfg.Events.EnableTLS,
+						"nats_username":    cfg.Events.AuthUsername,
+						"nats_password":    cfg.Events.AuthPassword,
+					},
 				},
 			},
 			"interceptors": map[string]interface{}{

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -85,7 +85,7 @@ func Local(cfg *config.Config) map[string]interface{} {
 }
 
 // Posix is the config mapping for the Posix storage driver
-func Posix(cfg *config.Config) map[string]interface{} {
+func Posix(cfg *config.Config, enableFSWatch bool) map[string]interface{} {
 	return map[string]interface{}{
 		"root":                       cfg.Drivers.Posix.Root,
 		"personalspacepath_template": cfg.Drivers.Posix.PersonalSpacePathTemplate,
@@ -105,6 +105,7 @@ func Posix(cfg *config.Config) map[string]interface{} {
 			"cache_auth_password":       cfg.IDCache.AuthPassword,
 		},
 		"use_space_groups":           cfg.Drivers.Posix.UseSpaceGroups,
+		"watch_fs":                   enableFSWatch,
 		"watch_type":                 cfg.Drivers.Posix.WatchType,
 		"watch_path":                 cfg.Drivers.Posix.WatchPath,
 		"watch_folder_kafka_brokers": cfg.Drivers.Posix.WatchFolderKafkaBrokers,

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -94,6 +94,7 @@ func Posix(cfg *config.Config, enableFSWatch bool) map[string]interface{} {
 		"permissionssvc_tls_mode":    cfg.Commons.GRPCClientTLS.Mode,
 		"treetime_accounting":        true,
 		"treesize_accounting":        true,
+		"asyncfileuploads":           cfg.Drivers.Posix.AsyncUploads,
 		"idcache": map[string]interface{}{
 			"cache_store":               cfg.IDCache.Store,
 			"cache_nodes":               cfg.IDCache.Nodes,

--- a/services/storage-users/pkg/revaconfig/user.go
+++ b/services/storage-users/pkg/revaconfig/user.go
@@ -14,7 +14,7 @@ func StorageProviderDrivers(cfg *config.Config) map[string]interface{} {
 		"ocis":        OcisNoEvents(cfg),
 		"s3":          S3(cfg),
 		"s3ng":        S3NGNoEvents(cfg),
-		"posix":       Posix(cfg),
+		"posix":       Posix(cfg, true),
 	}
 }
 
@@ -30,6 +30,6 @@ func DataProviderDrivers(cfg *config.Config) map[string]interface{} {
 		"ocis":        Ocis(cfg),
 		"s3":          S3(cfg),
 		"s3ng":        S3NG(cfg),
-		"posix":       Posix(cfg),
+		"posix":       Posix(cfg, false),
 	}
 }


### PR DESCRIPTION
This PR adapts to the latest reva changes and fixes the config so that `posixfs` can emit events. It also enables async uploads by default as we also do with the `ocis` driver.

Depends on https://github.com/cs3org/reva/pull/4739