### PR TITLE
Log user agent and remote addr on auth errors

### DIFF
--- a/changelog/unreleased/log-useragent-and-remoteaddr.md
+++ b/changelog/unreleased/log-useragent-and-remoteaddr.md
@@ -1,0 +1,5 @@
+Enhancement: Log user agent and remote addr on auth errors
+
+The proxy will now log `user_agent`, `client.address`, `network.peer.address` and `network.peer.port` to help operations debug authentication errors. The latter three follow the [Semantic Conventions 1.26.0 / General / Attributes](https://opentelemetry.io/docs/specs/semconv/general/attributes/) naming to better integrate with log aggregation tools.
+
+https://github.com/owncloud/ocis/pull/9475

--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"encoding/base64"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -181,10 +182,15 @@ func (m *OIDCAuthenticator) Authenticate(r *http.Request) (*http.Request, bool) 
 
 	claims, err := m.getClaims(token, r)
 	if err != nil {
+		host, port, _ := net.SplitHostPort(r.RemoteAddr)
 		m.Logger.Error().
 			Err(err).
 			Str("authenticator", "oidc").
 			Str("path", r.URL.Path).
+			Str("user_agent", r.UserAgent()).
+			Str("client.address", r.Header.Get("X-Forwarded-For")).
+			Str("network.peer.address", host).
+			Str("network.peer.port", port).
 			Msg("failed to authenticate the request")
 		return nil, false
 	}


### PR DESCRIPTION
The proxy will now log `user_agent`, `client.address`, `network.peer.address` and `network.peer.port` to help operations debug authentication errors. The latter three follow the [Semantic Conventions 1.26.0 / General / Attributes](https://opentelemetry.io/docs/specs/semconv/general/attributes/) naming to better integrate with log aggregation tools.


Trying to help pin down the occurrence very old access tokens... like 120+ days.