### PR TITLE
Allow to track last sign-in time of users

### DIFF
--- a/changelog/unreleased/ldap-signin-timestamp.md
+++ b/changelog/unreleased/ldap-signin-timestamp.md
@@ -1,0 +1,6 @@
+Enhancement: allow to maintain the last sign-in timestamp of a user
+
+When the LDAP identity backend is configured to have write access to the database
+we're now able to maintain the ocLastSignInTimestamp attribute for the users.
+
+https://github.com/owncloud/ocis/pull/9942

--- a/deployments/examples/ocis_ldap/config/ldap/schemas/10_owncloud_schema.ldif
+++ b/deployments/examples/ocis_ldap/config/ldap/schemas/10_owncloud_schema.ldif
@@ -21,6 +21,11 @@ olcAttributeTypes: ( ownCloudOid:1.1.5 NAME 'ownCloudUserType'
   DESC 'User type (e.g. Member or Guest)'
   EQUALITY caseIgnoreMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcAttributeTypes: ( ownCloudOid:1.1.6 NAME 'ocLastSignInTimestamp'
+  DESC 'The timestamp of the last sign-in'
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch
+  SYNTAX  1.3.6.1.4.1.1466.115.121.1.24 SINGLE-VALUE )
 olcObjectClasses: ( ownCloudOid:1.2.1 NAME 'ownCloud'
   DESC 'ownCloud LDAP Schema'
   AUXILIARY
@@ -29,4 +34,4 @@ olcObjectClasses: ( ownCloudOid:1.2.2 NAME 'ownCloudUser'
   DESC 'ownCloud User LDAP Schema'
   SUP ownCloud
   AUXILIARY
-  MAY ( ocExternalIdentity $ ownCloudUserEnabled $ ownCloudUserType ) )
+  MAY ( ocExternalIdentity $ ownCloudUserEnabled $ ownCloudUserType $ ocLastSignInTimestamp) )

--- a/ocis-pkg/oidc/context.go
+++ b/ocis-pkg/oidc/context.go
@@ -5,6 +5,9 @@ import "context"
 // contextKey is the key for oidc claims in a context
 type contextKey struct{}
 
+// newSessionFlagKey is the key for the new session flag in a context
+type newSessionFlagKey struct{}
+
 // NewContext makes a new context that contains the OpenID connect claims in a map.
 func NewContext(parent context.Context, c map[string]interface{}) context.Context {
 	return context.WithValue(parent, contextKey{}, c)
@@ -13,5 +16,16 @@ func NewContext(parent context.Context, c map[string]interface{}) context.Contex
 // FromContext returns the claims map stored in a context, or nil if there isn't one.
 func FromContext(ctx context.Context) map[string]interface{} {
 	s, _ := ctx.Value(contextKey{}).(map[string]interface{})
+	return s
+}
+
+// NewContextSessionFlag makes a new context that contains the new session flag.
+func NewContextSessionFlag(ctx context.Context, flag bool) context.Context {
+	return context.WithValue(ctx, newSessionFlagKey{}, flag)
+}
+
+// NewSessionFlagFromContext returns the new session flag stored in a context.
+func NewSessionFlagFromContext(ctx context.Context) bool {
+	s, _ := ctx.Value(newSessionFlagKey{}).(bool)
 	return s
 }

--- a/services/graph/.mockery.yaml
+++ b/services/graph/.mockery.yaml
@@ -12,8 +12,12 @@ packages:
             DriveItemPermissionsProvider:
             HTTPClient:
             Permissions:
-            Publisher:
             RoleService:
+    github.com/cs3org/reva/v2/pkg/events:
+        config:
+            dir: "mocks"
+        interfaces:
+            Publisher:
     github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool:
         config:
             dir: "mocks"

--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -125,10 +125,10 @@ func CreateUserModelFromCS3(u *cs3user.User) *libregraph.User {
 			IssuerAssignedId: &u.GetId().OpaqueId,
 		}},
 		UserType:                 &userType,
-		DisplayName:              u.DisplayName,
+		DisplayName:              u.GetDisplayName(),
 		Mail:                     &u.Mail,
-		OnPremisesSamAccountName: u.Username,
-		Id:                       &u.Id.OpaqueId,
+		OnPremisesSamAccountName: u.GetUsername(),
+		Id:                       &u.GetId().OpaqueId,
 	}
 	// decode the remote id if the user is federated
 	if u.GetId().GetType() == cs3user.UserType_USER_TYPE_FEDERATED {

--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"context"
 	"net/url"
+	"time"
 
 	"github.com/CiscoM31/godata"
 	cs3group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
@@ -36,6 +37,7 @@ type Backend interface {
 	UpdateUser(ctx context.Context, nameOrID string, user libregraph.UserUpdate) (*libregraph.User, error)
 	GetUser(ctx context.Context, nameOrID string, oreq *godata.GoDataRequest) (*libregraph.User, error)
 	GetUsers(ctx context.Context, oreq *godata.GoDataRequest) ([]*libregraph.User, error)
+	UpdateLastSignInDate(ctx context.Context, userID string, timestamp time.Time) error
 
 	// CreateGroup creates the supplied group in the identity backend.
 	CreateGroup(ctx context.Context, group libregraph.Group) (*libregraph.Group, error)

--- a/services/graph/pkg/identity/cs3.go
+++ b/services/graph/pkg/identity/cs3.go
@@ -61,14 +61,14 @@ func (i *CS3) GetUser(ctx context.Context, userID string, _ *godata.GoDataReques
 	case err != nil:
 		logger.Error().Str("backend", "cs3").Err(err).Str("userid", userID).Msg("error sending get user by claim id grpc request: transport error")
 		return nil, errorcode.New(errorcode.ServiceNotAvailable, err.Error())
-	case res.Status.Code != cs3rpc.Code_CODE_OK:
-		if res.Status.Code == cs3rpc.Code_CODE_NOT_FOUND {
-			return nil, errorcode.New(errorcode.ItemNotFound, res.Status.Message)
+	case res.GetStatus().GetCode() != cs3rpc.Code_CODE_OK:
+		if res.GetStatus().GetCode() == cs3rpc.Code_CODE_NOT_FOUND {
+			return nil, errorcode.New(errorcode.ItemNotFound, res.GetStatus().GetMessage())
 		}
 		logger.Debug().Str("backend", "cs3").Err(err).Str("userid", userID).Msg("error sending get user by claim id grpc request")
-		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
+		return nil, errorcode.New(errorcode.GeneralException, res.GetStatus().GetMessage())
 	}
-	return CreateUserModelFromCS3(res.User), nil
+	return CreateUserModelFromCS3(res.GetUser()), nil
 }
 
 // GetUsers implements the Backend Interface.
@@ -103,9 +103,9 @@ func (i *CS3) GetUsers(ctx context.Context, oreq *godata.GoDataRequest) ([]*libr
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 
-	users := make([]*libregraph.User, 0, len(res.Users))
+	users := make([]*libregraph.User, 0, len(res.GetUsers()))
 
-	for _, user := range res.Users {
+	for _, user := range res.GetUsers() {
 		users = append(users, CreateUserModelFromCS3(user))
 	}
 
@@ -150,9 +150,9 @@ func (i *CS3) GetGroups(ctx context.Context, oreq *godata.GoDataRequest) ([]*lib
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 
-	groups := make([]*libregraph.Group, 0, len(res.Groups))
+	groups := make([]*libregraph.Group, 0, len(res.GetGroups()))
 
-	for _, group := range res.Groups {
+	for _, group := range res.GetGroups() {
 		groups = append(groups, CreateGroupModelFromCS3(group))
 	}
 
@@ -191,7 +191,7 @@ func (i *CS3) GetGroup(ctx context.Context, groupID string, queryParam url.Value
 		return nil, errorcode.New(errorcode.GeneralException, res.Status.Message)
 	}
 
-	return CreateGroupModelFromCS3(res.Group), nil
+	return CreateGroupModelFromCS3(res.GetGroup()), nil
 }
 
 // DeleteGroup implements the Backend Interface. It's currently not supported for the CS3 backend

--- a/services/graph/pkg/identity/cs3.go
+++ b/services/graph/pkg/identity/cs3.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"context"
 	"net/url"
+	"time"
 
 	"github.com/CiscoM31/godata"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -109,6 +110,11 @@ func (i *CS3) GetUsers(ctx context.Context, oreq *godata.GoDataRequest) ([]*libr
 	}
 
 	return users, nil
+}
+
+// UpdateLastSignInDate implements the Backend Interface. It's currently not supported for the CS3 backend
+func (i *CS3) UpdateLastSignInDate(ctx context.Context, userID string, timestamp time.Time) error {
+	return errNotImplemented
 }
 
 // GetGroups implements the Backend Interface.

--- a/services/graph/pkg/identity/ldap_education_school.go
+++ b/services/graph/pkg/identity/ldap_education_school.go
@@ -47,8 +47,6 @@ const (
 	schoolPropertiesUpdated
 )
 
-const ldapDateFormat = "20060102150405Z0700"
-
 var (
 	errNotSet             = errors.New("attribute not set")
 	errSchoolNameExists   = errorcode.New(errorcode.NameAlreadyExists, "A school with that name is already present")

--- a/services/graph/pkg/identity/mocks/backend.go
+++ b/services/graph/pkg/identity/mocks/backend.go
@@ -11,6 +11,8 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
+	time "time"
+
 	url "net/url"
 )
 
@@ -677,6 +679,54 @@ func (_c *Backend_UpdateGroupName_Call) Return(_a0 error) *Backend_UpdateGroupNa
 }
 
 func (_c *Backend_UpdateGroupName_Call) RunAndReturn(run func(context.Context, string, string) error) *Backend_UpdateGroupName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateLastSignInDate provides a mock function with given fields: ctx, userID, timestamp
+func (_m *Backend) UpdateLastSignInDate(ctx context.Context, userID string, timestamp time.Time) error {
+	ret := _m.Called(ctx, userID, timestamp)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateLastSignInDate")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Time) error); ok {
+		r0 = rf(ctx, userID, timestamp)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Backend_UpdateLastSignInDate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateLastSignInDate'
+type Backend_UpdateLastSignInDate_Call struct {
+	*mock.Call
+}
+
+// UpdateLastSignInDate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - timestamp time.Time
+func (_e *Backend_Expecter) UpdateLastSignInDate(ctx interface{}, userID interface{}, timestamp interface{}) *Backend_UpdateLastSignInDate_Call {
+	return &Backend_UpdateLastSignInDate_Call{Call: _e.mock.On("UpdateLastSignInDate", ctx, userID, timestamp)}
+}
+
+func (_c *Backend_UpdateLastSignInDate_Call) Run(run func(ctx context.Context, userID string, timestamp time.Time)) *Backend_UpdateLastSignInDate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(time.Time))
+	})
+	return _c
+}
+
+func (_c *Backend_UpdateLastSignInDate_Call) Return(_a0 error) *Backend_UpdateLastSignInDate_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Backend_UpdateLastSignInDate_Call) RunAndReturn(run func(context.Context, string, time.Time) error) *Backend_UpdateLastSignInDate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/services/graph/pkg/server/http/server.go
+++ b/services/graph/pkg/server/http/server.go
@@ -49,11 +49,11 @@ func Server(opts ...Option) (http.Service, error) {
 		return http.Service{}, fmt.Errorf("could not initialize http service: %w", err)
 	}
 
-	var publisher events.Stream
+	var eventsStream events.Stream
 
 	if options.Config.Events.Endpoint != "" {
 		var err error
-		publisher, err = stream.NatsFromConfig(options.Config.Service.Name, false, stream.NatsConfig(options.Config.Events))
+		eventsStream, err = stream.NatsFromConfig(options.Config.Service.Name, false, stream.NatsConfig(options.Config.Events))
 		if err != nil {
 			options.Logger.Error().
 				Err(err).
@@ -130,10 +130,12 @@ func Server(opts ...Option) (http.Service, error) {
 
 	var handle svc.Service
 	handle, err = svc.NewService(
+		svc.Context(options.Context),
 		svc.Logger(options.Logger),
 		svc.Config(options.Config),
 		svc.Middleware(middlewares...),
-		svc.EventsPublisher(publisher),
+		svc.EventsPublisher(eventsStream),
+		svc.EventsConsumer(eventsStream),
 		svc.WithRoleService(roleService),
 		svc.WithValueService(valueService),
 		svc.WithRequireAdminMiddleware(requireAdminMiddleware),

--- a/services/graph/pkg/service/v0/graph.go
+++ b/services/graph/pkg/service/v0/graph.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jellydator/ttlcache/v3"
 	"go-micro.dev/v4/client"
-	mevents "go-micro.dev/v4/events"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -27,11 +26,6 @@ import (
 	"github.com/owncloud/ocis/v2/services/graph/pkg/errorcode"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/identity"
 )
-
-// Publisher is the interface for events publisher
-type Publisher interface {
-	Publish(string, interface{}, ...mevents.PublishOption) error
-}
 
 // Permissions is the interface used to access the permissions service
 type Permissions interface {
@@ -68,6 +62,7 @@ type Graph struct {
 	valueService             settingssvc.ValueService
 	specialDriveItemsCache   *ttlcache.Cache[string, interface{}]
 	eventsPublisher          events.Publisher
+	eventsConsumer           events.Consumer
 	searchService            searchsvc.SearchProviderService
 	keycloakClient           keycloak.Client
 	historyClient            ehsvc.EventHistoryService

--- a/services/graph/pkg/service/v0/option.go
+++ b/services/graph/pkg/service/v0/option.go
@@ -1,6 +1,7 @@
 package svc
 
 import (
+	"context"
 	"net/http"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -22,6 +23,7 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
+	Context                  context.Context
 	Logger                   log.Logger
 	Config                   *config.Config
 	Middleware               []func(http.Handler) http.Handler
@@ -34,6 +36,7 @@ type Options struct {
 	ValueService             settingssvc.ValueService
 	RoleManager              *roles.Manager
 	EventsPublisher          events.Publisher
+	EventsConsumer           events.Consumer
 	SearchService            searchsvc.SearchProviderService
 	KeycloakClient           keycloak.Client
 	EventHistoryClient       ehsvc.EventHistoryService
@@ -49,6 +52,13 @@ func newOptions(opts ...Option) Options {
 	}
 
 	return opt
+}
+
+// Context provides a function to set the context option.
+func Context(ctx context.Context) Option {
+	return func(o *Options) {
+		o.Context = ctx
+	}
 }
 
 // Logger provides a function to set the logger option.
@@ -139,6 +149,13 @@ func RoleManager(val *roles.Manager) Option {
 func EventsPublisher(val events.Publisher) Option {
 	return func(o *Options) {
 		o.EventsPublisher = val
+	}
+}
+
+// EventsConsumer provides a function to set the EventsConsumer option.
+func EventsConsumer(val events.Consumer) Option {
+	return func(o *Options) {
+		o.EventsConsumer = val
 	}
 }
 

--- a/services/proxy/pkg/middleware/options.go
+++ b/services/proxy/pkg/middleware/options.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
@@ -69,7 +70,8 @@ type Options struct {
 	// TraceProvider sets the tracing provider.
 	TraceProvider trace.TracerProvider
 	// SkipUserInfo prevents the oidc middleware from querying the userinfo endpoint and read any claims directly from the access token instead
-	SkipUserInfo bool
+	SkipUserInfo    bool
+	EventsPublisher events.Publisher
 }
 
 // newOptions initializes the available default options.
@@ -234,5 +236,12 @@ func TraceProvider(tp trace.TracerProvider) Option {
 func SkipUserInfo(val bool) Option {
 	return func(o *Options) {
 		o.SkipUserInfo = val
+	}
+}
+
+// EventsPublisher sets the events publisher.
+func EventsPublisher(ep events.Publisher) Option {
+	return func(o *Options) {
+		o.EventsPublisher = ep
 	}
 }


### PR DESCRIPTION
Related issue: https://github.com/owncloud/enterprise/issues/6726

To allow tracking new user signins we're are now emitting an `UserSignedIn` event from the proxy's account resolve middleware.

A goroutine, started as part of the graph service (the only service that might have write access to the idm database currently) consumes that event and updates a new LDAP attribute `ocLastSignInTimestamp` on the user object.

The PR does not yet expose the attribute on the `users` endpoint. Support for that will be added in a separate PR.