### PR TITLE
log grpc requests in debug mode

### DIFF
--- a/changelog/unreleased/log-grpc-requests.md
+++ b/changelog/unreleased/log-grpc-requests.md
@@ -1,0 +1,5 @@
+Bugfix: Log GRPC requests in debug mode
+
+When log level is set to debug we will now also log grpc requests.
+
+https://github.com/owncloud/ocis/pull/10438


### PR DESCRIPTION
When log level is set to debug we will now also log grpc requests.

This adds lines like these (below is a full page reload)
```
2024-10-29T12:52:52+01:00 DBG grpc call content-type=application/grpc+proto duration=1.005583 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=67e577dbfcb349c565b8fc29c79550bc
2024-10-29T12:52:52+01:00 DBG grpc call content-type=application/grpc+proto duration=0.71773 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=9e886ffd9dd79a1459b1ead2df1e3a46
2024-10-29T12:52:52+01:00 DBG grpc call content-type=application/grpc+proto duration=0.633523 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=d7027a1f7574f48b9b2b3daf5f3a7ef9
2024-10-29T12:52:52+01:00 DBG grpc call content-type=application/grpc+proto duration=0.357254 endpoint=ValueService.GetValueByUniqueIdentifiers headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=ValueService.GetValueByUniqueIdentifiers service=com.owncloud.api.settings traceid=ba9a03046414d94666fba79a4d8c4876
2024-10-29T12:52:52+01:00 DBG grpc call content-type=application/grpc+proto duration=0.75657 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=97ed95b76460c691daebc81260292405
2024-10-29T12:52:52+01:00 DBG grpc call content-type=application/grpc+proto duration=0.811237 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=b439f5938c0900b2478ed62c0a0e08ac
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=0.597818 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=4df07393eb1f80c64effd2d04dbf20a9
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=0.578564 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=7968661cfc356f6715365eaa8b9594cb
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=0.687374 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=faf77b03990f45b61a651e2fe0976d3b
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=0.648734 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=284448da7d6ef3b40a783022c93ff93a
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=0.481296 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=808984d7caf2bbf7efc13df0e4be75fd
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=2.288931 endpoint=PermissionService.GetPermissionByID headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=PermissionService.GetPermissionByID service=com.owncloud.api.settings traceid=ce33394efff18f6dca12e18a832116a9
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc duration=2.382211 endpoint=PermissionsAPI.CheckPermission headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=PermissionsAPI.CheckPermission service=com.owncloud.api.settings traceid=e431b31b0c2064e816f3e3010b79a61d
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=2.389724 endpoint=PermissionService.GetPermissionByID headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=PermissionService.GetPermissionByID service=com.owncloud.api.settings traceid=75d2dfc55ddd961c1a8f8272c0561f16
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc duration=1.924784 endpoint=PermissionsAPI.CheckPermission headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=PermissionsAPI.CheckPermission service=com.owncloud.api.settings traceid=c5ab036cf29439d8cc0236d15d6ab0c6
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=0.9394 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=e9133ab87586ae5d030b166c7151d41f
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=0.695712 endpoint=RoleService.ListRoleAssignments headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=RoleService.ListRoleAssignments service=com.owncloud.api.settings traceid=d9f95c29fef2f18d1b0f8510852563a1
2024-10-29T12:52:53+01:00 DBG grpc call content-type=application/grpc+proto duration=5.78465 endpoint=ThumbnailService.GetThumbnail headers=null line=/home/jfd/Repositories/ocis/ocis-pkg/service/grpc/service.go:113 method=ThumbnailService.GetThumbnail service=com.owncloud.api.thumbnails traceid=d99f1887f759468653bbc0341483a601
```
