### PR TITLE
[docs-only] Clarify introduction version when adding an envvar to an existing one

### DIFF
--- a/docs/services/general-info/envvar-scopes.md
+++ b/docs/services/general-info/envvar-scopes.md
@@ -58,6 +58,10 @@ For the documentation to show the correct value for the `IV` (introduction versi
 
 During the releasing process for a production release, the placeholder `%%NEXT%%` has to be replaced with the new production version number like `%%NEXT%%` → `7.0.0`.
 
+### Adding Envvars to Existing Ones
+
+If an envvar has been introduced with a particular version, the `introductionVersion` gets a value accordingly. If an additional envvar like a global one is added to this existing envvar later on, the introduction version will *not* be changed.
+
 ### Deprecate Existing Envvars
 
 See the [deprecation rules]({{< ref "./deprecating-variables.md" >}}) documentation for more details.


### PR DESCRIPTION
References: #10043 ([docs-only][chore] Update env_vars.yaml)

@phil-davis raised an important question that was not covered in our dev docs:

Does adding an envvar to an existing one change the introduction version --> No

This is now documented.