### PR TITLE
ignore addresses for kubernetes registry

### DIFF
--- a/changelog/unreleased/ignore-address-for-kubernetes-registry.md
+++ b/changelog/unreleased/ignore-address-for-kubernetes-registry.md
@@ -1,0 +1,5 @@
+Bugfix: Ignore address for kubernetes registry
+
+We no longer pass an address to the go micro kubernetes registry implementation. This causes the implementation to autodetect the namespace and not hardcode it to `default`.
+
+https://github.com/owncloud/ocis/pull/9490

--- a/ocis-pkg/registry/registry.go
+++ b/ocis-pkg/registry/registry.go
@@ -68,9 +68,7 @@ func GetRegistry(opts ...Option) mRegistry.Registry {
 			cfg.DisableCache = true // no cache needed for in-memory registry
 		case "kubernetes":
 			fmt.Println("Attention: kubernetes registry is deprecated, use nats-js-kv instead")
-			_reg = kubernetesr.NewRegistry(
-				mRegistry.Addrs(cfg.Addresses...),
-			)
+			_reg = kubernetesr.NewRegistry()
 		case "nats":
 			fmt.Println("Attention: nats registry is deprecated, use nats-js-kv instead")
 			_reg = natsr.NewRegistry(


### PR DESCRIPTION
We no longer pass an address to the go micro kubernetes registry implementation. This causes the implementation to autodetect the namespace and not hardcode it to `default`.

related https://github.com/owncloud/ocis/issues/8589
