### PR TITLE
set the configured protocol transport for service metadata

### DIFF
--- a/changelog/unreleased/set-service-transport.md
+++ b/changelog/unreleased/set-service-transport.md
@@ -1,0 +1,6 @@
+Enhancement: We now set the configured protocol transport for service metadata
+
+This allows using `dns` or `unix` as the grpc protocol for services. Requires reva changes to have an effect
+
+https://github.com/owncloud/ocis/pull/9490
+https://github.com/cs3org/reva/pull/4744

--- a/changelog/unreleased/set-service-transport.md
+++ b/changelog/unreleased/set-service-transport.md
@@ -1,6 +1,6 @@
 Enhancement: We now set the configured protocol transport for service metadata
 
-This allows using `dns` or `unix` as the grpc protocol for services. Requires reva changes to have an effect
+This allows configuring services to listan on `tcp` or `unix` sockets and clients to use the `dns`, `kubernetes` or `unix` protocol URIs instead of service names.
 
 https://github.com/owncloud/ocis/pull/9490
 https://github.com/cs3org/reva/pull/4744

--- a/ocis-pkg/config/config.go
+++ b/ocis-pkg/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	GRPCClientTLS  *shared.GRPCClientTLS  `yaml:"grpc_client_tls"`
 	GRPCServiceTLS *shared.GRPCServiceTLS `yaml:"grpc_service_tls"`
 	HTTPServiceTLS shared.HTTPServiceTLS  `yaml:"http_service_tls"`
+	Reva           *shared.Reva           `yaml:"reva"`
 
 	Mode    Mode // DEPRECATED
 	File    string

--- a/ocis-pkg/config/defaultconfig.go
+++ b/ocis-pkg/config/defaultconfig.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	activitylog "github.com/owncloud/ocis/v2/services/activitylog/pkg/config/defaults"
 	antivirus "github.com/owncloud/ocis/v2/services/antivirus/pkg/config/defaults"
 	appProvider "github.com/owncloud/ocis/v2/services/app-provider/pkg/config/defaults"
@@ -51,6 +52,9 @@ func DefaultConfig() *Config {
 		Runtime: Runtime{
 			Port: "9250",
 			Host: "localhost",
+		},
+		Reva: &shared.Reva{
+			Address: "com.owncloud.api.gateway",
 		},
 
 		Activitylog:       activitylog.DefaultConfig(),

--- a/ocis-pkg/config/parser/parse.go
+++ b/ocis-pkg/config/parser/parse.go
@@ -58,7 +58,9 @@ func EnsureDefaults(cfg *config.Config) {
 	if cfg.GRPCServiceTLS == nil {
 		cfg.GRPCServiceTLS = &shared.GRPCServiceTLS{}
 	}
-
+	if cfg.Reva == nil {
+		cfg.Reva = &shared.Reva{}
+	}
 }
 
 // EnsureCommons copies applicable parts of the oCIS config into the commons part
@@ -111,6 +113,8 @@ func EnsureCommons(cfg *config.Config) {
 	if cfg.OcisURL != "" {
 		cfg.Commons.OcisURL = cfg.OcisURL
 	}
+
+	cfg.Commons.Reva = structs.CopyOrZeroValue(cfg.Reva)
 }
 
 // Validate checks that all required configs are set. If a required config value

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -526,7 +526,7 @@ func pingNats(cfg *ociscfg.Config) error {
 	return err
 }
 
-func pingGateway(_ *ociscfg.Config) error {
+func pingGateway(cfg *ociscfg.Config) error {
 	// init grpc connection
 	_, err := ogrpc.NewClient()
 	if err != nil {
@@ -536,7 +536,7 @@ func pingGateway(_ *ociscfg.Config) error {
 	b := backoff.NewExponentialBackOff()
 	o := func() error {
 		n := b.NextBackOff()
-		_, err := pool.GetGatewayServiceClient("com.owncloud.api.gateway")
+		_, err := pool.GetGatewayServiceClient(cfg.Reva.Address)
 		if err != nil && n > time.Second {
 			logger.New().Error().Err(err).Msgf("can't connect to gateway service, retrying in %s", n)
 		}

--- a/services/app-provider/pkg/command/server.go
+++ b/services/app-provider/pkg/command/server.go
@@ -81,7 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/app-provider/pkg/config/config.go
+++ b/services/app-provider/pkg/config/config.go
@@ -48,7 +48,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"APP_PROVIDER_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"APP_PROVIDER_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;APP_PROVIDER_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
 }
 
 type Drivers struct {

--- a/services/app-registry/pkg/command/server.go
+++ b/services/app-registry/pkg/command/server.go
@@ -76,7 +76,7 @@ func Server(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/app-registry/pkg/config/config.go
+++ b/services/app-registry/pkg/config/config.go
@@ -47,7 +47,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"APP_REGISTRY_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"APP_REGISTRY_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;APP_REGISTRY_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }
 
 type AppRegistry struct {

--- a/services/auth-app/pkg/command/server.go
+++ b/services/auth-app/pkg/command/server.go
@@ -89,7 +89,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-app/pkg/config/config.go
+++ b/services/auth-app/pkg/config/config.go
@@ -58,7 +58,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"AUTH_APP_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"%%NEXT%%"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"AUTH_APP_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"%%NEXT%%"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;AUTH_APP_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"%%NEXT%%"`
 }
 
 // HTTP defines the available http configuration.

--- a/services/auth-basic/pkg/command/server.go
+++ b/services/auth-basic/pkg/command/server.go
@@ -94,7 +94,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-basic/pkg/config/config.go
+++ b/services/auth-basic/pkg/config/config.go
@@ -48,7 +48,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"AUTH_BASIC_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"AUTH_BASIC_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;AUTH_BASIC_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }
 
 type AuthProviders struct {

--- a/services/auth-bearer/pkg/command/server.go
+++ b/services/auth-bearer/pkg/command/server.go
@@ -81,7 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-bearer/pkg/config/config.go
+++ b/services/auth-bearer/pkg/config/config.go
@@ -48,7 +48,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"AUTH_BEARER_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"AUTH_BEARER_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;AUTH_BEARER_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }
 
 type OIDC struct {

--- a/services/auth-machine/pkg/command/server.go
+++ b/services/auth-machine/pkg/command/server.go
@@ -81,7 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-machine/pkg/config/config.go
+++ b/services/auth-machine/pkg/config/config.go
@@ -48,5 +48,5 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"AUTH_MACHINE_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"AUTH_MACHINE_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;AUTH_MACHINE_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }

--- a/services/auth-service/pkg/command/server.go
+++ b/services/auth-service/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-service/pkg/config/config.go
+++ b/services/auth-service/pkg/config/config.go
@@ -47,7 +47,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"AUTH_SERVICE_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"AUTH_SERVICE_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;AUTH_SERVICE_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"5.0"`
 }
 
 // ServiceAccount is the configuration for the used service account

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -33,6 +33,7 @@ func DefaultConfig() *config.Config {
 		},
 		GRPC: config.GRPC{
 			Addr:      "127.0.0.1:9301",
+			Protocol:  "tcp",
 			Namespace: "com.owncloud.api",
 		},
 		HTTP: config.HTTP{

--- a/services/collaboration/pkg/config/grpc.go
+++ b/services/collaboration/pkg/config/grpc.go
@@ -3,7 +3,7 @@ package config
 // GRPC defines the available grpc configuration.
 type GRPC struct {
 	Addr     string `yaml:"addr" env:"COLLABORATION_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"6.0.0"`
-	Protocol string `yaml:"protocol" env:"COLLABORATION_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"%%NEXT%%"`
+	Protocol string `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;COLLABORATION_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"%%NEXT%%"`
 
 	Namespace string `yaml:"-"`
 }

--- a/services/collaboration/pkg/config/grpc.go
+++ b/services/collaboration/pkg/config/grpc.go
@@ -2,6 +2,8 @@ package config
 
 // GRPC defines the available grpc configuration.
 type GRPC struct {
-	Addr      string `yaml:"addr" env:"COLLABORATION_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"6.0.0"`
+	Addr     string `yaml:"addr" env:"COLLABORATION_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"6.0.0"`
+	Protocol string `yaml:"protocol" env:"COLLABORATION_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"%%NEXT%%"`
+
 	Namespace string `yaml:"-"`
 }

--- a/services/collaboration/pkg/helpers/registration.go
+++ b/services/collaboration/pkg/helpers/registration.go
@@ -18,7 +18,7 @@ import (
 // There are no explicit requirements for the context, and it will be passed
 // without changes to the underlying RegisterService method.
 func RegisterOcisService(ctx context.Context, cfg *config.Config, logger log.Logger) error {
-	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name+"."+cfg.App.Name, cfg.GRPC.Addr, version.GetString())
+	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name+"."+cfg.App.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 	return registry.RegisterService(ctx, svc, logger)
 }
 

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -31,6 +31,72 @@ Store specific notes:
   -   When using `nats-js-kv` it is recommended to set `OCIS_CACHE_STORE_NODES` to the same value as `OCIS_EVENTS_ENDPOINT`. That way the cache uses the same nats instance as the event bus.
   -   When using the `nats-js-kv` store, it is possible to set `OCIS_CACHE_DISABLE_PERSISTENCE` to instruct nats to not persist cache data on disc.
 
+## Service endpoints
+
+The gateway acts as a proxy for other CS3 services. As such it has to forward requests to a lot of services and needs to establish connections by looking up the IP address using the service registry. Instead of using the service registry each endpoint can also be configured to use the grpc `dns://` or `kubernetes://` URLs, which might be useful when running in kubernetes.
+
+For a local single node deployment you might want to use `unix:` sockets as shown below. Using unix sockets will reduce the amount of service lookups and omit the TCP stack. For now, this is experimental and the services do not delete the socket on shutdown. PRs welcome.
+
+```console
+USERS_GRPC_PROTOCOL=unix"
+USERS_GRPC_ADDR=/var/run/ocis/users.sock"
+GATEWAY_USERS_ENDPOINT=unix:/var/run/ocis/users.sock"
+
+GROUPS_GRPC_PROTOCOL=unix"
+GROUPS_GRPC_ADDR=/var/run/ocis/groups.sock"
+GATEWAY_GROUPS_ENDPOINT=unix:/var/run/ocis/groups.sock"
+
+AUTH_APP_GRPC_PROTOCOL=unix"
+AUTH_APP_GRPC_ADDR=/var/run/ocis/auth-app.sock"
+GATEWAY_AUTH_APP_ENDPOINT=unix:/var/run/ocis/auth-app.sock"
+
+AUTH_BASIC_GRPC_PROTOCOL=unix"
+AUTH_BASIC_GRPC_ADDR=/var/run/ocis/auth-basic.sock"
+GATEWAY_AUTH_BASIC_ENDPOINT=unix:/var/run/ocis/auth-basic.sock"
+
+AUTH_MACHINE_GRPC_PROTOCOL=unix"
+AUTH_MACHINE_GRPC_ADDR=/var/run/ocis/auth-machine.sock"
+GATEWAY_AUTH_MACHINE_ENDPOINT=unix:/var/run/ocis/auth-machine.sock"
+
+AUTH_SERVICE_GRPC_PROTOCOL=unix"
+AUTH_SERVICE_GRPC_ADDR=/var/run/ocis/auth-service.sock"
+GATEWAY_AUTH_SERVICE_ENDPOINT=unix:/var/run/ocis/auth-service.sock"
+
+STORAGE_PUBLIC_LINK_GRPC_PROTOCOL=unix"
+STORAGE_PUBLIC_LINK_GRPC_ADDR=/var/run/ocis/storage-public-link.sock"
+GATEWAY_STORAGE_PUBLIC_LINK_ENDPOINT=unix:/var/run/ocis/storage-public-link.sock"
+
+STORAGE_USERS_GRPC_PROTOCOL=unix"
+STORAGE_USERS_GRPC_ADDR=/var/run/ocis/storage-users.sock"
+GATEWAY_STORAGE_USERS_ENDPOINT=unix:/var/run/ocis/storage-users.sock"
+// graph sometimes bypasses the gateway so we need to configure the socket here as wel
+GRAPH_SPACES_STORAGE_USERS_ADDRESS=unix:/var/run/ocis/storage-users.sock"
+
+STORAGE_SHARES_GRPC_PROTOCOL=unix"
+STORAGE_SHARES_GRPC_ADDR=/var/run/ocis/storage-shares.sock"
+GATEWAY_STORAGE_SHARES_ENDPOINT=unix:/var/run/ocis/storage-shares.sock"
+
+APP_REGISTRY_GRPC_PROTOCOL=unix"
+APP_REGISTRY_GRPC_ADDR=/var/run/ocis/app-registry.sock"
+GATEWAY_APP_REGISTRY_ENDPOINT=unix:/var/run/ocis/app-registry.sock"
+
+OCM_GRPC_PROTOCOL=unix"
+OCM_GRPC_ADDR=/var/run/ocis/ocm.sock"
+GATEWAY_OCM_ENDPOINT=unix:/var/run/ocis/ocm.sock"
+
+// storage system
+STORAGE_SYSTEM_GRPC_PROTOCOL="unix"
+STORAGE_SYSTEM_GRPC_ADDR="/var/run/ocis/storage-system.sock"
+STORAGE_GATEWAY_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
+STORAGE_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
+SHARING_USER_CS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
+SHARING_USER_JSONCS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
+SHARING_PUBLIC_CS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
+SHARING_PUBLIC_JSONCS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
+```
+
+
+
 ## Storage registry
 
 In order to add another storage provider the CS3 storage registry that is running as part of the CS3 gateway hes to be made aware of it. The easiest cleanest way to do it is to set `GATEWAY_STORAGE_REGISTRY_CONFIG_JSON=/path/to/storages.json` and list all storage providers like this:

--- a/services/gateway/pkg/command/server.go
+++ b/services/gateway/pkg/command/server.go
@@ -81,7 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/gateway/pkg/config/config.go
+++ b/services/gateway/pkg/config/config.go
@@ -31,20 +31,20 @@ type Config struct {
 
 	FrontendPublicURL string `yaml:"frontend_public_url" env:"OCIS_URL;GATEWAY_FRONTEND_PUBLIC_URL" desc:"The public facing URL of the oCIS frontend." introductionVersion:"pre5.0"`
 
-	UsersEndpoint             string `yaml:"users_endpoint" env:"GATEWAY_USERS_ENDPOINT" desc:"The USERS API endpoint." introductionVersion:"%%NEXT%%"`
-	GroupsEndpoint            string `yaml:"groups_endpoint" env:"GATEWAY_GROUPS_ENDPOINT" desc:"The GROUPS API endpoint." introductionVersion:"%%NEXT%%"`
-	PermissionsEndpoint       string `yaml:"permissions_endpoint" env:"GATEWAY_PERMISSIONS_ENDPOINT" desc:"The SETTINGS API endpoint." introductionVersion:"%%NEXT%%"`
-	SharingEndpoint           string `yaml:"sharing_endpoint" env:"GATEWAY_SHARING_ENDPOINT" desc:"The SHARE API endpoint." introductionVersion:"%%NEXT%%"`
-	AuthAppEndpoint           string `yaml:"auth_app_endpoint" env:"GATEWAY_AUTH_APP_ENDPOINT" desc:"The AUTH APP API endpoint." introductionVersion:"%%NEXT%%"`
-	AuthBasicEndpoint         string `yaml:"auth_basic_endpoint" env:"GATEWAY_AUTH_BASIC_ENDPOINT" desc:"The AUTH BASIC API endpoint." introductionVersion:"%%NEXT%%"`
-	AuthBearerEndpoint        string `yaml:"auth_bearer_endpoint" env:"GATEWAY_AUTH_BEARER_ENDPOINT" desc:"The AUTH BEARER API endpoint." introductionVersion:"%%NEXT%%"`
-	AuthMachineEndpoint       string `yaml:"auth_machine_endpoint" env:"GATEWAY_AUTH_MACHINE_ENDPOINT" desc:"The AUTH MACHINE API endpoint." introductionVersion:"%%NEXT%%"`
-	AuthServiceEndpoint       string `yaml:"auth_service_endpoint" env:"GATEWAY_AUTH_SERVICE_ENDPOINT" desc:"The AUTH SERVICE API endpoint." introductionVersion:"%%NEXT%%"`
-	StoragePublicLinkEndpoint string `yaml:"storage_public_link_endpoint" env:"GATEWAY_STORAGE_PUBLIC_LINK_ENDPOINT" desc:"The STORAGE PUBLICLINK API endpoint." introductionVersion:"%%NEXT%%"`
-	StorageUsersEndpoint      string `yaml:"storage_users_endpoint" env:"GATEWAY_STORAGE_USERS_ENDPOINT" desc:"The STORAGE USERS API endpoint." introductionVersion:"%%NEXT%%"`
-	StorageSharesEndpoint     string `yaml:"storage_shares_endpoint" env:"GATEWAY_STORAGE_SHARES_ENDPOINT" desc:"The STORAGE SHARES API endpoint." introductionVersion:"%%NEXT%%"`
-	AppRegistryEndpoint       string `yaml:"app_registry_endpoint" env:"GATEWAY_APP_REGISTRY_ENDPOINT" desc:"The APP REGISTRY API endpoint." introductionVersion:"%%NEXT%%"`
-	OCMEndpoint               string `yaml:"ocm_endpoint" env:"GATEWAY_OCM_ENDPOINT" desc:"The OCM API endpoint." introductionVersion:"%%NEXT%%"`
+	UsersEndpoint             string `yaml:"users_endpoint" env:"GATEWAY_USERS_ENDPOINT" desc:"The endpoint of the users service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	GroupsEndpoint            string `yaml:"groups_endpoint" env:"GATEWAY_GROUPS_ENDPOINT" desc:"The endpoint of the groups service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	PermissionsEndpoint       string `yaml:"permissions_endpoint" env:"GATEWAY_PERMISSIONS_ENDPOINT" desc:"The endpoint of the permissions service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	SharingEndpoint           string `yaml:"sharing_endpoint" env:"GATEWAY_SHARING_ENDPOINT" desc:"The endpoint of the shares service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	AuthAppEndpoint           string `yaml:"auth_app_endpoint" env:"GATEWAY_AUTH_APP_ENDPOINT" desc:"The endpoint of the auth-app service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	AuthBasicEndpoint         string `yaml:"auth_basic_endpoint" env:"GATEWAY_AUTH_BASIC_ENDPOINT" desc:"The endpoint of the auth-basic service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	AuthBearerEndpoint        string `yaml:"auth_bearer_endpoint" env:"GATEWAY_AUTH_BEARER_ENDPOINT" desc:"The endpoint of the auth-bearer service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	AuthMachineEndpoint       string `yaml:"auth_machine_endpoint" env:"GATEWAY_AUTH_MACHINE_ENDPOINT" desc:"The endpoint of the auth-machine service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	AuthServiceEndpoint       string `yaml:"auth_service_endpoint" env:"GATEWAY_AUTH_SERVICE_ENDPOINT" desc:"The endpoint of the auth-service service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	StoragePublicLinkEndpoint string `yaml:"storage_public_link_endpoint" env:"GATEWAY_STORAGE_PUBLIC_LINK_ENDPOINT" desc:"The endpoint of the storage-publiclink service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	StorageUsersEndpoint      string `yaml:"storage_users_endpoint" env:"GATEWAY_STORAGE_USERS_ENDPOINT" desc:"The endpoint of the storage-users service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	StorageSharesEndpoint     string `yaml:"storage_shares_endpoint" env:"GATEWAY_STORAGE_SHARES_ENDPOINT" desc:"The endpoint of the storag-shares service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	AppRegistryEndpoint       string `yaml:"app_registry_endpoint" env:"GATEWAY_APP_REGISTRY_ENDPOINT" desc:"The endpoint of the app-registry service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
+	OCMEndpoint               string `yaml:"ocm_endpoint" env:"GATEWAY_OCM_ENDPOINT" desc:"The endpoint of the ocm service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol." introductionVersion:"%%NEXT%%"`
 
 	StorageRegistry StorageRegistry `yaml:"storage_registry"` // TODO: should we even support switching this?
 
@@ -74,7 +74,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"OCIS_GATEWAY_GRPC_ADDR;GATEWAY_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"GATEWAY_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;GATEWAY_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }
 
 type StorageRegistry struct {

--- a/services/gateway/pkg/config/config.go
+++ b/services/gateway/pkg/config/config.go
@@ -31,20 +31,20 @@ type Config struct {
 
 	FrontendPublicURL string `yaml:"frontend_public_url" env:"OCIS_URL;GATEWAY_FRONTEND_PUBLIC_URL" desc:"The public facing URL of the oCIS frontend." introductionVersion:"pre5.0"`
 
-	UsersEndpoint             string `yaml:"-"`
-	GroupsEndpoint            string `yaml:"-"`
-	PermissionsEndpoint       string `yaml:"-"`
-	SharingEndpoint           string `yaml:"-"`
-	AuthAppEndpoint           string `yaml:"-"`
-	AuthBasicEndpoint         string `yaml:"-"`
-	AuthBearerEndpoint        string `yaml:"-"`
-	AuthMachineEndpoint       string `yaml:"-"`
-	AuthServiceEndpoint       string `yaml:"-"`
-	StoragePublicLinkEndpoint string `yaml:"-"`
-	StorageUsersEndpoint      string `yaml:"-"`
-	StorageSharesEndpoint     string `yaml:"-"`
-	AppRegistryEndpoint       string `yaml:"-"`
-	OCMEndpoint               string `yaml:"-"`
+	UsersEndpoint             string `yaml:"users_endpoint" env:"GATEWAY_USERS_ENDPOINT" desc:"The USERS API endpoint." introductionVersion:"%%NEXT%%"`
+	GroupsEndpoint            string `yaml:"groups_endpoint" env:"GATEWAY_GROUPS_ENDPOINT" desc:"The GROUPS API endpoint." introductionVersion:"%%NEXT%%"`
+	PermissionsEndpoint       string `yaml:"permissions_endpoint" env:"GATEWAY_PERMISSIONS_ENDPOINT" desc:"The SETTINGS API endpoint." introductionVersion:"%%NEXT%%"`
+	SharingEndpoint           string `yaml:"sharing_endpoint" env:"GATEWAY_SHARING_ENDPOINT" desc:"The SHARE API endpoint." introductionVersion:"%%NEXT%%"`
+	AuthAppEndpoint           string `yaml:"auth_app_endpoint" env:"GATEWAY_AUTH_APP_ENDPOINT" desc:"The AUTH APP API endpoint." introductionVersion:"%%NEXT%%"`
+	AuthBasicEndpoint         string `yaml:"auth_basic_endpoint" env:"GATEWAY_AUTH_BASIC_ENDPOINT" desc:"The AUTH BASIC API endpoint." introductionVersion:"%%NEXT%%"`
+	AuthBearerEndpoint        string `yaml:"auth_bearer_endpoint" env:"GATEWAY_AUTH_BEARER_ENDPOINT" desc:"The AUTH BEARER API endpoint." introductionVersion:"%%NEXT%%"`
+	AuthMachineEndpoint       string `yaml:"auth_machine_endpoint" env:"GATEWAY_AUTH_MACHINE_ENDPOINT" desc:"The AUTH MACHINE API endpoint." introductionVersion:"%%NEXT%%"`
+	AuthServiceEndpoint       string `yaml:"auth_service_endpoint" env:"GATEWAY_AUTH_SERVICE_ENDPOINT" desc:"The AUTH SERVICE API endpoint." introductionVersion:"%%NEXT%%"`
+	StoragePublicLinkEndpoint string `yaml:"storage_public_link_endpoint" env:"GATEWAY_STORAGE_PUBLIC_LINK_ENDPOINT" desc:"The STORAGE PUBLICLINK API endpoint." introductionVersion:"%%NEXT%%"`
+	StorageUsersEndpoint      string `yaml:"storage_users_endpoint" env:"GATEWAY_STORAGE_USERS_ENDPOINT" desc:"The STORAGE USERS API endpoint." introductionVersion:"%%NEXT%%"`
+	StorageSharesEndpoint     string `yaml:"storage_shares_endpoint" env:"GATEWAY_STORAGE_SHARES_ENDPOINT" desc:"The STORAGE SHARES API endpoint." introductionVersion:"%%NEXT%%"`
+	AppRegistryEndpoint       string `yaml:"app_registry_endpoint" env:"GATEWAY_APP_REGISTRY_ENDPOINT" desc:"The APP REGISTRY API endpoint." introductionVersion:"%%NEXT%%"`
+	OCMEndpoint               string `yaml:"ocm_endpoint" env:"GATEWAY_OCM_ENDPOINT" desc:"The OCM API endpoint." introductionVersion:"%%NEXT%%"`
 
 	StorageRegistry StorageRegistry `yaml:"storage_registry"` // TODO: should we even support switching this?
 

--- a/services/graph/pkg/service/v0/graph_suite_test.go
+++ b/services/graph/pkg/service/v0/graph_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/groups/pkg/command/server.go
+++ b/services/groups/pkg/command/server.go
@@ -94,7 +94,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/groups/pkg/config/config.go
+++ b/services/groups/pkg/config/config.go
@@ -49,7 +49,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"GROUPS_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"GROUPS_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;GROUPS_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }
 
 type Drivers struct {

--- a/services/notifications/pkg/service/notification_suite_test.go
+++ b/services/notifications/pkg/service/notification_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/ocm/pkg/command/server.go
+++ b/services/ocm/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -77,7 +77,7 @@ type GRPCConfig struct {
 	Addr      string                 `ocisConfig:"addr" env:"OCM_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"5.0"`
 	Namespace string                 `ocisConfig:"-" yaml:"-"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
-	Protocol  string                 `yaml:"protocol" env:"OCM_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;OCM_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"5.0"`
 }
 
 type ScienceMesh struct {

--- a/services/search/pkg/search/search_suite_test.go
+++ b/services/search/pkg/search/search_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/sharing/pkg/command/server.go
+++ b/services/sharing/pkg/command/server.go
@@ -98,7 +98,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/sharing/pkg/config/config.go
+++ b/services/sharing/pkg/config/config.go
@@ -56,7 +56,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"SHARING_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"SHARING_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;SHARING_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }
 
 type UserSharingDrivers struct {

--- a/services/storage-publiclink/pkg/command/server.go
+++ b/services/storage-publiclink/pkg/command/server.go
@@ -81,7 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/storage-publiclink/pkg/config/config.go
+++ b/services/storage-publiclink/pkg/config/config.go
@@ -48,7 +48,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"STORAGE_PUBLICLINK_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"STORAGE_PUBLICLINK_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;STORAGE_PUBLICLINK_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }
 
 type StorageProvider struct {

--- a/services/storage-shares/pkg/command/server.go
+++ b/services/storage-shares/pkg/command/server.go
@@ -81,7 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/storage-shares/pkg/config/config.go
+++ b/services/storage-shares/pkg/config/config.go
@@ -49,5 +49,5 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"STORAGE_SHARES_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"STORAGE_SHARES_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;STORAGE_SHARES_GRPC_PROTOCOL" desc:"The transport protocol of the GRPC service." introductionVersion:"pre5.0"`
 }

--- a/services/storage-system/pkg/command/server.go
+++ b/services/storage-system/pkg/command/server.go
@@ -81,7 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/storage-system/pkg/config/config.go
+++ b/services/storage-system/pkg/config/config.go
@@ -61,7 +61,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"STORAGE_SYSTEM_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"STORAGE_SYSTEM_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;STORAGE_SYSTEM_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
 }
 
 // HTTPConfig holds HTTPConfig config

--- a/services/storage-system/pkg/config/config.go
+++ b/services/storage-system/pkg/config/config.go
@@ -18,10 +18,11 @@ type Config struct {
 	GRPC GRPCConfig `yaml:"grpc"`
 	HTTP HTTPConfig `yaml:"http"`
 
-	TokenManager     *TokenManager `yaml:"token_manager"`
-	Reva             *shared.Reva  `yaml:"reva"`
-	SystemUserID     string        `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID" desc:"ID of the oCIS storage-system system user. Admins need to set the ID for the STORAGE-SYSTEM system user in this config option which is then used to reference the user. Any reasonable long string is possible, preferably this would be an UUIDv4 format." introductionVersion:"pre5.0"`
-	SystemUserAPIKey string        `yaml:"system_user_api_key" env:"OCIS_SYSTEM_USER_API_KEY" desc:"API key for the STORAGE-SYSTEM system user." introductionVersion:"pre5.0"`
+	TokenManager *TokenManager `yaml:"token_manager"`
+	Reva         *shared.Reva  `yaml:"reva"`
+
+	SystemUserID     string `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID" desc:"ID of the oCIS storage-system system user. Admins need to set the ID for the STORAGE-SYSTEM system user in this config option which is then used to reference the user. Any reasonable long string is possible, preferably this would be an UUIDv4 format." introductionVersion:"pre5.0"`
+	SystemUserAPIKey string `yaml:"system_user_api_key" env:"OCIS_SYSTEM_USER_API_KEY" desc:"API key for the STORAGE-SYSTEM system user." introductionVersion:"pre5.0"`
 
 	SkipUserGroupsInToken bool `yaml:"skip_user_groups_in_token" env:"STORAGE_SYSTEM_SKIP_USER_GROUPS_IN_TOKEN" desc:"Disables the loading of user's group memberships from the reva access token." introductionVersion:"pre5.0"`
 

--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -92,7 +92,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/storage-users/pkg/config/config.go
+++ b/services/storage-users/pkg/config/config.go
@@ -75,7 +75,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"STORAGE_USERS_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"STORAGE_USERS_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;STORAGE_USERS_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
 }
 
 // HTTPConfig is the configuration for the http server

--- a/services/storage-users/pkg/task/task_suite_test.go
+++ b/services/storage-users/pkg/task/task_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/userlog/pkg/service/service_suit_test.go
+++ b/services/userlog/pkg/service/service_suit_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/users/pkg/command/server.go
+++ b/services/users/pkg/command/server.go
@@ -94,7 +94,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Protocol, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/users/pkg/config/config.go
+++ b/services/users/pkg/config/config.go
@@ -48,7 +48,7 @@ type GRPCConfig struct {
 	Addr      string                 `yaml:"addr" env:"USERS_GRPC_ADDR" desc:"The bind address of the GRPC service." introductionVersion:"pre5.0"`
 	TLS       *shared.GRPCServiceTLS `yaml:"tls"`
 	Namespace string                 `yaml:"-"`
-	Protocol  string                 `yaml:"protocol" env:"USERS_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
+	Protocol  string                 `yaml:"protocol" env:"OCIS_GRPC_PROTOCOL;USERS_GRPC_PROTOCOL" desc:"The transport protocol of the GPRC service." introductionVersion:"pre5.0"`
 }
 
 type Drivers struct {


### PR DESCRIPTION
This allows using `dns` or `unix` as the grpc protocol for services. Required [reva changes](https://github.com/cs3org/reva/pull/4744) have been bumped.

related:
- https://github.com/owncloud/ocis/issues/8589
- https://github.com/owncloud/ocis/pull/9488

With this PR we can configure the grpc clients to use dns:///service with headless services in kubernetes to gracefully handle connection errors when a pod goes down.
To also handle scale up we need to make grpc servers force close connections by setting the keep alive parameter:
- reva PR https://github.com/cs3org/reva/pull/4772
- ocis PR https://github.com/owncloud/ocis/pull/9657