### PR TITLE
[full-ci] Forbid Sharee access to Activities

### DIFF
--- a/changelog/unreleased/forbid-activities-for-sharees.md
+++ b/changelog/unreleased/forbid-activities-for-sharees.md
@@ -1,0 +1,5 @@
+Bugfix: Forbid Activities for Sharees
+
+Sharees may not see item activities. We now bind it to ListGrants permission.
+
+https://github.com/owncloud/ocis/pull/10136

--- a/services/activitylog/pkg/service/http.go
+++ b/services/activitylog/pkg/service/http.go
@@ -67,8 +67,14 @@ func (s *ActivitylogService) HandleGetItemActivities(w http.ResponseWriter, r *h
 		return
 	}
 
-	_, err = utils.GetResourceByID(ctx, rid, gwc)
+	info, err := utils.GetResourceByID(ctx, rid, gwc)
 	if err != nil {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	// you need ListGrants to see activities
+	if !info.GetPermissionSet().GetListGrants() {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
Forbids sharees to see item activities

Fixes https://github.com/owncloud/ocis/issues/9849