### PR TITLE
fix: verify file id in URL matches the one inside the access token

### DIFF
--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -3,7 +3,6 @@ package connector
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -20,11 +19,11 @@ import (
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/config"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/connector/fileinfo"
+	"github.com/owncloud/ocis/v2/services/collaboration/pkg/helpers"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/middleware"
 	"github.com/rs/zerolog"
 )
@@ -1172,10 +1171,7 @@ func (f *FileConnector) generateWOPISrc(ctx context.Context, wopiContext middlew
 	}
 
 	// get the reference
-	resourceId := wopiContext.FileReference.GetResourceId()
-	c := sha256.New()
-	c.Write([]byte(storagespace.FormatResourceID(resourceId)))
-	fileRef := hex.EncodeToString(c.Sum(nil))
+	fileRef := helpers.HashResourceId(wopiContext.FileReference.GetResourceId())
 
 	// generate the URL for the WOPI app to access the new created file
 	wopiSrcURL, err := url.Parse(f.cfg.Wopi.WopiSrc)

--- a/services/collaboration/pkg/helpers/cs3.go
+++ b/services/collaboration/pkg/helpers/cs3.go
@@ -1,8 +1,13 @@
 package helpers
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+
 	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/config"
 )
 
@@ -24,4 +29,12 @@ func GetCS3apiClient(cfg *config.Config, forceNew bool) (gatewayv1beta1.GatewayA
 		commonCS3ApiClient = client
 	}
 	return client, err
+}
+
+// HashResourceId builds a urlsafe and stable file reference that can be used for proxy routing,
+// so that all sessions on one file end on the same office server
+func HashResourceId(resourceId *providerv1beta1.ResourceId) string {
+	c := sha256.New()
+	c.Write([]byte(storagespace.FormatResourceID(resourceId)))
+	return hex.EncodeToString(c.Sum(nil))
 }

--- a/services/collaboration/pkg/service/grpc/v0/service.go
+++ b/services/collaboration/pkg/service/grpc/v0/service.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/url"
 	"path"
@@ -19,6 +17,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/config"
+	"github.com/owncloud/ocis/v2/services/collaboration/pkg/helpers"
 	"github.com/owncloud/ocis/v2/services/collaboration/pkg/middleware"
 )
 
@@ -83,10 +82,7 @@ func (s *Service) OpenInApp(
 
 	// build a urlsafe and stable file reference that can be used for proxy routing,
 	// so that all sessions on one file end on the same office server
-
-	c := sha256.New()
-	c.Write([]byte(req.GetResourceInfo().GetId().GetStorageId() + "$" + req.GetResourceInfo().GetId().GetSpaceId() + "!" + req.GetResourceInfo().GetId().GetOpaqueId()))
-	fileRef := hex.EncodeToString(c.Sum(nil))
+	fileRef := helpers.HashResourceId(req.GetResourceInfo().GetId())
 
 	// get the file extension to use the right wopi app url
 	fileExt := path.Ext(req.GetResourceInfo().GetPath())


### PR DESCRIPTION
We're using the file id from the access token, so changing the file id in the URL shouldn't matter. However, the file id must represent a single file.
It will also help to detect unwanted changes in the URL.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The `HashResourceId` is used to generate the `/wopi/files/abcdef123` URLs. This is needed in the `OpenInApp` method (when the user requests opening a file in Collabora or any other WOPI app) as well as in the `PutRelativeFile` method (when the user saves the document with a different file name).

The URL is expected to be stable and point to a single file. So far, we've used the data contained in the access token to get the file id. While this is fine, the file id contained in the URL could be different.
For example, `/wopi/files/abc` and `/wopi/files/123` both could point to the same file as long as the access token is the same. This shouldn't be a big problem, but it makes things awkward.

This PR verifies that the file id in the URL matches the one in the access token. This would make tampering the URL more difficult.
Note that, due to how the fileid for the URL is generated, there could be collisions with other files. Code-wise it shouldn't be a problem on our side because we still get all the information from the access token, but it's unclear how the WOPI app  or the network will behave.

## Related Issue
Spotted in https://github.com/owncloud/ocis/issues/8712#issuecomment-2285822501

## Motivation and Context
This is mostly to prevent tampering the URL, although these URLs should be handled by the WOPI app, which should be trusted.

## How Has This Been Tested?
Manually tested. Basic operations with a WOPI app work without problems.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
