### PR TITLE
[docs-only] Fixes to the ocis full deployment example

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -1,12 +1,15 @@
+## Basic Settings ##
 # Define the docker compose log driver used.
 # Defaults to local
 LOG_DRIVER=
-# If you're on an internet facing server. comment out following line.
+# If you're on an internet facing server, comment out following line.
 # It skips certificate validation for various parts of Infinite Scale and is
 # needed when self signed certificates are used.
 INSECURE=true
 
-### Traefik Settings ###
+
+## Traefik Settings ##
+# Note: Traefik is always enabled and can't be disabled.
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=
@@ -27,9 +30,10 @@ TRAEFIK_ACME_MAIL=
 TRAEFIK_ACME_CASERVER=
 
 
-### Infinite Scale Settings ###
+## Infinite Scale Settings ##
 # Beside Traefik, this service must stay enabled.
 # Disable only for testing purposes.
+# Note: the leading colon is required to enable the service.
 OCIS=:ocis.yml
 # The oCIS container image.
 # Defaults to "owncloud/ocis" which contains the production releases.
@@ -46,23 +50,22 @@ ADMIN_PASSWORD=
 # because their passwords are public. Defaults to "false".
 # Also see: https://doc.owncloud.com/ocis/latest/deployment/general/general-info.html#demo-users-and-groups
 DEMO_USERS=
-# Define the loglevel used.
+# Define the oCIS loglevel used.
 # For more details see:
 # https://doc.owncloud.com/ocis/latest/deployment/services/env-vars-special-scope.html
 LOG_LEVEL=
 # Define the kind of logging.
 # The default log can be read by machines.
-# Set this to true to make the log human readable
+# Set this to true to make the log human readable.
 # LOG_PRETTY=true
 
-# S3 Storage configuration
-#
-# - optional
-#
+# S3 Storage configuration - optional
 # Infinite Scale supports S3 storage as primary storage.
-# Per default, S3 storage is disabled and we use the local filesystem.
-# To enable S3 storage, uncomment the following lines and configure the S3 storage.
-# The leading colon is required to enable the service.
+# Per default, S3 storage is disabled and the local filesystem is used.
+# To enable S3 storage, uncomment the following line and configure the S3 storage.
+# For more details see:
+# https://doc.owncloud.com/ocis/next/deployment/storage/s3.html
+# Note: the leading colon is required to enable the service.
 #S3NG=:s3ng.yml
 # Configure the S3 storage endpoint. Defaults to "http://minio:9000" for testing purposes.
 S3NG_ENDPOINT=
@@ -74,8 +77,8 @@ S3NG_ACCESS_KEY=
 S3NG_SECRET_KEY=
 # S3 bucket. Defaults to "ocis"
 S3NG_BUCKET=
-# Add local minio S3 storage to the docker-compose file.
-# This is needed for testing purposes.
+#
+# For testing purposes, add local minio S3 storage to the docker-compose file.
 # The leading colon is required to enable the service.
 #S3NG_MINIO=:minio.yml
 # Minio domain. Defaults to "minio.owncloud.test".
@@ -84,7 +87,7 @@ MINIO_DOMAIN=
 # Define SMPT settings if you would like to send Infinite Scale email notifications.
 # For more details see:
 # https://doc.owncloud.com/ocis/latest/deployment/services/s-list/notifications.html
-# NOTE: this doesn't work if you are using inbucket.
+# NOTE: when configuring Inbucket, these settings have no effect, see inbucket.yml for details.
 # SMTP host to connect to.
 SMTP_HOST=
 # Port of the SMTP host to connect to.
@@ -101,19 +104,21 @@ SMTP_AUTHENTICATION=
 # Allow insecure connections to the SMTP server. Defaults to false.
 SMTP_INSECURE=
 
+
 ## Default Enabled Services ##
 
 ### Apache Tika Content Analysis Toolkit ###
 # Tika (search) is enabled by default, comment if not required.
-# The leading colon is required to enable the service.
+# Note: the leading colon is required to enable the service.
 TIKA=:tika.yml
 # Set the desired docker image tag or digest.
 # Defaults to "latest"
 TIKA_IMAGE=
 
+
 ### Collabora Settings ###
 # Collabora web office is default enabled, comment if not required.
-# The leading colon is required to enable the service.
+# Note: the leading colon is required to enable the service.
 COLLABORA=:collabora.yml
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.owncloud.test"
@@ -135,18 +140,21 @@ COLLABORA_SSL_ENABLE=false
 # Please comment out the following line:
 COLLABORA_SSL_VERIFICATION=false
 
-### Supplemental Configurations ###
+
+## Supplemental Configurations ##
 # If you want to use supplemental configurations,
 # you need to uncomment lines containing :path/file.yml
-# and configure the service if required.
+# and configure the service as required.
 
-## Debugging - Monitoring ##
+
+### Debugging - Monitoring ###
 # Please see documentation at: https://owncloud.dev/ocis/deployment/monitoring-tracing/
-# The leading colon is required to enable the service.
+# Note: the leading colon is required to enable the service.
 #MONITORING=:monitoring_tracing/monitoring.yml
 
-## Uppy Companion Settings ##
-# The leading colon is required to enable the service.
+
+### Uppy Companion Settings ###
+# Note: the leading colon is required to enable the service.
 #CLOUD_IMPORTER=:cloudimporter.yml
 ## The docker image to be used for uppy companion.
 # owncloud has built a container with public link import support.
@@ -158,31 +166,35 @@ COMPANION_DOMAIN=
 COMPANION_ONEDRIVE_KEY=
 COMPANION_ONEDRIVE_SECRET=
 
-## Virusscanner Settings ##
-# The leading colon is required to enable the service.
+
+### Virusscanner Settings ###
+# Note: the leading colon is required to enable the service.
 # CLAMAV=:clamav.yml
 # Image version of the ClamAV container.
 # Defaults to "latest"
 CLAMAV_DOCKER_TAG=
 
-## OnlyOffice Settings ##
-# The leading colon is required to enable the service.
+
+### OnlyOffice Settings ###
+# Note: the leading colon is required to enable the service.
 #ONLYOFFICE=:onlyoffice.yml
 # Domain for OnlyOffice. Defaults to "onlyoffice.owncloud.test".
 ONLYOFFICE_DOMAIN=
 # Domain for the wopiserver which handles OnlyOffice.
 WOPISERVER_ONLYOFFICE_DOMAIN=
 
-## Inbucket Settings ##
+
+### Inbucket Settings ###
 # Inbucket is a mail catcher tool for testing purposes.
 # DO NOT use in Production.
-# The leading colon is required to enable the service.
+# Note: the leading colon is required to enable the service.
 #INBUCKET=:inbucket.yml
 # email server (in this case inbucket acts as mail catcher).
 # Domain for Inbucket. Defaults to "mail.owncloud.test".
 INBUCKET_DOMAIN=
 
-### IMPORTANT ###
+
+## IMPORTANT ##
 # This MUST be the last line as it assembles the supplemental compose files to be used.
 # ALL supplemental configs must be added here, whether commented or not.
 # Each var must either be empty or contain :path/file.yml

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -34,7 +34,8 @@ services:
       - "certs:/certs"
     labels:
       - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
-      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$$apr1$$4vqie50r$$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
+       # defaults to admin:admin
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$$apr1$$4vqie50r$$YQAmQdtmz5n9rEALhxJ4l.}"
       - "traefik.http.routers.traefik.entrypoints=https"
       - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
       - "traefik.http.routers.traefik.middlewares=traefik-auth"

--- a/deployments/examples/ocis_full/inbucket.yml
+++ b/deployments/examples/ocis_full/inbucket.yml
@@ -2,13 +2,12 @@
 services:
   ocis:
     environment:
-      # enable the notifications service
-      OCIS_ADD_RUN_SERVICES": "notifications"
       NOTIFICATIONS_SMTP_HOST: inbucket
       NOTIFICATIONS_SMTP_PORT: 2500
       NOTIFICATIONS_SMTP_SENDER: oCIS notifications <notifications@${OCIS_DOMAIN:-ocis.owncloud.test}>
       NOTIFICATIONS_SMTP_USERNAME: notifications@${OCIS_DOMAIN:-ocis.owncloud.test}
-      NOTIFICATIONS_SMTP_INSECURE: "true" # the mail catcher uses self signed certificates
+      # the mail catcher uses self signed certificates
+      NOTIFICATIONS_SMTP_INSECURE: "true"
 
   inbucket:
     image: inbucket/inbucket

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -16,12 +16,16 @@ services:
     # therefore we ignore the error and then start the ocis server
     command: ["-c", "ocis init || true; ocis server"]
     environment:
+      # enable the notifications service as it is not started automatically
+      OCIS_ADD_RUN_SERVICES": "notifications"
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${LOG_LEVEL:-info}
       OCIS_LOG_COLOR: "${LOG_PRETTY:-false}"
       OCIS_LOG_PRETTY: "${LOG_PRETTY:-false}"
-      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
-      GATEWAY_GRPC_ADDR: 0.0.0.0:9142 # make the REVA gateway accessible to the app drivers
+      # do not use SSL between Traefik and oCIS
+      PROXY_TLS: "false"
+      # make the REVA gateway accessible to the app drivers
+      GATEWAY_GRPC_ADDR: 0.0.0.0:9142
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)

--- a/deployments/examples/ocis_full/s3ng.yml
+++ b/deployments/examples/ocis_full/s3ng.yml
@@ -4,7 +4,8 @@ services:
     environment:
       # activate s3ng storage driver
       STORAGE_USERS_DRIVER: s3ng
-      STORAGE_SYSTEM_DRIVER: ocis # keep system data on ocis storage since this are only small files atm
+      # keep system data on ocis storage since this are only small files atm
+      STORAGE_SYSTEM_DRIVER: ocis
       # s3ng specific settings
       STORAGE_USERS_S3NG_ENDPOINT: ${S3NG_ENDPOINT:-http://minio:9000}
       STORAGE_USERS_S3NG_REGION: ${S3NG_REGION:-default}


### PR DESCRIPTION
Fixes: #9632 (ocis_full deployment example is missing to startup (at least) the notification service)

* This PR moves the start of the notification service from `inbucket.yml` to `ocis.yml`
* Improve `.env` readability + some fixes
* Make comments in yml files consistently be in a new line where applicapable

Note that #9772 ([docs-only] Add variables to .env to configure the data- and config directory) adds some good stuff with regards to volumes. I will rebase that PR post merging this one and check the texts and approve/merge it afterwards.