### PR TITLE
limit the number of workers of the jsoncs3 share manager

### DIFF
--- a/changelog/unreleased/limit-sharing-workers.md
+++ b/changelog/unreleased/limit-sharing-workers.md
@@ -1,0 +1,5 @@
+Bugfix: We now limit the number of workers of the jsoncs3 share manager
+
+We now restrict the number of workers that look up shares to 5. The number can be changed with `SHARING_USER_JSONCS3_MAX_CONCURRENCY`.
+
+https://github.com/owncloud/ocis/pull/10552

--- a/services/sharing/pkg/config/config.go
+++ b/services/sharing/pkg/config/config.go
@@ -106,6 +106,7 @@ type UserSharingJSONCS3Driver struct {
 	SystemUserIDP    string `yaml:"system_user_idp" env:"OCIS_SYSTEM_USER_IDP;SHARING_USER_JSONCS3_SYSTEM_USER_IDP" desc:"IDP of the oCIS STORAGE-SYSTEM system user." introductionVersion:"pre5.0"`
 	SystemUserAPIKey string `yaml:"system_user_api_key" env:"OCIS_SYSTEM_USER_API_KEY;SHARING_USER_JSONCS3_SYSTEM_USER_API_KEY" desc:"API key for the STORAGE-SYSTEM system user." introductionVersion:"pre5.0"`
 	CacheTTL         int    `yaml:"cache_ttl" env:"SHARING_USER_JSONCS3_CACHE_TTL" desc:"TTL for the internal caches in seconds." introductionVersion:"pre5.0"`
+	MaxConcurrency   int    `yaml:"max_concurrency" env:"SHARING_USER_JSONCS3_MAX_CONCURRENCY" desc:"Maximum number of workers for requests to the storage system." introductionVersion:"7.0.0"`
 }
 type PublicSharingDrivers struct {
 	JSON    PublicSharingJSONDriver    `yaml:"json"`

--- a/services/sharing/pkg/config/defaults/defaultconfig.go
+++ b/services/sharing/pkg/config/defaults/defaultconfig.go
@@ -45,8 +45,9 @@ func DefaultConfig() *config.Config {
 				SystemUserIDP: "internal",
 			},
 			JSONCS3: config.UserSharingJSONCS3Driver{
-				ProviderAddr:  "com.owncloud.api.storage-system",
-				SystemUserIDP: "internal",
+				ProviderAddr:   "com.owncloud.api.storage-system",
+				SystemUserIDP:  "internal",
+				MaxConcurrency: 5,
 			},
 			OwnCloudSQL: config.UserSharingOwnCloudSQLDriver{
 				DBUsername: "owncloud",

--- a/services/sharing/pkg/revaconfig/config.go
+++ b/services/sharing/pkg/revaconfig/config.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/owncloud/ocis/v2/ocis-pkg/log"
-
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/sharing/pkg/config"
 )
 
@@ -76,6 +75,7 @@ func SharingConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string]
 							"service_user_idp":    cfg.UserSharingDrivers.JSONCS3.SystemUserIDP,
 							"machine_auth_apikey": cfg.UserSharingDrivers.JSONCS3.SystemUserAPIKey,
 							"ttl":                 cfg.UserSharingDrivers.JSONCS3.CacheTTL,
+							"max_concurrency":     cfg.UserSharingDrivers.JSONCS3.MaxConcurrency,
 							"events": map[string]interface{}{
 								"natsaddress":          cfg.Events.Addr,
 								"natsclusterid":        cfg.Events.ClusterID,


### PR DESCRIPTION
We now restrict the number of workers that look up shares to 5. The number can be changed with `SHARING_USER_JSONCS3_MAX_CONCURRENCY`.