### PR TITLE
feat: include additional metadata for tracing the collaboration service

### DIFF
--- a/changelog/unreleased/collaboration-improved-tracing.md
+++ b/changelog/unreleased/collaboration-improved-tracing.md
@@ -1,0 +1,6 @@
+Enhancement: Tracing improvements in the collaboration service
+
+Uploads and downloads through the collaboration service will be traced. The openInApp request will also be linked properly with other requests in the tracing.
+In addition, the collaboration service will include some additional information in the traces. Filtering based on that information might be an option.
+
+https://github.com/owncloud/ocis/pull/9684

--- a/services/collaboration/pkg/command/server.go
+++ b/services/collaboration/pkg/command/server.go
@@ -63,6 +63,7 @@ func Server(cfg *config.Config) *cli.Command {
 				grpc.AppURLs(appUrls),
 				grpc.Config(cfg),
 				grpc.Logger(logger),
+				grpc.TraceProvider(traceProvider),
 			)
 			defer teardown()
 			if err != nil {

--- a/services/collaboration/pkg/connector/contentconnector.go
+++ b/services/collaboration/pkg/connector/contentconnector.go
@@ -15,9 +15,11 @@ import (
 	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	revactx "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/config"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/middleware"
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // ContentConnectorService is the interface to implement the "File contents"
@@ -143,6 +145,8 @@ func (c *ContentConnector) GetFile(ctx context.Context, writer io.Writer) error 
 	} else {
 		httpReq.Header.Add("X-Access-Token", wopiContext.AccessToken)
 	}
+	tracingProp := tracing.GetPropagator()
+	tracingProp.Inject(ctx, propagation.HeaderCarrier(httpReq.Header))
 
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
@@ -341,6 +345,8 @@ func (c *ContentConnector) PutFile(ctx context.Context, stream io.Reader, stream
 		//if lockID, ok := ctxpkg.ContextGetLockID(ctx); ok {
 		//	httpReq.Header.Add("X-Lock-Id", lockID)
 		//}
+		tracingProp := tracing.GetPropagator()
+		tracingProp.Inject(ctx, propagation.HeaderCarrier(httpReq.Header))
 
 		httpResp, err := httpClient.Do(httpReq)
 		if err != nil {

--- a/services/collaboration/pkg/middleware/proofkeys.go
+++ b/services/collaboration/pkg/middleware/proofkeys.go
@@ -10,6 +10,16 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// ProofKeysMiddleware will verify the proof keys of the requests.
+// This is a middleware that could be disabled / not set.
+//
+// Requests will fail with a 500 HTTP status if the verification fails.
+// As said, this can be disabled (via configuration) if you want to skip
+// the verification.
+// The middleware requires hitting the "/hosting/discovery" endpoint of the
+// WOPI app in order to get the keys. The keys will be cached in memory for
+// 12 hours (or the configured value) before hitting the endpoint again to
+// request new / updated keys.
 func ProofKeysMiddleware(cfg *config.Config, next http.Handler) http.Handler {
 	wopiDiscovery := cfg.App.Addr + "/hosting/discovery"
 	insecure := cfg.App.Insecure

--- a/services/collaboration/pkg/middleware/tracing.go
+++ b/services/collaboration/pkg/middleware/tracing.go
@@ -23,6 +23,7 @@ func CollaborationTracingMiddleware(next http.Handler) http.Handler {
 		wopiUser := wopiContext.User.GetId()
 
 		attrs := []attribute.KeyValue{
+			attribute.String("ocis.wopi.sessionid", r.Header.Get("X-WOPI-SessionId")),
 			attribute.String("ocis.wopi.method", wopiMethod),
 			attribute.String("ocis.wopi.resource.id.storage", wopiFile.GetResourceId().GetStorageId()),
 			attribute.String("ocis.wopi.resource.id.opaque", wopiFile.GetResourceId().GetOpaqueId()),

--- a/services/collaboration/pkg/middleware/tracing.go
+++ b/services/collaboration/pkg/middleware/tracing.go
@@ -7,6 +7,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// CollaborationTracingMiddleware adds a new middleware in order to include
+// more attributes in the traced span.
+//
+// In order not to mess with the expected responses, this middleware won't do
+// anything if there is no available WOPI context set in the request (there is
+// nothing to report). This means that the WopiContextAuthMiddleware should be
+// set before this middleware.
 func CollaborationTracingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wopiContext, err := WopiContextFromCtx(r.Context())

--- a/services/collaboration/pkg/middleware/tracing.go
+++ b/services/collaboration/pkg/middleware/tracing.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func CollaborationTracingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wopiContext, err := WopiContextFromCtx(r.Context())
+		if err != nil {
+			// if we can't get the context, skip this middleware
+			next.ServeHTTP(w, r)
+		}
+
+		span := trace.SpanFromContext(r.Context())
+
+		wopiMethod := r.Header.Get("X-WOPI-Override")
+
+		wopiFile := wopiContext.FileReference
+		wopiUser := wopiContext.User.GetId()
+
+		attrs := []attribute.KeyValue{
+			attribute.String("ocis.wopi.method", wopiMethod),
+			attribute.String("ocis.wopi.resource.id.storage", wopiFile.GetResourceId().GetStorageId()),
+			attribute.String("ocis.wopi.resource.id.opaque", wopiFile.GetResourceId().GetOpaqueId()),
+			attribute.String("ocis.wopi.resource.id.space", wopiFile.GetResourceId().GetSpaceId()),
+			attribute.String("ocis.wopi.resource.path", wopiFile.GetPath()),
+			attribute.String("ocis.wopi.user.idp", wopiUser.GetIdp()),
+			attribute.String("ocis.wopi.user.opaque", wopiUser.GetOpaqueId()),
+			attribute.String("ocis.wopi.user.type", wopiUser.GetType().String()),
+		}
+		span.SetAttributes(attrs...)
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/services/collaboration/pkg/middleware/wopicontext.go
+++ b/services/collaboration/pkg/middleware/wopicontext.go
@@ -90,6 +90,7 @@ func WopiContextAuthMiddleware(cfg *config.Config, next http.Handler) http.Handl
 		// although some headers might not be sent depending on the client.
 		logger := zerolog.Ctx(ctx)
 		ctx = logger.With().
+			Str("WopiSessionId", r.Header.Get("X-WOPI-SessionId")).
 			Str("WopiOverride", r.Header.Get("X-WOPI-Override")).
 			Str("WopiProof", r.Header.Get("X-WOPI-Proof")).
 			Str("WopiProofOld", r.Header.Get("X-WOPI-ProofOld")).

--- a/services/collaboration/pkg/server/grpc/server.go
+++ b/services/collaboration/pkg/server/grpc/server.go
@@ -2,15 +2,25 @@ package grpc
 
 import (
 	appproviderv1beta1 "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
+	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	svc "github.com/owncloud/ocis/v2/services/collaboration/pkg/service/grpc/v0"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 )
 
 // Server initializes a new grpc service ready to run
 // THIS SERVICE IS REGISTERED AGAINST REVA, NOT GO-MICRO
 func Server(opts ...Option) (*grpc.Server, func(), error) {
-	grpcOpts := []grpc.ServerOption{}
 	options := newOptions(opts...)
+
+	grpcOpts := []grpc.ServerOption{
+		grpc.StatsHandler(
+			otelgrpc.NewServerHandler(
+				otelgrpc.WithTracerProvider(options.TraceProvider),
+				otelgrpc.WithPropagators(tracing.GetPropagator()),
+			),
+		),
+	}
 	grpcServer := grpc.NewServer(grpcOpts...)
 
 	handle, teardown, err := svc.NewHandler(

--- a/services/proxy/pkg/middleware/tracing.go
+++ b/services/proxy/pkg/middleware/tracing.go
@@ -32,6 +32,8 @@ func (m tracer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		span trace.Span
 	)
 
+	ctx = pkgtrace.Propagator.Extract(ctx, propagation.HeaderCarrier(r.Header))
+
 	tracer := m.traceProvider.Tracer("proxy")
 	spanOpts := []trace.SpanStartOption{
 		trace.WithSpanKind(trace.SpanKindServer),


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Improve tracing of the collaboration service. This includes:
* Content data upload and download through the WOPI server will be traced. Upload and download times are shown now.
* Some file and user metadata included in the collaboration span. This can help to filter traces by user or by file. It might be useful if users come from different idps, or files are stored in multiple places
* Included the request method in the span name.

It might be better if the `X-WOPI-Override` header was part of the span name, but it seems we'd need to replace the otelchi middleware with our custom version. For now, the header is included as span attribute.

![Screenshot from 2024-07-24 18-15-19](https://github.com/user-attachments/assets/bb8b71a6-76a7-44dd-adff-76d26e09b0b1)

![Screenshot from 2024-07-24 18-31-40](https://github.com/user-attachments/assets/4310bc17-420c-451b-98ec-6c909e44ffff)


## Related Issue
no open issue

## Motivation and Context
This should reflect better how much time is spent in other services, specially since the upload and download times weren't being shown before.

## How Has This Been Tested?
Manually checked with a jaeger instance.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Additional things to consider
* Tracing middleware might be merged with the wopiContext one. This could improve the performance because with this PR we need to get the wopiContext several times per requests. However, this could be confusing in the long run because the resulting middleware would do multiple things.
* Including the `X-WOPI-Override` header in the span name might be ideal. However, there is no good way to do it.
  * We can set a new name, but we can't get the current name. In order to set the name we want, we'd need to copy the otelchi code in our tracing code (at least the relevant part in order to get the name), so we'd do the same thing twice adding more overhead to every request.
  * We can replace the otelchi implementation with a custom one. However, the setup is kind of standard in ocis. Using a custom implementation in a specific service might be confusing.
* I don't think there isn't any other useful information that could be added in the span attributes