### PR TITLE
[tests-only][full-ci] test: add test coverage for opening file using /app/open-with-web  endpoint with different view mode

### DIFF
--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -466,3 +466,30 @@ Feature: collaboration (wopi)
       | app-endpoint                                              | url-query       |
       | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice& |
       | /app/open-with-web?file_id=<<FILEID>>                     |                 |
+
+
+  Scenario Outline: open file with .odt extension with different view mode (open-with-web)
+    Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
+    And we save it into "FILEID"
+    When user "Alice" sends HTTP method "POST" to URL "<app-endpoint>"
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "uri"
+        ],
+        "properties": {
+          "uri": {
+            "type": "string",
+             "pattern": "%base_url%/external\\?app=FakeOffice&contextRouteName=files-spaces-personal&fileId=%uuidv4_pattern%%24%uuidv4_pattern%%21%uuidv4_pattern%$"
+          }
+        }
+      }
+      """
+    Examples:
+      | app-endpoint                                                              |
+      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice&view_mode=view  |
+      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice&view_mode=read  |
+      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice&view_mode=write |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added test to send post request to /app/open-with-web endpoint with different view mode, view_mode=[view | read | write]

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to: https://github.com/owncloud/ocis/issues/9682

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
