### PR TITLE
fix: copy app name if product name isn't provided

### DIFF
--- a/changelog/unreleased/collaboration-product-name.md
+++ b/changelog/unreleased/collaboration-product-name.md
@@ -4,3 +4,4 @@ The product name will allow using a different app name.
 For example, a "CoolBox" app name might use a branded Collabora instance by using "Collabora" as product name.
 
 https://github.com/owncloud/ocis/pull/10335
+https://github.com/owncloud/ocis/pull/10490

--- a/services/collaboration/pkg/config/defaults/defaultconfig.go
+++ b/services/collaboration/pkg/config/defaults/defaultconfig.go
@@ -24,7 +24,6 @@ func DefaultConfig() *config.Config {
 		},
 		App: config.App{
 			Name:        "Collabora",
-			Product:     "Collabora",
 			Description: "Open office documents with Collabora",
 			Icon:        "image-edit",
 			Addr:        "https://127.0.0.1:9980",
@@ -105,6 +104,14 @@ func EnsureDefaults(cfg *config.Config) {
 	}
 	if cfg.CS3Api.GRPCClientTLS == nil && cfg.Commons != nil {
 		cfg.CS3Api.GRPCClientTLS = structs.CopyOrZeroValue(cfg.Commons.GRPCClientTLS)
+	}
+
+	// Copy the app name into the product name if empty.
+	// This is for the upgrade from OCIS 6 to 7 where we didn't have product
+	// name and the app name was acting as such. From OCIS 7, the product name
+	// should be set manually in the configuration.
+	if cfg.App.Product == "" {
+		cfg.App.Product = cfg.App.Name
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This is mostly to help with the upgrade from OCIS 6 to 7. The `COLLABORATION_APP_PRODUCT` is new in OCIS 7 and is needed in order to identify the target product (Collabora, OnlyOffice) and distinguish it from the app name, which could be a brand (CoolBox3, PrivateOffice, etc)

In OCIS 6, the `COLLABORATION_APP_NAME` acted as product name, so it was mostly limited to "Collabora", "OnlyOffice" and "Microsoft" values, but this won't be the case any longer.

The problem comes during the upgrade, where the product name might not be filled yet. This means that an "OnlyOffice" product (set in `COLLABORATION_APP_NAME`) might be mistakenly consider as a "Collabora" product (the default). This mistake could cause issues: so far we've detected that the "OnlyOffice" editor would open in view-only mode despite the user having enough permissions.

In order to make things easier, if the product name is not filled, the app name will be copied over.
* For the upgrade scenario, this should work fine because the `COLLABORATION_APP_NAME` is expected to follow the name limitations from OCIS 6.
* For new installations, both the app name and product name should be manually filled.

After the upgrade from 6 to 7, it is expected that, if there is a change in the `COLLABORATION_APP_NAME`, the `COLLABORATION_APP_PRODUCT` should be filled and / or adjusted.

## Related Issue
Related to https://github.com/owncloud/ocis/issues/10479

## Motivation and Context
Less friction with the upgrade.

## How Has This Been Tested?
Manually tested by removing the `COLLABORATION_APP_PRODUCT` env variable. The OnlyOffice installation (with "OnlyOffice" as `COLLABORATION_APP_NAME`) can edit the files.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
