### PR TITLE
[docs-only] Document the expected location of the ocmproviders.json file

### DIFF
--- a/services/ocm/README.md
+++ b/services/ocm/README.md
@@ -17,7 +17,7 @@ Internal GRPC APIs:
 
 The `ocm` services implements an invitation workflow which needs to be followed before creating federated shares. Invitations are limited to trusted instances, however.
 
-The list of trusted instances is managed by the `ocmproviderauthorizer` service. The only supported backend currently is `json` which stores the list in a json file on disk.
+The list of trusted instances is managed by the `ocmproviderauthorizer` service. The only supported backend currently is `json` which stores the list in a json file on disk. Note that the `ocmproviders.json` file, which holds that configuration, is expected to be located in the root of the ocis config directory.
 
 Example `ocmproviders.json` file:
 ```


### PR DESCRIPTION
Fixes: 9794 (Document the location of ocmproviders.json --> config directory)

Introduced with #9778, the location of the `ocmproviders.json` file is now expected to be in the root of the ocis config directory. This was not documented - fixed now.
