### PR TITLE
[docs-only] Fix envvar name in collaboration service readme

### DIFF
--- a/services/collaboration/README.md
+++ b/services/collaboration/README.md
@@ -37,7 +37,7 @@ There are a few variables that you need to set:
 * `COLLABORATION_APP_INSECURE`:\
   In case you are using a self signed certificate for the WOPI app you can tell the collaboration service to allow an insecure connection.
 
-* `COLLABORATION_APP_WOPISRC`:\
+* `COLLABORATION_WOPI_SRC`:\
   The external address of the collaboration service. The target app (onlyoffice, collabora, etc) will use this address to read and write files from Infinite Scale.\
   For example: `https://wopi.example.com`.
 


### PR DESCRIPTION
References: https://github.com/owncloud/docs-ocis/pull/1014 (Fix envvar name in collaboration service)

Documentation for collaboration refers to
`COLLABORATION_APP_WOPISRC` instead of `COLLABORATION_WOPI_SRC`
