### PR TITLE
[docs-only] Describe CLI-API commands in auth-app to manage tokens

### DIFF
--- a/services/auth-app/README.md
+++ b/services/auth-app/README.md
@@ -35,9 +35,85 @@ Once generated, these tokens can be used to authenticate requests to ocis. They 
 
 ### Via API
 
-The `auth-app` service provides an API to create (POST), list (GET) and delete (DELETE) tokens at `/auth-app/tokens`.
+The `auth-app` service provides an API to create (POST), list (GET) and delete (DELETE) tokens at  the `/auth-app/tokens` endpoint.
+
+When using curl for the respective command, you need to authenticate with a header. To do so, get from the browsers developer console the currently active bearer token. Consider that this token has a short lifetime. In any example, replace `<your host[:port]>` with the URL:port of your Infinite Scale instance, and `{token}`  `{value}` accordingly. Note that the active bearer token authenticates the user the token was issued for.
+
+* **Create a token**\
+  The POST request requires:
+  * A `expiry` key/value pair in the form of `expiry=<number><h|m|s>`\
+    Example: `expiry=72h`
+  * An active bearer token
+  ```bash
+  curl --request POST 'https://<your host:9200>/auth-app/tokens?expiry={value}' \
+       --header 'Accept: application/json' \
+       --header 'Authorization: bearer {token}'
+  ```
+  Example output:
+  ```
+  {
+  "token": "3s2K7816M4vuSpd5",
+  "expiration_date": "2024-08-08T13:42:42.796888022+02:00",
+  "created_date": "2024-08-07T13:42:42+02:00",
+  "label": "Generated via API"
+  }
+  ```
+
+* **List tokens**\
+  The GET request only requires an active bearer token for authentication:\
+  Note that `--request GET` is technically not required because it is curl default. 
+  ```bash
+  curl --request GET 'https://<your host:9200>/auth-app/tokens' \
+       --header 'Accept: application/json' \
+       --header 'Authorization: bearer {token}'
+  ```
+  Example output:
+  ```
+  [
+    {
+      "token": "$2a$11$EyudDGAJ18bBf5NG6PL9Ru9gygZAu0oPyLawdieNjGozcbXyyuUhG",
+      "expiration_date": "2024-08-08T13:44:31.025199075+02:00",
+      "created_date": "2024-08-07T13:44:31+02:00",
+      "label": "Generated via Impersonation API"
+    },
+    {
+      "token": "$2a$11$dfRBQrxRMPg8fvyvkFwaX.IPoIUiokvhzK.YNI/pCafk0us3MyPzy",
+      "expiration_date": "2024-08-08T13:46:41.936052281+02:00",
+      "created_date": "2024-08-07T13:46:42+02:00",
+      "label": "Generated via Impersonation API"
+    }
+  ]
+  ```
+
+* **Delete a token**\
+  The DELETE request requires:
+  * A `token` key/value pair in the form of `token=<token_issued>`\
+    Example: `token=Z3s2K7816M4vuSpd5`
+  * An active bearer token
+  ```bash
+  curl --request GET 'https://<your host:9200>/auth-app/tokens?token={value}' \
+       --header 'Accept: application/json' \
+       --header 'Authorization: bearer {token}'
+  ```
 
 ### Via Impersonation API
 
-When setting the environment variable `AUTH_APP_ENABLE_IMPERSONATION` to `true`, admins will be able to use the `/auth-app/tokens` endpoint to create tokens for other users. This is crucial for migration scenarios,
-but should not be used on a productive system.
+When setting the environment variable `AUTH_APP_ENABLE_IMPERSONATION` to `true`, admins will be able to use the `/auth-app/tokens` endpoint to create tokens for other users but using their own bearer token for authentication. This can be important for migration scenarios, but should not be considered for regular tasks on a production system for security reasons.
+
+To impersonate, the respective requests from the CLI commands above extend with the following parameters, where you can use one or the other:
+
+* The `userID` in the form of: `userID={value}`\
+  Example:\
+  `userID=4c510ada- ... -42cdf82c3d51`
+
+* The `userName` in the form of: `userName={value}`\
+  Example:\
+  `userName=einstein`
+
+Example:\
+A final create request would then look like:
+```bash
+curl --request POST 'https://<your host:9200>/auth-app/tokens?expiry={value}?userName={value}' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: bearer {token}'
+```

--- a/services/auth-app/README.md
+++ b/services/auth-app/README.md
@@ -35,7 +35,7 @@ Once generated, these tokens can be used to authenticate requests to ocis. They 
 
 ### Via API
 
-The `auth-app` service provides an API to create (POST), list (GET) and delete (DELETE) tokens at  the `/auth-app/tokens` endpoint.
+The `auth-app` service provides an API to create (POST), list (GET) and delete (DELETE) tokens at the `/auth-app/tokens` endpoint.
 
 When using curl for the respective command, you need to authenticate with a header. To do so, get from the browsers developer console the currently active bearer token. Consider that this token has a short lifetime. In any example, replace `<your host[:port]>` with the URL:port of your Infinite Scale instance, and `{token}`  `{value}` accordingly. Note that the active bearer token authenticates the user the token was issued for.
 


### PR DESCRIPTION
Fixes: #10605 (Minimal description in dev docs for auth-app token generation via API necessary)

This PR adds the description how to manage tokens using the API.

@ScharfViktor fyi