### PR TITLE
[docs-only] Fix the default deployment release type

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -38,8 +38,8 @@ OCIS=:ocis.yml
 # The oCIS container image.
 # For production releases: "owncloud/ocis"
 # For rolling releases:    "owncloud/ocis-rolling"
-# Defaults to "owncloud/ocis-rolling" (rolling release)
-OCIS_DOCKER_IMAGE=
+# Defaults to production if not set otherwise
+OCIS_DOCKER_IMAGE=owncloud/ocis-rolling
 # The oCIS container version.
 # Defaults to "latest" and points to the latest stable tag.
 OCIS_DOCKER_TAG=

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -6,9 +6,7 @@ services:
         aliases:
           - ${OCIS_DOMAIN:-ocis.owncloud.test}
   ocis:
-    # FIXME: move back to "owncloud/ocis" once the collaboration service is
-    # part of a production release. set the text in .env for the default accordingly
-    image: ${OCIS_DOCKER_IMAGE:-owncloud/ocis-rolling}:${OCIS_DOCKER_TAG:-latest}
+    image: ${OCIS_DOCKER_IMAGE:-owncloud/ocis}:${OCIS_DOCKER_TAG:-latest}
     networks:
       ocis-net:
     entrypoint:

--- a/docs/ocis/deployment/ocis_full.md
+++ b/docs/ocis/deployment/ocis_full.md
@@ -113,8 +113,8 @@ See also [example server setup]({{< ref "preparing_server" >}})
   # The oCIS container image.
   # For production releases: "owncloud/ocis"
   # For rolling releases:    "owncloud/ocis-rolling"
-  # Defaults to "owncloud/ocis-rolling" (rolling release)
-  OCIS_DOCKER_IMAGE=
+  # Defaults to production if not set otherwise
+  OCIS_DOCKER_IMAGE=owncloud/ocis-rolling
   # The oCIS container version.
   # Defaults to "latest" and points to the latest stable tag.
   OCIS_DOCKER_TAG=


### PR DESCRIPTION
References: #9798 ([docs-only] deployments: Default to "ocis-rolling" for the ocis_full example for now)

Found turing testing.

The referenced PR was incomplete as it only covered ocis.yml but not the office suites yaml files. This leaded to the situation that ocis started rolling but the office containers started production.

This PR fixes this by setting the default in the .env file correctly to rolling which is then used in all yaml files that need the ocis image.