### PR TITLE
[docs-only] Fix translatable text string in notifications

### DIFF
--- a/services/notifications/pkg/email/templates.go
+++ b/services/notifications/pkg/email/templates.go
@@ -85,7 +85,7 @@ Even though this membership has expired you still might have access through othe
 To accept the invite, please visit the following URL:
 {ShareLink}
 
-Alternatively, you can visit your federation provider and use the following details:
+Alternatively, you can visit your federation settings and use the following details:
   Token: {Token}
   ProviderDomain: {ProviderDomain}`),
 	}
@@ -99,7 +99,7 @@ Alternatively, you can visit your federation provider and use the following deta
 		Greeting: l10n.Template(`Hi,`),
 		// ScienceMeshInviteTokenGeneratedWithoutShareLink email template, resolves via {{ .MessageBody }}
 		MessageBody: l10n.Template(`{ShareSharer} ({ShareSharerMail}) wants to start sharing collaboration resources with you.
-Please visit your federation provider and use the following details:
+Please visit your federation settings and use the following details:
   Token: {Token}
   ProviderDomain: {ProviderDomain}`),
 	}


### PR DESCRIPTION
While translating the text on Transifex, I identified that the source needs a small change to fix the meaning. This is because the reciever needs to go into _his_ federation settings...