### PR TITLE
feat: use only the app name in order to name the lock

### DIFF
--- a/services/collaboration/pkg/config/app.go
+++ b/services/collaboration/pkg/config/app.go
@@ -6,7 +6,6 @@ type App struct {
 	Product     string `yaml:"product" env:"COLLABORATION_APP_PRODUCT" desc:"The WebOffice app, either Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline" introductionVersion:"%%NEXT%%"`
 	Description string `yaml:"description" env:"COLLABORATION_APP_DESCRIPTION" desc:"App description" introductionVersion:"6.0.0"`
 	Icon        string `yaml:"icon" env:"COLLABORATION_APP_ICON" desc:"Icon for the app" introductionVersion:"6.0.0"`
-	LockName    string `yaml:"lockname" env:"COLLABORATION_APP_LOCKNAME" desc:"Name for the app lock" introductionVersion:"6.0.0"`
 
 	Addr     string `yaml:"addr" env:"COLLABORATION_APP_ADDR" desc:"The URL where the WOPI app is located, such as https://127.0.0.1:8080." introductionVersion:"6.0.0"`
 	Insecure bool   `yaml:"insecure" env:"COLLABORATION_APP_INSECURE" desc:"Skip TLS certificate verification when connecting to the WOPI app" introductionVersion:"6.0.0"`

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -27,7 +27,6 @@ func DefaultConfig() *config.Config {
 			Product:     "Collabora",
 			Description: "Open office documents with Collabora",
 			Icon:        "image-edit",
-			LockName:    "com.github.owncloud.collaboration",
 			Addr:        "https://127.0.0.1:9980",
 			Insecure:    false,
 			ProofKeys: config.ProofKeys{

--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -209,7 +209,7 @@ func (f *FileConnector) Lock(ctx context.Context, lockID, oldLockID string) (*Co
 			Ref: wopiContext.FileReference,
 			Lock: &providerv1beta1.Lock{
 				LockId:  lockID,
-				AppName: f.cfg.App.LockName + "." + f.cfg.App.Name,
+				AppName: f.cfg.App.Name,
 				Type:    providerv1beta1.LockType_LOCK_TYPE_WRITE,
 				Expiration: &typesv1beta1.Timestamp{
 					Seconds: uint64(time.Now().Add(lockDuration).Unix()),
@@ -235,7 +235,7 @@ func (f *FileConnector) Lock(ctx context.Context, lockID, oldLockID string) (*Co
 			Ref: wopiContext.FileReference,
 			Lock: &providerv1beta1.Lock{
 				LockId:  lockID,
-				AppName: f.cfg.App.LockName + "." + f.cfg.App.Name,
+				AppName: f.cfg.App.Name,
 				Type:    providerv1beta1.LockType_LOCK_TYPE_WRITE,
 				Expiration: &typesv1beta1.Timestamp{
 					Seconds: uint64(time.Now().Add(lockDuration).Unix()),
@@ -378,7 +378,7 @@ func (f *FileConnector) RefreshLock(ctx context.Context, lockID string) (*Connec
 		Ref: wopiContext.FileReference,
 		Lock: &providerv1beta1.Lock{
 			LockId:  lockID,
-			AppName: f.cfg.App.LockName + "." + f.cfg.App.Name,
+			AppName: f.cfg.App.Name,
 			Type:    providerv1beta1.LockType_LOCK_TYPE_WRITE,
 			Expiration: &typesv1beta1.Timestamp{
 				Seconds: uint64(time.Now().Add(lockDuration).Unix()),
@@ -518,7 +518,7 @@ func (f *FileConnector) UnLock(ctx context.Context, lockID string) (*ConnectorRe
 		Ref: wopiContext.FileReference,
 		Lock: &providerv1beta1.Lock{
 			LockId:  lockID,
-			AppName: f.cfg.App.LockName + "." + f.cfg.App.Name,
+			AppName: f.cfg.App.Name,
 		},
 	}
 

--- a/services/collaboration/pkg/connector/fileconnector_test.go
+++ b/services/collaboration/pkg/connector/fileconnector_test.go
@@ -46,9 +46,8 @@ var _ = Describe("FileConnector", func() {
 				OcisURL: "https://ocis.example.prv",
 			},
 			App: config.App{
-				LockName: "testName_for_unittests", // Only the LockName is used
-				Name:     "test",
-				Product:  "Microsoft",
+				Name:    "test",
+				Product: "Microsoft",
 			},
 			Wopi: config.Wopi{
 				WopiSrc: "https://ocis.server.prv",


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Use only the app name for the lock. The lock owner should show `OnlyOffice` (the app name) instead of `com.github.owncloud.collaboration.OnlyOffice` (the lock name + app name)

## Related Issue
https://github.com/owncloud/web/issues/11008

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually checked with a propfind request. It shows just the app name

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 


## TODO
* The `LockName` configuration option becomes unused with this change. We can remove the option.