### PR TITLE
[docs-only] Update gateway readme

### DIFF
--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -30,7 +30,7 @@ Store specific notes:
 ## Service Endpoints
 
 **IMPORTANT**\
-This functionality is currently highly experimental and intended for testing only! There are known bugs that need to be sorted out like not closing sockets when a service ends.
+This functionality is currently highly experimental and intended for testing only! There are known bugs that need to be sorted out like not removing sockets when a service ends.
 
 The gateway acts as a proxy for other CS3 services. As such it has to forward requests to a lot of services and needs to establish connections by looking up the IP address using the service registry. Instead of using the service registry each endpoint can also be configured to use the grpc `dns://` or `kubernetes://` URLs, which might be useful when running in kubernetes.
 

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -30,11 +30,19 @@ Store specific notes:
 ## Service Endpoints
 
 **IMPORTANT**\
-This functionality is currently experimental.
+This functionality is currently highly experimental and intended for testing only! There are known bugs that need to be sorted out like not closing sockets when a service ends.
 
 The gateway acts as a proxy for other CS3 services. As such it has to forward requests to a lot of services and needs to establish connections by looking up the IP address using the service registry. Instead of using the service registry each endpoint can also be configured to use the grpc `dns://` or `kubernetes://` URLs, which might be useful when running in kubernetes.
 
 For a local single node deployment you might want to use `unix:` sockets as shown below. Using unix sockets will reduce the amount of service lookups and omit the TCP stack. For now, this is experimental and the services do not delete the socket on shutdown. PRs welcome.
+
+The scheme for this setup is the following. Note that there is, except storage, always a service and a gateway envvar triple:
+
+| **envvar** | **default** | **alternative** |
+|------|------|------|
+| OCIS_GRPC_PROTOCOL or <br> `<service>`_GRPC_PROTOCOL | tcp | unix |
+| `<service>`_GRPC_ADDR | 127.0.0.1:`<port>` | /var/run/ocis/`<service>`.sock |
+| GATEWAY_`<service>`_ENDPOINT | com.owncloud.api.`<service>` | unix:/var/run/ocis/`<service>`.sock <br> dns: ... <br> kubernetes: ... |
 
 ```console
 USERS_GRPC_PROTOCOL=unix"
@@ -83,15 +91,17 @@ OCM_GRPC_PROTOCOL=unix"
 OCM_GRPC_ADDR=/var/run/ocis/ocm.sock"
 GATEWAY_OCM_ENDPOINT=unix:/var/run/ocis/ocm.sock"
 
-// storage system
+// storage related
 STORAGE_SYSTEM_GRPC_PROTOCOL="unix"
 STORAGE_SYSTEM_GRPC_ADDR="/var/run/ocis/storage-system.sock"
-STORAGE_GATEWAY_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
-STORAGE_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
 SHARING_USER_CS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
 SHARING_USER_JSONCS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
 SHARING_PUBLIC_CS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
 SHARING_PUBLIC_JSONCS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
+
+// the STORAGE_xxx envvars should (and will) be named SETTINGS_STORAGE_xxx
+STORAGE_GATEWAY_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
+STORAGE_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
 ```
 
 ## Storage Registry

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -92,16 +92,14 @@ OCM_GRPC_ADDR=/var/run/ocis/ocm.sock"
 GATEWAY_OCM_ENDPOINT=unix:/var/run/ocis/ocm.sock"
 
 // storage related
+SETTINGS_STORAGE_GATEWAY_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
+SETTINGS_STORAGE_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
 STORAGE_SYSTEM_GRPC_PROTOCOL="unix"
 STORAGE_SYSTEM_GRPC_ADDR="/var/run/ocis/storage-system.sock"
 SHARING_USER_CS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
 SHARING_USER_JSONCS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
 SHARING_PUBLIC_CS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
 SHARING_PUBLIC_JSONCS3_PROVIDER_ADDR="unix:/var/run/ocis/storage-system.sock"
-
-// the STORAGE_xxx envvars should (and will) be named SETTINGS_STORAGE_xxx
-STORAGE_GATEWAY_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
-STORAGE_GRPC_ADDR="unix:/var/run/ocis/storage-system.sock"
 ```
 
 ## Storage Registry


### PR DESCRIPTION
References:
#9490 (set the configured protocol transport for service metadata)
#10362 ([docs-only] ADDING 2 envvars to existing ones in settings service)
Note that 10362 is not mandatory, but if merged timely, we need to update this PR to fix the envvar names.

Based on a discussion with @butonic, the current readme text needs some sharpening and an overview what is meant with that (experimental) change.

![image](https://github.com/user-attachments/assets/bed3efee-0ef0-4865-b292-4c32f53ac4a1)
