### PR TITLE
[docs-only] Create envvar delta files after v5 to master (v7.0.0)

### DIFF
--- a/docs/helpers/changed_envvars.py
+++ b/docs/helpers/changed_envvars.py
@@ -1,0 +1,181 @@
+import yaml
+import sys
+import os
+from datetime import date
+from urllib.request import urlopen
+
+## this python script generates based on defined variables adoc files for added, removed and deprecated
+## envvars based on the env_vars.yaml that must exist in each referenced version.
+## it is CRUCIAL that the version compared TO is actual - do required updates first!
+## note that env_vars.yaml has been introduced with v6.0.0, comparing earlier is not possible
+## note that we are always comparing from github sources and NOT local files
+
+## when the files got created, you MUST do some post work manually like referencing services with xref:
+## when running, files get recreated, existing content gets overwritten!!
+
+## you MUST run this script from the local ocis repo root !!
+## like: python3 docs/helpers/changed_envvars.py
+## create a branch to prepare the changes
+
+# CHANGE according your needs
+# old is the base version to compare from
+# new is the target version to compare to
+# tagged versions must be of format: 'tags/v6.0.0'
+# master is different, it must be:   'heads/master'
+versionOld = 'tags/v6.0.0'
+versionNew = 'heads/master'
+
+# CHANGE according your needs
+from_version = '5.0.0'
+to_version = '7.0.0'
+
+# CHANGE according your needs
+# this will create files like 5.0.0-7.0.0-added and 5.0.0-7.0.0-removed
+# this should match which versions you compare. master is ok if that is the base for a named release
+nameComponent = '5.0.0-7.0.0'
+
+# ADD new elements when a new version has been published so that it gets excluded
+# array of version patterns to be excluded for added items. we dont need patch versions
+excludePattern = ['pre5.0', '5.0', '6.0']
+
+# DO NOT CHANGE
+# this is the path the added/removed result is written to
+adocWritePath = 'docs/services/general-info/env-var-deltas'
+
+addedWith = {}
+removedWith = {}
+deprecatedWith = {}
+
+def check_path():
+	# check which path the script started. we can do this because the target path must be present
+	# exit if not present
+	if not os.path.exists(adocWritePath):
+		print('Path not found: ' + adocWritePath)
+		sys.exit()
+
+def get_sources(versionOld, versionNew):
+	# get the sources from github
+	git_bleft_dir = 'https://raw.githubusercontent.com/owncloud/ocis/refs/'
+	git_right_dir ='/docs/helpers/env_vars.yaml'
+
+	urlOld = git_bleft_dir + versionOld + git_right_dir
+	urlNew = git_bleft_dir + versionNew + git_right_dir
+
+	try:
+		fileOld = urlopen(urlOld).read().decode('utf-8')
+		fileNew = urlopen(urlNew).read().decode('utf-8')
+		return	yaml.safe_load(fileOld), yaml.safe_load(fileNew)
+
+	except Exception as e:
+		print(e)
+		sys.exit()
+
+def get_added(fileNew, excludePattern):
+	# create dict with added items
+	addedWith = {}
+	for key, value in fileNew.items():
+		if not fileNew[key]['introductionVersion'] in str(excludePattern):
+			addedWith[key] = value
+	return addedWith
+
+def get_removed(fileOld, fileNew):
+	# create dict with removed items
+	removedWith = {}
+	for key, value in fileOld.items():
+		if not key in fileNew:
+			removedWith[key] = value
+	return removedWith
+
+def get_deprecated(fileNew):
+	# create dict with deprecated items
+	deprecatedWith = {}
+	for key, value in fileNew.items():
+		if value['removalVersion']:
+			deprecatedWith[key] = value
+	return deprecatedWith
+
+def create_adoc_start(type_text, from_version, to_version, creation_date, default):
+	# create the page/table header
+	a = '''// # {ftype} Variables between oCIS {ffrom} and oCIS {fto}
+// commenting the headline to make it better includable
+
+// table created per {fdate}
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service| Variable| Description| {fdefault}
+
+'''.format(ftype = type_text, ffrom = from_version, fto = to_version, fdate = creation_date, fdefault = default)
+	return a
+
+def create_adoc_end():
+	# close the table
+	a = '''|===
+
+'''
+	return a
+
+def add_adoc_line(service, variable, description, default):
+	# add a table line
+	a = '''| {fservice}
+| {fvariable}
+| {fdescription}
+| {fdefault}
+
+'''.format(fservice = service, fvariable = variable, fdescription = description, fdefault = default)
+	return a
+
+def create_table(type_text, source_dict, from_version, to_version, date_today, default = 'Default'):
+	# get the table header
+	a = create_adoc_start(type_text, from_version, to_version, date_today, default)
+	cond_value = 'defaultValue' if default == 'Default' else 'removalVersion'
+	# first add all ocis_
+	for key, value in source_dict.items():
+		if key.startswith('OCIS_'):
+			a += add_adoc_line(
+					'xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]',
+					key,
+					value['description'],
+					value[cond_value]
+				)
+	# then add all others
+	for key, value in source_dict.items():
+		if not key.startswith('OCIS_'):
+			a += add_adoc_line(
+					'xref:{s-path}/xxx.adoc[xxx]',
+					key,
+					value['description'],
+					value[cond_value]
+				)
+	# finally close the table
+	a += create_adoc_end()
+	return a
+
+def write_output(a, type_text):
+	# write the content to a file
+	try:
+		with open(adocWritePath + '/' + nameComponent + '-' + type_text + '.adoc', 'w') as file:
+			file.write(a)
+	except Exception as e:
+		print('Failed creating ' + type_text + ' file')
+		print(e)
+		sys.exit()
+
+## here are the tasks in sequence
+
+check_path()
+fileOld, fileNew = get_sources(versionOld, versionNew)
+addedWith = get_added(fileNew, excludePattern)
+removedWith = get_removed(fileOld, fileNew)
+deprecatedWith = get_deprecated(fileNew)
+
+a = create_table('Added', addedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'))
+r = create_table('Removed', removedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'))
+d = create_table('Deprecated', deprecatedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'), 'Removalversion')
+
+write_output(a, 'added')
+write_output(r, 'removed')
+write_output(d, 'deprecated')
+
+print('Success, see files created in: ' + adocWritePath)

--- a/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-added.adoc
+++ b/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-added.adoc
@@ -1,0 +1,617 @@
+// # Added Variables between oCIS 5.0.0 and oCIS 7.0.0
+// commenting the headline to make it better includable
+
+// table created per 2024.11.07
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service| Variable| Description| Default
+
+| xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
+| OCIS_ASSET_THEMES_PATH
+| Serve ownCloud themes from a path on the filesystem instead of the builtin assets. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/web/assets/themes
+| /var/lib/ocis/web/assets/themes
+
+| xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
+| OCIS_DISABLE_VERSIONING
+| Disables versioning of files. When set to true, new uploads with the same filename will overwrite existing files instead of creating a new version.
+| false
+
+| 
+| OCIS_SHOW_USER_EMAIL_IN_RESULTS
+| Include user email addresses in responses. If absent or set to false emails will be omitted from results. Please note that admin users can always see all email addresses.
+| false
+
+| 
+| OCIS_WOPI_DISABLE_CHAT
+| Disable chat in the office web frontend. This feature applies to OnlyOffice and Microsoft.
+| false
+
+| xref:{s-path}/activitylog.adoc[Activitylog]
+| ACTIVITYLOG_TRANSLATION_PATH
+| (optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details.
+| 
+
+| xref:{s-path}/antivirus.adoc[Antivirus]
+| ANTIVIRUS_WORKERS
+| The number of concurrent go routines that fetch events from the event queue.
+| 10
+
+| xref:{s-path}/auth-app.adoc[Auth-App]
+| AUTH_APP_DEBUG_ADDR
+| Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed.
+| 127.0.0.1:9245
+
+| 
+| AUTH_APP_DEBUG_PPROF
+| Enables pprof, which can be used for profiling.
+| false
+
+| 
+| AUTH_APP_DEBUG_TOKEN
+| Token to secure the metrics endpoint.
+| 
+
+| 
+| AUTH_APP_DEBUG_ZPAGES
+| Enables zpages, which can  be used for collecting and viewing traces in-memory.
+| false
+
+| 
+| AUTH_APP_ENABLE_IMPERSONATION
+| Allows admins to create app tokens for other users. Used for migration. Do NOT use in productive deployments.
+| false
+
+| 
+| AUTH_APP_GRPC_ADDR
+| The bind address of the GRPC service.
+| 127.0.0.1:9246
+
+| 
+| AUTH_APP_GRPC_PROTOCOL
+| The transport protocol of the GRPC service.
+| tcp
+
+| 
+| AUTH_APP_JWT_SECRET
+| The secret to mint and validate jwt tokens.
+| 
+
+| 
+| AUTH_APP_LOG_COLOR
+| Activates colorized log output.
+| false
+
+| 
+| AUTH_APP_LOG_FILE
+| The path to the log file. Activates logging to this file if set.
+| 
+
+| 
+| AUTH_APP_LOG_LEVEL
+| The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'.
+| 
+
+| 
+| AUTH_APP_LOG_PRETTY
+| Activates pretty log output.
+| false
+
+| 
+| AUTH_APP_MACHINE_AUTH_API_KEY
+| The machine auth API key used to validate internal requests necessary to access resources from other services.
+| 
+
+| 
+| AUTH_APP_SKIP_USER_GROUPS_IN_TOKEN
+| Disables the encoding of the user's group memberships in the access token. This reduces the token size, especially when users are members of a large number of groups.
+| false
+
+| 
+| AUTH_APP_TRACING_COLLECTOR
+| The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset.
+| 
+
+| 
+| AUTH_APP_TRACING_ENABLED
+| Activates tracing.
+| false
+
+| 
+| AUTH_APP_TRACING_ENDPOINT
+| The endpoint of the tracing agent.
+| 
+
+| 
+| AUTH_APP_TRACING_TYPE
+| The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.
+| 
+
+| xref:{s-path}/collaboration.adoc[Collaboration]
+| COLLABORATION_APP_ADDR
+| The URL where the WOPI app is located, such as https://127.0.0.1:8080.
+| https://127.0.0.1:9980
+
+| 
+| COLLABORATION_APP_DESCRIPTION
+| App description
+| Open office documents with Collabora
+
+| 
+| COLLABORATION_APP_ICON
+| Icon for the app
+| image-edit
+
+| 
+| COLLABORATION_APP_INSECURE
+| Skip TLS certificate verification when connecting to the WOPI app
+| false
+
+| 
+| COLLABORATION_APP_LICENSE_CHECK_ENABLE
+| Enable license checking to edit files. Needs to be enabled when using Microsoft365 with the business flow.
+| false
+
+| 
+| COLLABORATION_APP_LOCKNAME
+| Name for the app lock
+| com.github.owncloud.collaboration
+
+| 
+| COLLABORATION_APP_NAME
+| The name of the app which is shown to the user. You can chose freely but you are limited to a single word without special characters or whitespaces. We recommend to use pascalCase like 'CollaboraOnline'.
+| Collabora
+
+| 
+| COLLABORATION_APP_PRODUCT
+| The WebOffice app, either Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline.
+| Collabora
+
+| 
+| COLLABORATION_APP_PROOF_DISABLE
+| Disable the proof keys verification
+| false
+
+| 
+| COLLABORATION_APP_PROOF_DURATION
+| Duration for the proof keys to be cached in memory, using time.ParseDuration format. If the duration can't be parsed, we'll use the default 12h as duration
+| 12h
+
+| 
+| COLLABORATION_CS3API_DATAGATEWAY_INSECURE
+| Connect to the CS3API data gateway insecurely.
+| false
+
+| 
+| COLLABORATION_CS3API_GATEWAY_NAME
+| CS3 gateway used to look up user metadata.
+| com.owncloud.api.gateway
+
+| 
+| COLLABORATION_DEBUG_ADDR
+| Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed.
+| 127.0.0.1:9304
+
+| 
+| COLLABORATION_DEBUG_PPROF
+| Enables pprof, which can be used for profiling.
+| false
+
+| 
+| COLLABORATION_DEBUG_TOKEN
+| Token to secure the metrics endpoint.
+| 
+
+| 
+| COLLABORATION_DEBUG_ZPAGES
+| Enables zpages, which can be used for collecting and viewing in-memory traces.
+| false
+
+| 
+| COLLABORATION_GRPC_ADDR
+| The bind address of the GRPC service.
+| 127.0.0.1:9301
+
+| 
+| COLLABORATION_GRPC_PROTOCOL
+| The transport protocol of the GRPC service.
+| tcp
+
+| 
+| COLLABORATION_HTTP_ADDR
+| The bind address of the HTTP service.
+| 127.0.0.1:9300
+
+| 
+| COLLABORATION_LOG_COLOR
+| Activates colorized log output.
+| false
+
+| 
+| COLLABORATION_LOG_FILE
+| The path to the log file. Activates logging to this file if set.
+| 
+
+| 
+| COLLABORATION_LOG_LEVEL
+| The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'.
+| 
+
+| 
+| COLLABORATION_LOG_PRETTY
+| Activates pretty log output.
+| false
+
+| 
+| COLLABORATION_STORE
+| The type of the store. Supported values are: 'memory', 'nats-js-kv', 'redis-sentinel', 'noop'. See the text description for details.
+| nats-js-kv
+
+| 
+| COLLABORATION_STORE_AUTH_PASSWORD
+| The password to authenticate with the store. Only applies when store type 'nats-js-kv' is configured.
+| 
+
+| 
+| COLLABORATION_STORE_AUTH_USERNAME
+| The username to authenticate with the store. Only applies when store type 'nats-js-kv' is configured.
+| 
+
+| 
+| COLLABORATION_STORE_DATABASE
+| The database name the configured store should use.
+| collaboration
+
+| 
+| COLLABORATION_STORE_NODES
+| A list of nodes to access the configured store. This has no effect when 'memory' store is configured. Note that the behaviour how nodes are used is dependent on the library of the configured store. See the Environment Variable Types description for more details.
+| [127.0.0.1:9233]
+
+| 
+| COLLABORATION_STORE_TABLE
+| The database table the store should use.
+| 
+
+| 
+| COLLABORATION_STORE_TTL
+| Time to live for events in the store. Defaults to '30m' (30 minutes). See the Environment Variable Types description for more details.
+| 30m0s
+
+| 
+| COLLABORATION_TRACING_COLLECTOR
+| The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset.
+| 
+
+| 
+| COLLABORATION_TRACING_ENABLED
+| Activates tracing.
+| false
+
+| 
+| COLLABORATION_TRACING_ENDPOINT
+| The endpoint of the tracing agent.
+| 
+
+| 
+| COLLABORATION_TRACING_TYPE
+| The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.
+| 
+
+| 
+| COLLABORATION_WOPI_DISABLE_CHAT
+| Disable chat in the office web frontend. This feature applies to OnlyOffice and Microsoft.
+| false
+
+| 
+| COLLABORATION_WOPI_PROXY_SECRET
+| Optional, the secret to authenticate against the ownCloud Office365 WOPI proxy. This secret can be obtained from ownCloud via the office365 proxy subscription.
+| 
+
+| 
+| COLLABORATION_WOPI_PROXY_URL
+| The URL to the ownCloud Office365 WOPI proxy. Optional. To use this feature, you need an office365 proxy subscription. If you become part of the Microsoft CSP program (https://learn.microsoft.com/en-us/partner-center/enroll/csp-overview), you can use WebOffice without a proxy.
+| 
+
+| 
+| COLLABORATION_WOPI_SECRET
+| Used to mint and verify WOPI JWT tokens and encrypt and decrypt the REVA JWT token embedded in the WOPI JWT token.
+| 
+
+| 
+| COLLABORATION_WOPI_SHORTTOKENS
+| Use short access tokens for WOPI access. This is useful for office packages, like Microsoft Office Online, which have URL length restrictions. If enabled, a persistent store must be configured.
+| false
+
+| 
+| COLLABORATION_WOPI_SRC
+| The WOPI source base URL containing schema, host and port. Set this to the schema and domain where the collaboration service is reachable for the wopi app, such as https://office.owncloud.test.
+| https://localhost:9300
+
+| xref:{s-path}/frontend.adoc[Frontend]
+| FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR
+| Service name or address of the app provider to use for secure view. Should match the service name or address of the registered CS3 app provider.
+| com.owncloud.api.collaboration
+
+| xref:{s-path}/gateway.adoc[Gateway]
+| GATEWAY_APP_REGISTRY_ENDPOINT
+| The endpoint of the app-registry service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.app-registry
+
+| 
+| GATEWAY_AUTH_APP_ENDPOINT
+| The endpoint of the auth-app service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.auth-app
+
+| 
+| GATEWAY_AUTH_BASIC_ENDPOINT
+| The endpoint of the auth-basic service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.auth-basic
+
+| 
+| GATEWAY_AUTH_BEARER_ENDPOINT
+| The endpoint of the auth-bearer service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| 
+
+| 
+| GATEWAY_AUTH_MACHINE_ENDPOINT
+| The endpoint of the auth-machine service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.auth-machine
+
+| 
+| GATEWAY_AUTH_SERVICE_ENDPOINT
+| The endpoint of the auth-service service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.auth-service
+
+| 
+| GATEWAY_GROUPS_ENDPOINT
+| The endpoint of the groups service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.groups
+
+| 
+| GATEWAY_OCM_ENDPOINT
+| The endpoint of the ocm service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.ocm
+
+| 
+| GATEWAY_PERMISSIONS_ENDPOINT
+| The endpoint of the permissions service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.settings
+
+| 
+| GATEWAY_SHARING_ENDPOINT
+| The endpoint of the shares service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.sharing
+
+| 
+| GATEWAY_STORAGE_PUBLIC_LINK_ENDPOINT
+| The endpoint of the storage-publiclink service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.storage-publiclink
+
+| 
+| GATEWAY_STORAGE_SHARES_ENDPOINT
+| The endpoint of the storage-shares service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.storage-shares
+
+| 
+| GATEWAY_STORAGE_USERS_ENDPOINT
+| The endpoint of the storage-users service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.storage-users
+
+| 
+| GATEWAY_USERS_ENDPOINT
+| The endpoint of the users service. Can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.users
+
+| xref:{s-path}/graph.adoc[Graph]
+| GRAPH_AVAILABLE_ROLES
+| A comma separated list of roles that are available for assignment.
+| [b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5 a8d5fe5e-96e3-418d-825b-534dbdf22b99 fb6c3e19-e378-47e5-b277-9732f9de6e21 58c63c02-1d89-4572-916a-870abc5a1b7d 2d00ce52-1fc2-4dbc-8b95-a73b73395f5a 1c996275-f1c9-4e71-abdf-a42f6495e960 312c0871-5ef7-4b3a-85b6-0e4074c64049]
+
+| 
+| GRAPH_TRANSLATION_PATH
+| (optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details.
+| 
+
+| xref:{s-path}/ocm.adoc[OCM]
+| OCM_OCM_INVITE_MANAGER_TIMEOUT
+| Timeout specifies a time limit for requests made to OCM endpoints.
+| 30s
+
+| 
+| OCM_OCM_INVITE_MANAGER_TOKEN_EXPIRATION
+| Expiry duration for invite tokens.
+| 24h0m0s
+
+| 
+| OCM_OCM_STORAGE_DATA_SERVER_URL
+| URL of the data server, needs to be reachable by the data gateway provided by the frontend service or the user if directly exposed.
+| http://localhost:9280/data
+
+| xref:{s-path}/postprocessing.adoc[Postprocessing]
+| POSTPROCESSING_WORKERS
+| The number of concurrent go routines that fetch events from the event queue.
+| 3
+
+| xref:{s-path}/proxy.adoc[Proxy]
+| PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME
+| The name of the OIDC claim that holds the display name.
+| name
+
+| 
+| PROXY_AUTOPROVISION_CLAIM_EMAIL
+| The name of the OIDC claim that holds the email.
+| email
+
+| 
+| PROXY_AUTOPROVISION_CLAIM_GROUPS
+| The name of the OIDC claim that holds the groups.
+| groups
+
+| 
+| PROXY_AUTOPROVISION_CLAIM_USERNAME
+| The name of the OIDC claim that holds the username.
+| preferred_username
+
+| 
+| PROXY_CSP_CONFIG_FILE_LOCATION
+| The location of the CSP configuration file.
+| 
+
+| 
+| PROXY_ENABLE_APP_AUTH
+| Allow app authentication. This can be used to authenticate 3rd party applications. Note that auth-app service must be running for this feature to work.
+| false
+
+| 
+| PROXY_EVENTS_AUTH_PASSWORD
+| The password to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services.
+| 
+
+| 
+| PROXY_EVENTS_AUTH_USERNAME
+| The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services.
+| 
+
+| 
+| PROXY_EVENTS_CLUSTER
+| The clusterID of the event system. The event system is the message queuing service. It is used as message broker for the microservice architecture.
+| ocis-cluster
+
+| 
+| PROXY_EVENTS_ENABLE_TLS
+| Enable TLS for the connection to the events broker. The events broker is the ocis service which receives and delivers events between the services.
+| false
+
+| 
+| PROXY_EVENTS_ENDPOINT
+| The address of the event system. The event system is the message queuing service. It is used as message broker for the microservice architecture. Set to a empty string to disable emitting events.
+| 127.0.0.1:9233
+
+| 
+| PROXY_EVENTS_TLS_INSECURE
+| Whether to verify the server TLS certificates.
+| false
+
+| 
+| PROXY_EVENTS_TLS_ROOT_CA_CERTIFICATE
+| The root CA certificate used to validate the server's TLS certificate. If provided PROXY_EVENTS_TLS_INSECURE will be seen as false.
+| 
+
+| xref:{s-path}/sse.adoc[SSE]
+| SSE_KEEPALIVE_INTERVAL
+| To prevent intermediate proxies from closing the SSE connection, send periodic SSE comments to keep it open.
+| 0s
+
+| xref:{s-path}/storage-users.adoc[Storage-Users]
+| STORAGE_USERS_OCIS_GENERAL_SPACE_PATH_TEMPLATE
+| Template string to construct the paths of the projects space roots.
+| 
+
+| 
+| STORAGE_USERS_OCIS_PERSONAL_SPACE_PATH_TEMPLATE
+| Template string to construct the paths of the personal space roots.
+| 
+
+| 
+| STORAGE_USERS_PERMISSION_ENDPOINT
+| Endpoint of the permissions service. The endpoints can differ for 'ocis', 'posix' and 's3ng'.
+| com.owncloud.api.settings
+
+| 
+| STORAGE_USERS_POSIX_GENERAL_SPACE_PATH_TEMPLATE
+| Template string to construct the paths of the projects space roots.
+| projects/{{.SpaceId}}
+
+| 
+| STORAGE_USERS_POSIX_PERMISSIONS_ENDPOINT
+| Endpoint of the permissions service. The endpoints can differ for 'ocis', 'posix' and 's3ng'.
+| com.owncloud.api.settings
+
+| 
+| STORAGE_USERS_POSIX_PERSONAL_SPACE_PATH_TEMPLATE
+| Template string to construct the paths of the personal space roots.
+| users/{{.User.Username}}
+
+| 
+| STORAGE_USERS_POSIX_ROOT
+| The directory where the filesystem storage will store its data. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/storage/users.
+| 
+
+| 
+| STORAGE_USERS_POSIX_SCAN_DEBOUNCE_DELAY
+| The time in milliseconds to wait before scanning the filesystem for changes after a change has been detected.
+| 1s
+
+| 
+| STORAGE_USERS_POSIX_USE_SPACE_GROUPS
+| Use space groups to manage permissions on spaces.
+| false
+
+| 
+| STORAGE_USERS_POSIX_WATCH_FOLDER_KAFKA_BROKERS
+| Comma-separated list of kafka brokers to read the watchfolder events from.
+| 
+
+| 
+| STORAGE_USERS_POSIX_WATCH_PATH
+| Path to the watch directory/file. Only applies to the 'gpfsfileauditlogging' and 'inotifywait' watcher, in which case it is the path of the file audit log file/base directory to watch.
+| 
+
+| 
+| STORAGE_USERS_POSIX_WATCH_TYPE
+| Type of the watcher to use for getting notified about changes to the filesystem. Currently available options are 'inotifywait' (default), 'gpfswatchfolder' and 'gpfsfileauditlogging'.
+| 
+
+| 
+| STORAGE_USERS_S3NG_GENERAL_SPACE_PATH_TEMPLATE
+| Template string to construct the paths of the projects space roots.
+| 
+
+| 
+| STORAGE_USERS_S3NG_PERSONAL_SPACE_PATH_TEMPLATE
+| Template string to construct the paths of the personal space roots.
+| 
+
+| 
+| STORAGE_USERS_SERVICE_NAME
+| Service name to use. Change this when starting an additional storage provider with a custom configuration to prevent it from colliding with the default 'storage-users' service.
+| storage-users
+
+| xref:{s-path}/thumbnails.adoc[Thumbnails]
+| THUMBNAILS_MAX_CONCURRENT_REQUESTS
+| Number of maximum concurrent thumbnail requests. Default is 0 which is unlimited.
+| 0
+
+| 
+| THUMBNAILS_MAX_INPUT_HEIGHT
+| The maximum height of an input image which is being processed.
+| 7680
+
+| 
+| THUMBNAILS_MAX_INPUT_IMAGE_FILE_SIZE
+| The maximum file size of an input image which is being processed. Usable common abbreviations: [KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB], example: 2GB.
+| 50MB
+
+| 
+| THUMBNAILS_MAX_INPUT_WIDTH
+| The maximum width of an input image which is being processed.
+| 7680
+
+| xref:{s-path}/web.adoc[Web]
+| WEB_ASSET_APPS_PATH
+| Serve ownCloud Web apps assets from a path on the filesystem instead of the builtin assets. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/web/assets/apps
+| /var/lib/ocis/web/assets/apps
+
+| 
+| WEB_ASSET_CORE_PATH
+| Serve ownCloud Web assets from a path on the filesystem instead of the builtin assets. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/web/assets/core
+| /var/lib/ocis/web/assets/core
+
+| 
+| WEB_ASSET_THEMES_PATH
+| Serve ownCloud themes from a path on the filesystem instead of the builtin assets. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/web/assets/themes
+| /var/lib/ocis/web/assets/themes
+
+|===
+

--- a/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-deprecated.adoc
+++ b/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-deprecated.adoc
@@ -1,0 +1,17 @@
+// # Deprecated Variables between oCIS 5.0.0 and oCIS 7.0.0
+// commenting the headline to make it better includable
+
+// table created per 2024.11.07
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service| Variable| Description| Removalversion
+
+| xref:{s-path}/antivirus.adoc[Antivirus]
+| ANTIVIRUS_ICAP_TIMEOUT
+| Timeout for the ICAP client.
+| %%NEXT_PRODUCTION_VERSION%%
+
+|===
+

--- a/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-removed.adoc
+++ b/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-removed.adoc
@@ -1,0 +1,117 @@
+// # Removed Variables between oCIS 5.0.0 and oCIS 7.0.0
+// commenting the headline to make it better includable
+
+// table created per 2024.11.07
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service| Variable| Description| Default
+
+| xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
+| OCIS_ENABLE_RESHARING
+| Changing this value is NOT supported. Enables the support for re-sharing in the clients.
+| false
+
+| xref:{s-path}/frontend.adoc[Frontend]
+| FRONTEND_ENABLE_RESHARING
+| Changing this value is NOT supported. Enables the support for re-sharing in the clients.
+| false
+
+| xref:{s-path}/graph.adoc[Graph]
+| GRAPH_ENABLE_RESHARING
+| Changing this value is NOT supported. Enables the support for re-sharing.
+| false
+
+| xref:{s-path}/sharing.adoc[Sharing]
+| SHARING_ENABLE_RESHARING
+| Changing this value is NOT supported. Enables the support for resharing.
+| false
+
+| xref:{s-path}/storage-system.adoc[Storage-System]
+| STORAGE_SYSTEM_OCIS_METADATA_BACKEND
+| The backend to use for storing metadata. Supported values are 'messagepack' and 'xattrs'. The setting 'messagepack' uses a dedicated file to store file metadata while 'xattrs' uses extended attributes to store file metadata. Defaults to 'messagepack'.
+| messagepack
+
+| xref:{s-path}/storage-users.adoc[Storage-Users]
+| STORAGE_USERS_OCIS_METADATA_BACKEND
+| The backend to use for storing metadata. Supported values are 'messagepack' and 'xattrs'. The setting 'messagepack' uses a dedicated file to store file metadata while 'xattrs' uses extended attributes to store file metadata. Defaults to 'messagepack'.
+| messagepack
+
+| The `Store` service has fully been removed
+| STORE_DATA_PATH
+| The directory where the filesystem storage will store ocis settings. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/store.
+| /var/lib/ocis/store
+
+| 
+| STORE_DEBUG_ADDR
+| Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed.
+| 127.0.0.1:9464
+
+| 
+| STORE_DEBUG_PPROF
+| Enables pprof, which can be used for profiling.
+| false
+
+| 
+| STORE_DEBUG_TOKEN
+| Token to secure the metrics endpoint.
+| 
+
+| 
+| STORE_DEBUG_ZPAGES
+| Enables zpages, which can be used for collecting and viewing in-memory traces.
+| false
+
+| 
+| STORE_GRPC_ADDR
+| The bind address of the GRPC service.
+| 127.0.0.1:9460
+
+| 
+| STORE_LOG_COLOR
+| Activates colorized log output.
+| false
+
+| 
+| STORE_LOG_FILE
+| The path to the log file. Activates logging to this file if set.
+| 
+
+| 
+| STORE_LOG_LEVEL
+| The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'.
+| 
+
+| 
+| STORE_LOG_PRETTY
+| Activates pretty log output.
+| false
+
+| 
+| STORE_TRACING_COLLECTOR
+| The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces. Only used if the tracing endpoint is unset.
+| 
+
+| 
+| STORE_TRACING_ENABLED
+| Activates tracing.
+| false
+
+| 
+| STORE_TRACING_ENDPOINT
+| The endpoint of the tracing agent.
+| 
+
+| 
+| STORE_TRACING_TYPE
+| The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.
+| 
+
+| xref:{s-path}/web.adoc[Web]
+| WEB_ASSET_PATH
+| Serve ownCloud Web assets from a path on the filesystem instead of the builtin assets.
+| 
+
+|===
+

--- a/docs/services/general-info/env-var-deltas/make-adoc-table-from-python.txt
+++ b/docs/services/general-info/env-var-deltas/make-adoc-table-from-python.txt
@@ -1,0 +1,7 @@
+it is most easiest to create the added/removed/deprecated adoc tables using
+the python script in docs/helpers/changes_envvars.py
+
+the script creates based on variables that need to be adapted according your needs
+all files necessary. finally you only MUST handle xrefs manually, see existing files
+for an example for how to do so.
+


### PR DESCRIPTION
This PR:

* Adds a Python script generating the delta files automatically based on configuration. Note that we can compare any version that has been tagged or branched including master after v6! This means we do not need to wait until releasing has been done.
* Adds added/removed/deprecated adoc files for the admin docs. This is very important to finalize the upgrade/migration guide

Note that the respective .md files can only be created AFTER releasing as this requires (currently) a semver version to be accessed which mster is not.

I will file a second PR with some necessary doc helper stuff.

NOTE: To make this PR work, else hugo wants to render adoc files but has no parser configured, we needed to adapt config.yaml from hugo at its source to exclude directories: https://github.com/owncloud/owncloud.github.io/pull/94