### PR TITLE
[tests-only][full-ci] add TUS upload API test for invalid ".." path

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1576,7 +1576,7 @@ trait WebDav {
 			$type
 		);
 		$statusCode = $response->getStatusCode();
-		if ($statusCode < 401 || $statusCode > 404) {
+		if ($statusCode < 400 || $statusCode > 499) {
 			try {
 				$responseXml = HttpRequestHelper::getResponseXml(
 					$response,

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature
@@ -164,14 +164,17 @@ Feature: upload file
       | old              | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
       | old              | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
       | old              | "my\\file"              | bXkMaWxl                     |
+      | old              | ".."                    | Li4=                         |
       | new              | " "                     | IA==                         |
       | new              | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
       | new              | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
       | new              | "my\\file"              | bXkMaWxl                     |
+      | new              | ".."                    | Li4=                         |
       | spaces           | " "                     | IA==                         |
       | spaces           | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
       | spaces           | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
       | spaces           | "my\\file"              | bXkMaWxl                     |
+      | spaces           | ".."                    | Li4=                         |
 
 
   Scenario Outline: upload a zero-byte file


### PR DESCRIPTION
## Description
Added API tests for trying to create TUS upload with path `..`.

## Related Issue
- Coverage: https://github.com/owncloud/ocis/issues/1002

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
