### PR TITLE
fix: don't fetch idp logo.svg anymore

### DIFF
--- a/services/idp/Makefile
+++ b/services/idp/Makefile
@@ -32,17 +32,10 @@ ci-node-generate: assets
 .PHONY: assets
 assets: pnpm-build \
 		assets/identifier/static \
-		assets/identifier/static/logo.svg \
 		assets/identifier/static/favicon.ico
 
 assets/identifier/static:
 	mkdir -p assets/identifier/static
-
-LOGO_URL = https://raw.githubusercontent.com/owncloud/assets/main/logo.svg
-
-.PHONY: assets/identifier/static/logo.svg # force overwrite
-assets/identifier/static/logo.svg:
-	curl --fail -o assets/identifier/static/logo.svg ${LOGO_URL}
 
 FAVICON_URL = https://raw.githubusercontent.com/owncloud/assets/main/favicon.ico
 


### PR DESCRIPTION
We're always using the logo from the theme now so the logo.svg is not needed anymore.

Followup of https://github.com/owncloud/ocis/pull/10274 where the reference to the logo.svg got removed.