### PR TITLE
Fix thumbnails status code

### DIFF
--- a/changelog/unreleased/fix-thumbnails-statuscode.md
+++ b/changelog/unreleased/fix-thumbnails-statuscode.md
@@ -1,0 +1,9 @@
+Bugfix: Fix status code for thumbnail requests
+
+We fixed the status code returned by the thumbnails service when the image
+source for a thumbnail exceeds the configured maximum dimensions or file size.
+The service now returns a 403 Forbidden status code instead of a 500 Internal
+Server Error status code.
+
+https://github.com/owncloud/ocis/pull/10592
+https://github.com/owncloud/ocis/issues/10589


### PR DESCRIPTION
Return 403 instead of 500 when the image is too large (in dimensions or file size).

