### PR TITLE
[tests-only][full-ci] added cli test for changing password of non-existing user

### DIFF
--- a/tests/acceptance/features/bootstrap/CliContext.php
+++ b/tests/acceptance/features/bootstrap/CliContext.php
@@ -68,21 +68,24 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator resets the password of user :user to :password using the CLI
+	 * @When /^the administrator resets the password of (non-existing|existing) user "([^"]*)" to "([^"]*)" using the CLI$/
 	 *
+	 * @param string $status
 	 * @param string $user
 	 * @param string $password
 	 *
 	 * @return void
 	 */
-	public function theAdministratorResetsThePasswordOfUserUsingTheCLI(string $user, string $password): void {
+	public function theAdministratorResetsThePasswordOfUserUsingTheCLI(string $status, string $user, string $password): void {
 		$command = "idm resetpassword -u $user";
 		$body = [
 			"command" => $command,
 			"inputs" => [$password, $password]
 		];
-
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
+		if ($status === "non-existing") {
+			return;
+		}
 		$this->featureContext->updateUserPassword($user, $password);
 	}
 

--- a/tests/acceptance/features/cliCommands/resetUserPassword.feature
+++ b/tests/acceptance/features/cliCommands/resetUserPassword.feature
@@ -8,10 +8,17 @@ Feature: reset user password via CLI command
       | displayName | Alice Hansen |
       | password    | %alt1%       |
     And the administrator has stopped the server
-    When the administrator resets the password of user "Alice" to "newpass" using the CLI
+    When the administrator resets the password of existing user "Alice" to "newpass" using the CLI
     Then the command should be successful
     And the command output should contain "Password for user 'uid=Alice,ou=users,o=libregraph-idm' updated."
     But the command output should not contain "Failed to update user password: entry does not exist"
     And the administrator has started the server
     And user "Alice" should be able to create folder "newFolder" using password "newpass"
     But user "Alice" should not be able to create folder "anotherFolder" using password "%alt1%"
+
+
+  Scenario: try to reset password of non-existing user
+    Given the administrator has stopped the server
+    When the administrator resets the password of non-existing user "Alice" to "newpass" using the CLI
+    Then the command should be successful
+    But the command output should contain "Failed to update user password: entry does not exist"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Adding test scenario for changing password of non existing user via cli

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/9529


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
-  locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
