### PR TITLE
[tests-only][full-ci] added test for public user to create odt file inside public space

### DIFF
--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -122,18 +122,16 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When the public creates a file :file inside the last shared public link folder with password :password using wopi endpoint
-	 * @When the public tries to create a file :file inside the last shared public link folder with password :password using wopi endpoint
-	 *
 	 * @param string $file
 	 * @param string $password
+	 * @param string $folder
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function thePublicCreatesAFileInsideTheLastSharedPublicLinkFolderWithPasswordUsingWopiEndpoint(string $file, string $password): void {
+	public function createFile(string $file, string $password, string $folder = ""): void {
 		$token = $this->featureContext->shareNgGetLastCreatedLinkShareToken();
-		$davPath = WebDavHelper::getDavPath($token, null, "public-files-new");
+		$davPath = WebDavHelper::getDavPath($token, null, "public-files-new") . "/$folder";
 		$response = HttpRequestHelper::sendRequest(
 			$this->featureContext->getBaseUrl() . "/$davPath",
 			$this->featureContext->getStepLineRef(),
@@ -162,6 +160,35 @@ class CollaborationContext implements Context {
 				$headers
 			)
 		);
+	}
+
+	/**
+	 * @When the public creates a file :file inside the last shared public link folder with password :password using wopi endpoint
+	 * @When the public tries to create a file :file inside the last shared public link folder with password :password using wopi endpoint
+	 *
+	 * @param string $file
+	 * @param string $password
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function thePublicCreatesAFileInsideTheLastSharedPublicLinkFolderWithPasswordUsingWopiEndpoint(string $file, string $password): void {
+		$this->createFile($file, $password);
+	}
+
+	/**
+	 * @When the public creates a file :file inside folder :folder in the last shared public link space with password :password using wopi endpoint
+	 * @When the public tries to create a file :file inside folder :folder in the last shared public link space with password :password using wopi endpoint
+	 *
+	 * @param string $file
+	 * @param string $folder
+	 * @param string $password
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function thePublicCreatesAFileInsideFolderInTheLastSharedPublicLinkSpaceWithPasswordUsingWopiEndpoint(string $file, string $folder, string $password): void {
+		$this->createFile($file, $password, $folder);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added test for public user to create odt file inside public space using `/app/new` endpoint.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/9682

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
