### PR TITLE
increase bingo get timeout to 10min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ test-gherkin-lint-fix:
 
 .PHONY: bingo-update
 bingo-update: $(BINGO)
-	$(BINGO) get -l -v
+	$(BINGO) get -l -v -t 10
 
 .PHONY: check-licenses
 check-licenses: ci-go-check-licenses ci-node-check-licenses


### PR DESCRIPTION
The ci keeps running into the default 5min timeout quite often recently.

See e.g.:
https://drone.owncloud.com/owncloud/ocis/39281/6/4
https://drone.owncloud.com/owncloud/ocis/39282/6/4