### PR TITLE
Template Files for WebOffice

### DIFF
--- a/changelog/unreleased/template-conversions-for-apps.md
+++ b/changelog/unreleased/template-conversions-for-apps.md
@@ -1,0 +1,48 @@
+Enhancement: WebOffice Templates
+
+We are now able to use templates for WebOffice and use them as a starting point for new documents.
+
+We are supporting the following mime types:
+
+## OnlyOffice
+
+- **MimeType:** `application/vnd.ms-word.template.macroenabled.12`
+  **TargetExtension:** `docx`
+
+- **MimeType:** `application/vnd.oasis.opendocument.text-template`
+  **TargetExtension:** `docx`
+
+- **MimeType:** `application/vnd.openxmlformats-officedocument.wordprocessingml.template`
+  **TargetExtension:** `docx`
+
+- **MimeType:** `application/vnd.oasis.opendocument.spreadsheet-template`
+  **TargetExtension:** `xlsx`
+
+- **MimeType:** `application/vnd.ms-excel.template.macroenabled.12`
+  **TargetExtension:** `xlsx`
+
+- **MimeType:** `application/vnd.openxmlformats-officedocument.spreadsheetml.template`
+  **TargetExtension:** `xlsx`
+
+- **MimeType:** `application/vnd.oasis.opendocument.presentation-template`
+  **TargetExtension:** `pptx`
+
+- **MimeType:** `application/vnd.ms-powerpoint.template.macroenabled.12`
+  **TargetExtension:** `pptx`
+
+- **MimeType:** `application/vnd.openxmlformats-officedocument.presentationml.template`
+  **TargetExtension:** `pptx`
+
+## Collabora
+
+- **MimeType:** `application/vnd.oasis.opendocument.spreadsheet-template`
+  **TargetExtension:** `ods`
+
+- **MimeType:** `application/vnd.oasis.opendocument.text-template`
+  **TargetExtension:** `odt`
+
+- **MimeType:** `application/vnd.oasis.opendocument.presentation-template`
+  **TargetExtension:** `odp`
+
+https://github.com/owncloud/ocis/pull/10276
+https://github.com/owncloud/ocis/issues/9785

--- a/services/collaboration/pkg/connector/fileinfo/onlyoffice.go
+++ b/services/collaboration/pkg/connector/fileinfo/onlyoffice.go
@@ -77,6 +77,8 @@ type OnlyOffice struct {
 	FileNameMaxLength int `json:"FileNameMaxLength,omitempty"`
 	// copied from MS WOPI
 	LastModifiedTime string `json:"LastModifiedTime,omitempty"`
+	// The ID of file (like the wopi/files/ID) can be a non-existing file. In that case, the file will be created from a template when the template (eg. an OTT file) is specified as TemplateSource in the CheckFileInfo response. The TemplateSource is supposed to be an URL like https://somewhere/accessible/file.ott that is accessible by the Online. For the actual saving of the content, normal PutFile mechanism will be used.
+	TemplateSource string `json:"TemplateSource,omitempty"`
 
 	//
 	// User metadata properties
@@ -179,7 +181,8 @@ func (oinfo *OnlyOffice) SetProperties(props map[string]interface{}) {
 			oinfo.FileNameMaxLength = value.(int)
 		case KeyLastModifiedTime:
 			oinfo.LastModifiedTime = value.(string)
-
+		case KeyTemplateSource:
+			oinfo.TemplateSource = value.(string)
 		case KeyIsAnonymousUser:
 			oinfo.IsAnonymousUser = value.(bool)
 		case KeyUserFriendlyName:

--- a/services/collaboration/pkg/server/http/server.go
+++ b/services/collaboration/pkg/server/http/server.go
@@ -182,5 +182,17 @@ func prepareRoutes(r *chi.Mux, options Options) {
 				})
 			})
 		})
+		r.Route("/templates/{templateID}", func(r chi.Router) {
+			r.Use(
+				func(h stdhttp.Handler) stdhttp.Handler {
+					// authentication and wopi context
+					return colabmiddleware.WopiContextAuthMiddleware(options.Config, h)
+				},
+				colabmiddleware.CollaborationTracingMiddleware,
+			)
+			r.Get("/", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+				adapter.GetFile(w, r)
+			})
+		})
 	})
 }

--- a/services/collaboration/pkg/service/grpc/v0/service_test.go
+++ b/services/collaboration/pkg/service/grpc/v0/service_test.go
@@ -89,7 +89,8 @@ var _ = Describe("Discovery", func() {
 					".xlsb": "https://test.server.prv/hosting/wopi/cell/view",
 				},
 				"edit": map[string]string{
-					".docx": "https://test.server.prv/hosting/wopi/word/edit",
+					".docx":    "https://test.server.prv/hosting/wopi/word/edit",
+					".invalid": "://test.server.prv/hosting/wopi/cell/edit",
 				},
 			}),
 			service.GatewayAPIClient(gatewayClient),
@@ -240,6 +241,133 @@ var _ = Describe("Discovery", func() {
 			Expect(resp.GetStatus().GetCode()).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(resp.GetAppUrl().GetMethod()).To(Equal("POST"))
 			Expect(resp.GetAppUrl().GetAppUrl()).To(Equal("https://test.server.prv/hosting/wopi/word/edit?UI_LLCC=en-US&WOPISrc=https%3A%2F%2Foffice.proxy.test.prv%2Fwopi%2Ffiles%2FeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1IjoiaHR0cHM6Ly93b3Bpc2VydmVyLnRlc3QucHJ2L3dvcGkvZmlsZXMvIiwiZiI6IjJmNmVjMTg2OTZkZDEwMDgxMDY3NDliZDk0MTA2ZTVjZmFkNWMwOWUxNWRlN2I3NzA4OGQwMzg0M2U3MWI0M2UifQ.yfyLHZ18Z1MFOa6u7AP0LqfIiQ9X5AMkYauEZGhbCNs"))
+			Expect(resp.GetAppUrl().GetFormParameters()["access_token_ttl"]).To(Equal(strconv.FormatInt(nowTime.Add(5*time.Hour).Unix()*1000, 10)))
+		})
+		It("Fail with invalid app url", func() {
+			ctx := context.Background()
+			nowTime := time.Now()
+
+			cfg.Wopi.WopiSrc = "htttps://wopiserver.test.prv"
+			cfg.Wopi.Secret = "my_supa_secret"
+			cfg.App.Name = "Microsoft"
+
+			myself := &userv1beta1.User{
+				Id: &userv1beta1.UserId{
+					Idp:      "myIdp",
+					OpaqueId: "opaque001",
+					Type:     userv1beta1.UserType_USER_TYPE_PRIMARY,
+				},
+				Username: "username",
+			}
+
+			req := &appproviderv1beta1.OpenInAppRequest{
+				ResourceInfo: &providerv1beta1.ResourceInfo{
+					Id: &providerv1beta1.ResourceId{
+						StorageId: "myStorage",
+						OpaqueId:  "storageOpaque001",
+						SpaceId:   "SpaceA",
+					},
+					Path: "/path/to/file.invalid",
+				},
+				ViewMode:    appproviderv1beta1.ViewMode_VIEW_MODE_READ_WRITE,
+				AccessToken: MintToken(myself, cfg.Wopi.Secret, nowTime),
+			}
+			req.Opaque = utils.AppendPlainToOpaque(req.Opaque, "lang", "en")
+
+			gatewayClient.On("WhoAmI", mock.Anything, mock.Anything).Times(1).Return(&gatewayv1beta1.WhoAmIResponse{
+				Status: status.NewOK(ctx),
+				User:   myself,
+			}, nil)
+
+			resp, err := srv.OpenInApp(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp.GetStatus().GetCode()).To(Equal(rpcv1beta1.Code_CODE_INVALID_ARGUMENT))
+			Expect(resp.GetStatus().GetMessage()).To(Equal("OpenInApp: error parsing appUrl"))
+		})
+		It("Fail with invalid template id", func() {
+			ctx := context.Background()
+			nowTime := time.Now()
+
+			cfg.Wopi.WopiSrc = "htttps://wopiserver.test.prv"
+			cfg.Wopi.Secret = "my_supa_secret"
+			cfg.App.Name = "Microsoft"
+
+			myself := &userv1beta1.User{
+				Id: &userv1beta1.UserId{
+					Idp:      "myIdp",
+					OpaqueId: "opaque001",
+					Type:     userv1beta1.UserType_USER_TYPE_PRIMARY,
+				},
+				Username: "username",
+			}
+
+			req := &appproviderv1beta1.OpenInAppRequest{
+				ResourceInfo: &providerv1beta1.ResourceInfo{
+					Id: &providerv1beta1.ResourceId{
+						StorageId: "myStorage",
+						OpaqueId:  "storageOpaque001",
+						SpaceId:   "SpaceA",
+					},
+					Path: "/path/to/file.docx",
+				},
+				ViewMode:    appproviderv1beta1.ViewMode_VIEW_MODE_READ_WRITE,
+				AccessToken: MintToken(myself, cfg.Wopi.Secret, nowTime),
+			}
+			req.Opaque = utils.AppendPlainToOpaque(req.Opaque, "lang", "en")
+			req.Opaque = utils.AppendPlainToOpaque(req.Opaque, "template", "&file_id")
+
+			gatewayClient.On("WhoAmI", mock.Anything, mock.Anything).Times(1).Return(&gatewayv1beta1.WhoAmIResponse{
+				Status: status.NewOK(ctx),
+				User:   myself,
+			}, nil)
+
+			resp, err := srv.OpenInApp(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp.GetStatus().GetCode()).To(Equal(rpcv1beta1.Code_CODE_INVALID_ARGUMENT))
+			Expect(resp.GetStatus().GetMessage()).To(Equal("OpenInApp: error parsing templateID"))
+		})
+		It("Success with valid template id", func() {
+			ctx := context.Background()
+			nowTime := time.Now()
+
+			cfg.Wopi.WopiSrc = "htttps://wopiserver.test.prv"
+			cfg.Wopi.Secret = "my_supa_secret"
+			cfg.App.Name = "OnlyOffice"
+
+			myself := &userv1beta1.User{
+				Id: &userv1beta1.UserId{
+					Idp:      "myIdp",
+					OpaqueId: "opaque001",
+					Type:     userv1beta1.UserType_USER_TYPE_PRIMARY,
+				},
+				Username: "username",
+			}
+
+			req := &appproviderv1beta1.OpenInAppRequest{
+				ResourceInfo: &providerv1beta1.ResourceInfo{
+					Id: &providerv1beta1.ResourceId{
+						StorageId: "myStorage",
+						OpaqueId:  "storageOpaque001",
+						SpaceId:   "SpaceA",
+					},
+					Path: "/path/to/file.docx",
+				},
+				ViewMode:    appproviderv1beta1.ViewMode_VIEW_MODE_READ_WRITE,
+				AccessToken: MintToken(myself, cfg.Wopi.Secret, nowTime),
+			}
+			req.Opaque = utils.AppendPlainToOpaque(req.Opaque, "lang", "en")
+			req.Opaque = utils.AppendPlainToOpaque(req.Opaque, "template", "prodiderID$spaceID!opaqueID")
+
+			gatewayClient.On("WhoAmI", mock.Anything, mock.Anything).Times(1).Return(&gatewayv1beta1.WhoAmIResponse{
+				Status: status.NewOK(ctx),
+				User:   myself,
+			}, nil)
+
+			resp, err := srv.OpenInApp(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp.GetStatus().GetCode()).To(Equal(rpcv1beta1.Code_CODE_OK))
+			Expect(resp.GetAppUrl().GetMethod()).To(Equal("POST"))
+			Expect(resp.GetAppUrl().GetAppUrl()).To(Equal("https://test.server.prv/hosting/wopi/word/edit?WOPISrc=htttps%3A%2F%2Fwopiserver.test.prv%2Fwopi%2Ffiles%2F2f6ec18696dd1008106749bd94106e5cfad5c09e15de7b77088d03843e71b43e&ui=en-US"))
 			Expect(resp.GetAppUrl().GetFormParameters()["access_token_ttl"]).To(Equal(strconv.FormatInt(nowTime.Add(5*time.Hour).Unix()*1000, 10)))
 		})
 	})


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

Adds server-side template processing for WebOffice

We are supporting the following mime types:

### OnlyOffice

- **MimeType:** `application/vnd.ms-word.template.macroenabled.12`
  **TargetExtension:** `docx`

- **MimeType:** `application/vnd.oasis.opendocument.text-template`
  **TargetExtension:** `docx`

- **MimeType:** `application/vnd.openxmlformats-officedocument.wordprocessingml.template`
  **TargetExtension:** `docx`

- **MimeType:** `application/vnd.oasis.opendocument.spreadsheet-template`
  **TargetExtension:** `xlsx`

- **MimeType:** `application/vnd.ms-excel.template.macroenabled.12`
  **TargetExtension:** `xlsx`

- **MimeType:** `application/vnd.openxmlformats-officedocument.spreadsheetml.template`
  **TargetExtension:** `xlsx`

- **MimeType:** `application/vnd.oasis.opendocument.presentation-template`
  **TargetExtension:** `pptx`

- **MimeType:** `application/vnd.ms-powerpoint.template.macroenabled.12`
  **TargetExtension:** `pptx`

- **MimeType:** `application/vnd.openxmlformats-officedocument.presentationml.template`
  **TargetExtension:** `pptx`

### Collabora

- **MimeType:** `application/vnd.oasis.opendocument.spreadsheet-template`
  **TargetExtension:** `ods`

- **MimeType:** `application/vnd.oasis.opendocument.text-template`
  **TargetExtension:** `odt`

- **MimeType:** `application/vnd.oasis.opendocument.presentation-template`
  **TargetExtension:** `odp`


## API

### `app/list`

We have one new property. 

`target_ext`- string with the suggested file extension when creating a new empty file from that template.

```json
    {
      "mime_type": "application/vnd.oasis.opendocument.spreadsheet-template",
      "app_providers": [
        {
          "address": "com.owncloud.api.collaboration.OnlyOffice",
          "name": "OnlyOffice",
          "description": "Open office documents with Collabora",
          "icon": "https://onlyoffice.owncloud.test/web-apps/apps/documenteditor/main/resources/img/favicon.ico",
          "secure_view": false,
          "target_ext": "xlsx"
        }
      ]
    }
```
### `app/open`

There is a new parameter `template_id` which takes a fileid. It should be used to specify the template which should be loaded during the open request.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/9785

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
