### PR TITLE
feat: use info level for access log to the collaboration service

### DIFF
--- a/services/collaboration/pkg/connector/httpadapter.go
+++ b/services/collaboration/pkg/connector/httpadapter.go
@@ -65,6 +65,7 @@ func (h *HttpAdapter) GetLock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set(HeaderWopiLock, lockID)
+	w.WriteHeader(http.StatusOK)
 }
 
 // Lock adapts the "Lock" and "UnlockAndRelock" operations for WOPI.
@@ -91,8 +92,7 @@ func (h *HttpAdapter) Lock(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// If no error, a HTTP 200 should be sent automatically.
-	// X-WOPI-Lock header isn't needed on HTTP 200
+	w.WriteHeader(http.StatusOK)
 }
 
 // RefreshLock adapts the "RefreshLock" operation for WOPI
@@ -119,8 +119,7 @@ func (h *HttpAdapter) RefreshLock(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// If no error, a HTTP 200 should be sent automatically.
-	// X-WOPI-Lock header isn't needed on HTTP 200
+	w.WriteHeader(http.StatusOK)
 }
 
 // UnLock adapts the "Unlock" operation for WOPI
@@ -145,8 +144,7 @@ func (h *HttpAdapter) UnLock(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// If no error, a HTTP 200 should be sent automatically.
-	// X-WOPI-Lock header isn't needed on HTTP 200
+	w.WriteHeader(http.StatusOK)
 }
 
 // CheckFileInfo will retrieve the information of the file in json format
@@ -229,6 +227,5 @@ func (h *HttpAdapter) PutFile(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// If no error, a HTTP 200 should be sent automatically.
-	// X-WOPI-Lock header isn't needed on HTTP 200
+	w.WriteHeader(http.StatusOK)
 }

--- a/services/collaboration/pkg/middleware/accesslog.go
+++ b/services/collaboration/pkg/middleware/accesslog.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// AccessLog is a middleware to log http requests at info level logging.
+func AccessLog(logger log.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			requestID := middleware.GetReqID(r.Context())
+			// add Request Id to all responses
+			w.Header().Set(middleware.RequestIDHeader, requestID)
+			wrap := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			next.ServeHTTP(wrap, r)
+
+			spanContext := trace.SpanContextFromContext(r.Context())
+			logger.Info().
+				Str("proto", r.Proto).
+				Str(log.RequestIDString, requestID).
+				Str("traceid", spanContext.TraceID().String()).
+				Str("remote-addr", r.RemoteAddr).
+				Str("method", r.Method).
+				Int("status", wrap.Status()).
+				Str("path", r.URL.Path).
+				Dur("duration", time.Since(start)).
+				Int("bytes", wrap.BytesWritten()).
+				Msg("access-log")
+		})
+	}
+}

--- a/services/collaboration/pkg/server/http/server.go
+++ b/services/collaboration/pkg/server/http/server.go
@@ -44,7 +44,7 @@ func Server(opts ...Option) (http.Service, error) {
 			options.Config.Service.Name+"."+options.Config.App.Name,
 			version.GetString(),
 		),
-		middleware.Logger(
+		colabmiddleware.AccessLog(
 			options.Logger,
 		),
 		middleware.ExtractAccountUUID(


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Rise log level to info for the access log for the collaboration service. Information logged will be the same as the proxy service

## Related Issue
https://github.com/owncloud/ocis/issues/8769#issuecomment-2235891654

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested

```
{"level":"info","service":"collaboration","proto":"HTTP/1.1","request-id":"3e2bb28fdcc7/OSVUm62V06-000001","traceid":"00000000000000000000000000000000","remote-addr":"172.19.0.2:58614","method":"GET","status":200,"path":"/wopi/files/a27f186f006161194130058f922640fc4c92d6465d81921da83f425cce3bd45b","duration":15.772503,"bytes":565,"time":"2024-07-18T08:42:29Z","line":"/home/juan/src/ocis/ocis/services/collaboration/pkg/middleware/accesslog.go:34","message":"access-log"}
{"level":"info","service":"collaboration","proto":"HTTP/1.1","request-id":"3e2bb28fdcc7/OSVUm62V06-000002","traceid":"00000000000000000000000000000000","remote-addr":"172.19.0.2:58616","method":"POST","status":0,"path":"/wopi/files/a27f186f006161194130058f922640fc4c92d6465d81921da83f425cce3bd45b","duration":25.029887,"bytes":0,"time":"2024-07-18T08:42:29Z","line":"/home/juan/src/ocis/ocis/services/collaboration/pkg/middleware/accesslog.go:34","message":"access-log"}
{"level":"info","service":"collaboration","proto":"HTTP/1.1","request-id":"3e2bb28fdcc7/OSVUm62V06-000003","traceid":"00000000000000000000000000000000","remote-addr":"172.19.0.2:58622","method":"GET","status":200,"path":"/wopi/files/a27f186f006161194130058f922640fc4c92d6465d81921da83f425cce3bd45b/contents","duration":76.670402,"bytes":21171,"time":"2024-07-18T08:42:29Z","line":"/home/juan/src/ocis/ocis/services/collaboration/pkg/middleware/accesslog.go:34","message":"access-log"}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

@micbar I'm not sure how useful this will be for tracking because the requests come from the WOPI app, so forwarding the required headers might not be possible.
Additional headers we might want to log: https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/common-headers . As far as I know, most of them are for Microsoft only. This includes the `X-Request-ID`, so they'll be auto-generated for each request.

~There are requests returning a "0" status, which seems to be caused because we aren't explicitly set the status ourselves. That's an easy fix.~ Done