### PR TITLE
[docs-only] Add page to dev docs with services per release

### DIFF
--- a/docs/services/general-info/added-services.md
+++ b/docs/services/general-info/added-services.md
@@ -1,0 +1,61 @@
+---
+title: Addes Services per Release
+date: 2024-07-12T00:00:00+00:00
+weight: 20
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/services/general-info
+geekdocFilePath: added-services.md
+geekdocCollapseSection: true
+---
+
+Over time, services get added with new releases published. This page gives an overview which services exist respectively
+have been added per release.
+
+## Added Services
+
+The following table gives an overview about releases and their services.
+
+| 3.0                | 4.0                | 5.0                | Rolling            |
+| ------------------ | ------------------ | ------------------ | ------------------ |
+|                    |                    |                    | activitylog        |
+| antivirus          | antivirus          | antivirus          | antivirus          |
+| app-provider       | app-provider       | app-provider       | app-provider       |
+| app-registry       | app-registry       | app-registry       | app-registry       |
+| audit              | audit              | audit              | audit              |
+| auth-basic         | auth-basic         | auth-basic         | auth-basic         |
+| auth-bearer        | auth-bearer        | auth-bearer        | auth-bearer        |
+| auth-machine       | auth-machine       | auth-machine       | auth-machine       |
+| eventhistory       | eventhistory       | auth-service       | auth-service       |
+|                    |                    | clientlog          | clientlog          |
+|                    |                    |                    | collaboration      |
+|                    |                    | eventhistory       | eventhistory       |
+| frontend           | frontend           | frontend           | frontend           |
+| gateway            | gateway            | gateway            | gateway            |
+| graph              | graph              | graph              | graph              |
+| groups             | groups             | groups             | groups             |
+| idm                | idm                | idm                | idm                |
+| idp                | idp                | idp                | idp                |
+| invitations        | invitations        | invitations        | invitations        |
+| nats               | nats               | nats               | nats               |
+| notifications      | notifications      | notifications      | notifications      |
+| ocdav              | ocdav              | ocdav              | ocdav              |
+|                    |                    | ocm                | ocm                |
+| ocs                | ocs                | ocs                | ocs                |
+| policies           | policies           | policies           | policies           |
+| postprocessing     | postprocessing     | postprocessing     | postprocessing     |
+| proxy              | proxy              | proxy              | proxy              |
+| search             | search             | search             | search             |
+| settings           | settings           | settings           | settings           |
+| sharing            | sharing            | sharing            | sharing            |
+|                    |                    | sse                | sse                |
+| storage-publiclink | storage-publiclink | storage-publiclink | storage-publiclink |
+| storage-shares     | storage-shares     | storage-shares     | storage-shares     |
+| storage-system     | storage-system     | storage-system     | storage-system     |
+| storage-users      | storage-users      | storage-users      | storage-users      |
+| store              | store              | store              | store              |
+| thumbnails         | thumbnails         | thumbnails         | thumbnails         |
+| userlog            | userlog            | userlog            | userlog            |
+| users              | users              | users              | users              |
+| web                | web                | web                | web                |
+| webdav             | webdav             | webdav             | webdav             |
+| webfinger          | webfinger          | webfinger          | webfinger          |

--- a/docs/services/general-info/added-services.md
+++ b/docs/services/general-info/added-services.md
@@ -25,7 +25,7 @@ The following table gives an overview about releases and their services.
 | auth-basic         | auth-basic         | auth-basic         | auth-basic         |
 | auth-bearer        | auth-bearer        | auth-bearer        | auth-bearer        |
 | auth-machine       | auth-machine       | auth-machine       | auth-machine       |
-| eventhistory       | eventhistory       | auth-service       | auth-service       |
+|                    |                    | auth-service       | auth-service       |
 |                    |                    | clientlog          | clientlog          |
 |                    |                    |                    | collaboration      |
 |                    |                    | eventhistory       | eventhistory       |


### PR DESCRIPTION
This PR adds a page to dev docs to describe which services are available / been added per release.
We have a similar page in the [admin docs](https://doc.owncloud.com/ocis/next/deployment/services/services.html).