### PR TITLE
allow querying federated sharing roles

### DIFF
--- a/changelog/unreleased/federated-user-roles.md
+++ b/changelog/unreleased/federated-user-roles.md
@@ -1,0 +1,5 @@
+Enhancement: allow querying federated user roles for sharing
+
+When listing permissions clients can now fetch the list of available federated sharing roles by sending a `GET /graph/v1beta1/drives/{driveid}/items/{itemid}/permissions?$filter=@libre.graph.permissions.roles.allowedValues/rolePermissions/any(p:contains(p/condition, '@Subject.UserType=="Federated"'))` request. Note that this is the only supported filter expression. Federated sharing roles will be omitted from requests without this filter.
+
+https://github.com/owncloud/ocis/pull/9765

--- a/services/graph/mocks/drive_item_permissions_provider.go
+++ b/services/graph/mocks/drive_item_permissions_provider.go
@@ -294,9 +294,9 @@ func (_c *DriveItemPermissionsProvider_Invite_Call) RunAndReturn(run func(contex
 	return _c
 }
 
-// ListPermissions provides a mock function with given fields: ctx, itemID
-func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, itemID *providerv1beta1.ResourceId) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
-	ret := _m.Called(ctx, itemID)
+// ListPermissions provides a mock function with given fields: ctx, itemID, listFederatedRoles, selectRoles
+func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+	ret := _m.Called(ctx, itemID, listFederatedRoles, selectRoles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPermissions")
@@ -304,17 +304,17 @@ func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, ite
 
 	var r0 libregraph.CollectionOfPermissionsWithAllowedValues
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
-		return rf(ctx, itemID)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
+		return rf(ctx, itemID, listFederatedRoles, selectRoles)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
-		r0 = rf(ctx, itemID)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
+		r0 = rf(ctx, itemID, listFederatedRoles, selectRoles)
 	} else {
 		r0 = ret.Get(0).(libregraph.CollectionOfPermissionsWithAllowedValues)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId) error); ok {
-		r1 = rf(ctx, itemID)
+	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) error); ok {
+		r1 = rf(ctx, itemID, listFederatedRoles, selectRoles)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -330,13 +330,15 @@ type DriveItemPermissionsProvider_ListPermissions_Call struct {
 // ListPermissions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - itemID *providerv1beta1.ResourceId
-func (_e *DriveItemPermissionsProvider_Expecter) ListPermissions(ctx interface{}, itemID interface{}) *DriveItemPermissionsProvider_ListPermissions_Call {
-	return &DriveItemPermissionsProvider_ListPermissions_Call{Call: _e.mock.On("ListPermissions", ctx, itemID)}
+//   - listFederatedRoles bool
+//   - selectRoles bool
+func (_e *DriveItemPermissionsProvider_Expecter) ListPermissions(ctx interface{}, itemID interface{}, listFederatedRoles interface{}, selectRoles interface{}) *DriveItemPermissionsProvider_ListPermissions_Call {
+	return &DriveItemPermissionsProvider_ListPermissions_Call{Call: _e.mock.On("ListPermissions", ctx, itemID, listFederatedRoles, selectRoles)}
 }
 
-func (_c *DriveItemPermissionsProvider_ListPermissions_Call) Run(run func(ctx context.Context, itemID *providerv1beta1.ResourceId)) *DriveItemPermissionsProvider_ListPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListPermissions_Call) Run(run func(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectRoles bool)) *DriveItemPermissionsProvider_ListPermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId))
+		run(args[0].(context.Context), args[1].(*providerv1beta1.ResourceId), args[2].(bool), args[3].(bool))
 	})
 	return _c
 }
@@ -346,7 +348,7 @@ func (_c *DriveItemPermissionsProvider_ListPermissions_Call) Return(_a0 libregra
 	return _c
 }
 
-func (_c *DriveItemPermissionsProvider_ListPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListPermissions_Call {
+func (_c *DriveItemPermissionsProvider_ListPermissions_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ResourceId, bool, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)) *DriveItemPermissionsProvider_ListPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/services/graph/pkg/service/v0/sharedwithme_test.go
+++ b/services/graph/pkg/service/v0/sharedwithme_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/tidwall/gjson"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
@@ -182,16 +183,16 @@ var _ = Describe("SharedWithMe", func() {
 			}
 
 			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(func(_ context.Context, r *providerv1beta1.StatRequest, _ ...grpc.CallOption) (*providerv1beta1.StatResponse, error) {
+				// copy the response to	avoid side effects
+				res := proto.Clone(statResponse).(*providerv1beta1.StatResponse)
 				for _, share := range listReceivedSharesResponse.Shares {
 					if share.Share.ResourceId != r.Ref.ResourceId {
 						continue
 					}
 
-					if statResponse.Info.Id == nil {
-						statResponse.Info.Id = share.Share.ResourceId
-					}
+					res.Info.Id = share.Share.ResourceId
 
-					return statResponse, nil
+					return res, nil
 				}
 
 				return nil, nil

--- a/services/graph/pkg/service/v0/utils.go
+++ b/services/graph/pkg/service/v0/utils.go
@@ -72,6 +72,16 @@ func GetDriveAndItemIDParam(r *http.Request, logger *log.Logger) (storageprovide
 	return driveID, itemID, nil
 }
 
+// GetFilterParam returns the $filter query parameter from the request. If you need to parse the filter use godata.ParseRequest
+func GetFilterParam(r *http.Request) string {
+	return r.URL.Query().Get("$filter")
+}
+
+// GetSelectParam returns the $select query parameter from the request. If you need to parse the select filter use godata.ParseRequest
+func GetSelectParam(r *http.Request) string {
+	return r.URL.Query().Get("$select")
+}
+
 // GetGatewayClient returns a gateway client from the gatewaySelector.
 func (g Graph) GetGatewayClient(w http.ResponseWriter, r *http.Request) (gateway.GatewayAPIClient, bool) {
 	gatewayClient, err := g.gatewaySelector.Next()

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -37,7 +37,7 @@ const (
 	UnifiedRoleFederatedEditorID = "36279a93-e4e3-4bbb-8a23-53b05b560963"
 
 	// Wile the below conditions follow the SDDL syntax, they are not parsed anywhere. We use them as strings to
-	// represent the constraints that a role definition applies to. Fer the actual syntax, see the SDDL documentation
+	// represent the constraints that a role definition applies to. For the actual syntax, see the SDDL documentation
 	// at https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-definition-language-for-conditional-aces-#conditional-expressions
 
 	// Some roles apply to a specific type of resource, for example, a role that applies to a file or a folder.

--- a/services/graph/pkg/unifiedrole/unifiedrole.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole.go
@@ -156,6 +156,14 @@ func NewViewerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 				AllowedResourceActions: convert(r),
 				Condition:              proto.String(UnifiedRoleConditionFolder),
 			},
+			{
+				AllowedResourceActions: convert(r),
+				Condition:              proto.String(UnifiedRoleConditionFileFederatedUser),
+			},
+			{
+				AllowedResourceActions: convert(r),
+				Condition:              proto.String(UnifiedRoleConditionFolderFederatedUser),
+			},
 		},
 		LibreGraphWeight: proto.Int32(0),
 	}
@@ -190,6 +198,10 @@ func NewEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 				AllowedResourceActions: convert(r),
 				Condition:              proto.String(UnifiedRoleConditionFolder),
 			},
+			{
+				AllowedResourceActions: convert(r),
+				Condition:              proto.String(UnifiedRoleConditionFolderFederatedUser),
+			},
 		},
 		LibreGraphWeight: proto.Int32(0),
 	}
@@ -223,6 +235,10 @@ func NewFileEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 			{
 				AllowedResourceActions: convert(r),
 				Condition:              proto.String(UnifiedRoleConditionFile),
+			},
+			{
+				AllowedResourceActions: convert(r),
+				Condition:              proto.String(UnifiedRoleConditionFileFederatedUser),
 			},
 		},
 		LibreGraphWeight: proto.Int32(0),
@@ -284,48 +300,6 @@ func NewSecureViewerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	}
 }
 
-// NewFederatedViewerUnifiedRole creates a federated viewer role
-func NewFederatedViewerUnifiedRole() *libregraph.UnifiedRoleDefinition {
-	r := conversions.NewViewerRole()
-	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleFederatedViewerID),
-		Description: proto.String("View and download."),
-		DisplayName: displayName(r),
-		RolePermissions: []libregraph.UnifiedRolePermission{
-			{
-				AllowedResourceActions: convert(r),
-				Condition:              proto.String(UnifiedRoleConditionFileFederatedUser),
-			},
-			{
-				AllowedResourceActions: convert(r),
-				Condition:              proto.String(UnifiedRoleConditionFolderFederatedUser),
-			},
-		},
-		LibreGraphWeight: proto.Int32(0),
-	}
-}
-
-// NewFederatedEditorUnifiedRole creates a federated editor role
-func NewFederatedEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
-	r := conversions.NewEditorRole()
-	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleFederatedEditorID),
-		Description: proto.String("View, download and edit."),
-		DisplayName: displayName(r),
-		RolePermissions: []libregraph.UnifiedRolePermission{
-			{
-				AllowedResourceActions: convert(r),
-				Condition:              proto.String(UnifiedRoleConditionFileFederatedUser),
-			},
-			{
-				AllowedResourceActions: convert(r),
-				Condition:              proto.String(UnifiedRoleConditionFolderFederatedUser),
-			},
-		},
-		LibreGraphWeight: proto.Int32(0),
-	}
-}
-
 // NewUnifiedRoleFromID returns a unified role definition from the provided id
 func NewUnifiedRoleFromID(id string) (*libregraph.UnifiedRoleDefinition, error) {
 	for _, definition := range GetBuiltinRoleDefinitionList() {
@@ -349,8 +323,6 @@ func GetBuiltinRoleDefinitionList() []*libregraph.UnifiedRoleDefinition {
 		NewEditorLiteUnifiedRole(),
 		NewManagerUnifiedRole(),
 		NewSecureViewerUnifiedRole(),
-		NewFederatedViewerUnifiedRole(),
-		NewFederatedEditorUnifiedRole(),
 	}
 }
 

--- a/services/graph/pkg/unifiedrole/unifiedrole_test.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole_test.go
@@ -155,22 +155,34 @@ var _ = Describe("unifiedroles", func() {
 			),
 
 			Entry(
-				"FederatedViewerUnifiedRole | share",
-				rolesToAction(unifiedrole.NewFederatedViewerUnifiedRole()),
+				"ViewerUnifiedRole | share",
+				rolesToAction(unifiedrole.NewViewerUnifiedRole()),
 				unifiedrole.UnifiedRoleConditionFile,
 				true,
 				[]*libregraph.UnifiedRoleDefinition{
-					unifiedrole.NewFederatedViewerUnifiedRole(),
+					unifiedrole.NewViewerUnifiedRole(),
 				},
 			),
+
 			Entry(
-				"FederatedEditorUnifiedRole | share",
-				rolesToAction(unifiedrole.NewFederatedEditorUnifiedRole()),
+				"EditorUnifiedRole | share folder",
+				rolesToAction(unifiedrole.NewEditorUnifiedRole()),
+				unifiedrole.UnifiedRoleConditionFolder,
+				true,
+				[]*libregraph.UnifiedRoleDefinition{
+					unifiedrole.NewViewerUnifiedRole(),
+					unifiedrole.NewEditorUnifiedRole(),
+				},
+			),
+
+			Entry(
+				"EditorUnifiedRole | share file",
+				rolesToAction(unifiedrole.NewEditorUnifiedRole()),
 				unifiedrole.UnifiedRoleConditionFile,
 				true,
 				[]*libregraph.UnifiedRoleDefinition{
-					unifiedrole.NewFederatedViewerUnifiedRole(),
-					unifiedrole.NewFederatedEditorUnifiedRole(),
+					unifiedrole.NewViewerUnifiedRole(),
+					unifiedrole.NewFileEditorUnifiedRole(),
 				},
 			),
 

--- a/services/graph/pkg/unifiedrole/unifiedrole_test.go
+++ b/services/graph/pkg/unifiedrole/unifiedrole_test.go
@@ -1,7 +1,6 @@
 package unifiedrole_test
 
 import (
-	"fmt"
 	"slices"
 
 	rConversions "github.com/cs3org/reva/v2/pkg/conversions"
@@ -114,9 +113,9 @@ var _ = Describe("unifiedroles", func() {
 		}
 
 		DescribeTable("GetApplicableRoleDefinitionsForActions",
-			func(givenActions []string, constraints string, expectedDefinitions []*libregraph.UnifiedRoleDefinition) {
+			func(givenActions []string, constraints string, listFederatedRoles bool, expectedDefinitions []*libregraph.UnifiedRoleDefinition) {
 
-				generatedDefinitions := unifiedrole.GetApplicableRoleDefinitionsForActions(givenActions, constraints, false)
+				generatedDefinitions := unifiedrole.GetApplicableRoleDefinitionsForActions(givenActions, constraints, listFederatedRoles, false)
 
 				Expect(len(generatedDefinitions)).To(Equal(len(expectedDefinitions)))
 
@@ -137,6 +136,7 @@ var _ = Describe("unifiedroles", func() {
 				"ViewerUnifiedRole",
 				rolesToAction(unifiedrole.NewViewerUnifiedRole()),
 				unifiedrole.UnifiedRoleConditionFolder,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSecureViewerUnifiedRole(),
 					unifiedrole.NewViewerUnifiedRole(),
@@ -147,6 +147,7 @@ var _ = Describe("unifiedroles", func() {
 				"ViewerUnifiedRole | share",
 				rolesToAction(unifiedrole.NewViewerUnifiedRole()),
 				unifiedrole.UnifiedRoleConditionFile,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSecureViewerUnifiedRole(),
 					unifiedrole.NewViewerUnifiedRole(),
@@ -154,9 +155,30 @@ var _ = Describe("unifiedroles", func() {
 			),
 
 			Entry(
+				"FederatedViewerUnifiedRole | share",
+				rolesToAction(unifiedrole.NewFederatedViewerUnifiedRole()),
+				unifiedrole.UnifiedRoleConditionFile,
+				true,
+				[]*libregraph.UnifiedRoleDefinition{
+					unifiedrole.NewFederatedViewerUnifiedRole(),
+				},
+			),
+			Entry(
+				"FederatedEditorUnifiedRole | share",
+				rolesToAction(unifiedrole.NewFederatedEditorUnifiedRole()),
+				unifiedrole.UnifiedRoleConditionFile,
+				true,
+				[]*libregraph.UnifiedRoleDefinition{
+					unifiedrole.NewFederatedViewerUnifiedRole(),
+					unifiedrole.NewFederatedEditorUnifiedRole(),
+				},
+			),
+
+			Entry(
 				"NewFileEditorUnifiedRole",
 				rolesToAction(unifiedrole.NewFileEditorUnifiedRole()),
 				unifiedrole.UnifiedRoleConditionFile,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSecureViewerUnifiedRole(),
 					unifiedrole.NewViewerUnifiedRole(),
@@ -168,6 +190,7 @@ var _ = Describe("unifiedroles", func() {
 				"NewEditorUnifiedRole",
 				rolesToAction(unifiedrole.NewEditorUnifiedRole()),
 				unifiedrole.UnifiedRoleConditionFolder,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSecureViewerUnifiedRole(),
 					unifiedrole.NewViewerUnifiedRole(),
@@ -180,6 +203,7 @@ var _ = Describe("unifiedroles", func() {
 				"GetBuiltinRoleDefinitionList",
 				rolesToAction(unifiedrole.GetBuiltinRoleDefinitionList()...),
 				unifiedrole.UnifiedRoleConditionFile,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSecureViewerUnifiedRole(),
 					unifiedrole.NewViewerUnifiedRole(),
@@ -191,6 +215,7 @@ var _ = Describe("unifiedroles", func() {
 				"GetBuiltinRoleDefinitionList",
 				rolesToAction(unifiedrole.GetBuiltinRoleDefinitionList()...),
 				unifiedrole.UnifiedRoleConditionFolder,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSecureViewerUnifiedRole(),
 					unifiedrole.NewViewerUnifiedRole(),
@@ -203,6 +228,7 @@ var _ = Describe("unifiedroles", func() {
 				"GetBuiltinRoleDefinitionList",
 				rolesToAction(unifiedrole.GetBuiltinRoleDefinitionList()...),
 				unifiedrole.UnifiedRoleConditionDrive,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSpaceViewerUnifiedRole(),
 					unifiedrole.NewSpaceEditorUnifiedRole(),
@@ -214,6 +240,7 @@ var _ = Describe("unifiedroles", func() {
 				"single",
 				[]string{unifiedrole.DriveItemQuotaRead},
 				unifiedrole.UnifiedRoleConditionFile,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{},
 			),
 
@@ -221,6 +248,7 @@ var _ = Describe("unifiedroles", func() {
 				"mixed",
 				append(rolesToAction(unifiedrole.NewEditorLiteUnifiedRole()), unifiedrole.DriveItemQuotaRead),
 				unifiedrole.UnifiedRoleConditionFolder,
+				false,
 				[]*libregraph.UnifiedRoleDefinition{
 					unifiedrole.NewSecureViewerUnifiedRole(),
 					unifiedrole.NewEditorLiteUnifiedRole(),
@@ -233,7 +261,7 @@ var _ = Describe("unifiedroles", func() {
 		var newUnifiedRoleFromIDEntries []TableEntry
 		attachEntry := func(name, id string, definition *libregraph.UnifiedRoleDefinition, errors bool) {
 			e := Entry(
-				fmt.Sprintf("%s", name),
+				name,
 				id,
 				definition,
 				errors,

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -146,6 +146,12 @@ func OwnCloudSQL(cfg *config.Config) map[string]interface{} {
 		"dbport":          cfg.Drivers.OwnCloudSQL.DBPort,
 		"dbname":          cfg.Drivers.OwnCloudSQL.DBName,
 		"userprovidersvc": cfg.Drivers.OwnCloudSQL.UsersProviderEndpoint,
+		"tokens": map[string]interface{}{
+			"download_endpoint":      cfg.DataServerURL,
+			"datagateway_endpoint":   cfg.DataGatewayURL,
+			"transfer_shared_secret": cfg.Commons.TransferSecret,
+			"transfer_expires":       cfg.TransferExpires,
+		},
 	}
 }
 

--- a/services/web/pkg/theme/theme.go
+++ b/services/web/pkg/theme/theme.go
@@ -49,6 +49,14 @@ var themeDefaults = KV{
 				"label":    "UnifiedRoleSecureView",
 				"iconName": "shield",
 			},
+			unifiedrole.UnifiedRoleFederatedViewerID: KV{
+				"label":    "UnifiedRoleFederatedViewer",
+				"iconName": "eye",
+			},
+			unifiedrole.UnifiedRoleFederatedEditorID: KV{
+				"label":    "UnifiedRoleFederatedEditor",
+				"iconName": "pencil",
+			},
 		},
 	},
 }

--- a/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
+++ b/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
@@ -14,8 +14,8 @@ Feature: permissions role definitions
       """
       {
         "type": "array",
-        "maxItems": 8,
-        "minItems": 8,
+        "maxItems": 10,
+        "minItems": 10,
         "uniqueItems": true,
         "items": {
           "oneOf": [
@@ -503,6 +503,172 @@ Feature: permissions role definitions
                           },
                           "condition": {
                             "const": "exists @Resource.Folder"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "@libre.graph.weight",
+                "description",
+                "displayName",
+                "id",
+                "rolePermissions"
+              ],
+              "properties": {
+                "@libre.graph.weight": {
+                  "const": 0
+                },
+                "description": {
+                  "const": "View and download."
+                },
+                "displayName": {
+                  "const": "Can view"
+                },
+                "id": {
+                  "const": "be531789-063c-48bf-a9fe-857e6fbee7da"
+                },
+                "rolePermissions": {
+                  "type": "array",
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "uniqueItems": true,
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.File \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.Folder \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "@libre.graph.weight",
+                "description",
+                "displayName",
+                "id",
+                "rolePermissions"
+              ],
+              "properties": {
+                "@libre.graph.weight": {
+                  "const": 0
+                },
+                "description": {
+                  "const": "View, download and edit."
+                },
+                "displayName": {
+                  "const": "Can edit"
+                },
+                "id": {
+                  "const": "36279a93-e4e3-4bbb-8a23-53b05b560963"
+                },
+                "rolePermissions": {
+                  "type": "array",
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "uniqueItems": true,
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/children/create",
+                              "libre.graph/driveItem/standard/delete",
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/path/update",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.File \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/children/create",
+                              "libre.graph/driveItem/standard/delete",
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/path/update",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.Folder \u0026\u0026 @Subject.UserType==\"Federated\""
                           }
                         }
                       }

--- a/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
+++ b/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
@@ -14,8 +14,8 @@ Feature: permissions role definitions
       """
       {
         "type": "array",
-        "maxItems": 10,
-        "minItems": 10,
+        "maxItems": 8,
+        "minItems": 8,
         "uniqueItems": true,
         "items": {
           "oneOf": [
@@ -43,8 +43,8 @@ Feature: permissions role definitions
                 },
                 "rolePermissions": {
                   "type": "array",
-                  "maxItems": 2,
-                  "minItems": 2,
+                  "maxItems": 4,
+                  "minItems": 4,
                   "uniqueItems": true,
                   "items": {
                     "oneOf": [
@@ -89,6 +89,50 @@ Feature: permissions role definitions
                           },
                           "condition": {
                             "const": "exists @Resource.Folder"
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.File \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.Folder \u0026\u0026 @Subject.UserType==\"Federated\""
                           }
                         }
                       }
@@ -174,35 +218,66 @@ Feature: permissions role definitions
                 },
                 "rolePermissions": {
                   "type": "array",
-                  "maxItems": 1,
-                  "minItems": 1,
+                  "maxItems": 2,
+                  "minItems": 2,
                   "uniqueItems": true,
                   "items": {
-                    "type": "object",
-                    "required": [
-                      "allowedResourceActions",
-                      "condition"
-                    ],
-                    "properties": {
-                      "allowedResourceActions": {
-                        "const": [
-                          "libre.graph/driveItem/children/create",
-                          "libre.graph/driveItem/standard/delete",
-                          "libre.graph/driveItem/path/read",
-                          "libre.graph/driveItem/quota/read",
-                          "libre.graph/driveItem/content/read",
-                          "libre.graph/driveItem/upload/create",
-                          "libre.graph/driveItem/children/read",
-                          "libre.graph/driveItem/deleted/read",
-                          "libre.graph/driveItem/path/update",
-                          "libre.graph/driveItem/deleted/update",
-                          "libre.graph/driveItem/basic/read"
-                        ]
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/children/create",
+                              "libre.graph/driveItem/standard/delete",
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/path/update",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.Folder"
+                          }
+                        }
                       },
-                      "condition": {
-                        "const": "exists @Resource.Folder"
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/children/create",
+                              "libre.graph/driveItem/standard/delete",
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/path/update",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.Folder \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
                       }
-                    }
+                    ]
                   }
                 }
               }
@@ -291,32 +366,60 @@ Feature: permissions role definitions
                 },
                 "rolePermissions": {
                   "type": "array",
-                  "maxItems": 1,
-                  "minItems": 1,
+                  "maxItems": 2,
+                  "minItems": 2,
                   "uniqueItems": true,
                   "items": {
-                    "type": "object",
-                    "required": [
-                      "allowedResourceActions",
-                      "condition"
-                    ],
-                    "properties": {
-                      "allowedResourceActions": {
-                        "const": [
-                          "libre.graph/driveItem/path/read",
-                          "libre.graph/driveItem/quota/read",
-                          "libre.graph/driveItem/content/read",
-                          "libre.graph/driveItem/upload/create",
-                          "libre.graph/driveItem/children/read",
-                          "libre.graph/driveItem/deleted/read",
-                          "libre.graph/driveItem/deleted/update",
-                          "libre.graph/driveItem/basic/read"
-                        ]
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const":"exists @Resource.File"
+                          }
+                        }
                       },
-                      "condition": {
-                        "const":"exists @Resource.File"
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const":"exists @Resource.File \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
                       }
-                    }
+                    ]
                   }
                 }
               }
@@ -510,172 +613,6 @@ Feature: permissions role definitions
                   }
                 }
               }
-            },
-            {
-              "type": "object",
-              "required": [
-                "@libre.graph.weight",
-                "description",
-                "displayName",
-                "id",
-                "rolePermissions"
-              ],
-              "properties": {
-                "@libre.graph.weight": {
-                  "const": 0
-                },
-                "description": {
-                  "const": "View and download."
-                },
-                "displayName": {
-                  "const": "Can view"
-                },
-                "id": {
-                  "const": "be531789-063c-48bf-a9fe-857e6fbee7da"
-                },
-                "rolePermissions": {
-                  "type": "array",
-                  "maxItems": 2,
-                  "minItems": 2,
-                  "uniqueItems": true,
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "allowedResourceActions",
-                          "condition"
-                        ],
-                        "properties": {
-                          "allowedResourceActions": {
-                            "const": [
-                              "libre.graph/driveItem/path/read",
-                              "libre.graph/driveItem/quota/read",
-                              "libre.graph/driveItem/content/read",
-                              "libre.graph/driveItem/children/read",
-                              "libre.graph/driveItem/deleted/read",
-                              "libre.graph/driveItem/basic/read"
-                            ]
-                          },
-                          "condition": {
-                            "const": "exists @Resource.File \u0026\u0026 @Subject.UserType==\"Federated\""
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "allowedResourceActions",
-                          "condition"
-                        ],
-                        "properties": {
-                          "allowedResourceActions": {
-                            "const": [
-                              "libre.graph/driveItem/path/read",
-                              "libre.graph/driveItem/quota/read",
-                              "libre.graph/driveItem/content/read",
-                              "libre.graph/driveItem/children/read",
-                              "libre.graph/driveItem/deleted/read",
-                              "libre.graph/driveItem/basic/read"
-                            ]
-                          },
-                          "condition": {
-                            "const": "exists @Resource.Folder \u0026\u0026 @Subject.UserType==\"Federated\""
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            {
-              "type": "object",
-              "required": [
-                "@libre.graph.weight",
-                "description",
-                "displayName",
-                "id",
-                "rolePermissions"
-              ],
-              "properties": {
-                "@libre.graph.weight": {
-                  "const": 0
-                },
-                "description": {
-                  "const": "View, download and edit."
-                },
-                "displayName": {
-                  "const": "Can edit"
-                },
-                "id": {
-                  "const": "36279a93-e4e3-4bbb-8a23-53b05b560963"
-                },
-                "rolePermissions": {
-                  "type": "array",
-                  "maxItems": 2,
-                  "minItems": 2,
-                  "uniqueItems": true,
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "allowedResourceActions",
-                          "condition"
-                        ],
-                        "properties": {
-                          "allowedResourceActions": {
-                            "const": [
-                              "libre.graph/driveItem/children/create",
-                              "libre.graph/driveItem/standard/delete",
-                              "libre.graph/driveItem/path/read",
-                              "libre.graph/driveItem/quota/read",
-                              "libre.graph/driveItem/content/read",
-                              "libre.graph/driveItem/upload/create",
-                              "libre.graph/driveItem/children/read",
-                              "libre.graph/driveItem/deleted/read",
-                              "libre.graph/driveItem/path/update",
-                              "libre.graph/driveItem/deleted/update",
-                              "libre.graph/driveItem/basic/read"
-                            ]
-                          },
-                          "condition": {
-                            "const": "exists @Resource.File \u0026\u0026 @Subject.UserType==\"Federated\""
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "allowedResourceActions",
-                          "condition"
-                        ],
-                        "properties": {
-                          "allowedResourceActions": {
-                            "const": [
-                              "libre.graph/driveItem/children/create",
-                              "libre.graph/driveItem/standard/delete",
-                              "libre.graph/driveItem/path/read",
-                              "libre.graph/driveItem/quota/read",
-                              "libre.graph/driveItem/content/read",
-                              "libre.graph/driveItem/upload/create",
-                              "libre.graph/driveItem/children/read",
-                              "libre.graph/driveItem/deleted/read",
-                              "libre.graph/driveItem/path/update",
-                              "libre.graph/driveItem/deleted/update",
-                              "libre.graph/driveItem/basic/read"
-                            ]
-                          },
-                          "condition": {
-                            "const": "exists @Resource.Folder \u0026\u0026 @Subject.UserType==\"Federated\""
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
             }
           ]
         }
@@ -710,60 +647,104 @@ Feature: permissions role definitions
             "id": {
               "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"
             },
-            "rolePermissions": {
-              "type": "array",
-              "maxItems": 2,
-              "minItems": 2,
-              "uniqueItems": true,
-              "items": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "required": [
-                      "allowedResourceActions",
-                      "condition"
-                    ],
-                    "properties": {
-                      "allowedResourceActions": {
-                        "const": [
-                          "libre.graph/driveItem/path/read",
-                          "libre.graph/driveItem/quota/read",
-                          "libre.graph/driveItem/content/read",
-                          "libre.graph/driveItem/children/read",
-                          "libre.graph/driveItem/deleted/read",
-                          "libre.graph/driveItem/basic/read"
-                        ]
+                "rolePermissions": {
+                  "type": "array",
+                  "maxItems": 4,
+                  "minItems": 4,
+                  "uniqueItems": true,
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.File"
+                          }
+                        }
                       },
-                      "condition": {
-                        "const": "exists @Resource.File"
-                      }
-                    }
-                  },
-                  {
-                    "type": "object",
-                    "required": [
-                      "allowedResourceActions",
-                      "condition"
-                    ],
-                    "properties": {
-                      "allowedResourceActions": {
-                        "const": [
-                          "libre.graph/driveItem/path/read",
-                          "libre.graph/driveItem/quota/read",
-                          "libre.graph/driveItem/content/read",
-                          "libre.graph/driveItem/children/read",
-                          "libre.graph/driveItem/deleted/read",
-                          "libre.graph/driveItem/basic/read"
-                        ]
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.Folder"
+                          }
+                        }
                       },
-                      "condition": {
-                        "const": "exists @Resource.Folder"
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.File \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "allowedResourceActions",
+                          "condition"
+                        ],
+                        "properties": {
+                          "allowedResourceActions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "condition": {
+                            "const": "exists @Resource.Folder \u0026\u0026 @Subject.UserType==\"Federated\""
+                          }
+                        }
                       }
-                    }
+                    ]
                   }
-                ]
-              }
-            }
+                }
           }
       }
       """


### PR DESCRIPTION
When listing permissions clients can now fetch the list of available federated sharing roles by sending a `GET /graph/v1beta1/drives/{driveid}/items/{itemid}/permissions?$filter=@libre.graph.permissions.roles.allowedValues/rolePermissions/any(p:contains(p/condition, '@Subject.UserType=="Federated"'))` request. Note that this is the only supported filter expression. Federated sharing roles will be omitted from requests without this filter.

The `/roleManagement/permissions/roleDefinitions` also returns the new roles. Filtering them is done in a subsequent PR which requires https://github.com/owncloud/ocis/pull/9727

server part of https://github.com/owncloud/ocis/issues/9745

```json
 $ curl 'https://cloud.owncloud.test/graph/v1beta1/drives/storage-users-2%244c510ada-c86b-4815-8820-42cdf82c3d51/items/storage-users-2%244c510ada-c86b-4815-8820-42cdf82c3d51!f071293a-7cfe-4361-813d-008b791b113c/permissions?$filter=@libre.graph.permissions.roles.allowedValues/rolePermissions/any(p:contains(p/condition,%20\'@Subject.UserType=="Federated"\'))' -H 'Authorization: Bearer your.jwt.token'  -k | jq
{
  "@libre.graph.permissions.actions.allowedValues": [
    "libre.graph/driveItem/permissions/create",
    "libre.graph/driveItem/children/create",
    "libre.graph/driveItem/standard/delete",
    "libre.graph/driveItem/path/read",
    "libre.graph/driveItem/quota/read",
    "libre.graph/driveItem/content/read",
    "libre.graph/driveItem/upload/create",
    "libre.graph/driveItem/permissions/read",
    "libre.graph/driveItem/children/read",
    "libre.graph/driveItem/versions/read",
    "libre.graph/driveItem/deleted/read",
    "libre.graph/driveItem/path/update",
    "libre.graph/driveItem/permissions/delete",
    "libre.graph/driveItem/deleted/delete",
    "libre.graph/driveItem/versions/update",
    "libre.graph/driveItem/deleted/update",
    "libre.graph/driveItem/basic/read",
    "libre.graph/driveItem/permissions/update",
    "libre.graph/driveItem/permissions/deny"
  ],
  "@libre.graph.permissions.roles.allowedValues": [
    {
      "@libre.graph.weight": 1,
      "description": "View and download.",
      "displayName": "Can view",
      "id": "be531789-063c-48bf-a9fe-857e6fbee7da"
    },
    {
      "@libre.graph.weight": 2,
      "description": "View, download and edit.",
      "displayName": "Can edit",
      "id": "36279a93-e4e3-4bbb-8a23-53b05b560963"
    }
  ]
}
```