### PR TITLE
[test-only] add federated users to space

### DIFF
--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -351,7 +351,7 @@ class SharingNgContext implements Context {
 			$shareeId = "";
 			if ($shareType === "user") {
 				$shareeId = $this->featureContext->getAttributeOfCreatedUser($sharee, 'id');
-				if (isset($shareInfo['federatedServer'])) {
+				if (isset($rows['federatedServer'])) {
 					$shareeId = ($this->featureContext->ocmContext->getAcceptedUserByName($user, $sharee))['user_id'];
 				}
 			} elseif ($shareType === "group") {
@@ -436,6 +436,7 @@ class SharingNgContext implements Context {
 
 	/**
 	 * @When /^user "([^"]*)" sends the following space share invitation using permissions endpoint of the Graph API:$/
+	 * @When /^user "([^"]*)" tries to send the following space share invitation to federated user using permissions endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table
@@ -1429,6 +1430,7 @@ class SharingNgContext implements Context {
 
 	/**
 	 * @When /^user "([^"]*)" (?:tries to send|sends) the following space share invitation using root endpoint of the Graph API:$/
+	 * @When /^user "([^"]*)" tries to send the following space share invitation to federated user using root endpoint of the Graph API:$/
 	 *
 	 * @param string $user
 	 * @param TableNode $table

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -270,5 +270,11 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 - [apiOcm/deleteFederatedConnections.feature:103](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/deleteFederatedConnections.feature#L103)
 
+#### [OCM. Prevent federated users from being added as members of the space](https://github.com/owncloud/ocis/issues/10051)
+
+- [apiOcm/share.feature:231](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L231)
+- [apiOcm/share.feature:232](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L232)
+- [apiOcm/share.feature:233](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L233)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -619,6 +619,7 @@ Feature: collaboration (wopi)
       | permissionsRole | Viewer     |
     When user "Brian" tries to create a file "testFile.txt" inside folder "testFolder" in space "Shares" using wopi endpoint
     Then the HTTP status code should be "403"
+    And the JSON data of the response should match
       """
       {
         "type": "object",

--- a/tests/acceptance/features/apiOcm/share.feature
+++ b/tests/acceptance/features/apiOcm/share.feature
@@ -189,3 +189,102 @@ Feature: an user shares resources usin ScienceMesh application
       | resource      |
       | folderToShare |
       | textfile.txt  |
+
+  @issue-10051
+  Scenario Outline: try to add federated user as a member of a project space (permissions endpoint)
+    Given using server "LOCAL"
+    And "Alice" has created the federation share invitation
+    And using server "REMOTE"
+    And "Brian" has accepted invitation
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Brian" using the Graph API
+    And user "Brian" has created a space "brian's space" with the default quota using the Graph API
+    When user "Brian" tries to send the following space share invitation to federated user using permissions endpoint of the Graph API:
+      | space           | brian's space      |
+      | sharee          | Alice              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+      | federatedServer | @ocis-server:9200  |
+    Then the HTTP status code should be "403"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "const": "PERMISSION_DENIED"
+          },
+          "message": {
+            "const": "permission denied to create the file"
+          }
+        }
+      }
+      """
+    And using server "LOCAL"
+    And the user "Alice" should not have a space called "brian's space"
+    Examples:
+      | permissions-role |
+      | Space Viewer     |
+      | Space Editor     |
+      | Manager          |
+
+
+  Scenario Outline: try to add federated user as a member of a project space (root endpoint)
+    Given using server "LOCAL"
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "alice's space" with the default quota using the Graph API
+    And "Alice" has created the federation share invitation
+    And using server "REMOTE"
+    And "Brian" has accepted invitation
+    And using server "LOCAL"
+    When user "Alice" tries to send the following space share invitation to federated user using root endpoint of the Graph API:
+      | space           | alice's space                 |
+      | sharee          | Brian                         |
+      | shareType       | user                          |
+      | permissionsRole | <permissions-role>            |
+      | federatedServer | @federation-ocis-server:10200 |
+    Then the HTTP status code should be "400"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "innererror",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "const": "invalidRequest"
+              },
+              "innererror": {
+                "type": "object",
+                "required": [
+                  "date",
+                  "request-id"
+                ]
+              },
+              "message": {
+                "const": "federated user can not become a space member"
+              }
+            }
+          }
+        }
+      }
+      """
+    And using server "REMOTE"
+    And the user "Brian" should not have a space called "alice's space"
+    Examples:
+      | permissions-role |
+      | Space Viewer     |
+      | Space Editor     |
+      | Manager          |


### PR DESCRIPTION
related https://github.com/owncloud/ocis/pull/10060
https://github.com/owncloud/ocis/issues/10051

- [ ] user tries to send the following space share invitation using permissions endpoint to federated user using the Graph API Actual: 200 Expected: 403 
- [x] user tries to send the following space share invitation using root endpoint to federated user using the Graph API - Actual: 400

cc @2403905 
