### PR TITLE
[docs-only] Small fix for ocm envvar description text

### DIFF
--- a/services/ocm/README.md
+++ b/services/ocm/README.md
@@ -15,17 +15,11 @@ Internal GRPC APIs:
 
 ## Enable OCM
 
-To enable OpenCloudMesh, you have to set the following environment variables. The path  `/etc/ocis/` in the example below depends on the installation type and derives, if not otherwise defined, from the `OCIS_CONFIG_DIR` envvar.
+To enable OpenCloudMesh, you have to set the following environment variable.
 
 ```console
-export OCIS_ENABLE_OCM=true
-export OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE="/etc/ocis/ocmproviders.json"
+OCIS_ENABLE_OCM=true
 ```
-
-{{< hint info >}}
-Point `OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE` to a file as described below.
-{{< /hint >}}
-
 
 ## Trust Between Instances
 

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -103,7 +103,7 @@ type OCMInviteManagerDrivers struct {
 }
 
 type OCMInviteManagerJSONDriver struct {
-	File string `yaml:"file" env:"OCM_OCM_INVITE_MANAGER_JSON_FILE" desc:"Path to the JSON file where OCM invite data will be stored. This file is maintained by the instance and must not be changed manually. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/storage." introductionVersion:"5.0"`
+	File string `yaml:"file" env:"OCM_OCM_INVITE_MANAGER_JSON_FILE" desc:"Path to the JSON file where OCM invite data will be stored. This file is maintained by the instance and must not be changed manually. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/storage/ocm." introductionVersion:"5.0"`
 }
 
 type OCMProviderAuthorizerDrivers struct {


### PR DESCRIPTION
The default path shows `/var/lib/ocis/storage/ocm` but the description text only `$OCIS_BASE_DATA_PATH:/storage`. Fixed by adding `/ocm`.

The readme also has a text fix which was a leftover. 