### PR TITLE
fix(graph): treat LDAP attribute names case-insensitive everywhere

### DIFF
--- a/changelog/unreleased/fix-ldap-attributename-case.md
+++ b/changelog/unreleased/fix-ldap-attributename-case.md
@@ -1,0 +1,7 @@
+Bugfix: always treat LDAP attribute names case-insensitively
+
+We fixes a bug where some LDAP attributes (e.g. owncloudUUID) were not
+treated case-insensitively.
+
+https://github.com/owncloud/ocis/pull/10204
+https://github.com/owncloud/ocis/issues/10200

--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -291,7 +291,7 @@ func (i *LDAP) UpdateUser(ctx context.Context, nameOrID string, user libregraph.
 	if user.GetId() != "" {
 		id, err := i.ldapUUIDtoString(e, i.userAttributeMap.id, i.userIDisOctetString)
 		if err != nil {
-			i.logger.Warn().Str("dn", e.DN).Str(i.userAttributeMap.id, e.GetAttributeValue(i.userAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
+			i.logger.Warn().Str("dn", e.DN).Str(i.userAttributeMap.id, e.GetEqualFoldAttributeValue(i.userAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
 			return nil, errorcode.New(errorcode.GeneralException, "error converting uuid")
 		}
 		if id != user.GetId() {
@@ -815,7 +815,7 @@ func (i *LDAP) createUserModelFromLDAP(e *ldap.Entry) *libregraph.User {
 	opsan := e.GetEqualFoldAttributeValue(i.userAttributeMap.userName)
 	id, err := i.ldapUUIDtoString(e, i.userAttributeMap.id, i.userIDisOctetString)
 	if err != nil {
-		i.logger.Warn().Str("dn", e.DN).Str(i.userAttributeMap.id, e.GetAttributeValue(i.userAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
+		i.logger.Warn().Str("dn", e.DN).Str(i.userAttributeMap.id, e.GetEqualFoldAttributeValue(i.userAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
 	}
 	surname := e.GetEqualFoldAttributeValue(i.userAttributeMap.surname)
 
@@ -887,7 +887,7 @@ func (i *LDAP) userToLDAPAttrValues(user libregraph.User) (map[string][]string, 
 	}
 
 	if !i.useServerUUID {
-		attrs["owncloudUUID"] = []string{uuid.New().String()}
+		attrs[i.userAttributeMap.id] = []string{uuid.New().String()}
 	}
 
 	if user.AccountEnabled != nil {

--- a/services/graph/pkg/identity/ldap_education_class.go
+++ b/services/graph/pkg/identity/ldap_education_class.go
@@ -152,7 +152,7 @@ func (i *LDAP) UpdateEducationClass(ctx context.Context, id string, class libreg
 	if class.GetId() != "" {
 		id, err := i.ldapUUIDtoString(g, i.groupAttributeMap.id, i.groupIDisOctetString)
 		if err != nil {
-			i.logger.Warn().Str("dn", g.DN).Str(i.userAttributeMap.id, g.GetAttributeValue(i.userAttributeMap.id)).Msg("Invalid class. Cannot convert UUID")
+			i.logger.Warn().Str("dn", g.DN).Str(i.userAttributeMap.id, g.GetEqualFoldAttributeValue(i.userAttributeMap.id)).Msg("Invalid class. Cannot convert UUID")
 			return nil, errorcode.New(errorcode.GeneralException, "error converting uuid")
 		}
 		if id != class.GetId() {

--- a/services/graph/pkg/identity/ldap_education_user.go
+++ b/services/graph/pkg/identity/ldap_education_user.go
@@ -90,7 +90,7 @@ func (i *LDAP) UpdateEducationUser(ctx context.Context, nameOrID string, user li
 	if user.GetId() != "" {
 		id, err := i.ldapUUIDtoString(e, i.userAttributeMap.id, i.userIDisOctetString)
 		if err != nil {
-			i.logger.Warn().Str("dn", e.DN).Str(i.userAttributeMap.id, e.GetAttributeValue(i.userAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
+			i.logger.Warn().Str("dn", e.DN).Str(i.userAttributeMap.id, e.GetEqualFoldAttributeValue(i.userAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
 			return nil, errorcode.New(errorcode.GeneralException, "error converting uuid")
 		}
 		if id != user.GetId() {

--- a/services/graph/pkg/identity/ldap_group.go
+++ b/services/graph/pkg/identity/ldap_group.go
@@ -556,7 +556,7 @@ func (i *LDAP) createGroupModelFromLDAP(e *ldap.Entry) *libregraph.Group {
 	name := e.GetEqualFoldAttributeValue(i.groupAttributeMap.name)
 	id, err := i.ldapUUIDtoString(e, i.groupAttributeMap.id, i.groupIDisOctetString)
 	if err != nil {
-		i.logger.Warn().Str("dn", e.DN).Str(i.groupAttributeMap.id, e.GetAttributeValue(i.groupAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
+		i.logger.Warn().Str("dn", e.DN).Str(i.groupAttributeMap.id, e.GetEqualFoldAttributeValue(i.groupAttributeMap.id)).Msg("Invalid User. Cannot convert UUID")
 	}
 	groupTypes := []string{}
 


### PR DESCRIPTION
There were a couple of places where we were using the case-sensitive GetAttributeValue method instead of the case-insensitive variant.

Fixes: #10200
