### PR TITLE
reuse node id when registering services

### DIFF
--- a/changelog/unreleased/fix-natsjskv-registry.md
+++ b/changelog/unreleased/fix-natsjskv-registry.md
@@ -2,6 +2,7 @@ Bugfix: Repair nats-js-kv registry
 
 The registry would always send traffic to only one pod. This is now fixed and load should be spread evenly. Also implements watcher method so the cache can use it.
 
+https://github.com/owncloud/ocis/pull/9656
 https://github.com/owncloud/ocis/pull/9662
 https://github.com/owncloud/ocis/pull/9654
 https://github.com/owncloud/ocis/pull/9620

--- a/go.mod
+++ b/go.mod
@@ -361,7 +361,7 @@ replace github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-2
 
 replace github.com/unrolled/secure => github.com/DeepDiver1975/secure v0.0.0-20240611112133-abc838fb797c
 
-replace github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240723073728-b36ea3314b73
+replace github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240724102745-4bc93ffd7ab6
 
 // exclude the v2 line of go-sqlite3 which was released accidentally and prevents pulling in newer versions of go-sqlite3
 // see https://github.com/mattn/go-sqlite3/issues/965 for more details

--- a/go.sum
+++ b/go.sum
@@ -1609,8 +1609,8 @@ github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/48xc=
 github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
-github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240723073728-b36ea3314b73 h1:Cgg5BVWG99INUMX43nD5jhZgNzQJyFA0MvZkctNn0Lw=
-github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240723073728-b36ea3314b73/go.mod h1:pjcozWijkNPbEtX5SIQaxEW/h8VAVZYTLx+70bmB3LY=
+github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240724102745-4bc93ffd7ab6 h1:NNXx1/XWR6Ryud6qNanwrl/JuRx2KdCW1jS2/Cf/TO8=
+github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240724102745-4bc93ffd7ab6/go.mod h1:pjcozWijkNPbEtX5SIQaxEW/h8VAVZYTLx+70bmB3LY=
 github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b/go.mod h1:o03bZfuBwAXHetKXuInt4S7omeXUu62/A845kiycsSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/ocis-pkg/natsjsregistry/watcher.go
+++ b/ocis-pkg/natsjsregistry/watcher.go
@@ -1,21 +1,23 @@
 package natsjsregistry
 
 import (
+	"encoding/json"
 	"errors"
 
+	natsjskv "github.com/go-micro/plugins/v4/store/nats-js-kv"
 	"github.com/nats-io/nats.go"
 	"go-micro.dev/v4/registry"
 )
 
 // NatsWatcher is the watcher of the nats interface
 type NatsWatcher interface {
-	WatchAll(bucket string, opts ...nats.WatchOpt) (nats.KeyWatcher, error)
+	WatchAll(bucket string, opts ...nats.WatchOpt) (<-chan *natsjskv.StoreUpdate, func() error, error)
 }
 
 // Watcher is used to keep track of changes in the registry
 type Watcher struct {
-	watch   nats.KeyWatcher
-	updates <-chan nats.KeyValueEntry
+	updates <-chan *natsjskv.StoreUpdate
+	stop    func() error
 	reg     *storeregistry
 }
 
@@ -26,14 +28,14 @@ func NewWatcher(s *storeregistry) (*Watcher, error) {
 		return nil, errors.New("store does not implement watcher interface")
 	}
 
-	watcher, err := w.WatchAll("service-registry")
+	watcher, stop, err := w.WatchAll("service-registry")
 	if err != nil {
 		return nil, err
 	}
 
 	return &Watcher{
-		watch:   watcher,
-		updates: watcher.Updates(),
+		updates: watcher,
+		stop:    stop,
 		reg:     s,
 	}, nil
 }
@@ -45,30 +47,18 @@ func (w *Watcher) Next() (*registry.Result, error) {
 		return nil, errors.New("watcher stopped")
 	}
 
-	service, err := w.reg.getService(kve.Key())
-	if err != nil {
+	var svc *registry.Service
+	if err := json.Unmarshal(kve.Value.Data, svc); err != nil {
 		return nil, err
 	}
 
-	var action string
-	switch kve.Operation() {
-	default:
-		action = "create"
-	case nats.KeyValuePut:
-		action = "create"
-	case nats.KeyValueDelete:
-		action = "delete"
-	case nats.KeyValuePurge:
-		action = "delete"
-	}
-
 	return &registry.Result{
-		Service: service,
-		Action:  action,
+		Service: svc,
+		Action:  kve.Action,
 	}, nil
 }
 
 // Stop stops the watcher
 func (w *Watcher) Stop() {
-	_ = w.watch.Stop()
+	_ = w.stop()
 }

--- a/ocis-pkg/registry/service.go
+++ b/ocis-pkg/registry/service.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 
 	mRegistry "go-micro.dev/v4/registry"
+	"go-micro.dev/v4/server"
 	"go-micro.dev/v4/util/addr"
 )
 
-func BuildGRPCService(serviceID, uuid, address string, version string) *mRegistry.Service {
+func BuildGRPCService(serviceID, address string, version string) *mRegistry.Service {
 	var host string
 	var port int
 
@@ -28,7 +29,7 @@ func BuildGRPCService(serviceID, uuid, address string, version string) *mRegistr
 	}
 
 	node := &mRegistry.Node{
-		Id:       serviceID + "-" + uuid,
+		Id:       serviceID + "-" + server.DefaultId,
 		Address:  net.JoinHostPort(addr, fmt.Sprint(port)),
 		Metadata: make(map[string]string),
 	}
@@ -46,7 +47,7 @@ func BuildGRPCService(serviceID, uuid, address string, version string) *mRegistr
 	}
 }
 
-func BuildHTTPService(serviceID, uuid, address string, version string) *mRegistry.Service {
+func BuildHTTPService(serviceID, address string, version string) *mRegistry.Service {
 	var host string
 	var port int
 
@@ -64,7 +65,7 @@ func BuildHTTPService(serviceID, uuid, address string, version string) *mRegistr
 	}
 
 	node := &mRegistry.Node{
-		Id:       serviceID + "-" + uuid,
+		Id:       serviceID + "-" + server.DefaultId,
 		Address:  net.JoinHostPort(addr, fmt.Sprint(port)),
 		Metadata: make(map[string]string),
 	}

--- a/ocis-pkg/service/grpc/service.go
+++ b/ocis-pkg/service/grpc/service.go
@@ -25,6 +25,7 @@ func NewServiceWithClient(client client.Client, opts ...Option) (Service, error)
 	var mServer server.Server
 	sopts := newOptions(opts...)
 	tlsConfig := &tls.Config{}
+
 	if sopts.TLSEnabled {
 		var cert tls.Certificate
 		var err error

--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -1,7 +1,10 @@
 package command
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/clihelper"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
@@ -25,5 +28,6 @@ func Execute() error {
 		)
 	}
 
-	return app.Run(os.Args)
+	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	return app.RunContext(ctx, os.Args)
 }

--- a/ocis/pkg/command/root.go
+++ b/ocis/pkg/command/root.go
@@ -28,6 +28,6 @@ func Execute() error {
 		)
 	}
 
-	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	return app.RunContext(ctx, os.Args)
 }

--- a/ocis/pkg/command/server.go
+++ b/ocis/pkg/command/server.go
@@ -21,7 +21,7 @@ func Server(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			// Prefer the in-memory registry as the default when running in single-binary mode
 			r := runtime.New(cfg)
-			return r.Start()
+			return r.Start(c.Context)
 		},
 	}
 }

--- a/ocis/pkg/runtime/runtime.go
+++ b/ocis/pkg/runtime/runtime.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"context"
+
 	"github.com/owncloud/ocis/v2/ocis-pkg/config"
 	"github.com/owncloud/ocis/v2/ocis/pkg/runtime/service"
 )
@@ -18,6 +20,6 @@ func New(cfg *config.Config) Runtime {
 }
 
 // Start rpc runtime
-func (r *Runtime) Start() error {
-	return service.Start(service.WithConfig(r.c))
+func (r *Runtime) Start(ctx context.Context) error {
+	return service.Start(ctx, service.WithConfig(r.c))
 }

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -96,7 +96,7 @@ type Service struct {
 // calls are done explicitly to loadFromEnv().
 // Since this is the public constructor, options need to be added, at the moment only logging options
 // are supported in order to match the running OwnCloud services structured log.
-func NewService(options ...Option) (*Service, error) {
+func NewService(ctx context.Context, options ...Option) (*Service, error) {
 	opts := NewOptions()
 
 	for _, f := range options {
@@ -109,7 +109,7 @@ func NewService(options ...Option) (*Service, error) {
 		log.Level(opts.Config.Log.Level),
 	)
 
-	globalCtx, cancelGlobal := context.WithCancel(context.Background())
+	globalCtx, cancelGlobal := context.WithCancel(ctx)
 
 	s := &Service{
 		Services:   make([]serviceFuncMap, len(_waitFuncs)),
@@ -352,12 +352,12 @@ func NewService(options ...Option) (*Service, error) {
 
 // Start a rpc service. By default, the package scope Start will run all default services to provide with a working
 // oCIS instance.
-func Start(o ...Option) error {
+func Start(ctx context.Context, o ...Option) error {
 	// Start the runtime. Most likely this was called ONLY by the `ocis server` subcommand, but since we cannot protect
 	// from the caller, the previous statement holds truth.
 
 	// prepare a new rpc Service struct.
-	s, err := NewService(o...)
+	s, err := NewService(ctx, o...)
 	if err != nil {
 		return err
 	}

--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -7,10 +7,8 @@ import (
 	"net/http"
 	"net/rpc"
 	"os"
-	"os/signal"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	authapp "github.com/owncloud/ocis/v2/services/auth-app/pkg/command"
@@ -362,9 +360,8 @@ func Start(ctx context.Context, o ...Option) error {
 		return err
 	}
 
-	// halt listens for interrupt signals and blocks.
-	halt := make(chan os.Signal, 1)
-	signal.Notify(halt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
+	// get a cancel function to stop the service
+	ctx, cancel := context.WithCancel(ctx)
 
 	// tolerance controls backoff cycles from the supervisor.
 	tolerance := 5
@@ -376,7 +373,7 @@ func Start(ctx context.Context, o ...Option) error {
 			if e.Type() == suture.EventTypeBackoff {
 				totalBackoff++
 				if totalBackoff == tolerance {
-					halt <- os.Interrupt
+					cancel()
 				}
 			}
 			s.Log.Info().Str("event", e.String()).Msg(fmt.Sprintf("supervisor: %v", e.Map()["supervisor_name"]))
@@ -424,8 +421,8 @@ func Start(ctx context.Context, o ...Option) error {
 	// https://pkg.go.dev/github.com/thejerf/suture/v4@v4.0.0#Supervisor
 	go s.Supervisor.ServeBackground(s.context)
 
-	// trap will block on halt channel for interruptions.
-	go trap(s, halt)
+	// trap will block on context done channel for interruptions.
+	go trap(s, ctx)
 
 	for i, service := range s.Services {
 		scheduleServiceTokens(s, service)
@@ -508,9 +505,8 @@ func (s *Service) List(_ struct{}, reply *string) error {
 
 // trap blocks on halt channel. When the runtime is interrupted it
 // signals the controller to stop any supervised process.
-func trap(s *Service, halt chan os.Signal) {
-	<-halt
-	s.cancel()
+func trap(s *Service, ctx context.Context) {
+	<-ctx.Done()
 	for sName := range s.serviceToken {
 		for i := range s.serviceToken[sName] {
 			if err := s.Supervisor.Remove(s.serviceToken[sName][i]); err != nil {

--- a/services/activitylog/cmd/activitylog/main.go
+++ b/services/activitylog/cmd/activitylog/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/activitylog/pkg/command"
 	"github.com/owncloud/ocis/v2/services/activitylog/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/activitylog/cmd/activitylog/main.go
+++ b/services/activitylog/cmd/activitylog/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/activitylog/pkg/command/root.go
+++ b/services/activitylog/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/activitylog/pkg/command/server.go
+++ b/services/activitylog/pkg/command/server.go
@@ -61,12 +61,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)

--- a/services/activitylog/pkg/command/server.go
+++ b/services/activitylog/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/stream"
@@ -140,7 +139,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/antivirus/cmd/antivirus/main.go
+++ b/services/antivirus/cmd/antivirus/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/antivirus/pkg/command"
 	"github.com/owncloud/ocis/v2/services/antivirus/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/antivirus/cmd/antivirus/main.go
+++ b/services/antivirus/cmd/antivirus/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/antivirus/pkg/command/root.go
+++ b/services/antivirus/pkg/command/root.go
@@ -25,5 +25,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/antivirus/pkg/command/server.go
+++ b/services/antivirus/pkg/command/server.go
@@ -29,13 +29,8 @@ func Server(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				logger = log.NewLogger(
+				ctx, cancel = context.WithCancel(c.Context)
+				logger      = log.NewLogger(
 					log.Name(cfg.Service.Name),
 					log.Level(cfg.Log.Level),
 					log.Pretty(cfg.Log.Pretty),

--- a/services/app-provider/cmd/app-provider/main.go
+++ b/services/app-provider/cmd/app-provider/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/app-provider/cmd/app-provider/main.go
+++ b/services/app-provider/cmd/app-provider/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/app-provider/pkg/command"
 	"github.com/owncloud/ocis/v2/services/app-provider/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/app-provider/pkg/command/root.go
+++ b/services/app-provider/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/app-provider/pkg/command/server.go
+++ b/services/app-provider/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/app-provider/pkg/command/server.go
+++ b/services/app-provider/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -90,15 +90,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/app-provider/pkg/command/server.go
+++ b/services/app-provider/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/app-registry/cmd/app-registry/main.go
+++ b/services/app-registry/cmd/app-registry/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/app-registry/cmd/app-registry/main.go
+++ b/services/app-registry/cmd/app-registry/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/app-registry/pkg/command"
 	"github.com/owncloud/ocis/v2/services/app-registry/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/app-registry/pkg/command/root.go
+++ b/services/app-registry/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/app-registry/pkg/command/server.go
+++ b/services/app-registry/pkg/command/server.go
@@ -60,7 +60,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/app-registry/pkg/command/server.go
+++ b/services/app-registry/pkg/command/server.go
@@ -77,7 +77,7 @@ func Server(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/app-registry/pkg/command/server.go
+++ b/services/app-registry/pkg/command/server.go
@@ -37,7 +37,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -85,15 +85,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/audit/cmd/audit/main.go
+++ b/services/audit/cmd/audit/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/audit/pkg/command"
 	"github.com/owncloud/ocis/v2/services/audit/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/audit/cmd/audit/main.go
+++ b/services/audit/cmd/audit/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/audit/pkg/command/root.go
+++ b/services/audit/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/audit/pkg/command/server.go
+++ b/services/audit/pkg/command/server.go
@@ -34,12 +34,7 @@ func Server(cfg *config.Config) *cli.Command {
 				gr     = run.Group{}
 				logger = logging.Configure(cfg.Service.Name, cfg.Log)
 
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
+				ctx, cancel = context.WithCancel(c.Context)
 			)
 			defer cancel()
 

--- a/services/audit/pkg/command/server.go
+++ b/services/audit/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/stream"
@@ -55,7 +54,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Err(err).
 					Msg("Shutting down server")
 				cancel()
-				os.Exit(1)
 			})
 
 			{

--- a/services/auth-app/cmd/auth-app/main.go
+++ b/services/auth-app/cmd/auth-app/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/auth-app/cmd/auth-app/main.go
+++ b/services/auth-app/cmd/auth-app/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/auth-app/pkg/command"
 	"github.com/owncloud/ocis/v2/services/auth-app/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/auth-app/pkg/command/root.go
+++ b/services/auth-app/pkg/command/root.go
@@ -31,5 +31,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/auth-app/pkg/command/server.go
+++ b/services/auth-app/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-app/pkg/command/server.go
+++ b/services/auth-app/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/auth-basic/cmd/auth-basic/main.go
+++ b/services/auth-basic/cmd/auth-basic/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/auth-basic/pkg/command"
 	"github.com/owncloud/ocis/v2/services/auth-basic/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/auth-basic/cmd/auth-basic/main.go
+++ b/services/auth-basic/cmd/auth-basic/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/auth-basic/pkg/command/root.go
+++ b/services/auth-basic/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/auth-basic/pkg/command/server.go
+++ b/services/auth-basic/pkg/command/server.go
@@ -39,7 +39,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -103,15 +103,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/auth-basic/pkg/command/server.go
+++ b/services/auth-basic/pkg/command/server.go
@@ -95,7 +95,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-basic/pkg/command/server.go
+++ b/services/auth-basic/pkg/command/server.go
@@ -74,7 +74,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/auth-bearer/cmd/auth-bearer/main.go
+++ b/services/auth-bearer/cmd/auth-bearer/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/auth-bearer/pkg/command"
 	"github.com/owncloud/ocis/v2/services/auth-bearer/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/auth-bearer/cmd/auth-bearer/main.go
+++ b/services/auth-bearer/cmd/auth-bearer/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/auth-bearer/pkg/command/root.go
+++ b/services/auth-bearer/pkg/command/root.go
@@ -33,7 +33,7 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }
 
 // SutureService allows for the accounts command to be embedded and supervised by a suture supervisor tree.

--- a/services/auth-bearer/pkg/command/server.go
+++ b/services/auth-bearer/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-bearer/pkg/command/server.go
+++ b/services/auth-bearer/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -90,15 +90,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/auth-bearer/pkg/command/server.go
+++ b/services/auth-bearer/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/auth-machine/cmd/auth-machine/main.go
+++ b/services/auth-machine/cmd/auth-machine/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/auth-machine/cmd/auth-machine/main.go
+++ b/services/auth-machine/cmd/auth-machine/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/auth-machine/pkg/command"
 	"github.com/owncloud/ocis/v2/services/auth-machine/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/auth-machine/pkg/command/root.go
+++ b/services/auth-machine/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/auth-machine/pkg/command/server.go
+++ b/services/auth-machine/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-machine/pkg/command/server.go
+++ b/services/auth-machine/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -90,15 +90,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/auth-machine/pkg/command/server.go
+++ b/services/auth-machine/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/auth-service/cmd/auth-service/main.go
+++ b/services/auth-service/cmd/auth-service/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/auth-service/cmd/auth-service/main.go
+++ b/services/auth-service/cmd/auth-service/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/auth-service/pkg/command"
 	"github.com/owncloud/ocis/v2/services/auth-service/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/auth-service/pkg/command/root.go
+++ b/services/auth-service/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/auth-service/pkg/command/server.go
+++ b/services/auth-service/pkg/command/server.go
@@ -83,7 +83,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/auth-service/pkg/command/server.go
+++ b/services/auth-service/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/auth-service/pkg/command/server.go
+++ b/services/auth-service/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -91,15 +91,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/clientlog/cmd/clientlog/main.go
+++ b/services/clientlog/cmd/clientlog/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/clientlog/cmd/clientlog/main.go
+++ b/services/clientlog/cmd/clientlog/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/clientlog/pkg/command"
 	"github.com/owncloud/ocis/v2/services/clientlog/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/clientlog/pkg/command/root.go
+++ b/services/clientlog/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/clientlog/pkg/command/server.go
+++ b/services/clientlog/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/stream"
@@ -113,7 +112,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/clientlog/pkg/command/server.go
+++ b/services/clientlog/pkg/command/server.go
@@ -62,12 +62,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)

--- a/services/collaboration/pkg/command/root.go
+++ b/services/collaboration/pkg/command/root.go
@@ -25,5 +25,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/collaboration/pkg/command/server.go
+++ b/services/collaboration/pkg/command/server.go
@@ -36,12 +36,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 			defer cancel()
 
 			// prepare components

--- a/services/collaboration/pkg/helpers/registration.go
+++ b/services/collaboration/pkg/helpers/registration.go
@@ -8,7 +8,6 @@ import (
 	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/mime"
-	"github.com/gofrs/uuid"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -19,7 +18,7 @@ import (
 // There are no explicit requirements for the context, and it will be passed
 // without changes to the underlying RegisterService method.
 func RegisterOcisService(ctx context.Context, cfg *config.Config, logger log.Logger) error {
-	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name+"."+cfg.App.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+	svc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name+"."+cfg.App.Name, cfg.GRPC.Addr, version.GetString())
 	return registry.RegisterService(ctx, svc, logger)
 }
 

--- a/services/eventhistory/cmd/eventhistory/main.go
+++ b/services/eventhistory/cmd/eventhistory/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/eventhistory/pkg/command"
 	"github.com/owncloud/ocis/v2/services/eventhistory/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/eventhistory/cmd/eventhistory/main.go
+++ b/services/eventhistory/cmd/eventhistory/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/eventhistory/pkg/command/root.go
+++ b/services/eventhistory/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/eventhistory/pkg/command/server.go
+++ b/services/eventhistory/pkg/command/server.go
@@ -47,13 +47,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				m = metrics.New()
+				ctx, cancel = context.WithCancel(c.Context)
+				m           = metrics.New()
 			)
 
 			defer cancel()

--- a/services/frontend/cmd/frontend/main.go
+++ b/services/frontend/cmd/frontend/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/frontend/pkg/command"
 	"github.com/owncloud/ocis/v2/services/frontend/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/frontend/cmd/frontend/main.go
+++ b/services/frontend/cmd/frontend/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/frontend/pkg/command/root.go
+++ b/services/frontend/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/frontend/pkg/command/server.go
+++ b/services/frontend/pkg/command/server.go
@@ -86,7 +86,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			httpSvc := registry.BuildHTTPService(cfg.HTTP.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.HTTP.Addr, version.GetString())
+			httpSvc := registry.BuildHTTPService(cfg.HTTP.Namespace+"."+cfg.Service.Name, cfg.HTTP.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, httpSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the http service")
 			}

--- a/services/frontend/pkg/command/server.go
+++ b/services/frontend/pkg/command/server.go
@@ -65,7 +65,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/frontend/pkg/command/server.go
+++ b/services/frontend/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -101,15 +101,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/gateway/cmd/gateway/main.go
+++ b/services/gateway/cmd/gateway/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/gateway/pkg/command"
 	"github.com/owncloud/ocis/v2/services/gateway/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/gateway/cmd/gateway/main.go
+++ b/services/gateway/cmd/gateway/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/gateway/pkg/command/root.go
+++ b/services/gateway/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/gateway/pkg/command/server.go
+++ b/services/gateway/pkg/command/server.go
@@ -37,7 +37,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -51,7 +51,9 @@ func Server(cfg *config.Config) *cli.Command {
 					runtime.WithRegistry(reg),
 					runtime.WithTraceProvider(traceProvider),
 				)
-
+				logger.Info().
+					Str("server", cfg.Service.Name).
+					Msg("reva runtime exited")
 				return nil
 			}, func(err error) {
 				logger.Error().
@@ -60,7 +62,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(
@@ -74,6 +75,9 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			gr.Add(debugServer.ListenAndServe, func(_ error) {
+				logger.Info().
+					Str("server", cfg.Service.Name).
+					Msg("Shutting down debug erver")
 				cancel()
 			})
 
@@ -85,15 +89,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/gateway/pkg/command/server.go
+++ b/services/gateway/pkg/command/server.go
@@ -77,7 +77,7 @@ func Server(cfg *config.Config) *cli.Command {
 				cancel()
 			})
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/graph/cmd/graph/main.go
+++ b/services/graph/cmd/graph/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/graph/pkg/command"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/graph/cmd/graph/main.go
+++ b/services/graph/cmd/graph/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/graph/pkg/command/root.go
+++ b/services/graph/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Usage:    "Serve Graph API for oCIS",
 		Commands: GetCommands(cfg),
 	})
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/graph/pkg/command/server.go
+++ b/services/graph/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
@@ -64,7 +63,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/graph/pkg/command/server.go
+++ b/services/graph/pkg/command/server.go
@@ -35,12 +35,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 			mtrcs := metrics.New()
 
 			defer cancel()

--- a/services/graph/pkg/service/v0/graph_suite_test.go
+++ b/services/graph/pkg/service/v0/graph_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/groups/cmd/groups/main.go
+++ b/services/groups/cmd/groups/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/groups/cmd/groups/main.go
+++ b/services/groups/cmd/groups/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/groups/pkg/command"
 	"github.com/owncloud/ocis/v2/services/groups/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/groups/pkg/command/root.go
+++ b/services/groups/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/groups/pkg/command/server.go
+++ b/services/groups/pkg/command/server.go
@@ -39,7 +39,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -103,15 +103,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/groups/pkg/command/server.go
+++ b/services/groups/pkg/command/server.go
@@ -95,7 +95,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/groups/pkg/command/server.go
+++ b/services/groups/pkg/command/server.go
@@ -74,7 +74,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/idm/cmd/idm/main.go
+++ b/services/idm/cmd/idm/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/idm/pkg/command"
 	"github.com/owncloud/ocis/v2/services/idm/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/idm/cmd/idm/main.go
+++ b/services/idm/cmd/idm/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/idm/pkg/command/resetpw.go
+++ b/services/idm/pkg/command/resetpw.go
@@ -40,12 +40,7 @@ func ResetPassword(cfg *config.Config) *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			logger := logging.Configure(cfg.Service.Name, cfg.Log)
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 			return resetPassword(ctx, logger, cfg, c.String("user-name"))

--- a/services/idm/pkg/command/root.go
+++ b/services/idm/pkg/command/root.go
@@ -31,5 +31,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -40,12 +40,7 @@ func Server(cfg *config.Config) *cli.Command {
 			var (
 				gr          = run.Group{}
 				logger      = logging.Configure(cfg.Service.Name, cfg.Log)
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
+				ctx, cancel = context.WithCancel(c.Context)
 			)
 
 			defer cancel()

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -90,7 +90,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Err(err).
 						Msg("Shutting down server")
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/idp/cmd/idp/main.go
+++ b/services/idp/cmd/idp/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/idp/cmd/idp/main.go
+++ b/services/idp/cmd/idp/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/idp/pkg/command"
 	"github.com/owncloud/ocis/v2/services/idp/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/idp/pkg/command/root.go
+++ b/services/idp/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/idp/pkg/command/server.go
+++ b/services/idp/pkg/command/server.go
@@ -56,13 +56,8 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				metrics = metrics.New()
+				ctx, cancel = context.WithCancel(c.Context)
+				metrics     = metrics.New()
 			)
 
 			defer cancel()

--- a/services/idp/pkg/command/server.go
+++ b/services/idp/pkg/command/server.go
@@ -90,7 +90,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/invitations/cmd/invitations/main.go
+++ b/services/invitations/cmd/invitations/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/invitations/pkg/command"
 	"github.com/owncloud/ocis/v2/services/invitations/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/invitations/cmd/invitations/main.go
+++ b/services/invitations/cmd/invitations/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/invitations/pkg/command/root.go
+++ b/services/invitations/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/invitations/pkg/command/server.go
+++ b/services/invitations/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
@@ -84,7 +83,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/invitations/pkg/command/server.go
+++ b/services/invitations/pkg/command/server.go
@@ -37,13 +37,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				metrics = metrics.New(metrics.Logger(logger))
+				ctx, cancel = context.WithCancel(c.Context)
+				metrics     = metrics.New(metrics.Logger(logger))
 			)
 
 			defer cancel()

--- a/services/nats/cmd/nats/main.go
+++ b/services/nats/cmd/nats/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/nats/pkg/command"
 	"github.com/owncloud/ocis/v2/services/nats/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/nats/cmd/nats/main.go
+++ b/services/nats/cmd/nats/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/nats/pkg/command/root.go
+++ b/services/nats/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/nats/pkg/command/server.go
+++ b/services/nats/pkg/command/server.go
@@ -33,12 +33,7 @@ func Server(cfg *config.Config) *cli.Command {
 			logger := logging.Configure(cfg.Service.Name, cfg.Log)
 
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 

--- a/services/nats/pkg/command/server.go
+++ b/services/nats/pkg/command/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 
@@ -109,7 +108,6 @@ func Server(cfg *config.Config) *cli.Command {
 
 				natsServer.Shutdown()
 				cancel()
-				os.Exit(1)
 			})
 
 			return gr.Run()

--- a/services/notifications/cmd/notifications/main.go
+++ b/services/notifications/cmd/notifications/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/notifications/cmd/notifications/main.go
+++ b/services/notifications/cmd/notifications/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/command"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/notifications/pkg/command/root.go
+++ b/services/notifications/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -53,13 +53,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			gr := run.Group{}
 
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
-
+			ctx, cancel := context.WithCancel(c.Context)
 			defer cancel()
 
 			{

--- a/services/notifications/pkg/service/notification_suite_test.go
+++ b/services/notifications/pkg/service/notification_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/ocdav/cmd/ocdav/main.go
+++ b/services/ocdav/cmd/ocdav/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/ocdav/pkg/command"
 	"github.com/owncloud/ocis/v2/services/ocdav/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/ocdav/cmd/ocdav/main.go
+++ b/services/ocdav/cmd/ocdav/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/ocdav/pkg/command/root.go
+++ b/services/ocdav/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/ocdav/pkg/command/server.go
+++ b/services/ocdav/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cs3org/reva/v2/pkg/micro/ocdav"
 	"github.com/cs3org/reva/v2/pkg/sharedconf"
@@ -104,7 +103,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Str("server", c.Command.Name).
 					Msg("Shutting down server")
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/ocdav/pkg/command/server.go
+++ b/services/ocdav/pkg/command/server.go
@@ -36,7 +36,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -126,15 +126,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/ocm/cmd/ocm/main.go
+++ b/services/ocm/cmd/ocm/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/ocm/pkg/command"
 	"github.com/owncloud/ocis/v2/services/ocm/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/ocm/cmd/ocm/main.go
+++ b/services/ocm/cmd/ocm/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/ocm/pkg/command/root.go
+++ b/services/ocm/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/ocm/pkg/command/server.go
+++ b/services/ocm/pkg/command/server.go
@@ -62,7 +62,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/ocm/pkg/command/server.go
+++ b/services/ocm/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -96,15 +96,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/ocm/pkg/command/server.go
+++ b/services/ocm/pkg/command/server.go
@@ -83,12 +83,12 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}
 
-			httpSvc := registry.BuildHTTPService(cfg.HTTP.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.HTTP.Addr, version.GetString())
+			httpSvc := registry.BuildHTTPService(cfg.HTTP.Namespace+"."+cfg.Service.Name, cfg.HTTP.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, httpSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the http service")
 			}

--- a/services/ocs/cmd/ocs/main.go
+++ b/services/ocs/cmd/ocs/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/ocs/pkg/command"
 	"github.com/owncloud/ocis/v2/services/ocs/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/ocs/cmd/ocs/main.go
+++ b/services/ocs/cmd/ocs/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/ocs/pkg/command/root.go
+++ b/services/ocs/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/ocs/pkg/command/server.go
+++ b/services/ocs/pkg/command/server.go
@@ -42,13 +42,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				metrics = metrics.New()
+				ctx, cancel = context.WithCancel(c.Context)
+				metrics     = metrics.New()
 			)
 
 			defer cancel()

--- a/services/ocs/pkg/command/server.go
+++ b/services/ocs/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
@@ -77,7 +76,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/policies/cmd/policies/main.go
+++ b/services/policies/cmd/policies/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/policies/pkg/command"
 	"github.com/owncloud/ocis/v2/services/policies/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/policies/cmd/policies/main.go
+++ b/services/policies/cmd/policies/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/policies/pkg/command/root.go
+++ b/services/policies/pkg/command/root.go
@@ -25,5 +25,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/policies/pkg/command/server.go
+++ b/services/policies/pkg/command/server.go
@@ -35,13 +35,8 @@ func Server(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				logger = log.NewLogger(
+				ctx, cancel = context.WithCancel(c.Context)
+				logger      = log.NewLogger(
 					log.Name(cfg.Service.Name),
 					log.Level(cfg.Log.Level),
 					log.Pretty(cfg.Log.Pretty),

--- a/services/postprocessing/cmd/postprocessing/main.go
+++ b/services/postprocessing/cmd/postprocessing/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/postprocessing/cmd/postprocessing/main.go
+++ b/services/postprocessing/cmd/postprocessing/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/postprocessing/pkg/command"
 	"github.com/owncloud/ocis/v2/services/postprocessing/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/postprocessing/pkg/command/root.go
+++ b/services/postprocessing/pkg/command/root.go
@@ -31,5 +31,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/postprocessing/pkg/command/server.go
+++ b/services/postprocessing/pkg/command/server.go
@@ -36,15 +36,9 @@ func Server(cfg *config.Config) *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			var (
-				gr     = run.Group{}
-				logger = logging.Configure(cfg.Service.Name, cfg.Log)
-
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
+				gr          = run.Group{}
+				logger      = logging.Configure(cfg.Service.Name, cfg.Log)
+				ctx, cancel = context.WithCancel(c.Context)
 			)
 			defer cancel()
 

--- a/services/postprocessing/pkg/command/server.go
+++ b/services/postprocessing/pkg/command/server.go
@@ -82,7 +82,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Str("server", "http").
 						Msg("Shutting down server")
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/proxy/cmd/proxy/main.go
+++ b/services/proxy/cmd/proxy/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/proxy/cmd/proxy/main.go
+++ b/services/proxy/cmd/proxy/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/command"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/proxy/pkg/command/root.go
+++ b/services/proxy/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -216,7 +215,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -120,12 +120,7 @@ func Server(cfg *config.Config) *cli.Command {
 			m := metrics.New()
 
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 

--- a/services/search/cmd/search/main.go
+++ b/services/search/cmd/search/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/search/cmd/search/main.go
+++ b/services/search/cmd/search/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/search/pkg/command"
 	"github.com/owncloud/ocis/v2/services/search/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/search/pkg/command/root.go
+++ b/services/search/pkg/command/root.go
@@ -31,5 +31,5 @@ func Execute(cfg *config.Config) error {
 		Usage:    "Serve search API for oCIS",
 		Commands: GetCommands(cfg),
 	})
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/search/pkg/command/server.go
+++ b/services/search/pkg/command/server.go
@@ -41,12 +41,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 			defer cancel()
 
 			mtrcs := metrics.New()

--- a/services/search/pkg/search/search_suite_test.go
+++ b/services/search/pkg/search/search_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/settings/cmd/settings/main.go
+++ b/services/settings/cmd/settings/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/settings/pkg/command"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/settings/cmd/settings/main.go
+++ b/services/settings/cmd/settings/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/settings/pkg/command/root.go
+++ b/services/settings/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/settings/pkg/command/server.go
+++ b/services/settings/pkg/command/server.go
@@ -44,12 +44,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			servers := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 			defer cancel()
 
 			mtrcs := metrics.New()

--- a/services/settings/pkg/command/server.go
+++ b/services/settings/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
@@ -74,7 +73,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Str("server", "http").
 					Msg("shutting down server")
 				cancel()
-				os.Exit(1)
 			})
 
 			// prepare a gRPC server and add it to the group run.
@@ -93,7 +91,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Str("server", "grpc").
 					Msg("shutting down server")
 				cancel()
-				os.Exit(1)
 			})
 
 			// prepare a debug server and add it to the group run.

--- a/services/sharing/cmd/sharing/main.go
+++ b/services/sharing/cmd/sharing/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/sharing/cmd/sharing/main.go
+++ b/services/sharing/cmd/sharing/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/sharing/pkg/command"
 	"github.com/owncloud/ocis/v2/services/sharing/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/sharing/pkg/command/root.go
+++ b/services/sharing/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/sharing/pkg/command/server.go
+++ b/services/sharing/pkg/command/server.go
@@ -39,7 +39,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -107,15 +107,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/sharing/pkg/command/server.go
+++ b/services/sharing/pkg/command/server.go
@@ -77,7 +77,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/sharing/pkg/command/server.go
+++ b/services/sharing/pkg/command/server.go
@@ -99,7 +99,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/sse/cmd/sse/main.go
+++ b/services/sse/cmd/sse/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/sse/cmd/sse/main.go
+++ b/services/sse/cmd/sse/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/sse/pkg/command"
 	"github.com/owncloud/ocis/v2/services/sse/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/sse/pkg/command/root.go
+++ b/services/sse/pkg/command/root.go
@@ -26,5 +26,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/sse/pkg/command/server.go
+++ b/services/sse/pkg/command/server.go
@@ -37,13 +37,8 @@ func Server(cfg *config.Config) *cli.Command {
 		Action: func(c *cli.Context) error {
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				logger = log.NewLogger(
+				ctx, cancel = context.WithCancel(c.Context)
+				logger      = log.NewLogger(
 					log.Name(cfg.Service.Name),
 					log.Level(cfg.Log.Level),
 					log.Pretty(cfg.Log.Pretty),

--- a/services/storage-publiclink/cmd/storage-publiclink/main.go
+++ b/services/storage-publiclink/cmd/storage-publiclink/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/storage-publiclink/cmd/storage-publiclink/main.go
+++ b/services/storage-publiclink/cmd/storage-publiclink/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/storage-publiclink/pkg/command"
 	"github.com/owncloud/ocis/v2/services/storage-publiclink/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/storage-publiclink/pkg/command/root.go
+++ b/services/storage-publiclink/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/storage-publiclink/pkg/command/server.go
+++ b/services/storage-publiclink/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/storage-publiclink/pkg/command/server.go
+++ b/services/storage-publiclink/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -90,15 +90,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/storage-publiclink/pkg/command/server.go
+++ b/services/storage-publiclink/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/storage-shares/cmd/storage-shares/main.go
+++ b/services/storage-shares/cmd/storage-shares/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/storage-shares/pkg/command"
 	"github.com/owncloud/ocis/v2/services/storage-shares/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/storage-shares/cmd/storage-shares/main.go
+++ b/services/storage-shares/cmd/storage-shares/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/storage-shares/pkg/command/root.go
+++ b/services/storage-shares/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/storage-shares/pkg/command/server.go
+++ b/services/storage-shares/pkg/command/server.go
@@ -82,7 +82,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/storage-shares/pkg/command/server.go
+++ b/services/storage-shares/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -90,15 +90,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/storage-shares/pkg/command/server.go
+++ b/services/storage-shares/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/storage-system/cmd/storage-system/main.go
+++ b/services/storage-system/cmd/storage-system/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/storage-system/pkg/command"
 	"github.com/owncloud/ocis/v2/services/storage-system/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/storage-system/cmd/storage-system/main.go
+++ b/services/storage-system/cmd/storage-system/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/storage-system/pkg/command/root.go
+++ b/services/storage-system/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/storage-system/pkg/command/server.go
+++ b/services/storage-system/pkg/command/server.go
@@ -38,7 +38,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -95,15 +95,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/storage-system/pkg/command/server.go
+++ b/services/storage-system/pkg/command/server.go
@@ -61,7 +61,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/storage-system/pkg/command/server.go
+++ b/services/storage-system/pkg/command/server.go
@@ -82,12 +82,12 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}
 
-			httpScv := registry.BuildHTTPService(cfg.HTTP.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.HTTP.Addr, version.GetString())
+			httpScv := registry.BuildHTTPService(cfg.HTTP.Namespace+"."+cfg.Service.Name, cfg.HTTP.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, httpScv, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the http service")
 			}

--- a/services/storage-users/cmd/storage-users/main.go
+++ b/services/storage-users/cmd/storage-users/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/command"
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/storage-users/cmd/storage-users/main.go
+++ b/services/storage-users/cmd/storage-users/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/storage-users/pkg/command/root.go
+++ b/services/storage-users/pkg/command/root.go
@@ -32,5 +32,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -93,7 +93,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -63,7 +63,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -40,7 +40,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -127,15 +127,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/storage-users/pkg/task/task_suite_test.go
+++ b/services/storage-users/pkg/task/task_suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/store/cmd/store/main.go
+++ b/services/store/cmd/store/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/store/cmd/store/main.go
+++ b/services/store/cmd/store/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/store/pkg/command"
 	"github.com/owncloud/ocis/v2/services/store/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/store/pkg/command/root.go
+++ b/services/store/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/store/pkg/command/server.go
+++ b/services/store/pkg/command/server.go
@@ -35,9 +35,6 @@ func Server(cfg *config.Config) *cli.Command {
 			if err != nil {
 				return err
 			}
-			if err != nil {
-				return err
-			}
 			cfg.GrpcClient, err = ogrpc.NewClient(
 				append(ogrpc.GetClientOptions(cfg.GRPCClientTLS), ogrpc.WithTraceProvider(traceProvider))...,
 			)
@@ -47,13 +44,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				metrics = metrics.New()
+				ctx, cancel = context.WithCancel(c.Context)
+				metrics     = metrics.New()
 			)
 
 			defer cancel()

--- a/services/store/pkg/command/server.go
+++ b/services/store/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 
@@ -68,7 +67,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/thumbnails/cmd/thumbnails/main.go
+++ b/services/thumbnails/cmd/thumbnails/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/thumbnails/cmd/thumbnails/main.go
+++ b/services/thumbnails/cmd/thumbnails/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/command"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/thumbnails/pkg/command/root.go
+++ b/services/thumbnails/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/thumbnails/pkg/command/server.go
+++ b/services/thumbnails/pkg/command/server.go
@@ -29,7 +29,7 @@ func Server(cfg *config.Config) *cli.Command {
 		Before: func(_ *cli.Context) error {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
-		Action: func(_ *cli.Context) error {
+		Action: func(c *cli.Context) error {
 			logger := logging.Configure(cfg.Service.Name, cfg.Log)
 
 			traceProvider, err := tracing.GetServiceTraceProvider(cfg.Tracing, cfg.Service.Name)
@@ -43,13 +43,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				m = metrics.New()
+				ctx, cancel = context.WithCancel(c.Context)
+				m           = metrics.New()
 			)
 
 			defer cancel()

--- a/services/thumbnails/pkg/command/server.go
+++ b/services/thumbnails/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
@@ -69,7 +68,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			server, err := debug.Server(

--- a/services/userlog/cmd/userlog/main.go
+++ b/services/userlog/cmd/userlog/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/userlog/pkg/command"
 	"github.com/owncloud/ocis/v2/services/userlog/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/userlog/cmd/userlog/main.go
+++ b/services/userlog/cmd/userlog/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/userlog/pkg/command/root.go
+++ b/services/userlog/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/userlog/pkg/command/server.go
+++ b/services/userlog/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/stream"
@@ -141,7 +140,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/userlog/pkg/command/server.go
+++ b/services/userlog/pkg/command/server.go
@@ -70,12 +70,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			gr := run.Group{}
-			ctx, cancel := func() (context.Context, context.CancelFunc) {
-				if cfg.Context == nil {
-					return context.WithCancel(context.Background())
-				}
-				return context.WithCancel(cfg.Context)
-			}()
+			ctx, cancel := context.WithCancel(c.Context)
 
 			mtrcs := metrics.New()
 			mtrcs.BuildInfo.WithLabelValues(version.GetString()).Set(1)

--- a/services/userlog/pkg/service/service_suit_test.go
+++ b/services/userlog/pkg/service/service_suit_test.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r := registry.GetRegistry(registry.Inmemory())
-	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "", "")
+	service := registry.BuildGRPCService("com.owncloud.api.gateway", "", "")
 	service.Nodes = []*mRegistry.Node{{
 		Address: "any",
 	}}

--- a/services/users/cmd/user/main.go
+++ b/services/users/cmd/user/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/users/pkg/command"
 	"github.com/owncloud/ocis/v2/services/users/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/users/cmd/user/main.go
+++ b/services/users/cmd/user/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/users/pkg/command/root.go
+++ b/services/users/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/users/pkg/command/server.go
+++ b/services/users/pkg/command/server.go
@@ -39,7 +39,7 @@ func Server(cfg *config.Config) *cli.Command {
 				return err
 			}
 			gr := run.Group{}
-			ctx, cancel := defineContext(cfg)
+			ctx, cancel := context.WithCancel(c.Context)
 
 			defer cancel()
 
@@ -103,15 +103,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// defineContext sets the context for the service. If there is a context configured it will create a new child from it,
-// if not, it will create a root context that can be cancelled.
-func defineContext(cfg *config.Config) (context.Context, context.CancelFunc) {
-	return func() (context.Context, context.CancelFunc) {
-		if cfg.Context == nil {
-			return context.WithCancel(context.Background())
-		}
-		return context.WithCancel(cfg.Context)
-	}()
 }

--- a/services/users/pkg/command/server.go
+++ b/services/users/pkg/command/server.go
@@ -95,7 +95,7 @@ func Server(cfg *config.Config) *cli.Command {
 				sync.Trap(&gr, cancel)
 			}
 
-			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, uuid.Must(uuid.NewV4()).String(), cfg.GRPC.Addr, version.GetString())
+			grpcSvc := registry.BuildGRPCService(cfg.GRPC.Namespace+"."+cfg.Service.Name, cfg.GRPC.Addr, version.GetString())
 			if err := registry.RegisterService(ctx, grpcSvc, logger); err != nil {
 				logger.Fatal().Err(err).Msg("failed to register the grpc service")
 			}

--- a/services/users/pkg/command/server.go
+++ b/services/users/pkg/command/server.go
@@ -74,7 +74,6 @@ func Server(cfg *config.Config) *cli.Command {
 					Msg("Shutting down server")
 
 				cancel()
-				os.Exit(1)
 			})
 
 			debugServer, err := debug.Server(

--- a/services/web/cmd/web/main.go
+++ b/services/web/cmd/web/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/web/cmd/web/main.go
+++ b/services/web/cmd/web/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/web/pkg/command"
 	"github.com/owncloud/ocis/v2/services/web/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/web/pkg/command/root.go
+++ b/services/web/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/web/pkg/command/server.go
+++ b/services/web/pkg/command/server.go
@@ -27,7 +27,7 @@ func Server(cfg *config.Config) *cli.Command {
 		Before: func(_ *cli.Context) error {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
-		Action: func(_ *cli.Context) error {
+		Action: func(c *cli.Context) error {
 			logger := logging.Configure(cfg.Service.Name, cfg.Log)
 			traceProvider, err := tracing.GetServiceTraceProvider(cfg.Tracing, cfg.Service.Name)
 			if err != nil {
@@ -49,13 +49,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				m = metrics.New()
+				ctx, cancel = context.WithCancel(c.Context)
+				m           = metrics.New()
 			)
 
 			defer cancel()

--- a/services/web/pkg/command/server.go
+++ b/services/web/pkg/command/server.go
@@ -89,7 +89,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/webdav/cmd/webdav/main.go
+++ b/services/webdav/cmd/webdav/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/webdav/pkg/command"
 	"github.com/owncloud/ocis/v2/services/webdav/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/webdav/cmd/webdav/main.go
+++ b/services/webdav/cmd/webdav/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/webdav/pkg/command/root.go
+++ b/services/webdav/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/webdav/pkg/command/server.go
+++ b/services/webdav/pkg/command/server.go
@@ -44,13 +44,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				metrics = metrics.New()
+				ctx, cancel = context.WithCancel(c.Context)
+				metrics     = metrics.New()
 			)
 
 			defer cancel()

--- a/services/webdav/pkg/command/server.go
+++ b/services/webdav/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
@@ -79,7 +78,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/webfinger/cmd/webfinger/main.go
+++ b/services/webfinger/cmd/webfinger/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	cfg := defaults.DefaultConfig()
-	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}

--- a/services/webfinger/cmd/webfinger/main.go
+++ b/services/webfinger/cmd/webfinger/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/owncloud/ocis/v2/services/webfinger/pkg/command"
 	"github.com/owncloud/ocis/v2/services/webfinger/pkg/config/defaults"
 )
 
 func main() {
-	if err := command.Execute(defaults.DefaultConfig()); err != nil {
+	cfg := defaults.DefaultConfig()
+	cfg.Context, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if err := command.Execute(cfg); err != nil {
 		os.Exit(1)
 	}
 }

--- a/services/webfinger/pkg/command/root.go
+++ b/services/webfinger/pkg/command/root.go
@@ -30,5 +30,5 @@ func Execute(cfg *config.Config) error {
 		Commands: GetCommands(cfg),
 	})
 
-	return app.Run(os.Args)
+	return app.RunContext(cfg.Context, os.Args)
 }

--- a/services/webfinger/pkg/command/server.go
+++ b/services/webfinger/pkg/command/server.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
@@ -92,7 +91,6 @@ func Server(cfg *config.Config) *cli.Command {
 						Msg("Shutting down server")
 
 					cancel()
-					os.Exit(1)
 				})
 			}
 

--- a/services/webfinger/pkg/command/server.go
+++ b/services/webfinger/pkg/command/server.go
@@ -38,13 +38,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			var (
 				gr          = run.Group{}
-				ctx, cancel = func() (context.Context, context.CancelFunc) {
-					if cfg.Context == nil {
-						return context.WithCancel(context.Background())
-					}
-					return context.WithCancel(cfg.Context)
-				}()
-				m = metrics.New(metrics.Logger(logger))
+				ctx, cancel = context.WithCancel(c.Context)
+				m           = metrics.New(metrics.Logger(logger))
 			)
 
 			defer cancel()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -963,7 +963,7 @@ github.com/go-micro/plugins/v4/server/http
 # github.com/go-micro/plugins/v4/store/nats-js v1.2.1-0.20231129143103-d72facc652f0
 ## explicit; go 1.21
 github.com/go-micro/plugins/v4/store/nats-js
-# github.com/go-micro/plugins/v4/store/nats-js-kv v0.0.0-20231226212146-94a49ba3e06e => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240723073728-b36ea3314b73
+# github.com/go-micro/plugins/v4/store/nats-js-kv v0.0.0-20231226212146-94a49ba3e06e => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240724102745-4bc93ffd7ab6
 ## explicit; go 1.21
 github.com/go-micro/plugins/v4/store/nats-js-kv
 # github.com/go-micro/plugins/v4/store/redis v1.2.1
@@ -2422,4 +2422,4 @@ stash.kopano.io/kgol/rndm
 # github.com/studio-b12/gowebdav => github.com/aduffeck/gowebdav v0.0.0-20231215102054-212d4a4374f6
 # github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240123094924-5af178158eaf
 # github.com/unrolled/secure => github.com/DeepDiver1975/secure v0.0.0-20240611112133-abc838fb797c
-# github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240723073728-b36ea3314b73
+# github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240724102745-4bc93ffd7ab6


### PR DESCRIPTION
we now use the default nodeid when registering services. so all services started in the same binary will receive the same id.