### PR TITLE
[tests-only][full-ci]added test for sharee to open file with `/app/open` endpoint

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -406,6 +406,7 @@ default:
       context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
+        - SharingNgContext:
 
     cliCommands:
       paths:

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -118,3 +118,56 @@ Feature: collaboration (wopi)
         }
       }
       """
+
+
+  Scenario Outline: sharee open file with .odt extension
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | simple.odt |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    When user "Brian" sends HTTP method "POST" to URL "<app-endpoint>"
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "app_url",
+          "method",
+          "form_parameters"
+        ],
+        "properties": {
+          "app_url": {
+            "type": "string",
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+          },
+          "method": {
+            "const": "POST"
+          },
+          "form_parameters": {
+            "type": "object",
+            "required": [
+              "access_token",
+              "access_token_ttl"
+            ],
+            "properties": {
+              "access_token": {
+                "type": "string"
+              },
+              "access_token_ttl": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | app-endpoint                                     |
+      | /app/open?file_id=<<FILEID>>&app_name=FakeOffice |
+      | /app/open?file_id=<<FILEID>>                     |

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -94,7 +94,7 @@ Feature: collaboration (wopi)
       }
       """
 
-
+  @issue-9928
   Scenario: open text file without app name in url query (MIME type not registered in app-registry)
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
     And we save it into "FILEID"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added test for sharee to open `.odt` file with `/app/open` endpoint with and without `app_name` parameter.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/9682

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
