### PR TITLE
fix: 'ocis backup consistency' file regex

### DIFF
--- a/changelog/unreleased/fix-backup-consistency-cmd.md
+++ b/changelog/unreleased/fix-backup-consistency-cmd.md
@@ -1,0 +1,8 @@
+Bugfix: 'ocis backup consistency' fixed for file revisions
+
+A bug was fixed that caused the 'ocis backup consistency' command to incorrectly report
+inconistencies when file revisions with a zero value for the nano-second part of the
+timestamp were present.
+
+https://github.com/owncloud/ocis/pull/10493
+https://github.com/owncloud/ocis/issues/9498

--- a/ocis/pkg/backup/backup.go
+++ b/ocis/pkg/backup/backup.go
@@ -28,9 +28,9 @@ var (
 
 	// regex to determine if a node is trashed or versioned.
 	// 9113a718-8285-4b32-9042-f930f1a58ac2.REV.2024-05-22T07:32:53.89969726Z
-	_versionRegex = regexp.MustCompile(`\.REV\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z$`)
+	_versionRegex = regexp.MustCompile(`\.REV\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$`)
 	//   9113a718-8285-4b32-9042-f930f1a58ac2.T.2024-05-23T08:25:20.006571811Z <- this HAS a symlink
-	_trashRegex = regexp.MustCompile(`\.T\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z$`)
+	_trashRegex = regexp.MustCompile(`\.T\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$`)
 )
 
 // Consistency holds the node and blob data of a storage provider


### PR DESCRIPTION
'ocis backup consistency' was stumbling over revision (and trash) nodes whose timestamp lacked the nanosecond component (which happens if the nanoseconds of the mtime are 0)

Fixes: #9498

