### PR TITLE
fix unmarshaling

### DIFF
--- a/changelog/unreleased/fix-natsjskv-registry-2.md
+++ b/changelog/unreleased/fix-natsjskv-registry-2.md
@@ -2,4 +2,5 @@ Bugfix: Repair nats-js-kv registry
 
 The registry would always send traffic to only one pod. This is now fixed and load should be spread evenly. Also implements watcher method so the cache can use it.
 
+https://github.com/owncloud/ocis/pull/9726
 https://github.com/owncloud/ocis/pull/9656

--- a/ocis-pkg/natsjsregistry/watcher.go
+++ b/ocis-pkg/natsjsregistry/watcher.go
@@ -47,13 +47,14 @@ func (w *Watcher) Next() (*registry.Result, error) {
 		return nil, errors.New("watcher stopped")
 	}
 
-	var svc *registry.Service
-	if err := json.Unmarshal(kve.Value.Data, svc); err != nil {
+	var svc registry.Service
+	if err := json.Unmarshal(kve.Value.Data, &svc); err != nil {
+		_ = w.stop()
 		return nil, err
 	}
 
 	return &registry.Result{
-		Service: svc,
+		Service: &svc,
 		Action:  kve.Action,
 	}, nil
 }


### PR DESCRIPTION
- fixes a bug introduced with https://github.com/owncloud/ocis/pull/9656
- we must pass a pointer to unmarshal
- on error we must stop the watcher
