### PR TITLE
[docs-only] Update translation docs + transifex configuration (add resource_name)

### DIFF
--- a/docs/services/general-info/add-translations.md
+++ b/docs/services/general-info/add-translations.md
@@ -39,10 +39,12 @@ Translations have a `context` and a `translatable string`. The context is shown 
   [o:owncloud-org:p:owncloud:r:ocis-<service-name>]
   file_filter = locale/<lang>/LC_MESSAGES/<service-name>.po
   minimum_perc = 75
+  resource_name = ocis-<service-name>
   source_file = <service-name>.pot
   source_lang = en
   type = PO
   ```
+  Note: o: organsiation, p: project, r: resource
 
 * Create a go file like `templates.go` in `ocis/services/<service-name>/pkg/service` that will define your translation sources like the following:
   ```
@@ -57,6 +59,7 @@ Translations have a `context` and a `translatable string`. The context is shown 
   	services/notifications \
   	services/userlog \
   	services/graph \
+  	services/activitylog \
   	services/<service-name>
   ```
 

--- a/docs/services/general-info/add-translations.md
+++ b/docs/services/general-info/add-translations.md
@@ -44,7 +44,7 @@ Translations have a `context` and a `translatable string`. The context is shown 
   source_lang = en
   type = PO
   ```
-  Note: o: organsiation, p: project, r: resource
+  Note: o: organization, p: project, r: resource
 
 * Create a go file like `templates.go` in `ocis/services/<service-name>/pkg/service` that will define your translation sources like the following:
   ```

--- a/services/activitylog/pkg/service/l10n/.tx/config
+++ b/services/activitylog/pkg/service/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud:r:ocis-activitylog]
 file_filter = locale/<lang>/LC_MESSAGES/activitylog.po
 minimum_perc = 75
+resource_name = ocis-activitylog
 source_file = activitylog.pot
 source_lang = en
 type = PO

--- a/services/graph/pkg/l10n/.tx/config
+++ b/services/graph/pkg/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud:r:ocis-graph]
 file_filter = locale/<lang>/LC_MESSAGES/graph.po
 minimum_perc = 75
+resource_name = ocis-graph
 source_file = graph.pot
 source_lang = en
 type = PO

--- a/services/notifications/pkg/email/l10n/.tx/config
+++ b/services/notifications/pkg/email/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud:r:ocis-notifications]
 file_filter = locale/<lang>/LC_MESSAGES/notifications.po
 minimum_perc = 75
+resource_name = ocis-notifications
 source_file = notifications.pot
 source_lang = en
 type = PO

--- a/services/userlog/pkg/service/l10n/.tx/config
+++ b/services/userlog/pkg/service/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud:r:ocis-userlog]
 file_filter = locale/<lang>/LC_MESSAGES/userlog.po
 minimum_perc = 75
+resource_name = ocis-userlog
 source_file = userlog.pot
 source_lang = en
 type = PO


### PR DESCRIPTION
The translation docs missed the entry that we need to have `resource_name` added in the definition when setting up a new translation for a service. This leaded to the situation that we have thought we defined a name to show up in TX as `ocis-<service-name>` but its showed up as `<service-name>.pot`. Then we manually needed to fix the name in TX for ease of identification.

This is now fixed not only in the dev docs, but also corrected in the TX definition of all 4 services which have translations set up.

@kobergj @2403905 fyi 😃 

Thanks for @DeepDiver1975 pointing me to the missing piece