### PR TITLE
save ocm providers config file to config path (not user space) 

### DIFF
--- a/changelog/unreleased/change-ocmproviders-defaultpath.md
+++ b/changelog/unreleased/change-ocmproviders-defaultpath.md
@@ -1,0 +1,5 @@
+Bugfix: change ocmproviders config defaultpath
+
+We moved the default location of the `ocmproviders.json` config file out of the data directory of the ocm service to the ocis config directory.
+
+https://github.com/owncloud/ocis/pull/9778

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -105,7 +105,7 @@ func DefaultConfig() *config.Config {
 		OCMProviderAuthorizerDriver: "json",
 		OCMProviderAuthorizerDrivers: config.OCMProviderAuthorizerDrivers{
 			JSON: config.OCMProviderAuthorizerJSONDriver{
-				Providers: filepath.Join(defaults.BaseDataPath(), "storage", "ocm", "ocmproviders.json"),
+				Providers: filepath.Join(defaults.BaseConfigPath(), "ocmproviders.json"),
 			},
 		},
 		OCMShareProvider: config.OCMShareProvider{


### PR DESCRIPTION
We moved the default location of the `ocmproviders.json` config file out of the data directory of the ocm service to the ocis config directory.
