### PR TITLE
[tests-only][full-ci] added test to restart upload sessions using CLI command

### DIFF
--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -8,7 +8,7 @@ Feature: List upload sessions via CLI command
     Given user "Alice" has been created with default attributes and without skeleton files
 
 
-  Scenario: user lists all upload sessions
+  Scenario: list all upload sessions
     Given user "Alice" has uploaded file with content "uploaded content" to "/file0.txt"
     And the config "POSTPROCESSING_DELAY" has been set to "10s"
     And user "Alice" has uploaded file with content "uploaded content" to "/file1.txt"
@@ -22,7 +22,7 @@ Feature: List upload sessions via CLI command
       | file0.txt |
 
 
-  Scenario: user lists all upload sessions that are currently in postprocessing
+  Scenario: list all upload sessions that are currently in postprocessing
     Given the following configs have been set:
       | config                           | value     |
       | POSTPROCESSING_STEPS             | virusscan |
@@ -40,7 +40,7 @@ Feature: List upload sessions via CLI command
       | virusFile.txt |
 
 
-  Scenario: user lists all upload sessions that are infected by virus
+  Scenario: list all upload sessions that are infected by virus
     Given the following configs have been set:
       | config                           | value     |
       | POSTPROCESSING_STEPS             | virusscan |
@@ -55,7 +55,7 @@ Feature: List upload sessions via CLI command
       | file1.txt |
 
 
-  Scenario: user lists all expired upload sessions
+  Scenario: list all expired upload sessions
     Given the config "POSTPROCESSING_DELAY" has been set to "10s"
     And user "Alice" has uploaded file with content "uploaded content" to "/file1.txt"
     And the config "STORAGE_USERS_UPLOAD_EXPIRATION" has been set to "0"
@@ -70,7 +70,7 @@ Feature: List upload sessions via CLI command
       | file1.txt |
 
 
-  Scenario: user cleans all expired upload sessions
+  Scenario: clean all expired upload sessions
     Given the config "POSTPROCESSING_DELAY" has been set to "10s"
     And user "Alice" has uploaded file with content "upload content" to "/file1.txt"
     And the config "STORAGE_USERS_UPLOAD_EXPIRATION" has been set to "0"
@@ -83,3 +83,27 @@ Feature: List upload sessions via CLI command
       | file3.txt |
     And the CLI response should not contain these entries:
       | file1.txt |
+
+
+  Scenario: restart upload sessions that are in postprocessing
+    Given user "Alice" has uploaded file with content "upload content" to "/file1.txt"
+    And the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And user "Alice" has uploaded file with content "upload content" to "/file2.txt"
+    When the administrator restarts the upload sessions that are in postprocessing
+    Then the command should be successful
+    And the CLI response should contain these entries:
+      | file2.txt |
+    And the CLI response should not contain these entries:
+      | file1.txt |
+
+
+  Scenario: restart upload sessions of a single file
+    Given the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And user "Alice" has uploaded file with content "upload content" to "/file1.txt"
+    And user "Alice" has uploaded file with content "upload content" to "/file2.txt"
+    When the administrator restarts the upload sessions of file "file1.txt"
+    Then the command should be successful
+    And the CLI response should contain these entries:
+      | file1.txt |
+    And the CLI response should not contain these entries:
+      | file2.txt |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds test to restart upload sessions using CLI command.
Added Scenarios:
```feature
Scenario: restart upload sessions that are processing
Scenario: restart specific upload sessions
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10167

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
