### PR TITLE
Fix ocis wopi env settings

### DIFF
--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -45,7 +45,7 @@ OCIS=:ocis.yml
 OCIS_DOCKER_IMAGE=
 
 # The oCIS container version.
-# Defaults to "latest". Use the latest stable tag like 5.0.5.
+# Defaults to "latest". This will point to the latest production tag.
 OCIS_DOCKER_TAG=
 
 # Domain of oCIS, where you can find the frontend.

--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -45,7 +45,7 @@ OCIS=:ocis.yml
 OCIS_DOCKER_IMAGE=
 
 # The oCIS container version.
-# Defaults to "latest". This will point to the latest stable tag.
+# Defaults to "latest". Use the latest stable tag like 5.0.5.
 OCIS_DOCKER_TAG=
 
 # Domain of oCIS, where you can find the frontend.
@@ -99,6 +99,7 @@ SMTP_INSECURE=
 # Tika (search) is enabled by default, comment if not required.
 # the leading colon is required to enable the service
 TIKA=:tika.yml
+
 # Set the desired docker image tag or digest.
 # Defaults to "latest"
 TIKA_IMAGE=
@@ -159,7 +160,7 @@ COLLABORA_ADMIN_PASSWORD=
 
 ## Uppy Companion Settings ##
 # the leading colon is required to enable the service
-COMPANION=:companion.yml
+#COMPANION=:companion.yml
 
 COMPANION_IMAGE=
 
@@ -175,14 +176,14 @@ COMPANION_ONEDRIVE_SECRET=
 
 ## OnlyOffice Settings ##
 # the leading colon is required to enable the service
-# ONLYOFFICE=:onlyoffice.yml
+#ONLYOFFICE=:onlyoffice.yml
 
 # Domain for OnlyOffice. Defaults to "onlyoffice.owncloud.test"
 ONLYOFFICE_DOMAIN=
 
 
 ## Inbucket Settings ##
-# INBUCKET=:inbucket.yml
+#INBUCKET=:inbucket.yml
 
 # email server (in this case inbucket acts as mail catcher)
 # Domain for Inbucket. Defaults to "mail.owncloud.test"

--- a/deployments/examples/ocis_wopi/README.md
+++ b/deployments/examples/ocis_wopi/README.md
@@ -1,4 +1,4 @@
 Please refer to our [admin documentation](https://doc.owncloud.com/ocis/latest/depl-examples/ubuntu-compose/ubuntu-compose-prod.html) for instructions on how to deploy this scenario.
 
-Note: This deployment setup is highly configurable. At minimum, it starts traefik`, ocis`, tika`, the wopiserver` and collabora`. Additional services can be started by removing the respective comment in the `.env` file. Depending on the service added, related variables need to be configured.
+Note: This deployment setup is highly configurable. At minimum, it starts `traefik`, `ocis`, `tika`, the `wopiserver` and `collabora`. Additional services can be started by removing the respective comment in the `.env` file. Depending on the service added, related variables need to be configured.
 


### PR DESCRIPTION
This are small fixes to the .env file:

* `latest` does not point to 5.0.5 as rolling was introduced with 6.
If we write that text, we confuse users and the wrong version (master) gets used. Note we are on stable5.
For master, the text including latest, if it points to the latest production version, would be correct.
* Companion is optional and not included in the minimal deployment, see readme.
* Removing some blanks as those are not ordinary comments but commented commands. Same as we do with other commented commands.
* Backtick corrections in the readme file.
 