### PR TITLE
[docs-only] Fix Antivirus readme

### DIFF
--- a/services/antivirus/README.md
+++ b/services/antivirus/README.md
@@ -18,6 +18,10 @@ Several factors can make it necessary to limit the maximum filesize the antiviru
 > [!CAUTION]
 > Streaming of files to the virus scan service still [needs to be implemented](https://github.com/owncloud/ocis/issues/6803). To prevent OOM errors `ANTIVIRUS_MAX_SCAN_SIZE` needs to be set lower than available ram.
 
+### Antivirus Workers
+
+The number of concurrent scans can be increased by setting `ANTIVIRUS_WORKERS`. Be aware that this will also increase memory usage.
+
 ### Infected File Handling
 
 The antivirus service allows three different ways of handling infected files. Those can be set via the `ANTIVIRUS_INFECTED_FILE_HANDLING` environment variable:
@@ -44,4 +48,4 @@ The number of concurrent scans can be increased by setting `ANTIVIRUS_WORKERS`, 
 
 ### Scaling in Kubernetes
 
-In kubernetes `ANTIVIRUS_WORKERS` and `ANTIVIRUS_MAX_SCAN_SIZE` can be used to trigger the horizontal pod autoscaler by requesting a memory size that is below `ANTIVIRUS_MAX_SCAN_SIZE`. Keep in mind that `ANTIVIRUS_MAX_SCAN_SIZE` amount of memory might be held by `ANTIVIRUS_WORKERS` number of go routines.
+In kubernetes, `ANTIVIRUS_WORKERS` and `ANTIVIRUS_MAX_SCAN_SIZE` can be used to trigger the horizontal pod autoscaler by requesting a memory size that is below `ANTIVIRUS_MAX_SCAN_SIZE`. Keep in mind that `ANTIVIRUS_MAX_SCAN_SIZE` amount of memory might be held by `ANTIVIRUS_WORKERS` number of go routines.


### PR DESCRIPTION
References: #10383 (Antivirus workers)

Fix the antivirus readme text, missing envvar `ANTIVIRUS_WORKERS`.