### PR TITLE
add patch command to the ocis image

### DIFF
--- a/ocis/docker/Dockerfile.linux.amd64
+++ b/ocis/docker/Dockerfile.linux.amd64
@@ -3,7 +3,7 @@ FROM amd64/alpine:3.20
 ARG VERSION=""
 ARG REVISION=""
 
-RUN apk add --no-cache attr bash ca-certificates curl inotify-tools libc6-compat mailcap tree vips && \
+RUN apk add --no-cache attr bash ca-certificates curl inotify-tools libc6-compat mailcap tree vips patch && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \

--- a/ocis/docker/Dockerfile.linux.arm64
+++ b/ocis/docker/Dockerfile.linux.arm64
@@ -3,7 +3,7 @@ FROM arm64v8/alpine:3.20
 ARG VERSION=""
 ARG REVISION=""
 
-RUN apk add --no-cache attr bash ca-certificates curl inotify-tools libc6-compat mailcap tree vips && \
+RUN apk add --no-cache attr bash ca-certificates curl inotify-tools libc6-compat mailcap tree vips patch && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \

--- a/ocis/docker/Dockerfile.linux.debug.amd64
+++ b/ocis/docker/Dockerfile.linux.debug.amd64
@@ -3,7 +3,7 @@ FROM amd64/alpine:latest
 ARG VERSION=""
 ARG REVISION=""
 
-RUN apk add --no-cache attr bash ca-certificates curl delve inotify-tools libc6-compat mailcap tree vips && \
+RUN apk add --no-cache attr bash ca-certificates curl delve inotify-tools libc6-compat mailcap tree vips patch && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \


### PR DESCRIPTION
References:
https://github.com/owncloud/docs-ocis/pull/1029 (Migration and Update Guide for 5 to 7)
https://github.com/owncloud/ocis/issues/10373#issuecomment-2468525545 (Release 7.0.0)

Add `patch` command to the ocis image.
