### PR TITLE
Remove 'OCM_OCM_PROVIDER_AUTHORIZER_VERIFY_REQUEST_HOSTNAME' setting

### DIFF
--- a/changelog/unreleased/fix-remove-non-working-ocm-setting.md
+++ b/changelog/unreleased/fix-remove-non-working-ocm-setting.md
@@ -1,0 +1,12 @@
+Bugfix: Removed 'OCM_OCM_PROVIDER_AUTHORIZER_VERIFY_REQUEST_HOSTNAME' setting
+
+The config option 'OCM_OCM_PROVIDER_AUTHORIZER_VERIFY_REQUEST_HOSTNAME' was
+removed from the OCM service. The additional security provided by this setting
+is somewhat questionable and only provided in very specific setups.
+
+We are not going through the normal deprecation process for this setting, as it
+was never really working anyway. If you have this setting in your configuration,
+it will be ignored. You can safely remove it.
+
+https://github.com/owncloud/ocis/pull/104xx
+https://github.com/owncloud/ocis/issues/10355

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -114,8 +114,7 @@ type OCMProviderAuthorizerDrivers struct {
 }
 
 type OCMProviderAuthorizerJSONDriver struct {
-	Providers             string `yaml:"providers" env:"OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE" desc:"Path to the JSON file where ocm invite data will be stored. Defaults to $OCIS_CONFIG_DIR/ocmproviders.json." introductionVersion:"5.0"`
-	VerifyRequestHostname bool   `yaml:"verify_request_hostname" env:"OCM_OCM_PROVIDER_AUTHORIZER_VERIFY_REQUEST_HOSTNAME" desc:"Verify the hostname of the incoming request against the hostname of the OCM provider." introductionVersion:"5.0"`
+	Providers string `yaml:"providers" env:"OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE" desc:"Path to the JSON file where ocm invite data will be stored. Defaults to $OCIS_CONFIG_DIR/ocmproviders.json." introductionVersion:"5.0"`
 }
 
 type OCMCore struct {

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -109,8 +109,7 @@ func DefaultConfig() *config.Config {
 		OCMProviderAuthorizerDriver: "json",
 		OCMProviderAuthorizerDrivers: config.OCMProviderAuthorizerDrivers{
 			JSON: config.OCMProviderAuthorizerJSONDriver{
-				Providers:             filepath.Join(defaults.BaseConfigPath(), "ocmproviders.json"),
-				VerifyRequestHostname: true,
+				Providers: filepath.Join(defaults.BaseConfigPath(), "ocmproviders.json"),
 			},
 		},
 		OCMShareProvider: config.OCMShareProvider{

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -130,8 +130,7 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 					"driver": cfg.OCMProviderAuthorizerDriver,
 					"drivers": map[string]interface{}{
 						"json": map[string]interface{}{
-							"providers":               cfg.OCMProviderAuthorizerDrivers.JSON.Providers,
-							"verify_request_hostname": cfg.OCMProviderAuthorizerDrivers.JSON.VerifyRequestHostname,
+							"providers": cfg.OCMProviderAuthorizerDrivers.JSON.Providers,
 						},
 					},
 				},


### PR DESCRIPTION
The feature never really worked correctly and it's added value is at least arguable.

I think we do not need to go through the usual deprecation cycle here since the feature was not really working at any time. If you disagree please  holler.

For details see  #10355
