### PR TITLE
[docs-only] Docs adoc template: make a space between deprecations and standard

### DIFF
--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -1,6 +1,6 @@
 // set the attribute to true or leave empty, true without any quotes.
 // if the generated adoc file is used outside tabs, it renders correctly depending on the attribute set.
-// if inside, you need additioanlly use the xxx_deprecation.adoc file. attributes cant be defined inside tabs.
+// if inside, you need to also use the xxx_deprecation.adoc file. attributes can't be defined inside tabs.
 
 :show-deprecation: {{ .HasDeprecations }}
 

--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -1,4 +1,6 @@
 // set the attribute to true or leave empty, true without any quotes.
+// if the generated adoc file is used outside tabs, it renders correctly depending on the attribute set.
+// if inside, you need additioanlly use the xxx_deprecation.adoc file. attributes cant be defined inside tabs.
 
 :show-deprecation: {{ .HasDeprecations }}
 
@@ -22,6 +24,8 @@ ifeval::[{show-deprecation} == true]
 | {{ .DeprecationReplacement }}
 {{- end }}
 |===
+
+{empty} +
 
 endif::[]
 


### PR DESCRIPTION
As part of a necessary admin docs cleanup.

Adds some space between deprecations - if present - and standard envvar printout.
Also added more explanations as comment.

Backport to `stable-5.0` necessary.