### PR TITLE
[test-only] do not run coding standart php step when releasing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -773,7 +773,6 @@ def codestyle(ctx):
                     "ref": [
                         "refs/heads/stable-*",
                         "refs/pull/**",
-                        "refs/tags/**",
                     ],
                 },
             }


### PR DESCRIPTION
while creating a tag I noticed that we run coding-standart-php but we don't run tests
I removed this step from CI if we create tag

<img width="1085" alt="Screenshot 2024-09-30 at 17 46 52" src="https://github.com/user-attachments/assets/a21aef90-ba20-406c-b82e-ee418cd2d368">
