### PR TITLE
chore: bump production version to v5.0.6 for ocis_full

### DIFF
--- a/deployments/continuous-deployment-config/ocis_full/production.yml
+++ b/deployments/continuous-deployment-config/ocis_full/production.yml
@@ -32,7 +32,7 @@
         env:
           INSECURE: "false"
           TRAEFIK_ACME_MAIL: mbarz@owncloud.com
-          OCIS_DOCKER_TAG: 5.0.5
+          OCIS_DOCKER_TAG: 5.0.6
           OCIS_DOMAIN: ocis.ocis.production.owncloud.works
           COMPANION_DOMAIN: companion.ocis.production.owncloud.works
           COMPANION_IMAGE: owncloud/uppy-companion:3.12.13-owncloud


### PR DESCRIPTION
Release `v5.0.6` is done, now updating the deployment example `ocis_full` for production demo.