### PR TITLE
fix autoaccept concurrency

### DIFF
--- a/changelog/unreleased/concurrent-autoaccept.md
+++ b/changelog/unreleased/concurrent-autoaccept.md
@@ -2,4 +2,5 @@ Enhancement: Concurrent autoaccept for shares
 
 Shares for groups are now concurrently accepted. Tha default of 25 goroutinges can be changed with the new `FRONTEND_MAX_CONCURRENCY` environment variable.
 
+https://github.com/owncloud/ocis/pull/10505
 https://github.com/owncloud/ocis/pull/10476


### PR DESCRIPTION
not only update multiple members concurrently but also handle multiple events concurrently