### PR TITLE
fix: properly return an error and use cache for public keys if possible

### DIFF
--- a/changelog/unreleased/collaboration-public-keys.md
+++ b/changelog/unreleased/collaboration-public-keys.md
@@ -1,0 +1,11 @@
+Bugfix: Return an error if we can't get the keys and ensure they're cached
+
+Previously, there was an issue where we could get an error while getting the
+public keys from the /hosting/discovery endpoint but we're returning a wrong
+success value instead. This is fixed now and we're returning the error.
+
+In addition, the public keys weren't being cached, so we hit the
+/hosting/discovery endpoint every time we need to use the public keys. The keys
+are now cached so we don't need to hit the endpoint more than what we need.
+
+https://github.com/owncloud/ocis/pull/10590

--- a/services/collaboration/pkg/proofkeys/handler.go
+++ b/services/collaboration/pkg/proofkeys/handler.go
@@ -104,6 +104,7 @@ func (vh *VerifyHandler) Verify(accessToken, url, timestamp, sig64, oldSig64 str
 			return err
 		}
 		pubkeys = newpubkeys
+		vh.cachedKeys = newpubkeys
 	}
 
 	// build and hash the expected proof
@@ -195,6 +196,8 @@ func (vh *VerifyHandler) generateProof(accessToken, url, timestamp string) []byt
 // The PubKeys returned might be either nil (with the non-nil error), or might
 // contain only a PubKeys.Key field (the PubKeys.OldKey might be nil)
 func (vh *VerifyHandler) fetchPublicKeys(logger *zerolog.Logger) (*PubKeys, error) {
+	logger.Debug().Str("WopiAppUrl", vh.discoveryURL).Msg("WopiDiscovery: requesting new public keys")
+
 	httpClient := http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -220,7 +223,7 @@ func (vh *VerifyHandler) fetchPublicKeys(logger *zerolog.Logger) (*PubKeys, erro
 			Str("WopiAppUrl", vh.discoveryURL).
 			Int("HttpCode", httpResp.StatusCode).
 			Msg("WopiDiscovery: wopi app url failed with unexpected code")
-		return nil, err
+		return nil, errors.New("wopi app url failed with unexpected code")
 	}
 
 	doc := etree.NewDocument()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Return an error properly if we can't get the public keys.
In addition, ensure the new keys are cached to prevent unneeded hits to the "/hosting/discovery" endpoint, and log when we're requesting new keys.

Steps to reproduce the original issue seems unclear. WOPI requests are expected to come from the WOPI app (OnlyOffice in this case), and those should be the only ones triggering the issue, so it shouldn't be possible that a request to the discovery endpoint fails when the service is making a request. There might be some race condition, but it seems weird.

## Related Issue
https://github.com/owncloud/ocis/issues/10588

## Motivation and Context
Wrong error value was causing a panic because we assume we got the keys although it wasn't true.

## How Has This Been Tested?
Note that you can adjust the cache time of the public keys with `COLLABORATION_APP_PROOF_DURATION`

#### test 1
1. Open and close a document with OnlyOffice
2. Repeat step 1
-> Only one "requesting new public keys" message is shown (at debug level). Step 2 won't trigger that message assuming the keys are still valid in the cache.

#### test 2
1. Open and close a document with OnlyOffice
2. Wait until `COLLABORATION_APP_PROOF_DURATION` goes by
3. Repeat step 1
-> "requesting new public keys" message (at debug level) will show twice

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
