### PR TITLE
fix: return 404 code if file isn't found on CheckFileInfo request

### DIFF
--- a/changelog/unreleased/collaboration-fileinfo-error-code.md
+++ b/changelog/unreleased/collaboration-fileinfo-error-code.md
@@ -1,0 +1,5 @@
+Bugfix: CheckFileInfo will return a 404 error if the target file isn't found
+
+Previously, the request failed with a 500 error code, but it it will fail with a 404 error code
+
+https://github.com/owncloud/ocis/pull/10112

--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -1058,6 +1058,10 @@ func (f *FileConnector) CheckFileInfo(ctx context.Context) (*ConnectorResponse, 
 			Str("StatusCode", statRes.GetStatus().GetCode().String()).
 			Str("StatusMsg", statRes.GetStatus().GetMessage()).
 			Msg("CheckFileInfo: stat failed with unexpected status")
+
+		if statRes.GetStatus().GetCode() == rpcv1beta1.Code_CODE_NOT_FOUND {
+			return NewResponse(404), nil
+		}
 		return NewResponse(500), nil
 	}
 

--- a/services/collaboration/pkg/connector/fileconnector_test.go
+++ b/services/collaboration/pkg/connector/fileconnector_test.go
@@ -1634,6 +1634,19 @@ var _ = Describe("FileConnector", func() {
 			Expect(response.Body).To(BeNil())
 		})
 
+		It("Stat fails status not found", func() {
+			ctx := middleware.WopiContextToCtx(context.Background(), wopiCtx)
+
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Times(1).Return(&providerv1beta1.StatResponse{
+				Status: status.NewNotFound(ctx, "something not found"),
+			}, nil)
+
+			response, err := fc.CheckFileInfo(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.Status).To(Equal(404))
+			Expect(response.Body).To(BeNil())
+		})
+
 		It("Stat success", func() {
 			ctx := middleware.WopiContextToCtx(context.Background(), wopiCtx)
 			u := &userv1beta1.User{


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The `CheckFileInfo` request will now return a 404 error code if the target file isn't found

## Related Issue
https://github.com/owncloud/ocis/issues/10097

## Motivation and Context
Server should return a proper error code instead of a generic 500

## How Has This Been Tested?
Manually tested following steps in https://github.com/owncloud/ocis/issues/10097 , and unit tests added for this specific case

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
