### PR TITLE
[docs-only] Add libvips build dependencies for macOS

### DIFF
--- a/services/thumbnails/README.md
+++ b/services/thumbnails/README.md
@@ -99,7 +99,13 @@ enabled at buildtime and has a couple of implications:
 *  Therefore, the libvips shared libraries need to be available at runtime in the same release that was used to build the ocis binary.
 *  When using the ocis docker images, the libvips shared libraries are included in the image and are correctly embedded.
 
-Support of libvips is disabled by default. To enable it, make sure libvips and its buildtime dependencies are installed in your build environment.
+Support of libvips is disabled by default. To enable it, make sure libvips and its buildtime dependencies are installed in your build environment. For macOS users, add the build time dependencies via:
+
+```shell
+brew install vips pkg-config
+export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
+```
+
 Then you just need to set the `ENABLE_VIPS` variable on the `make` command:
 
 ```shell


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/10310#issuecomment-2440339813

Add macOS libvips build dependencies for ease of building ocis with vips enabled.