### PR TITLE
[tests-only][full-ci]Add test for sending request to check file info with invalid file id

### DIFF
--- a/tests/acceptance/TestHelpers/CollaborationHelper.php
+++ b/tests/acceptance/TestHelpers/CollaborationHelper.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+/**
+ * ownCloud
+ *
+ * @author Amrita Shrestha <amrita@jankaritech.com>
+ * @copyright Copyright (c) 2024 Amrita Shrestha amrita@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace TestHelpers;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A helper class for managing wopi requests
+ */
+class CollaborationHelper {
+
+	/**
+	 * @param string $fileId
+	 * @param string $app
+	 * @param string $username
+	 * @param string $password
+	 * @param string $baseUrl
+	 * @param string $xRequestId
+	 * @param string|null $viewMode
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function sendPOSTRequestToAppOpen(
+		string $fileId,
+		string $app,
+		string $username,
+		string $password,
+		string $baseUrl,
+		string $xRequestId,
+		?string $viewMode = null,
+	): ResponseInterface {
+		$url = $baseUrl . "/app/open?app_name=$app&file_id=$fileId";
+		if ($viewMode) {
+			$url .= "&view_mode=$viewMode";
+		}
+
+		return HttpRequestHelper::post(
+			$url,
+			$xRequestId,
+			$username,
+			$password,
+			['Content-Type' => 'application/json']
+		);
+	}
+}

--- a/tests/acceptance/TestHelpers/EmailHelper.php
+++ b/tests/acceptance/TestHelpers/EmailHelper.php
@@ -4,6 +4,20 @@
  *
  * @author Prajwol Amatya <prajwol@jankaritech.com>
  * @copyright Copyright (c) 2023 Prajwol Amatya prajwol@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
  */
 
 namespace TestHelpers;

--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -4,6 +4,20 @@
  *
  * @author Kiran Parajuli <kiran@jankaritech.com>
  * @copyright Copyright (c) 2022 Kiran Parajuli kiran@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
  */
 
 namespace TestHelpers;

--- a/tests/acceptance/TestHelpers/OcmHelper.php
+++ b/tests/acceptance/TestHelpers/OcmHelper.php
@@ -4,6 +4,20 @@
  *
  * @author Viktor Scharf <scharf.vi@gmail.com>
  * @copyright Copyright (c) 2024 Viktor Scharf <scharf.vi@gmail.com>
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
  */
 
 namespace TestHelpers;
@@ -23,7 +37,7 @@ class OcmHelper {
 			'Content-Type' => 'application/json',
 		];
 	}
-  
+
 	/**
 	 * @param string $baseUrl
 	 * @param string $path

--- a/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
+++ b/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
@@ -588,3 +588,14 @@ Feature: check file info with different wopi apps
       | view  | true          | false          | false           |
       | read  | false         | false          | false           |
       | write | false         | true           | true            |
+
+
+  Scenario Outline: try to get file info using invalid file id with office suites
+    Given user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
+    When user "Alice" tries to check the information of file "textfile0.txt" of space "Personal" using office "<office-suites>" with invalid file-id
+    Then the HTTP status code should be "401"
+    Examples:
+      | office-suites |
+      | Collabora     |
+      | FakeOffice    |
+      | OnlyOffice    |


### PR DESCRIPTION
## Description
This PR has test coverage for check file info on different office suites with valid access token and invalid file id

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/9844

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
