### PR TITLE
[tests-only][full-ci] add test to clean upload sessions that are not processing using CLI command

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -257,12 +257,19 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator cleans all expired upload sessions
+	 * @When the administrator cleans upload sessions with the following flags:
+	 *
+	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
-	public function theAdministratorCleansAllExpiredUploadSessions(): void {
-		$command = "storage-users uploads sessions --expired --clean --json";
+	public function theAdministratorCleansUploadSessionsWithTheFollowingFlags(TableNode $table): void {
+		$flag = "";
+		foreach ($table->getRows() as $row) {
+			$flag .= "--$row[0] ";
+		}
+		$flagString = trim($flag);
+		$command = "storage-users uploads sessions $flagString --clean --json";
 		$body = [
 			"command" => $command
 		];

--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -76,7 +76,8 @@ Feature: List upload sessions via CLI command
     And the config "STORAGE_USERS_UPLOAD_EXPIRATION" has been set to "0"
     And user "Alice" has uploaded file with content "upload content" to "/file2.txt"
     And user "Alice" has uploaded file with content "upload content" to "/file3.txt"
-    When the administrator cleans all expired upload sessions
+    When the administrator cleans upload sessions with the following flags:
+      | expired |
     Then the command should be successful
     And the CLI response should contain these entries:
       | file2.txt |
@@ -107,3 +108,20 @@ Feature: List upload sessions via CLI command
       | file1.txt |
     And the CLI response should not contain these entries:
       | file2.txt |
+
+
+  Scenario: clean all upload sessions that are not in post-processing
+    Given the following configs have been set:
+      | config                           | value     |
+      | POSTPROCESSING_STEPS             | virusscan |
+      | ANTIVIRUS_INFECTED_FILE_HANDLING | abort     |
+    And user "Alice" has uploaded file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt"
+    And the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And user "Alice" has uploaded file with content "upload content" to "/file1.txt"
+    When the administrator cleans upload sessions with the following flags:
+      | processing=false |
+    Then the command should be successful
+    And the CLI response should contain these entries:
+      | virusFile.txt |
+    And the CLI response should not contain these entries:
+      | file1.txt |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the test to clean upload sessions that are not processing using CLI command.
Added Scenarios:
```feature
Scenario: clean all upload sessions that are not processing
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10167

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
