### PR TITLE
make sse keepalive interval configurable

### DIFF
--- a/changelog/unreleased/sse-keepalive.md
+++ b/changelog/unreleased/sse-keepalive.md
@@ -1,0 +1,5 @@
+Bugfix: make SSE keepalive interval configurable
+
+To prevent intermediate proxies from closing the SSE connection admins can now configure a `SSE_KEEPALIVE_INTERVAL`.
+
+https://github.com/owncloud/ocis/pull/10411

--- a/services/sse/README.md
+++ b/services/sse/README.md
@@ -12,3 +12,8 @@ Log services like the `userlog`, `clientlog` and `sse` are responsible for compo
 ## Subscribing
 
 Clients can subscribe to the `/sse` endpoint to be informed by the server when an event happens. The `sse` endpoint will respect language changes of the user without needing to reconnect. Note that SSE has a limitation of six open connections per browser which can be reached if one has opened various tabs of the Web UI pointing to the same Infinite Scale instance.
+
+## Keep SSE Connections Alive
+
+Some intermediate proxies drop connections after an idle time with no activity. If this is the case, configure the `SSE_KEEPALIVE_INTERVAL` envvar. This will send periodic SSE comments to keep connections open.
+

--- a/services/sse/pkg/config/config.go
+++ b/services/sse/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"time"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
 )
@@ -14,7 +15,8 @@ type Config struct {
 	Debug   Debug    `mask:"struct" yaml:"debug"`
 	Tracing *Tracing `yaml:"tracing"`
 
-	Service Service `yaml:"-"`
+	Service           Service       `yaml:"-"`
+	KeepAliveInterval time.Duration `yaml:"keepalive_interval" env:"SSE_KEEPALIVE_INTERVAL" desc:"To prevent intermediate proxies from closing the SSE connection send periodic SSE comments." introductionVersion:"6.7"`
 
 	Events       Events
 	HTTP         HTTP          `yaml:"http"`

--- a/services/sse/pkg/config/config.go
+++ b/services/sse/pkg/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Tracing *Tracing `yaml:"tracing"`
 
 	Service           Service       `yaml:"-"`
-	KeepAliveInterval time.Duration `yaml:"keepalive_interval" env:"SSE_KEEPALIVE_INTERVAL" desc:"To prevent intermediate proxies from closing the SSE connection send periodic SSE comments." introductionVersion:"6.7"`
+	KeepAliveInterval time.Duration `yaml:"keepalive_interval" env:"SSE_KEEPALIVE_INTERVAL" desc:"To prevent intermediate proxies from closing the SSE connection, send periodic SSE comments to keep it open." introductionVersion:"7.0"`
 
 	Events       Events
 	HTTP         HTTP          `yaml:"http"`


### PR DESCRIPTION
To prevent intermediate proxies from closing the SSE connection admins can now configure a `SSE_KEEPALIVE_INTERVAL`.
