### PR TITLE
[tests-only] add test coverage for new props from personal space

### DIFF
--- a/tests/acceptance/features/apiSearchContent/propfindExtractedProps.feature
+++ b/tests/acceptance/features/apiSearchContent/propfindExtractedProps.feature
@@ -4,11 +4,13 @@ Feature: propfind extracted props
   I want to get extracted properties of resource
   So that I can make sure that the response contains audio, location, image and photo properties
 
-
-  Scenario: check extracted properties of a file from project space
+  Background:
     Given user "Alice" has been created with default attributes and without skeleton files
     And using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+
+
+  Scenario: check extracted properties of a file from project space
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has uploaded a file "filesForUpload/testaudio.mp3" to "testaudio.mp3" in space "new-space"
     And user "Alice" has uploaded a file "filesForUpload/testavatar.jpg" to "testavatar.jpg" in space "new-space"
@@ -40,3 +42,37 @@ Feature: propfind extracted props
       | oc:photo/oc:camera-model         | COOLPIX P6000        |
       | oc:photo/oc:f-number             | 4.5                  |
       | oc:photo/oc:focal-length         | 6                    |
+
+
+  Scenario: check extracted properties of a file from personal space
+    Given user "Alice" has uploaded file "filesForUpload/testaudio.mp3" to "testaudio.mp3"
+    And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
+    When user "Alice" gets the following extracted properties of resource "testaudio.mp3" inside space "Personal" using the WebDAV API
+      | propertyName |
+      | oc:audio     |
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response to user "Alice" should contain a mountpoint "testaudio.mp3" with these key and value pairs:
+      | key                | value                          |
+      | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
+      | oc:audio/oc:artist | ARTIST123456789012345678901234 |
+      | oc:audio/oc:genre  | Pop                            |
+      | oc:audio/oc:title  | TITLE1234567890123456789012345 |
+      | oc:audio/oc:track  | 1                              |
+      | oc:audio/oc:year   | 2001                           |
+    When user "Alice" gets the following extracted properties of resource "testavatar.jpg" inside space "Personal" using the WebDAV API
+      | propertyName |
+      | oc:image     |
+      | oc:location  |
+      | oc:photo     |
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response to user "Alice" should contain a mountpoint "testavatar.jpg" with these key and value pairs:
+      | key                              | value                |
+      | oc:image/oc:width                | 640                  |
+      | oc:image/oc:height               | 480                  |
+      | oc:location/oc:latitude          | 43.467157            |
+      | oc:location/oc:longitude         | 11.885395            |
+      | oc:photo/oc:camera-make          | NIKON                |
+      | oc:photo/oc:camera-model         | COOLPIX P6000        |
+      | oc:photo/oc:f-number             | 4.5                  |
+      | oc:photo/oc:focal-length         | 6                    |
+

--- a/tests/acceptance/features/apiSearchContent/propfindExtractedProps.feature
+++ b/tests/acceptance/features/apiSearchContent/propfindExtractedProps.feature
@@ -76,3 +76,52 @@ Feature: propfind extracted props
       | oc:photo/oc:f-number             | 4.5                  |
       | oc:photo/oc:focal-length         | 6                    |
 
+
+  Scenario: check extracted properties of a file by sharee from shares space
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/testaudio.mp3" to "testaudio.mp3"
+    And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testaudio.mp3 |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    And user "Brian" has a share "testaudio.mp3" synced
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testavatar.jpg |
+      | space           | Personal       |
+      | sharee          | Brian          |
+      | shareType       | user           |
+      | permissionsRole | Viewer         |
+    And user "Brian" has a share "testavatar.jpg" synced
+    When user "Brian" gets the following extracted properties of resource "testaudio.mp3" inside space "Shares" using the WebDAV API
+      | propertyName |
+      | oc:audio     |
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
+      | key                | value                          |
+      | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
+      | oc:audio/oc:artist | ARTIST123456789012345678901234 |
+      | oc:audio/oc:genre  | Pop                            |
+      | oc:audio/oc:title  | TITLE1234567890123456789012345 |
+      | oc:audio/oc:track  | 1                              |
+      | oc:audio/oc:year   | 2001                           |
+    When user "Brian" gets the following extracted properties of resource "testavatar.jpg" inside space "Shares" using the WebDAV API
+      | propertyName |
+      | oc:image     |
+      | oc:location  |
+      | oc:photo     |
+    Then the HTTP status code should be "207"
+    And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
+      | key                              | value                |
+      | oc:image/oc:width                | 640                  |
+      | oc:image/oc:height               | 480                  |
+      | oc:location/oc:latitude          | 43.467157            |
+      | oc:location/oc:longitude         | 11.885395            |
+      | oc:photo/oc:camera-make          | NIKON                |
+      | oc:photo/oc:camera-model         | COOLPIX P6000        |
+      | oc:photo/oc:f-number             | 4.5                  |
+      | oc:photo/oc:focal-length         | 6                    |


### PR DESCRIPTION
## Description
Added scenarios for checking audio, location, image and photo props of the file from `Personal` space by space admin and `Shares` space by sharee.

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/9180

## How Has This Been Tested?
- CI 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
