### PR TITLE
[docs-only] SSE_KEEPALIVE_INTERVAL envvar version consistenty

### DIFF
--- a/services/sse/pkg/config/config.go
+++ b/services/sse/pkg/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Tracing *Tracing `yaml:"tracing"`
 
 	Service           Service       `yaml:"-"`
-	KeepAliveInterval time.Duration `yaml:"keepalive_interval" env:"SSE_KEEPALIVE_INTERVAL" desc:"To prevent intermediate proxies from closing the SSE connection, send periodic SSE comments to keep it open." introductionVersion:"7.0"`
+	KeepAliveInterval time.Duration `yaml:"keepalive_interval" env:"SSE_KEEPALIVE_INTERVAL" desc:"To prevent intermediate proxies from closing the SSE connection, send periodic SSE comments to keep it open." introductionVersion:"7.0.0"`
 
 	Events       Events
 	HTTP         HTTP          `yaml:"http"`


### PR DESCRIPTION
The `SSE_KEEPALIVE_INTERVAL` envvar had a "wrong" introduction version. it should be `7.0.0` as all other have too.