### PR TITLE
Running ocis without inbucket by default

### DIFF
--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -37,7 +37,7 @@ services:
       # email server (if configured)
       NOTIFICATIONS_SMTP_HOST: "${SMTP_HOST}"
       NOTIFICATIONS_SMTP_PORT: "${SMTP_PORT}"
-      NOTIFICATIONS_SMTP_SENDER: "${SMTP_SENDER}"
+      NOTIFICATIONS_SMTP_SENDER: "${SMTP_SENDER:-oCIS notifications <notifications@${OCIS_DOMAIN:-ocis.owncloud.test}>}"
       NOTIFICATIONS_SMTP_USERNAME: "${SMTP_USERNAME}"
       NOTIFICATIONS_SMTP_INSECURE: "${SMTP_INSECURE}"
       # make the registry available to the app provider containers


### PR DESCRIPTION
during the testing release I catch one error: 
- I tried to start ocis-full without enabling inbucket and get some error: 
```
2024-09-12 11:40:55 the 'smtp_sender' must be a valid single RFC 5322 address. parsing error: the address cannot be empty

```

because 
<img width="544" alt="image" src="https://github.com/user-attachments/assets/38ee73a0-1cda-4315-a618-992f20e1090b">

are empty and we set it https://github.com/owncloud/ocis/blob/master/deployments/examples/ocis_full/inbucket.yml#L4-L10
when inbucket is enabled
I guess it happens after https://github.com/owncloud/ocis/commit/3cc29ce99bd5025cec2f9dfef2feb613b4136449



