### PR TITLE
Fix the panic for the translation-sync in the activities service.

### DIFF
--- a/changelog/unreleased/fix-acitivity-translation.md
+++ b/changelog/unreleased/fix-acitivity-translation.md
@@ -1,0 +1,5 @@
+Bugfix: Fix Activities translation
+
+Fix the panic for the translation-sync in the activities service.
+
+https://github.com/owncloud/ocis/pull/10175

--- a/services/activitylog/pkg/service/response.go
+++ b/services/activitylog/pkg/service/response.go
@@ -35,21 +35,12 @@ var (
 	MessageSpaceShared     = l10n.Template("{user} added {sharee} as member of {space}")
 	MessageSpaceUnshared   = l10n.Template("{user} removed {sharee} from {space}")
 
-	StrSomeField      = l10n.Template(_someField)
-	StrPermission     = l10n.Template(_permission)
-	StrPassword       = l10n.Template(_password)
-	StrExpirationDate = l10n.Template(_expirationDate)
-	StrDisplayName    = l10n.Template(_displayName)
-	StrDescription    = l10n.Template(_description)
-)
-
-const (
-	_someField      = "some field"
-	_permission     = "permission"
-	_password       = "password"
-	_expirationDate = "expiration date"
-	_displayName    = "display name"
-	_description    = "description"
+	StrSomeField      = l10n.Template("some field")
+	StrPermission     = l10n.Template("permission")
+	StrPassword       = l10n.Template("password")
+	StrExpirationDate = l10n.Template("expiration date")
+	StrDisplayName    = l10n.Template("display name")
+	StrDescription    = l10n.Template("description")
 )
 
 // GetActivitiesResponse is the response on GET activities requests
@@ -334,15 +325,15 @@ func getFolderName(ctx context.Context, gwc gateway.GatewayAPIClient, ref *provi
 func mapField(val string) string {
 	switch val {
 	case "TYPE_PERMISSIONS", "permission":
-		return _permission
+		return StrPermission
 	case "TYPE_PASSWORD", "password":
-		return _password
+		return StrPassword
 	case "TYPE_EXPIRATION", "expiration":
-		return _expirationDate
+		return StrExpirationDate
 	case "TYPE_DISPLAYNAME":
-		return _displayName
+		return StrDisplayName
 	case "TYPE_DESCRIPTION":
-		return _description
+		return StrDescription
 	}
-	return _someField
+	return StrSomeField
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
```
+ make l10n-read
make[1]: Entering directory '/drone/src/ocis/services/activitylog'
go-xgettext -o ./pkg/service/l10n/activitylog.pot --keyword=l10n.Template -s pkg/service/response.go
panic: unknown type: _someField
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
