### PR TITLE
[tests-only][full-ci] added test for copying files between spaces with secure viewer role using old/new dav-path-versions

### DIFF
--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -268,7 +268,7 @@ Feature: copy file
       | Editor           |
       | Viewer           |
 
-  @issue-9334
+  @issue-9482
   Scenario: user copies a file from share space with secure viewer role to personal space
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created folder "/testshare"
@@ -314,7 +314,7 @@ Feature: copy file
       | Space Editor | Editor           |
       | Space Editor | Viewer           |
 
-
+  @issue-9482
   Scenario Outline: user copies a file from share space with secure viewer role to project space with different role
     Given the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
     And user "Brian" has created a space "Project" with the default quota using the Graph API
@@ -399,7 +399,7 @@ Feature: copy file
       | Editor           |
       | Viewer           |
 
-
+  @issue-9482
   Scenario Outline: user copies a file from share space with different role to share space with role viewer or Secure viewer
     Given user "Brian" has created folder "/testshare1"
     And user "Brian" has created folder "/testshare2"

--- a/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature
@@ -979,3 +979,26 @@ Feature: copy file
       | old              |
       | new              |
       | spaces           |
+
+  @issue-9482
+  Scenario Outline: try to copy a file from shares space with secure viewer role to personal space
+    Given using <dav-path-version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has uploaded file with content "testshare content" to "/testshare/testshare.txt"
+    And user "Brian" has sent the following resource share invitation:
+      | resource        | testshare     |
+      | space           | Personal      |
+      | sharee          | Alice         |
+      | shareType       | user          |
+      | permissionsRole | Secure viewer |
+    And user "Alice" has a share "testshare" synced
+    When user "Alice" copies file "/Shares/testshare/testshare.txt" to "/testshare.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And for user "Alice" the space "Personal" should not contain these entries:
+      | /testshare.txt |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds tests for copying files from shares space to personal space with secure viewer role using both old and new dav-path-versions.

```
Scenario Outline: user copies a file from share space with secure viewer role to personal space
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to : https://github.com/owncloud/ocis/issues/9334

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
