### PR TITLE
[docs-only] The env_var.yaml file needs to be recreated

### DIFF
--- a/docs/helpers/env_vars.yaml
+++ b/docs/helpers/env_vars.yaml
@@ -214,17 +214,6 @@ ACTIVITYLOG_STORE_NODES:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-ACTIVITYLOG_STORE_SIZE:
-  name: OCIS_PERSISTENT_STORE_SIZE;ACTIVITYLOG_STORE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the store. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not explicitly set as default.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 ACTIVITYLOG_STORE_TABLE:
   name: ACTIVITYLOG_STORE_TABLE
   defaultValue: ""
@@ -290,15 +279,6 @@ ACTIVITYLOG_TRANSLATION_PATH:
     the builtin translations. Note that file and folder naming rules apply, see the
     documentation for more details.
   introductionVersion: 7.0.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-ACTIVITYOG_SERVICE_ACCOUNT_SECRET:
-  name: OCIS_SERVICE_ACCOUNT_SECRET;ACTIVITYOG_SERVICE_ACCOUNT_SECRET
-  defaultValue: ""
-  type: string
-  description: The service account secret.
-  introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -449,15 +429,6 @@ ANTIVIRUS_ICAP_SERVICE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-ANTIVIRUS_ICAP_TIMEOUT:
-  name: ANTIVIRUS_ICAP_TIMEOUT
-  defaultValue: "0"
-  type: int64
-  description: Timeout for the ICAP client.
-  introductionVersion: pre5.0
-  deprecationVersion: "5.0"
-  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
-  deprecationInfo: Changing the envvar type for consistency reasons.
 ANTIVIRUS_ICAP_URL:
   name: ANTIVIRUS_ICAP_URL
   defaultValue: icap://127.0.0.1:1344
@@ -636,7 +607,7 @@ APP_PROVIDER_DRIVER:
   deprecationInfo: ""
 APP_PROVIDER_EXTERNAL_ADDR:
   name: APP_PROVIDER_EXTERNAL_ADDR
-  defaultValue: ""
+  defaultValue: com.owncloud.api.app-provider
   type: string
   description: Address of the app provider, where the GATEWAY service can reach it.
   introductionVersion: pre5.0
@@ -812,11 +783,12 @@ APP_PROVIDER_WOPI_APP_URL:
   removalVersion: ""
   deprecationInfo: ""
 APP_PROVIDER_WOPI_DISABLE_CHAT:
-  name: APP_PROVIDER_WOPI_DISABLE_CHAT;OCIS_WOPI_DISABLE_CHAT
+  name: COLLABORATION_WOPI_DISABLE_CHAT;OCIS_WOPI_DISABLE_CHAT
   defaultValue: "false"
   type: bool
-  description: Disable the chat functionality of the office app.
-  introductionVersion: pre5.0
+  description: Disable chat in the office web frontend. This feature applies to OnlyOffice
+    and Microsoft.
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -1632,7 +1604,7 @@ AUTH_BASIC_LDAP_GROUP_OBJECTCLASS:
   removalVersion: ""
   deprecationInfo: ""
 AUTH_BASIC_LDAP_GROUP_SCHEMA_DISPLAYNAME:
-  name: OCIS_LDAP_GROUP_SCHEMA_DISPLAYNAME;AUTH_BASIC_LDAP_GROUP_SCHEMA_DISPLAYNAME
+  name: OCIS_LDAP_GROUP_SCHEMA_DISPLAYNAME;USERS_LDAP_GROUP_SCHEMA_DISPLAYNAME
   defaultValue: cn
   type: string
   description: LDAP Attribute to use for the displayname of groups (often the same
@@ -1672,7 +1644,7 @@ AUTH_BASIC_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING:
   removalVersion: ""
   deprecationInfo: ""
 AUTH_BASIC_LDAP_GROUP_SCHEMA_MAIL:
-  name: OCIS_LDAP_GROUP_SCHEMA_MAIL;AUTH_BASIC_LDAP_GROUP_SCHEMA_MAIL
+  name: OCIS_LDAP_GROUP_SCHEMA_MAIL;USERS_LDAP_GROUP_SCHEMA_MAIL
   defaultValue: mail
   type: string
   description: LDAP Attribute to use for the email address of groups (can be empty).
@@ -2631,9 +2603,9 @@ CLIENTLOG_REVA_GATEWAY:
   type: string
   description: CS3 gateway used to look up user metadata
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: "6.0"
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: CLIENTLOG_REVA_GATEWAY removed for simplicity.
 CLIENTLOG_SERVICE_ACCOUNT_ID:
   name: OCIS_SERVICE_ACCOUNT_ID;CLIENTLOG_SERVICE_ACCOUNT_ID
   defaultValue: ""
@@ -2774,15 +2746,6 @@ COLLABORATION_APP_LICENSE_CHECK_ENABLE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-COLLABORATION_APP_LOCKNAME:
-  name: COLLABORATION_APP_LOCKNAME
-  defaultValue: com.github.owncloud.collaboration
-  type: string
-  description: Name for the app lock
-  introductionVersion: 6.0.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 COLLABORATION_APP_NAME:
   name: COLLABORATION_APP_NAME
   defaultValue: Collabora
@@ -2827,15 +2790,6 @@ COLLABORATION_CS3API_DATAGATEWAY_INSECURE:
   defaultValue: "false"
   type: bool
   description: Connect to the CS3API data gateway insecurely.
-  introductionVersion: 6.0.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-COLLABORATION_CS3API_GATEWAY_NAME:
-  name: OCIS_REVA_GATEWAY;COLLABORATION_CS3API_GATEWAY_NAME
-  defaultValue: com.owncloud.api.gateway
-  type: string
-  description: CS3 gateway used to look up user metadata.
   introductionVersion: 6.0.0
   deprecationVersion: ""
   removalVersion: ""
@@ -3329,17 +3283,6 @@ EVENTHISTORY_STORE_NODES:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-EVENTHISTORY_STORE_SIZE:
-  name: OCIS_PERSISTENT_STORE_SIZE;EVENTHISTORY_STORE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the store. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived and used from the
-    ocmem package though no explicit default was set.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 EVENTHISTORY_STORE_TABLE:
   name: EVENTHISTORY_STORE_TABLE
   defaultValue: ""
@@ -3619,12 +3562,11 @@ FRONTEND_ENABLE_FAVORITES:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_ENABLE_FEDERATED_SHARING_INCOMING:
-  name: OCIS_ENABLE_OCM;FRONTEND_ENABLE_FEDERATED_SHARING_INCOMING
+  name: OCIS_ENABLE_OCM;GRAPH_INCLUDE_OCM_SHAREES
   defaultValue: "false"
   type: bool
-  description: Changing this value is NOT supported. Enables support for incoming
-    federated sharing for clients. The backend behaviour is not changed.
-  introductionVersion: pre5.0
+  description: Include OCM sharees when listing users.
+  introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -3754,7 +3696,7 @@ FRONTEND_JWT_SECRET:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_LDAP_SERVER_WRITE_ENABLED:
-  name: OCIS_LDAP_SERVER_WRITE_ENABLED;FRONTEND_LDAP_SERVER_WRITE_ENABLED
+  name: OCIS_LDAP_SERVER_WRITE_ENABLED;GRAPH_LDAP_SERVER_WRITE_ENABLED
   defaultValue: "true"
   type: bool
   description: Allow creating, modifying and deleting LDAP users via the GRAPH API.
@@ -3839,27 +3781,27 @@ FRONTEND_OCS_ADDITIONAL_INFO_ATTRIBUTE:
   type: string
   description: Additional information attribute for the user like {{.Mail}}.
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: The OCS API is deprecated
 FRONTEND_OCS_ENABLE_DENIALS:
   name: FRONTEND_OCS_ENABLE_DENIALS
   defaultValue: "false"
   type: bool
   description: 'EXPERIMENTAL: enable the feature to deny access on folders.'
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: The OCS API is deprecated
 FRONTEND_OCS_INCLUDE_OCM_SHAREES:
   name: OCIS_ENABLE_OCM;FRONTEND_OCS_INCLUDE_OCM_SHAREES
   defaultValue: "false"
   type: bool
   description: Include OCM sharees when listing sharees.
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_INCLUDE_OCM_SHAREES, the OCS API is deprecated
 FRONTEND_OCS_LIST_OCM_SHARES:
   name: OCIS_ENABLE_OCM;FRONTEND_OCS_LIST_OCM_SHARES
   defaultValue: "true"
@@ -3867,18 +3809,18 @@ FRONTEND_OCS_LIST_OCM_SHARES:
   description: Include OCM shares when listing shares. See the OCM service documentation
     for more details.
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_LIST_OCM_SHARES, the OCS API is deprecated
 FRONTEND_OCS_PERSONAL_NAMESPACE:
   name: FRONTEND_OCS_PERSONAL_NAMESPACE
   defaultValue: /users/{{.Id.OpaqueId}}
   type: string
   description: Home namespace identifier.
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: The OCS API is deprecated
 FRONTEND_OCS_PREFIX:
   name: FRONTEND_OCS_PREFIX
   defaultValue: ocs
@@ -3886,28 +3828,32 @@ FRONTEND_OCS_PREFIX:
   description: URL path prefix for the OCS service. Note that the string must not
     start with '/'.
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: The OCS API is deprecated
 FRONTEND_OCS_PUBLIC_SHARE_MUST_HAVE_PASSWORD:
-  name: OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD;FRONTEND_OCS_PUBLIC_SHARE_MUST_HAVE_PASSWORD
+  name: OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD;SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD
   defaultValue: "true"
   type: bool
   description: Set this to true if you want to enforce passwords on all public shares.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
-  deprecationInfo: ""
+  deprecationInfo: 'FRONTEND_OCS_PUBLIC_SHARE_MUST_HAVE_PASSWORD, the OCS API is deprecated
+    | '
 FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD:
-  name: OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD;FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD
+  name: OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD;SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD
   defaultValue: "false"
   type: bool
-  description: Set this to true if you want to enforce passwords for writable shares.
-    Only effective if the setting for 'passwords on all public shares' is set to false.
+  description: Set this to true if you want to enforce passwords on Uploader, Editor
+    or Contributor shares. If not using the global OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD,
+    you must define the FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD (deprecated)
+    in the frontend service.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
-  deprecationInfo: ""
+  deprecationInfo: 'FRONTEND_OCS_PUBLIC_WRITABLE_SHARE_MUST_HAVE_PASSWORD, the OCS
+    API is deprecated | '
 FRONTEND_OCS_SHARE_PREFIX:
   name: FRONTEND_OCS_SHARE_PREFIX
   defaultValue: /Shares
@@ -3915,9 +3861,9 @@ FRONTEND_OCS_SHARE_PREFIX:
   description: Path prefix for shares as part of an ocis resource. Note that the path
     must start with '/'.
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: The OCS API is deprecated
 FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD:
   name: OCIS_CACHE_AUTH_PASSWORD;FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD
   defaultValue: ""
@@ -3925,9 +3871,9 @@ FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD:
   description: The password to use for authentication. Only applies when using the
     'nats-js-kv' store type.
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD, the OCS API is deprecated
 FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME:
   name: OCIS_CACHE_AUTH_USERNAME;FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME
   defaultValue: ""
@@ -3935,9 +3881,9 @@ FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME:
   description: The username to use for authentication. Only applies when using the
     'nats-js-kv' store type.
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME, the OCS API is deprecated
 FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE:
   name: OCIS_CACHE_DISABLE_PERSISTENCE;FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE
   defaultValue: "false"
@@ -3945,18 +3891,9 @@ FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE:
   description: Disable persistence of the cache. Only applies when using the 'nats-js-kv'
     store type. Defaults to false.
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-FRONTEND_OCS_STAT_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;FRONTEND_OCS_STAT_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: Max number of entries to hold in the cache.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE, the OCS API is deprecated
 FRONTEND_OCS_STAT_CACHE_STORE:
   name: OCIS_CACHE_STORE;FRONTEND_OCS_STAT_CACHE_STORE
   defaultValue: memory
@@ -3964,9 +3901,9 @@ FRONTEND_OCS_STAT_CACHE_STORE:
   description: 'The type of the cache store. Supported values are: ''memory'', ''redis-sentinel'',
     ''nats-js-kv'', ''noop''. See the text description for details.'
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_STAT_CACHE_STORE, the OCS API is deprecated
 FRONTEND_OCS_STAT_CACHE_STORE_NODES:
   name: OCIS_CACHE_STORE_NODES;FRONTEND_OCS_STAT_CACHE_STORE_NODES
   defaultValue: '[127.0.0.1:9233]'
@@ -3976,18 +3913,18 @@ FRONTEND_OCS_STAT_CACHE_STORE_NODES:
     is dependent on the library of the configured store. See the Environment Variable
     Types description for more details.
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_STAT_CACHE_STORE_NODES, the OCS API is deprecated
 FRONTEND_OCS_STAT_CACHE_TABLE:
   name: FRONTEND_OCS_STAT_CACHE_TABLE
   defaultValue: ""
   type: string
   description: The database table the store should use.
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: The OCS API is deprecated
 FRONTEND_OCS_STAT_CACHE_TTL:
   name: OCIS_CACHE_TTL;FRONTEND_OCS_STAT_CACHE_TTL
   defaultValue: 5m0s
@@ -3996,11 +3933,11 @@ FRONTEND_OCS_STAT_CACHE_TTL:
     access tokens has no expiration. See the Environment Variable Types description
     for more details.
   introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
+  deprecationVersion: 7.0.0
+  removalVersion: '%%NEXT_PRODUCTION_VERSION%%'
+  deprecationInfo: FRONTEND_OCS_STAT_CACHE_TTL, the OCS API is deprecated
 FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST:
-  name: OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST;FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST
+  name: OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST;SHARING_PASSWORD_POLICY_BANNED_PASSWORDS_LIST
   defaultValue: ""
   type: string
   description: Path to the 'banned passwords list' file. This only impacts public
@@ -4010,7 +3947,7 @@ FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_PASSWORD_POLICY_DISABLED:
-  name: OCIS_PASSWORD_POLICY_DISABLED;FRONTEND_PASSWORD_POLICY_DISABLED
+  name: OCIS_PASSWORD_POLICY_DISABLED;SHARING_PASSWORD_POLICY_DISABLED
   defaultValue: "false"
   type: bool
   description: Disable the password policy. Defaults to false if not set.
@@ -4019,7 +3956,7 @@ FRONTEND_PASSWORD_POLICY_DISABLED:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS:
-  name: OCIS_PASSWORD_POLICY_MIN_CHARACTERS;FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS
+  name: OCIS_PASSWORD_POLICY_MIN_CHARACTERS;SHARING_PASSWORD_POLICY_MIN_CHARACTERS
   defaultValue: "8"
   type: int
   description: Define the minimum password length. Defaults to 8 if not set.
@@ -4028,7 +3965,7 @@ FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_PASSWORD_POLICY_MIN_DIGITS:
-  name: OCIS_PASSWORD_POLICY_MIN_DIGITS;FRONTEND_PASSWORD_POLICY_MIN_DIGITS
+  name: OCIS_PASSWORD_POLICY_MIN_DIGITS;SHARING_PASSWORD_POLICY_MIN_DIGITS
   defaultValue: "1"
   type: int
   description: Define the minimum number of digits. Defaults to 1 if not set.
@@ -4037,7 +3974,7 @@ FRONTEND_PASSWORD_POLICY_MIN_DIGITS:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS:
-  name: OCIS_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS;FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS
+  name: OCIS_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS;SHARING_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS
   defaultValue: "1"
   type: int
   description: Define the minimum number of uppercase letters. Defaults to 1 if not
@@ -4047,7 +3984,7 @@ FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS:
-  name: OCIS_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS;FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS
+  name: OCIS_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS;SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS
   defaultValue: "1"
   type: int
   description: Define the minimum number of characters from the special characters
@@ -4057,7 +3994,7 @@ FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS:
   removalVersion: ""
   deprecationInfo: ""
 FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS:
-  name: OCIS_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS;FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS
+  name: OCIS_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS;SHARING_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS
   defaultValue: "1"
   type: int
   description: Define the minimum number of lowercase letters. Defaults to 1 if not
@@ -4284,17 +4221,6 @@ GATEWAY_CREATE_HOME_CACHE_DISABLE_PERSISTENCE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-GATEWAY_CREATE_HOME_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;GATEWAY_CREATE_HOME_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the cache. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not explicitly set as default.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 GATEWAY_CREATE_HOME_CACHE_STORE:
   name: OCIS_CACHE_STORE;GATEWAY_CREATE_HOME_CACHE_STORE
   defaultValue: memory
@@ -4505,17 +4431,6 @@ GATEWAY_PROVIDER_CACHE_DISABLE_PERSISTENCE:
   description: Disables persistence of the provider cache. Only applies when store
     type 'nats-js-kv' is configured. Defaults to false.
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-GATEWAY_PROVIDER_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;GATEWAY_PROVIDER_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the cache. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not explicitly set as default.
-  introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -4779,17 +4694,6 @@ GRAPH_CACHE_DISABLE_PERSISTENCE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-GRAPH_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;GRAPH_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the store. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not explicitly set as default.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 GRAPH_CACHE_STORE:
   name: OCIS_CACHE_STORE;GRAPH_CACHE_STORE
   defaultValue: memory
@@ -4923,20 +4827,20 @@ GRAPH_DEBUG_ZPAGES:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_DISABLE_USER_MECHANISM:
-  name: OCIS_LDAP_DISABLE_USER_MECHANISM;GRAPH_DISABLE_USER_MECHANISM
+  name: OCIS_LDAP_DISABLE_USER_MECHANISM;USERS_LDAP_DISABLE_USER_MECHANISM
   defaultValue: attribute
   type: string
-  description: An option to control the behavior for disabling users. Supported options
+  description: An option to control the behavior for disabling users. Valid options
     are 'none', 'attribute' and 'group'. If set to 'group', disabling a user via API
     will add the user to the configured group for disabled users, if set to 'attribute'
     this will be done in the ldap user entry, if set to 'none' the disable request
-    is not processed. Default is 'attribute'.
+    is not processed.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_DISABLED_USERS_GROUP_DN:
-  name: OCIS_LDAP_DISABLED_USERS_GROUP_DN;GRAPH_DISABLED_USERS_GROUP_DN
+  name: OCIS_LDAP_DISABLED_USERS_GROUP_DN;USERS_LDAP_DISABLED_USERS_GROUP_DN
   defaultValue: cn=DisabledUsersGroup,ou=groups,o=libregraph-idm
   type: string
   description: The distinguished name of the group to which added users will be classified
@@ -5091,7 +4995,7 @@ GRAPH_JWT_SECRET:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_KEYCLOAK_BASE_PATH:
-  name: OCIS_KEYCLOAK_BASE_PATH;GRAPH_KEYCLOAK_BASE_PATH
+  name: OCIS_KEYCLOAK_BASE_PATH;INVITATIONS_KEYCLOAK_BASE_PATH
   defaultValue: ""
   type: string
   description: The URL to access keycloak.
@@ -5100,16 +5004,16 @@ GRAPH_KEYCLOAK_BASE_PATH:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_KEYCLOAK_CLIENT_ID:
-  name: OCIS_KEYCLOAK_CLIENT_ID;GRAPH_KEYCLOAK_CLIENT_ID
+  name: OCIS_KEYCLOAK_CLIENT_ID;INVITATIONS_KEYCLOAK_CLIENT_ID
   defaultValue: ""
   type: string
-  description: The client id to authenticate with keycloak.
+  description: The client ID to authenticate with keycloak.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_KEYCLOAK_CLIENT_REALM:
-  name: OCIS_KEYCLOAK_CLIENT_REALM;GRAPH_KEYCLOAK_CLIENT_REALM
+  name: OCIS_KEYCLOAK_CLIENT_REALM;INVITATIONS_KEYCLOAK_CLIENT_REALM
   defaultValue: ""
   type: string
   description: The realm the client is defined in.
@@ -5118,7 +5022,7 @@ GRAPH_KEYCLOAK_CLIENT_REALM:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_KEYCLOAK_CLIENT_SECRET:
-  name: OCIS_KEYCLOAK_CLIENT_SECRET;GRAPH_KEYCLOAK_CLIENT_SECRET
+  name: OCIS_KEYCLOAK_CLIENT_SECRET;INVITATIONS_KEYCLOAK_CLIENT_SECRET
   defaultValue: ""
   type: string
   description: The client secret to use in authentication.
@@ -5127,7 +5031,7 @@ GRAPH_KEYCLOAK_CLIENT_SECRET:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_KEYCLOAK_INSECURE_SKIP_VERIFY:
-  name: OCIS_KEYCLOAK_INSECURE_SKIP_VERIFY;GRAPH_KEYCLOAK_INSECURE_SKIP_VERIFY
+  name: OCIS_KEYCLOAK_INSECURE_SKIP_VERIFY;INVITATIONS_KEYCLOAK_INSECURE_SKIP_VERIFY
   defaultValue: "false"
   type: bool
   description: Disable TLS certificate validation for Keycloak connections. Do not
@@ -5137,7 +5041,7 @@ GRAPH_KEYCLOAK_INSECURE_SKIP_VERIFY:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_KEYCLOAK_USER_REALM:
-  name: OCIS_KEYCLOAK_USER_REALM;GRAPH_KEYCLOAK_USER_REALM
+  name: OCIS_KEYCLOAK_USER_REALM;INVITATIONS_KEYCLOAK_USER_REALM
   defaultValue: ""
   type: string
   description: The realm users are defined.
@@ -5146,8 +5050,8 @@ GRAPH_KEYCLOAK_USER_REALM:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_BIND_DN:
-  name: OCIS_LDAP_BIND_DN;GRAPH_LDAP_BIND_DN
-  defaultValue: uid=libregraph,ou=sysusers,o=libregraph-idm
+  name: OCIS_LDAP_BIND_DN;USERS_LDAP_BIND_DN
+  defaultValue: uid=reva,ou=sysusers,o=libregraph-idm
   type: string
   description: LDAP DN to use for simple bind authentication with the target LDAP
     server.
@@ -5156,7 +5060,7 @@ GRAPH_LDAP_BIND_DN:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_BIND_PASSWORD:
-  name: OCIS_LDAP_BIND_PASSWORD;GRAPH_LDAP_BIND_PASSWORD
+  name: OCIS_LDAP_BIND_PASSWORD;USERS_LDAP_BIND_PASSWORD
   defaultValue: ""
   type: string
   description: Password to use for authenticating the 'bind_dn'.
@@ -5165,7 +5069,7 @@ GRAPH_LDAP_BIND_PASSWORD:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_CACERT:
-  name: OCIS_LDAP_CACERT;GRAPH_LDAP_CACERT
+  name: OCIS_LDAP_CACERT;USERS_LDAP_CACERT
   defaultValue: /var/lib/ocis/idm/ldap.crt
   type: string
   description: Path/File name for the root CA certificate (in PEM format) used to
@@ -5185,7 +5089,7 @@ GRAPH_LDAP_EDUCATION_RESOURCES_ENABLED:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_BASE_DN:
-  name: OCIS_LDAP_GROUP_BASE_DN;GRAPH_LDAP_GROUP_BASE_DN
+  name: OCIS_LDAP_GROUP_BASE_DN;USERS_LDAP_GROUP_BASE_DN
   defaultValue: ou=groups,o=libregraph-idm
   type: string
   description: Search base DN for looking up LDAP groups.
@@ -5206,7 +5110,7 @@ GRAPH_LDAP_GROUP_CREATE_BASE_DN:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_FILTER:
-  name: OCIS_LDAP_GROUP_FILTER;GRAPH_LDAP_GROUP_FILTER
+  name: OCIS_LDAP_GROUP_FILTER;USERS_LDAP_GROUP_FILTER
   defaultValue: ""
   type: string
   description: LDAP filter to add to the default filters for group searches.
@@ -5215,17 +5119,17 @@ GRAPH_LDAP_GROUP_FILTER:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_ID_ATTRIBUTE:
-  name: OCIS_LDAP_GROUP_SCHEMA_ID;GRAPH_LDAP_GROUP_ID_ATTRIBUTE
-  defaultValue: owncloudUUID
+  name: OCIS_LDAP_GROUP_SCHEMA_ID;USERS_LDAP_GROUP_SCHEMA_ID
+  defaultValue: ownclouduuid
   type: string
-  description: LDAP Attribute to use as the unique id for groups. This should be a
+  description: LDAP Attribute to use as the unique ID for groups. This should be a
     stable globally unique ID like a UUID.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_MEMBER_ATTRIBUTE:
-  name: OCIS_LDAP_GROUP_SCHEMA_MEMBER;GRAPH_LDAP_GROUP_MEMBER_ATTRIBUTE
+  name: OCIS_LDAP_GROUP_SCHEMA_MEMBER;USERS_LDAP_GROUP_SCHEMA_MEMBER
   defaultValue: member
   type: string
   description: LDAP Attribute that is used for group members.
@@ -5234,7 +5138,7 @@ GRAPH_LDAP_GROUP_MEMBER_ATTRIBUTE:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_NAME_ATTRIBUTE:
-  name: OCIS_LDAP_GROUP_SCHEMA_GROUPNAME;GRAPH_LDAP_GROUP_NAME_ATTRIBUTE
+  name: OCIS_LDAP_GROUP_SCHEMA_GROUPNAME;USERS_LDAP_GROUP_SCHEMA_GROUPNAME
   defaultValue: cn
   type: string
   description: LDAP Attribute to use for the name of groups.
@@ -5243,38 +5147,38 @@ GRAPH_LDAP_GROUP_NAME_ATTRIBUTE:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_OBJECTCLASS:
-  name: OCIS_LDAP_GROUP_OBJECTCLASS;GRAPH_LDAP_GROUP_OBJECTCLASS
+  name: OCIS_LDAP_GROUP_OBJECTCLASS;USERS_LDAP_GROUP_OBJECTCLASS
   defaultValue: groupOfNames
   type: string
   description: The object class to use for groups in the default group search filter
-    ('groupOfNames').
+    like 'groupOfNames'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING:
-  name: OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING;GRAPH_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING
+  name: OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING;USERS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING
   defaultValue: "false"
   type: bool
-  description: Set this to true if the defined 'ID' attribute for groups is of the
-    'OCTETSTRING' syntax. This is required when using the 'objectGUID' attribute of
-    Active Directory for the group ID's.
+  description: Set this to true if the defined 'id' attribute for groups is of the
+    'OCTETSTRING' syntax. This is e.g. required when using the 'objectGUID' attribute
+    of Active Directory for the group ID's.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_GROUP_SEARCH_SCOPE:
-  name: OCIS_LDAP_GROUP_SCOPE;GRAPH_LDAP_GROUP_SEARCH_SCOPE
+  name: OCIS_LDAP_GROUP_SCOPE;USERS_LDAP_GROUP_SCOPE
   defaultValue: sub
   type: string
-  description: LDAP search scope to use when looking up groups. Supported scopes are
+  description: LDAP search scope to use when looking up groups. Supported values are
     'base', 'one' and 'sub'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_INSECURE:
-  name: OCIS_LDAP_INSECURE;GRAPH_LDAP_INSECURE
+  name: OCIS_LDAP_INSECURE;USERS_LDAP_INSECURE
   defaultValue: "false"
   type: bool
   description: Disable TLS certificate validation for the LDAP connections. Do not
@@ -5400,7 +5304,7 @@ GRAPH_LDAP_SERVER_WRITE_ENABLED:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_URI:
-  name: OCIS_LDAP_URI;GRAPH_LDAP_URI
+  name: OCIS_LDAP_URI;USERS_LDAP_URI
   defaultValue: ldaps://localhost:9235
   type: string
   description: URI of the LDAP Server to connect to. Supported URI schemes are 'ldaps://'
@@ -5410,7 +5314,7 @@ GRAPH_LDAP_URI:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_BASE_DN:
-  name: OCIS_LDAP_USER_BASE_DN;GRAPH_LDAP_USER_BASE_DN
+  name: OCIS_LDAP_USER_BASE_DN;USERS_LDAP_USER_BASE_DN
   defaultValue: ou=users,o=libregraph-idm
   type: string
   description: Search base DN for looking up LDAP users.
@@ -5419,16 +5323,16 @@ GRAPH_LDAP_USER_BASE_DN:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_DISPLAYNAME_ATTRIBUTE:
-  name: OCIS_LDAP_USER_SCHEMA_DISPLAYNAME;LDAP_USER_SCHEMA_DISPLAY_NAME;GRAPH_LDAP_USER_DISPLAYNAME_ATTRIBUTE
-  defaultValue: displayName
+  name: OCIS_LDAP_USER_SCHEMA_DISPLAYNAME;USERS_LDAP_USER_SCHEMA_DISPLAYNAME
+  defaultValue: displayname
   type: string
-  description: LDAP Attribute to use for the display name of users.
+  description: LDAP Attribute to use for the displayname of users.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
-  deprecationInfo: ""
+  deprecationInfo: 'LDAP_USER_SCHEMA_DISPLAY_NAME changing name for consistency |  |  | '
 GRAPH_LDAP_USER_EMAIL_ATTRIBUTE:
-  name: OCIS_LDAP_USER_SCHEMA_MAIL;GRAPH_LDAP_USER_EMAIL_ATTRIBUTE
+  name: OCIS_LDAP_USER_SCHEMA_MAIL;USERS_LDAP_USER_SCHEMA_MAIL
   defaultValue: mail
   type: string
   description: LDAP Attribute to use for the email address of users.
@@ -5437,7 +5341,7 @@ GRAPH_LDAP_USER_EMAIL_ATTRIBUTE:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_FILTER:
-  name: OCIS_LDAP_USER_FILTER;GRAPH_LDAP_USER_FILTER
+  name: OCIS_LDAP_USER_FILTER;USERS_LDAP_USER_FILTER
   defaultValue: ""
   type: string
   description: LDAP filter to add to the default filters for user search like '(objectclass=ownCloud)'.
@@ -5446,7 +5350,7 @@ GRAPH_LDAP_USER_FILTER:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_NAME_ATTRIBUTE:
-  name: OCIS_LDAP_USER_SCHEMA_USERNAME;GRAPH_LDAP_USER_NAME_ATTRIBUTE
+  name: OCIS_LDAP_USER_SCHEMA_USERNAME;USERS_LDAP_USER_SCHEMA_USERNAME
   defaultValue: uid
   type: string
   description: LDAP Attribute to use for username of users.
@@ -5455,38 +5359,38 @@ GRAPH_LDAP_USER_NAME_ATTRIBUTE:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_OBJECTCLASS:
-  name: OCIS_LDAP_USER_OBJECTCLASS;GRAPH_LDAP_USER_OBJECTCLASS
+  name: OCIS_LDAP_USER_OBJECTCLASS;USERS_LDAP_USER_OBJECTCLASS
   defaultValue: inetOrgPerson
   type: string
   description: The object class to use for users in the default user search filter
-    ('inetOrgPerson').
+    like 'inetOrgPerson'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING:
-  name: OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING;GRAPH_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING
+  name: OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING;USERS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING
   defaultValue: "false"
   type: bool
   description: Set this to true if the defined 'ID' attribute for users is of the
-    'OCTETSTRING' syntax. This is required when using the 'objectGUID' attribute of
-    Active Directory for the user ID's.
+    'OCTETSTRING' syntax. This is e.g. required when using the 'objectGUID' attribute
+    of Active Directory for the user ID's.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_SCOPE:
-  name: OCIS_LDAP_USER_SCOPE;GRAPH_LDAP_USER_SCOPE
+  name: OCIS_LDAP_USER_SCOPE;USERS_LDAP_USER_SCOPE
   defaultValue: sub
   type: string
-  description: LDAP search scope to use when looking up users. Supported scopes are
+  description: LDAP search scope to use when looking up users. Supported values are
     'base', 'one' and 'sub'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_TYPE_ATTRIBUTE:
-  name: OCIS_LDAP_USER_SCHEMA_USER_TYPE;GRAPH_LDAP_USER_TYPE_ATTRIBUTE
+  name: OCIS_LDAP_USER_SCHEMA_USER_TYPE;USERS_LDAP_USER_TYPE_ATTRIBUTE
   defaultValue: ownCloudUserType
   type: string
   description: LDAP Attribute to distinguish between 'Member' and 'Guest' users. Default
@@ -5496,8 +5400,8 @@ GRAPH_LDAP_USER_TYPE_ATTRIBUTE:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_LDAP_USER_UID_ATTRIBUTE:
-  name: OCIS_LDAP_USER_SCHEMA_ID;GRAPH_LDAP_USER_UID_ATTRIBUTE
-  defaultValue: owncloudUUID
+  name: OCIS_LDAP_USER_SCHEMA_ID;USERS_LDAP_USER_SCHEMA_ID
+  defaultValue: ownclouduuid
   type: string
   description: LDAP Attribute to use as the unique ID for users. This should be a
     stable globally unique ID like a UUID.
@@ -5674,10 +5578,10 @@ GRAPH_TRANSLATION_PATH:
   removalVersion: ""
   deprecationInfo: ""
 GRAPH_USER_ENABLED_ATTRIBUTE:
-  name: OCIS_LDAP_USER_ENABLED_ATTRIBUTE;GRAPH_USER_ENABLED_ATTRIBUTE
+  name: OCIS_LDAP_USER_ENABLED_ATTRIBUTE;USERS_LDAP_USER_ENABLED_ATTRIBUTE
   defaultValue: ownCloudUserEnabled
   type: string
-  description: LDAP Attribute to use as a flag telling if the user is enabled or disabled.
+  description: LDAP attribute to use as a flag telling if the user is enabled or disabled.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -6211,7 +6115,7 @@ IDM_ADMIN_PASSWORD:
   removalVersion: ""
   deprecationInfo: ""
 IDM_ADMIN_USER_ID:
-  name: OCIS_ADMIN_USER_ID;IDM_ADMIN_USER_ID
+  name: OCIS_ADMIN_USER_ID;SETTINGS_ADMIN_USER_ID
   defaultValue: ""
   type: string
   description: ID of the user that should receive admin privileges. Consider that
@@ -6318,7 +6222,7 @@ IDM_LDAPS_KEY:
   removalVersion: ""
   deprecationInfo: ""
 IDM_LOG_COLOR:
-  name: OCIS_LOG_COLOR;IDM_LOG_COLOR
+  name: OCIS_LOG_COLOR;USERS_LOG_COLOR
   defaultValue: "false"
   type: bool
   description: Activates colorized log output.
@@ -6327,7 +6231,7 @@ IDM_LOG_COLOR:
   removalVersion: ""
   deprecationInfo: ""
 IDM_LOG_FILE:
-  name: OCIS_LOG_FILE;IDM_LOG_FILE
+  name: OCIS_LOG_FILE;USERS_LOG_FILE
   defaultValue: ""
   type: string
   description: The path to the log file. Activates logging to this file if set.
@@ -6336,7 +6240,7 @@ IDM_LOG_FILE:
   removalVersion: ""
   deprecationInfo: ""
 IDM_LOG_LEVEL:
-  name: OCIS_LOG_LEVEL;IDM_LOG_LEVEL
+  name: OCIS_LOG_LEVEL;USERS_LOG_LEVEL
   defaultValue: ""
   type: string
   description: 'The log level. Valid values are: ''panic'', ''fatal'', ''error'',
@@ -6346,7 +6250,7 @@ IDM_LOG_LEVEL:
   removalVersion: ""
   deprecationInfo: ""
 IDM_LOG_PRETTY:
-  name: OCIS_LOG_PRETTY;IDM_LOG_PRETTY
+  name: OCIS_LOG_PRETTY;USERS_LOG_PRETTY
   defaultValue: "false"
   type: bool
   description: Activates pretty log output.
@@ -6375,7 +6279,7 @@ IDM_SVC_PASSWORD:
   removalVersion: ""
   deprecationInfo: ""
 IDM_TRACING_COLLECTOR:
-  name: OCIS_TRACING_COLLECTOR;IDM_TRACING_COLLECTOR
+  name: OCIS_TRACING_COLLECTOR;USERS_TRACING_COLLECTOR
   defaultValue: ""
   type: string
   description: The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces.
@@ -6385,7 +6289,7 @@ IDM_TRACING_COLLECTOR:
   removalVersion: ""
   deprecationInfo: ""
 IDM_TRACING_ENABLED:
-  name: OCIS_TRACING_ENABLED;IDM_TRACING_ENABLED
+  name: OCIS_TRACING_ENABLED;USERS_TRACING_ENABLED
   defaultValue: "false"
   type: bool
   description: Activates tracing.
@@ -6394,7 +6298,7 @@ IDM_TRACING_ENABLED:
   removalVersion: ""
   deprecationInfo: ""
 IDM_TRACING_ENDPOINT:
-  name: OCIS_TRACING_ENDPOINT;IDM_TRACING_ENDPOINT
+  name: OCIS_TRACING_ENDPOINT;USERS_TRACING_ENDPOINT
   defaultValue: ""
   type: string
   description: The endpoint of the tracing agent.
@@ -6403,7 +6307,7 @@ IDM_TRACING_ENDPOINT:
   removalVersion: ""
   deprecationInfo: ""
 IDM_TRACING_TYPE:
-  name: OCIS_TRACING_TYPE;IDM_TRACING_TYPE
+  name: OCIS_TRACING_TYPE;USERS_TRACING_TYPE
   defaultValue: ""
   type: string
   description: The type of tracing. Defaults to '', which is the same as 'jaeger'.
@@ -7176,14 +7080,14 @@ LDAP_LOGIN_ATTRIBUTES:
   removalVersion: ""
   deprecationInfo: ""
 LDAP_USER_SCHEMA_DISPLAY_NAME:
-  name: OCIS_LDAP_USER_SCHEMA_DISPLAYNAME;LDAP_USER_SCHEMA_DISPLAY_NAME;GRAPH_LDAP_USER_DISPLAYNAME_ATTRIBUTE
-  defaultValue: displayName
+  name: OCIS_LDAP_USER_SCHEMA_DISPLAYNAME;USERS_LDAP_USER_SCHEMA_DISPLAYNAME
+  defaultValue: displayname
   type: string
-  description: LDAP Attribute to use for the display name of users.
+  description: LDAP Attribute to use for the displayname of users.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
-  deprecationInfo: ""
+  deprecationInfo: 'LDAP_USER_SCHEMA_DISPLAY_NAME changing name for consistency |  |  | '
 LDAP_USER_SUBSTRING_FILTER_TYPE:
   name: LDAP_USER_SUBSTRING_FILTER_TYPE;USERS_LDAP_USER_SUBSTRING_FILTER_TYPE
   defaultValue: any
@@ -7672,7 +7576,7 @@ NOTIFICATIONS_TRACING_TYPE:
   removalVersion: ""
   deprecationInfo: ""
 NOTIFICATIONS_TRANSLATION_PATH:
-  name: OCIS_TRANSLATION_PATH;NOTIFICATIONS_TRANSLATION_PATH
+  name: OCIS_TRANSLATION_PATH;USERLOG_TRANSLATION_PATH
   defaultValue: ""
   type: string
   description: (optional) Set this to a path with custom translations to overwrite
@@ -7704,8 +7608,8 @@ OCDAV_ALLOW_PROPFIND_DEPTH_INFINITY:
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_CORS_ALLOW_CREDENTIALS:
-  name: OCIS_CORS_ALLOW_CREDENTIALS;OCDAV_CORS_ALLOW_CREDENTIALS
-  defaultValue: "false"
+  name: OCIS_CORS_ALLOW_CREDENTIALS;WEBDAV_CORS_ALLOW_CREDENTIALS
+  defaultValue: "true"
   type: bool
   description: 'Allow credentials for CORS.See following chapter for more details:
     *Access-Control-Allow-Credentials* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials.'
@@ -7714,11 +7618,9 @@ OCDAV_CORS_ALLOW_CREDENTIALS:
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_CORS_ALLOW_HEADERS:
-  name: OCIS_CORS_ALLOW_HEADERS;OCDAV_CORS_ALLOW_HEADERS
-  defaultValue: '[Origin Accept Content-Type Depth Authorization Ocs-Apirequest If-None-Match
-    If-Match Destination Overwrite X-Request-Id X-Requested-With Tus-Resumable Tus-Checksum-Algorithm
-    Upload-Concat Upload-Length Upload-Metadata Upload-Defer-Length Upload-Expires
-    Upload-Checksum Upload-Offset X-HTTP-Method-Override Cache-Control]'
+  name: OCIS_CORS_ALLOW_HEADERS;WEBDAV_CORS_ALLOW_HEADERS
+  defaultValue: '[Authorization Origin Content-Type Accept X-Requested-With X-Request-Id
+    Cache-Control]'
   type: '[]string'
   description: 'A list of allowed CORS headers. See following chapter for more details:
     *Access-Control-Request-Headers* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers.
@@ -7728,9 +7630,8 @@ OCDAV_CORS_ALLOW_HEADERS:
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_CORS_ALLOW_METHODS:
-  name: OCIS_CORS_ALLOW_METHODS;OCDAV_CORS_ALLOW_METHODS
-  defaultValue: '[OPTIONS HEAD GET PUT POST DELETE MKCOL PROPFIND PROPPATCH MOVE COPY
-    REPORT SEARCH]'
+  name: OCIS_CORS_ALLOW_METHODS;WEBDAV_CORS_ALLOW_METHODS
+  defaultValue: '[GET POST PUT PATCH DELETE OPTIONS]'
   type: '[]string'
   description: 'A list of allowed CORS methods. See following chapter for more details:
     *Access-Control-Request-Method* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method.
@@ -7740,8 +7641,8 @@ OCDAV_CORS_ALLOW_METHODS:
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_CORS_ALLOW_ORIGINS:
-  name: OCIS_CORS_ALLOW_ORIGINS;OCDAV_CORS_ALLOW_ORIGINS
-  defaultValue: '[https://localhost:9200]'
+  name: OCIS_CORS_ALLOW_ORIGINS;WEBDAV_CORS_ALLOW_ORIGINS
+  defaultValue: '[*]'
   type: '[]string'
   description: 'A list of allowed CORS origins. See following chapter for more details:
     *Access-Control-Allow-Origin* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin.
@@ -7789,7 +7690,7 @@ OCDAV_DEBUG_ZPAGES:
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_EDITION:
-  name: OCIS_EDITION;OCDAV_EDITION
+  name: OCIS_EDITION;FRONTEND_EDITION
   defaultValue: Community
   type: string
   description: Edition of oCIS. Used for branding purposes.
@@ -7845,16 +7746,17 @@ OCDAV_HTTP_PROTOCOL:
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_INSECURE:
-  name: OCIS_INSECURE;OCDAV_INSECURE
+  name: OCIS_INSECURE;POLICIES_EVENTS_TLS_INSECURE
   defaultValue: "false"
   type: bool
-  description: Allow insecure connections to the GATEWAY service.
+  description: Whether the server should skip the client certificate verification
+    during the TLS handshake.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_JWT_SECRET:
-  name: OCIS_JWT_SECRET;OCDAV_JWT_SECRET
+  name: OCIS_JWT_SECRET;USERS_JWT_SECRET
   defaultValue: ""
   type: string
   description: The secret to mint and validate jwt tokens.
@@ -7900,7 +7802,7 @@ OCDAV_LOG_PRETTY:
   removalVersion: ""
   deprecationInfo: ""
 OCDAV_MACHINE_AUTH_API_KEY:
-  name: OCIS_MACHINE_AUTH_API_KEY;OCDAV_MACHINE_AUTH_API_KEY
+  name: OCIS_MACHINE_AUTH_API_KEY;AUTH_MACHINE_API_KEY
   defaultValue: ""
   type: string
   description: Machine auth API key used to validate internal requests necessary for
@@ -7996,12 +7898,12 @@ OCDAV_WEBDAV_NAMESPACE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_ADMIN_USER_ID:
-  name: OCIS_ADMIN_USER_ID;STORAGE_USERS_PURGE_TRASH_BIN_USER_ID
+  name: OCIS_ADMIN_USER_ID;SETTINGS_ADMIN_USER_ID
   defaultValue: ""
   type: string
-  description: ID of the user who collects all necessary information for deletion.
-    Consider that the UUID can be encoded in some LDAP deployment configurations like
-    in .ldif files. These need to be decoded beforehand.
+  description: ID of the user that should receive admin privileges. Consider that
+    the UUID can be encoded in some LDAP deployment configurations like in .ldif files.
+    These need to be decoded beforehand.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -8017,7 +7919,7 @@ OCIS_ASSET_THEMES_PATH:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_ASYNC_UPLOADS:
-  name: OCIS_ASYNC_UPLOADS
+  name: OCIS_ASYNC_UPLOADS;SEARCH_EVENTS_ASYNC_UPLOADS
   defaultValue: "true"
   type: bool
   description: Enable asynchronous file uploads.
@@ -8026,28 +7928,28 @@ OCIS_ASYNC_UPLOADS:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CACHE_AUTH_PASSWORD:
-  name: OCIS_CACHE_AUTH_PASSWORD;STORAGE_USERS_ID_CACHE_AUTH_PASSWORD
+  name: OCIS_CACHE_AUTH_PASSWORD;STORAGE_SYSTEM_CACHE_AUTH_PASSWORD
   defaultValue: ""
   type: string
-  description: The password to authenticate with the cache store. Only applies when
-    store type 'nats-js-kv' is configured.
+  description: Password for the configured store. Only applies when store type 'nats-js-kv'
+    is configured.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CACHE_AUTH_USERNAME:
-  name: OCIS_CACHE_AUTH_USERNAME;STORAGE_USERS_ID_CACHE_AUTH_USERNAME
+  name: OCIS_CACHE_AUTH_USERNAME;STORAGE_SYSTEM_CACHE_AUTH_USERNAME
   defaultValue: ""
   type: string
-  description: The username to authenticate with the cache store. Only applies when
-    store type 'nats-js-kv' is configured.
+  description: Username for the configured store. Only applies when store type 'nats-js-kv'
+    is configured.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CACHE_DATABASE:
   name: OCIS_CACHE_DATABASE
-  defaultValue: ids-storage-users
+  defaultValue: storage-system
   type: string
   description: The database name the configured store should use.
   introductionVersion: pre5.0
@@ -8055,7 +7957,7 @@ OCIS_CACHE_DATABASE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CACHE_DISABLE_PERSISTENCE:
-  name: OCIS_CACHE_DISABLE_PERSISTENCE;STORAGE_USERS_ID_CACHE_DISABLE_PERSISTENCE
+  name: OCIS_CACHE_DISABLE_PERSISTENCE;STORAGE_SYSTEM_CACHE_DISABLE_PERSISTENCE
   defaultValue: "false"
   type: bool
   description: Disables persistence of the cache. Only applies when store type 'nats-js-kv'
@@ -8064,19 +7966,8 @@ OCIS_CACHE_DISABLE_PERSISTENCE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-OCIS_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;GATEWAY_CREATE_HOME_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the cache. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not explicitly set as default.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 OCIS_CACHE_STORE:
-  name: OCIS_CACHE_STORE;STORAGE_USERS_ID_CACHE_STORE
+  name: OCIS_CACHE_STORE;STORAGE_SYSTEM_CACHE_STORE
   defaultValue: memory
   type: string
   description: 'The type of the cache store. Supported values are: ''memory'', ''redis-sentinel'',
@@ -8086,7 +7977,7 @@ OCIS_CACHE_STORE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CACHE_STORE_NODES:
-  name: OCIS_CACHE_STORE_NODES;STORAGE_USERS_ID_CACHE_STORE_NODES
+  name: OCIS_CACHE_STORE_NODES;STORAGE_SYSTEM_CACHE_STORE_NODES
   defaultValue: '[127.0.0.1:9233]'
   type: '[]string'
   description: A list of nodes to access the configured store. This has no effect
@@ -8098,33 +7989,30 @@ OCIS_CACHE_STORE_NODES:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CACHE_TTL:
-  name: OCIS_CACHE_TTL;STORAGE_USERS_ID_CACHE_TTL
+  name: OCIS_CACHE_TTL;STORAGE_SYSTEM_CACHE_TTL
   defaultValue: 24m0s
   type: Duration
   description: Default time to live for user info in the user info cache. Only applied
-    when access tokens have no expiration. Defaults to 300s which is derived from
-    the underlaying package though not explicitly set as default. See the Environment
-    Variable Types description for more details.
+    when access tokens has no expiration. See the Environment Variable Types description
+    for more details.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CORS_ALLOW_CREDENTIALS:
-  name: OCIS_CORS_ALLOW_CREDENTIALS;WEB_CORS_ALLOW_CREDENTIALS
-  defaultValue: "false"
+  name: OCIS_CORS_ALLOW_CREDENTIALS;WEBDAV_CORS_ALLOW_CREDENTIALS
+  defaultValue: "true"
   type: bool
-  description: 'Allow credentials for CORS. See following chapter for more details:
+  description: 'Allow credentials for CORS.See following chapter for more details:
     *Access-Control-Allow-Credentials* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials.'
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CORS_ALLOW_HEADERS:
-  name: OCIS_CORS_ALLOW_HEADERS;WEB_CORS_ALLOW_HEADERS
-  defaultValue: '[Origin Accept Content-Type Depth Authorization Ocs-Apirequest If-None-Match
-    If-Match Destination Overwrite X-Request-Id X-Requested-With Tus-Resumable Tus-Checksum-Algorithm
-    Upload-Concat Upload-Length Upload-Metadata Upload-Defer-Length Upload-Expires
-    Upload-Checksum Upload-Offset X-HTTP-Method-Override]'
+  name: OCIS_CORS_ALLOW_HEADERS;WEBDAV_CORS_ALLOW_HEADERS
+  defaultValue: '[Authorization Origin Content-Type Accept X-Requested-With X-Request-Id
+    Cache-Control]'
   type: '[]string'
   description: 'A list of allowed CORS headers. See following chapter for more details:
     *Access-Control-Request-Headers* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers.
@@ -8134,9 +8022,8 @@ OCIS_CORS_ALLOW_HEADERS:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CORS_ALLOW_METHODS:
-  name: OCIS_CORS_ALLOW_METHODS;WEB_CORS_ALLOW_METHODS
-  defaultValue: '[OPTIONS HEAD GET PUT PATCH POST DELETE MKCOL PROPFIND PROPPATCH
-    MOVE COPY REPORT SEARCH]'
+  name: OCIS_CORS_ALLOW_METHODS;WEBDAV_CORS_ALLOW_METHODS
+  defaultValue: '[GET POST PUT PATCH DELETE OPTIONS]'
   type: '[]string'
   description: 'A list of allowed CORS methods. See following chapter for more details:
     *Access-Control-Request-Method* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method.
@@ -8146,8 +8033,8 @@ OCIS_CORS_ALLOW_METHODS:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_CORS_ALLOW_ORIGINS:
-  name: OCIS_CORS_ALLOW_ORIGINS;WEB_CORS_ALLOW_ORIGINS
-  defaultValue: '[https://localhost:9200]'
+  name: OCIS_CORS_ALLOW_ORIGINS;WEBDAV_CORS_ALLOW_ORIGINS
+  defaultValue: '[*]'
   type: '[]string'
   description: 'A list of allowed CORS origins. See following chapter for more details:
     *Access-Control-Allow-Origin* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin.
@@ -8176,17 +8063,6 @@ OCIS_CORS_MAX_AGE:
   description: 'The max cache duration of preflight headers. See following chapter
     for more details: *Access-Control-Max-Age* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age.
     See the Environment Variable Types description for more details.'
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-OCIS_DECOMPOSEDFS_METADATA_BACKEND:
-  name: OCIS_DECOMPOSEDFS_METADATA_BACKEND;STORAGE_SYSTEM_OCIS_METADATA_BACKEND
-  defaultValue: messagepack
-  type: string
-  description: The backend to use for storing metadata. Supported values are 'messagepack'
-    and 'xattrs'. The setting 'messagepack' uses a dedicated file to store file metadata
-    while 'xattrs' uses extended attributes to store file metadata. Defaults to 'messagepack'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -8271,16 +8147,16 @@ OCIS_EMAIL_TEMPLATE_PATH:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_ENABLE_OCM:
-  name: OCIS_ENABLE_OCM;FRONTEND_OCS_INCLUDE_OCM_SHAREES
+  name: OCIS_ENABLE_OCM;GRAPH_INCLUDE_OCM_SHAREES
   defaultValue: "false"
   type: bool
-  description: Include OCM sharees when listing sharees.
+  description: Include OCM sharees when listing users.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_EVENTS_AUTH_PASSWORD:
-  name: OCIS_EVENTS_AUTH_PASSWORD;STORAGE_USERS_EVENTS_AUTH_PASSWORD
+  name: OCIS_EVENTS_AUTH_PASSWORD;POLICIES_EVENTS_AUTH_PASSWORD
   defaultValue: ""
   type: string
   description: The password to authenticate with the events broker. The events broker
@@ -8290,7 +8166,7 @@ OCIS_EVENTS_AUTH_PASSWORD:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_EVENTS_AUTH_USERNAME:
-  name: OCIS_EVENTS_AUTH_USERNAME;STORAGE_USERS_EVENTS_AUTH_USERNAME
+  name: OCIS_EVENTS_AUTH_USERNAME;POLICIES_EVENTS_AUTH_USERNAME
   defaultValue: ""
   type: string
   description: The username to authenticate with the events broker. The events broker
@@ -8300,7 +8176,7 @@ OCIS_EVENTS_AUTH_USERNAME:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_EVENTS_CLUSTER:
-  name: OCIS_EVENTS_CLUSTER;STORAGE_USERS_EVENTS_CLUSTER
+  name: OCIS_EVENTS_CLUSTER;POLICIES_EVENTS_CLUSTER
   defaultValue: ocis-cluster
   type: string
   description: The clusterID of the event system. The event system is the message
@@ -8311,7 +8187,7 @@ OCIS_EVENTS_CLUSTER:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_EVENTS_ENABLE_TLS:
-  name: OCIS_EVENTS_ENABLE_TLS;STORAGE_USERS_EVENTS_ENABLE_TLS
+  name: OCIS_EVENTS_ENABLE_TLS;POLICIES_EVENTS_ENABLE_TLS
   defaultValue: "false"
   type: bool
   description: Enable TLS for the connection to the events broker. The events broker
@@ -8321,7 +8197,7 @@ OCIS_EVENTS_ENABLE_TLS:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_EVENTS_ENDPOINT:
-  name: OCIS_EVENTS_ENDPOINT;STORAGE_USERS_EVENTS_ENDPOINT
+  name: OCIS_EVENTS_ENDPOINT;POLICIES_EVENTS_ENDPOINT
   defaultValue: 127.0.0.1:9233
   type: string
   description: The address of the event system. The event system is the message queuing
@@ -8331,21 +8207,21 @@ OCIS_EVENTS_ENDPOINT:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_EVENTS_TLS_ROOT_CA_CERTIFICATE:
-  name: OCIS_EVENTS_TLS_ROOT_CA_CERTIFICATE;STORAGE_USERS_EVENTS_TLS_ROOT_CA_CERTIFICATE
+  name: OCIS_EVENTS_TLS_ROOT_CA_CERTIFICATE;POLICIES_EVENTS_TLS_ROOT_CA_CERTIFICATE
   defaultValue: ""
   type: string
   description: The root CA certificate used to validate the server's TLS certificate.
-    If provided STORAGE_USERS_EVENTS_TLS_INSECURE will be seen as false.
+    If provided POLICIES_EVENTS_TLS_INSECURE will be seen as false.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_GATEWAY_GRPC_ADDR:
-  name: OCIS_GATEWAY_GRPC_ADDR;STORAGE_USERS_GATEWAY_GRPC_ADDR
+  name: OCIS_GATEWAY_GRPC_ADDR;GATEWAY_GRPC_ADDR
   defaultValue: 127.0.0.1:9142
   type: string
-  description: The bind address of the gateway GRPC address.
-  introductionVersion: "5.0"
+  description: The bind address of the GRPC service.
+  introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -8373,7 +8249,7 @@ OCIS_GRPC_CLIENT_TLS_MODE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_GRPC_PROTOCOL:
-  name: OCIS_GRPC_PROTOCOL;STORAGE_USERS_GRPC_PROTOCOL
+  name: OCIS_GRPC_PROTOCOL;USERS_GRPC_PROTOCOL
   defaultValue: ""
   type: string
   description: The transport protocol of the GPRC service.
@@ -8413,16 +8289,17 @@ OCIS_HTTP_TLS_KEY:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_INSECURE:
-  name: OCIS_INSECURE;STORAGE_USERS_EVENTS_TLS_INSECURE
+  name: OCIS_INSECURE;POLICIES_EVENTS_TLS_INSECURE
   defaultValue: "false"
   type: bool
-  description: Whether to verify the server TLS certificates.
+  description: Whether the server should skip the client certificate verification
+    during the TLS handshake.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_JWT_SECRET:
-  name: OCIS_JWT_SECRET;WEB_JWT_SECRET
+  name: OCIS_JWT_SECRET;USERS_JWT_SECRET
   defaultValue: ""
   type: string
   description: The secret to mint and validate jwt tokens.
@@ -8431,7 +8308,7 @@ OCIS_JWT_SECRET:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_KEYCLOAK_BASE_PATH:
-  name: OCIS_KEYCLOAK_BASE_PATH;GRAPH_KEYCLOAK_BASE_PATH
+  name: OCIS_KEYCLOAK_BASE_PATH;INVITATIONS_KEYCLOAK_BASE_PATH
   defaultValue: ""
   type: string
   description: The URL to access keycloak.
@@ -8440,16 +8317,16 @@ OCIS_KEYCLOAK_BASE_PATH:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_KEYCLOAK_CLIENT_ID:
-  name: OCIS_KEYCLOAK_CLIENT_ID;GRAPH_KEYCLOAK_CLIENT_ID
+  name: OCIS_KEYCLOAK_CLIENT_ID;INVITATIONS_KEYCLOAK_CLIENT_ID
   defaultValue: ""
   type: string
-  description: The client id to authenticate with keycloak.
+  description: The client ID to authenticate with keycloak.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_KEYCLOAK_CLIENT_REALM:
-  name: OCIS_KEYCLOAK_CLIENT_REALM;GRAPH_KEYCLOAK_CLIENT_REALM
+  name: OCIS_KEYCLOAK_CLIENT_REALM;INVITATIONS_KEYCLOAK_CLIENT_REALM
   defaultValue: ""
   type: string
   description: The realm the client is defined in.
@@ -8458,7 +8335,7 @@ OCIS_KEYCLOAK_CLIENT_REALM:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_KEYCLOAK_CLIENT_SECRET:
-  name: OCIS_KEYCLOAK_CLIENT_SECRET;GRAPH_KEYCLOAK_CLIENT_SECRET
+  name: OCIS_KEYCLOAK_CLIENT_SECRET;INVITATIONS_KEYCLOAK_CLIENT_SECRET
   defaultValue: ""
   type: string
   description: The client secret to use in authentication.
@@ -8467,7 +8344,7 @@ OCIS_KEYCLOAK_CLIENT_SECRET:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_KEYCLOAK_INSECURE_SKIP_VERIFY:
-  name: OCIS_KEYCLOAK_INSECURE_SKIP_VERIFY;GRAPH_KEYCLOAK_INSECURE_SKIP_VERIFY
+  name: OCIS_KEYCLOAK_INSECURE_SKIP_VERIFY;INVITATIONS_KEYCLOAK_INSECURE_SKIP_VERIFY
   defaultValue: "false"
   type: bool
   description: Disable TLS certificate validation for Keycloak connections. Do not
@@ -8477,7 +8354,7 @@ OCIS_KEYCLOAK_INSECURE_SKIP_VERIFY:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_KEYCLOAK_USER_REALM:
-  name: OCIS_KEYCLOAK_USER_REALM;GRAPH_KEYCLOAK_USER_REALM
+  name: OCIS_KEYCLOAK_USER_REALM;INVITATIONS_KEYCLOAK_USER_REALM
   defaultValue: ""
   type: string
   description: The realm users are defined.
@@ -8486,7 +8363,7 @@ OCIS_KEYCLOAK_USER_REALM:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_BIND_DN:
-  name: OCIS_LDAP_BIND_DN;GROUPS_LDAP_BIND_DN
+  name: OCIS_LDAP_BIND_DN;USERS_LDAP_BIND_DN
   defaultValue: uid=reva,ou=sysusers,o=libregraph-idm
   type: string
   description: LDAP DN to use for simple bind authentication with the target LDAP
@@ -8496,7 +8373,7 @@ OCIS_LDAP_BIND_DN:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_BIND_PASSWORD:
-  name: OCIS_LDAP_BIND_PASSWORD;GROUPS_LDAP_BIND_PASSWORD
+  name: OCIS_LDAP_BIND_PASSWORD;USERS_LDAP_BIND_PASSWORD
   defaultValue: ""
   type: string
   description: Password to use for authenticating the 'bind_dn'.
@@ -8505,7 +8382,7 @@ OCIS_LDAP_BIND_PASSWORD:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_CACERT:
-  name: OCIS_LDAP_CACERT;GROUPS_LDAP_CACERT
+  name: OCIS_LDAP_CACERT;USERS_LDAP_CACERT
   defaultValue: /var/lib/ocis/idm/ldap.crt
   type: string
   description: Path/File name for the root CA certificate (in PEM format) used to
@@ -8516,20 +8393,20 @@ OCIS_LDAP_CACERT:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_DISABLE_USER_MECHANISM:
-  name: OCIS_LDAP_DISABLE_USER_MECHANISM;GRAPH_DISABLE_USER_MECHANISM
+  name: OCIS_LDAP_DISABLE_USER_MECHANISM;USERS_LDAP_DISABLE_USER_MECHANISM
   defaultValue: attribute
   type: string
-  description: An option to control the behavior for disabling users. Supported options
+  description: An option to control the behavior for disabling users. Valid options
     are 'none', 'attribute' and 'group'. If set to 'group', disabling a user via API
     will add the user to the configured group for disabled users, if set to 'attribute'
     this will be done in the ldap user entry, if set to 'none' the disable request
-    is not processed. Default is 'attribute'.
+    is not processed.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_DISABLED_USERS_GROUP_DN:
-  name: OCIS_LDAP_DISABLED_USERS_GROUP_DN;GRAPH_DISABLED_USERS_GROUP_DN
+  name: OCIS_LDAP_DISABLED_USERS_GROUP_DN;USERS_LDAP_DISABLED_USERS_GROUP_DN
   defaultValue: cn=DisabledUsersGroup,ou=groups,o=libregraph-idm
   type: string
   description: The distinguished name of the group to which added users will be classified
@@ -8539,7 +8416,7 @@ OCIS_LDAP_DISABLED_USERS_GROUP_DN:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_BASE_DN:
-  name: OCIS_LDAP_GROUP_BASE_DN;GROUPS_LDAP_GROUP_BASE_DN
+  name: OCIS_LDAP_GROUP_BASE_DN;USERS_LDAP_GROUP_BASE_DN
   defaultValue: ou=groups,o=libregraph-idm
   type: string
   description: Search base DN for looking up LDAP groups.
@@ -8548,7 +8425,7 @@ OCIS_LDAP_GROUP_BASE_DN:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_FILTER:
-  name: OCIS_LDAP_GROUP_FILTER;GROUPS_LDAP_GROUP_FILTER
+  name: OCIS_LDAP_GROUP_FILTER;USERS_LDAP_GROUP_FILTER
   defaultValue: ""
   type: string
   description: LDAP filter to add to the default filters for group searches.
@@ -8557,17 +8434,17 @@ OCIS_LDAP_GROUP_FILTER:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_OBJECTCLASS:
-  name: OCIS_LDAP_GROUP_OBJECTCLASS;GROUPS_LDAP_GROUP_OBJECTCLASS
+  name: OCIS_LDAP_GROUP_OBJECTCLASS;USERS_LDAP_GROUP_OBJECTCLASS
   defaultValue: groupOfNames
   type: string
   description: The object class to use for groups in the default group search filter
-    ('groupOfNames').
+    like 'groupOfNames'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_SCHEMA_DISPLAYNAME:
-  name: OCIS_LDAP_GROUP_SCHEMA_DISPLAYNAME;GROUPS_LDAP_GROUP_SCHEMA_DISPLAYNAME
+  name: OCIS_LDAP_GROUP_SCHEMA_DISPLAYNAME;USERS_LDAP_GROUP_SCHEMA_DISPLAYNAME
   defaultValue: cn
   type: string
   description: LDAP Attribute to use for the displayname of groups (often the same
@@ -8577,7 +8454,7 @@ OCIS_LDAP_GROUP_SCHEMA_DISPLAYNAME:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_SCHEMA_GROUPNAME:
-  name: OCIS_LDAP_GROUP_SCHEMA_GROUPNAME;GROUPS_LDAP_GROUP_SCHEMA_GROUPNAME
+  name: OCIS_LDAP_GROUP_SCHEMA_GROUPNAME;USERS_LDAP_GROUP_SCHEMA_GROUPNAME
   defaultValue: cn
   type: string
   description: LDAP Attribute to use for the name of groups.
@@ -8586,17 +8463,17 @@ OCIS_LDAP_GROUP_SCHEMA_GROUPNAME:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_SCHEMA_ID:
-  name: OCIS_LDAP_GROUP_SCHEMA_ID;GROUPS_LDAP_GROUP_SCHEMA_ID
+  name: OCIS_LDAP_GROUP_SCHEMA_ID;USERS_LDAP_GROUP_SCHEMA_ID
   defaultValue: ownclouduuid
   type: string
-  description: LDAP Attribute to use as the unique id for groups. This should be a
+  description: LDAP Attribute to use as the unique ID for groups. This should be a
     stable globally unique ID like a UUID.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING:
-  name: OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING;GROUPS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING
+  name: OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING;USERS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING
   defaultValue: "false"
   type: bool
   description: Set this to true if the defined 'id' attribute for groups is of the
@@ -8607,7 +8484,7 @@ OCIS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_SCHEMA_MAIL:
-  name: OCIS_LDAP_GROUP_SCHEMA_MAIL;GROUPS_LDAP_GROUP_SCHEMA_MAIL
+  name: OCIS_LDAP_GROUP_SCHEMA_MAIL;USERS_LDAP_GROUP_SCHEMA_MAIL
   defaultValue: mail
   type: string
   description: LDAP Attribute to use for the email address of groups (can be empty).
@@ -8616,7 +8493,7 @@ OCIS_LDAP_GROUP_SCHEMA_MAIL:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_SCHEMA_MEMBER:
-  name: OCIS_LDAP_GROUP_SCHEMA_MEMBER;GROUPS_LDAP_GROUP_SCHEMA_MEMBER
+  name: OCIS_LDAP_GROUP_SCHEMA_MEMBER;USERS_LDAP_GROUP_SCHEMA_MEMBER
   defaultValue: member
   type: string
   description: LDAP Attribute that is used for group members.
@@ -8625,17 +8502,17 @@ OCIS_LDAP_GROUP_SCHEMA_MEMBER:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_GROUP_SCOPE:
-  name: OCIS_LDAP_GROUP_SCOPE;GROUPS_LDAP_GROUP_SCOPE
+  name: OCIS_LDAP_GROUP_SCOPE;USERS_LDAP_GROUP_SCOPE
   defaultValue: sub
   type: string
-  description: LDAP search scope to use when looking up groups. Supported scopes are
+  description: LDAP search scope to use when looking up groups. Supported values are
     'base', 'one' and 'sub'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_INSECURE:
-  name: OCIS_LDAP_INSECURE;GROUPS_LDAP_INSECURE
+  name: OCIS_LDAP_INSECURE;USERS_LDAP_INSECURE
   defaultValue: "false"
   type: bool
   description: Disable TLS certificate validation for the LDAP connections. Do not
@@ -8645,7 +8522,7 @@ OCIS_LDAP_INSECURE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_SERVER_WRITE_ENABLED:
-  name: OCIS_LDAP_SERVER_WRITE_ENABLED;FRONTEND_LDAP_SERVER_WRITE_ENABLED
+  name: OCIS_LDAP_SERVER_WRITE_ENABLED;GRAPH_LDAP_SERVER_WRITE_ENABLED
   defaultValue: "true"
   type: bool
   description: Allow creating, modifying and deleting LDAP users via the GRAPH API.
@@ -8657,7 +8534,7 @@ OCIS_LDAP_SERVER_WRITE_ENABLED:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_URI:
-  name: OCIS_LDAP_URI;GROUPS_LDAP_URI
+  name: OCIS_LDAP_URI;USERS_LDAP_URI
   defaultValue: ldaps://localhost:9235
   type: string
   description: URI of the LDAP Server to connect to. Supported URI schemes are 'ldaps://'
@@ -8667,7 +8544,7 @@ OCIS_LDAP_URI:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_BASE_DN:
-  name: OCIS_LDAP_USER_BASE_DN;GROUPS_LDAP_USER_BASE_DN
+  name: OCIS_LDAP_USER_BASE_DN;USERS_LDAP_USER_BASE_DN
   defaultValue: ou=users,o=libregraph-idm
   type: string
   description: Search base DN for looking up LDAP users.
@@ -8676,16 +8553,16 @@ OCIS_LDAP_USER_BASE_DN:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_ENABLED_ATTRIBUTE:
-  name: OCIS_LDAP_USER_ENABLED_ATTRIBUTE;IDP_USER_ENABLED_ATTRIBUTE
+  name: OCIS_LDAP_USER_ENABLED_ATTRIBUTE;USERS_LDAP_USER_ENABLED_ATTRIBUTE
   defaultValue: ownCloudUserEnabled
   type: string
-  description: LDAP Attribute to use as a flag telling if the user is enabled or disabled.
+  description: LDAP attribute to use as a flag telling if the user is enabled or disabled.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_FILTER:
-  name: OCIS_LDAP_USER_FILTER;GROUPS_LDAP_USER_FILTER
+  name: OCIS_LDAP_USER_FILTER;USERS_LDAP_USER_FILTER
   defaultValue: ""
   type: string
   description: LDAP filter to add to the default filters for user search like '(objectclass=ownCloud)'.
@@ -8694,36 +8571,36 @@ OCIS_LDAP_USER_FILTER:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_OBJECTCLASS:
-  name: OCIS_LDAP_USER_OBJECTCLASS;GROUPS_LDAP_USER_OBJECTCLASS
+  name: OCIS_LDAP_USER_OBJECTCLASS;USERS_LDAP_USER_OBJECTCLASS
   defaultValue: inetOrgPerson
   type: string
   description: The object class to use for users in the default user search filter
-    ('inetOrgPerson').
+    like 'inetOrgPerson'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_SCHEMA_DISPLAYNAME:
-  name: OCIS_LDAP_USER_SCHEMA_DISPLAYNAME;GROUPS_LDAP_USER_SCHEMA_DISPLAYNAME
+  name: OCIS_LDAP_USER_SCHEMA_DISPLAYNAME;USERS_LDAP_USER_SCHEMA_DISPLAYNAME
   defaultValue: displayname
   type: string
   description: LDAP Attribute to use for the displayname of users.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
-  deprecationInfo: ""
+  deprecationInfo: 'LDAP_USER_SCHEMA_DISPLAY_NAME changing name for consistency |  |  | '
 OCIS_LDAP_USER_SCHEMA_ID:
-  name: OCIS_LDAP_USER_SCHEMA_ID;GROUPS_LDAP_USER_SCHEMA_ID
+  name: OCIS_LDAP_USER_SCHEMA_ID;USERS_LDAP_USER_SCHEMA_ID
   defaultValue: ownclouduuid
   type: string
-  description: LDAP Attribute to use as the unique id for users. This should be a
-    stable globally unique id like a UUID.
+  description: LDAP Attribute to use as the unique ID for users. This should be a
+    stable globally unique ID like a UUID.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING:
-  name: OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING;GROUPS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING
+  name: OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING;USERS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING
   defaultValue: "false"
   type: bool
   description: Set this to true if the defined 'ID' attribute for users is of the
@@ -8734,7 +8611,7 @@ OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_SCHEMA_MAIL:
-  name: OCIS_LDAP_USER_SCHEMA_MAIL;GROUPS_LDAP_USER_SCHEMA_MAIL
+  name: OCIS_LDAP_USER_SCHEMA_MAIL;USERS_LDAP_USER_SCHEMA_MAIL
   defaultValue: mail
   type: string
   description: LDAP Attribute to use for the email address of users.
@@ -8743,7 +8620,7 @@ OCIS_LDAP_USER_SCHEMA_MAIL:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_SCHEMA_USER_TYPE:
-  name: OCIS_LDAP_USER_SCHEMA_USER_TYPE;GRAPH_LDAP_USER_TYPE_ATTRIBUTE
+  name: OCIS_LDAP_USER_SCHEMA_USER_TYPE;USERS_LDAP_USER_TYPE_ATTRIBUTE
   defaultValue: ownCloudUserType
   type: string
   description: LDAP Attribute to distinguish between 'Member' and 'Guest' users. Default
@@ -8753,7 +8630,7 @@ OCIS_LDAP_USER_SCHEMA_USER_TYPE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_SCHEMA_USERNAME:
-  name: OCIS_LDAP_USER_SCHEMA_USERNAME;GROUPS_LDAP_USER_SCHEMA_USERNAME
+  name: OCIS_LDAP_USER_SCHEMA_USERNAME;USERS_LDAP_USER_SCHEMA_USERNAME
   defaultValue: uid
   type: string
   description: LDAP Attribute to use for username of users.
@@ -8762,17 +8639,17 @@ OCIS_LDAP_USER_SCHEMA_USERNAME:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LDAP_USER_SCOPE:
-  name: OCIS_LDAP_USER_SCOPE;GROUPS_LDAP_USER_SCOPE
+  name: OCIS_LDAP_USER_SCOPE;USERS_LDAP_USER_SCOPE
   defaultValue: sub
   type: string
-  description: LDAP search scope to use when looking up users. Supported scopes are
+  description: LDAP search scope to use when looking up users. Supported values are
     'base', 'one' and 'sub'.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LOG_COLOR:
-  name: OCIS_LOG_COLOR;WEB_LOG_COLOR
+  name: OCIS_LOG_COLOR;USERS_LOG_COLOR
   defaultValue: "false"
   type: bool
   description: Activates colorized log output.
@@ -8781,7 +8658,7 @@ OCIS_LOG_COLOR:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LOG_FILE:
-  name: OCIS_LOG_FILE;WEB_LOG_FILE
+  name: OCIS_LOG_FILE;USERS_LOG_FILE
   defaultValue: ""
   type: string
   description: The path to the log file. Activates logging to this file if set.
@@ -8790,7 +8667,7 @@ OCIS_LOG_FILE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LOG_LEVEL:
-  name: OCIS_LOG_LEVEL;WEB_LOG_LEVEL
+  name: OCIS_LOG_LEVEL;USERS_LOG_LEVEL
   defaultValue: ""
   type: string
   description: 'The log level. Valid values are: ''panic'', ''fatal'', ''error'',
@@ -8800,7 +8677,7 @@ OCIS_LOG_LEVEL:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_LOG_PRETTY:
-  name: OCIS_LOG_PRETTY;WEB_LOG_PRETTY
+  name: OCIS_LOG_PRETTY;USERS_LOG_PRETTY
   defaultValue: "false"
   type: bool
   description: Activates pretty log output.
@@ -8809,23 +8686,23 @@ OCIS_LOG_PRETTY:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_MACHINE_AUTH_API_KEY:
-  name: OCIS_MACHINE_AUTH_API_KEY;STORAGE_USERS_MACHINE_AUTH_API_KEY
+  name: OCIS_MACHINE_AUTH_API_KEY;AUTH_MACHINE_API_KEY
   defaultValue: ""
   type: string
   description: Machine auth API key used to validate internal requests necessary for
     the access to resources from other services.
-  introductionVersion: "5.0"
+  introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_MAX_CONCURRENCY:
-  name: OCIS_MAX_CONCURRENCY;STORAGE_USERS_S3NG_MAX_CONCURRENCY
-  defaultValue: "5"
+  name: OCIS_MAX_CONCURRENCY;USERLOG_MAX_CONCURRENCY
+  defaultValue: "1"
   type: int
   description: Maximum number of concurrent go-routines. Higher values can potentially
     get work done faster but will also cause more load on the system. Values of 0
-    or below will be ignored and the default value of 100 will be used.
-  introductionVersion: pre5.0
+    or below will be ignored and the default value will be used.
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -8841,10 +8718,11 @@ OCIS_OIDC_CLIENT_ID:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_OIDC_ISSUER:
-  name: OCIS_URL;OCIS_OIDC_ISSUER;WEB_OIDC_AUTHORITY
+  name: OCIS_URL;OCIS_OIDC_ISSUER;USERS_IDP_URL
   defaultValue: https://localhost:9200
   type: string
-  description: URL of the OIDC issuer. It defaults to URL of the builtin IDP.
+  description: The identity provider value to set in the userids of the CS3 user objects
+    for users returned by this user provider.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -8917,65 +8795,54 @@ OCIS_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_PERSISTENT_STORE:
-  name: OCIS_PERSISTENT_STORE;USERLOG_STORE
-  defaultValue: memory
+  name: OCIS_PERSISTENT_STORE;COLLABORATION_STORE
+  defaultValue: nats-js-kv
   type: string
   description: 'The type of the store. Supported values are: ''memory'', ''nats-js-kv'',
     ''redis-sentinel'', ''noop''. See the text description for details.'
-  introductionVersion: pre5.0
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_PERSISTENT_STORE_AUTH_PASSWORD:
-  name: OCIS_PERSISTENT_STORE_AUTH_PASSWORD;USERLOG_STORE_AUTH_PASSWORD
+  name: OCIS_PERSISTENT_STORE_AUTH_PASSWORD;COLLABORATION_STORE_AUTH_PASSWORD
   defaultValue: ""
   type: string
   description: The password to authenticate with the store. Only applies when store
     type 'nats-js-kv' is configured.
-  introductionVersion: "5.0"
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_PERSISTENT_STORE_AUTH_USERNAME:
-  name: OCIS_PERSISTENT_STORE_AUTH_USERNAME;USERLOG_STORE_AUTH_USERNAME
+  name: OCIS_PERSISTENT_STORE_AUTH_USERNAME;COLLABORATION_STORE_AUTH_USERNAME
   defaultValue: ""
   type: string
   description: The username to authenticate with the store. Only applies when store
     type 'nats-js-kv' is configured.
-  introductionVersion: "5.0"
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_PERSISTENT_STORE_NODES:
-  name: OCIS_PERSISTENT_STORE_NODES;USERLOG_STORE_NODES
-  defaultValue: '[]'
+  name: OCIS_PERSISTENT_STORE_NODES;COLLABORATION_STORE_NODES
+  defaultValue: '[127.0.0.1:9233]'
   type: '[]string'
   description: A list of nodes to access the configured store. This has no effect
     when 'memory' store is configured. Note that the behaviour how nodes are used
     is dependent on the library of the configured store. See the Environment Variable
     Types description for more details.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-OCIS_PERSISTENT_STORE_SIZE:
-  name: OCIS_PERSISTENT_STORE_SIZE;EVENTHISTORY_STORE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the store. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived and used from the
-    ocmem package though no explicit default was set.
-  introductionVersion: pre5.0
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 OCIS_PERSISTENT_STORE_TTL:
-  name: OCIS_PERSISTENT_STORE_TTL;USERLOG_STORE_TTL
-  defaultValue: 336h0m0s
+  name: OCIS_PERSISTENT_STORE_TTL;COLLABORATION_STORE_TTL
+  defaultValue: 30m0s
   type: Duration
-  description: Time to live for events in the store. Defaults to '336h' (2 weeks).
+  description: Time to live for events in the store. Defaults to '30m' (30 minutes).
     See the Environment Variable Types description for more details.
-  introductionVersion: pre5.0
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -9020,7 +8887,7 @@ OCIS_REVA_GATEWAY_TLS_MODE:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_SERVICE_ACCOUNT_ID:
-  name: OCIS_SERVICE_ACCOUNT_ID;STORAGE_USERS_SERVICE_ACCOUNT_ID
+  name: OCIS_SERVICE_ACCOUNT_ID;SEARCH_SERVICE_ACCOUNT_ID
   defaultValue: ""
   type: string
   description: The ID of the service account the service should use. See the 'auth-service'
@@ -9030,7 +8897,7 @@ OCIS_SERVICE_ACCOUNT_ID:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_SERVICE_ACCOUNT_SECRET:
-  name: OCIS_SERVICE_ACCOUNT_SECRET;STORAGE_USERS_SERVICE_ACCOUNT_SECRET
+  name: OCIS_SERVICE_ACCOUNT_SECRET;SEARCH_SERVICE_ACCOUNT_SECRET
   defaultValue: ""
   type: string
   description: The service account secret.
@@ -9046,7 +8913,8 @@ OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD:
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
-  deprecationInfo: ""
+  deprecationInfo: 'FRONTEND_OCS_PUBLIC_SHARE_MUST_HAVE_PASSWORD, the OCS API is deprecated
+    | '
 OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD:
   name: OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD;SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD
   defaultValue: "false"
@@ -9058,7 +8926,8 @@ OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD:
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
-  deprecationInfo: ""
+  deprecationInfo: 'FRONTEND_OCS_PUBLIC_WRITABLE_SHARE_MUST_HAVE_PASSWORD, the OCS
+    API is deprecated | '
 OCIS_SHOW_USER_EMAIL_IN_RESULTS:
   name: OCIS_SHOW_USER_EMAIL_IN_RESULTS
   defaultValue: "false"
@@ -9071,12 +8940,11 @@ OCIS_SHOW_USER_EMAIL_IN_RESULTS:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_SPACES_MAX_QUOTA:
-  name: OCIS_SPACES_MAX_QUOTA;STORAGE_USERS_OCIS_MAX_QUOTA
+  name: OCIS_SPACES_MAX_QUOTA;FRONTEND_MAX_QUOTA
   defaultValue: "0"
   type: uint64
-  description: Set a global max quota for spaces in bytes. A value of 0 equals unlimited.
-    If not using the global OCIS_SPACES_MAX_QUOTA, you must define the FRONTEND_MAX_QUOTA
-    in the frontend service.
+  description: Set the global max quota value in bytes. A value of 0 equals unlimited.
+    The value is provided via capabilities.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -9112,7 +8980,7 @@ OCIS_SYSTEM_USER_IDP:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_TRACING_COLLECTOR:
-  name: OCIS_TRACING_COLLECTOR;WEB_TRACING_COLLECTOR
+  name: OCIS_TRACING_COLLECTOR;USERS_TRACING_COLLECTOR
   defaultValue: ""
   type: string
   description: The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces.
@@ -9122,7 +8990,7 @@ OCIS_TRACING_COLLECTOR:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_TRACING_ENABLED:
-  name: OCIS_TRACING_ENABLED;WEB_TRACING_ENABLED
+  name: OCIS_TRACING_ENABLED;USERS_TRACING_ENABLED
   defaultValue: "false"
   type: bool
   description: Activates tracing.
@@ -9131,7 +8999,7 @@ OCIS_TRACING_ENABLED:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_TRACING_ENDPOINT:
-  name: OCIS_TRACING_ENDPOINT;WEB_TRACING_ENDPOINT
+  name: OCIS_TRACING_ENDPOINT;USERS_TRACING_ENDPOINT
   defaultValue: ""
   type: string
   description: The endpoint of the tracing agent.
@@ -9140,7 +9008,7 @@ OCIS_TRACING_ENDPOINT:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_TRACING_TYPE:
-  name: OCIS_TRACING_TYPE;WEB_TRACING_TYPE
+  name: OCIS_TRACING_TYPE;USERS_TRACING_TYPE
   defaultValue: ""
   type: string
   description: The type of tracing. Defaults to '', which is the same as 'jaeger'.
@@ -9159,7 +9027,7 @@ OCIS_TRANSFER_SECRET:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_TRANSLATION_PATH:
-  name: OCIS_TRANSLATION_PATH;NOTIFICATIONS_TRANSLATION_PATH
+  name: OCIS_TRANSLATION_PATH;USERLOG_TRANSLATION_PATH
   defaultValue: ""
   type: string
   description: (optional) Set this to a path with custom translations to overwrite
@@ -9170,10 +9038,11 @@ OCIS_TRANSLATION_PATH:
   removalVersion: ""
   deprecationInfo: ""
 OCIS_URL:
-  name: OCIS_URL;OCIS_OIDC_ISSUER;WEB_OIDC_AUTHORITY
+  name: OCIS_URL;OCIS_OIDC_ISSUER;USERS_IDP_URL
   defaultValue: https://localhost:9200
   type: string
-  description: URL of the OIDC issuer. It defaults to URL of the builtin IDP.
+  description: The identity provider value to set in the userids of the CS3 user objects
+    for users returned by this user provider.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -9516,16 +9385,6 @@ OCM_OCM_PROVIDER_AUTHORIZER_PROVIDERS_FILE:
   type: string
   description: Path to the JSON file where ocm invite data will be stored. Defaults
     to $OCIS_CONFIG_DIR/ocmproviders.json.
-  introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-OCM_OCM_PROVIDER_AUTHORIZER_VERIFY_REQUEST_HOSTNAME:
-  name: OCM_OCM_PROVIDER_AUTHORIZER_VERIFY_REQUEST_HOSTNAME
-  defaultValue: "true"
-  type: bool
-  description: Verify the hostname of the incoming request against the hostname of
-    the OCM provider.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
@@ -10346,32 +10205,32 @@ POSTPROCESSING_STEPS:
   removalVersion: ""
   deprecationInfo: ""
 POSTPROCESSING_STORE:
-  name: OCIS_PERSISTENT_STORE;POSTPROCESSING_STORE
+  name: OCIS_PERSISTENT_STORE;COLLABORATION_STORE
   defaultValue: nats-js-kv
   type: string
-  description: 'The type of the store. Supported values are: ''memory'', ''redis-sentinel'',
-    ''nats-js-kv'', ''noop''. See the text description for details.'
-  introductionVersion: pre5.0
+  description: 'The type of the store. Supported values are: ''memory'', ''nats-js-kv'',
+    ''redis-sentinel'', ''noop''. See the text description for details.'
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 POSTPROCESSING_STORE_AUTH_PASSWORD:
-  name: OCIS_PERSISTENT_STORE_AUTH_PASSWORD;POSTPROCESSING_STORE_AUTH_PASSWORD
+  name: OCIS_PERSISTENT_STORE_AUTH_PASSWORD;COLLABORATION_STORE_AUTH_PASSWORD
   defaultValue: ""
   type: string
   description: The password to authenticate with the store. Only applies when store
     type 'nats-js-kv' is configured.
-  introductionVersion: "5.0"
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 POSTPROCESSING_STORE_AUTH_USERNAME:
-  name: OCIS_PERSISTENT_STORE_AUTH_USERNAME;POSTPROCESSING_STORE_AUTH_USERNAME
+  name: OCIS_PERSISTENT_STORE_AUTH_USERNAME;COLLABORATION_STORE_AUTH_USERNAME
   defaultValue: ""
   type: string
   description: The username to authenticate with the store. Only applies when store
     type 'nats-js-kv' is configured.
-  introductionVersion: "5.0"
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -10385,25 +10244,14 @@ POSTPROCESSING_STORE_DATABASE:
   removalVersion: ""
   deprecationInfo: ""
 POSTPROCESSING_STORE_NODES:
-  name: OCIS_PERSISTENT_STORE_NODES;POSTPROCESSING_STORE_NODES
+  name: OCIS_PERSISTENT_STORE_NODES;COLLABORATION_STORE_NODES
   defaultValue: '[127.0.0.1:9233]'
   type: '[]string'
   description: A list of nodes to access the configured store. This has no effect
     when 'memory' store is configured. Note that the behaviour how nodes are used
     is dependent on the library of the configured store. See the Environment Variable
     Types description for more details.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-POSTPROCESSING_STORE_SIZE:
-  name: OCIS_PERSISTENT_STORE_SIZE;POSTPROCESSING_STORE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the store. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not exclicitly set as default.
-  introductionVersion: pre5.0
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -10417,12 +10265,12 @@ POSTPROCESSING_STORE_TABLE:
   removalVersion: ""
   deprecationInfo: ""
 POSTPROCESSING_STORE_TTL:
-  name: OCIS_PERSISTENT_STORE_TTL;POSTPROCESSING_STORE_TTL
-  defaultValue: 0s
+  name: OCIS_PERSISTENT_STORE_TTL;COLLABORATION_STORE_TTL
+  defaultValue: 30m0s
   type: Duration
-  description: Time to live for events in the store. See the Environment Variable
-    Types description for more details.
-  introductionVersion: pre5.0
+  description: Time to live for events in the store. Defaults to '30m' (30 minutes).
+    See the Environment Variable Types description for more details.
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -10879,17 +10727,6 @@ PROXY_OIDC_USERINFO_CACHE_DISABLE_PERSISTENCE:
   type: bool
   description: Disables persistence of the cache. Only applies when store type 'nats-js-kv'
     is configured. Defaults to false.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-PROXY_OIDC_USERINFO_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;PROXY_OIDC_USERINFO_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the user info cache. Only applies
-    when store type 'ocmem' is configured. Defaults to 512 which is derived from the
-    ocmem package though not explicitly set as default.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -11511,17 +11348,6 @@ SETTINGS_CACHE_DISABLE_PERSISTENCE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-SETTINGS_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;SETTINGS_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the cache. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not exclicitly set as default.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 SETTINGS_CACHE_STORE:
   name: OCIS_CACHE_STORE;SETTINGS_CACHE_STORE
   defaultValue: memory
@@ -11594,16 +11420,6 @@ SETTINGS_CORS_ALLOW_ORIGINS:
   description: 'A list of allowed CORS origins. See following chapter for more details:
     *Access-Control-Allow-Origin* at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin.
     See the Environment Variable Types description for more details.'
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-SETTINGS_DATA_PATH:
-  name: SETTINGS_DATA_PATH
-  defaultValue: /var/lib/ocis/settings
-  type: string
-  description: The directory where the filesystem storage will store ocis settings.
-    If not defined, the root directory derives from $OCIS_BASE_DATA_PATH:/settings.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -11776,21 +11592,11 @@ SETTINGS_STORAGE_GRPC_ADDR:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-SETTINGS_STORE_TYPE:
-  name: SETTINGS_STORE_TYPE
-  defaultValue: metadata
-  type: string
-  description: Store type configures the persistency driver. Supported values are
-    'metadata' and 'filesystem'. Note that the value 'filesystem' is considered deprecated.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 SETTINGS_SYSTEM_USER_ID:
-  name: OCIS_SYSTEM_USER_ID;SETTINGS_SYSTEM_USER_ID
+  name: OCIS_SYSTEM_USER_ID
   defaultValue: ""
   type: string
-  description: ID of the oCIS STORAGE-SYSTEM system user. Admins need to set the ID
+  description: ID of the oCIS storage-system system user. Admins need to set the ID
     for the STORAGE-SYSTEM system user in this config option which is then used to
     reference the user. Any reasonable long string is possible, preferably this would
     be an UUIDv4 format.
@@ -11799,7 +11605,7 @@ SETTINGS_SYSTEM_USER_ID:
   removalVersion: ""
   deprecationInfo: ""
 SETTINGS_SYSTEM_USER_IDP:
-  name: OCIS_SYSTEM_USER_IDP;SETTINGS_SYSTEM_USER_IDP
+  name: OCIS_SYSTEM_USER_IDP;SHARING_PUBLIC_CS3_SYSTEM_USER_IDP
   defaultValue: internal
   type: string
   description: IDP of the oCIS STORAGE-SYSTEM system user.
@@ -13083,17 +12889,6 @@ STORAGE_SYSTEM_CACHE_DISABLE_PERSISTENCE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-STORAGE_SYSTEM_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;STORAGE_SYSTEM_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the user info cache. Only applies
-    when store type 'ocmem' is configured. Defaults to 512 which is derived from the
-    ocmem package though not exclicitly set as default.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 STORAGE_SYSTEM_CACHE_STORE:
   name: OCIS_CACHE_STORE;STORAGE_SYSTEM_CACHE_STORE
   defaultValue: memory
@@ -13508,7 +13303,7 @@ STORAGE_USERS_DRIVER:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_EVENTS_AUTH_PASSWORD:
-  name: OCIS_EVENTS_AUTH_PASSWORD;STORAGE_USERS_EVENTS_AUTH_PASSWORD
+  name: OCIS_EVENTS_AUTH_PASSWORD;POLICIES_EVENTS_AUTH_PASSWORD
   defaultValue: ""
   type: string
   description: The password to authenticate with the events broker. The events broker
@@ -13518,7 +13313,7 @@ STORAGE_USERS_EVENTS_AUTH_PASSWORD:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_EVENTS_AUTH_USERNAME:
-  name: OCIS_EVENTS_AUTH_USERNAME;STORAGE_USERS_EVENTS_AUTH_USERNAME
+  name: OCIS_EVENTS_AUTH_USERNAME;POLICIES_EVENTS_AUTH_USERNAME
   defaultValue: ""
   type: string
   description: The username to authenticate with the events broker. The events broker
@@ -13528,7 +13323,7 @@ STORAGE_USERS_EVENTS_AUTH_USERNAME:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_EVENTS_CLUSTER:
-  name: OCIS_EVENTS_CLUSTER;STORAGE_USERS_EVENTS_CLUSTER
+  name: OCIS_EVENTS_CLUSTER;POLICIES_EVENTS_CLUSTER
   defaultValue: ocis-cluster
   type: string
   description: The clusterID of the event system. The event system is the message
@@ -13539,7 +13334,7 @@ STORAGE_USERS_EVENTS_CLUSTER:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_EVENTS_ENABLE_TLS:
-  name: OCIS_EVENTS_ENABLE_TLS;STORAGE_USERS_EVENTS_ENABLE_TLS
+  name: OCIS_EVENTS_ENABLE_TLS;POLICIES_EVENTS_ENABLE_TLS
   defaultValue: "false"
   type: bool
   description: Enable TLS for the connection to the events broker. The events broker
@@ -13549,7 +13344,7 @@ STORAGE_USERS_EVENTS_ENABLE_TLS:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_EVENTS_ENDPOINT:
-  name: OCIS_EVENTS_ENDPOINT;STORAGE_USERS_EVENTS_ENDPOINT
+  name: OCIS_EVENTS_ENDPOINT;POLICIES_EVENTS_ENDPOINT
   defaultValue: 127.0.0.1:9233
   type: string
   description: The address of the event system. The event system is the message queuing
@@ -13580,11 +13375,11 @@ STORAGE_USERS_EVENTS_TLS_INSECURE:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_EVENTS_TLS_ROOT_CA_CERTIFICATE:
-  name: OCIS_EVENTS_TLS_ROOT_CA_CERTIFICATE;STORAGE_USERS_EVENTS_TLS_ROOT_CA_CERTIFICATE
+  name: OCIS_EVENTS_TLS_ROOT_CA_CERTIFICATE;POLICIES_EVENTS_TLS_ROOT_CA_CERTIFICATE
   defaultValue: ""
   type: string
   description: The root CA certificate used to validate the server's TLS certificate.
-    If provided STORAGE_USERS_EVENTS_TLS_INSECURE will be seen as false.
+    If provided POLICIES_EVENTS_TLS_INSECURE will be seen as false.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -13600,27 +13395,27 @@ STORAGE_USERS_EXPOSE_DATA_SERVER:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_FILEMETADATA_CACHE_AUTH_PASSWORD:
-  name: OCIS_CACHE_AUTH_PASSWORD;STORAGE_USERS_FILEMETADATA_CACHE_AUTH_PASSWORD
+  name: OCIS_CACHE_AUTH_PASSWORD;STORAGE_SYSTEM_CACHE_AUTH_PASSWORD
   defaultValue: ""
   type: string
-  description: The password to authenticate with the cache store. Only applies when
-    store type 'nats-js-kv' is configured.
+  description: Password for the configured store. Only applies when store type 'nats-js-kv'
+    is configured.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_FILEMETADATA_CACHE_AUTH_USERNAME:
-  name: OCIS_CACHE_AUTH_USERNAME;STORAGE_USERS_FILEMETADATA_CACHE_AUTH_USERNAME
+  name: OCIS_CACHE_AUTH_USERNAME;STORAGE_SYSTEM_CACHE_AUTH_USERNAME
   defaultValue: ""
   type: string
-  description: The username to authenticate with the cache store. Only applies when
-    store type 'nats-js-kv' is configured.
+  description: Username for the configured store. Only applies when store type 'nats-js-kv'
+    is configured.
   introductionVersion: "5.0"
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_FILEMETADATA_CACHE_DISABLE_PERSISTENCE:
-  name: OCIS_CACHE_DISABLE_PERSISTENCE;STORAGE_USERS_FILEMETADATA_CACHE_DISABLE_PERSISTENCE
+  name: OCIS_CACHE_DISABLE_PERSISTENCE;STORAGE_SYSTEM_CACHE_DISABLE_PERSISTENCE
   defaultValue: "false"
   type: bool
   description: Disables persistence of the cache. Only applies when store type 'nats-js-kv'
@@ -13629,19 +13424,8 @@ STORAGE_USERS_FILEMETADATA_CACHE_DISABLE_PERSISTENCE:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-STORAGE_USERS_FILEMETADATA_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;STORAGE_USERS_FILEMETADATA_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the user info cache. Only applies
-    when store type 'ocmem' is configured. Defaults to 512 which is derived from the
-    ocmem package though not exclicitly set as default.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 STORAGE_USERS_FILEMETADATA_CACHE_STORE:
-  name: OCIS_CACHE_STORE;STORAGE_USERS_FILEMETADATA_CACHE_STORE
+  name: OCIS_CACHE_STORE;STORAGE_SYSTEM_CACHE_STORE
   defaultValue: memory
   type: string
   description: 'The type of the cache store. Supported values are: ''memory'', ''redis-sentinel'',
@@ -13651,7 +13435,7 @@ STORAGE_USERS_FILEMETADATA_CACHE_STORE:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES:
-  name: OCIS_CACHE_STORE_NODES;STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES
+  name: OCIS_CACHE_STORE_NODES;STORAGE_SYSTEM_CACHE_STORE_NODES
   defaultValue: '[127.0.0.1:9233]'
   type: '[]string'
   description: A list of nodes to access the configured store. This has no effect
@@ -13663,7 +13447,7 @@ STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_FILEMETADATA_CACHE_TTL:
-  name: OCIS_CACHE_TTL;STORAGE_USERS_FILEMETADATA_CACHE_TTL
+  name: OCIS_CACHE_TTL;STORAGE_SYSTEM_CACHE_TTL
   defaultValue: 24m0s
   type: Duration
   description: Default time to live for user info in the user info cache. Only applied
@@ -13674,11 +13458,11 @@ STORAGE_USERS_FILEMETADATA_CACHE_TTL:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_GATEWAY_GRPC_ADDR:
-  name: OCIS_GATEWAY_GRPC_ADDR;STORAGE_USERS_GATEWAY_GRPC_ADDR
+  name: OCIS_GATEWAY_GRPC_ADDR;GATEWAY_GRPC_ADDR
   defaultValue: 127.0.0.1:9142
   type: string
-  description: The bind address of the gateway GRPC address.
-  introductionVersion: "5.0"
+  description: The bind address of the GRPC service.
+  introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -13704,8 +13488,8 @@ STORAGE_USERS_GRPC_ADDR:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_GRPC_PROTOCOL:
-  name: OCIS_GRPC_PROTOCOL;STORAGE_USERS_GRPC_PROTOCOL
-  defaultValue: tcp
+  name: OCIS_GRPC_PROTOCOL;USERS_GRPC_PROTOCOL
+  defaultValue: ""
   type: string
   description: The transport protocol of the GPRC service.
   introductionVersion: pre5.0
@@ -13757,17 +13541,6 @@ STORAGE_USERS_ID_CACHE_DISABLE_PERSISTENCE:
   description: Disables persistence of the cache. Only applies when store type 'nats-js-kv'
     is configured. Defaults to false.
   introductionVersion: "5.0"
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-STORAGE_USERS_ID_CACHE_SIZE:
-  name: OCIS_CACHE_SIZE;STORAGE_USERS_ID_CACHE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the user info cache. Only applies
-    when store type 'ocmem' is configured. Defaults to 512 which is derived from the
-    ocmem package though not exclicitly set as default.
-  introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -13912,34 +13685,33 @@ STORAGE_USERS_OCIS_MAX_ACQUIRE_LOCK_CYCLES:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_OCIS_MAX_CONCURRENCY:
-  name: OCIS_MAX_CONCURRENCY;STORAGE_USERS_OCIS_MAX_CONCURRENCY
-  defaultValue: "5"
+  name: OCIS_MAX_CONCURRENCY;USERLOG_MAX_CONCURRENCY
+  defaultValue: "1"
   type: int
   description: Maximum number of concurrent go-routines. Higher values can potentially
     get work done faster but will also cause more load on the system. Values of 0
     or below will be ignored and the default value will be used.
-  introductionVersion: pre5.0
+  introductionVersion: 7.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_OCIS_MAX_QUOTA:
-  name: OCIS_SPACES_MAX_QUOTA;STORAGE_USERS_OCIS_MAX_QUOTA
+  name: OCIS_SPACES_MAX_QUOTA;FRONTEND_MAX_QUOTA
   defaultValue: "0"
   type: uint64
-  description: Set a global max quota for spaces in bytes. A value of 0 equals unlimited.
-    If not using the global OCIS_SPACES_MAX_QUOTA, you must define the FRONTEND_MAX_QUOTA
-    in the frontend service.
+  description: Set the global max quota value in bytes. A value of 0 equals unlimited.
+    The value is provided via capabilities.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_OCIS_PERMISSIONS_ENDPOINT:
-  name: STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_OCIS_PERMISSIONS_ENDPOINT
+  name: STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_POSIX_PERMISSIONS_ENDPOINT
   defaultValue: com.owncloud.api.settings
   type: string
-  description: Endpoint of the permissions service. The endpoints can differ for 'ocis'
-    and 's3ng'.
-  introductionVersion: pre5.0
+  description: Endpoint of the permissions service. The endpoints can differ for 'ocis',
+    'posix' and 's3ng'.
+  introductionVersion: 6.0.0
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
@@ -13962,7 +13734,7 @@ STORAGE_USERS_OCIS_PERSONAL_SPACE_PATH_TEMPLATE:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_OCIS_PROPAGATOR:
-  name: OCIS_DECOMPOSEDFS_PROPAGATOR;STORAGE_USERS_OCIS_PROPAGATOR
+  name: OCIS_DECOMPOSEDFS_PROPAGATOR;STORAGE_USERS_S3NG_PROPAGATOR
   defaultValue: sync
   type: string
   description: The propagator used for decomposedfs. At the moment, only 'sync' is
@@ -14132,7 +13904,7 @@ STORAGE_USERS_POSIX_PERSONAL_SPACE_PATH_TEMPLATE:
   deprecationInfo: ""
 STORAGE_USERS_POSIX_ROOT:
   name: STORAGE_USERS_POSIX_ROOT
-  defaultValue: ""
+  defaultValue: /var/lib/ocis/storage/users
   type: string
   description: The directory where the filesystem storage will store its data. If
     not defined, the root directory derives from $OCIS_BASE_DATA_PATH/storage/users.
@@ -14313,18 +14085,6 @@ STORAGE_USERS_S3NG_MAX_CONCURRENCY:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-STORAGE_USERS_S3NG_METADATA_BACKEND:
-  name: STORAGE_USERS_S3NG_METADATA_BACKEND
-  defaultValue: messagepack
-  type: string
-  description: The backend to use for storing metadata. Supported values are 'xattrs'
-    and 'messagepack'. The setting 'xattrs' uses extended attributes to store file
-    metadata while 'messagepack' uses a dedicated file to store file metadata. Defaults
-    to 'xattrs'.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 STORAGE_USERS_S3NG_PERMISSIONS_ENDPOINT:
   name: STORAGE_USERS_PERMISSION_ENDPOINT;STORAGE_USERS_S3NG_PERMISSIONS_ENDPOINT
   defaultValue: com.owncloud.api.settings
@@ -14464,7 +14224,7 @@ STORAGE_USERS_S3NG_USER_LAYOUT:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_SERVICE_ACCOUNT_ID:
-  name: OCIS_SERVICE_ACCOUNT_ID;STORAGE_USERS_SERVICE_ACCOUNT_ID
+  name: OCIS_SERVICE_ACCOUNT_ID;SEARCH_SERVICE_ACCOUNT_ID
   defaultValue: ""
   type: string
   description: The ID of the service account the service should use. See the 'auth-service'
@@ -14474,7 +14234,7 @@ STORAGE_USERS_SERVICE_ACCOUNT_ID:
   removalVersion: ""
   deprecationInfo: ""
 STORAGE_USERS_SERVICE_ACCOUNT_SECRET:
-  name: OCIS_SERVICE_ACCOUNT_SECRET;STORAGE_USERS_SERVICE_ACCOUNT_SECRET
+  name: OCIS_SERVICE_ACCOUNT_SECRET;SEARCH_SERVICE_ACCOUNT_SECRET
   defaultValue: ""
   type: string
   description: The service account secret.
@@ -15155,17 +14915,6 @@ USERLOG_STORE_NODES:
     when 'memory' store is configured. Note that the behaviour how nodes are used
     is dependent on the library of the configured store. See the Environment Variable
     Types description for more details.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-USERLOG_STORE_SIZE:
-  name: OCIS_PERSISTENT_STORE_SIZE;USERLOG_STORE_SIZE
-  defaultValue: "0"
-  type: int
-  description: The maximum quantity of items in the store. Only applies when store
-    type 'ocmem' is configured. Defaults to 512 which is derived from the ocmem package
-    though not exclicitly set as default.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""
@@ -16104,18 +15853,6 @@ WEB_OPTION_DISABLE_FEEDBACK_LINK:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-WEB_OPTION_DISABLE_PREVIEWS:
-  name: OCIS_DISABLE_PREVIEWS;WEB_OPTION_DISABLE_PREVIEWS
-  defaultValue: "false"
-  type: bool
-  description: Set this option to 'true' to disable previews in all the different
-    web file listing views. This can speed up file listings in folders with many files.
-    The only list view that is not affected by this setting is the trash bin, as it
-    does not allow previewing at all.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 WEB_OPTION_DISABLED_EXTENSIONS:
   name: WEB_OPTION_DISABLED_EXTENSIONS
   defaultValue: '[]'
@@ -16190,32 +15927,6 @@ WEB_OPTION_EMBED_TARGET:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-WEB_OPTION_HOME_FOLDER:
-  name: WEB_OPTION_HOME_FOLDER
-  defaultValue: ""
-  type: string
-  description: Specifies a folder that is used when the user navigates 'home'. Navigating
-    home gets triggered by clicking on the 'All files' menu item. The user will not
-    be jailed in that directory, it simply serves as a default location. A static
-    location can be provided, or variables of the user object to come up with a user
-    specific home path can be used. This uses the twig template variable style and
-    allows picking a value or a substring of a value of the authenticated user. Examples
-    are '/Shares', '/{{.Id}}' and '/{{substr 0 3 .Id}}/{{.Id}'.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-WEB_OPTION_HOVERABLE_QUICK_ACTIONS:
-  name: WEB_OPTION_HOVERABLE_QUICK_ACTIONS
-  defaultValue: "false"
-  type: bool
-  description: Set this option to 'true' to hide quick actions (buttons appearing
-    on file rows) and only show them when the user hovers over the row with his mouse.
-    Defaults to 'false'.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 WEB_OPTION_LOGIN_URL:
   name: WEB_OPTION_LOGIN_URL
   defaultValue: ""
@@ -16247,67 +15958,12 @@ WEB_OPTION_OPEN_APPS_IN_TAB:
   deprecationVersion: ""
   removalVersion: ""
   deprecationInfo: ""
-WEB_OPTION_OPEN_LINKS_WITH_DEFAULT_APP:
-  name: WEB_OPTION_OPEN_LINKS_WITH_DEFAULT_APP
-  defaultValue: "true"
-  type: bool
-  description: Specifies whether single file link shares should be opened with the
-    default app or not. If not opened by the default app, the Web UI just displays
-    the file details.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-WEB_OPTION_PREVIEW_FILE_MIMETYPES:
-  name: WEB_OPTION_PREVIEW_FILE_MIMETYPES
-  defaultValue: '[image/gif image/png image/jpeg text/plain image/tiff image/bmp image/x-ms-bmp
-    application/vnd.geogebra.slides]'
-  type: '[]string'
-  description: A list of mimeTypes to specify which ones will be previewed in the
-    UI. For example, to only preview jpg and text files, set this option to 'image/jpeg,text/plain'.
-    See the Environment Variable Types description for more details.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-WEB_OPTION_ROUTING_ID_BASED:
-  name: WEB_OPTION_ROUTING_ID_BASED
-  defaultValue: "true"
-  type: bool
-  description: 'Enable or disable fileIds being added to the URL. Defaults to ''true'',
-    because otherwise spaces with name clashes cannot be resolved correctly. Note:
-    Only disable this if you can guarantee on the server side, that spaces of the
-    same namespace cannot have name clashes.'
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
 WEB_OPTION_RUNNING_ON_EOS:
   name: WEB_OPTION_RUNNING_ON_EOS
   defaultValue: "false"
   type: bool
   description: Set this option to 'true' if running on an EOS storage backend (https://eos-web.web.cern.ch/eos-web/)
     to enable its specific features. Defaults to 'false'.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-WEB_OPTION_SHARING_RECIPIENTS_PER_PAGE:
-  name: WEB_OPTION_SHARING_RECIPIENTS_PER_PAGE
-  defaultValue: "200"
-  type: int
-  description: Sets the number of users shown as recipients in the dropdown menu when
-    sharing resources.
-  introductionVersion: pre5.0
-  deprecationVersion: ""
-  removalVersion: ""
-  deprecationInfo: ""
-WEB_OPTION_SIDEBAR_SHARES_SHOW_ALL_ON_LOAD:
-  name: WEB_OPTION_SIDEBAR_SHARES_SHOW_ALL_ON_LOAD
-  defaultValue: "false"
-  type: bool
-  description: Sets the list of the (link) shares list in the sidebar to be initially
-    expanded. Default is a collapsed state, only showing the first three shares.
   introductionVersion: pre5.0
   deprecationVersion: ""
   removalVersion: ""


### PR DESCRIPTION
For an "unknown" reason, we needed to recreate the `env_vars.yaml` file because new deprecations did not show up.

Discussed with @dragonchaser 