### PR TITLE
[docs-only] Update imgage versions for the ocis_full deployment example

### DIFF
--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -53,7 +53,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:24.04.5.1.1
+    image: collabora/code:24.04.9.2.1
     networks:
       ocis-net:
     environment:

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   traefik:
-    image: traefik:v3.1.6
+    image: traefik:v3.2.1
     networks:
       ocis-net:
     command:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -51,7 +51,7 @@ services:
   onlyoffice:
     # if you want to use oo enterprise edition, use: onlyoffice/documentserver-ee:<version>
     # note, you also need to add a volume, see below
-    image: onlyoffice/documentserver:8.2.0
+    image: onlyoffice/documentserver:8.2.1
     networks:
       ocis-net:
     entrypoint:


### PR DESCRIPTION
This PR updates the image versions used for our ocis_full deployment examples.

I tested this with my Hetzner deployment and have not found any issue.