### PR TITLE
only check nats if it is used

### DIFF
--- a/changelog/unreleased/fix-gateway-nats-checks.md
+++ b/changelog/unreleased/fix-gateway-nats-checks.md
@@ -1,0 +1,5 @@
+Bugfix: fix gateway nats checks
+
+We now only check if nats is available when the gateway actually uses it. Furthermore, we added a backoff for checking the readys endpoint.
+
+https://github.com/owncloud/ocis/pull/10502

--- a/ocis-pkg/registry/register.go
+++ b/ocis-pkg/registry/register.go
@@ -27,11 +27,15 @@ func RegisterService(ctx context.Context, logger log.Logger, service *mRegistry.
 
 	go func() {
 		// check if the service is ready
+		delay := 500 * time.Millisecond
 		for {
 			resp, err := http.DefaultClient.Get("http://" + debugAddr + "/readyz")
 			if err == nil && resp.StatusCode == http.StatusOK {
+				resp.Body.Close()
 				break
 			}
+			time.Sleep(delay)
+			delay *= 2
 		}
 		for {
 			select {

--- a/services/gateway/pkg/server/debug/server.go
+++ b/services/gateway/pkg/server/debug/server.go
@@ -17,7 +17,7 @@ func Server(opts ...Option) (*http.Server, error) {
 	readyHandlerConfiguration := handlers.NewCheckHandlerConfiguration().
 		WithLogger(options.Logger).
 		WithCheck("nats reachability", func(ctx context.Context) error {
-			if len(options.Config.Cache.ProviderCacheNodes) > 0 {
+			if options.Config.Cache.ProviderCacheStore == "nats-js-kv" && len(options.Config.Cache.ProviderCacheNodes) > 0 {
 				return checks.NewNatsCheck(options.Config.Cache.ProviderCacheNodes[0])(ctx)
 			}
 			return nil


### PR DESCRIPTION
We now only check if nats is available when the gateway actually uses it. Furthermore, we added a backoff for checking the readys endpoint.
