### PR TITLE
add ocm wellknown config

### DIFF
--- a/changelog/unreleased/add-ocm-wellknown-config.md
+++ b/changelog/unreleased/add-ocm-wellknown-config.md
@@ -1,0 +1,5 @@
+Enhancement: Add OCM wellknown configuration
+
+We now configure the `wellknown` service for OCM.
+
+https://github.com/owncloud/ocis/pull/9815

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -41,6 +41,18 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 			},
 			// TODO build services dynamically
 			"services": map[string]interface{}{
+				"wellknown": map[string]interface{}{
+					"prefix": ".well-known",
+					"ocmprovider": map[string]interface{}{
+						"ocm_prefix":    cfg.OCMD.Prefix,
+						"endpoint":      cfg.Commons.OcisURL,
+						"provider":      "oCIS",
+						"webdav_root":   "/dav/ocm",
+						"webapp_root":   cfg.ScienceMesh.Prefix,
+						"enable_webapp": false,
+						"enable_datatx": false,
+					},
+				},
 				"sciencemesh": map[string]interface{}{
 					"prefix":             cfg.ScienceMesh.Prefix,
 					"smtp_credentials":   map[string]string{},

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -113,6 +113,11 @@ func DefaultPolicies() []config.Policy {
 					Unprotected: true,
 				},
 				{
+					Endpoint:    "/.well-known/ocm",
+					Service:     "com.owncloud.web.ocm",
+					Unprotected: true,
+				},
+				{
 					Endpoint:    "/.well-known/webfinger",
 					Service:     "com.owncloud.web.webfinger",
 					Unprotected: true,


### PR DESCRIPTION
We now configure the `wellknown` service for OCM.

counterpart of https://github.com/cs3org/reva/pull/4809 that will properly configure the wellknown service once reva is bumped.