### PR TITLE
[docs-only] Add comment in ocis_full / onlyoffice.yml

### DIFF
--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -48,6 +48,8 @@ services:
     restart: always
 
   onlyoffice:
+    # if you want to use oo enterprise edition, use: onlyoffice/documentserver-ee:<version>
+    # note, you also need to add a volume, see below
     image: onlyoffice/documentserver:8.2.0
     networks:
       ocis-net:
@@ -62,6 +64,9 @@ services:
       # paths are relative to the main compose file
       - ./config/onlyoffice/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/onlyoffice/local.json:/etc/onlyoffice/documentserver/local.dist.json
+      # if you want to use oo enterprise edition, you need to add a volume for the license file
+      # for details see: Registering your Enterprise Edition version -->
+      # https://helpcenter.onlyoffice.com/installation/docs-enterprise-install-docker.aspx
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.onlyoffice.entrypoints=https"


### PR DESCRIPTION
Just adding two comments in `onlyoffice.yml` what to do if one wants to use oo-enterprise edition.

Because this change is up to the user, we (currently) do not provide any `.env` handling. 