### PR TITLE
[full-ci] chore: bump web to v9.2.0-alpha.1

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=b92e0c3d353ba72174e9941ed4ef1ff528a35862
+WEB_COMMITID=862a4b4a419cf4e7cb2811c456675cd55a1924c6
 WEB_BRANCH=master

--- a/changelog/unreleased/update-web-9.2.0.md
+++ b/changelog/unreleased/update-web-9.2.0.md
@@ -1,0 +1,10 @@
+Enhancement: Update web to v9.1.0-alpha.1
+
+Tags: web
+
+We updated ownCloud Web to v9.1.0-alpha.1. Please refer to the changelog (linked) for details on the web release.
+
+- Enhancement [owncloud/web#11101](https://github.com/owncloud/web/issues/11101): Add share role icon to shared with me table
+
+https://github.com/owncloud/ocis/pull/9585
+https://github.com/owncloud/web/releases/tag/v9.2.0-alpha.1

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v9.1.0
+WEB_ASSETS_VERSION = v9.2.0-alpha.1
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
bumping web to pre-release `v9.2.0-alpha.1`