### PR TITLE
chore|bugfix: mixed sharing errors lot

### DIFF
--- a/changelog/unreleased/fix-group-sharing-panic.md
+++ b/changelog/unreleased/fix-group-sharing-panic.md
@@ -1,0 +1,7 @@
+Bugfix: Fix panic when sharing with groups
+
+We fixed a bug which caused a panic when sharing with groups, this only happened under a heavy load.
+Besides the bugfix, we also reduced the number of share auto accept log messages to avoid flooding the logs.
+
+https://github.com/owncloud/ocis/pull/10279
+https://github.com/owncloud/ocis/issues/10258


### PR DESCRIPTION
## Description
This is a mixed lot of share related fixes which weve found during load testing:

- it bumps reva
- it reduces the share auto accept errors during load testing


## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/10036#issuecomment-2346023045

## How Has This Been Tested?
- load tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)