### PR TITLE
[full-ci] chore: bump web to v11.0.5

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=3088a7d9a353ebf5e128d9d784b28fb103a30a40
+WEB_COMMITID=0cd1e233374c302bc1c8f0db91bb62d6244cbd09
 WEB_BRANCH=stable-11.0

--- a/changelog/unreleased/update-web-11.0.5.md
+++ b/changelog/unreleased/update-web-11.0.5.md
@@ -1,0 +1,11 @@
+Enhancement: Update web to v11.0.5
+
+Tags: web
+
+We updated ownCloud Web to v11.0.5. Please refer to the changelog (linked) for details on the web release.
+
+- Bugfix [owncloud/web#11883](https://github.com/owncloud/web/issues/11883): Preview app Shared with me page
+- Bugfix [owncloud/web#11951](https://github.com/owncloud/web/pull/11951): Export request ID when delete fails
+
+https://github.com/owncloud/ocis/pull/10667
+https://github.com/owncloud/web/releases/tag/v11.0.5

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v11.0.4
+WEB_ASSETS_VERSION = v11.0.5
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
- Bugfix [owncloud/web#11883](https://github.com/owncloud/web/issues/11883): Preview app Shared with me page
- Bugfix [owncloud/web#11951](https://github.com/owncloud/web/pull/11951): Export request ID when delete fails