### PR TITLE
[tests-only][full-ci] Add test coverage for checking file info with different view mode

### DIFF
--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -52,22 +52,29 @@ class CollaborationContext implements Context {
 
 	/**
 	 * @When user :user checks the information of file :file of space :space using office :app
+	 * @When user :user checks the information of file :file of space :space using office :app with view mode :view
 	 *
 	 * @param string $user
 	 * @param string $file
 	 * @param string $space
 	 * @param string $app
+	 * @param string|null $viewMode
 	 *
 	 * @return void
 	 *
 	 * @throws GuzzleException
-	 * @throws JsonException
 	 */
-	public function userChecksTheInformationOfFileOfSpaceUsingOffice(string $user, string $file, string $space, string $app): void {
+	public function userChecksTheInformationOfFileOfSpaceUsingOffice(string $user, string $file, string $space, string $app, string $viewMode = null): void {
 		$fileId = $this->spacesContext->getFileId($user, $space, $file);
+		$url = $this->featureContext->getBaseUrl() . "/app/open?app_name=$app&file_id=$fileId";
+
+		if ($viewMode) {
+			$url .= "&view_mode=$viewMode";
+		}
+
 		$response = \json_decode(
 			HttpRequestHelper::post(
-				$this->featureContext->getBaseUrl() . "/app/open?app_name=$app&file_id=$fileId",
+				$url,
 				$this->featureContext->getStepLineRef(),
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),

--- a/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
+++ b/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
@@ -289,3 +289,302 @@ Feature: check file info with different wopi apps
         }
       }
       """
+
+
+  Scenario Outline: check file info with different mode (onlyOffice)
+    Given user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
+    When user "Alice" checks the information of file "textfile0.txt" of space "Personal" using office "OnlyOffice" with view mode "<mode>"
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "BaseFileName",
+          "Version",
+          "BreadcrumbDocName",
+          "BreadcrumbFolderName",
+          "BreadcrumbFolderUrl",
+          "PostMessageOrigin",
+          "DisablePrint",
+          "UserFriendlyName",
+          "UserId",
+          "ReadOnly",
+          "UserCanNotWriteRelative",
+          "UserCanRename",
+          "UserCanWrite",
+          "SupportsLocks",
+          "SupportsRename",
+          "SupportsUpdate"
+        ],
+        "properties": {
+          "BaseFileName": {
+            "const": "textfile0.txt"
+          },
+          "UserId": {
+            "type": "string"
+          },
+          "Version": {
+            "type": "string"
+          },
+          "SupportsLocks": {
+            "const": true
+          },
+          "SupportsRename": {
+            "const": true
+          },
+          "SupportsUpdate": {
+            "const": true
+          },
+          "UserFriendlyName": {
+            "const": "Alice Hansen"
+          },
+          "ReadOnly": {
+            "const": false
+          },
+          "UserCanNotWriteRelative": {
+            "const": false
+          },
+          "UserCanRename": {
+            "const": <user-can-rename>
+          },
+          "UserCanWrite": {
+            "const": <user-can-write>
+          },
+          "DisablePrint": {
+            "const": <disable-print>
+          },
+          "BreadcrumbDocName": {
+            "const": "textfile0.txt"
+          },
+          "BreadcrumbFolderName": {
+            "const": "Alice Hansen"
+          },
+          "BreadcrumbFolderUrl": {
+            "type": "string"
+          },
+          "PostMessageOrigin": {
+            "type": "string"
+          }
+        }
+      }
+      """
+    Examples:
+      | mode  | disable-print | user-can-write | user-can-rename |
+      | view  | true          | false          | false           |
+      | read  | false         | false          | false           |
+      | write | false         | true           | true            |
+
+
+  Scenario Outline: check file info with different mode (fakeOffice)
+    Given user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
+    When user "Alice" checks the information of file "textfile0.txt" of space "Personal" using office "FakeOffice" with view mode "<mode>"
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "BaseFileName",
+          "OwnerId",
+          "Size",
+          "UserId",
+          "Version",
+          "SupportsCobalt",
+          "SupportsContainers",
+          "SupportsDeleteFile",
+          "SupportsEcosystem",
+          "SupportsExtendedLockLength",
+          "SupportsFolders",
+          "SupportsGetLock",
+          "SupportsLocks",
+          "SupportsRename",
+          "SupportsUpdate",
+          "SupportsUserInfo",
+          "UserFriendlyName",
+          "ReadOnly",
+          "RestrictedWebViewOnly",
+          "UserCanAttend",
+          "UserCanNotWriteRelative",
+          "UserCanPresent",
+          "UserCanRename",
+          "UserCanWrite",
+          "AllowAdditionalMicrosoftServices",
+          "AllowExternalMarketplace",
+          "DisablePrint",
+          "DisableTranslation",
+          "BreadcrumbDocName"
+        ],
+        "properties": {
+          "BaseFileName": {
+            "const": "textfile0.txt"
+          },
+          "OwnerId": {
+            "type": "string"
+          },
+          "Size": {
+            "const": 11
+          },
+          "UserId": {
+            "type": "string"
+          },
+          "Version": {
+            "type": "string"
+          },
+          "SupportsCobalt": {
+            "const": false
+          },
+          "SupportsContainers": {
+            "const": false
+          },
+          "SupportsDeleteFile": {
+            "const": true
+          },
+          "SupportsEcosystem": {
+            "const": false
+          },
+          "SupportsExtendedLockLength": {
+            "const": true
+          },
+          "SupportsFolders": {
+            "const": false
+          },
+          "SupportsGetLock": {
+            "const": true
+          },
+          "SupportsLocks": {
+            "const": true
+          },
+          "SupportsRename": {
+            "const": true
+          },
+          "SupportsUpdate": {
+            "const": true
+          },
+          "SupportsUserInfo": {
+            "const": false
+          },
+          "UserFriendlyName": {
+            "const": "Alice Hansen"
+          },
+          "ReadOnly": {
+            "const": false
+          },
+          "RestrictedWebViewOnly": {
+            "const": false
+          },
+          "UserCanAttend": {
+            "const": false
+          },
+          "UserCanNotWriteRelative": {
+            "const": false
+          },
+          "UserCanPresent": {
+            "const": false
+          },
+          "UserCanRename": {
+            "const": <user-can-rename>
+          },
+          "UserCanWrite": {
+            "const": <user-can-write>
+          },
+          "AllowAdditionalMicrosoftServices": {
+            "const": false
+          },
+          "AllowExternalMarketplace": {
+            "const": false
+          },
+          "DisablePrint": {
+            "const": <disable-print>
+          },
+          "DisableTranslation": {
+            "const": false
+          },
+          "BreadcrumbDocName": {
+            "const": "textfile0.txt"
+          }
+        }
+      }
+      """
+    Examples:
+      | mode  | disable-print | user-can-write | user-can-rename |
+      | view  | true          | false          | false           |
+      | read  | false         | false          | false           |
+      | write | false         | true           | true            |
+
+
+  Scenario Outline: check file info with different view-mode (collabora)
+    Given user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
+    When user "Alice" checks the information of file "textfile0.txt" of space "Personal" using office "Collabora" with view mode "<mode>"
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "BaseFileName",
+          "DisablePrint",
+          "OwnerId",
+          "PostMessageOrigin",
+          "Size",
+          "UserCanWrite",
+          "UserCanNotWriteRelative",
+          "UserId",
+          "UserFriendlyName",
+          "EnableOwnerTermination",
+          "SupportsLocks",
+          "SupportsRename",
+          "UserCanRename",
+          "BreadcrumbDocName"
+        ],
+        "properties": {
+          "BaseFileName": {
+            "const": "textfile0.txt"
+          },
+          "PostMessageOrigin": {
+            "const": "https://localhost:9200"
+          },
+          "DisablePrint": {
+            "const": <disable-print>
+          },
+          "OwnerId": {
+            "type": "string"
+          },
+          "Size": {
+            "const": 11
+          },
+          "UserCanWrite": {
+            "const": <user-can-write>
+          },
+          "UserCanNotWriteRelative": {
+            "const": false
+          },
+          "EnableOwnerTermination": {
+            "const": true
+          },
+          "UserId": {
+            "type": "string"
+          },
+          "SupportsLocks": {
+            "const": true
+          },
+          "SupportsRename": {
+            "const": true
+          },
+          "UserFriendlyName": {
+            "const": "Alice Hansen"
+          },
+          "UserCanRename": {
+            "const": <user-can-rename>
+          },
+          "BreadcrumbDocName": {
+            "const": "textfile0.txt"
+          }
+        }
+      }
+      """
+    Examples:
+      | mode  | disable-print | user-can-write | user-can-rename |
+      | view  | true          | false          | false           |
+      | read  | false         | false          | false           |
+      | write | false         | true           | true            |


### PR DESCRIPTION
## Description
This PR add tests coverage for checking file info with different view-mode

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/9844

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
