### PR TITLE
use secure config defaults for OCM

### DIFF
--- a/changelog/unreleased/secure-ocm-by-default.md
+++ b/changelog/unreleased/secure-ocm-by-default.md
@@ -1,0 +1,4 @@
+Bugfix: use secure config defaults for OCM
+
+https://github.com/owncloud/ocis/pull/10307
+

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -109,7 +109,8 @@ func DefaultConfig() *config.Config {
 		OCMProviderAuthorizerDriver: "json",
 		OCMProviderAuthorizerDrivers: config.OCMProviderAuthorizerDrivers{
 			JSON: config.OCMProviderAuthorizerJSONDriver{
-				Providers: filepath.Join(defaults.BaseConfigPath(), "ocmproviders.json"),
+				Providers:             filepath.Join(defaults.BaseConfigPath(), "ocmproviders.json"),
+				VerifyRequestHostname: true,
 			},
 		},
 		OCMShareProvider: config.OCMShareProvider{


### PR DESCRIPTION
we default to secure configs