### PR TITLE
continue listing shares on error

### DIFF
--- a/changelog/unreleased/continue-listing-shares-on-error.md
+++ b/changelog/unreleased/continue-listing-shares-on-error.md
@@ -1,0 +1,5 @@
+Bugfix: Continue listing shares on error
+
+We now continue listing received shares when one of the shares cannot be statted or converted to a driveItem.
+
+https://github.com/owncloud/ocis/pull/10243

--- a/services/graph/pkg/service/v0/sharedwithme.go
+++ b/services/graph/pkg/service/v0/sharedwithme.go
@@ -55,7 +55,7 @@ func (g Graph) listSharedWithMe(ctx context.Context) ([]libregraph.DriveItem, er
 		}
 		ocmDriveItems, err := cs3ReceivedOCMSharesToDriveItems(ctx, g.logger, gatewayClient, g.identityCache, listReceivedOCMSharesResponse.GetShares(), availableRoles)
 		if err != nil {
-			g.logger.Error().Err(err).Msg("could not convert received shares to drive items")
+			g.logger.Error().Err(err).Msg("could not convert received ocm shares to drive items")
 			return nil, err
 		}
 		driveItems = append(driveItems, ocmDriveItems...)


### PR DESCRIPTION
We now continue listing received shares when one of the shares cannot be statted or converted to a driveItem.

related: https://github.com/owncloud/ocis/issues/10213