### PR TITLE
[docs-only] Small ocm text fix

### DIFF
--- a/services/ocm/README.md
+++ b/services/ocm/README.md
@@ -15,11 +15,11 @@ Internal GRPC APIs:
 
 ## Enable OCM
 
-To enable OpenCloudMesh you have to set three environment variables. The path  `/etc/ocis` in the example below depends on the installation type and derives, if not otherwise defined from the `OCIS_CONFIG_DIR` envvar.
+To enable OpenCloudMesh, you have to set the following environment variables. The path  `/etc/ocis/` in the example below depends on the installation type and derives, if not otherwise defined, from the `OCIS_CONFIG_DIR` envvar.
+
 ```console
 export OCIS_ENABLE_OCM=true
 export OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE="/etc/ocis/ocmproviders.json"
-export OCIS_ADD_RUN_SERVICES="ocm"
 ```
 
 {{< hint info >}}

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -103,7 +103,7 @@ type OCMInviteManagerDrivers struct {
 }
 
 type OCMInviteManagerJSONDriver struct {
-	File string `yaml:"file" env:"OCM_OCM_INVITE_MANAGER_JSON_FILE" desc:"Path to the JSON file where OCM invite data will be stored. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/storage." introductionVersion:"5.0"`
+	File string `yaml:"file" env:"OCM_OCM_INVITE_MANAGER_JSON_FILE" desc:"Path to the JSON file where OCM invite data will be stored. This file is maintained by the instance and must not be changed manually. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/storage." introductionVersion:"5.0"`
 }
 
 type OCMProviderAuthorizerDrivers struct {


### PR DESCRIPTION
References: #9814 ([docs-only] update ocm service readme)

* After clarification with @micbar, the ocm service is started, for the time being, automatically with the runtime.
* After clarification with @butonic the `OCM_OCM_INVITE_MANAGER_JSON_FILE` is maintained by the instance. This makes it clear that the location is therefore different compared to `OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE`...