### PR TITLE
test: require at least coding-standard 5.3

### DIFF
--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-      "owncloud/coding-standard": "^5.1"
+      "owncloud/coding-standard": "^5.3"
     }
   }


### PR DESCRIPTION
## Description
https://github.com/owncloud/coding-standard/releases/tag/5.3.0 updates the config for php-cs-fixer to remove deprecated fixer rules, and replace them with the relevant new rules.

Previously, php-cs-fixer was warning:
```
- Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "control_structure_continuation_position", "declare_parentheses", "no_multiple_statements_per_line", "braces_position", "statement_indentation" and "no_extra_blank_lines" instead.
- Rule "no_spaces_inside_parenthesis" is deprecated. Use "spaces_inside_parentheses" instead.
```

Now those warnings are no longer emitted. But a similar set of new rules are enforced.

## How Has This Been Tested?
Local run of
```
make test-php-style
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
