### PR TITLE
enhancement: Load CSP configuration file if it exists

### DIFF
--- a/changelog/unreleased/enhancement-load-csp-if-exists.md
+++ b/changelog/unreleased/enhancement-load-csp-if-exists.md
@@ -1,0 +1,8 @@
+Enhancement: Load CSP configuration file if it exists
+
+The Content Security Policy (CSP) configuration file is now loaded by default if it exists.
+The configuration file looked for should be located at `$OCIS_BASE_DATA_PATH/proxy/csp.yaml`.
+If the file does not exist, the default CSP configuration is used.
+
+https://github.com/owncloud/ocis/pull/10139
+https://github.com/owncloud/ocis/issues/10021

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -1,7 +1,9 @@
 package defaults
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -331,6 +333,14 @@ func Sanitize(cfg *config.Config) {
 
 	if cfg.HTTP.Root != "/" {
 		cfg.HTTP.Root = strings.TrimSuffix(cfg.HTTP.Root, "/")
+	}
+
+	// if the CSP config file path is not set, we check if the default file exists and set it if it does
+	if cfg.CSPConfigFileLocation == "" {
+		defaultCSPConfigFilePath := filepath.Join(defaults.BaseDataPath(), "proxy", "csp.yaml")
+		if _, err := os.Stat(defaultCSPConfigFilePath); err == nil {
+			cfg.CSPConfigFileLocation = defaultCSPConfigFilePath
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
The Content Security Policy (CSP) configuration file is now loaded by default if it exists.
The configuration file looked for should be located at `$OCIS_BASE_DATA_PATH/proxy/csp.yaml`.
If the file does not exist, the default CSP configuration is used.

## Related Issue
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/10021

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)