### PR TITLE
[docs-only] ADDING 2 envvars to existing ones in settings service

### DIFF
--- a/services/settings/pkg/config/config.go
+++ b/services/settings/pkg/config/config.go
@@ -44,8 +44,8 @@ type Config struct {
 
 // Metadata configures the metadata store to use
 type Metadata struct {
-	GatewayAddress string `yaml:"gateway_addr" env:"STORAGE_GATEWAY_GRPC_ADDR" desc:"GRPC address of the STORAGE-SYSTEM service." introductionVersion:"pre5.0"`
-	StorageAddress string `yaml:"storage_addr" env:"STORAGE_GRPC_ADDR" desc:"GRPC address of the STORAGE-SYSTEM service." introductionVersion:"pre5.0"`
+	GatewayAddress string `yaml:"gateway_addr" env:"SETTINGS_STORAGE_GATEWAY_GRPC_ADDR;STORAGE_GATEWAY_GRPC_ADDR" desc:"GRPC address of the STORAGE-SYSTEM service." introductionVersion:"pre5.0"`
+	StorageAddress string `yaml:"storage_addr" env:"SETTINGS_STORAGE_GRPC_ADDR;STORAGE_GRPC_ADDR" desc:"GRPC address of the STORAGE-SYSTEM service." introductionVersion:"pre5.0"`
 
 	SystemUserID     string `yaml:"system_user_id" env:"OCIS_SYSTEM_USER_ID;SETTINGS_SYSTEM_USER_ID" desc:"ID of the oCIS STORAGE-SYSTEM system user. Admins need to set the ID for the STORAGE-SYSTEM system user in this config option which is then used to reference the user. Any reasonable long string is possible, preferably this would be an UUIDv4 format." introductionVersion:"pre5.0"`
 	SystemUserIDP    string `yaml:"system_user_idp" env:"OCIS_SYSTEM_USER_IDP;SETTINGS_SYSTEM_USER_IDP" desc:"IDP of the oCIS STORAGE-SYSTEM system user." introductionVersion:"pre5.0"`


### PR DESCRIPTION
Fixes: #10359 (Settings service: 2 envvars needed to be added to existin ones)

This PR fixes that the settings service has two envvars that do not start with `SETTINGS_` making these envvars unfindable. There is NO code change!

Note that the original (wrong named) envvars are not marked for deprecation which could/should be done but is not a hard requirement.

Prepared as requested in the referenced issue, merging whenever this fits.