### PR TITLE
fix(graph): Allow to combine $search and $filter in users query

### DIFF
--- a/services/graph/pkg/identity/ldap_education_class.go
+++ b/services/graph/pkg/identity/ldap_education_class.go
@@ -239,7 +239,7 @@ func (i *LDAP) GetEducationClassMembers(ctx context.Context, id string) ([]*libr
 		return nil, err
 	}
 
-	memberEntries, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member)
+	memberEntries, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member, "")
 	result := make([]*libregraph.EducationUser, 0, len(memberEntries))
 	if err != nil {
 		return nil, err
@@ -366,7 +366,7 @@ func (i *LDAP) GetEducationClassTeachers(ctx context.Context, classID string) ([
 		return nil, err
 	}
 
-	teacherEntries, err := i.expandLDAPAttributeEntries(ctx, class, i.educationConfig.classAttributeMap.teachers)
+	teacherEntries, err := i.expandLDAPAttributeEntries(ctx, class, i.educationConfig.classAttributeMap.teachers, "")
 	result := make([]*libregraph.EducationUser, 0, len(teacherEntries))
 	if err != nil {
 		return nil, err

--- a/services/graph/pkg/identity/ldap_group.go
+++ b/services/graph/pkg/identity/ldap_group.go
@@ -38,7 +38,7 @@ func (i *LDAP) GetGroup(ctx context.Context, nameOrID string, queryParam url.Val
 		return nil, errorcode.New(errorcode.ItemNotFound, "not found")
 	}
 	if slices.Contains(sel, "members") || slices.Contains(exp, "members") {
-		members, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member)
+		members, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member, "")
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +123,7 @@ func (i *LDAP) GetGroups(ctx context.Context, oreq *godata.GoDataRequest) ([]*li
 			continue
 		}
 		if expandMembers {
-			members, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member)
+			members, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member, "")
 			if err != nil {
 				return nil, err
 			}
@@ -156,7 +156,12 @@ func (i *LDAP) GetGroupMembers(ctx context.Context, groupID string, req *godata.
 		return nil, err
 	}
 
-	memberEntries, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member)
+	searchTerm, err := GetSearchValues(req.Query)
+	if err != nil {
+		return nil, err
+	}
+
+	memberEntries, err := i.expandLDAPAttributeEntries(ctx, e, i.groupAttributeMap.member, searchTerm)
 	result := make([]*libregraph.User, 0, len(memberEntries))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the 'graph/v1.0/users' endpoint to allow a combination of a memberOf filter in $filter with a search string in $search.

Allowing queries like:

```
$filter=(memberOf/any(m:m/id eq 509a9dcd-bb37-4f4f-a01a-19dca27d9cfa))&$search="example"
```

Fixes: https://github.com/owncloud/enterprise/issues/6600