### PR TITLE
[full-ci] chore: bump ownCloud Web to v8.0.5

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=cced82ea44f4dee524eae365c5c82e0831f2453c
+WEB_COMMITID=2095462acf3163569802daef1eba0bc9b17710f4
 WEB_BRANCH=stable-8.0

--- a/changelog/unreleased/update-web-8.0.5.md
+++ b/changelog/unreleased/update-web-8.0.5.md
@@ -1,0 +1,13 @@
+Enhancement: Update web to v8.0.5
+
+Tags: web
+
+We updated ownCloud Web to v8.0.5. Please refer to the changelog (linked) for details on the web release.
+
+- Bugfix [owncloud/web#11395](https://github.com/owncloud/web/pull/11395): Missing space members for group memberships
+- Bugfix [owncloud/web#11263](https://github.com/owncloud/web/pull/11263): Show more toggle in space members view not reactive
+- Bugfix [owncloud/web#11263](https://github.com/owncloud/web/pull/11263): Space show links from other spaces
+- Bugfix [owncloud/web#11303](https://github.com/owncloud/web/pull/11303): Uploading nested folders
+
+https://github.com/owncloud/ocis/pull/9958
+https://github.com/owncloud/web/releases/tag/v8.0.5

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v8.0.4
+WEB_ASSETS_VERSION = v8.0.5
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
- Bugfix [owncloud/web#11395](https://github.com/owncloud/web/pull/11395): Missing space members for group memberships
- Bugfix [owncloud/web#11263](https://github.com/owncloud/web/pull/11263): Show more toggle in space members view not reactive
- Bugfix [owncloud/web#11263](https://github.com/owncloud/web/pull/11263): Space show links from other spaces
- Bugfix [owncloud/web#11303](https://github.com/owncloud/web/pull/11303): Uploading nested folders