### PR TITLE
[docs-only] Update traefik image in ocis_full deployment

### DIFF
--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   traefik:
-    image: traefik:v3.1.2
+    image: traefik:v3.1.6
     networks:
       ocis-net:
     command:


### PR DESCRIPTION
Updating the traefik image version (patch only, 3.1.2 -> 3.1.6) for our `ocis_full` deployment example
