### PR TITLE
feat: include a provider option to allow custom app names

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2935,14 +2935,17 @@ def wopiCollaborationService(name):
 
     if name == "collabora":
         environment["COLLABORATION_APP_NAME"] = "Collabora"
+        environment["COLLABORATION_APP_PRODUCT"] = "Collabora"
         environment["COLLABORATION_APP_ADDR"] = "https://collabora:9980"
         environment["COLLABORATION_APP_ICON"] = "https://collabora:9980/favicon.ico"
     elif name == "onlyoffice":
         environment["COLLABORATION_APP_NAME"] = "OnlyOffice"
+        environment["COLLABORATION_APP_PRODUCT"] = "OnlyOffice"
         environment["COLLABORATION_APP_ADDR"] = "https://onlyoffice"
         environment["COLLABORATION_APP_ICON"] = "https://onlyoffice/web-apps/apps/documenteditor/main/resources/img/favicon.ico"
     elif name == "fakeoffice":
         environment["COLLABORATION_APP_NAME"] = "FakeOffice"
+        environment["COLLABORATION_APP_PRODUCT"] = "Microsoft"
         environment["COLLABORATION_APP_ADDR"] = "http://fakeoffice:8080"
 
     environment["COLLABORATION_WOPI_SRC"] = "http://%s:9300" % service_name

--- a/services/collaboration/pkg/config/app.go
+++ b/services/collaboration/pkg/config/app.go
@@ -3,7 +3,7 @@ package config
 // App defines the available app configuration.
 type App struct {
 	Name        string `yaml:"name" env:"COLLABORATION_APP_NAME" desc:"The name of the app" introductionVersion:"6.0.0"`
-	Provider    string `yaml:"provider" env:"COLLABORATION_APP_PROVIDER" desc:"The provider of the app, either Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline" introductionVersion:"%%NEXT%%"`
+	Product     string `yaml:"product" env:"COLLABORATION_APP_PRODUCT" desc:"The WebOffice app, either Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline" introductionVersion:"%%NEXT%%"`
 	Description string `yaml:"description" env:"COLLABORATION_APP_DESCRIPTION" desc:"App description" introductionVersion:"6.0.0"`
 	Icon        string `yaml:"icon" env:"COLLABORATION_APP_ICON" desc:"Icon for the app" introductionVersion:"6.0.0"`
 	LockName    string `yaml:"lockname" env:"COLLABORATION_APP_LOCKNAME" desc:"Name for the app lock" introductionVersion:"6.0.0"`

--- a/services/collaboration/pkg/config/app.go
+++ b/services/collaboration/pkg/config/app.go
@@ -2,7 +2,8 @@ package config
 
 // App defines the available app configuration.
 type App struct {
-	Name        string `yaml:"name" env:"COLLABORATION_APP_NAME" desc:"The name of the app, either Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline" introductionVersion:"6.0.0"`
+	Name        string `yaml:"name" env:"COLLABORATION_APP_NAME" desc:"The name of the app" introductionVersion:"6.0.0"`
+	Provider    string `yaml:"provider" env:"COLLABORATION_APP_PROVIDER" desc:"The provider of the app, either Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline" introductionVersion:"%%NEXT%%"`
 	Description string `yaml:"description" env:"COLLABORATION_APP_DESCRIPTION" desc:"App description" introductionVersion:"6.0.0"`
 	Icon        string `yaml:"icon" env:"COLLABORATION_APP_ICON" desc:"Icon for the app" introductionVersion:"6.0.0"`
 	LockName    string `yaml:"lockname" env:"COLLABORATION_APP_LOCKNAME" desc:"Name for the app lock" introductionVersion:"6.0.0"`

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -24,6 +24,7 @@ func DefaultConfig() *config.Config {
 		},
 		App: config.App{
 			Name:        "Collabora",
+			Provider:    "Collabora",
 			Description: "Open office documents with Collabora",
 			Icon:        "image-edit",
 			LockName:    "com.github.owncloud.collaboration",

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -24,7 +24,7 @@ func DefaultConfig() *config.Config {
 		},
 		App: config.App{
 			Name:        "Collabora",
-			Provider:    "Collabora",
+			Product:     "Collabora",
 			Description: "Open office documents with Collabora",
 			Icon:        "image-edit",
 			LockName:    "com.github.owncloud.collaboration",

--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -1172,7 +1172,7 @@ func (f *FileConnector) CheckFileInfo(ctx context.Context) (*ConnectorResponse, 
 	// This will help with the CI because we're using a "FakeOffice" app
 	// for the wopi validator, which requires a Microsoft fileinfo
 	var info fileinfo.FileInfo
-	switch strings.ToLower(f.cfg.App.Name) {
+	switch strings.ToLower(f.cfg.App.Provider) {
 	case "collabora":
 		info = &fileinfo.Collabora{}
 	case "onlyoffice":

--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -1172,7 +1172,7 @@ func (f *FileConnector) CheckFileInfo(ctx context.Context) (*ConnectorResponse, 
 	// This will help with the CI because we're using a "FakeOffice" app
 	// for the wopi validator, which requires a Microsoft fileinfo
 	var info fileinfo.FileInfo
-	switch strings.ToLower(f.cfg.App.Provider) {
+	switch strings.ToLower(f.cfg.App.Product) {
 	case "collabora":
 		info = &fileinfo.Collabora{}
 	case "onlyoffice":

--- a/services/collaboration/pkg/connector/fileconnector_test.go
+++ b/services/collaboration/pkg/connector/fileconnector_test.go
@@ -48,6 +48,7 @@ var _ = Describe("FileConnector", func() {
 			App: config.App{
 				LockName: "testName_for_unittests", // Only the LockName is used
 				Name:     "test",
+				Product:  "Microsoft",
 			},
 			Wopi: config.Wopi{
 				WopiSrc: "https://ocis.server.prv",
@@ -1761,6 +1762,7 @@ var _ = Describe("FileConnector", func() {
 
 			// change wopi app provider
 			cfg.App.Name = "Collabora"
+			cfg.App.Product = "Collabora"
 
 			expectedFileInfo := &fileinfo.Collabora{
 				OwnerID:                 "61616262636340637573746f6d496470", // hex of aabbcc@customIdp
@@ -1834,6 +1836,7 @@ var _ = Describe("FileConnector", func() {
 
 			// change wopi app provider
 			cfg.App.Name = "Collabora"
+			cfg.App.Product = "Collabora"
 
 			expectedFileInfo := &fileinfo.Collabora{
 				OwnerID:                 "61616262636340637573746f6d496470", // hex of aabbcc@customIdp
@@ -1921,6 +1924,7 @@ var _ = Describe("FileConnector", func() {
 
 			// change wopi app provider
 			cfg.App.Name = "OnlyOffice"
+			cfg.App.Product = "OnlyOffice"
 
 			response, err := fc.CheckFileInfo(ctx)
 			Expect(err).ToNot(HaveOccurred())

--- a/services/collaboration/pkg/helpers/registration.go
+++ b/services/collaboration/pkg/helpers/registration.go
@@ -68,6 +68,7 @@ func RegisterAppProvider(
 			Icon:        cfg.App.Icon,
 			Address:     cfg.GRPC.Namespace + "." + cfg.Service.Name + "." + cfg.App.Name,
 			MimeTypes:   mimeTypes,
+			ProductName: cfg.App.Product,
 		},
 	}
 	gwc, err := gws.Next()

--- a/services/collaboration/pkg/service/grpc/v0/service.go
+++ b/services/collaboration/pkg/service/grpc/v0/service.go
@@ -188,7 +188,7 @@ func (s *Service) getAppUrl(fileExt string, viewMode appproviderv1beta1.ViewMode
 	// prioritize view action if possible
 	appURL := s.getAppUrlFor("view", fileExt)
 
-	if strings.ToLower(s.config.App.Name) == "collabora" {
+	if strings.ToLower(s.config.App.Provider) == "collabora" {
 		// collabora provides only one action per extension. usual options
 		// are "view" (checked above), "edit" or "view_comment" (this last one
 		// is exclusive of collabora)
@@ -276,7 +276,7 @@ func (s *Service) addQueryToURL(baseURL string, req *appproviderv1beta1.OpenInAp
 	}
 
 	if lang != "" {
-		switch strings.ToLower(s.config.App.Name) {
+		switch strings.ToLower(s.config.App.Provider) {
 		case "collabora":
 			q.Add("lang", lang)
 		case "onlyoffice":

--- a/services/collaboration/pkg/service/grpc/v0/service.go
+++ b/services/collaboration/pkg/service/grpc/v0/service.go
@@ -188,7 +188,7 @@ func (s *Service) getAppUrl(fileExt string, viewMode appproviderv1beta1.ViewMode
 	// prioritize view action if possible
 	appURL := s.getAppUrlFor("view", fileExt)
 
-	if strings.ToLower(s.config.App.Provider) == "collabora" {
+	if strings.ToLower(s.config.App.Product) == "collabora" {
 		// collabora provides only one action per extension. usual options
 		// are "view" (checked above), "edit" or "view_comment" (this last one
 		// is exclusive of collabora)
@@ -276,7 +276,7 @@ func (s *Service) addQueryToURL(baseURL string, req *appproviderv1beta1.OpenInAp
 	}
 
 	if lang != "" {
-		switch strings.ToLower(s.config.App.Provider) {
+		switch strings.ToLower(s.config.App.Product) {
 		case "collabora":
 			q.Add("lang", lang)
 		case "onlyoffice":

--- a/services/collaboration/pkg/service/grpc/v0/service_test.go
+++ b/services/collaboration/pkg/service/grpc/v0/service_test.go
@@ -147,6 +147,7 @@ var _ = Describe("Discovery", func() {
 				cfg.Wopi.Secret = "my_supa_secret"
 				cfg.Wopi.DisableChat = disableChat
 				cfg.App.Name = appName
+				cfg.App.Product = appName
 
 				myself := &userv1beta1.User{
 					Id: &userv1beta1.UserId{
@@ -333,6 +334,7 @@ var _ = Describe("Discovery", func() {
 			cfg.Wopi.WopiSrc = "htttps://wopiserver.test.prv"
 			cfg.Wopi.Secret = "my_supa_secret"
 			cfg.App.Name = "OnlyOffice"
+			cfg.App.Product = "OnlyOffice"
 
 			myself := &userv1beta1.User{
 				Id: &userv1beta1.UserId{


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Introduce the `Provider` option to handle some differences between web office products. This will be used instead of the `Name`. Note that the `Name` will still be used in other places such as service names, and it will be shown in the web interface.

The intention is to provide a bit of extra branding: you could have a specific Collabora installation fully customized and branded to your liking, so you could use `BBox` as `Name` and keep `Collabora` as `Provider`.

**Note**: There are some issues with the naming used as `Name`, so it's highly recommended to use only alphanumeric chars. Spaces are known to cause issues.

## Related Issue
https://github.com/owncloud/ocis/issues/10306

## Motivation and Context
We need to distinguish between the name and the provider.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Notes
Need to consider a migration, otherwise it could be a breaking change.
For installations with Collabora, this change shouldn't cause any issue because the default provider will also be Collabora. However, for other installations, the provider will also be Collabora despite connecting to an OnlyOffice installation (for example). This might cause some features to break.

We also need changes in reva for the new templates. It's currently using the app name (which might be different) instead of the provider name. Right now, the collaboration service can't sent the provider name to reva.