### PR TITLE
Fix trash command

### DIFF
--- a/changelog/unreleased/fix-trash-command.md
+++ b/changelog/unreleased/fix-trash-command.md
@@ -1,0 +1,5 @@
+Enhancement: Fix trash command
+
+The `ocis trash purge-empty-dirs` command should work on any storage provider, not just `storage/users`.
+
+https://github.com/owncloud/ocis/pull/9665

--- a/ocis/pkg/trash/trash.go
+++ b/ocis/pkg/trash/trash.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// _trashGlobPattern is the glob pattern to find all trash items
-	_trashGlobPattern = "storage/users/spaces/*/*/trash/*/*/*/*"
+	_trashGlobPattern = "spaces/*/*/trash/*/*/*/*"
 )
 
 // PurgeTrashEmptyPaths purges empty paths in the trash


### PR DESCRIPTION
The `ocis trash purge-empty-dirs` commands should work on any storage provider, not just `storage/users`

Fixes https://github.com/owncloud/ocis/issues/9615