### PR TITLE
fix node cache ttl updates

### DIFF
--- a/changelog/unreleased/fix-node-cache-ttl-updates.md
+++ b/changelog/unreleased/fix-node-cache-ttl-updates.md
@@ -1,0 +1,5 @@
+Bugfix: Fix node cache ttl updates
+
+We now only udpate the TTL of the node that is created or updated.
+
+https://github.com/owncloud/ocis/pull/10575

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ replace github.com/unrolled/secure => github.com/DeepDiver1975/secure v0.0.0-202
 
 replace github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240807130109-f62bb67e8c90
 
-replace go-micro.dev/v4 => github.com/butonic/go-micro/v4 v4.11.1-0.20241028133844-ac2cdce96c71
+replace go-micro.dev/v4 => github.com/butonic/go-micro/v4 v4.11.1-0.20241115112658-b5d4de5ed9b3
 
 // exclude the v2 line of go-sqlite3 which was released accidentally and prevents pulling in newer versions of go-sqlite3
 // see https://github.com/mattn/go-sqlite3/issues/965 for more details

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/bombsimon/logrusr/v3 v3.1.0/go.mod h1:PksPPgSFEL2I52pla2glgCyyd2OqOHA
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
-github.com/butonic/go-micro/v4 v4.11.1-0.20241028133844-ac2cdce96c71 h1:O26NWIQEs6vT4j/mQBH81D82ix7NE2ks1lekZ+g+C2k=
-github.com/butonic/go-micro/v4 v4.11.1-0.20241028133844-ac2cdce96c71/go.mod h1:eE/tD53n3KbVrzrWxKLxdkGw45Fg1qaNLWjpJMvIUF4=
+github.com/butonic/go-micro/v4 v4.11.1-0.20241115112658-b5d4de5ed9b3 h1:h8Z0hBv5tg/uZMKu8V47+DKWYVQg0lYP8lXDQq7uRpE=
+github.com/butonic/go-micro/v4 v4.11.1-0.20241115112658-b5d4de5ed9b3/go.mod h1:eE/tD53n3KbVrzrWxKLxdkGw45Fg1qaNLWjpJMvIUF4=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 h1:3uZCA/BLTIu+DqCfguByNMJa2HVHpXvjfy0Dy7g6fuA=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2/go.mod h1:RnUjnIXxEJcL6BgCvNyzCCRzZcxCgsZCi+RNlvYor5Q=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1884,7 +1884,7 @@ github.com/xrash/smetrics
 # github.com/yashtewari/glob-intersection v0.2.0
 ## explicit; go 1.17
 github.com/yashtewari/glob-intersection
-# go-micro.dev/v4 v4.11.0 => github.com/butonic/go-micro/v4 v4.11.1-0.20241028133844-ac2cdce96c71
+# go-micro.dev/v4 v4.11.0 => github.com/butonic/go-micro/v4 v4.11.1-0.20241115112658-b5d4de5ed9b3
 ## explicit; go 1.18
 go-micro.dev/v4
 go-micro.dev/v4/api
@@ -2406,4 +2406,4 @@ stash.kopano.io/kgol/rndm
 # github.com/egirna/icap-client => github.com/fschade/icap-client v0.0.0-20240802074440-aade4a234387
 # github.com/unrolled/secure => github.com/DeepDiver1975/secure v0.0.0-20240611112133-abc838fb797c
 # github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/kobergj/plugins/v4/store/nats-js-kv v0.0.0-20240807130109-f62bb67e8c90
-# go-micro.dev/v4 => github.com/butonic/go-micro/v4 v4.11.1-0.20241028133844-ac2cdce96c71
+# go-micro.dev/v4 => github.com/butonic/go-micro/v4 v4.11.1-0.20241115112658-b5d4de5ed9b3


### PR DESCRIPTION
We now only udpate the TTL of the node that is created or updated.
