### PR TITLE
Fix Activitylog Issues

### DIFF
--- a/changelog/unreleased/fix-activitylog-issues.md
+++ b/changelog/unreleased/fix-activitylog-issues.md
@@ -1,0 +1,6 @@
+Bugfix: Fix Activitylog issues
+
+Fixes multiple activititylog issues. There was an error about `max payload exceeded` when there were too many activities on one folder. Listing would take very long even with a limit activated. All of these
+issues are now fixed.
+
+https://github.com/owncloud/ocis/pull/10376


### PR DESCRIPTION
Fixes the `max payload exceeded` error
Also speeds up fetching of activities when a limit is set.

Fixes https://github.com/owncloud/ocis/issues/9462