### PR TITLE
[tests-only][full-ci] ensure share is available

### DIFF
--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -8,8 +8,8 @@ Basic file management like up and download, move, copy, properties, trash, versi
 
 #### [copy personal space file to shared folder root result share in decline state](https://github.com/owncloud/ocis/issues/6999)
 
-- [coreApiWebdavProperties/copyFile.feature:257](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L257)
-- [coreApiWebdavProperties/copyFile.feature:258](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L258)
+- [coreApiWebdavProperties/copyFile.feature:261](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L261)
+- [coreApiWebdavProperties/copyFile.feature:262](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L262)
 
 #### [Custom dav properties with namespaces are rendered incorrectly](https://github.com/owncloud/ocis/issues/2140)
 
@@ -18,7 +18,7 @@ _ocdav: double-check the webdav property parsing when custom namespaces are used
 - [coreApiWebdavProperties/setFileProperties.feature:32](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature#L32)
 - [coreApiWebdavProperties/setFileProperties.feature:33](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature#L33)
 - [coreApiWebdavProperties/setFileProperties.feature:34](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature#L34)
-- [coreApiWebdavProperties/setFileProperties.feature:66](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature#L66)
+- [coreApiWebdavProperties/setFileProperties.feature:69](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature#L69)
 - [coreApiWebdavProperties/setFileProperties.feature:67](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature#L67)
 - [coreApiWebdavProperties/setFileProperties.feature:68](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature#L68)
 
@@ -34,16 +34,16 @@ _ocdav: double-check the webdav property parsing when custom namespaces are used
 #### [file versions do not report the version author](https://github.com/owncloud/ocis/issues/2914)
 
 - [coreApiVersions/fileVersionAuthor.feature:15](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L15)
-- [coreApiVersions/fileVersionAuthor.feature:58](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L58)
-- [coreApiVersions/fileVersionAuthor.feature:88](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L88)
-- [coreApiVersions/fileVersionAuthor.feature:117](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L117)
-- [coreApiVersions/fileVersionAuthor.feature:153](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L153)
-- [coreApiVersions/fileVersionAuthor.feature:183](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L183)
-- [coreApiVersions/fileVersionAuthor.feature:217](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L217)
-- [coreApiVersions/fileVersionAuthor.feature:258](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L258)
-- [coreApiVersions/fileVersionAuthor.feature:334](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L334)
-- [coreApiVersions/fileVersionAuthor.feature:407](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L407)
+- [coreApiVersions/fileVersionAuthor.feature:61](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L61)
+- [coreApiVersions/fileVersionAuthor.feature:93](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L93)
+- [coreApiVersions/fileVersionAuthor.feature:124](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L124)
+- [coreApiVersions/fileVersionAuthor.feature:162](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L162)
+- [coreApiVersions/fileVersionAuthor.feature:194](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L194)
+- [coreApiVersions/fileVersionAuthor.feature:230](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L230)
+- [coreApiVersions/fileVersionAuthor.feature:275](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L275)
+- [coreApiVersions/fileVersionAuthor.feature:357](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L357)
 - [coreApiVersions/fileVersionAuthor.feature:436](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L436)
+- [coreApiVersions/fileVersionAuthor.feature:467](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L467)
 
 ### Sync
 
@@ -51,8 +51,8 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 #### [Uploading an old method chunked file with checksum should fail using new DAV path](https://github.com/owncloud/ocis/issues/2323)
 
-- [coreApiMain/checksums.feature:217](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiMain/checksums.feature#L217)
-- [coreApiMain/checksums.feature:218](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiMain/checksums.feature#L218)
+- [coreApiMain/checksums.feature:219](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiMain/checksums.feature#L219)
+- [coreApiMain/checksums.feature:220](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiMain/checksums.feature#L220)
 
 ### Share
 
@@ -67,26 +67,26 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 #### [d:quota-available-bytes in dprop of PROPFIND give wrong response value](https://github.com/owncloud/ocis/issues/8197)
 
-- [coreApiWebdavProperties/getQuota.feature:56](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L56)
 - [coreApiWebdavProperties/getQuota.feature:57](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L57)
 - [coreApiWebdavProperties/getQuota.feature:58](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L58)
-- [coreApiWebdavProperties/getQuota.feature:72](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L72)
+- [coreApiWebdavProperties/getQuota.feature:59](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L59)
 - [coreApiWebdavProperties/getQuota.feature:73](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L73)
 - [coreApiWebdavProperties/getQuota.feature:74](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L74)
+- [coreApiWebdavProperties/getQuota.feature:75](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature#L75)
 
 #### [deleting a file inside a received shared folder is moved to the trash-bin of the sharer not the receiver](https://github.com/owncloud/ocis/issues/1124)
 
 - [coreApiTrashbin/trashbinSharingToShares.feature:30](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L30)
-- [coreApiTrashbin/trashbinSharingToShares.feature:51](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L51)
-- [coreApiTrashbin/trashbinSharingToShares.feature:52](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L52)
-- [coreApiTrashbin/trashbinSharingToShares.feature:77](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L77)
-- [coreApiTrashbin/trashbinSharingToShares.feature:78](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L78)
-- [coreApiTrashbin/trashbinSharingToShares.feature:130](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L130)
-- [coreApiTrashbin/trashbinSharingToShares.feature:131](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L131)
-- [coreApiTrashbin/trashbinSharingToShares.feature:185](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L185)
-- [coreApiTrashbin/trashbinSharingToShares.feature:186](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L186)
-- [coreApiTrashbin/trashbinSharingToShares.feature:209](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L209)
-- [coreApiTrashbin/trashbinSharingToShares.feature:233](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L233)
+- [coreApiTrashbin/trashbinSharingToShares.feature:53](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L53)
+- [coreApiTrashbin/trashbinSharingToShares.feature:54](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L54)
+- [coreApiTrashbin/trashbinSharingToShares.feature:81](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L81)
+- [coreApiTrashbin/trashbinSharingToShares.feature:82](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L82)
+- [coreApiTrashbin/trashbinSharingToShares.feature:138](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L138)
+- [coreApiTrashbin/trashbinSharingToShares.feature:139](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L139)
+- [coreApiTrashbin/trashbinSharingToShares.feature:196](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L196)
+- [coreApiTrashbin/trashbinSharingToShares.feature:197](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L197)
+- [coreApiTrashbin/trashbinSharingToShares.feature:220](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L220)
+- [coreApiTrashbin/trashbinSharingToShares.feature:245](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L245)
 
 ### Other
 
@@ -142,8 +142,8 @@ And other missing implementation of favorites
 - [coreApiFavorites/favorites.feature:174](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favorites.feature#L174)
 - [coreApiFavorites/favorites.feature:175](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favorites.feature#L175)
 - [coreApiFavorites/favorites.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favorites.feature#L176)
-- [coreApiFavorites/favoritesSharingToShares.feature:84](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature#L84)
-- [coreApiFavorites/favoritesSharingToShares.feature:85](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature#L85)
+- [coreApiFavorites/favoritesSharingToShares.feature:88](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature#L88)
+- [coreApiFavorites/favoritesSharingToShares.feature:89](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature#L89)
 
 #### [WWW-Authenticate header for unauthenticated requests is not clear](https://github.com/owncloud/ocis/issues/2285)
 
@@ -175,16 +175,16 @@ And other missing implementation of favorites
 - [coreApiWebdavUploadTUS/checksums.feature:244](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/checksums.feature#L244)
 - [coreApiWebdavUploadTUS/optionsRequest.feature:10](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/optionsRequest.feature#L10)
 - [coreApiWebdavUploadTUS/optionsRequest.feature:25](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/optionsRequest.feature#L25)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:216](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L216)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:217](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L217)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:239](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L239)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:240](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L240)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:262](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L262)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:263](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L263)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:304](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L304)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:305](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L305)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:354](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L354)
-- [coreApiWebdavUploadTUS/uploadToShare.feature:355](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L355)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:226](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L226)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:227](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L227)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:250](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L250)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:251](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L251)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:274](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L274)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:275](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L275)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:317](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L317)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:318](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L318)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:369](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L369)
+- [coreApiWebdavUploadTUS/uploadToShare.feature:370](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature#L370)
 
 #### [TUS OPTIONS requests do not reply with TUS headers when invalid password](https://github.com/owncloud/ocis/issues/1012)
 
@@ -193,14 +193,14 @@ And other missing implementation of favorites
 
 #### [copying the file inside Shares folder returns 412](https://github.com/owncloud/ocis/issues/3874)
 
-- [coreApiWebdavProperties/copyFile.feature:399](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L399)
-- [coreApiWebdavProperties/copyFile.feature:400](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L400)
-- [coreApiWebdavProperties/copyFile.feature:401](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L401)
-- [coreApiWebdavProperties/copyFile.feature:425](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L425)
-- [coreApiWebdavProperties/copyFile.feature:426](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L426)
-- [coreApiWebdavProperties/copyFile.feature:427](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L427)
-- [coreApiWebdavProperties/copyFile.feature:235](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L235)
-- [coreApiWebdavProperties/copyFile.feature:236](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L236)
+- [coreApiWebdavProperties/copyFile.feature:408](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L408)
+- [coreApiWebdavProperties/copyFile.feature:409](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L409)
+- [coreApiWebdavProperties/copyFile.feature:410](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L410)
+- [coreApiWebdavProperties/copyFile.feature:435](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L435)
+- [coreApiWebdavProperties/copyFile.feature:436](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L436)
+- [coreApiWebdavProperties/copyFile.feature:437](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L437)
+- [coreApiWebdavProperties/copyFile.feature:238](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L238)
+- [coreApiWebdavProperties/copyFile.feature:239](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L239)
 
 ### Won't fix
 
@@ -211,9 +211,9 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 
 #### [Blacklist files extensions](https://github.com/owncloud/ocis/issues/2177)
 
-- [coreApiWebdavProperties/copyFile.feature:105](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L105)
-- [coreApiWebdavProperties/copyFile.feature:106](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L106)
 - [coreApiWebdavProperties/copyFile.feature:107](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L107)
+- [coreApiWebdavProperties/copyFile.feature:108](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L108)
+- [coreApiWebdavProperties/copyFile.feature:109](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature#L109)
 - [coreApiWebdavProperties/createFileFolder.feature:95](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/createFileFolder.feature#L95)
 - [coreApiWebdavProperties/createFileFolder.feature:96](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/createFileFolder.feature#L96)
 - [coreApiWebdavProperties/createFileFolder.feature:97](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/createFileFolder.feature#L97)
@@ -249,8 +249,8 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [coreApiWebdavMove1/moveFolder.feature:217](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature#L217)
 - [coreApiWebdavMove1/moveFolder.feature:218](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature#L218)
 - [coreApiWebdavMove1/moveFolder.feature:219](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove1/moveFolder.feature#L219)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:303](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L303)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:306](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L306)
+- [coreApiWebdavMove2/moveShareOnOcis.feature:307](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L307)
+- [coreApiWebdavMove2/moveShareOnOcis.feature:310](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L310)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -76,7 +76,6 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 #### [deleting a file inside a received shared folder is moved to the trash-bin of the sharer not the receiver](https://github.com/owncloud/ocis/issues/1124)
 
-- [coreApiTrashbin/trashbinSharingToShares.feature:30](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L30)
 - [coreApiTrashbin/trashbinSharingToShares.feature:53](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L53)
 - [coreApiTrashbin/trashbinSharingToShares.feature:54](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L54)
 - [coreApiTrashbin/trashbinSharingToShares.feature:81](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L81)
@@ -85,8 +84,6 @@ Synchronization features like etag propagation, setting mtime and locking files
 - [coreApiTrashbin/trashbinSharingToShares.feature:139](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L139)
 - [coreApiTrashbin/trashbinSharingToShares.feature:196](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L196)
 - [coreApiTrashbin/trashbinSharingToShares.feature:197](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L197)
-- [coreApiTrashbin/trashbinSharingToShares.feature:220](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L220)
-- [coreApiTrashbin/trashbinSharingToShares.feature:245](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L245)
 
 ### Other
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2858,6 +2858,29 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" (declines|accepts) the already (?:accepted|declined) share "([^"]*)" offered by user "([^"]*)" using the sharing API$/
+	 *
+	 * @param string $user
+	 * @param string $action
+	 * @param string $share
+	 * @param string $offeredBy
+	 * @param string|null $state specify 'accepted', 'pending', 'rejected' or 'declined' to only consider shares in that state
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userAcceptsTheAlreadyAcceptedShareOfferedByUsingTheSharingApi(string $user, string $action, string $share, string $offeredBy, ?string $state = ''):void {
+		$response = $this->reactToShareOfferedBy(
+			$user,
+			$action,
+			"/Shares/" . \trim($share, "/"),
+			$offeredBy
+		);
+		$this->setResponse($response);
+		$this->pushToLastStatusCodesArrays();
+	}
+
+	/**
 	 * @When /^user "([^"]*)" (declines|accepts) the following shares offered by user "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature
+++ b/tests/acceptance/features/coreApiFavorites/favoritesSharingToShares.feature
@@ -19,6 +19,7 @@ Feature: favorite
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "PARENT" synced
     When user "Brian" favorites element "/Shares/PARENT/parent.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Brian" file "/Shares/PARENT/parent.txt" should be favorited
@@ -38,6 +39,7 @@ Feature: favorite
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "PARENT" synced
     When user "Brian" favorites element "/Shares/PARENT/sub-folder" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Brian" folder "/Shares/PARENT/sub-folder" should be favorited
@@ -56,6 +58,7 @@ Feature: favorite
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "PARENT" synced
     When user "Brian" favorites element "/Shares/PARENT" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Brian" folder "/Shares/PARENT" should be favorited
@@ -74,6 +77,7 @@ Feature: favorite
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "PARENT" synced
     And user "Brian" has favorited element "/Shares/PARENT/parent.txt"
     When user "Brian" moves file "/Shares/PARENT/parent.txt" to "/taken_out.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -94,6 +98,7 @@ Feature: favorite
       | sharee          | Brian             |
       | shareType       | user              |
       | permissionsRole | File Editor       |
+    And user "Brian" has a share "parent.txt" synced
     When user "Brian" favorites element "/Shares/parent.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Brian" file "/Shares/parent.txt" should be favorited

--- a/tests/acceptance/features/coreApiMain/checksums.feature
+++ b/tests/acceptance/features/coreApiMain/checksums.feature
@@ -146,6 +146,7 @@ Feature: checksums
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | File Editor        |
+    And user "Brian" has a share "myChecksumFile.txt" synced
     When user "Brian" requests the checksum of "/Shares/myChecksumFile.txt" via propfind
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
@@ -161,6 +162,7 @@ Feature: checksums
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | File Editor        |
+    And user "Brian" has a share "myChecksumFile.txt" synced
     When user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/Shares/myChecksumFile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as user "Alice" the webdav checksum of "/myChecksumFile.txt" via propfind should match "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a"

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -22,6 +22,7 @@ Feature: sharing works when a username and group name are the same
       | sharee          | Brian          |
       | shareType       | group          |
       | permissionsRole | File Editor    |
+    And user "Carol" has a share "randomfile.txt" synced
     When user "Alice" shares file "randomfile.txt" with user "Brian" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
@@ -47,6 +48,7 @@ Feature: sharing works when a username and group name are the same
       | sharee          | Brian          |
       | shareType       | user           |
       | permissionsRole | File Editor    |
+    And user "Brian" has a share "randomfile.txt" synced
     When user "Alice" shares file "randomfile.txt" with group "Brian" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
@@ -72,6 +74,7 @@ Feature: sharing works when a username and group name are the same
       | sharee          | brian          |
       | shareType       | group          |
       | permissionsRole | File Editor    |
+    And user "Carol" has a share "randomfile.txt" synced
     When user "Alice" shares file "randomfile.txt" with user "Brian" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
@@ -95,8 +98,9 @@ Feature: sharing works when a username and group name are the same
       | resource        | randomfile.txt |
       | space           | Personal       |
       | sharee          | Brian          |
-      | shareType       | user              |
+      | shareType       | user           |
       | permissionsRole | File Editor    |
+    And user "Brian" has a share "randomfile.txt" synced
     When user "Alice" shares file "randomfile.txt" with group "brian" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -378,7 +378,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | shareType       | group    |
       | permissionsRole | Viewer   |
     And user "Alice" has a share "parent" synced
-    And user "Brian" has a share "child1" synced
+    And user "Brian" has a share "parent" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |

--- a/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/coreApiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -178,6 +178,7 @@ Feature: share resources where the sharee receives the share in multiple ways
   Scenario Outline: share with a group and then add a user to that group that already has a file with the shared name
     Given using OCS API version "<ocs-api-version>"
     And user "Carol" has been created with default attributes and without skeleton files
+    And user "Carol" has disabled auto-accepting
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -190,6 +191,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp1        |
       | shareType       | group       |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "lorem.txt" synced
     When the administrator adds user "Carol" to group "grp1" using the provisioning API
     Then the HTTP status code should be "204"
     And user "Carol" should be able to accept pending share "/lorem.txt" offered by user "Alice"
@@ -218,12 +220,15 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "parent" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | Viewer        |
+    And user "Alice" has a share "child1" synced
+    And user "Brian" has a share "child1" synced
     And user "Brian" should be able to create folder "/Shares/parent/fo1"
     And user "Brian" should be able to create folder "/Shares/parent/child1/fo2"
     And user "Alice" should not be able to create folder "/Shares/child1/fo3"
@@ -246,13 +251,16 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "parent" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | Viewer        |
-    And user "Brian" should be able to rename file "/Shares/parent/child1/child2/textfile-2.txt" to "/Shares/parent/child1/child2/rename.txt"
+    And user "Alice" has a share "child1" synced
+    And user "Brian" has a share "child1" synced
+    Then user "Brian" should be able to rename file "/Shares/parent/child1/child2/textfile-2.txt" to "/Shares/parent/child1/child2/rename.txt"
     And user "Brian" should be able to rename file "/Shares/child1/child2/rename.txt" to "/Shares/child1/child2/rename2.txt"
     And user "Alice" should not be able to rename file "/Shares/child1/child2/rename2.txt" to "/Shares/child1/child2/rename3.txt"
 
@@ -275,12 +283,15 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "parent" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | Viewer        |
+    And user "Alice" has a share "child1" synced
+    And user "Brian" has a share "child1" synced
     And user "Brian" should be able to delete file "/Shares/parent/child1/child2/child3/textfile-2.txt"
     And user "Brian" should be able to delete folder "/Shares/child1/child2/child3"
     And user "Alice" should not be able to delete folder "/Shares/child1/child2"
@@ -302,12 +313,15 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Alice" has a share "parent" synced
+    And user "Brian" has a share "parent" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "child1" synced
     Then user "Brian" should be able to create folder "/Shares/child1/fo1"
     And user "Brian" should be able to create folder "/Shares/child1/child2/fo2"
     But user "Brian" should not be able to create folder "/Shares/parent/fo3"
@@ -332,12 +346,15 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "parent" synced
+    And user "Alice" has a share "parent" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "child1" synced
     And user "Brian" should be able to rename file "/Shares/child1/child2/textfile-2.txt" to "/Shares/child1/child2/rename.txt"
     And user "Brian" should be able to rename file "/Shares/parent/child1/child2/rename.txt" to "/Shares/parent/child1/child2/rename2.txt"
     And user "Alice" should not be able to rename file "/Shares/parent/child1/child2/rename2.txt" to "/Shares/parent/child1/child2/rename3.txt"
@@ -360,12 +377,15 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Alice" has a share "parent" synced
+    And user "Brian" has a share "child1" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "child1" synced
     And user "Brian" should be able to delete file "/Shares/child1/child2/textfile-2.txt"
     And user "Brian" should be able to delete folder "/Shares/parent/child1/child2"
     And user "Alice" should not be able to delete folder "/Shares/parent/child1"
@@ -392,13 +412,15 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Alice" has a share "parent" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | parent/child1 |
       | space           | Personal      |
       | sharee          | grp2          |
       | shareType       | group         |
       | permissionsRole | Viewer        |
-    And user "Alice" should be able to create folder "/Shares/parent/child1/fo1"
+    And user "Brian" has a share "child1" synced
+    Then user "Alice" should be able to create folder "/Shares/parent/child1/fo1"
     And user "Alice" should be able to create folder "/Shares/parent/child1/child2/fo2"
     And user "Alice" should be able to delete folder "/Shares/parent/child1/fo1"
     And user "Alice" should be able to delete folder "/Shares/parent/child1/child2/fo2"
@@ -424,6 +446,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp      |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "parent" synced
     And user "Brian" should be able to rename folder "/Shares/parent" to "/Shares/sharedParent"
     And user "Alice" should be able to share folder "parent" with user "Brian" with permissions "read" using the sharing API
     # Note: Brian has already accepted the share of this resource as a member of "grp".
@@ -449,6 +472,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp      |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "parent" synced
     And user "Brian" has moved folder "/Shares/parent" to "/Shares/sharedParent"
     When user "Alice" shares folder "parent" with user "Brian" with permissions "all" using the sharing API
     # Note: Brian has already accepted the share of this resource as a member of "grp".
@@ -477,6 +501,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | sharee          | grp      |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "parent" synced
     And user "Brian" should be able to rename folder "/Shares/parent" to "/Shares/sharedParent"
     And user "Alice" should be able to share folder "parent" with user "Brian" with permissions "read" using the sharing API
     # Note: Brian has already accepted the share of this resource as a member of "grp".

--- a/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -481,6 +481,8 @@ Feature: sharing
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
+    And user "Carol" has a share "textfile0.txt" synced
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -520,12 +522,15 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "common" synced
+    And user "Carol" has a share "common" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Carol         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Carol" has a share "textfile0.txt" synced
     And user "Alice" has moved file "/textfile0.txt" to "/common/textfile0.txt"
     And user "Alice" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
     When user "Carol" uploads file "filesForUpload/file_to_overwrite.txt" to "/Shares/textfile0.txt" using the WebDAV API

--- a/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
@@ -133,14 +133,14 @@ Feature: accept/decline shares coming from internal users
 
 
   Scenario: accept an accepted share
-    Given user "Brian" has disabled auto-accepting
-    And user "Alice" has created folder "/shared"
+    Given user "Alice" has created folder "/shared"
     And user "Alice" has sent the following resource share invitation:
       | resource        | shared   |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "shared" synced
     When user "Brian" accepts share "/shared" offered by user "Alice" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -214,7 +214,8 @@ Feature: accept/decline shares coming from internal users
 
 
   Scenario: deleting shares in pending state
-    Given user "Alice" has sent the following resource share invitation:
+    Given user "Brian" has disabled auto-accepting
+    And user "Alice" has sent the following resource share invitation:
       | resource        | PARENT   |
       | space           | Personal |
       | sharee          | Brian    |
@@ -320,6 +321,7 @@ Feature: accept/decline shares coming from internal users
       | sharee          | Carol        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
+    And user "Carol" has a share "testfile.txt" synced
     And user "Carol" has declined share "/Shares/testfile.txt" offered by user "Alice"
     And user "Carol" has disabled auto-accepting
     And user "Brian" has sent the following resource share invitation:

--- a/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature
@@ -141,7 +141,7 @@ Feature: accept/decline shares coming from internal users
       | shareType       | user     |
       | permissionsRole | Viewer   |
     And user "Brian" has a share "shared" synced
-    When user "Brian" accepts share "/shared" offered by user "Alice" using the sharing API
+    When user "Brian" accepts the already accepted share "/shared" offered by user "Alice" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "Brian" should see the following elements

--- a/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
@@ -19,12 +19,14 @@ Feature: sharing
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
+    And user "Brian" has a share "sharefile.txt" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | sharefile.txt |
       | space           | Personal      |
       | sharee          | Carol         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
+    And user "Carol" has a share "sharefile.txt" synced
     When user "Alice" moves file "sharefile.txt" to "renamedsharefile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "renamedsharefile.txt" should exist
@@ -57,12 +59,14 @@ Feature: sharing
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
+    And user "Brian" has a share "sharefile.txt" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | sharefile.txt |
       | space           | Personal      |
       | sharee          | Carol         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
+    And user "Carol" has a share "sharefile.txt" synced
     When user "Alice" moves file "sharefile.txt" to "renamedsharefile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "renamedsharefile.txt" should exist
@@ -96,12 +100,14 @@ Feature: sharing
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Brian" has a share "sharefile.txt" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | sharefile.txt      |
       | space           | Personal           |
       | sharee          | Carol              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Carol" has a share "sharefile.txt" synced
     When user "Carol" moves file "Shares/sharefile.txt" to "Shares/renamedsharefile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Carol" file "Shares/renamedsharefile.txt" should exist
@@ -137,12 +143,14 @@ Feature: sharing
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Brian" has a share "sharefile.txt" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | sharefile.txt      |
       | space           | Personal           |
       | sharee          | Carol              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Carol" has a share "sharefile.txt" synced
     When user "Carol" moves file "Shares/sharefile.txt" to "Shares/renamedsharefile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Carol" file "Shares/renamedsharefile.txt" should exist
@@ -196,6 +204,7 @@ Feature: sharing
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "folderToShare" synced
     When user "Brian" moves folder "/Shares/folderToShare" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "/Shares/myFolder" should exist
@@ -217,6 +226,7 @@ Feature: sharing
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Brian" has a share "folderToShare" synced
     When user "Brian" moves folder "/Shares/folderToShare" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "/Shares/myFolder" should exist
@@ -243,6 +253,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "PARENT" synced
     When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "/Shares/myFolder" should exist
@@ -257,6 +268,7 @@ Feature: sharing
       | sharee          | Brian           |
       | shareType       | user            |
       | permissionsRole | File Editor     |
+    And user "Brian" has a share "fileToShare.txt" synced
     When user "Brian" moves file "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/newFile.txt" should exist
@@ -273,6 +285,7 @@ Feature: sharing
       | sharee          | grp1            |
       | shareType       | group           |
       | permissionsRole | File Editor     |
+    And user "Brian" has a share "fileToShare.txt" synced
     When user "Brian" moves file "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/newFile.txt" should exist
@@ -289,6 +302,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "PARENT" synced
     When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "/Shares/myFolder" should exist
@@ -305,6 +319,7 @@ Feature: sharing
       | sharee          | grp1            |
       | shareType       | group           |
       | permissionsRole | File Editor     |
+    And user "Brian" has a share "fileToShare.txt" synced
     When user "Brian" moves folder "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/newFile.txt" should exist
@@ -321,6 +336,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "PARENT" synced
     When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "/Shares/myFolder" should exist
@@ -337,6 +353,7 @@ Feature: sharing
       | sharee          | grp1            |
       | shareType       | group           |
       | permissionsRole | Viewer          |
+    And user "Brian" has a share "fileToShare.txt" synced
     When user "Brian" moves file "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/newFile.txt" should exist
@@ -353,6 +370,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "PARENT" synced
     When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" folder "/Shares/myFolder" should exist
@@ -370,6 +388,7 @@ Feature: sharing
       | sharee          | Brian           |
       | shareType       | user            |
       | permissionsRole | Editor          |
+    And user "Brian" has a share "<sharer-folder>" synced
     When user "Brian" moves folder "/Shares/<sharer-folder>" to "/Shares/<receiver-folder>" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" folder "<receiver-folder>" should not exist
@@ -398,6 +417,7 @@ Feature: sharing
       | sharee          | Brian           |
       | shareType       | user            |
       | permissionsRole | Editor          |
+    And user "Brian" has a share "<sharer-folder>" synced
     When user "Brian" moves folder "/Shares/<sharer-folder>/fileInside" to "/Shares/<sharer-folder>/<receiver_file>" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "<sharer-folder>/<receiver_file>" should exist

--- a/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/moveShareInsideAnotherShare.feature
@@ -20,12 +20,14 @@ Feature: moving a share inside another share
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "folderA" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | folderB  |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "folderB" synced
 
 
   Scenario: share receiver cannot move a whole share inside another share

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/changingFilesShare.feature
@@ -23,12 +23,14 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "share1" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | /share2  |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "share2" synced
     When user "Brian" moves file "/Shares/share1/textfile0.txt" to "/Shares/share2/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "502"
     And as "Brian" file "/Shares/share1/textfile0.txt" should exist
@@ -50,6 +52,7 @@ Feature: sharing
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile1.txt" synced
     When user "Brian" uploads file with content "this is a new content" to "/Shares/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Brian" file "Shares/textfile1.txt" should exist

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
@@ -126,7 +126,7 @@ Feature: sharing
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
-    And user "Carol" has a share "textfile0.txt" synced
+    And user "Brian" has a share "textfile0.txt" synced
     And using SharingNG
     When user "Carol" gets the info of the last share using the sharing API
     Then the OCS status code should be "404"

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingShares.feature
@@ -126,6 +126,7 @@ Feature: sharing
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
+    And user "Carol" has a share "textfile0.txt" synced
     And using SharingNG
     When user "Carol" gets the info of the last share using the sharing API
     Then the OCS status code should be "404"

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -36,6 +36,7 @@ Feature: sharing
       | sharee          | Brian       |
       | shareType       | user        |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "tmp.txt" synced
     When user "Brian" gets the following properties of file "/Shares/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
@@ -58,6 +59,7 @@ Feature: sharing
       | sharee          | grp1        |
       | shareType       | group       |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "tmp.txt" synced
     When user "Brian" gets the following properties of file "/Shares/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
@@ -78,6 +80,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "tmp.txt" synced
     When user "Brian" gets the following properties of file "/Shares/tmp.txt" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
@@ -113,6 +116,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "tmp" synced
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
@@ -135,6 +139,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "tmp" synced
     When user "Brian" gets the following properties of folder "/Shares/tmp" using the WebDAV API
       | propertyName          |
       | ocs:share-permissions |
@@ -155,6 +160,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "tmp" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | delete,create,read |
@@ -178,6 +184,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "tmp" synced
     When user "Alice" updates the last share using the sharing API with
       | permissions | delete,create,read |
     Then the HTTP status code should be "200"
@@ -197,6 +204,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "tmp" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | delete,update,read |
@@ -220,6 +228,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "tmp" synced
     When user "Alice" updates the last share using the sharing API with
       | permissions | delete,update,read |
     Then the HTTP status code should be "200"
@@ -239,6 +248,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "tmp" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | create,update,read |
@@ -262,6 +272,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "tmp" synced
     When user "Alice" updates the last share using the sharing API with
       | permissions | create,update,read |
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/shareAccessByID.feature
@@ -109,6 +109,7 @@ Feature: share access by ID
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
     And using SharingNG
     When user "Brian" declines share with ID "%last_share_id%" using the sharing API
     Then the OCS status code should be "<ocs-status-code>"

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
@@ -34,6 +34,8 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "FOLDER" synced
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
@@ -53,6 +55,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Uploader |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
@@ -81,6 +84,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Uploader |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
@@ -107,6 +111,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
@@ -133,6 +138,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
@@ -158,6 +164,7 @@ Feature: sharing
       | sharee          | Brian       |
       | shareType       | user        |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "myfile.txt" synced
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the following headers should match these regular expressions for user "Brian"
@@ -184,6 +191,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
@@ -206,6 +214,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
@@ -226,6 +235,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Uploader |
+    And user "Brian" has a share "FOLDER" synced
     And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
@@ -248,6 +258,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Uploader |
+    And user "Brian" has a share "FOLDER" synced
     And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
@@ -268,6 +279,7 @@ Feature: sharing
       | sharee          | Brian              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "some content" to "/Shares/FOLDER/textFile.txt" using the WebDAV API
     And user "Alice" downloads file "/FOLDER/textFile.txt" using the WebDAV API
     Then the HTTP status code should be "200"
@@ -288,6 +300,7 @@ Feature: sharing
       | sharee          | Alice           |
       | shareType       | user            |
       | permissionsRole | Editor          |
+    And user "Alice" has a share "folder-to-share" synced
     When user "Alice" uploads file "filesForUpload/zerobyte.txt" to "/Shares/folder-to-share/zerobyte.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/Shares/folder-to-share/zerobyte.txt" should exist

--- a/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature
@@ -21,6 +21,7 @@ Feature: sharing
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
     And using SharingNG
     And user "Brian" has moved file "/Shares/textfile0.txt" to "/Shares/textfile_new.txt"
     When user "Alice" updates the last share using the sharing API with
@@ -78,6 +79,7 @@ Feature: sharing
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Viewer        |
+    And user "Brian" has a share "textfile0.txt" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | <permissions> |
@@ -107,6 +109,7 @@ Feature: sharing
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | Viewer        |
+    And user "Brian" has a share "textfile0.txt" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | <permissions> |
@@ -138,12 +141,14 @@ Feature: sharing
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Brian" has a share "Alice-folder" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | Carol-folder |
       | space           | Personal     |
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Brian" has a share "Carol-folder" synced
     When user "Brian" moves folder "/Shares/Alice-folder/folder2" to "/Shares/Carol-folder/folder2" using the WebDAV API
     Then the HTTP status code should be "502"
 
@@ -158,6 +163,7 @@ Feature: sharing
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Viewer       |
+    And user "Brian" has a share "Alice-folder" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | all |
@@ -211,6 +217,7 @@ Feature: sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And using SharingNG
     And user "Carol" has updated the last share with
       | permissions | read |
@@ -235,6 +242,7 @@ Feature: sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Uploader |
+    And user "Brian" has a share "FOLDER" synced
     And user "Brian" has uploaded file with content "some content" to "/Shares/FOLDER/textFile.txt"
     When user "Alice" deletes file "/FOLDER/textFile.txt" using the WebDAV API
     Then the HTTP status code should be "204"

--- a/tests/acceptance/features/coreApiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/coreApiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
@@ -24,12 +24,14 @@ Feature: updating shares to users and groups that have the same name
       | sharee          | Brian    |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Carol" has a share "TMP" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | TMP      |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "TMP" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | read |
@@ -53,12 +55,14 @@ Feature: updating shares to users and groups that have the same name
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "TMP" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | TMP      |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Carol" has a share "TMP" synced
     And using SharingNG
     When user "Alice" updates the last share using the sharing API with
       | permissions | read |

--- a/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
@@ -59,6 +59,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "shared" synced
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
@@ -81,6 +82,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "shared" synced
     When user "Alice" deletes folder "/shared" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" the folder with original path "/shared" should exist in the trashbin

--- a/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
@@ -155,7 +155,7 @@ Feature: using trashbin together with sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
-    And user "Brain" has a share "shared" synced
+    And user "Brian" has a share "shared" synced
     And user "Carol" has a share "shared" synced
     When user "Alice" deletes file "/shared/sub/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -179,7 +179,7 @@ Feature: using trashbin together with sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
-    And user "Brain" has a share "shared" synced
+    And user "Brian" has a share "shared" synced
     And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
     And user "Brian" has deleted file "/Shares/renamed_shared/shared_file.txt"
     When user "Brian" restores the file with original path "/Shares/renamed_shared/shared_file.txt" using the trashbin API

--- a/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature
@@ -20,6 +20,7 @@ Feature: using trashbin together with sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "shared" synced
     And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
     When user "Brian" deletes folder "/Shares/renamed_shared" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -41,6 +42,7 @@ Feature: using trashbin together with sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "shared" synced
     And user "Brian" has moved file "/Shares/shared" to "/Shares/renamed_shared"
     When user "Brian" deletes file "/Shares/renamed_shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -67,6 +69,8 @@ Feature: using trashbin together with sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "shared" synced
+    And user "Carol" has a share "shared" synced
     When user "Brian" deletes file "/Shares/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Brian" the file with original path "/Shares/shared/shared_file.txt" should exist in the trashbin
@@ -93,6 +97,8 @@ Feature: using trashbin together with sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "shared" synced
+    And user "Carol" has a share "shared" synced
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
@@ -120,6 +126,8 @@ Feature: using trashbin together with sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "shared" synced
+    And user "Carol" has a share "shared" synced
     When user "Brian" deletes file "/Shares/shared/sub/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should exist in the trashbin
@@ -147,6 +155,8 @@ Feature: using trashbin together with sharing
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brain" has a share "shared" synced
+    And user "Carol" has a share "shared" synced
     When user "Alice" deletes file "/shared/sub/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
@@ -169,6 +179,7 @@ Feature: using trashbin together with sharing
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brain" has a share "shared" synced
     And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
     And user "Brian" has deleted file "/Shares/renamed_shared/shared_file.txt"
     When user "Brian" restores the file with original path "/Shares/renamed_shared/shared_file.txt" using the trashbin API
@@ -196,6 +207,7 @@ Feature: using trashbin together with sharing
       | sharee          | Alice             |
       | shareType       | user              |
       | permissionsRole | Viewer            |
+    And user "Alice" has a share "shareFolderParent" synced
     And as "Alice" folder "/Shares/shareFolderParent" should exist
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" restores the file with original path "/textfile0.txt" to "/Shares/shareFolderParent/textfile0.txt" using the trashbin API
@@ -220,6 +232,7 @@ Feature: using trashbin together with sharing
       | sharee          | Alice             |
       | shareType       | user              |
       | permissionsRole | Viewer            |
+    And user "Alice" has a share "shareFolderParent" synced
     And as "Alice" folder "/Shares/shareFolderParent/shareFolderChild" should exist
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" restores the file with original path "/textfile0.txt" to "/Shares/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API

--- a/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature
@@ -21,18 +21,21 @@ Feature: file versions remember the author of each version
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | test     |
       | space           | Personal |
       | sharee          | Carol    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Carol" has a share "test" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | test     |
       | space           | Personal |
       | sharee          | David    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "David" has a share "test" synced
     And user "Alice" has uploaded file with content "uploaded content alice" to "/test/textfile0.txt"
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/test/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/test/textfile0.txt"
@@ -67,6 +70,8 @@ Feature: file versions remember the author of each version
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test" synced
+    And user "Carol" has a share "test" synced
     And user "Alice" has uploaded file with content "uploaded content alice" to "/test/textfile0.txt"
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/test/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/test/textfile0.txt"
@@ -97,6 +102,8 @@ Feature: file versions remember the author of each version
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
+    And user "Carol" has a share "textfile0.txt" synced
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/textfile0.txt"
     When user "Alice" gets the number of versions of file "textfile0.txt"
@@ -126,6 +133,8 @@ Feature: file versions remember the author of each version
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test" synced
+    And user "Carol" has a share "test" synced
     And user "Alice" has uploaded file with content "uploaded content alice" to "/test/textfile0.txt"
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/test/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/test/textfile0.txt"
@@ -162,6 +171,8 @@ Feature: file versions remember the author of each version
       | sharee          | grp1        |
       | shareType       | group       |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "exist.txt" synced
+    And user "Carol" has a share "exist.txt" synced
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/exist.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/exist.txt"
     And user "Alice" has moved file "/exist.txt" to "/textfile0.txt"
@@ -192,6 +203,8 @@ Feature: file versions remember the author of each version
       | sharee          | grp1        |
       | shareType       | group       |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "exist.txt" synced
+    And user "Carol" has a share "exist.txt" synced
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/exist.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/exist.txt"
     And user "Brian" has moved file "/Shares/exist.txt" to "/Shares/textfile0.txt"
@@ -226,6 +239,8 @@ Feature: file versions remember the author of each version
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test" synced
+    And user "Carol" has a share "test" synced
     And user "Alice" has uploaded file with content "uploaded content alice" to "/test/textfile0.txt"
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/test/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/test/textfile0.txt"
@@ -237,6 +252,8 @@ Feature: file versions remember the author of each version
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test" synced
+    And user "Carol" has a share "test" synced
     When user "Alice" gets the number of versions of file "/test/textfile0.txt"
     Then the HTTP status code should be "207"
     And the number of versions should be "3"
@@ -266,20 +283,23 @@ Feature: file versions remember the author of each version
       | sharee          | Carol    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Carol" has a share "test" synced
     And user "Brian" has sent the following resource share invitation:
       | resource        | test     |
       | space           | Personal |
       | sharee          | David    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "David" has a share "test" synced
     And user "Carol" has created folder "/test"
     And user "Carol" has uploaded file with content "duplicate carol" to "/test/textfile0.txt"
     And user "Carol" has sent the following resource share invitation:
       | resource        | test     |
       | space           | Personal |
-      | sharee          | David    |
+      | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test" synced
     And user "Alice" has created folder "/test"
     And user "Alice" has sent the following resource share invitation:
       | resource        | test     |
@@ -287,18 +307,21 @@ Feature: file versions remember the author of each version
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test (1)" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | test     |
       | space           | Personal |
       | sharee          | Carol    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Carol" has a share "test (1)" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | test     |
       | space           | Personal |
       | sharee          | David    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "David" has a share "test (1)" synced
     And user "Alice" has uploaded file with content "uploaded content alice" to "/test/textfile0.txt"
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/test (1)/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/test (1)/textfile0.txt"
@@ -341,12 +364,14 @@ Feature: file versions remember the author of each version
       | sharee          | Carol         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Carol" has a share "textfile0.txt" synced
     And user "Brian" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | David         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "David" has a share "textfile0.txt" synced
     And user "Carol" has uploaded file with content "duplicate carol" to "/textfile0.txt"
     And user "Carol" has sent the following resource share invitation:
       | resource        | textfile0.txt |
@@ -354,6 +379,7 @@ Feature: file versions remember the author of each version
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
     And user "Alice" has uploaded file with content "uploaded content alice" to "/textfile0.txt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
@@ -361,18 +387,21 @@ Feature: file versions remember the author of each version
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0 (1).txt" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Carol         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Carol" has a share "textfile0 (1).txt" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | David         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "David" has a share "textfile0 (1).txt" synced
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/textfile0 (1).txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/textfile0 (1).txt"
     And user "David" has uploaded file with content "uploaded content david" to "/Shares/textfile0 (1).txt"
@@ -412,12 +441,14 @@ Feature: file versions remember the author of each version
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "test" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | test     |
       | space           | Personal |
       | sharee          | Carol    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Carol" has a share "test" synced
     And user "Alice" has uploaded file with content "uploaded content alice" to "/test/textfile0.txt"
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/test/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/test/textfile0.txt"
@@ -441,12 +472,14 @@ Feature: file versions remember the author of each version
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile0.txt |
       | space           | Personal      |
       | sharee          | Carol         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Carol" has a share "textfile0.txt" synced
     And user "Brian" has uploaded file with content "uploaded content brian" to "/Shares/textfile0.txt"
     And user "Carol" has uploaded file with content "uploaded content carol" to "/Shares/textfile0.txt"
     When user "Brian" restores version index "1" of file "/Shares/textfile0.txt" using the WebDAV API

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -280,6 +280,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "sharefile.txt" synced
     When user "Brian" uploads file with content "Second content" to "/Shares/sharefile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the version folder of file "/sharefile.txt" for user "Alice" should contain "1" element
@@ -296,6 +297,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "sharefile.txt" synced
     And user "Brian" has uploaded file with content "Second content" to "/Shares/sharefile.txt"
     When user "Alice" restores version index "1" of file "/sharefile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -312,6 +314,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "sharingfolder" synced
     And user "Alice" has uploaded file with content "First content" to "/sharingfolder/sharefile.txt"
     And user "Brian" has uploaded file with content "Second content" to "/Shares/sharingfolder/sharefile.txt"
     When user "Alice" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
@@ -329,6 +332,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "sharingfolder" synced
     And user "Alice" has uploaded file with content "First content" to "/sharingfolder/sharefile.txt"
     When user "Brian" has uploaded file with content "Second content" to "/Shares/sharingfolder/sharefile.txt"
     And user "Brian" gets the number of versions of file "/Shares/sharingfolder/sharefile.txt"
@@ -346,6 +350,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "sharingfolder" synced
     And user "Brian" has uploaded file with content "First content" to "/Shares/sharingfolder/sharefile.txt"
     And user "Alice" has uploaded file with content "Second content" to "/sharingfolder/sharefile.txt"
     When user "Alice" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
@@ -363,6 +368,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "sharingfolder" synced
     And user "Brian" has uploaded file with content "old content" to "/Shares/sharingfolder/sharefile.txt"
     And user "Brian" has uploaded file with content "new content" to "/Shares/sharingfolder/sharefile.txt"
     When user "Alice" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
@@ -384,6 +390,8 @@ Feature: dav-versions
       | sharee          | grp1          |
       | shareType       | group         |
       | permissionsRole | Editor        |
+    And user "Brian" has a share "sharingfolder" synced
+    And user "Carol" has a share "sharingfolder" synced
     And user "Alice" has uploaded file with content "First content" to "/sharingfolder/sharefile.txt"
     And user "Brian" has uploaded file with content "Second content" to "/Shares/sharingfolder/sharefile.txt"
     And user "Carol" has uploaded file with content "Third content" to "/Shares/sharingfolder/sharefile.txt"
@@ -404,6 +412,7 @@ Feature: dav-versions
       | sharee          | Alice              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Alice" has a share "testshare" synced
     And user "Brian" has uploaded file with content "test data 1" to "/testfile.txt"
     And user "Brian" has uploaded file with content "test data 2" to "/testfile.txt"
     And user "Brian" has uploaded file with content "test data 3" to "/testfile.txt"
@@ -434,6 +443,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
     When user "Brian" tries to get versions of file "textfile1.txt" from "Alice"
     Then the HTTP status code should be "404"
     And the value of the item "//s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
@@ -451,6 +461,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
     When user "Brian" tries to get versions of file "textfile0.txt" from "Alice"
     Then the HTTP status code should be "403"
 
@@ -466,6 +477,7 @@ Feature: dav-versions
       | sharee          | Brian         |
       | shareType       | user          |
       | permissionsRole | File Editor   |
+    And user "Brian" has a share "textfile0.txt" synced
     When user "Brian" tries to get versions of file "textfile0.txt" from "Alice"
     Then the HTTP status code should be "403"
     And the value of the item "//s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\Forbidden"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -83,6 +83,7 @@ Feature: propagation of etags when deleting a file or folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/sub"
@@ -118,6 +119,7 @@ Feature: propagation of etags when deleting a file or folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/sub"
@@ -153,6 +155,7 @@ Feature: propagation of etags when deleting a file or folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/sub"
@@ -188,6 +191,7 @@ Feature: propagation of etags when deleting a file or folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/sub"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
@@ -144,6 +144,7 @@ Feature: propagation of etags when moving files or folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Brian" has stored etag of element "/"
@@ -175,6 +176,7 @@ Feature: propagation of etags when moving files or folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Brian" has stored etag of element "/"
@@ -207,12 +209,14 @@ Feature: propagation of etags when moving files or folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "src" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | dst      |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "dst" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/src"
     And user "Alice" has stored etag of element "/dst"
@@ -249,12 +253,14 @@ Feature: propagation of etags when moving files or folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "src" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | dst      |
       | space           | Personal |
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "dst" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/src"
     And user "Alice" has stored etag of element "/dst"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
@@ -148,6 +148,7 @@ Feature: propagation of etags when copying files or folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
@@ -189,6 +190,7 @@ Feature: propagation of etags when copying files or folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
@@ -56,6 +56,7 @@ Feature: propagation of etags when creating folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "folder" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/folder"
     And user "Brian" has stored etag of element "/"
@@ -86,6 +87,7 @@ Feature: propagation of etags when creating folders
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "folder" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/folder"
     And user "Brian" has stored etag of element "/"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
@@ -54,6 +54,7 @@ Feature: propagation of etags when uploading data
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Brian" has stored etag of element "/"
@@ -83,6 +84,7 @@ Feature: propagation of etags when uploading data
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Brian" has stored etag of element "/"
@@ -113,6 +115,7 @@ Feature: propagation of etags when uploading data
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Brian" has stored etag of element "/"
@@ -143,6 +146,7 @@ Feature: propagation of etags when uploading data
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "upload" synced
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Brian" has stored etag of element "/"

--- a/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
+++ b/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature
@@ -19,6 +19,7 @@ Feature: move (rename) file
       | sharee          | Alice              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Alice" has a share "testshare" synced
     And user "Brian" has uploaded file with content "test data" to "/testfile.txt"
     When user "Brian" moves file "/testfile.txt" to "testshare/testfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -73,6 +74,7 @@ Feature: move (rename) file
       | sharee          | Alice              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Alice" has a share "testshare" synced
     When user "Brian" moves file "/testshare/testfile.txt" to "/testfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/testfile.txt" for user "Brian" should be "test data"
@@ -124,6 +126,7 @@ Feature: move (rename) file
       | sharee          | Alice              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Alice" has a share "testshare" synced
     And user "Brian" has created folder "/testsubfolder"
     And user "Brian" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
     When user "Brian" moves folder "/testsubfolder" to "testshare/testsubfolder" using the WebDAV API
@@ -183,6 +186,7 @@ Feature: move (rename) file
       | sharee          | Alice              |
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
+    And user "Alice" has a share "testshare" synced
     When user "Brian" moves folder "/testshare/testsubfolder" to "/testsubfolder" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/testsubfolder/testfile.txt" for user "Brian" should be "test data"

--- a/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/previews.feature
@@ -145,6 +145,7 @@ Feature: previews of files downloaded through the webdav API
       | sharee          | Brian       |
       | shareType       | user        |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "<file-name>" synced
     When user "Brian" downloads the preview of shared resource "/Shares/<file-name>" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
@@ -223,6 +224,7 @@ Feature: previews of files downloaded through the webdav API
       | sharee          | Brian       |
       | shareType       | user        |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "parent.txt" synced
     And user "Brian" has downloaded the preview of shared resource "/Shares/parent.txt" with width "32" and height "32"
     When user "Alice" uploads file with content "this is a file to upload" to "/parent.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -260,6 +262,7 @@ Feature: previews of files downloaded through the webdav API
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
     And user "Brian" has downloaded the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32"
     When user "Alice" uploads file "filesForUpload/lorem.txt" to "/FOLDER/lorem.txt" using the WebDAV API
@@ -292,6 +295,8 @@ Feature: previews of files downloaded through the webdav API
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
+    And user "Carol" has a share "FOLDER" synced
     And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
     And user "Brian" has downloaded the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32"
     And user "Carol" has downloaded the preview of shared resource "Shares/FOLDER/lorem.txt" with width "32" and height "32"

--- a/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature
@@ -59,6 +59,7 @@ Feature: copy file
       | sharee          | Alice     |
       | shareType       | user      |
       | permissionsRole | Viewer    |
+    And user "Alice" has a share "testshare" synced
     When user "Alice" copies file "/textfile0.txt" to "/Shares/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "Alice" should not be able to download file "/Shares/testshare/textfile0.txt"
@@ -79,6 +80,7 @@ Feature: copy file
       | sharee          | Alice     |
       | shareType       | user      |
       | permissionsRole | Viewer    |
+    And user "Alice" has a share "testshare" synced
     And user "Brian" has copied file "textfile1.txt" to "/testshare/overwritethis.txt"
     When user "Alice" copies file "/textfile0.txt" to "/Shares/testshare/overwritethis.txt" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -224,6 +226,7 @@ Feature: copy file
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-Folder" synced
     When user "Alice" copies file "/textfile1.txt" to "/Shares/BRIAN-Folder" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/Shares/BRIAN-Folder" for user "Alice" should be "ownCloud test text file 1"
@@ -246,6 +249,7 @@ Feature: copy file
       | sharee          | Alice           |
       | shareType       | user            |
       | permissionsRole | File Editor     |
+    And user "Alice" has a share "sharedfile1.txt" synced
     And user "Alice" has created folder "FOLDER/sample-folder"
     When user "Alice" copies folder "/FOLDER" to "/Shares/sharedfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -271,6 +275,7 @@ Feature: copy file
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "Sample-Folder-A"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b/sample-folder-c"
@@ -299,6 +304,7 @@ Feature: copy file
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "Sample-Folder-A"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
     And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
@@ -328,6 +334,7 @@ Feature: copy file
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "Sample-Folder-A"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
     And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
@@ -358,6 +365,7 @@ Feature: copy file
       | sharee          | Alice        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "FOLDER/second-level-folder"
     And user "Alice" has created folder "FOLDER/second-level-folder/third-level-folder"
     When user "Alice" copies folder "FOLDER/second-level-folder" to "/Shares/BRIAN-FOLDER/second-level-folder/third-level-file.txt" using the WebDAV API
@@ -388,6 +396,7 @@ Feature: copy file
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-Folder" synced
     When user "Alice" copies file "/textfile1.txt" to "/Shares/BRIAN-Folder" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/Shares/BRIAN-Folder" for user "Alice" should be "ownCloud test text file 1"
@@ -414,6 +423,7 @@ Feature: copy file
       | sharee          | grp1            |
       | shareType       | group           |
       | permissionsRole | File Editor     |
+    And user "Alice" has a share "sharedfile1.txt" synced
     And user "Alice" has created folder "FOLDER/sample-folder"
     When user "Alice" copies folder "/FOLDER" to "/Shares/sharedfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -443,6 +453,7 @@ Feature: copy file
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "Sample-Folder-A"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b/sample-folder-c"
@@ -474,6 +485,7 @@ Feature: copy file
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "Sample-Folder-A"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
     And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
@@ -506,6 +518,7 @@ Feature: copy file
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "Sample-Folder-A"
     And user "Alice" has created folder "Sample-Folder-A/sample-folder-b"
     And user "Alice" has uploaded file with content "sample file-c" to "Sample-Folder-A/sample-folder-b/textfile-c.txt"
@@ -539,6 +552,7 @@ Feature: copy file
       | sharee          | grp1         |
       | shareType       | group        |
       | permissionsRole | Editor       |
+    And user "Alice" has a share "BRIAN-FOLDER" synced
     And user "Alice" has created folder "FOLDER/second-level-folder"
     And user "Alice" has created folder "FOLDER/second-level-folder/third-level-folder"
     When user "Alice" copies folder "FOLDER/second-level-folder" to "Shares/BRIAN-FOLDER/second-level-folder/third-level-file.txt" using the WebDAV API
@@ -619,6 +633,7 @@ Feature: copy file
       | sharee          | Alice     |
       | shareType       | user      |
       | permissionsRole | Editor    |
+    And user "Alice" has a share "testshare" synced
     When user "Alice" copies file "/textfile0.txt" to "/Shares/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/Shares/testshare/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
@@ -639,6 +654,7 @@ Feature: copy file
       | sharee          | Alice     |
       | shareType       | user      |
       | permissionsRole | Editor    |
+    And user "Alice" has a share "testshare" synced
     And user "Brian" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Brian" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -660,6 +676,7 @@ Feature: copy file
       | sharee          | Alice     |
       | shareType       | user      |
       | permissionsRole | Editor    |
+    And user "Alice" has a share "testshare" synced
     And user "Alice" has uploaded file with content "ownCloud test text file inside share" to "/Shares/testshare/fileInsideShare.txt"
     When user "Alice" copies file "/Shares/testshare/fileInsideShare.txt" to "/fileInsideShare.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -683,6 +700,7 @@ Feature: copy file
       | sharee          | Alice     |
       | shareType       | user      |
       | permissionsRole | Editor    |
+    And user "Alice" has a share "testshare" synced
     When user "Brian" copies file "testshare/fileInsideShare.txt" to "/fileInsideShare.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/fileInsideShare.txt" should exist
@@ -730,12 +748,14 @@ Feature: copy file
       | sharee          | Alice      |
       | shareType       | user       |
       | permissionsRole | Editor     |
+    And user "Alice" has a share "testshare0" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | testshare1 |
       | space           | Personal   |
       | sharee          | Alice      |
       | shareType       | user       |
       | permissionsRole | Editor     |
+    And user "Alice" has a share "testshare1" synced
     When user "Alice" copies file "/Shares/testshare0/testshare0.txt" to "/Shares/testshare1/testshare0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Carol" file "testshare1/testshare0.txt" should exist
@@ -762,12 +782,14 @@ Feature: copy file
       | sharee          | Alice      |
       | shareType       | user       |
       | permissionsRole | Editor     |
+    And user "Alice" has a share "testshare0" synced
     And user "Carol" has sent the following resource share invitation:
       | resource        | testshare1 |
       | space           | Personal   |
       | sharee          | Alice      |
       | shareType       | user       |
       | permissionsRole | Editor     |
+    And user "Alice" has a share "testshare1" synced
     When user "Alice" copies file "/Shares/testshare0/folder_to_copy/" to "/Shares/testshare1/folder_to_copy/" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Carol" file "testshare1/folder_to_copy/testshare0.txt" should exist
@@ -791,12 +813,14 @@ Feature: copy file
       | sharee          | Brian     |
       | shareType       | user      |
       | permissionsRole | Editor    |
+    And user "Brian" has a share "testshare" synced
     And user "Alice" has sent the following resource share invitation:
       | resource        | testshare |
       | space           | Personal  |
       | sharee          | Carol     |
       | shareType       | user      |
       | permissionsRole | Editor    |
+    And user "Carol" has a share "testshare" synced
     When user "Alice" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/testshare/textfile0.txt" should exist

--- a/tests/acceptance/features/coreApiWebdavProperties/createFileFolderWhenSharesExist.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/createFileFolderWhenSharesExist.feature
@@ -16,6 +16,7 @@ Feature: create file or folder named similar to Shares folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "FOLDER" synced
 
 
   Scenario Outline: create a folder with a name similar to Shares

--- a/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature
@@ -46,6 +46,7 @@ Feature: get quota
       | sharee          | Alice     |
       | shareType       | user      |
       | permissionsRole | Editor    |
+    And user "Alice" has a share "testquota" synced
     When user "Alice" gets the following properties of folder "<folder-name>" inside space "Shares" using the WebDAV API
       | propertyName            |
       | d:quota-available-bytes |
@@ -85,6 +86,7 @@ Feature: get quota
       | sharee          | Brian       |
       | shareType       | user        |
       | permissionsRole | File Editor |
+    And user "Brian" has a share "Alice.txt" synced
     When user "Brian" gets the following properties of folder "/" using the WebDAV API
       | propertyName            |
       | d:quota-available-bytes |

--- a/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature
@@ -58,6 +58,7 @@ Feature: set file properties
       | sharee          | Brian                    |
       | shareType       | user                     |
       | permissionsRole | File Editor              |
+    And user "Brian" has a share "testcustompropshared.txt" synced
     And user "Alice" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustompropshared.txt" to "valueForSharetest"
     When user "Brian" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustompropshared.txt"
     Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and value "valueForSharetest"

--- a/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
@@ -337,6 +337,7 @@ Feature: upload file
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | File Editor  |
+    And user "Brian" has a share "textfile.txt" synced
     When user "Brian" uploads file with content "" to shared resource "Shares/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And for user "Brian" the content of the file "/test.txt" of the space "Shares" should be ""

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtimeShares.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtimeShares.feature
@@ -20,6 +20,7 @@ Feature: upload file
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "toShare" synced
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
@@ -38,6 +39,7 @@ Feature: upload file
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "toShare" synced
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
     And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
@@ -56,6 +58,7 @@ Feature: upload file
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "toShare" synced
     And user "Alice" has uploaded file with content "uploaded content" to "/toShare/file.txt"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
@@ -75,6 +78,7 @@ Feature: upload file
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "toShare" synced
     And user "Brian" has uploaded file with content "uploaded content" to "/Shares/toShare/file.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
     Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToNonExistingFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToNonExistingFolder.feature
@@ -41,6 +41,7 @@ Feature: upload file
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/nonExistentFolder/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Brian" folder "/Shares/FOLDER/nonExistentFolder" should not exist
     And as "Brian" file "/Shares/FOLDER/nonExistentFolder/textfile.txt" should not exist
@@ -60,6 +61,7 @@ Feature: upload file
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/nonExistentFolder/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Brian" folder "/Shares/FOLDER/nonExistentFolder" should not exist
     And as "Brian" file "/Shares/FOLDER/nonExistentFolder/textfile.txt" should not exist

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadToShare.feature
@@ -20,6 +20,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
@@ -38,6 +39,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Uploader |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
@@ -58,6 +60,7 @@ Feature: upload file to shared folder
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Uploader |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
@@ -77,6 +80,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "overwritten content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "overwritten content"
@@ -95,6 +99,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Viewer   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
     Then as "Brian" file "/Shares/FOLDER/textfile.txt" should not exist
     Examples:
@@ -112,6 +117,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                                     |
       #    L0ZPTERFUi90ZXh0RmlsZS50eHQ= is the base64 encode of /FOLDER/textFile.txt
@@ -135,6 +141,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                                     |
       #    L0ZPTERFUi90ZXh0RmlsZS50eHQ= is the base64 encode of /FOLDER/textFile.txt
@@ -162,6 +169,7 @@ Feature: upload file to shared folder
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | File Editor  |
+    And user "Brian" has a share "textFile.txt" synced
     When user "Brian" requests the checksum of "/Shares/textFile.txt" via propfind
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964 MD5:827ccb0eea8a706c4c34a16891f84e7b ADLER32:02f80100"
@@ -184,6 +192,7 @@ Feature: upload file to shared folder
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | File Editor  |
+    And user "Brian" has a share "textFile.txt" synced
     When user "Brian" downloads file "/Shares/textFile.txt" using the WebDAV API
     Then the HTTP status code should be "200"
     And the header checksum should match "SHA1:8cb2237d0679ca88db6464eac60da96345513964"
@@ -202,6 +211,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
       | Upload-Length   | 16                                            |
@@ -226,6 +236,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     When user "Brian" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
       | Upload-Length   | 16                                            |
@@ -249,6 +260,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                                     |
       #    L0ZPTERFUi90ZXh0RmlsZS50eHQ= is the base64 encode of /FOLDER/textFile.txt
@@ -289,6 +301,7 @@ Feature: upload file to shared folder
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
+    And user "Brian" has a share "FOLDER" synced
     And user "Brian" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
       | Upload-Length   | 10                                            |
@@ -318,6 +331,7 @@ Feature: upload file to shared folder
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | File Editor  |
+    And user "Brian" has a share "textFile.txt" synced
     When user "Brian" overwrites recently shared file with offset "0" and data "overwritten content" with checksum "SHA1 fe990d2686a0fc86004efc31f5bf2475a45d4905" using the TUS protocol on the WebDAV API with these headers:
       | Upload-Length   | 19                                    |
         #    dGV4dEZpbGUudHh0 is the base64 encode of /Shares/textFile.txt
@@ -343,6 +357,7 @@ Feature: upload file to shared folder
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | File Editor  |
+    And user "Brian" has a share "textFile.txt" synced
     When user "Brian" overwrites recently shared file with offset "0" and data "overwritten content" with checksum "SHA1 fe990d2686a0fc86004efc31f5bf2475a45d4906" using the TUS protocol on the WebDAV API with these headers:
       | Upload-Length   | 19                                    |
       #    dGV4dEZpbGUudHh0 is the base64 encode of /Shares/textFile.txt

--- a/tests/parallelDeployAcceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/parallelDeployAcceptance/features/apiShareManagement/acceptShares.feature
@@ -20,6 +20,7 @@ Feature: sharing files and folders
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Editor       |
+    And user "Brian" has a share "textfile.txt" synced
     And using "ocis" as owncloud selector
     And the sharing API should report to user "Brian" that these shares are in the accepted state
       | path                 |


### PR DESCRIPTION
## Description
Added share status assertion after the share invitation step for coreAPI test suites.
Also fixed the requests for spaces endpoint related to the Shares space.

## Related Issue

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
