### PR TITLE
[docs-only] Fix ocis_full for services to be started manually

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -114,9 +114,18 @@ SMTP_AUTHENTICATION=
 # Allow insecure connections to the SMTP server. Defaults to false.
 SMTP_INSECURE=
 
+# Addititional services to be started on ocis startup
+# The following list of services is not startet automatically and must be
+# manually defined for startup:
+# IMPORTANT: The notification service is MANDATORY, do not delete!
+# IMPORTANT: Add any services to the startup list comma separated like "notifications,antivirus" etc.
+START_ADDITIONAL_SERVICES="notifications"
+
+
 ## oCIS Web Extensions ##
 # It is possible to use the oCIS Web Extensions to add custom functionality to the oCIS frontend.
 # For more details see https://github.com/owncloud/web-extensions/blob/main/README.md
+# Note: the leading colon is required to enable the service.
 # Enable this to create a new named volume
 #EXTENSIONS=:web_extensions/extensions.yml
 # Enable the desired extensions by uncommenting the following lines.
@@ -196,6 +205,8 @@ COLLABORA_SSL_VERIFICATION=false
 
 
 ### Virusscanner Settings ###
+# IMPORTANT: If you enable antivirus, you also MUST configure the START_ADDITIONAL_SERVICES
+# envvar in the Infinite Scale Settings above by adding 'antivirus' to the list.
 # Note: the leading colon is required to enable the service.
 #CLAMAV=:clamav.yml
 # Image version of the ClamAV container.

--- a/deployments/examples/ocis_full/clamav.yml
+++ b/deployments/examples/ocis_full/clamav.yml
@@ -4,8 +4,7 @@ services:
     environment:
       ANTIVIRUS_SCANNER_TYPE: "clamav"
       ANTIVIRUS_CLAMAV_SOCKET: "/var/run/clamav/clamd.sock"
-      # enable the antivirus service
-      OCIS_ADD_RUN_SERVICES: "antivirus"
+      # the antivirus service needs manual startup, see .env and ocis.yaml for START_ADDITIONAL_SERVICES
       # configure the antivirus service
       POSTPROCESSING_STEPS: "virusscan"
       # PROXY_TLS is set to "false", the download url has no https

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -16,8 +16,8 @@ services:
     # therefore we ignore the error and then start the ocis server
     command: ["-c", "ocis init || true; ocis server"]
     environment:
-      # enable the notifications service as it is not started automatically
-      OCIS_ADD_RUN_SERVICES: "notifications"
+      # enable services that are not started automatically
+      OCIS_ADD_RUN_SERVICES: ${START_ADDITIONAL_SERVICES}
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${LOG_LEVEL:-info}
       OCIS_LOG_COLOR: "${LOG_PRETTY:-false}"


### PR DESCRIPTION
As discussed with @micbar and @dragonchaser:

The current situation adding ocis services to the startup caused, that any item added has overwritten other settings made. This is now fixed by adapting the `.env`, `ocis.yml` and `clamav.yml` files accordingly.