### PR TITLE
use less selectors

### DIFF
--- a/changelog/unreleased/use-less-selectors.md
+++ b/changelog/unreleased/use-less-selectors.md
@@ -1,0 +1,5 @@
+Bugfix: use less selectors that watch the registry
+
+The proxy now shares the service selector for all host lookups.
+
+https://github.com/owncloud/ocis/pull/9741

--- a/services/proxy/pkg/proxy/proxy_integration_test.go
+++ b/services/proxy/pkg/proxy/proxy_integration_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/router"
+	"go-micro.dev/v4/selector"
 )
 
 func TestProxyIntegration(t *testing.T) {
@@ -111,12 +113,15 @@ func TestProxyIntegration(t *testing.T) {
 			expectProxyTo("http://users.example.com/user/1234"),
 	}
 
+	reg := registry.GetRegistry()
+	sel := selector.NewSelector(selector.Registry(reg))
+
 	for k := range tests {
 		t.Run(tests[k].id, func(t *testing.T) {
 			t.Parallel()
 			tc := tests[k]
 
-			rt := router.Middleware(nil, tc.conf, log.NewLogger())
+			rt := router.Middleware(sel, nil, tc.conf, log.NewLogger())
 			rp := newTestProxy(testConfig(tc.conf), func(req *http.Request) *http.Response {
 				if got, want := req.URL.String(), tc.expect.String(); got != want {
 					t.Errorf("Proxied url should be %v got %v", want, got)

--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -15,13 +15,11 @@ import (
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	utils "github.com/cs3org/reva/v2/pkg/utils"
 	libregraph "github.com/owncloud/libre-graph-api-go"
-	"go-micro.dev/v4/selector"
-
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
-	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/errorcode"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
+	"go-micro.dev/v4/selector"
 )
 
 type cs3backend struct {
@@ -36,6 +34,7 @@ type Option func(o *Options)
 type Options struct {
 	logger              log.Logger
 	gatewaySelector     pool.Selectable[gateway.GatewayAPIClient]
+	selector            selector.Selector
 	machineAuthAPIKey   string
 	oidcISS             string
 	serviceAccount      config.ServiceAccount
@@ -57,6 +56,13 @@ func WithLogger(l log.Logger) Option {
 func WithRevaGatewaySelector(selectable pool.Selectable[gateway.GatewayAPIClient]) Option {
 	return func(o *Options) {
 		o.gatewaySelector = selectable
+	}
+}
+
+// WithSelector set the Selector option
+func WithSelector(selector selector.Selector) Option {
+	return func(o *Options) {
+		o.selector = selector
 	}
 }
 
@@ -94,12 +100,9 @@ func NewCS3UserBackend(opts ...Option) UserBackend {
 		o(&opt)
 	}
 
-	reg := registry.GetRegistry()
-	sel := selector.NewSelector(selector.Registry(reg))
-
 	b := cs3backend{
 		Options:       opt,
-		graphSelector: sel,
+		graphSelector: opt.selector,
 	}
 
 	return &b


### PR DESCRIPTION
The proxy now shares the service selector for all host lookups.

We were creating a new selector for ever host in the routing policy config. Each one was registering a new nats watcher, wasting memory and traffic.
