### PR TITLE
feat(graph): add support for filtering users by type

### DIFF
--- a/changelog/unreleased/ocm_users_graph.md
+++ b/changelog/unreleased/ocm_users_graph.md
@@ -1,0 +1,14 @@
+Enhancement: OCM related adjustments in graph
+
+The /users enpdoint of the graph service was changed with respect to how
+it handles OCM federeated users:
+- The 'userType' property is now alway returned. As new usertype 'Federated'
+  was introduced. To indicate that the user is a federated user.
+- Supported for filtering users by 'userType' as added. Queries like
+  "$filter=userType eq 'Federated'" are now possible.
+- Federated users are only returned when explicitly requested via filter.
+  When no filter is provider only 'Member' users are returned.
+
+https://github.com/owncloud/ocis/pull/9788
+https://github.com/owncloud/ocis/pull/9757
+https://github.com/owncloud/ocis/issues/9702

--- a/services/graph/pkg/service/v0/users_filter.go
+++ b/services/graph/pkg/service/v0/users_filter.go
@@ -124,18 +124,16 @@ func (g Graph) applyFilterLogical(ctx context.Context, req *godata.GoDataRequest
 		return users, invalidFilterError()
 	}
 
+	// As we currently don't suppport the 'has' or 'in' operator, all our
+	// currently supported user filters of the ExpressionTokenLogical type
+	// require exactly two operands.
+	if len(root.Children) != 2 {
+		return users, invalidFilterError()
+	}
 	switch root.Token.Value {
 	case "and":
-		// 'and' needs 2 operands
-		if len(root.Children) != 2 {
-			return users, invalidFilterError()
-		}
 		return g.applyFilterLogicalAnd(ctx, req, root.Children[0], root.Children[1])
 	case "or":
-		// 'or' needs 2 operands
-		if len(root.Children) != 2 {
-			return users, invalidFilterError()
-		}
 		return g.applyFilterLogicalOr(ctx, req, root.Children[0], root.Children[1])
 	}
 	logger.Debug().Str("Token", root.Token.Value).Msg("unsupported logical filter")

--- a/tests/TestHelpers/GraphHelper.php
+++ b/tests/TestHelpers/GraphHelper.php
@@ -309,6 +309,32 @@ class GraphHelper {
 	/**
 	 * @param string $baseUrl
 	 * @param string $xRequestId
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @param string $searchTerm
+	 *
+	 * @return ResponseInterface
+	 */
+	public static function searchFederatedUser(
+		string $baseUrl,
+		string $xRequestId,
+		string $adminUser,
+		string $adminPassword,
+		string $searchTerm
+	): ResponseInterface {
+		$url = self::getFullUrl($baseUrl, "users?\$filter=userType eq 'Federated'&\$search=$searchTerm");
+		return HttpRequestHelper::get(
+			$url,
+			$xRequestId,
+			$adminUser,
+			$adminPassword,
+			self::getRequestHeaders()
+		);
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $xRequestId
 	 * @param string $user
 	 * @param string $userPassword
 	 *

--- a/tests/acceptance/features/apiOcm/searchFederationUsers.feature
+++ b/tests/acceptance/features/apiOcm/searchFederationUsers.feature
@@ -18,7 +18,7 @@ Feature: search federation users
     And "Alice" has created the federation share invitation
     And using server "REMOTE"
     And "Brian" has accepted invitation
-    When user "Brian" searches for user "ali" using Graph API
+    When user "Brian" searches for federated user "ali" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -53,7 +53,7 @@ Feature: search federation users
       }
       """
     And using server "LOCAL"
-    When user "Alice" searches for user "bri" using Graph API
+    When user "Alice" searches for federated user "bri" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -94,7 +94,7 @@ Feature: search federation users
     And "Alice" has created the federation share invitation
     And using server "REMOTE"
     And "Brian" has accepted invitation
-    When user "Brian" searches for user "%22alice@example.org%22" using Graph API
+    When user "Brian" searches for federated user "%22alice@example.org%22" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -129,7 +129,7 @@ Feature: search federation users
       }
       """
     And using server "LOCAL"
-    When user "Alice" searches for user "%22brian@example.org%22" using Graph API
+    When user "Alice" searches for federated user "%22brian@example.org%22" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -170,7 +170,7 @@ Feature: search federation users
     And "Alice" has created the federation share invitation
     And using server "REMOTE"
     And "Brian" has accepted invitation
-    When user "Brian" searches for user "%22carol@example.org%22" using Graph API
+    When user "Brian" searches for federated user "%22carol@example.org%22" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -189,7 +189,7 @@ Feature: search federation users
       }
       """
     And using server "LOCAL"
-    When user "Carol" searches for user "bria" using Graph API
+    When user "Carol" searches for federated user "bria" using Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """

--- a/tests/acceptance/features/bootstrap/GraphContext.php
+++ b/tests/acceptance/features/bootstrap/GraphContext.php
@@ -1254,6 +1254,27 @@ class GraphContext implements Context {
 	}
 
 	/**
+	 * @When user :byUser searches for federated user :searchTerm using Graph API
+	 *
+	 * @param string $byUser
+	 * @param string $searchTerm
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userSearchesForFederatedUserUsingGraphApi(string $byUser, string $searchTerm): void {
+		$credentials = $this->getAdminOrUserCredentials($byUser);
+		$response = GraphHelper::searchFederatedUser(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getStepLineRef(),
+			$credentials['username'],
+			$credentials['password'],
+			$searchTerm,
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @When user :user tries to get all users using the Graph API
 	 * @When user :user gets all users using the Graph API
 	 *


### PR DESCRIPTION
This adds support for equality filters on the `userType` property of users  for the /users endpoint.

It also changes the behavior of the /users endpoint to only return federated users when explicitly request via a `userType` filter.
    
E.g. to search for federated users with matching "albert" you can use:
    
    `$filter=userType eq 'Federated'&$search="albert"`
    
Related Issue: #9702
