### PR TITLE
Fix some deployment stuff

### DIFF
--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -36,7 +36,6 @@ services:
       COLLABORATION_CS3API_DATAGATEWAY_INSECURE: "${INSECURE:-true}"
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
-      - ocis-config:/etc/ocis
       # configure the .env file to use own paths instead docker internal volumes
       - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     labels:

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -36,7 +36,7 @@ services:
       COLLABORATION_CS3API_DATAGATEWAY_INSECURE: "${INSECURE:-true}"
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
-      # configure the .env file to use own paths instead docker internal volumes
+      # configure the .env file to use own paths instead of docker internal volumes
       - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     labels:
       - "traefik.enable=true"

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -37,6 +37,8 @@ services:
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - ocis-config:/etc/ocis
+      # configure the .env file to use own paths instead docker internal volumes
+      - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.collaboration.entrypoints=https"

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -1,8 +1,7 @@
 ---
-
 services:
   traefik:
-    image: traefik:v3.0.3
+    image: traefik:v3.1.2
     networks:
       ocis-net:
     command:

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -55,7 +55,7 @@ services:
       - ./config/ocis/app-registry.yaml:/etc/ocis/app-registry.yaml
       - ./config/ocis/csp.yaml:/etc/ocis/csp.yaml
       - ./config/ocis/banned-password-list.txt:/etc/ocis/banned-password-list.txt
-      # configure the .env file to use own paths instead docker internal volumes
+      # configure the .env file to use own paths instead of docker internal volumes
       - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
       - ${OCIS_DATA_DIR:-ocis-data}:/var/lib/ocis
     labels:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -33,7 +33,7 @@ services:
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
       COLLABORATION_APP_PROOF_DISABLE: "true"
     volumes:
-      # configure the .env file to use own paths instead docker internal volumes
+      # configure the .env file to use own paths instead of docker internal volumes
       - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     labels:
       - "traefik.enable=true"

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -33,7 +33,8 @@ services:
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
       COLLABORATION_APP_PROOF_DISABLE: "true"
     volumes:
-      - ocis-config:/etc/ocis
+      # configure the .env file to use own paths instead docker internal volumes
+      - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.collaboration-oo.entrypoints=https"


### PR DESCRIPTION
References: #9772 ([docs-only] Add variables to .env to configure the data- and config directory)

While working on the deployment examples the following popped up which now is fixed:

* The volumes used, which now can be configured via #9772, also need to be added in the two office yml definitions.
* Traefik is updated from 3.0.3 to 3.1.2

The traefik update had no issues during testing. 