### PR TITLE
[tests-only] [full-ci] Test for resource(file|folder) rename activity

### DIFF
--- a/tests/acceptance/features/apiGraph/activities.feature
+++ b/tests/acceptance/features/apiGraph/activities.feature
@@ -428,10 +428,12 @@ Feature: check activities
       """
 
   @issue-9712
-  Scenario: check move activity for a file
+  Scenario: check move activity for a file and a folder
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has created folder "/New Folder"
     And user "Alice" has moved file "textfile0.txt" to "New Folder/textfile0.txt"
+    And user "Alice" has moved folder "FOLDER" to "New Folder/FOLDER"
     When user "Alice" lists the activities for file "New Folder/textfile0.txt" of space "Personal" using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -491,6 +493,116 @@ Feature: check activities
                                 },
                                 "name": {
                                   "const": "textfile0.txt"
+                                }
+                              }
+                            },
+                            "space": {
+                              "type": "object",
+                              "required": ["id","name"],
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%user_id_pattern%!%user_id_pattern%$"
+                                },
+                                "name": {
+                                  "const": "Alice Hansen"
+                                }
+                              }
+                            },
+                            "user": {
+                              "type": "object",
+                              "required": ["id","displayName"],
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "%user_id_pattern%"
+                                },
+                                "displayName": {
+                                  "const": "Alice"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "times": {
+                      "type": "object",
+                      "required": ["recordedTime"],
+                      "properties": {
+                        "recordedTime": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    When user "Alice" lists the activities for folder "New Folder/FOLDER" of space "Personal" using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "uniqueItems": true,
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "required": ["id","template","times"],
+                  "properties": {
+                    "template": {
+                      "type": "object",
+                      "required": ["message","variables"],
+                      "properties": {
+                        "message": {
+                          "const": "{user} added {resource} to {space}"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["id","template","times"],
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^%user_id_pattern%$"
+                    },
+                    "template": {
+                      "type": "object",
+                      "required": ["message","variables"],
+                      "properties": {
+                        "message": {
+                          "const": "{user} moved {resource} to {space}"
+                        },
+                        "variables": {
+                          "type": "object",
+                          "required": ["resource","space","user"],
+                          "properties": {
+                            "resource": {
+                              "type": "object",
+                              "required": ["id","name"],
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%file_id_pattern%$"
+                                },
+                                "name": {
+                                  "const": "FOLDER"
                                 }
                               }
                             },

--- a/tests/acceptance/features/apiGraph/activities.feature
+++ b/tests/acceptance/features/apiGraph/activities.feature
@@ -445,3 +445,228 @@ Feature: check activities
         }
       }
       """
+
+  @issue-9712
+  Scenario: check rename activity for a file and a folder
+    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has moved file "textfile0.txt" to "renamed.txt"
+    And user "Alice" has moved folder "/FOLDER" to "RENAMED FOLDER"
+    When user "Alice" lists the activities for file "renamed.txt" of space "Personal" using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "uniqueItems": true,
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "required": ["id", "template", "times"],
+                  "properties": {
+                    "template": {
+                      "type": "object",
+                      "required": ["message", "variables"],
+                      "properties": {
+                        "message": {
+                          "const": "{user} added {resource} to {space}"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["id", "template", "times"],
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^%user_id_pattern%$"
+                    },
+                    "template": {
+                      "type": "object",
+                      "required": ["message", "variables"],
+                      "properties": {
+                        "message": {
+                          "const": "{user} renamed {oldResource} to {resource}"
+                        },
+                        "variables": {
+                          "type": "object",
+                          "required": ["oldResource", "resource", "user"],
+                          "properties": {
+                            "oldResource": {
+                              "type": "object",
+                              "required": ["id", "name"],
+                              "properties": {
+                                "id": {
+                                  "const": ""
+                                },
+                                "name": {
+                                  "const": "textfile0.txt"
+                                }
+                              }
+                            },
+                            "resource": {
+                              "type": "object",
+                              "required": ["id", "name"],
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%file_id_pattern%$"
+                                },
+                                "name": {
+                                  "const": "renamed.txt"
+                                }
+                              }
+                            },
+                            "user": {
+                              "type": "object",
+                              "required": ["id", "displayName"],
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%user_id_pattern%$"
+                                },
+                                "displayName": {
+                                  "const": "Alice"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "times": {
+                      "type": "object",
+                      "required": ["recordedTime"],
+                      "properties": {
+                        "recordedTime": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    When user "Alice" lists the activities for folder "RENAMED FOLDER" of space "Personal" using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "uniqueItems": true,
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "required": ["id", "template", "times"],
+                  "properties": {
+                    "template": {
+                      "type": "object",
+                      "required": ["message", "variables"],
+                      "properties": {
+                        "message": {
+                          "const": "{user} added {resource} to {space}"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["id", "template", "times"],
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^%user_id_pattern%$"
+                    },
+                    "template": {
+                      "type": "object",
+                      "required": ["message", "variables"],
+                      "properties": {
+                        "message": {
+                          "const": "{user} renamed {oldResource} to {resource}"
+                        },
+                        "variables": {
+                          "type": "object",
+                          "required": ["oldResource", "resource", "user"],
+                          "properties": {
+                            "oldResource": {
+                              "type": "object",
+                              "required": ["id", "name"],
+                              "properties": {
+                                "id": {
+                                  "const": ""
+                                },
+                                "name": {
+                                  "const": "FOLDER"
+                                }
+                              }
+                            },
+                            "resource": {
+                              "type": "object",
+                              "required": ["id", "name"],
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%file_id_pattern%$"
+                                },
+                                "name": {
+                                  "const": "RENAMED FOLDER"
+                                }
+                              }
+                            },
+                            "user": {
+                              "type": "object",
+                              "required": ["id", "displayName"],
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%user_id_pattern%$"
+                                },
+                                "displayName": {
+                                  "const": "Alice"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "times": {
+                      "type": "object",
+                      "required": ["recordedTime"],
+                      "properties": {
+                        "recordedTime": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """

--- a/tests/acceptance/features/apiGraph/activities.feature
+++ b/tests/acceptance/features/apiGraph/activities.feature
@@ -101,9 +101,11 @@ Feature: check activities
       """
 
   @issue-9712
-  Scenario: check activities after deleting a file
+  Scenario: check activities after deleting a file and a folder
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "FOLDER"
     When user "Alice" lists the activities of space "Personal" using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -114,8 +116,8 @@ Feature: check activities
         "properties": {
           "value": {
             "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
+            "minItems": 4,
+            "maxItems": 4,
             "uniqueItems": true,
             "items": {
               "oneOf": [
@@ -129,6 +131,51 @@ Feature: check activities
                       "properties": {
                         "message": {
                           "const": "{user} added {resource} to {space}"
+                        },
+                        "variables": {
+                          "type": "object",
+                          "required": ["resource", "space", "user"],
+                          "properties": {
+                            "resource": {
+                              "type": "object",
+                              "required": ["id", "name"],
+                              "properties": {
+                                "name": {
+                                  "const": "textfile0.txt"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["id","template","times"],
+                  "properties": {
+                    "template": {
+                      "type": "object",
+                      "required": ["message","variables"],
+                      "properties": {
+                        "message": {
+                          "const": "{user} added {resource} to {space}"
+                        },
+                        "variables": {
+                          "type": "object",
+                          "required": ["resource", "space", "user"],
+                          "properties": {
+                            "resource": {
+                              "type": "object",
+                              "required": ["id", "name"],
+                              "properties": {
+                                "name": {
+                                  "const": "FOLDER"
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -203,47 +250,6 @@ Feature: check activities
                         "recordedTime": {
                           "type": "string",
                           "format": "date-time"
-                        }
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      }
-      """
-
-  @issue-9712
-  Scenario: check activities after deleting a folder
-    Given user "Alice" has created folder "/FOLDER"
-    And user "Alice" has deleted folder "FOLDER"
-    When user "Alice" lists the activities of space "Personal" using the Graph API
-    Then the HTTP status code should be "200"
-    And the JSON data of the response should match
-      """
-      {
-        "type": "object",
-        "required": ["value"],
-        "properties": {
-          "value": {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "uniqueItems": true,
-            "items": {
-              "oneOf": [
-                {
-                  "type": "object",
-                  "required": ["id","template","times"],
-                  "properties": {
-                    "template": {
-                      "type": "object",
-                      "required": ["message","variables"],
-                      "properties": {
-                        "message": {
-                          "const": "{user} added {resource} to {space}"
                         }
                       }
                     }

--- a/tests/acceptance/features/apiGraph/activities.feature
+++ b/tests/acceptance/features/apiGraph/activities.feature
@@ -7,8 +7,9 @@ Feature: check activities
     Given user "Alice" has been created with default attributes and without skeleton files
 
   @issue-9712
-  Scenario: check activities after uploading a file
+  Scenario: check activities after uploading a file and a folder
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" lists the activities for file "textfile0.txt" of space "Personal" using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -50,6 +51,96 @@ Feature: check activities
                             },
                             "name": {
                               "const": "textfile0.txt"
+                            }
+                          }
+                        },
+                        "space": {
+                          "type": "object",
+                          "required": ["id","name"],
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "pattern": "^%user_id_pattern%!%user_id_pattern%$"
+                            },
+                            "name": {
+                              "const": "Alice Hansen"
+                            }
+                          }
+                        },
+                        "user": {
+                          "type": "object",
+                          "required": ["id","displayName"],
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "pattern": "%user_id_pattern%"
+                            },
+                            "displayName": {
+                              "const": "Alice"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "times": {
+                  "type": "object",
+                  "required": ["recordedTime"],
+                  "properties": {
+                    "recordedTime": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    When user "Alice" lists the activities for folder "FOLDER" of space "Personal" using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id","template","times"],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "pattern": "^%user_id_pattern%$"
+                },
+                "template": {
+                  "type": "object",
+                  "required": ["message","variables"],
+                  "properties": {
+                    "message": {
+                      "const": "{user} added {resource} to {space}"
+                    },
+                    "variables": {
+                      "type": "object",
+                      "required": ["resource","space","user"],
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "required": ["id","name"],
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "pattern": "%file_id_pattern%"
+                            },
+                            "name": {
+                              "const": "FOLDER"
                             }
                           }
                         },


### PR DESCRIPTION
## Description
Adds test to check activity for file rename event.

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/9543
-  https://github.com/owncloud/ocis/issues/9744

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- CI
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
