### PR TITLE
[tests-only] add tests to check file uploads with same mtime and different content

### DIFF
--- a/tests/acceptance/bootstrap/TUSContext.php
+++ b/tests/acceptance/bootstrap/TUSContext.php
@@ -399,6 +399,37 @@ class TUSContext implements Context {
 	}
 
 	/**
+	 * @Given user :user has uploaded file :source to :destination with mtime :mtime using the TUS protocol
+	 *
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destination
+	 * @param string $mtime Time in human-readable format is taken as input which is converted into milliseconds that is used by API
+	 *
+	 * @return void
+	 * @throws Exception
+	 * @throws GuzzleException
+	 */
+	public function userHasUploadedFileWithMtimeUsingTUS(
+		string $user,
+		string $source,
+		string $destination,
+		string $mtime
+	): void {
+		$mtime = new DateTime($mtime);
+		$mtime = $mtime->format('U');
+		$user = $this->featureContext->getActualUsername($user);
+		$this->uploadFileUsingTus(
+			$user,
+			$source,
+			$destination,
+			null,
+			['mtime' => $mtime]
+		);
+		$this->featureContext->setLastUploadDeleteTime(\time());
+	}
+
+	/**
 	 * @When user :user uploads file :source to :destination with mtime :mtime using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user

--- a/tests/acceptance/bootstrap/WebDav.php
+++ b/tests/acceptance/bootstrap/WebDav.php
@@ -2278,7 +2278,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user has uploaded file :source to :destination with mtime :mtime using the WebDAV API
+	 * @Given user :user has uploaded file :source to :destination with mtime :mtime
 	 *
 	 * @param string $user
 	 * @param string $source

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -195,6 +195,15 @@ _ocdav: api compatibility, return correct status code_
 
 - [coreApiTrashbin/trashbinSharingToShares.feature:277](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinSharingToShares.feature#L277)
 
+#### [Uploading with the same mtime and filename causes "internal server errors"](https://github.com/owncloud/ocis/issues/10496)
+
+- [coreApiWebdavUpload/uploadFile.feature:400](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature#L400)
+- [coreApiWebdavUpload/uploadFile.feature:401](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature#L401)
+- [coreApiWebdavUpload/uploadFile.feature:402](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature#L402)
+- [coreApiWebdavUploadTUS/uploadFileMtime.feature:79](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature#L79)
+- [coreApiWebdavUploadTUS/uploadFileMtime.feature:80](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature#L80)
+- [coreApiWebdavUploadTUS/uploadFileMtime.feature:81](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature#L81)
+
 ### Won't fix
 
 Not everything needs to be implemented for ocis. While the oc10 testsuite covers these things we are not looking at them right now.

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -317,7 +317,7 @@ Feature: create a public link share
   Scenario Outline: get the mtime of a file shared by public link
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And using <dav-path-version> DAV path
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | file.txt |
       | permissions | read     |
@@ -333,7 +333,7 @@ Feature: create a public link share
     Given the config "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD" has been set to "false"
     And using <dav-path-version> DAV path
     And user "Alice" has created folder "testFolder"
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testFolder |
       | permissions | read        |

--- a/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
@@ -305,7 +305,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @issue-541
   Scenario Outline: deleted file has appropriate deletion time information
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2018 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2018 04:18:13 GMT"
     And user "Alice" has deleted file "file.txt"
     When user "Alice" tries to list the trashbin content for user "Alice"
     Then the HTTP status code should be "207"

--- a/tests/acceptance/features/coreApiVersions/fileVersions.feature
+++ b/tests/acceptance/features/coreApiVersions/fileVersions.feature
@@ -277,7 +277,7 @@ Feature: dav-versions
 
   Scenario Outline: upload the same file twice with the same mtime and a version is available
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     Then the HTTP status code should be "204"
     And the version folder of file "/file.txt" for user "Alice" should contain "1" element
@@ -287,14 +287,15 @@ Feature: dav-versions
       | new              |
       | spaces           |
 
-
+  @issue-10496
   Scenario Outline: upload the same file more than twice with the same mtime and only one version is available
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     Then the HTTP status code should be "204"
     And the version folder of file "/file.txt" for user "Alice" should contain "1" element
+    And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
       | dav-path-version |
       | old              |
@@ -303,8 +304,8 @@ Feature: dav-versions
 
 
   Scenario: upload the same file twice with the same mtime and no version after restoring
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
     When user "Alice" restores version index "1" of file "/file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the version folder of file "/file.txt" for user "Alice" should contain "0" element

--- a/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
@@ -385,3 +385,18 @@ Feature: upload file
     When the public uploads file "test.txt" with password "%public%" and content "test-file" using the public WebDAV API
     Then the HTTP status code should be "201"
     And for user "Alice" the content of the file "/test.txt" of the space "new-space" should be "test-file"
+
+  @issue-10496
+  Scenario Outline: upload a file with the same mtime and different content multiple times (atleast 3 times)
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
+    And user "Alice" has uploaded file "filesForUpload/davtest.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT"
+    When user "Alice" uploads file "filesForUpload/lorem.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the version folder of file "file.txt" for user "Alice" should contain "2" element
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |

--- a/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature
+++ b/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature
@@ -51,3 +51,31 @@ Feature: upload file
       | old              |
       | new              |
       | spaces           |
+
+  @issue-10346
+  Scenario Outline: upload a file with the same mtime and same content multiple times (atleast 3 times)
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the version folder of file "file.txt" for user "Alice" should contain "1" element
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |
+
+  @issue-10346
+  Scenario Outline: upload a file with the same mtime and different content multiple times (atleast 3 times)
+    Given using <dav-path-version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol
+    And user "Alice" has uploaded file "filesForUpload/davtest.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol
+    When user "Alice" uploads file "filesForUpload/lorem.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the version folder of file "file.txt" for user "Alice" should contain "2" element
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |


### PR DESCRIPTION
## Description
Added scenarios:
```feature
# normal and TUS upload
Scenario Outline: upload a file with the same mtime and same content multiple times (atleast 3 times)
Scenario Outline: upload a file with the same mtime and different content multiple times (atleast 3 times)
```

## Related Issue
- Test coverage for https://github.com/owncloud/ocis/issues/10496

## Motivation and Context

## How Has This Been Tested?
- test environment: :raised_hands: :robot: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
