### PR TITLE
Fix ocis init

### DIFF
--- a/ocis/pkg/init/functions.go
+++ b/ocis/pkg/init/functions.go
@@ -86,6 +86,10 @@ func writePatch(configPath string, yamlOutput []byte) error {
 	cmd := exec.Command("diff", "-u", path.Join(configPath, configFilename), tmpFile)
 	stdout, err := cmd.Output()
 	if err == nil {
+		err = os.Remove(tmpFile)
+		if err != nil {
+			return err
+		}
 		fmt.Println("no changes, your config is up to date")
 		return nil
 	}

--- a/ocis/pkg/init/init.go
+++ b/ocis/pkg/init/init.go
@@ -83,6 +83,12 @@ func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword
 		revaServicePassword = oldCfg.Idm.ServiceUserPasswords.RevaPassword
 		tokenManagerJwtSecret = oldCfg.TokenManager.JWTSecret
 		collaborationWOPISecret = oldCfg.Collaboration.WopiApp.Secret
+		if collaborationWOPISecret == "" {
+			collaborationWOPISecret, err = generators.GenerateRandomPassword(passwordLength)
+			if err != nil {
+				return fmt.Errorf("could not generate random wopi secret for collaboration service: %s", err)
+			}
+		}
 		machineAuthAPIKey = oldCfg.MachineAuthAPIKey
 		systemUserAPIKey = oldCfg.SystemUserAPIKey
 		revaTransferSecret = oldCfg.TransferSecret


### PR DESCRIPTION
This PR fixes

- missing remove of tmp file if the patch is empty on `ocis init --diff`
- generate an uuid for the collaboration wopi secret if the old config does not contain it.

refs  #10560 
refs #10444 