### PR TITLE
list ocm shares in sharedByMe

### DIFF
--- a/changelog/unreleased/ocm-listing-fixes.md
+++ b/changelog/unreleased/ocm-listing-fixes.md
@@ -1,5 +1,7 @@
-Bugfix: add missing properties to when listing ocm shares 
+Bugfix: fix listing ocm shares
 
 The libre graph API now returns an etag, the role and the creation time for ocm shares.
+It also includes ocm shares in the sharedByMe endpoint.
 
+https://github.com/owncloud/ocis/pull/9925
 https://github.com/owncloud/ocis/pull/9920

--- a/services/graph/pkg/service/v0/sharedbyme.go
+++ b/services/graph/pkg/service/v0/sharedbyme.go
@@ -25,6 +25,14 @@ func (g Graph) GetSharedByMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if g.config.IncludeOCMSharees {
+		driveItems, err = g.listOCMShares(ctx, nil, driveItems)
+		if err != nil {
+			errorcode.RenderError(w, r, err)
+			return
+		}
+	}
+
 	driveItems, err = g.listPublicShares(ctx, nil, driveItems)
 	if err != nil {
 		errorcode.RenderError(w, r, err)


### PR DESCRIPTION
The sharedByMe endpoint now includes ocm shares if ocm is enabled.

fixes https://github.com/owncloud/ocis/issues/9908