### PR TITLE
[full-ci] feat: remove draw-io from default web config

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=7ee2d90c8a78d115347d0a98c4015e736b6395a7
+WEB_COMMITID=6f86dd23d9b1f6907ab02d3aa40099ca05cc43e8
 WEB_BRANCH=master

--- a/services/web/pkg/config/defaults/defaultconfig.go
+++ b/services/web/pkg/config/defaults/defaultconfig.go
@@ -98,7 +98,7 @@ func DefaultConfig() *config.Config {
 					ResponseType: "code",
 					Scope:        "openid profile email",
 				},
-				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader", "draw-io"},
+				Apps: []string{"files", "search", "text-editor", "pdf-viewer", "external", "admin-settings", "epub-reader"},
 				ExternalApps: []config.ExternalApp{
 					{
 						ID:   "preview",

--- a/tests/config/drone/ocis-config.json
+++ b/tests/config/drone/ocis-config.json
@@ -21,7 +21,6 @@
   },
   "apps": [
     "files",
-    "draw-io",
     "text-editor",
     "preview",
     "pdf-viewer",

--- a/tests/config/drone/ocis-config.json
+++ b/tests/config/drone/ocis-config.json
@@ -11,7 +11,6 @@
   },
   "options": {
     "topCenterNotifications": true,
-    "disablePreviews": true,
     "displayResourcesLazy": false,
     "sidebar": {
       "shares": {


### PR DESCRIPTION
## Description
The `draw-io` app has been removed from the Web default apps, hence this removes it here as well.

The app is now available via the [web-extensions repository](https://github.com/owncloud/web-extensions).

I guess we can omit a changelog item since it will be included in the Web changelog?

See https://github.com/owncloud/web/issues/11248

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
