### PR TITLE
[full-ci] enhancement: handle ocm event notifications

### DIFF
--- a/changelog/unreleased/enhancement-ocm-handle-invite-generated-event.md
+++ b/changelog/unreleased/enhancement-ocm-handle-invite-generated-event.md
@@ -1,0 +1,10 @@
+Enhancement: Handle OCM invite generated event
+
+Both the notification and audit services now handle the OCM invite generated event.
+
+ - The notification service is responsible for sending an email to the invited user.
+ - The audit service is responsible for logging the event.
+
+https://github.com/owncloud/ocis/pull/9966
+https://github.com/cs3org/reva/pull/4832
+https://github.com/owncloud/ocis/issues/9583

--- a/services/audit/pkg/service/service.go
+++ b/services/audit/pkg/service/service.go
@@ -109,6 +109,8 @@ func StartAuditLogger(ctx context.Context, ch <-chan events.Event, log log.Logge
 				auditEvent = types.GroupMemberAdded(ev)
 			case events.GroupMemberRemoved:
 				auditEvent = types.GroupMemberRemoved(ev)
+			case events.ScienceMeshInviteTokenGenerated:
+				auditEvent = types.ScienceMeshInviteTokenGenerated(ev)
 			default:
 				log.Error().Interface("event", ev).Msg(fmt.Sprintf("can't handle event of type '%T'", ev))
 				continue

--- a/services/audit/pkg/service/service_test.go
+++ b/services/audit/pkg/service/service_test.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/audit/pkg/types"
-	"github.com/stretchr/testify/require"
 
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -556,6 +557,33 @@ var testCases = []struct {
 			checkBaseAuditEvent(t, ev.AuditEvent, "", "0001-01-01T00:00:00Z", "user 'uid-123' deleted the space 'space-123' (storage: 'storage-1')", "space_deleted")
 			// AuditEventSpaces fields
 			checkSpacesAuditEvent(t, ev.AuditEventSpaces, "storage-1$space-123")
+		},
+	},
+	{
+		Alias: "ScienceMesh - InviteTokenGenerated",
+		SystemEvent: events.Event{
+			Event: events.ScienceMeshInviteTokenGenerated{
+				Sharer:        userID("sharer-user-id"),
+				RecipientMail: "mail@ocis.test",
+				Token:         "token-123",
+				Description:   "some-description",
+				Expiration:    uint64(10e8),
+				InviteLink:    "http://ocis.test/invite",
+				Timestamp:     timestamp(10e8),
+			},
+		},
+		CheckAuditEvent: func(t *testing.T, b []byte) {
+			ev := types.AuditEventScienceMeshInviteTokenGenerated{}
+			require.NoError(t, json.Unmarshal(b, &ev))
+
+			// AuditEvent fields
+			checkBaseAuditEvent(t, ev.AuditEvent, "sharer-user-id", "2001-09-09T01:46:40Z", "user 'sharer-user-id' generated a ScienceMesh invite with token 'token-123'", "science_mesh_invite_token_generated")
+			// AuditEventScienceMeshInviteTokenGenerated fields
+			require.Equal(t, "mail@ocis.test", ev.RecipientMail)
+			require.Equal(t, "token-123", ev.Token)
+			require.Equal(t, "some-description", ev.Description)
+			require.Equal(t, uint64(10e8), ev.Expiration)
+			require.Equal(t, "http://ocis.test/invite", ev.InviteLink)
 		},
 	},
 }

--- a/services/audit/pkg/types/conversion.go
+++ b/services/audit/pkg/types/conversion.go
@@ -13,6 +13,7 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+
 	sdk "github.com/cs3org/reva/v2/pkg/sdk/common"
 )
 
@@ -502,6 +503,20 @@ func GroupMemberRemoved(ev events.GroupMemberRemoved) AuditEventGroupMemberRemov
 		AuditEvent: base,
 		GroupID:    ev.GroupID,
 		UserID:     ev.UserID,
+	}
+}
+
+// ScienceMeshInviteTokenGenerated converts a ScienceMeshInviteTokenGenerated event to an AuditEventScienceMeshInviteTokenGenerated
+func ScienceMeshInviteTokenGenerated(ev events.ScienceMeshInviteTokenGenerated) AuditEventScienceMeshInviteTokenGenerated {
+	msg := MessageScienceMeshInviteTokenGenerated(ev.Sharer.GetOpaqueId(), ev.Token)
+	base := BasicAuditEvent(ev.Sharer.GetOpaqueId(), formatTime(ev.Timestamp), msg, ActionScienceMeshInviteTokenGenerated)
+	return AuditEventScienceMeshInviteTokenGenerated{
+		AuditEvent:    base,
+		RecipientMail: ev.RecipientMail,
+		Token:         ev.Token,
+		Description:   ev.Description,
+		Expiration:    ev.Expiration,
+		InviteLink:    ev.InviteLink,
 	}
 }
 

--- a/services/audit/pkg/types/events.go
+++ b/services/audit/pkg/types/events.go
@@ -40,5 +40,6 @@ func RegisteredEvents() []events.Unmarshaller {
 		events.GroupMemberAdded{},
 		events.GroupMemberRemoved{},
 		events.BackchannelLogout{},
+		events.ScienceMeshInviteTokenGenerated{},
 	}
 }

--- a/services/audit/pkg/types/messages.go
+++ b/services/audit/pkg/types/messages.go
@@ -51,6 +51,9 @@ const (
 	ActionGroupDeleted       = "group_deleted"
 	ActionGroupMemberAdded   = "group_member_added"
 	ActionGroupMemberRemoved = "group_member_removed"
+
+	// ScienceMesh
+	ActionScienceMeshInviteTokenGenerated = "science_mesh_invite_token_generated"
 )
 
 // MessageShareCreated returns the human-readable string that describes the action
@@ -233,4 +236,9 @@ func MessageGroupMemberAdded(executant, userID, groupID string) string {
 // MessageGroupMemberRemoved returns the human-readable string that describes the action
 func MessageGroupMemberRemoved(executant, userID, groupID string) string {
 	return fmt.Sprintf("user '%s' added user '%s' was removed from group '%s'", executant, userID, groupID)
+}
+
+// MessageScienceMeshInviteTokenGenerated returns the human-readable string that describes the action
+func MessageScienceMeshInviteTokenGenerated(user, token string) string {
+	return fmt.Sprintf("user '%s' generated a ScienceMesh invite with token '%s'", user, token)
 }

--- a/services/audit/pkg/types/types.go
+++ b/services/audit/pkg/types/types.go
@@ -274,3 +274,13 @@ type AuditEventGroupMemberRemoved struct {
 	GroupID string
 	UserID  string
 }
+
+// AuditEventScienceMeshInviteTokenGenerated is the event logged when a ScienceMesh invite token is generated
+type AuditEventScienceMeshInviteTokenGenerated struct {
+	AuditEvent
+	RecipientMail string
+	Token         string
+	Description   string
+	Expiration    uint64
+	InviteLink    string
+}

--- a/services/notifications/pkg/channels/channels.go
+++ b/services/notifications/pkg/channels/channels.go
@@ -7,10 +7,11 @@ import (
 	stdmail "net/mail"
 	"strings"
 
-	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
 	"github.com/pkg/errors"
 	mail "github.com/xhit/go-simple-mail/v2"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
 )
 
 // Channel defines the methods of a communication channel.
@@ -108,7 +109,7 @@ func (m Mail) getMailClient() (*mail.SMTPClient, error) {
 }
 
 // SendMessage sends a message to all given users.
-func (m Mail) SendMessage(ctx context.Context, message *Message) error {
+func (m Mail) SendMessage(_ context.Context, message *Message) error {
 	if m.conf.Notifications.SMTP.Host == "" {
 		m.logger.Info().Str("mail", "SendMessage").Msg("failed to send a message. SMTP host is  not set")
 		return nil

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oklog/run"
+	"github.com/urfave/cli/v2"
+
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/stream"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
-	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
 	"github.com/owncloud/ocis/v2/ocis-pkg/handlers"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
@@ -21,7 +23,6 @@ import (
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config/parser"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/logging"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/service"
-	"github.com/urfave/cli/v2"
 )
 
 // Server is the entrypoint for the server command.
@@ -82,6 +83,7 @@ func Server(cfg *config.Config) *cli.Command {
 				events.SpaceShared{},
 				events.SpaceUnshared{},
 				events.SpaceMembershipExpired{},
+				events.ScienceMeshInviteTokenGenerated{},
 			}
 			client, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Notifications.Events))
 			if err != nil {

--- a/services/notifications/pkg/email/email.go
+++ b/services/notifications/pkg/email/email.go
@@ -25,7 +25,7 @@ var (
 	imgDir = filepath.Join("templates", "html", "img")
 )
 
-// RenderEmailTemplate renders the email template for a new share
+// RenderEmailTemplate is responsible to prepare a message which than can be used to notify the user via email.
 func RenderEmailTemplate(mt MessageTemplate, locale, defaultLocale string, emailTemplatePath string, translationPath string, vars map[string]string) (*channels.Message, error) {
 	textMt, err := NewTextTemplate(mt, locale, defaultLocale, translationPath, vars)
 	if err != nil {

--- a/services/notifications/pkg/email/templates.go
+++ b/services/notifications/pkg/email/templates.go
@@ -81,12 +81,12 @@ Even though this membership has expired you still might have access through othe
 		// ScienceMeshInviteTokenGenerated email template, resolves via {{ .Greeting }}
 		Greeting: l10n.Template(`Hi,`),
 		// ScienceMeshInviteTokenGenerated email template, resolves via {{ .MessageBody }}
-		MessageBody: l10n.Template(`{ShareSharer} ({ShareSharerMail}) wants to start sharing OCM resources with you.
+		MessageBody: l10n.Template(`{ShareSharer} ({ShareSharerMail}) wants to start sharing collaboration resources with you.
 {{if .ShareLink }}To accept the invite, please visit the following URL:
 {ShareLink}
 
 Alternatively, you can{{else}}
-Please{{end}} visit your mesh provider and use the following details:
+Please{{end}} visit your federation provider and use the following details:
   Token: {Token}
   ProviderDomain: {ProviderDomain}`),
 	}

--- a/services/notifications/pkg/email/templates.go
+++ b/services/notifications/pkg/email/templates.go
@@ -72,18 +72,39 @@ You might still have access through your other groups or direct membership.`),
 
 Even though this membership has expired you still might have access through other shares and/or space memberships`),
 	}
+
+	ScienceMeshInviteTokenGenerated = MessageTemplate{
+		textTemplate: "templates/text/email.text.tmpl",
+		htmlTemplate: "templates/html/email.html.tmpl",
+		// ScienceMeshInviteTokenGenerated email template, Subject field (resolves directly)
+		Subject: l10n.Template(`ScienceMesh: {InitiatorName} wants to collaborate with you`),
+		// ScienceMeshInviteTokenGenerated email template, resolves via {{ .Greeting }}
+		Greeting: l10n.Template(`Hi,`),
+		// ScienceMeshInviteTokenGenerated email template, resolves via {{ .MessageBody }}
+		MessageBody: l10n.Template(`{ShareSharer} ({ShareSharerMail}) wants to start sharing OCM resources with you.
+{{if .ShareLink }}To accept the invite, please visit the following URL:
+{ShareLink}
+
+Alternatively, you can{{else}}
+Please{{end}} visit your mesh provider and use the following details:
+  Token: {Token}
+  ProviderDomain: {ProviderDomain}`),
+	}
 )
 
 // holds the information to turn the raw template into a parseable go template
 var _placeholders = map[string]string{
-	"{ShareSharer}":  "{{ .ShareSharer }}",
-	"{ShareFolder}":  "{{ .ShareFolder }}",
-	"{ShareGrantee}": "{{ .ShareGrantee }}",
-	"{ShareLink}":    "{{ .ShareLink }}",
-	"{SpaceName}":    "{{ .SpaceName }}",
-	"{SpaceGrantee}": "{{ .SpaceGrantee }}",
-	"{SpaceSharer}":  "{{ .SpaceSharer }}",
-	"{ExpiredAt}":    "{{ .ExpiredAt }}",
+	"{ShareSharer}":     "{{ .ShareSharer }}",
+	"{ShareFolder}":     "{{ .ShareFolder }}",
+	"{ShareGrantee}":    "{{ .ShareGrantee }}",
+	"{ShareLink}":       "{{ .ShareLink }}",
+	"{SpaceName}":       "{{ .SpaceName }}",
+	"{SpaceGrantee}":    "{{ .SpaceGrantee }}",
+	"{SpaceSharer}":     "{{ .SpaceSharer }}",
+	"{ExpiredAt}":       "{{ .ExpiredAt }}",
+	"{ShareSharerMail}": "{{ .ShareSharerMail }}",
+	"{ProviderDomain}":  "{{ .ProviderDomain }}",
+	"{Token}":           "{{ .Token }}",
 }
 
 // MessageTemplate is the data structure for the email

--- a/services/notifications/pkg/service/sciencemesh.go
+++ b/services/notifications/pkg/service/sciencemesh.go
@@ -1,0 +1,9 @@
+package service
+
+import (
+	"github.com/cs3org/reva/v2/pkg/events"
+)
+
+func (s eventsNotifier) handleScienceMeshInviteTokenGenerated(e events.ScienceMeshInviteTokenGenerated) {
+	// fixMe: add implementation
+}

--- a/services/notifications/pkg/service/sciencemesh.go
+++ b/services/notifications/pkg/service/sciencemesh.go
@@ -1,9 +1,77 @@
 package service
 
 import (
+	"context"
+
 	"github.com/cs3org/reva/v2/pkg/events"
+	"github.com/cs3org/reva/v2/pkg/utils"
+	"github.com/owncloud/ocis/v2/services/notifications/pkg/channels"
+	"github.com/owncloud/ocis/v2/services/notifications/pkg/email"
 )
 
 func (s eventsNotifier) handleScienceMeshInviteTokenGenerated(e events.ScienceMeshInviteTokenGenerated) {
-	// fixMe: add implementation
+	logger := s.logger.With().
+		Str("event", "ScienceMeshInviteTokenGenerated").
+		Logger()
+
+	gatewayClient, err := s.gatewaySelector.Next()
+	if err != nil {
+		logger.Error().Err(err).Msg("could not select next gateway client")
+		return
+	}
+
+	ctx, err := utils.GetServiceUserContextWithContext(context.Background(), gatewayClient, s.serviceAccountID, s.serviceAccountSecret)
+	if err != nil {
+		logger.Error().Err(err).Msg("Could not impersonate service user")
+		return
+	}
+
+	owner, err := utils.GetUserWithContext(ctx, e.Sharer, gatewayClient)
+	if err != nil {
+		logger.Error().Err(err).Msg("unable to get user")
+		return
+	}
+
+	msgENV := map[string]string{
+		"ShareSharer":     owner.GetDisplayName(),
+		"ShareSharerMail": owner.GetMail(),
+		"ShareLink":       e.InviteLink,
+		"Token":           e.Token,
+		"ProviderDomain":  owner.GetId().GetIdp(),
+		"RecipientMail":   e.RecipientMail,
+	}
+
+	// validate the message, we only need recipient mail at the moment,
+	// event that is optional when the event got triggered...
+	// this means if we get a validation error, we can't send the message and skip it
+	{
+		validationEnv := make(map[string]interface{}, len(msgENV))
+		for k, v := range msgENV {
+			validationEnv[k] = v
+		}
+		if errs := validate.ValidateMap(validationEnv,
+			map[string]interface{}{
+				"RecipientMail": "required,email", // only recipient mail is required to send the message
+			}); len(errs) > 0 {
+			return // no mail, no message
+		}
+	}
+
+	msg, err := email.RenderEmailTemplate(
+		email.ScienceMeshInviteTokenGenerated,
+		s.defaultLanguage, // fixMe: the recipient is unknown, should it be the defaultLocale?,
+		s.defaultLanguage, // fixMe: the defaultLocale is not set by default, shouldn't it be?,
+		s.emailTemplatePath,
+		s.translationPath,
+		msgENV,
+	)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("building the message has failed")
+		return
+	}
+
+	msg.Sender = owner.GetDisplayName()
+	msg.Recipient = []string{e.RecipientMail}
+
+	s.send(ctx, []*channels.Message{msg})
 }

--- a/services/notifications/pkg/service/service.go
+++ b/services/notifications/pkg/service/service.go
@@ -16,6 +16,7 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/go-playground/validator/v10"
 	"go-micro.dev/v4/metadata"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -29,6 +30,13 @@ import (
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/email"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/store/defaults"
 )
+
+// validate is the package level validator instance
+var validate *validator.Validate
+
+func init() {
+	validate = validator.New()
+}
 
 // Service should be named `Runner`
 type Service interface {

--- a/services/notifications/pkg/service/service.go
+++ b/services/notifications/pkg/service/service.go
@@ -16,6 +16,9 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"go-micro.dev/v4/metadata"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/ocis/v2/ocis-pkg/l10n"
@@ -25,8 +28,6 @@ import (
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/channels"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/email"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/store/defaults"
-	"go-micro.dev/v4/metadata"
-	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // Service should be named `Runner`
@@ -92,6 +93,8 @@ func (s eventsNotifier) Run() error {
 					s.handleShareCreated(e)
 				case events.ShareExpired:
 					s.handleShareExpired(e)
+				case events.ScienceMeshInviteTokenGenerated:
+					s.handleScienceMeshInviteTokenGenerated(e)
 				}
 			}()
 		case <-s.signals:

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 	"go-micro.dev/v4/client"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 )
 
 // Config combines all available configuration parts.
@@ -24,6 +25,7 @@ type Config struct {
 	GRPCClientTLS  *shared.GRPCClientTLS `yaml:"grpc_client_tls"`
 	GrpcClient     client.Client         `yaml:"-"`
 	ServiceAccount ServiceAccount        `yaml:"service_account"`
+	Events         Events                `yaml:"-"`
 
 	Reva                         *shared.Reva                 `yaml:"reva"`
 	OCMD                         OCMD                         `yaml:"ocmd"`
@@ -145,4 +147,15 @@ type OCMShareProviderDrivers struct {
 
 type OCMShareProviderJSONDriver struct {
 	File string `yaml:"file" env:"OCM_OCM_SHAREPROVIDER_JSON_FILE" desc:"Path to the JSON file where OCM share data will be stored. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/storage." introductionVersion:"5.0"`
+}
+
+// Events combine the configuration options for the event bus.
+type Events struct {
+	Endpoint             string `yaml:"endpoint" env:"OCIS_EVENTS_ENDPOINT;OCM_EVENTS_ENDPOINT" desc:"The address of the event system. The event system is the message queuing service. It is used as message broker for the microservice architecture." introductionVersion:"pre5.0"`
+	Cluster              string `yaml:"cluster" env:"OCIS_EVENTS_CLUSTER;OCM_EVENTS_CLUSTER" desc:"The clusterID of the event system. The event system is the message queuing service. It is used as message broker for the microservice architecture. Mandatory when using NATS as event system." introductionVersion:"pre5.0"`
+	TLSInsecure          bool   `yaml:"tls_insecure" env:"OCIS_INSECURE;OCM_EVENTS_TLS_INSECURE" desc:"Whether to verify the server TLS certificates." introductionVersion:"pre5.0"`
+	TLSRootCACertificate string `yaml:"tls_root_ca_certificate" env:"OCIS_EVENTS_TLS_ROOT_CA_CERTIFICATE;OCM_EVENTS_TLS_ROOT_CA_CERTIFICATE" desc:"The root CA certificate used to validate the server's TLS certificate. If provided OCM_EVENTS_TLS_INSECURE will be seen as false." introductionVersion:"pre5.0"`
+	EnableTLS            bool   `yaml:"enable_tls" env:"OCIS_EVENTS_ENABLE_TLS;OCM_EVENTS_ENABLE_TLS" desc:"Enable TLS for the connection to the events broker. The events broker is the ocis service which receives and delivers events between the services." introductionVersion:"pre5.0"`
+	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;OCM_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services." introductionVersion:"5.0"`
+	AuthPassword         string `yaml:"password" env:"OCIS_EVENTS_AUTH_PASSWORD;OCM_EVENTS_AUTH_PASSWORD" desc:"The password to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services." introductionVersion:"5.0"`
 }

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -85,6 +85,10 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "ocm",
 		},
+		Events: config.Events{
+			Endpoint: "127.0.0.1:9233",
+			Cluster:  "ocis-cluster",
+		},
 		ScienceMesh: config.ScienceMesh{
 			Prefix: "sciencemesh",
 		},

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -47,6 +47,14 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 					"gatewaysvc":         cfg.Reva.Address,
 					"mesh_directory_url": cfg.ScienceMesh.MeshDirectoryURL,
 					"provider_domain":    cfg.Commons.OcisURL,
+					"events": map[string]interface{}{
+						"natsaddress":          cfg.Events.Endpoint,
+						"natsclusterid":        cfg.Events.Cluster,
+						"tlsinsecure":          cfg.Events.TLSInsecure,
+						"tlsrootcacertificate": cfg.Events.TLSRootCACertificate,
+						"authusername":         cfg.Events.AuthUsername,
+						"authpassword":         cfg.Events.AuthPassword,
+					},
 				},
 				"ocmd": map[string]interface{}{
 					"prefix":                        cfg.OCMD.Prefix,


### PR DESCRIPTION
## Description
By now, the sciencemesh part in reva was responsible to notify the invitee that a invitaion happened, in ocis we have a event driven approach.

This PR introduces that and handles those invitation events in the notification service by sending mails.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/9583
- Needs: https://github.com/cs3org/reva/pull/4832
- Needs: https://github.com/owncloud/web/pull/11512

## How Has This Been Tested?
- not at all right now, next step

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
