### PR TITLE
[k6-test]trigger k6 test in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -418,7 +418,7 @@ def testPipelines(ctx):
     pipelines += e2eTestPipeline(ctx)
 
     if ("skip" not in config["k6LoadTests"] or not config["k6LoadTests"]["skip"]) and ("k6-test" in ctx.build.title.lower() or ctx.build.event == "cron"):
-        pipelines.append(k6LoadTests(ctx))
+        pipelines += k6LoadTests(ctx)
 
     return pipelines
 


### PR DESCRIPTION
1. running k6 tests automatically in CI during the release process
for that we need
- create empty PR with `[k6-test] `title  

2. do not fail `ocis-log` and `open-grafana-dashboard` if `k6-load-test` has exit 1. related https://github.com/owncloud/cdperf/pull/69
3. added to info how to run k6 test to ocis release process doc [how to run k6 test]( https://infinite.owncloud.com/pdf-viewer/project/engineering/oCIS%20Release%20Process/QA-rollingReleaseProcess.pdf?fileId=31e6d44f-f373-557c-9ab3-1748fc0c650d%244994cd9c-1c17-4254-829a-f5ef6e1ff7e3%217ce4f911-5274-400e-a9ef-bd8c564ccff4&contextRouteName=files-spaces-generic&contextRouteParams.driveAliasAndItem=project%2Fengineering%2FoCIS%20Release%20Process&contextRouteQuery.fileId=31e6d44f-f373-557c-9ab3-1748fc0c650d%244994cd9c-1c17-4254-829a-f5ef6e1ff7e3%218468e54b-c29d-4a16-a861-09abe0a354ba&contextRouteQuery.sort-by=name&contextRouteQuery.sort-dir=asc)

@saw-jan I added new secrets to the droneCi which allowed pull-request. old secrets I'll delete after merging this PR 