### PR TITLE
[tests-only] [full-ci] Add test coverage for copying file using file id from share space

### DIFF
--- a/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/copyByFileId.feature
@@ -242,11 +242,11 @@ Feature: copying file using file id
     And user "Alice" has uploaded file with content "some data" to "/folder/test.txt"
     And we save it into "FILEID"
     And user "Alice" has sent the following resource share invitation:
-      | resource        | folder   |
-      | space           | Personal |
-      | sharee          | Brian    |
-      | shareType       | user     |
-      | permissionsRole | Editor   |
+      | resource        | folder            |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | <permission-role> |
     And user "Brian" has a share "folder" synced
     When user "Brian" copies a file "/test.txt" into "/" inside space "Personal" using file-id path "<dav-path>"
     Then the HTTP status code should be "201"
@@ -257,9 +257,13 @@ Feature: copying file using file id
     And for user "Alice" folder "folder" of the space "Personal" should contain these files:
       | test.txt |
     Examples:
-      | dav-path                          |
-      | /remote.php/dav/spaces/<<FILEID>> |
-      | /dav/spaces/<<FILEID>>            |
+      | permission-role | dav-path                          |
+      | Editor          | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | /dav/spaces/<<FILEID>>            |
+      | Viewer          | /dav/spaces/<<FILEID>>            |
+      | Uploader        | /dav/spaces/<<FILEID>>            |
 
 
   Scenario Outline: copy a file between two project spaces
@@ -280,3 +284,213 @@ Feature: copying file using file id
       | dav-path                          |
       | /remote.php/dav/spaces/<<FILEID>> |
       | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: sharee tries to copy a file from shares space with secure viewer to personal space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folder        |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure viewer |
+    And user "Brian" has a share "folder" synced
+    When user "Brian" copies a file "/test.txt" into "/" inside space "Personal" using file-id path "<dav-path>"
+    Then the HTTP status code should be "403"
+    And for user "Brian" folder "folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "/" of the space "Personal" should not contain these files:
+      | test.txt |
+    Examples:
+      | dav-path                          |
+      | /remote.php/dav/spaces/<<FILEID>> |
+      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: sharee copies a file from shares to project space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folder            |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | <permission-role> |
+    And user "Brian" has a share "folder" synced
+    And user "Alice" has created a space "project-space" with the default quota using the Graph API
+    And user "Alice" has sent the following space share invitation:
+      | space           | project-space |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | <space-role>  |
+    When user "Brian" copies a file "Shares/folder/test.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Brian" folder "folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "/" of the space "project-space" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "/" of the space "project-space" should contain these files:
+      | test.txt |
+    Examples:
+      | permission-role | space-role    | dav-path                          |
+      | Viewer          | Manager       | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | Space Editor  | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | Manager       | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | Space Editor  | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | Manager       | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | Space Editor  | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | Manager       | /dav/spaces/<<FILEID>>            |
+      | Viewer          | Space Editor  | /dav/spaces/<<FILEID>>            |
+      | Editor          | Manager       | /dav/spaces/<<FILEID>>            |
+      | Editor          | Space Editor  | /dav/spaces/<<FILEID>>            |
+      | Uploader        | Manager       | /dav/spaces/<<FILEID>>            |
+      | Uploader        | Space Editor  | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: sharee tries to copy a file from shares to project space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "some data" to "/folder/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folder            |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | <permission-role> |
+    And user "Brian" has a share "folder" synced
+    And user "Alice" has created a space "project-space" with the default quota using the Graph API
+    And user "Alice" has sent the following space share invitation:
+      | space           | project-space |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | <space-role>  |
+    When user "Brian" copies a file "Shares/folder/test.txt" into "/" inside space "project-space" using file-id path "<dav-path>"
+    Then the HTTP status code should be "403"
+    And for user "Brian" folder "folder" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "/" of the space "project-space" should not contain these files:
+      | test.txt |
+    And for user "Alice" folder "/" of the space "project-space" should not contain these files:
+      | test.txt |
+    Examples:
+      | permission-role | space-role    | dav-path                          |
+      | Secure viewer   | Manager       | /remote.php/dav/spaces/<<FILEID>> |
+      | Secure viewer   | Space Viewer  | /remote.php/dav/spaces/<<FILEID>> |
+      | Secure viewer   | Space Editor  | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | Space Viewer  | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | Space Viewer  | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | Space Viewer  | /remote.php/dav/spaces/<<FILEID>> |
+      | Secure viewer   | Manager       | /dav/spaces/<<FILEID>>            |
+      | Secure viewer   | Space Viewer  | /dav/spaces/<<FILEID>>            |
+      | Secure viewer   | Space Editor  | /dav/spaces/<<FILEID>>            |
+      | Editor          | Space Viewer  | /dav/spaces/<<FILEID>>            |
+      | Viewer          | Space Viewer  | /dav/spaces/<<FILEID>>            |
+      | Uploader        | Space Viewer  | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: sharee copies a file between shares spaces
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/share1"
+    And user "Alice" has created folder "/share2"
+    And user "Alice" has uploaded file with content "some data" to "/share1/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | share1            |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | <from-share-role> |
+    And user "Brian" has a share "share1" synced
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | share2          |
+      | space           | Personal        |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <to-share-role> |
+    And user "Brian" has a share "share2" synced
+    When user "Brian" copies a file "Shares/share1/test.txt" into "share2" inside space "Shares" using file-id path "<dav-path>"
+    Then the HTTP status code should be "201"
+    And for user "Brian" folder "share1" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "share2" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "share1" of the space "Personal" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "share2" of the space "Personal" should contain these files:
+      | test.txt |
+    Examples:
+      | from-share-role | to-share-role | dav-path                          |
+      | Viewer          | Editor        | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | Uploader      | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | Editor        | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | Uploader      | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | Editor        | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | Uploader      | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | Editor        | /dav/spaces/<<FILEID>>            |
+      | Viewer          | Uploader      | /dav/spaces/<<FILEID>>            |
+      | Editor          | Editor        | /dav/spaces/<<FILEID>>            |
+      | Editor          | Uploader      | /dav/spaces/<<FILEID>>            |
+      | Uploader        | Editor        | /dav/spaces/<<FILEID>>            |
+      | Uploader        | Uploader      | /dav/spaces/<<FILEID>>            |
+
+
+  Scenario Outline: sharee tries to copy a file between shares space
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/share1"
+    And user "Alice" has created folder "/share2"
+    And user "Alice" has uploaded file with content "some data" to "/share1/test.txt"
+    And we save it into "FILEID"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | share1            |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | <from-share-role> |
+    And user "Brian" has a share "share1" synced
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | share2          |
+      | space           | Personal        |
+      | sharee          | Brian           |
+      | shareType       | user            |
+      | permissionsRole | <to-share-role> |
+    And user "Brian" has a share "share2" synced
+    When user "Brian" copies a file "Shares/share1/test.txt" into "share2" inside space "Shares" using file-id path "<dav-path>"
+    Then the HTTP status code should be "403"
+    And for user "Brian" folder "share1" of the space "Shares" should contain these files:
+      | test.txt |
+    And for user "Brian" folder "share2" of the space "Shares" should not contain these files:
+      | test.txt |
+    And for user "Alice" folder "share1" of the space "Personal" should contain these files:
+      | test.txt |
+    And for user "Alice" folder "share2" of the space "Personal" should not contain these files:
+      | test.txt |
+    Examples:
+      | from-share-role | to-share-role | dav-path                          |
+      | Secure viewer   | Viewer        | /remote.php/dav/spaces/<<FILEID>> |
+      | Secure viewer   | Editor        | /remote.php/dav/spaces/<<FILEID>> |
+      | Secure viewer   | Uploader      | /remote.php/dav/spaces/<<FILEID>> |
+      | Secure viewer   | Secure viewer | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | Viewer        | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | Viewer        | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | Viewer        | /remote.php/dav/spaces/<<FILEID>> |
+      | Viewer          | Secure viewer | /remote.php/dav/spaces/<<FILEID>> |
+      | Editor          | Secure viewer | /remote.php/dav/spaces/<<FILEID>> |
+      | Uploader        | Secure viewer | /remote.php/dav/spaces/<<FILEID>> |
+      | Secure viewer   | Viewer        | /dav/spaces/<<FILEID>>            |
+      | Secure viewer   | Editor        | /dav/spaces/<<FILEID>>            |
+      | Secure viewer   | Uploader      | /dav/spaces/<<FILEID>>            |
+      | Secure viewer   | Secure viewer | /dav/spaces/<<FILEID>>            |
+      | Viewer          | Viewer        | /dav/spaces/<<FILEID>>            |
+      | Editor          | Viewer        | /dav/spaces/<<FILEID>>            |
+      | Uploader        | Viewer        | /dav/spaces/<<FILEID>>            |
+      | Viewer          | Secure viewer | /dav/spaces/<<FILEID>>            |
+      | Editor          | Secure viewer | /dav/spaces/<<FILEID>>            |
+      | Uploader        | Secure viewer | /dav/spaces/<<FILEID>>            |


### PR DESCRIPTION
## Description
Added test coverage for copying file using fileId from share space:
| |from (space) | from (role) | to (space) | to (role) 
--|--|--|--|--|
| 1. | share | different permission | project | different permission 
| 2. | share | different permission | share | different permission
| 3. | share | different permission	| personal

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/9878

## How Has This Been Tested?
- locally 
- CI :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
