### PR TITLE
fix: clarify description of OCIS_SHOW_USER_EMAIL_IN_RESULTS

### DIFF
--- a/docs/helpers/env_vars.yaml
+++ b/docs/helpers/env_vars.yaml
@@ -8477,7 +8477,7 @@ OCIS_SHOW_USER_EMAIL_IN_RESULTS:
   name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
   defaultValue: "false"
   type: bool
-  description: Mask user email addresses in responses.
+  description: Mask user email addresses in responses when set to 'false' (the default). Only effective for non-admin users."
   introductionVersion: 6.0.0
   deprecationVersion: ""
   removalVersion: ""

--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -145,7 +145,7 @@ type OCS struct {
 	PublicShareMustHavePassword          bool               `yaml:"public_sharing_share_must_have_password" env:"OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD;FRONTEND_OCS_PUBLIC_SHARE_MUST_HAVE_PASSWORD" desc:"Set this to true if you want to enforce passwords on all public shares." introductionVersion:"5.0"`
 	WriteablePublicShareMustHavePassword bool               `yaml:"public_sharing_writeableshare_must_have_password" env:"OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD;FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD" desc:"Set this to true if you want to enforce passwords for writable shares. Only effective if the setting for 'passwords on all public shares' is set to false." introductionVersion:"5.0"`
 	IncludeOCMSharees                    bool               `yaml:"include_ocm_sharees" env:"FRONTEND_OCS_INCLUDE_OCM_SHAREES" desc:"Include OCM sharees when listing sharees." introductionVersion:"5.0"`
-	ShowUserEmailInResults               bool               `yaml:"show_email_in_results" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"6.0.0"`
+	ShowUserEmailInResults               bool               `yaml:"show_email_in_results" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses when set to 'false' (the default). Only effective for non-admin users." introductionVersion:"6.0.0"`
 }
 
 type CacheWarmupDrivers struct {

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -113,7 +113,7 @@ type API struct {
 	UsernameMatch           string `yaml:"graph_username_match" env:"GRAPH_USERNAME_MATCH" desc:"Apply restrictions to usernames. Supported values are 'default' and 'none'. When set to 'default', user names must not start with a number and are restricted to ASCII characters. When set to 'none', no restrictions are applied. The default value is 'default'." introductionVersion:"pre5.0"`
 	AssignDefaultUserRole   bool   `yaml:"graph_assign_default_user_role" env:"GRAPH_ASSIGN_DEFAULT_USER_ROLE" desc:"Whether to assign newly created users the default role 'User'. Set this to 'false' if you want to assign roles manually, or if the role assignment should happen at first login. Set this to 'true' (the default) to assign the role 'User' when creating a new user." introductionVersion:"pre5.0"`
 	IdentitySearchMinLength int    `yaml:"graph_identity_search_min_length" env:"GRAPH_IDENTITY_SEARCH_MIN_LENGTH" desc:"The minimum length the search term needs to have for unprivileged users when searching for users or groups." introductionVersion:"5.0"`
-	ShowUserEmailInResults  bool   `yaml:"show_email_in_results" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses." introductionVersion:"6.0.0"`
+	ShowUserEmailInResults  bool   `yaml:"show_email_in_results" env:"OCIS_SHOW_USER_EMAIL_IN_RESULTS" desc:"Mask user email addresses in responses when set to 'false' (the default). Only effective for non-admin users." introductionVersion:"6.0.0"`
 }
 
 // Events combines the configuration options for the event bus.


### PR DESCRIPTION
I am saying 'non-admin' users, that is a bit unprecise ... not sure, if we should mention AccountManagementPermission 
here?

I found the string in 3 places. hope that's correct.