### PR TITLE
Don't re-create thumbnail if we have one already

### DIFF
--- a/changelog/unreleased/fix-use-existing-thumbnails.md
+++ b/changelog/unreleased/fix-use-existing-thumbnails.md
@@ -1,0 +1,6 @@
+Bugfix: Avoid re-creating thumbnails
+
+We fixed a bug that caused the system to re-create thumbnails for images, even
+if a thumbnail already existed in the cache.
+
+https://github.com/owncloud/ocis/pull/10251

--- a/services/thumbnails/pkg/service/grpc/v0/service.go
+++ b/services/thumbnails/pkg/service/grpc/v0/service.go
@@ -116,10 +116,10 @@ func (g Thumbnail) GetThumbnail(ctx context.Context, req *thumbnailssvc.GetThumb
 	return nil
 }
 
-func (g Thumbnail) checkThumbnail(req *thumbnailssvc.GetThumbnailRequest, sRes *provider.StatResponse) (thumbnail.Request, error) {
+func (g Thumbnail) checkThumbnail(req *thumbnailssvc.GetThumbnailRequest, sRes *provider.StatResponse) (string, thumbnail.Request, error) {
 	tr := thumbnail.Request{}
 	if !sRes.GetInfo().GetPermissionSet().GetInitiateFileDownload() {
-		return tr, merrors.Forbidden(g.serviceID, "no download permission")
+		return "", tr, merrors.Forbidden(g.serviceID, "no download permission")
 	}
 
 	tType := thumbnail.GetExtForMime(sRes.GetInfo().GetMimeType())
@@ -128,13 +128,13 @@ func (g Thumbnail) checkThumbnail(req *thumbnailssvc.GetThumbnailRequest, sRes *
 	}
 	tr, err := thumbnail.PrepareRequest(int(req.GetWidth()), int(req.GetHeight()), tType, sRes.GetInfo().GetChecksum().GetSum(), req.GetProcessor())
 	if err != nil {
-		return tr, merrors.BadRequest(g.serviceID, err.Error())
+		return "", tr, merrors.BadRequest(g.serviceID, err.Error())
 	}
 
-	if _, exists := g.manager.CheckThumbnail(tr); exists {
-		return tr, nil
+	if key, exists := g.manager.CheckThumbnail(tr); exists {
+		return key, tr, nil
 	}
-	return tr, nil
+	return "", tr, nil
 }
 
 func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetThumbnailRequest) (string, error) {
@@ -144,7 +144,7 @@ func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetTh
 		return "", err
 	}
 
-	tr, err := g.checkThumbnail(req, sRes)
+	key, tr, err := g.checkThumbnail(req, sRes)
 	if err != nil {
 		return "", err
 	}
@@ -164,7 +164,7 @@ func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetTh
 		return "", merrors.InternalServerError(g.serviceID, "could not get image")
 	}
 
-	key, err := g.manager.Generate(tr, img)
+	key, err = g.manager.Generate(tr, img)
 	if err != nil {
 		return "", err
 	}
@@ -219,7 +219,7 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *thumbnailssvc.Ge
 		return "", err
 	}
 
-	tr, err := g.checkThumbnail(req, sRes)
+	key, tr, err := g.checkThumbnail(req, sRes)
 	if err != nil {
 		return "", err
 	}
@@ -248,7 +248,7 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *thumbnailssvc.Ge
 		return "", merrors.InternalServerError(g.serviceID, "could not get image")
 	}
 
-	key, err := g.manager.Generate(tr, img)
+	key, err = g.manager.Generate(tr, img)
 	if err != nil {
 		return "", err
 	}

--- a/services/thumbnails/pkg/service/grpc/v0/service.go
+++ b/services/thumbnails/pkg/service/grpc/v0/service.go
@@ -145,8 +145,12 @@ func (g Thumbnail) handleCS3Source(ctx context.Context, req *thumbnailssvc.GetTh
 	}
 
 	key, tr, err := g.checkThumbnail(req, sRes)
-	if err != nil {
+	switch {
+	case err != nil:
 		return "", err
+	case key != "":
+		// we have matching thumbnail already, use that
+		return key, nil
 	}
 
 	ctx = imgsource.ContextSetAuthorization(ctx, src.GetAuthorization())
@@ -220,9 +224,14 @@ func (g Thumbnail) handleWebdavSource(ctx context.Context, req *thumbnailssvc.Ge
 	}
 
 	key, tr, err := g.checkThumbnail(req, sRes)
-	if err != nil {
+	switch {
+	case err != nil:
 		return "", err
+	case key != "":
+		// we have matching thumbnail already, use that
+		return key, nil
 	}
+
 	if src.GetWebdavAuthorization() != "" {
 		ctx = imgsource.ContextSetAuthorization(ctx, src.GetWebdavAuthorization())
 	}


### PR DESCRIPTION
Thumbnails were  re-created even if we already had a matching thumbnail in the storage.

Seem that this was introduced with https://github.com/owncloud/ocis/pull/9299