### PR TITLE
fix ocm token

### DIFF
--- a/changelog/unreleased/fix-ocm-token.md
+++ b/changelog/unreleased/fix-ocm-token.md
@@ -1,0 +1,5 @@
+Bugfix: Fixed the ocm tocken
+
+We now pass the JWT secret to the reva runtime.
+
+https://github.com/owncloud/ocis/pull/10050

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	ServiceAccount ServiceAccount        `yaml:"service_account"`
 	Events         Events                `yaml:"-"`
 
+	TokenManager                 *TokenManager                `yaml:"token_manager"`
 	Reva                         *shared.Reva                 `yaml:"reva"`
 	OCMD                         OCMD                         `yaml:"ocmd"`
 	ScienceMesh                  ScienceMesh                  `yaml:"sciencemesh"`

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -165,6 +165,14 @@ func EnsureDefaults(cfg *config.Config) {
 		cfg.Reva = structs.CopyOrZeroValue(cfg.Commons.Reva)
 	}
 
+	if cfg.TokenManager == nil && cfg.Commons != nil && cfg.Commons.TokenManager != nil {
+		cfg.TokenManager = &config.TokenManager{
+			JWTSecret: cfg.Commons.TokenManager.JWTSecret,
+		}
+	} else if cfg.TokenManager == nil {
+		cfg.TokenManager = &config.TokenManager{}
+	}
+
 	if cfg.GRPCClientTLS == nil && cfg.Commons != nil {
 		cfg.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
 	}

--- a/services/ocm/pkg/config/reva.go
+++ b/services/ocm/pkg/config/reva.go
@@ -1,0 +1,6 @@
+package config
+
+// TokenManager is the config for using the reva token manager
+type TokenManager struct {
+	JWTSecret string `yaml:"jwt_secret" env:"OCIS_JWT_SECRET;OCM_JWT_SECRET" desc:"The secret to mint and validate jwt tokens." introductionVersion:"pre5.0"`
+}

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -11,6 +11,7 @@ import (
 func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]interface{} {
 	return map[string]interface{}{
 		"shared": map[string]interface{}{
+			"jwt_secret":          cfg.TokenManager.JWTSecret,
 			"gatewaysvc":          cfg.Reva.Address, // Todo or address?
 			"grpc_client_options": cfg.Reva.GetGRPCClientConfig(),
 		},


### PR DESCRIPTION
We now pass the JWT secret to the reva runtime.

The ocm service only picks up the shared jwt because the sharedConf package is a singleton and other services in ocis initialize it ... 😞 