### PR TITLE
fix: wopi lock header in get lock response

### DIFF
--- a/changelog/unreleased/fix-get-lock-header.md
+++ b/changelog/unreleased/fix-get-lock-header.md
@@ -1,0 +1,5 @@
+Bugfix: Return wopi lock header in get lock response
+
+We fixed a bug where the wopi lock header was not returned in the get lock response. This is now fixed and the wopi validator tests are passing.
+
+https://github.com/owncloud/ocis/pull/10469

--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -147,8 +147,10 @@ func (f *FileConnector) GetLock(ctx context.Context) (*ConnectorResponse, error)
 			Str("StatusCode", resp.GetStatus().GetCode().String()).
 			Str("StatusMsg", resp.GetStatus().GetMessage()).
 			Msg("GetLock failed with unexpected status")
-		// TODO: Should we be more strict? There could be more causes for the failure
-		return NewResponse(404), nil
+		// Return 404 and the required header, even if it's empty
+		// https://docs.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/files/getlock#response-headers
+		// This is needed to fulfill the requirements of online WOPI validator
+		return NewResponseWithLock(404, ""), nil
 	}
 
 	lockID := ""

--- a/services/collaboration/pkg/connector/fileconnector_test.go
+++ b/services/collaboration/pkg/connector/fileconnector_test.go
@@ -113,7 +113,7 @@ var _ = Describe("FileConnector", func() {
 			response, err := fc.GetLock(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.Status).To(Equal(404))
-			Expect(response.Headers).To(BeNil())
+			Expect(response.Headers[connector.HeaderWopiLock]).To(Equal(""))
 		})
 
 		It("Get lock success", func() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

Bugfix: Return wopi lock header in get lock response

We fixed a bug where the wopi lock header was not returned in the get lock response. This is now fixed and the wopi validator tests are passing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
