### PR TITLE
Fix docs helpers

### DIFF
--- a/docs/helpers/templates/adoc-generator.go.tmpl
+++ b/docs/helpers/templates/adoc-generator.go.tmpl
@@ -19,12 +19,13 @@ import (
 
 // ConfigField is the representation of one configuration field
 type ConfigField struct {
-	EnvVars         []string
-	DefaultValue    string
-	Type            string
-	Description     string
-	VersionInfo     string
-	DeprecationLink string
+	EnvVars         	[]string
+	DefaultValue    	string
+	IntroductionVersion string
+	Type            	string
+	Description     	string
+	VersionInfo     	string
+	DeprecationLink 	string
 }
 
 // DeprecationField holds information about deprecation
@@ -37,11 +38,12 @@ type DeprecationField struct {
 
 // EnvVar holds information about one envvar
 type EnvVar struct {
-    Name 	 string
-    DefaultValue string
-    Type 	 string
-    Description  string
-    Services 	 []string
+	Name 	 string
+	IntroductionVersion string
+	DefaultValue string
+	Type 	 string
+	Description  string
+	Services 	 []string
 }
 
 type templateData struct {
@@ -103,6 +105,7 @@ func main() {
 		    } else {
 			all[e] = EnvVar{
 			    Name:         e,
+				IntroductionVersion: f.IntroductionVersion,
 			    Description:  f.Description,
 			    Type: 	  f.Type,
 			    DefaultValue: f.DefaultValue,
@@ -153,7 +156,7 @@ func main() {
 			"Description":  env.Description,
 			"DefaultValue": env.DefaultValue,
 			"Type":         env.Type,
-		})	    
+		})
 	    }
 	}
 
@@ -198,6 +201,7 @@ func GetAnnotatedVariables(s interface{}, timestamp string) ([]ConfigField, []De
 			if !ok {
 				continue
 			}
+			introductionVersion, _ := field.Tag.Lookup("introductionVersion")
 			deprecationVersion, _ := field.Tag.Lookup("deprecationVersion")
 			removalVersion, _ := field.Tag.Lookup("removalVersion")
 			deprecationInfo, _ := field.Tag.Lookup("deprecationInfo")
@@ -223,6 +227,7 @@ func GetAnnotatedVariables(s interface{}, timestamp string) ([]ConfigField, []De
 			fields = append(fields,
 				ConfigField{
 					EnvVars:         td,
+					IntroductionVersion: introductionVersion,
 					DefaultValue:    v,
 					Description:     desc,
 					Type:            typeName,

--- a/docs/helpers/templates/adoc-generator.go.tmpl
+++ b/docs/helpers/templates/adoc-generator.go.tmpl
@@ -152,6 +152,7 @@ func main() {
 	    if len(env.Services) > 1 {
 		tmplValues = append(tmplValues, map[string]interface{}{
 			"Name":         env.Name,
+			"IntroductionVersion": env.IntroductionVersion,
 			"Services":     env.Services,
 			"Description":  env.Description,
 			"DefaultValue": env.DefaultValue,

--- a/docs/helpers/templates/adoc-generator.go.tmpl
+++ b/docs/helpers/templates/adoc-generator.go.tmpl
@@ -38,12 +38,12 @@ type DeprecationField struct {
 
 // EnvVar holds information about one envvar
 type EnvVar struct {
-	Name 	 			string
+	Name                string
 	IntroductionVersion string
-	DefaultValue 		string
-	Type 	 			string
-	Description  		string
-	Services 	 		[]string
+	DefaultValue        string
+	Type                string
+	Description         string
+	Services            []string
 }
 
 type templateData struct {

--- a/docs/helpers/templates/adoc-generator.go.tmpl
+++ b/docs/helpers/templates/adoc-generator.go.tmpl
@@ -21,7 +21,7 @@ import (
 type ConfigField struct {
 	EnvVars         	[]string
 	DefaultValue    	string
-	IntroductionVersion string
+	IntroductionVersion	string
 	Type            	string
 	Description     	string
 	VersionInfo     	string
@@ -38,12 +38,12 @@ type DeprecationField struct {
 
 // EnvVar holds information about one envvar
 type EnvVar struct {
-	Name 	 string
+	Name 	 			string
 	IntroductionVersion string
-	DefaultValue string
-	Type 	 string
-	Description  string
-	Services 	 []string
+	DefaultValue 		string
+	Type 	 			string
+	Description  		string
+	Services 	 		[]string
 }
 
 type templateData struct {

--- a/docs/helpers/templates/adoc-generator.go.tmpl
+++ b/docs/helpers/templates/adoc-generator.go.tmpl
@@ -105,7 +105,7 @@ func main() {
 		    } else {
 			all[e] = EnvVar{
 			    Name:         e,
-				IntroductionVersion: f.IntroductionVersion,
+				IntroductionVersion: replaceEnvVarPlaceHolder(f.IntroductionVersion),
 			    Description:  f.Description,
 			    Type: 	  f.Type,
 			    DefaultValue: f.DefaultValue,
@@ -152,7 +152,7 @@ func main() {
 	    if len(env.Services) > 1 {
 		tmplValues = append(tmplValues, map[string]interface{}{
 			"Name":         env.Name,
-			"IntroductionVersion": env.IntroductionVersion,
+			"IntroductionVersion": replaceEnvVarPlaceHolder(env.IntroductionVersion),
 			"Services":     env.Services,
 			"Description":  env.Description,
 			"DefaultValue": env.DefaultValue,
@@ -182,6 +182,15 @@ func main() {
 	}
 
 	fmt.Println("done")
+}
+
+func replaceEnvVarPlaceHolder(s string) string {
+	return strings.Replace(
+		strings.Replace(s, "%%NEXT%%", "next", -1),
+		"%%NEXT_PRODUCTION_VERSION%%",
+		"next-prod",
+		-1,
+	)
 }
 
 func GetAnnotatedVariables(s interface{}, timestamp string) ([]ConfigField, []DeprecationField) {
@@ -228,7 +237,7 @@ func GetAnnotatedVariables(s interface{}, timestamp string) ([]ConfigField, []De
 			fields = append(fields,
 				ConfigField{
 					EnvVars:         td,
-					IntroductionVersion: introductionVersion,
+					IntroductionVersion: replaceEnvVarPlaceHolder(introductionVersion),
 					DefaultValue:    v,
 					Description:     desc,
 					Type:            typeName,
@@ -237,10 +246,10 @@ func GetAnnotatedVariables(s interface{}, timestamp string) ([]ConfigField, []De
 			if deprecationLink != "" {
 				deprecations = append(deprecations,
 					DeprecationField{
-						DeprecationVersion:     deprecationVersion,
+						DeprecationVersion:     replaceEnvVarPlaceHolder(deprecationVersion),
 						DeprecationInfo:        deprecationInfo,
 						DeprecationReplacement: deprecationReplacement,
-						RemovalVersion:         removalVersion,
+						RemovalVersion:         replaceEnvVarPlaceHolder(removalVersion),
 					})
 			}
 		case reflect.Ptr:

--- a/docs/templates/ADOC.tmpl
+++ b/docs/templates/ADOC.tmpl
@@ -34,6 +34,7 @@ endif::[]
 [width="100%",cols="~,~,~,~",options="header"]
 |===
 | Name
+| IV
 | Type
 | Default Value
 | Description
@@ -45,6 +46,8 @@ a| {{- range $i, $value := .EnvVars }}{{- if $i }} +
 `{{- $value }}`
 {{- end }} +
 {{ .DeprecationLink }}
+a| [subs=-attributes]
+++{{.IntroductionVersion}} ++
 a| [subs=-attributes]
 ++{{.Type}} ++
 a| [subs=-attributes]

--- a/docs/templates/ADOC_global.tmpl
+++ b/docs/templates/ADOC_global.tmpl
@@ -6,12 +6,16 @@
 [width="100%",cols="30%,25%,~,~,~",options="header"]
 |===
 | Name
+| IV
 | Services
 | Type
 | Default Value
 | Description
 {{ range . }}
 a| `{{ .Name }}`
+
+a| [subs=-attributes]
+++{{ .IntroductionVersion }} ++
 
 a| [subs=attributes+]
 {{- range .Services}}


### PR DESCRIPTION
This PR adds the `IntroductionVersion` to the adoc outputs and replaces `%%NEXT%%` and `%%NEXT_PRODUCTION_VERSION%%` in the same outputs.

refs #9525 
refs #9316 