### PR TITLE
[tests-only][full-ci] check parent-id of shares

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -318,5 +318,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSearchContent/contentSearch.feature:266](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/contentSearch.feature#L266)
 - [apiSearchContent/contentSearch.feature:267](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/contentSearch.feature#L267)
 
+#### [Shares Jail PROPFIND returns different File IDs for the same item](https://github.com/owncloud/ocis/issues/9933)
+
+- [apiSharingNg1/propfindShares.feature:149](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg1/propfindShares.feature#L149)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSharingNg1/propfindShares.feature
+++ b/tests/acceptance/features/apiSharingNg1/propfindShares.feature
@@ -123,18 +123,25 @@ Feature: propfind a shares
     When user "Brian" sends PROPFIND request from the space "Shares" to the resource "/" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Brian" the PROPFIND response should contain a resource "folderToShare" with these key and value pairs:
-      | key       | value     |
-      | oc:fileid | <pattern> |
+      | key            | value                               |
+      | oc:fileid      | <pattern>                           |
+      | oc:file-parent | %self::oc:spaceid%!%uuidv4_pattern% |
     When user "Brian" sends PROPFIND request from the space "Shares" to the resource "folderToShare" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Brian" the PROPFIND response should contain a resource "folderToShare" with these key and value pairs:
-      | key       | value     |
-      | oc:fileid | <pattern> |
+      | key            | value                               |
+      | oc:fileid      | <pattern>                           |
+      | oc:file-parent | %self::oc:spaceid%!%uuidv4_pattern% |
+    And as user "Brian" the PROPFIND response should contain a resource "folderToShare/textfile.txt" with these key and value pairs:
+      | key            | value                               |
+      | oc:fileid      | %file_id_pattern%                   |
+      | oc:file-parent | %self::oc:spaceid%!%uuidv4_pattern% |
     When user "Brian" sends PROPFIND request from the space "Shares" to the resource "folderToShare/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And as user "Brian" the PROPFIND response should contain a resource "folderToShare/textfile.txt" with these key and value pairs:
-      | key       | value             |
-      | oc:fileid | %file_id_pattern% |
+      | key            | value                               |
+      | oc:fileid      | %file_id_pattern%                   |
+      | oc:file-parent | %self::oc:spaceid%!%uuidv4_pattern% |
     Examples:
       | dav-path-version | pattern            |
       | old              | %file_id_pattern%  |


### PR DESCRIPTION
## Description
Check the `oc:file-parent` of shares

## Related Issue
- Bu report: https://github.com/owncloud/ocis/issues/9933#issuecomment-2388850236

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
