### PR TITLE
[tests-only][full-ci] added test to create .odt file inside shared folder using `/app/new` endpoint

### DIFF
--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -825,7 +825,7 @@ Feature: collaboration (wopi)
       | Manager          |
 
 
-  Scenario: user with Viewer role tries to create a text file inside shared project space using wopi endpoint
+  Scenario: user with Viewer role tries to create a odt file inside shared project space using wopi endpoint
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
@@ -859,3 +859,68 @@ Feature: collaboration (wopi)
       | simple.odt |
     And for user "Brian" folder "testFolder" of the space "new-space" should not contain these files:
       | simple.odt |
+
+
+  Scenario Outline: sharee with permission Editor/Uploader creates odt file inside shared folder using wopi endpoint
+    Given user "Alice" has created folder "testFolder"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testFolder         |
+      | space           | Personal           |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+    When user "Brian" creates a file "simple.odt" inside folder "testFolder" in space "Shares" using wopi endpoint
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "file_id"
+        ],
+        "properties": {
+          "file_id": {
+            "type": "string",
+            "pattern": "^%file_id_pattern%$"
+          }
+        }
+      }
+      """
+    And as "Alice" file "testFolder/simple.odt" should exist
+    And as "Brian" file "Shares/testFolder/simple.odt" should exist
+    Examples:
+      | permissions-role |
+      | Editor           |
+      | Uploader         |
+
+
+  Scenario: sharee with permission Viewer tries to create odt file inside shared folder using wopi endpoint
+    Given user "Alice" has created folder "testFolder"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testFolder |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    When user "Brian" tries to create a file "simple.odt" inside folder "testFolder" in space "Shares" using wopi endpoint
+    Then the HTTP status code should be "500"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "const": "SERVER_ERROR"
+          },
+          "message": {
+            "const": "error calling InitiateFileUpload"
+          }
+        }
+      }
+      """
+    And as "Alice" file "testFolder/simple.odt" should not exist
+    And as "Brian" file "Shares/testFolder/simple.odt" should not exist


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added test to create .odt file inside a shared folder using `/app/new` endpoint.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/9682

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
