### PR TITLE
add volume to ldap to keep users and groups

### DIFF
--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       - ./config/ldap/schemas:/schemas
       - ./config/ldap/docker-entrypoint-override.sh:/opt/bitnami/scripts/openldap/docker-entrypoint-override.sh
       - ldap-certs:/opt/bitnami/openldap/share
+      - ldap-data:/bitnami/openldap
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
@@ -154,6 +155,7 @@ volumes:
   ldap-certs:
   ocis-config:
   ocis-data:
+  ldap-data:
 
 
 networks:


### PR DESCRIPTION
during the upgrade testing https://github.com/owncloud/ocis/issues/10373 I found that all created users and groups are gone after ocis update
- we added volumes to docker ldap example deployments