### PR TITLE
Activitylog fixes

### DIFF
--- a/changelog/unreleased/activitylog-fixes.md
+++ b/changelog/unreleased/activitylog-fixes.md
@@ -1,0 +1,5 @@
+Enhancement: Various fixes for the activitylog service
+
+First round of fixes to make the activitylog service more robust and reliable.
+
+https://github.com/owncloud/ocis/pull/9467

--- a/services/activitylog/pkg/command/server.go
+++ b/services/activitylog/pkg/command/server.go
@@ -33,6 +33,7 @@ var _registeredEvents = []events.Unmarshaller{
 	events.FileTouched{},
 	events.ContainerCreated{},
 	events.ItemTrashed{},
+	events.ItemPurged{},
 	events.ItemMoved{},
 	events.ShareCreated{},
 	events.ShareRemoved{},

--- a/services/activitylog/pkg/service/http.go
+++ b/services/activitylog/pkg/service/http.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"google.golang.org/grpc/metadata"
 
+	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/ocis-pkg/ast"
 	"github.com/owncloud/ocis/v2/ocis-pkg/kql"
 	"github.com/owncloud/ocis/v2/ocis-pkg/l10n"
@@ -83,7 +84,7 @@ func (s *ActivitylogService) HandleGetItemActivities(w http.ResponseWriter, r *h
 		return
 	}
 
-	var resp GetActivitiesResponse
+	resp := GetActivitiesResponse{Activities: make([]libregraph.Activity, 0, len(evRes.GetEvents()))}
 	for _, e := range evRes.GetEvents() {
 		delete(toDelete, e.GetId())
 
@@ -268,6 +269,10 @@ func (s *ActivitylogService) getFilters(query string) (*provider.ResourceId, int
 	rid, err := storagespace.ParseID(itemID)
 	if err != nil {
 		return nil, limit, nil, nil, err
+	}
+	if rid.GetOpaqueId() == "" {
+		// space root requested - fix format
+		rid.OpaqueId = rid.GetSpaceId()
 	}
 	pref := func(a RawActivity) bool {
 		for _, f := range prefilters {

--- a/services/activitylog/pkg/service/service.go
+++ b/services/activitylog/pkg/service/service.go
@@ -225,6 +225,10 @@ func (a *ActivitylogService) RemoveActivities(rid *provider.ResourceId, toDelete
 
 // RemoveResource removes the resource from the store
 func (a *ActivitylogService) RemoveResource(rid *provider.ResourceId) error {
+	if rid == nil {
+		return fmt.Errorf("resource id is required")
+	}
+
 	a.lock.Lock()
 	defer a.lock.Unlock()
 

--- a/services/activitylog/pkg/service/service.go
+++ b/services/activitylog/pkg/service/service.go
@@ -104,6 +104,8 @@ func (a *ActivitylogService) Run() {
 			err = a.AddActivity(ev.Ref, e.ID, utils.TSToTime(ev.Timestamp))
 		case events.ItemTrashed:
 			err = a.AddActivityTrashed(ev.ID, ev.Ref, e.ID, utils.TSToTime(ev.Timestamp))
+		case events.ItemPurged:
+			err = a.RemoveResource(ev.ID)
 		case events.ItemMoved:
 			err = a.AddActivity(ev.Ref, e.ID, utils.TSToTime(ev.Timestamp))
 		case events.ShareCreated:
@@ -219,6 +221,14 @@ func (a *ActivitylogService) RemoveActivities(rid *provider.ResourceId, toDelete
 		Key:   storagespace.FormatResourceID(*rid),
 		Value: b,
 	})
+}
+
+// RemoveResource removes the resource from the store
+func (a *ActivitylogService) RemoveResource(rid *provider.ResourceId) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	return a.store.Delete(storagespace.FormatResourceID(*rid))
 }
 
 func (a *ActivitylogService) activities(rid *provider.ResourceId) ([]RawActivity, error) {


### PR DESCRIPTION
Fixes multiple small activitylog issues:
* understand ids of format `uuid1$uuid2`
* return an empty list instead of null when there are no activities.
* return messages even if resource/user/space got removed meanwhile
* delete the document from the store when the corresponding item is purged
* allow sorting result `"asc"` (default) or `"desc"` using the `"sort"` kql parameter