### PR TITLE
allow configuring grpc max connection age

### DIFF
--- a/changelog/unreleased/add-grpc-max-connection-age-env.md
+++ b/changelog/unreleased/add-grpc-max-connection-age-env.md
@@ -1,0 +1,5 @@
+Enhancement: Allow configuring grpc max connection age
+
+We added a GRPC_MAX_CONNECTION_AGE env var that allows limiting the lifespan of connections. A closed connection triggers grpc clients to do a new DNS lookup to pick up new IPs.
+
+https://github.com/owncloud/ocis/pull/9657

--- a/ocis-pkg/service/grpc/keepalive.go
+++ b/ocis-pkg/service/grpc/keepalive.go
@@ -1,0 +1,24 @@
+package grpc
+
+import (
+	"math"
+	"os"
+	"time"
+)
+
+const (
+	_serverMaxConnectionAgeEnv = "GRPC_MAX_CONNECTION_AGE"
+
+	// same default as grpc
+	infinity                 = time.Duration(math.MaxInt64)
+	_defaultMaxConnectionAge = infinity
+)
+
+// GetMaxConnectionAge returns the maximum grpc connection age.
+func GetMaxConnectionAge() time.Duration {
+	d, err := time.ParseDuration(os.Getenv(_serverMaxConnectionAgeEnv))
+	if err != nil {
+		return _defaultMaxConnectionAge
+	}
+	return d
+}


### PR DESCRIPTION
We added a GRPC_MAX_CONNECTION_AGE env var that allows limiting the lifespan of connections. A closed connection triggers grpc clients to do a new DNS lookup to pick up new IPs.

see https://github.com/owncloud/ocis/pull/9488

reva part in https://github.com/cs3org/reva/pull/4772