### PR TITLE
[docs-only] Mini text only fix for .env

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -179,7 +179,7 @@ COMPANION_ONEDRIVE_SECRET=
 
 ### Virusscanner Settings ###
 # Note: the leading colon is required to enable the service.
-# CLAMAV=:clamav.yml
+#CLAMAV=:clamav.yml
 # Image version of the ClamAV container.
 # Defaults to "latest"
 CLAMAV_DOCKER_TAG=


### PR DESCRIPTION
This is just a mini fix for the `.env` file in the ocis_full deployment example removing a blank for consistency reasons as all lines of the same type should have the same look and feel.