### PR TITLE
[tests-only][full-ci] fix shares propfind tests

### DIFF
--- a/tests/acceptance/TestHelpers/CollaborationHelper.php
+++ b/tests/acceptance/TestHelpers/CollaborationHelper.php
@@ -29,7 +29,6 @@ use Psr\Http\Message\ResponseInterface;
  * A helper class for managing wopi requests
  */
 class CollaborationHelper {
-
 	/**
 	 * @param string $fileId
 	 * @param string $app

--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -132,7 +132,7 @@ class GraphHelper {
 	 *
 	 * @return string regex pattern
 	 */
-	public static function sanitizeRegexPattern(string $pattern): string {
+	public static function jsonSchemaRegexToPureRegex(string $pattern): string {
 		$pattern = \str_replace("\\\\", "\\", $pattern);
 		$pattern = \str_replace("/", "\/", $pattern);
 		$pattern = \preg_replace('/^\^/', '', $pattern);

--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -116,6 +116,7 @@ class GraphHelper {
 	public static function getEtagRegex(): string {
 		return "^\\\"[a-f0-9:.]{1,32}\\\"$";
 	}
+
 	/**
 	 * Federated users have a base64 encoded string of {remoteid}@{provider} as their id
 	 * This regex matches only non empty base64 encoded strings
@@ -124,6 +125,19 @@ class GraphHelper {
 	 */
 	public static function getFederatedUserRegex(): string {
 		return '^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$';
+	}
+
+	/**
+	 * @param string $pattern
+	 *
+	 * @return string regex pattern
+	 */
+	public static function sanitizeRegexPattern(string $pattern): string {
+		$pattern = \str_replace("\\\\", "\\", $pattern);
+		$pattern = \str_replace("/", "\/", $pattern);
+		$pattern = \preg_replace('/^\^/', '', $pattern);
+		$pattern = \preg_replace('/\$$/', '', $pattern);
+		return "/^$pattern$/";
 	}
 
 	/**

--- a/tests/acceptance/TestHelpers/HttpRequestHelper.php
+++ b/tests/acceptance/TestHelpers/HttpRequestHelper.php
@@ -674,7 +674,7 @@ class HttpRequestHelper {
 	}
 
 	/**
-	 * @return bool
+	 * @return string
 	 */
 	public static function getXRequestIdRegex(): string {
 		if (self::sendScenarioLineReferencesInXRequestId()) {

--- a/tests/acceptance/TestHelpers/HttpRequestHelper.php
+++ b/tests/acceptance/TestHelpers/HttpRequestHelper.php
@@ -665,4 +665,22 @@ class HttpRequestHelper {
 	public static function getJsonDecodedResponseBodyContent(ResponseInterface $response): mixed {
 		return json_decode($response->getBody()->getContents(), null, 512, JSON_THROW_ON_ERROR);
 	}
+
+	/**
+	 * @return bool
+	 */
+	public static function sendScenarioLineReferencesInXRequestId(): bool {
+		return (\getenv("SEND_SCENARIO_LINE_REFERENCES") === "true");
+	}
+
+	/**
+	 * @return bool
+	 */
+	public static function getXRequestIdRegex(): string {
+		if (self::sendScenarioLineReferencesInXRequestId()) {
+			return '/^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/';
+		}
+		$host = gethostname();
+		return "/^$host\/.*$/";
+	}
 }

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -3775,7 +3775,7 @@ class SpacesContext implements Context {
 			if ($resource === '' || $resource === '/') {
 				$resource = $spaceName;
 			} else {
-				$resource = $spaceName . '/' . $resource;
+				$resource = "$spaceName/$resource";
 			}
 		}
 
@@ -3795,44 +3795,44 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^as user "([^"]*)" the (PROPFIND|REPORT) response should contain a (mountpoint|space) "([^"]*)" with these key and value pairs:$/
+	 * @Then /^as user "([^"]*)" the (PROPFIND|REPORT) response should contain a (resource|space) "([^"]*)" with these key and value pairs:$/
 	 *
 	 * @param string $user
 	 * @param string $method # method should be either PROPFIND or REPORT
-	 * @param string $type	# type should be either mountpoint or space
-	 * @param string $mountPoint
+	 * @param string $type	# type should be either resource or space
+	 * @param string $resource
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function asUsertheXMLResponseShouldContainMountpointWithTheseKeyAndValuePair(string $user, string $method, string $type, string $mountPoint, TableNode $table): void {
+	public function asUsertheXMLResponseShouldContainMountpointWithTheseKeyAndValuePair(string $user, string $method, string $type, string $resource, TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
 		if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES && $type === 'space') {
-			$space = $this->getSpaceByName($user, $mountPoint);
-			$mountPoint = $space['id'];
+			$space = $this->getSpaceByName($user, $resource);
+			$resource = $space['id'];
 		} else {
-			$mountPoint = \rawurlencode($mountPoint);
+			$resource = \rawurlencode($resource);
 		}
-		$this->theXMLResponseShouldContain($mountPoint, $table);
+		$this->theXMLResponseShouldContain($resource, $table);
 	}
 
 	/**
-	 * @param string $spaceNameOrMountPoint # an entity inside a space, or the space name itself
+	 * @param string $resource
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 * @throws JsonException
 	 */
-	public function theXMLResponseShouldContain(string $spaceNameOrMountPoint, TableNode $table): void {
+	public function theXMLResponseShouldContain(string $resource, TableNode $table): void {
 		$xmlResponse = $this->featureContext->getResponseXml();
-		$hrefs = array_map(fn($href) => $href->__toString(), $xmlResponse->xpath("//d:response/d:href"));
+		$hrefs = array_map(fn ($href) => $href->__toString(), $xmlResponse->xpath("//d:response/d:href"));
 
 		$currentHref = '';
 		foreach ($hrefs as $href) {
-			if (\str_ends_with(\rtrim($href, "/"), "/$spaceNameOrMountPoint")) {
+			if (\str_ends_with(\rtrim($href, "/"), "/$resource")) {
 				$currentHref = $href;
 				break;
 			}
@@ -3851,15 +3851,15 @@ class SpacesContext implements Context {
 
 			switch ($itemToFind) {
 				case "oc:fileid":
-					$expectedValue = GraphHelper::sanitizeRegexPattern($expectedValue);
+					$expectedValue = GraphHelper::jsonSchemaRegexToPureRegex($expectedValue);
 					Assert::assertRegExp($expectedValue, $actualValue, 'wrong "fileid" in the response');
 					break;
 				case "oc:file-parent":
-					$expectedValue = GraphHelper::sanitizeRegexPattern($expectedValue);
+					$expectedValue = GraphHelper::jsonSchemaRegexToPureRegex($expectedValue);
 					Assert::assertRegExp($expectedValue, $actualValue, 'wrong "file-parent" in the response');
 					break;
 				case "oc:privatelink":
-					$expectedValue = GraphHelper::sanitizeRegexPattern($expectedValue);
+					$expectedValue = GraphHelper::jsonSchemaRegexToPureRegex($expectedValue);
 					Assert::assertRegExp($expectedValue, $actualValue, 'wrong "privatelink" in the response');
 					break;
 				case "oc:tags":
@@ -3871,7 +3871,7 @@ class SpacesContext implements Context {
 
 					$actualTags = \explode(",", $actualValue);
 					\sort($actualTags);
-					$actualTags = \implode(",", $actualValue);
+					$actualTags = \implode(",", $actualTags);
 					Assert::assertEquals($expectedTags, $actualTags, "wrong '$itemToFind' in the response");
 					break;
 				case "d:lockdiscovery/d:activelock/d:timeout":
@@ -3887,7 +3887,7 @@ class SpacesContext implements Context {
 					}
 					break;
 				case "oc:remote-item-id":
-					$expectedValue = GraphHelper::sanitizeRegexPattern($expectedValue);
+					$expectedValue = GraphHelper::jsonSchemaRegexToPureRegex($expectedValue);
 					Assert::assertRegExp($expectedValue, $actualValue, 'wrong "remote-item-id" in the response');
 					break;
 				default:

--- a/tests/acceptance/features/apiContract/copy.feature
+++ b/tests/acceptance/features/apiContract/copy.feature
@@ -21,7 +21,7 @@ Feature: Copy test
       | Origin | %base_url% |
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
-      | Oc-Fileid                   | /^[a-f0-9!\$\-]{110}$/                       |
-      | Access-Control-Allow-Origin | /^%base_url%$/                               |
-      | X-Request-Id                | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+      | Oc-Fileid                   | /^[a-f0-9!\$\-]{110}$/ |
+      | Access-Control-Allow-Origin | /^%base_url%$/         |
+      | X-Request-Id                | %request_id_pattern%   |
 

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -18,7 +18,7 @@ Feature: Propfind test
     When user "Alice" sends PROPFIND request to space "new-space" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+      | X-Request-Id | %request_id_pattern% |
     And as user "Alice" the PROPFIND response should contain a space "new-space" with these key and value pairs:
       | key            | value                     |
       | oc:fileid      | %file_id_pattern%         |
@@ -38,7 +38,7 @@ Feature: Propfind test
     When user "Brian" sends PROPFIND request to space "new-space" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+      | X-Request-Id | %request_id_pattern% |
     And as user "Brian" the PROPFIND response should contain a space "new-space" with these key and value pairs:
       | key            | value                     |
       | oc:fileid      | %file_id_pattern%         |
@@ -46,7 +46,7 @@ Feature: Propfind test
       | oc:permissions | <oc-permission>           |
       | oc:privatelink | %base_url%/f/[0-9a-z-$%]+ |
       | oc:size        | 12                        |
-    Examples: 
+    Examples:
       | space-role   | oc-permission |
       | Manager      | RDNVCKZP      |
       | Space Editor | DNVCK         |
@@ -62,7 +62,7 @@ Feature: Propfind test
       | permissionsRole | <space-role> |
     When user "Brian" sends PROPFIND request from the space "new-space" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a mountpoint "folderMain" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "folderMain" with these key and value pairs:
       | key            | value             |
       | oc:fileid      | %file_id_pattern% |
       | oc:file-parent | %file_id_pattern% |
@@ -85,7 +85,7 @@ Feature: Propfind test
       | permissionsRole | <space-role> |
     When user "Brian" sends PROPFIND request from the space "new-space" to the resource "folderMain/subFolder1/subFolder2" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a mountpoint "subFolder2" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "subFolder2" with these key and value pairs:
       | key            | value             |
       | oc:fileid      | %file_id_pattern% |
       | oc:file-parent | %file_id_pattern% |
@@ -108,7 +108,7 @@ Feature: Propfind test
       | permissionsRole | <space-role> |
     When user "Brian" sends PROPFIND request from the space "new-space" to the resource "testfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a mountpoint "testfile.txt" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "testfile.txt" with these key and value pairs:
       | key            | value             |
       | oc:fileid      | %file_id_pattern% |
       | oc:file-parent | %file_id_pattern% |

--- a/tests/acceptance/features/apiContract/propfind.feature
+++ b/tests/acceptance/features/apiContract/propfind.feature
@@ -19,13 +19,13 @@ Feature: Propfind test
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
-      | key            | value            |
-      | oc:fileid      | UUIDof:new-space |
-      | oc:name        | new-space        |
-      | oc:permissions | RDNVCKZP         |
-      | oc:privatelink |                  |
-      | oc:size        | 12               |
+    And as user "Alice" the PROPFIND response should contain a space "new-space" with these key and value pairs:
+      | key            | value                     |
+      | oc:fileid      | %file_id_pattern%         |
+      | oc:name        | new-space                 |
+      | oc:permissions | RDNVCKZP                  |
+      | oc:privatelink | %base_url%/f/[0-9a-z-$%]+ |
+      | oc:size        | 12                        |
 
 
   Scenario Outline: space member with a different role checks the PROPFIND request of a space
@@ -39,14 +39,14 @@ Feature: Propfind test
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
-      | key            | value            |
-      | oc:fileid      | UUIDof:new-space |
-      | oc:name        | new-space        |
-      | oc:permissions | <oc-permission>  |
-      | oc:privatelink |                  |
-      | oc:size        | 12               |
-    Examples:
+    And as user "Brian" the PROPFIND response should contain a space "new-space" with these key and value pairs:
+      | key            | value                     |
+      | oc:fileid      | %file_id_pattern%         |
+      | oc:name        | new-space                 |
+      | oc:permissions | <oc-permission>           |
+      | oc:privatelink | %base_url%/f/[0-9a-z-$%]+ |
+      | oc:size        | 12                        |
+    Examples: 
       | space-role   | oc-permission |
       | Manager      | RDNVCKZP      |
       | Space Editor | DNVCK         |
@@ -62,10 +62,10 @@ Feature: Propfind test
       | permissionsRole | <space-role> |
     When user "Brian" sends PROPFIND request from the space "new-space" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a mountpoint "folderMain" with these key and value pairs:
       | key            | value             |
-      | oc:fileid      | UUIDof:folderMain |
-      | oc:file-parent | UUIDof:new-space  |
+      | oc:fileid      | %file_id_pattern% |
+      | oc:file-parent | %file_id_pattern% |
       | oc:name        | folderMain        |
       | oc:permissions | <oc-permission>   |
       | oc:size        | 0                 |
@@ -85,13 +85,13 @@ Feature: Propfind test
       | permissionsRole | <space-role> |
     When user "Brian" sends PROPFIND request from the space "new-space" to the resource "folderMain/subFolder1/subFolder2" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
-      | key            | value                                   |
-      | oc:fileid      | UUIDof:folderMain/subFolder1/subFolder2 |
-      | oc:file-parent | UUIDof:folderMain/subFolder1            |
-      | oc:name        | subFolder2                              |
-      | oc:permissions | <oc-permission>                         |
-      | oc:size        | 0                                       |
+    And as user "Brian" the PROPFIND response should contain a mountpoint "subFolder2" with these key and value pairs:
+      | key            | value             |
+      | oc:fileid      | %file_id_pattern% |
+      | oc:file-parent | %file_id_pattern% |
+      | oc:name        | subFolder2        |
+      | oc:permissions | <oc-permission>   |
+      | oc:size        | 0                 |
     Examples:
       | space-role   | oc-permission |
       | Manager      | RDNVCKZP      |
@@ -108,13 +108,13 @@ Feature: Propfind test
       | permissionsRole | <space-role> |
     When user "Brian" sends PROPFIND request from the space "new-space" to the resource "testfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
-      | key            | value               |
-      | oc:fileid      | UUIDof:testfile.txt |
-      | oc:file-parent | UUIDof:new-space    |
-      | oc:name        | testfile.txt        |
-      | oc:permissions | <oc-permission>     |
-      | oc:size        | 12                  |
+    And as user "Brian" the PROPFIND response should contain a mountpoint "testfile.txt" with these key and value pairs:
+      | key            | value             |
+      | oc:fileid      | %file_id_pattern% |
+      | oc:file-parent | %file_id_pattern% |
+      | oc:name        | testfile.txt      |
+      | oc:permissions | <oc-permission>   |
+      | oc:size        | 12                |
     Examples:
       | space-role   | oc-permission |
       | Manager      | RDNVWZP       |

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -25,8 +25,8 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Brian" the REPORT response should contain a mountpoint "SubFolder1" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Brian" the REPORT response should contain a resource "SubFolder1" with these key and value pairs:
       | key               | value                |
       | oc:fileid         | %file_id_pattern%    |
       | oc:file-parent    | %file_id_pattern%    |
@@ -47,8 +47,8 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "frodo.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Brian" the REPORT response should contain a mountpoint "frodo.txt" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Brian" the REPORT response should contain a resource "frodo.txt" with these key and value pairs:
       | key                | value             |
       | oc:fileid          | %file_id_pattern% |
       | oc:file-parent     | %file_id_pattern% |
@@ -77,7 +77,7 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "folderToBrian" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+      | X-Request-Id | %request_id_pattern% |
     And the search result should contain "0" entries
     Examples:
       | dav-path-version |
@@ -99,8 +99,8 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "secureFolder" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Brian" the REPORT response should contain a mountpoint "secureFolder" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Brian" the REPORT response should contain a resource "secureFolder" with these key and value pairs:
       | key               | value                |
       | oc:shareroot      | /secureFolder        |
       | oc:name           | secureFolder         |
@@ -110,9 +110,9 @@ Feature: REPORT request to Shares space
       | oc:remote-item-id | %file_id_pattern%    |
     When user "Brian" searches for "secure.txt" using the WebDAV API
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+      | X-Request-Id | %request_id_pattern% |
     Then the HTTP status code should be "207"
-    And as user "Brian" the REPORT response should contain a mountpoint "secure.txt" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a resource "secure.txt" with these key and value pairs:
       | key                | value         |
       | oc:shareroot       | /secureFolder |
       | oc:name            | secure.txt    |
@@ -139,8 +139,8 @@ Feature: REPORT request to Shares space
     When user "Brian" searches for "secure.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Brian" the REPORT response should contain a mountpoint "secure.txt" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Brian" the REPORT response should contain a resource "secure.txt" with these key and value pairs:
       | key                | value       |
       | oc:shareroot       | /secure.txt |
       | oc:name            | secure.txt  |

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -26,15 +26,15 @@ Feature: REPORT request to Shares space
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a mountpoint "SubFolder1" with these key and value pairs:
       | key               | value                |
-      | oc:fileid         | UUIDof:SubFolder1    |
-      | oc:file-parent    | UUIDof:folderMain    |
+      | oc:fileid         | %file_id_pattern%    |
+      | oc:file-parent    | %file_id_pattern%    |
       | oc:shareroot      | /folderMain          |
       | oc:name           | SubFolder1           |
       | d:getcontenttype  | httpd/unix-directory |
       | oc:permissions    | S                    |
-      | oc:remote-item-id | UUIDof:folderMain    |
+      | oc:remote-item-id | %file_id_pattern%    |
     Examples:
       | dav-path-version |
       | old              |
@@ -48,16 +48,16 @@ Feature: REPORT request to Shares space
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
-      | key                | value                                  |
-      | oc:fileid          | UUIDof:SubFolder1/subFOLDER2/frodo.txt |
-      | oc:file-parent     | UUIDof:SubFolder1/subFOLDER2           |
-      | oc:shareroot       | /folderMain                            |
-      | oc:name            | frodo.txt                              |
-      | d:getcontenttype   | text/plain                             |
-      | oc:permissions     | S                                      |
-      | d:getcontentlength | 34                                     |
-      | oc:remote-item-id  | UUIDof:folderMain                      |
+    And as user "Brian" the REPORT response should contain a mountpoint "frodo.txt" with these key and value pairs:
+      | key                | value             |
+      | oc:fileid          | %file_id_pattern% |
+      | oc:file-parent     | %file_id_pattern% |
+      | oc:shareroot       | /folderMain       |
+      | oc:name            | frodo.txt         |
+      | d:getcontenttype   | text/plain        |
+      | oc:permissions     | S                 |
+      | d:getcontentlength | 34                |
+      | oc:remote-item-id  | %file_id_pattern% |
     Examples:
       | dav-path-version |
       | old              |
@@ -100,19 +100,19 @@ Feature: REPORT request to Shares space
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Brian" should contain a mountpoint "secureFolder" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a mountpoint "secureFolder" with these key and value pairs:
       | key               | value                |
       | oc:shareroot      | /secureFolder        |
       | oc:name           | secureFolder         |
       | d:getcontenttype  | httpd/unix-directory |
       | oc:permissions    | SMX                  |
       | oc:size           | 14                   |
-      | oc:remote-item-id | UUIDof:secureFolder  |
+      | oc:remote-item-id | %file_id_pattern%    |
     When user "Brian" searches for "secure.txt" using the WebDAV API
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     Then the HTTP status code should be "207"
-    And the "REPORT" response to user "Brian" should contain a mountpoint "secureFolder" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a mountpoint "secure.txt" with these key and value pairs:
       | key                | value         |
       | oc:shareroot       | /secureFolder |
       | oc:name            | secure.txt    |
@@ -140,7 +140,7 @@ Feature: REPORT request to Shares space
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Brian" should contain a mountpoint "secure.txt" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a mountpoint "secure.txt" with these key and value pairs:
       | key                | value       |
       | oc:shareroot       | /secure.txt |
       | oc:name            | secure.txt  |

--- a/tests/acceptance/features/apiContract/spacesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesReport.feature
@@ -21,8 +21,8 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /testFile.txt |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Alice" the REPORT response should contain a resource "testFile.txt" with these key and value pairs:
       | key                | value             |
       | oc:fileid          | %file_id_pattern% |
       | oc:file-parent     | %file_id_pattern% |
@@ -41,8 +41,8 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Alice" the REPORT response should contain a resource "insideTheFolder.txt" with these key and value pairs:
       | key                | value               |
       | oc:fileid          | %file_id_pattern%   |
       | oc:file-parent     | %file_id_pattern%   |
@@ -60,8 +60,8 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /folderMain |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Alice" the REPORT response should contain a resource "folderMain" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | %file_id_pattern%    |
       | oc:file-parent   | %file_id_pattern%    |
@@ -79,9 +79,9 @@ Feature: REPORT request to project space
     And the search result of user "Alice" should contain only these entries:
       | /folderMain/sub-folder |
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+      | X-Request-Id | %request_id_pattern% |
     And the HTTP status code should be "207"
-    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
+    And as user "Alice" the REPORT response should contain a resource "sub-folder" with these key and value pairs:
       | key              | value                |
       | oc:fileid        | %file_id_pattern%    |
       | oc:file-parent   | %file_id_pattern%    |

--- a/tests/acceptance/features/apiContract/spacesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesReport.feature
@@ -22,14 +22,14 @@ Feature: REPORT request to project space
       | /testFile.txt |
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
-      | key                | value               |
-      | oc:fileid          | UUIDof:testFile.txt |
-      | oc:file-parent     | UUIDof:findData     |
-      | oc:name            | testFile.txt        |
-      | d:getcontenttype   | text/plain          |
-      | oc:permissions     | RDNVW               |
-      | d:getcontentlength | 12                  |
+    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
+      | key                | value             |
+      | oc:fileid          | %file_id_pattern% |
+      | oc:file-parent     | %file_id_pattern% |
+      | oc:name            | testFile.txt      |
+      | d:getcontenttype   | text/plain        |
+      | oc:permissions     | RDNVW             |
+      | d:getcontentlength | 12                |
 
 
   Scenario: check the response of the searched sub-file
@@ -42,14 +42,14 @@ Feature: REPORT request to project space
       | /folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
-      | key                | value                                                       |
-      | oc:fileid          | UUIDof:folderMain/SubFolder1/subFOLDER2/insideTheFolder.txt |
-      | oc:file-parent     | UUIDof:folderMain/SubFolder1/subFOLDER2                     |
-      | oc:name            | insideTheFolder.txt                                         |
-      | d:getcontenttype   | text/plain                                                  |
-      | oc:permissions     | RDNVW                                                       |
-      | d:getcontentlength | 12                                                          |
+    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
+      | key                | value               |
+      | oc:fileid          | %file_id_pattern%   |
+      | oc:file-parent     | %file_id_pattern%   |
+      | oc:name            | insideTheFolder.txt |
+      | d:getcontenttype   | text/plain          |
+      | oc:permissions     | RDNVW               |
+      | d:getcontentlength | 12                  |
 
 
   Scenario: check the response of the searched folder
@@ -61,10 +61,10 @@ Feature: REPORT request to project space
       | /folderMain |
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
+    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
       | key              | value                |
-      | oc:fileid        | UUIDof:folderMain    |
-      | oc:file-parent   | UUIDof:findData      |
+      | oc:fileid        | %file_id_pattern%    |
+      | oc:file-parent   | %file_id_pattern%    |
       | oc:name          | folderMain           |
       | d:getcontenttype | httpd/unix-directory |
       | oc:permissions   | RDNVCK               |
@@ -81,11 +81,11 @@ Feature: REPORT request to project space
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
     And the HTTP status code should be "207"
-    And the "REPORT" response to user "Alice" should contain a mountpoint "findData" with these key and value pairs:
-      | key              | value                        |
-      | oc:fileid        | UUIDof:folderMain/sub-folder |
-      | oc:file-parent   | UUIDof:folderMain            |
-      | oc:name          | sub-folder                   |
-      | d:getcontenttype | httpd/unix-directory         |
-      | oc:permissions   | RDNVCK                       |
-      | oc:size          | 0                            |
+    And as user "Alice" the REPORT response should contain a mountpoint "findData" with these key and value pairs:
+      | key              | value                |
+      | oc:fileid        | %file_id_pattern%    |
+      | oc:file-parent   | %file_id_pattern%    |
+      | oc:name          | sub-folder           |
+      | d:getcontenttype | httpd/unix-directory |
+      | oc:permissions   | RDNVCK               |
+      | oc:size          | 0                    |

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -31,16 +31,16 @@ Feature: Report test
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a mountpoint "folderMain" with these key and value pairs:
       | key               | value                |
-      | oc:fileid         | UUIDof:SubFolder1    |
-      | oc:file-parent    | UUIDof:folderMain    |
+      | oc:fileid         | %file_id_pattern%    |
+      | oc:file-parent    | %file_id_pattern%    |
       | oc:shareroot      | /folderMain          |
       | oc:name           | SubFolder1           |
       | d:getcontenttype  | httpd/unix-directory |
       | oc:permissions    | S                    |
       | oc:size           | 12                   |
-      | oc:remote-item-id | UUIDof:folderMain    |
+      | oc:remote-item-id | %file_id_pattern%    |
 
 
   Scenario: check the response of the found file
@@ -55,16 +55,16 @@ Feature: Report test
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
       | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And the "REPORT" response to user "Brian" should contain a mountpoint "folderMain" with these key and value pairs:
-      | key                | value                                            |
-      | oc:fileid          | UUIDof:SubFolder1/subFOLDER2/insideTheFolder.txt |
-      | oc:file-parent     | UUIDof:SubFolder1/subFOLDER2                     |
-      | oc:shareroot       | /folderMain                                      |
-      | oc:name            | insideTheFolder.txt                              |
-      | d:getcontenttype   | text/plain                                       |
-      | oc:permissions     | SD                                               |
-      | d:getcontentlength | 12                                               |
-      | oc:remote-item-id  | UUIDof:folderMain                                |
+    And as user "Brian" the REPORT response should contain a mountpoint "insideTheFolder.txt" with these key and value pairs:
+      | key                | value               |
+      | oc:fileid          | %file_id_pattern%   |
+      | oc:file-parent     | %file_id_pattern%   |
+      | oc:shareroot       | /folderMain         |
+      | oc:name            | insideTheFolder.txt |
+      | d:getcontenttype   | text/plain          |
+      | oc:permissions     | SD                  |
+      | d:getcontentlength | 12                  |
+      | oc:remote-item-id  | %file_id_pattern%   |
 
 
   Scenario: search for the shared folder when the share is not accepted

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -30,8 +30,8 @@ Feature: Report test
     When user "Brian" searches for "SubFolder1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Brian" the REPORT response should contain a mountpoint "folderMain" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Brian" the REPORT response should contain a resource "SubFolder1" with these key and value pairs:
       | key               | value                |
       | oc:fileid         | %file_id_pattern%    |
       | oc:file-parent    | %file_id_pattern%    |
@@ -54,8 +54,8 @@ Feature: Report test
     When user "Brian" searches for "insideTheFolder.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
-    And as user "Brian" the REPORT response should contain a mountpoint "insideTheFolder.txt" with these key and value pairs:
+      | X-Request-Id | %request_id_pattern% |
+    And as user "Brian" the REPORT response should contain a resource "insideTheFolder.txt" with these key and value pairs:
       | key                | value               |
       | oc:fileid          | %file_id_pattern%   |
       | oc:file-parent     | %file_id_pattern%   |
@@ -78,5 +78,5 @@ Feature: Report test
     When user "Brian" searches for "folderMain" using the WebDAV API
     Then the HTTP status code should be "207"
     And the following headers should match these regular expressions
-      | X-Request-Id | /^[a-zA-Z]+\/[a-zA-Z]+\.feature:\d+(-\d+)?$/ |
+      | X-Request-Id | %request_id_pattern% |
     And the search result should contain "0" entries

--- a/tests/acceptance/features/apiLocks/lockFiles.feature
+++ b/tests/acceptance/features/apiLocks/lockFiles.feature
@@ -17,7 +17,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -39,7 +39,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -61,7 +61,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -104,7 +104,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "Project" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -133,7 +133,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "Project" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -179,7 +179,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Brian Murphy |
@@ -206,7 +206,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Brian Murphy |
@@ -253,7 +253,7 @@ Feature: lock files
     Then the HTTP status code should be "423"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Alice Hansen |
@@ -277,7 +277,7 @@ Feature: lock files
     Then the HTTP status code should be "423"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Brian Murphy |

--- a/tests/acceptance/features/apiLocks/lockFiles.feature
+++ b/tests/acceptance/features/apiLocks/lockFiles.feature
@@ -17,7 +17,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -39,7 +39,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -61,7 +61,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -104,7 +104,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "Project" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Brian" should contain a space "Project" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -133,7 +133,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "Project" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Brian" should contain a space "Project" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/d:depth                 | Infinity     |
@@ -179,7 +179,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Brian Murphy |
@@ -206,7 +206,7 @@ Feature: lock files
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Brian Murphy |
@@ -253,7 +253,7 @@ Feature: lock files
     Then the HTTP status code should be "423"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Alice Hansen |
@@ -277,7 +277,7 @@ Feature: lock files
     Then the HTTP status code should be "423"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "textfile.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a space "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "Alice Hansen" with these key and value pairs:
       | key                                                  | value        |
       | d:lockdiscovery/d:activelock/d:lockscope/d:exclusive |              |
       | d:lockdiscovery/d:activelock/oc:ownername            | Brian Murphy |

--- a/tests/acceptance/features/apiSearchContent/extractedProps.feature
+++ b/tests/acceptance/features/apiSearchContent/extractedProps.feature
@@ -18,7 +18,7 @@ Feature: propfind extracted props
       | propertyName |
       | oc:audio     |
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "new-space" with these key and value pairs:
       | key                | value                          |
       | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
       | oc:audio/oc:artist | ARTIST123456789012345678901234 |
@@ -32,7 +32,7 @@ Feature: propfind extracted props
       | oc:location  |
       | oc:photo     |
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "new-space" with these key and value pairs:
       | key                              | value                |
       | oc:image/oc:width                | 640                  |
       | oc:image/oc:height               | 480                  |
@@ -51,7 +51,7 @@ Feature: propfind extracted props
       | propertyName |
       | oc:audio     |
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "testaudio.mp3" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "testaudio.mp3" with these key and value pairs:
       | key                | value                          |
       | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
       | oc:audio/oc:artist | ARTIST123456789012345678901234 |
@@ -65,7 +65,7 @@ Feature: propfind extracted props
       | oc:location  |
       | oc:photo     |
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "testavatar.jpg" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "testavatar.jpg" with these key and value pairs:
       | key                              | value                |
       | oc:image/oc:width                | 640                  |
       | oc:image/oc:height               | 480                  |
@@ -101,7 +101,7 @@ Feature: propfind extracted props
       | propertyName |
       | oc:audio     |
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a space "Shares" with these key and value pairs:
       | key                | value                          |
       | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
       | oc:audio/oc:artist | ARTIST123456789012345678901234 |
@@ -115,7 +115,7 @@ Feature: propfind extracted props
       | oc:location  |
       | oc:photo     |
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a space "Shares" with these key and value pairs:
       | key                              | value                |
       | oc:image/oc:width                | 640                  |
       | oc:image/oc:height               | 480                  |

--- a/tests/acceptance/features/apiSearchContent/extractedProps.feature
+++ b/tests/acceptance/features/apiSearchContent/extractedProps.feature
@@ -18,7 +18,7 @@ Feature: propfind extracted props
       | propertyName |
       | oc:audio     |
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "new-space" with these key and value pairs:
+    And as user "Alice" the REPORT response should contain a resource "testaudio.mp3" with these key and value pairs:
       | key                | value                          |
       | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
       | oc:audio/oc:artist | ARTIST123456789012345678901234 |
@@ -32,7 +32,7 @@ Feature: propfind extracted props
       | oc:location  |
       | oc:photo     |
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "new-space" with these key and value pairs:
+    And as user "Alice" the REPORT response should contain a resource "testavatar.jpg" with these key and value pairs:
       | key                              | value                |
       | oc:image/oc:width                | 640                  |
       | oc:image/oc:height               | 480                  |
@@ -51,7 +51,7 @@ Feature: propfind extracted props
       | propertyName |
       | oc:audio     |
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "testaudio.mp3" with these key and value pairs:
+    And as user "Alice" the REPORT response should contain a resource "testaudio.mp3" with these key and value pairs:
       | key                | value                          |
       | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
       | oc:audio/oc:artist | ARTIST123456789012345678901234 |
@@ -65,7 +65,7 @@ Feature: propfind extracted props
       | oc:location  |
       | oc:photo     |
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "testavatar.jpg" with these key and value pairs:
+    And as user "Alice" the REPORT response should contain a resource "testavatar.jpg" with these key and value pairs:
       | key                              | value                |
       | oc:image/oc:width                | 640                  |
       | oc:image/oc:height               | 480                  |
@@ -101,7 +101,7 @@ Feature: propfind extracted props
       | propertyName |
       | oc:audio     |
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a space "Shares" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a resource "testaudio.mp3" with these key and value pairs:
       | key                | value                          |
       | oc:audio/oc:album  | ALBUM1234567890123456789012345 |
       | oc:audio/oc:artist | ARTIST123456789012345678901234 |
@@ -115,7 +115,7 @@ Feature: propfind extracted props
       | oc:location  |
       | oc:photo     |
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a space "Shares" with these key and value pairs:
+    And as user "Brian" the REPORT response should contain a resource "testavatar.jpg" with these key and value pairs:
       | key                              | value                |
       | oc:image/oc:width                | 640                  |
       | oc:image/oc:height               | 480                  |

--- a/tests/acceptance/features/apiSharingNg1/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg1/propfindShares.feature
@@ -37,12 +37,12 @@ Feature: propfind a shares
       | key       | value             |
       | oc:fileid | %file_id_pattern% |
       | oc:name   | Shares            |
-    And as user "Brian" the PROPFIND response should contain a mountpoint "<resource>" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "<resource>" with these key and value pairs:
       | key            | value             |
       | oc:fileid      | %file_id_pattern% |
       | oc:name        | <resource>        |
       | oc:permissions | S                 |
-    And as user "Brian" the PROPFIND response should contain a mountpoint "<resource-2>" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "<resource-2>" with these key and value pairs:
       | key            | value             |
       | oc:fileid      | %file_id_pattern% |
       | oc:name        | <resource-2>      |
@@ -77,12 +77,12 @@ Feature: propfind a shares
     And user "Brian" has a share "folderToShare (1)" synced
     When user "Brian" sends PROPFIND request from the space "Shares" to the resource "folderToShare (1)" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a mountpoint "folderToShare (1)" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "folderToShare (1)" with these key and value pairs:
       | key            | value              |
       | oc:fileid      | %share_id_pattern% |
       | oc:name        | folderToShare      |
       | oc:permissions | S                  |
-    And as user "Brian" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
       | key            | value             |
       | oc:fileid      | %file_id_pattern% |
       | oc:name        | textfile.txt      |

--- a/tests/acceptance/features/apiSharingNg1/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg1/propfindShares.feature
@@ -10,47 +10,8 @@ Feature: propfind a shares
       | Brian    |
       | Carol    |
 
-  @issue-4421
+  @issue-4421 @issue-9933
   Scenario Outline: sharee PROPFIND same name shares shared by multiple users
-    Given using spaces DAV path
-    And user "Alice" has uploaded file with content "to share" to "textfile.txt"
-    And user "Alice" has created folder "folderToShare"
-    And user "Carol" has uploaded file with content "to share" to "textfile.txt"
-    And user "Carol" has created folder "folderToShare"
-    And user "Alice" has sent the following resource share invitation:
-      | resource        | <resource> |
-      | space           | Personal   |
-      | sharee          | Brian      |
-      | shareType       | user       |
-      | permissionsRole | Viewer     |
-    And user "Brian" has a share "<resource>" synced
-    And user "Carol" has sent the following resource share invitation:
-      | resource        | <resource> |
-      | space           | Personal   |
-      | sharee          | Brian      |
-      | shareType       | user       |
-      | permissionsRole | Viewer     |
-    And user "Brian" has a share "<resource-2>" synced
-    When user "Brian" sends PROPFIND request to space "Shares" using the WebDAV API
-    Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
-      | key       | value         |
-      | oc:fileid | UUIDof:Shares |
-    And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key            | value      |
-      | oc:name        | <resource> |
-      | oc:permissions | S          |
-    And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key            | value        |
-      | oc:name        | <resource-2> |
-      | oc:permissions | S            |
-    Examples:
-      | resource      | resource-2        |
-      | textfile.txt  | textfile (1).txt  |
-      | folderToShare | folderToShare (1) |
-
-  @issue-4421 @issue-9933 @skip
-  Scenario Outline: sharee PROPFIND same name shares shared by multiple users using new dav path
     Given using <dav-path-version> DAV path
     And user "Alice" has uploaded file with content "to share" to "textfile.txt"
     And user "Alice" has created folder "folderToShare"
@@ -70,22 +31,22 @@ Feature: propfind a shares
       | shareType       | user       |
       | permissionsRole | Viewer     |
     And user "Brian" has a share "<resource-2>" synced
-    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "Shares" using the WebDAV API
+    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "/" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Brian" should contain a space "Shares" with these key and value pairs:
-      | key       | value         |
-      | oc:fileid | UUIDof:Shares |
-      | oc:name   | Shares        |
-    And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a space "Shares" with these key and value pairs:
+      | key       | value             |
+      | oc:fileid | %file_id_pattern% |
+      | oc:name   | Shares            |
+    And as user "Brian" the PROPFIND response should contain a mountpoint "<resource>" with these key and value pairs:
       | key            | value             |
-      | oc:fileid      | UUIDof:<resource> |
+      | oc:fileid      | %file_id_pattern% |
       | oc:name        | <resource>        |
       | oc:permissions | S                 |
-    And the "PROPFIND" response to user "Brian" should contain a mountpoint "Shares" with these key and value pairs:
-      | key            | value               |
-      | oc:fileid      | UUIDof:<resource-2> |
-      | oc:name        | <resource-2>        |
-      | oc:permissions | S                   |
+    And as user "Brian" the PROPFIND response should contain a mountpoint "<resource-2>" with these key and value pairs:
+      | key            | value             |
+      | oc:fileid      | %file_id_pattern% |
+      | oc:name        | <resource-2>      |
+      | oc:permissions | S                 |
     Examples:
       | dav-path-version | resource      | resource-2        |
       | old              | textfile.txt  | textfile (1).txt  |
@@ -93,8 +54,8 @@ Feature: propfind a shares
       | new              | textfile.txt  | textfile (1).txt  |
       | new              | folderToShare | folderToShare (1) |
 
-  @issue-4421 @issue-9933 @skip
-  Scenario: sharee PROPFIND shares with bracket in the name
+  @issue-4421 @issue-9933
+  Scenario: sharee PROPFIND a share having bracket in the name
     Given using spaces DAV path
     And user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "to share" to "folderToShare/textfile.txt"
@@ -116,16 +77,16 @@ Feature: propfind a shares
     And user "Brian" has a share "folderToShare (1)" synced
     When user "Brian" sends PROPFIND request from the space "Shares" to the resource "folderToShare (1)" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Brian" should contain a mountpoint "folderToShare (1)" with these key and value pairs:
-      | key            | value                    |
-      | oc:fileid      | UUIDof:folderToShare (1) |
-      | oc:name        | folderToShare            |
-      | oc:permissions | S                        |
-    And the "PROPFIND" response to user "Brian" should contain a mountpoint "folderToShare (1)" with these key and value pairs:
-      | key            | value               |
-      | oc:fileid      | UUIDof:textfile.txt |
-      | oc:name        | textfile.txt        |
-      | oc:permissions | S                   |
+    And as user "Brian" the PROPFIND response should contain a mountpoint "folderToShare (1)" with these key and value pairs:
+      | key            | value              |
+      | oc:fileid      | %share_id_pattern% |
+      | oc:name        | folderToShare      |
+      | oc:permissions | S                  |
+    And as user "Brian" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+      | key            | value             |
+      | oc:fileid      | %file_id_pattern% |
+      | oc:name        | textfile.txt      |
+      | oc:permissions |                   |
 
 
   Scenario Outline: check file-id from PROPFIND with shared-with-me drive-item-id

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -30,7 +30,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "folderMain" with these key and value pairs:
       | key     | value                                      |
       | oc:tags | tag level#1,tag with symbols @^$#^%$@%!_+) |
     When user "Alice" creates the following tags for file "folderMain/insideTheFolder.txt" of space "use-tag":
@@ -38,7 +38,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "use-tag" to the resource "folderMain/insideTheFolder.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "insideTheFolder.txt" with these key and value pairs:
       | key     | value   |
       | oc:tags | fileTag |
     When user "Alice" lists all available tags via the Graph API
@@ -68,12 +68,12 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "folderMain" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "folderMain" with these key and value pairs:
       | key     | value            |
       | oc:tags | my tag,important |
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "file.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "file.txt" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "file.txt" with these key and value pairs:
       | key     | value                                 |
       | oc:tags | fileTag,tag with symbol @^$#^%$@%!_+) |
     When user "Alice" lists all available tags via the Graph API
@@ -188,7 +188,7 @@ Feature: Tag
       | marketing |
     And user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "folderMain" with these key and value pairs:
       | key     | value       |
       | oc:tags | development |
 
@@ -268,7 +268,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "folderMain" with these key and value pairs:
       | key     | value         |
       | oc:tags | finance,नेपाल |
     When user "Alice" creates the following tags for file "folderMain/insideTheFolder.txt" of space "use-tag":
@@ -276,7 +276,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "use-tag" to the resource "folderMain/insideTheFolder.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "insideTheFolder.txt" with these key and value pairs:
       | key     | value          |
       | oc:tags | file,नेपाल,Tag |
     When user "Alice" lists all available tags via the Graph API
@@ -295,8 +295,8 @@ Feature: Tag
       | engineering,finance,qa |
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
-    Then the HTTP status code should be "207":
-    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
+    Then the HTTP status code should be "207"
+    And as user "Alice" the PROPFIND response should contain a resource "folderMain" with these key and value pairs:
       | key     | value                     |
       | oc:tags | engineering,finance,hr,qa |
     When user "Alice" lists all available tags via the Graph API

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -30,7 +30,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
       | key     | value                                      |
       | oc:tags | tag level#1,tag with symbols @^$#^%$@%!_+) |
     When user "Alice" creates the following tags for file "folderMain/insideTheFolder.txt" of space "use-tag":
@@ -38,7 +38,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "use-tag" to the resource "folderMain/insideTheFolder.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
       | key     | value   |
       | oc:tags | fileTag |
     When user "Alice" lists all available tags via the Graph API
@@ -68,12 +68,12 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "folderMain" with these key and value pairs:
       | key     | value            |
       | oc:tags | my tag,important |
     When user "Alice" sends PROPFIND request from the space "Alice Hansen" to the resource "file.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "file.txt" with these key and value pairs:
       | key     | value                                 |
       | oc:tags | fileTag,tag with symbol @^$#^%$@%!_+) |
     When user "Alice" lists all available tags via the Graph API
@@ -188,7 +188,7 @@ Feature: Tag
       | marketing |
     And user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
       | key     | value       |
       | oc:tags | development |
 
@@ -268,7 +268,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
       | key     | value         |
       | oc:tags | finance,नेपाल |
     When user "Alice" creates the following tags for file "folderMain/insideTheFolder.txt" of space "use-tag":
@@ -276,7 +276,7 @@ Feature: Tag
     Then the HTTP status code should be "200"
     When user "Brian" sends PROPFIND request from the space "use-tag" to the resource "folderMain/insideTheFolder.txt" with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
       | key     | value          |
       | oc:tags | file,नेपाल,Tag |
     When user "Alice" lists all available tags via the Graph API
@@ -295,8 +295,8 @@ Feature: Tag
       | engineering,finance,qa |
     Then the HTTP status code should be "200"
     When user "Alice" sends PROPFIND request from the space "use-tag" to the resource "folderMain" with depth "0" using the WebDAV API
-    Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "use-tag" with these key and value pairs:
+    Then the HTTP status code should be "207":
+    And as user "Alice" the PROPFIND response should contain a space "use-tag" with these key and value pairs:
       | key     | value                     |
       | oc:tags | engineering,finance,hr,qa |
     When user "Alice" lists all available tags via the Graph API

--- a/tests/acceptance/features/apiSpacesDavOperation/propfindByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/propfindByFileId.feature
@@ -13,7 +13,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "<<FILEID>>" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -29,7 +29,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "<<FILEID>>" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -58,7 +58,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "<<FILEID>>" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -76,7 +76,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a resource "<<FILEID>>" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -113,7 +113,7 @@ Feature: propfind a file using file id
     And user "Brian" has a share "textfile.txt" synced
     When user "Brian" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "<<FILEID>>" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | SNVW         |
@@ -137,7 +137,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Brian" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And as user "Brian" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a resource "<<FILEID>>" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | DNVW         |

--- a/tests/acceptance/features/apiSpacesDavOperation/propfindByFileId.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/propfindByFileId.feature
@@ -13,7 +13,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -29,7 +29,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "Alice Hansen" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -58,7 +58,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -76,7 +76,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Alice" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response should contain a space "new-space" with these key and value pairs:
+    And as user "Alice" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | RDNVWZP      |
@@ -113,7 +113,7 @@ Feature: propfind a file using file id
     And user "Brian" has a share "textfile.txt" synced
     When user "Brian" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "Brian Murphy" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | SNVW         |
@@ -137,7 +137,7 @@ Feature: propfind a file using file id
     And we save it into "FILEID"
     When user "Brian" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
-    And the "PROPFIND" response to user "Alice" should contain a mountpoint "Brian Murphy" with these key and value pairs:
+    And as user "Brian" the PROPFIND response should contain a mountpoint "textfile.txt" with these key and value pairs:
       | key            | value        |
       | oc:name        | textfile.txt |
       | oc:permissions | DNVW         |


### PR DESCRIPTION
## Description
- compare the file-id pattern not the actual id in PROPFIND/REPORT response
  - because we were doing the same PROPFIND request to get the file-id and compare with similar PROPFIND request
- step changes:
```diff
-Then the "REPORT/PROPFIND" response should contain a space/mountpoint "<name>" with these key and value pairs:
-Then the "REPORT/PROPFIND" response to user "<user>" should contain a space/mountpoint "<name>" with these key and value pairs:
+Then as user "<user>" the REPORT/PROPFIND response should contain a space/resource "<name>" with these key and value pairs:
```
- added `jsonSchemaRegexToPureRegex` to convert existing json schema regex to php regex
- moved `sendScenarioLineReferencesInXRequestId` to `HttpRequestHelper`
- fix `X-Request-Id` header tests to make it pass when `SEND_SCENARIO_LINE_REFERENCES` is not set
- added `%request_id_pattern%` and `getXRequestIdRegex`

## Related Issue
- https://github.com/owncloud/ocis/pull/10172
- https://github.com/owncloud/ocis/issues/9933

## How Has This Been Tested?
- test environment:


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
