### PR TITLE
[tests-only][full-ci] add tests to check versions of file in a space shared via link with viewer/editor role

### DIFF
--- a/tests/acceptance/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/bootstrap/FilesVersionsContext.php
@@ -73,6 +73,32 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
+	 * @When the public tries to get the number of versions of file :file with password :password using file-id path :endpoint
+	 *
+	 * @param string $file
+	 * @param string $password
+	 * @param string $endpoint
+	 *
+	 * @return void
+	 */
+	public function thePublicGetsTheNumberOfVersionsOfFileWithPasswordUsingFileIdPath(string $file, string $password, string $endpoint): void {
+		$password = $this->featureContext->getActualPassword($password);
+		$this->featureContext->setResponse(
+			$this->featureContext->makeDavRequest(
+				"public",
+				"PROPFIND",
+				$endpoint,
+				null,
+				null,
+				"versions",
+				(string)$this->featureContext->getDavPathVersion(),
+				false,
+				$password
+			)
+		);
+	}
+
+	/**
 	 * @param string $user
 	 * @param string $file
 	 * @param string|null $fileOwner

--- a/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
@@ -175,3 +175,34 @@ Feature: checking file versions using file id
       | permissionsRole | Space Editor Without Versions |
     When user "Brian" gets the number of versions of file "/text.txt" using file-id path "/meta/<<FILEID>>/v"
     Then the HTTP status code should be "403"
+
+
+  Scenario Outline: public tries to check the versions of a file in a project space shared via link as viewer/editor
+    Given user "Alice" has created the following space link share:
+      | space           | Project1           |
+      | permissionsRole | <permissions-role> |
+      | password        | %public%           |
+    When the public tries to get the number of versions of file "/text.txt" with password "%public%" using file-id path "/meta/<<FILEID>>/v"
+    Then the HTTP status code should be "401"
+    Examples:
+      | permissions-role |
+      | view             |
+      | edit             |
+
+
+  Scenario Outline: public tries to check the versions of a file in a personal space shared via link as viewer/editor
+    Given user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+    And user "Alice" has uploaded file with content "some updated data" to "/PARENT/parent.txt"
+    And we save it into "FILEID"
+    And user "Alice" has created the following resource link share:
+      | resource           | PARENT             |
+      | space              | Personal           |
+      | permissionsRole    | <permissions-role> |
+      | password           | %public%           |
+    When the public tries to get the number of versions of file "/parent.txt" with password "%public%" using file-id path "/meta/<<FILEID>>/v"
+    Then the HTTP status code should be "401"
+    Examples:
+      | permissions-role |
+      | view             |
+      | edit             |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds tests to check versions of a file inside a Personal and Project space that is shared via link with viewer and editor roles.
``` feature
Scenario Outline: check the versions of a file in a space shared via link as viewer/editor
Scenario Outline: check the versions of a file in a personal space shared via link as viewer
```
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to: https://github.com/owncloud/ocis/issues/9955

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
