### PR TITLE
[tests-only] [full-ci] Add test to check activity after uploading a file

### DIFF
--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -2293,4 +2293,31 @@ class GraphHelper {
 			self::getRequestHeaders()
 		);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $requestId
+	 * @param string $user
+	 * @param string $password
+	 * @param string $resourceId
+	 *
+	 * @return ResponseInterface
+	 */
+	public static function getActivities(
+		string $baseUrl,
+		string $requestId,
+		string $user,
+		string $password,
+		string $resourceId
+	): ResponseInterface {
+		// 'kql=itemId' filter is required for the current implementation but it might change in future
+		// See: https://github.com/owncloud/ocis/issues/9194
+		$fullUrl = self::getBetaFullUrl($baseUrl, "extensions/org.libregraph/activities?kql=itemid%3A$resourceId");
+		return HttpRequestHelper::get(
+			$fullUrl,
+			$requestId,
+			$user,
+			$password
+		);
+	}
 }

--- a/tests/acceptance/features/apiGraph/activities.feature
+++ b/tests/acceptance/features/apiGraph/activities.feature
@@ -1,0 +1,99 @@
+Feature: check activities
+  As a user
+  I want to check who made which changes to files
+  So that I can track modifications
+
+
+  Scenario: check activities after uploading a file
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    When user "Alice" checks the activities for file "textfile0.txt" in space "Personal" using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id","template","times"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^%user_id_pattern%$"
+              },
+              "template": {
+                "type": "object",
+                "required": ["message","variables"],
+                "properties": {
+                  "message": {
+                    "const": "{user} added {resource} to {space}"
+                  },
+                  "variables": {
+                    "type": "object",
+                    "required": ["resource","space","user"],
+                    "properties": {
+                      "resource": {
+                        "type": "object",
+                        "required": ["id","name"],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "pattern": "%file_id_pattern%"
+                          },
+                          "name": {
+                            "const": "textfile0.txt"
+                          }
+                        }
+                      },
+                      "space": {
+                        "type": "object",
+                        "required": ["id","name"],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "pattern": "^%user_id_pattern%!%user_id_pattern%$"
+                          },
+                          "name": {
+                            "const": "Alice Hansen"
+                          }
+                        }
+                      },
+                      "user": {
+                        "type": "object",
+                        "required": ["id","displayName"],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "pattern": "%user_id_pattern%"
+                          },
+                          "displayName": {
+                            "const": "Alice"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "times": {
+                "type": "object",
+                "required": ["recordedTime"],
+                "properties": {
+                  "recordedTime": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -2775,4 +2775,27 @@ class GraphContext implements Context {
 			)
 		);
 	}
+
+	/**
+	 * @When /^user "([^"]*)" checks the activities for (?:folder|file) "([^"]*)" in space "([^"]*)" using the Graph API/
+	 *
+	 * @param string $user
+	 * @param string $resource
+	 * @param string $spaceName
+	 *
+	 * @return void
+	 * @throws Exception
+	 *
+	 */
+	public function userChecksTheActivitiesForResourceInSpaceUsingTheGraphAPI(string $user, string $resource, string $spaceName): void {
+		$resourceId = $this->featureContext->spacesContext->getResourceId($user, $spaceName, $resource);
+		$response = GraphHelper::getActivities(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$resourceId
+		);
+		$this->featureContext->setResponse($response);
+	}
 }


### PR DESCRIPTION
## Description
Using the new API endpoint `/v1beta1/extensions/org.libregraph/activities`, this test checks file activity information after a user has already uploaded a file.

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/9543

## How Has This Been Tested?
- CI :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
