### PR TITLE
Restart Postprocessing Properly

### DIFF
--- a/changelog/unreleased/restart-postprocessing.md
+++ b/changelog/unreleased/restart-postprocessing.md
@@ -1,0 +1,5 @@
+Bugfix: Restart Postprocessing properly
+
+Properly differentiate between resume and restart postprocessing.
+
+https://github.com/owncloud/ocis/pull/10439

--- a/services/postprocessing/README.md
+++ b/services/postprocessing/README.md
@@ -99,3 +99,5 @@ ocis postprocessing restart                # Restarts all uploads where postproc
 ocis postprocessing restart -s "finished"  # Equivalent to the above
 ocis postprocessing restart -s "virusscan" # Restart all uploads currently in virusscan step
 ```
+
+Note: All above commands containing the word `restart` can also be replaced by `resume`. This changes behaviour slightly. When `restarting` an upload, the whole postprocessing will be (re)done. If `resuming` an upload, it will only continue from the last step that was completed.

--- a/services/postprocessing/pkg/command/postprocessing.go
+++ b/services/postprocessing/pkg/command/postprocessing.go
@@ -17,7 +17,7 @@ func RestartPostprocessing(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:    "resume",
 		Aliases: []string{"restart"},
-		Usage:   "restart postprocessing for an uploadID",
+		Usage:   "resume postprocessing for an uploadID",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "upload-id",

--- a/services/postprocessing/pkg/command/postprocessing.go
+++ b/services/postprocessing/pkg/command/postprocessing.go
@@ -15,19 +15,25 @@ import (
 // RestartPostprocessing cli command to restart postprocessing
 func RestartPostprocessing(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "restart",
-		Usage: "restart postprocessing for an uploadID",
+		Name:    "resume",
+		Aliases: []string{"restart"},
+		Usage:   "restart postprocessing for an uploadID",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "upload-id",
 				Aliases: []string{"u"},
-				Usage:   "the uploadid to restart. Ignored if unset.",
+				Usage:   "the uploadid to resume. Ignored if unset.",
 			},
 			&cli.StringFlag{
 				Name:    "step",
 				Aliases: []string{"s"},
-				Usage:   "restarts all uploads in the given postprocessing step. Ignored if upload-id is set.",
-				Value:   "finished", // Calling `ocis postprocessing restart` without any arguments will restart all uploads that are finished but failed to move the uploed from the upload area to the blobstore.
+				Usage:   "resume all uploads in the given postprocessing step. Ignored if upload-id is set.",
+				Value:   "finished",
+			},
+			&cli.BoolFlag{
+				Name:    "restart",
+				Aliases: []string{"r"},
+				Usage:   "restart postprocessing for the given uploadID. Ignores the step flag.",
 			},
 		},
 		Before: func(c *cli.Context) error {
@@ -44,10 +50,19 @@ func RestartPostprocessing(cfg *config.Config) *cli.Command {
 				step = c.String("step")
 			}
 
-			ev := events.ResumePostprocessing{
-				UploadID:  uid,
-				Step:      events.Postprocessingstep(step),
-				Timestamp: utils.TSNow(),
+			var ev events.Unmarshaller
+			switch {
+			case c.Bool("retrigger"):
+				ev = events.RestartPostprocessing{
+					UploadID:  uid,
+					Timestamp: utils.TSNow(),
+				}
+			default:
+				ev = events.ResumePostprocessing{
+					UploadID:  uid,
+					Step:      events.Postprocessingstep(step),
+					Timestamp: utils.TSNow(),
+				}
 			}
 
 			return events.Publish(context.Background(), stream, ev)

--- a/services/storage-users/pkg/command/uploads.go
+++ b/services/storage-users/pkg/command/uploads.go
@@ -83,11 +83,15 @@ func ListUploadSessions(cfg *config.Config) *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "restart",
-				Usage: "send restart event for all listed sessions",
+				Usage: "send restart event for all listed sessions. Only one of resume/restart/clean can be set.",
+			},
+			&cli.BoolFlag{
+				Name:  "resume",
+				Usage: "send resume event for all listed sessions. Only one of resume/restart/clean can be set.",
 			},
 			&cli.BoolFlag{
 				Name:  "clean",
-				Usage: "remove uploads",
+				Usage: "remove uploads for all listed sessions. Only one of resume/restart/clean can be set.",
 			},
 		},
 		Before: func(c *cli.Context) error {
@@ -176,8 +180,9 @@ func ListUploadSessions(cfg *config.Config) *cli.Command {
 					})
 				}
 
-				if c.Bool("restart") {
-					if err := events.Publish(context.Background(), stream, events.ResumePostprocessing{
+				switch {
+				case c.Bool("restart"):
+					if err := events.Publish(context.Background(), stream, events.RestartPostprocessing{
 						UploadID:  u.ID(),
 						Timestamp: utils.TSNow(),
 					}); err != nil {
@@ -185,9 +190,18 @@ func ListUploadSessions(cfg *config.Config) *cli.Command {
 						// if publishing fails there is no need to try publishing other events - they will fail too.
 						os.Exit(1)
 					}
-				}
 
-				if c.Bool("clean") {
+				case c.Bool("resume"):
+					if err := events.Publish(context.Background(), stream, events.ResumePostprocessing{
+						UploadID:  u.ID(),
+						Timestamp: utils.TSNow(),
+					}); err != nil {
+						fmt.Fprintf(os.Stderr, "Failed to send resume event for upload session '%s'\n", u.ID())
+						// if publishing fails there is no need to try publishing other events - they will fail too.
+						os.Exit(1)
+					}
+
+				case c.Bool("clean"):
 					if err := u.Purge(c.Context); err != nil {
 						fmt.Fprintf(os.Stderr, "Failed to clean upload session '%s'\n", u.ID())
 					}


### PR DESCRIPTION
Allows differentiating between "restart" and "resume" postprocessing