### PR TITLE
fix: missing invitation in permission responses

### DIFF
--- a/changelog/unreleased/bugfix-missing-invitation-in-permissions.md
+++ b/changelog/unreleased/bugfix-missing-invitation-in-permissions.md
@@ -1,0 +1,6 @@
+Bugfix: Missing invitation in permission responses
+
+We have fixed a bug where the `invitation` property was missing in the response when creating, listing or updating graph permissions.
+
+https://github.com/owncloud/ocis/pull/9652
+https://github.com/owncloud/ocis/issues/9571

--- a/services/graph/pkg/service/v0/base.go
+++ b/services/graph/pkg/service/v0/base.go
@@ -404,6 +404,19 @@ func (g BaseGraphService) cs3UserShareToPermission(ctx context.Context, share *c
 		perm.SetRoles(nil)
 	}
 	perm.SetGrantedToV2(grantedTo)
+	if share.GetCreator() != nil {
+		identity, err := cs3UserIdToIdentity(ctx, g.identityCache, share.GetCreator())
+		if err != nil {
+			return nil, errorcode.New(errorcode.GeneralException, err.Error())
+		}
+		perm.SetInvitation(
+			libregraph.SharingInvitation{
+				InvitedBy: &libregraph.IdentitySet{
+					User: &identity,
+				},
+			},
+		)
+	}
 	return &perm, nil
 }
 


### PR DESCRIPTION

## Description
Fixes a bug where the `invitation` property is missing in the response when creating, listing or updating graph permissions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/9571

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
