### PR TITLE
fix(ocm): Adjust for recend change for federated user IDs

### DIFF
--- a/changelog/unreleased/fix-ocm-external-idp.md
+++ b/changelog/unreleased/fix-ocm-external-idp.md
@@ -1,0 +1,7 @@
+Bugfix: Fix federated sharing when using an external IDP
+
+We fixed a bug that caused federated sharing to fail, when the
+federated oCIS instances where sharing the same external IDP.
+
+https://github.com/owncloud/ocis/pull/1xxxx
+https://github.com/cs3org/reva/pull/4933

--- a/services/graph/pkg/identity/backend.go
+++ b/services/graph/pkg/identity/backend.go
@@ -8,7 +8,6 @@ import (
 	"github.com/CiscoM31/godata"
 	cs3group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	cs3user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	ocmuser "github.com/cs3org/reva/v2/pkg/ocm/user"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 	"github.com/owncloud/ocis/v2/services/graph/pkg/errorcode"
 )
@@ -133,12 +132,6 @@ func CreateUserModelFromCS3(u *cs3user.User) *libregraph.User {
 		Mail:                     &u.Mail,
 		OnPremisesSamAccountName: u.GetUsername(),
 		Id:                       &u.GetId().OpaqueId,
-	}
-	// decode the remote id if the user is federated
-	if u.GetId().GetType() == cs3user.UserType_USER_TYPE_FEDERATED {
-		remoteID := ocmuser.RemoteID(u.GetId())
-		user.Identities[0].Issuer = &remoteID.Idp
-		user.Identities[0].IssuerAssignedId = &remoteID.OpaqueId
 	}
 	return user
 }


### PR DESCRIPTION
The UserIds as returned by e.g. GetAcceptedUser do already contain the provider domain in the IDP field now.

Also adjust the provider domain in the OCM config to be really a domain without URI scheme and path.

