### PR TITLE
[k6-test] raise default concurrency to 5

### DIFF
--- a/changelog/unreleased/raise-default-concurrency.md
+++ b/changelog/unreleased/raise-default-concurrency.md
@@ -1,0 +1,5 @@
+Enhancement: raise default concurrency to 5
+
+We increased the default concurrency to get more work done concurrently.
+
+https://github.com/owncloud/ocis/pull/10595

--- a/services/sharing/pkg/config/defaults/defaultconfig.go
+++ b/services/sharing/pkg/config/defaults/defaultconfig.go
@@ -47,7 +47,7 @@ func DefaultConfig() *config.Config {
 			JSONCS3: config.UserSharingJSONCS3Driver{
 				ProviderAddr:   "com.owncloud.api.storage-system",
 				SystemUserIDP:  "internal",
-				MaxConcurrency: 1,
+				MaxConcurrency: 5,
 			},
 			OwnCloudSQL: config.UserSharingOwnCloudSQLDriver{
 				DBUsername: "owncloud",


### PR DESCRIPTION
We increased the default concurrency to 5 get more work done concurrently.

The goroutine leak was fixed in #10583. Lets see how k6 behaves now.

Related https://github.com/owncloud/ocis/pull/10580
