### PR TITLE
[docs-only] Improve error messages for health command output

### DIFF
--- a/ocis-pkg/shared/errors.go
+++ b/ocis-pkg/shared/errors.go
@@ -9,7 +9,7 @@ import (
 func MissingMachineAuthApiKeyError(service string) error {
 	return fmt.Errorf("The Machineauth API key has not been configured for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -17,7 +17,7 @@ func MissingMachineAuthApiKeyError(service string) error {
 func MissingSystemUserApiKeyError(service string) error {
 	return fmt.Errorf("The SystemUser API key has not been configured for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -25,7 +25,7 @@ func MissingSystemUserApiKeyError(service string) error {
 func MissingJWTTokenError(service string) error {
 	return fmt.Errorf("The jwt_secret has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -33,7 +33,7 @@ func MissingJWTTokenError(service string) error {
 func MissingRevaTransferSecretError(service string) error {
 	return fmt.Errorf("The transfer_secret has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -41,7 +41,7 @@ func MissingRevaTransferSecretError(service string) error {
 func MissingLDAPBindPassword(service string) error {
 	return fmt.Errorf("The ldap bind_password has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -49,7 +49,7 @@ func MissingLDAPBindPassword(service string) error {
 func MissingServiceUserPassword(service, serviceUser string) error {
 	return fmt.Errorf("The password of service user %s has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		serviceUser, service, defaults.BaseConfigPath())
 }
@@ -57,7 +57,7 @@ func MissingServiceUserPassword(service, serviceUser string) error {
 func MissingSystemUserID(service string) error {
 	return fmt.Errorf("The system user ID has not been configured for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -65,7 +65,7 @@ func MissingSystemUserID(service string) error {
 func MissingAdminUserID(service string) error {
 	return fmt.Errorf("The admin user ID has not been configured for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -73,7 +73,7 @@ func MissingAdminUserID(service string) error {
 func MissingServiceAccountID(service string) error {
 	return fmt.Errorf("The service account id has not been configured for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -81,7 +81,7 @@ func MissingServiceAccountID(service string) error {
 func MissingServiceAccountSecret(service string) error {
 	return fmt.Errorf("The service account secret has not been configured for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }
@@ -89,7 +89,7 @@ func MissingServiceAccountSecret(service string) error {
 func MissingWOPISecretError(service string) error {
 	return fmt.Errorf("The WOPI secret has not been set properly in your config for %s. "+
 		"Make sure your %s config contains the proper values "+
-		"(e.g. by running ocis init or setting it manually in "+
+		"(e.g. by using 'ocis init --diff' and applying the patch or setting a value manually in "+
 		"the config/corresponding environment variable).",
 		service, defaults.BaseConfigPath())
 }


### PR DESCRIPTION
When there is an issue reported from a `ocis <service-name> health` command, we should advice to run `ocis init --diff` and not `ocis init`. The diff option will only generate a patchable delta file which can be reviewed and applied while an init without diff will overwrite the config.

We do the same when upgrading...