### PR TITLE
[tests-only] skip activity translation test

### DIFF
--- a/tests/acceptance/features/apiActivities/activities.feature
+++ b/tests/acceptance/features/apiActivities/activities.feature
@@ -1232,7 +1232,7 @@ Feature: check activities
       }
       """
 
-  @issue-9856
+  @issue-9856 @issue-10127 @skip
   Scenario: check activity message with different language
     Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt"
     And user "Alice" has switched the system language to "de" using the Graph API


### PR DESCRIPTION
## Description
skipping the test so to ublock the CI

## Related Issue
- https://github.com/owncloud/ocis/issues/10127

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
