### PR TITLE
fix idp config generation

### DIFF
--- a/changelog/unreleased/idp-config-generation-fix.md
+++ b/changelog/unreleased/idp-config-generation-fix.md
@@ -1,0 +1,5 @@
+Bugfix: We fixed the client config generation for the built in IDP
+
+We now use the OCIS_URL to generate the web client registration configuration. It does not make sense use the OCIS_ISSUER_URL if the idp was configured to run on a different domain.
+
+https://github.com/owncloud/ocis/pull/9770

--- a/services/idp/pkg/service/v0/service.go
+++ b/services/idp/pkg/service/v0/service.go
@@ -48,7 +48,7 @@ func NewService(opts ...Option) Service {
 
 	if err := createTemporaryClientsConfig(
 		options.Config.IDP.IdentifierRegistrationConf,
-		options.Config.IDP.Iss,
+		options.Config.Commons.OcisURL,
 		options.Config.Clients,
 	); err != nil {
 		logger.Fatal().Err(err).Msg("could not create default config")


### PR DESCRIPTION

We now use the OCIS_URL to generate the web client registration configuration. It does not make sense use the OCIS_ISSUER_URL if the idp was configured to run on a different domain.

