### PR TITLE
[docs-only][stable-5.0] ocis_wopi deployment example, make data and config volumes configurable

### DIFF
--- a/deployments/examples/ocis_wopi/.env
+++ b/deployments/examples/ocis_wopi/.env
@@ -65,6 +65,14 @@ DEMO_USERS=
 # https://doc.owncloud.com/ocis/latest/deployment/services/env-vars-special-scope.html
 LOG_LEVEL=
 
+# Define the oCIS storage location. Set the paths for config and data to a local path.
+# Note that especially the data directory can grow big.
+# Leaving it default stores data in docker internal volumes.
+# For more details see:
+# https://doc.owncloud.com/ocis/next/deployment/general/general-info.html#default-paths
+# OCIS_CONFIG_DIR=/your/local/ocis/config
+# OCIS_DATA_DIR=/your/local/ocis/data
+
 # Define SMPT settings if you would like to send Infinite Scale email notifications.
 # For more details see:
 # https://doc.owncloud.com/ocis/latest/deployment/services/s-list/notifications.html

--- a/deployments/examples/ocis_wopi/collabora.yml
+++ b/deployments/examples/ocis_wopi/collabora.yml
@@ -56,7 +56,8 @@ services:
       # share the registry with the ocis container
       MICRO_REGISTRY_ADDRESS: ocis:9233
     volumes:
-      - ocis-config:/etc/ocis
+      # configure the .env file to use own paths instead of docker internal volumes
+      - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always

--- a/deployments/examples/ocis_wopi/ocis.yml
+++ b/deployments/examples/ocis_wopi/ocis.yml
@@ -43,9 +43,10 @@ services:
       # enable to allow using the banned passwords list
       #OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST: banned-password-list.txt
     volumes:
+      # configure the .env file to use own paths instead of docker internal volumes
+      - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
+      - ${OCIS_DATA_DIR:-ocis-data}:/var/lib/ocis
       # paths are relative to the main compose file
-      - ocis-config:/etc/ocis
-      - ocis-data:/var/lib/ocis
       - ./config/ocis/app-registry.yaml:/etc/ocis/app-registry.yaml
       - ./config/ocis/web.yaml:/etc/ocis/web.yaml
       - ./config/ocis/banned-password-list.txt:/etc/ocis/banned-password-list.txt

--- a/deployments/examples/ocis_wopi/onlyoffice.yml
+++ b/deployments/examples/ocis_wopi/onlyoffice.yml
@@ -62,7 +62,8 @@ services:
       # share the registry with the ocis container
       MICRO_REGISTRY_ADDRESS: ocis:9233
     volumes:
-      - ocis-config:/etc/ocis
+      # configure the .env file to use own paths instead of docker internal volumes
+      - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always


### PR DESCRIPTION
Same as we have recently added with rolling, the ocis volumes config and data paths are now configurable.

This will go on merging into the upcoming 5.0.7 release.

The reason to do so is:
* Align the configurations in versions
* Ease the prod - to - prod upgrade when released

The deployment description in the admin docs in master already has the relevant content, only selective text backports need to be made AFTER the 5.0.7 release is published.

@dragotin, @tbsbdr fyi