### PR TITLE
[test-only] fix ocm email test - issue/10059

### DIFF
--- a/tests/acceptance/bootstrap/NotificationContext.php
+++ b/tests/acceptance/bootstrap/NotificationContext.php
@@ -513,17 +513,41 @@ class NotificationContext implements Context {
 		$this->assertEmailContains($user, $expectedEmailBodyContent);
 	}
 
+	/**
+	 * @Then user :user should have received the following email from user :sender ignoring whitespaces
+	 *
+	 * @param string $user
+	 * @param string $sender
+	 * @param PyStringNode $content
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userShouldHaveReceivedTheFollowingEmailFromUserIgnoringWhitespaces(string $user, string $sender, PyStringNode $content):void {
+		$rawExpectedEmailBodyContent = \str_replace("\r\n", "\n", $content->getRaw());
+		$expectedEmailBodyContent = $this->featureContext->substituteInLineCodes(
+			$rawExpectedEmailBodyContent,
+			$sender
+		);
+		$this->assertEmailContains($user, $expectedEmailBodyContent, true);
+	}
+
 	/***
 	 * @param string $user
 	 * @param string $expectedEmailBodyContent
+	 * @param bool $ignoreWhiteSpace
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function assertEmailContains(string $user, string $expectedEmailBodyContent):void {
+	public function assertEmailContains(string $user, string $expectedEmailBodyContent, $ignoreWhiteSpace = false):void {
 		$address = $this->featureContext->getEmailAddressForUser($user);
 		$this->featureContext->pushEmailRecipientAsMailBox($address);
 		$actualEmailBodyContent = EmailHelper::getBodyOfLastEmail($address, $this->featureContext->getStepLineRef());
+		if ($ignoreWhiteSpace) {
+			$expectedEmailBodyContent = preg_replace('/\s+/', '', $expectedEmailBodyContent);
+			$actualEmailBodyContent = preg_replace('/\s+/', '', $actualEmailBodyContent);
+		}
 		Assert::assertStringContainsString(
 			$expectedEmailBodyContent,
 			$actualEmailBodyContent,

--- a/tests/acceptance/bootstrap/OcmContext.php
+++ b/tests/acceptance/bootstrap/OcmContext.php
@@ -32,6 +32,7 @@ use TestHelpers\WebDavHelper;
  */
 class OcmContext implements Context {
 	private FeatureContext $featureContext;
+	private NotificationContext $notificationContext;
 	private string $invitationToken;
 
 	/**
@@ -52,6 +53,18 @@ class OcmContext implements Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context from here
 		$this->featureContext = $environment->getContext('FeatureContext');
+		$this->notificationContext = $environment->getContext('NotificationContext');
+	}
+
+	/**
+	 * Delete all the inbucket emails
+	 *
+	 * @AfterScenario @email
+	 *
+	 * @return void
+	 */
+	public function clearInbucketMessages():void {
+		$this->notificationContext->clearInbucketMessages();
 	}
 
 	/**

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -200,6 +200,7 @@ default:
         - SettingsContext:
         - OcisConfigContext:
         - SharingNgContext:
+        - OcmContext:
 
     apiAntivirus:
       paths:

--- a/tests/acceptance/features/apiOcm/createInvitation.feature
+++ b/tests/acceptance/features/apiOcm/createInvitation.feature
@@ -134,17 +134,17 @@ Feature: create invitation
       | @domain.com                       | 400  |
       | user@domain..com                  | 400  |
 
-  @email @skip
+  @email @issue-10059
   Scenario: federated user gets an email notification if their email was specified when creating the federation share invitation
     Given using server "LOCAL"
     When "Alice" has created the federation share invitation with email "brian@example.com" and description "a share invitation from Alice"
-    And user "Brian" should have received the following email from user "Alice"
+    And user "Brian" should have received the following email from user "Alice" ignoring whitespaces
       """
       Hi,
 
       Alice Hansen (alice@example.org) wants to start sharing collaboration resources with you.
 
-      Please visit your federation provider and use the following details:
+      Please visit your federation settings and use the following details:
         Token: %fed_invitation_token%
         ProviderDomain: https://ocis-server:9200
       """


### PR DESCRIPTION
related #10059 

fixed two issues: 
- different invitation token

<img width="770" alt="Screenshot 2024-09-16 at 14 54 52" src="https://github.com/user-attachments/assets/c364b13f-f7b2-48e9-bd1a-53a2448603bd">

it happened because we didn't `clearInbucketMessages` in the `ocmContext` and as a result, we've had several emails to Brian

- ignoring extra spaces and blank lines 

<img width="783" alt="Screenshot 2024-09-16 at 10 42 02" src="https://github.com/user-attachments/assets/e3e5a497-b962-4505-8484-a6c0a8b64331">


it's weird. I can't explain it. As a solution -> I trim all spaces and blank lines and compare only the text with the body of the email
