### PR TITLE
[tests-only][full-ci] Add tests for version disable config

### DIFF
--- a/tests/acceptance/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/bootstrap/FilesVersionsContext.php
@@ -36,6 +36,25 @@ require_once 'bootstrap.php';
  */
 class FilesVersionsContext implements Context {
 	private FeatureContext $featureContext;
+	private SpacesContext $spacesContext;
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope):void {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = BehatHelper::getContext($scope, $environment, 'FeatureContext');
+		$this->spacesContext = BehatHelper::getContext($scope, $environment, 'SpacesContext');
+	}
 
 	/**
 	 * @When user :user tries to get versions of file :file from :fileOwner
@@ -547,19 +566,27 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
-	 * This will run before EVERY scenario.
-	 * It will set the properties for this object.
+	 * @When user :user gets the number of versions of file :file from space :space
+	 * @When user :user tries to get the number of versions of file :file from space :space
 	 *
-	 * @BeforeScenario
-	 *
-	 * @param BeforeScenarioScope $scope
+	 * @param string $user
+	 * @param string $file
+	 * @param string $space
 	 *
 	 * @return void
 	 */
-	public function before(BeforeScenarioScope $scope):void {
-		// Get the environment
-		$environment = $scope->getEnvironment();
-		// Get all the contexts you need in this context
-		$this->featureContext = BehatHelper::getContext($scope, $environment, 'FeatureContext');
+	public function userGetsTheNumberOfVersionsOfFileFromSpace(string $user, string $file, string $space): void {
+		$fileId = $this->spacesContext->getFileId($user, $space, $file);
+		$this->featureContext->setResponse(
+			$this->featureContext->makeDavRequest(
+				$user,
+				"PROPFIND",
+				$fileId,
+				null,
+				null,
+				null,
+				"versions"
+			)
+		);
 	}
 }

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -615,6 +615,7 @@ default:
         - WebDavPropertiesContext:
         - TrashbinContext:
         - SharingNgContext:
+        - OcisConfigContext:
 
     coreApiWebdavDelete:
       paths:

--- a/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
@@ -1,7 +1,7 @@
 Feature: checking file versions using file id
   As a user
-  I want to share file outside of the space
-  So that other users can access the file
+  I want the versions of files to be available
+  So that I can manage the changes made to the files
 
   Background:
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/coreApiVersions/disableFileVersioning.feature
+++ b/tests/acceptance/features/coreApiVersions/disableFileVersioning.feature
@@ -1,0 +1,83 @@
+@env-config @skipOnReva
+Feature: checking file versions
+  As a user
+  I want the versions of files to be available
+  So that I can manage the changes made to the files
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And using spaces DAV path
+
+
+  Scenario: check version number of a file when versioning is disabled
+    Given the config "OCIS_DISABLE_VERSIONING" has been set to "true"
+    And user "Alice" has uploaded file with content "test file version 1" to "/testfile.txt"
+    And user "Alice" has uploaded file with content "test file version 2" to "/testfile.txt"
+    When user "Alice" gets the number of versions of file "/testfile.txt"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "0"
+
+
+  Scenario: file version number should not be added after disabling versioning
+    Given user "Alice" has uploaded file with content "test file version 1" to "/testfile.txt"
+    And user "Alice" has uploaded file with content "test file version 2" to "/testfile.txt"
+    And the config "OCIS_DISABLE_VERSIONING" has been set to "true"
+    And user "Alice" has uploaded file with content "test file version 3" to "/testfile.txt"
+    And user "Alice" has uploaded file with content "test file version 4" to "/testfile.txt"
+    When user "Alice" gets the number of versions of file "/testfile.txt"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "1"
+
+
+  Scenario Outline: sharee tries to check version number of a file shared from project space when versioning is disabled
+    Given the config "OCIS_DISABLE_VERSIONING" has been set to "true"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "Project1" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "Project1" with content "hello world version 1" to "text.txt"
+    And user "Alice" has uploaded a file inside space "Project1" with content "hello world version 1.1" to "text.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | text.txt |
+      | space           | Project1 |
+      | sharee          | Brian    |
+      | shareType       | user     |
+      | permissionsRole | <role>   |
+    And user "Brian" has a share "text.txt" synced
+    When user "Brian" tries to get the number of versions of file "/text.txt" from space "Shares"
+    Then the HTTP status code should be "403"
+    Examples:
+      | role        |
+      | File Editor |
+      | Viewer      |
+
+
+  Scenario Outline: sharee tries to check version number of a file shared from personal space when versioning is disabled
+    Given the config "OCIS_DISABLE_VERSIONING" has been set to "true"
+    And user "Alice" has uploaded file with content "test file version 2" to "/text.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | text.txt          |
+      | space           | Personal          |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | <permissionsRole> |
+    And user "Brian" has a share "text.txt" synced
+    When user "Brian" tries to get the number of versions of file "/text.txt" from space "Shares"
+    Then the HTTP status code should be "403"
+    Examples:
+      | permissionsRole |
+      | File Editor     |
+      | Viewer          |
+
+
+  Scenario: check file version number after disabling versioning, creating versions and then enabling versioning
+    Given the config "OCIS_DISABLE_VERSIONING" has been set to "true"
+    And user "Alice" has uploaded file with content "test file version 1" to "/testfile.txt"
+    And user "Alice" has uploaded file with content "test file version 2" to "/testfile.txt"
+    And the config "OCIS_DISABLE_VERSIONING" has been set to "false"
+    And user "Alice" has uploaded file with content "test file version 3" to "/testfile.txt"
+    And user "Alice" has uploaded file with content "test file version 4" to "/testfile.txt"
+    When user "Alice" gets the number of versions of file "/testfile.txt"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "2"


### PR DESCRIPTION
## Description
This PR has added tests for checking file version when version is disabled using config

## Related Issue
- https://github.com/owncloud/ocis/issues/10095

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
