### PR TITLE
[docs-only] Show more info in deprecation table

### DIFF
--- a/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-added.adoc
+++ b/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-added.adoc
@@ -6,7 +6,7 @@
 
 [width="100%",cols="~,~,~,~",options="header"]
 |===
-| Service| Variable| Description| Default
+| Service | Variable | Description | Default
 
 | xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
 | OCIS_ASSET_THEMES_PATH

--- a/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-deprecated.adoc
+++ b/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-deprecated.adoc
@@ -4,89 +4,99 @@
 // table created per 2024.11.26
 // the table should be recreated/updated on source () changes
 
-[width="100%",cols="~,~,~,~",options="header"]
+[width="100%",cols="~,~,~,~,~",options="header"]
 |===
-| Service| Variable| Description| Removalversion
-
-| xref:{s-path}/antivirus.adoc[Antivirus]
-| ANTIVIRUS_ICAP_TIMEOUT
-| Timeout for the ICAP client.
-| %%NEXT_PRODUCTION_VERSION%%
+| Service | Variable | Description | Removal Version | Deprecation Info
 
 | xref:{s-path}/clientlog.adoc[Clientlog]
 | CLIENTLOG_REVA_GATEWAY
 | CS3 gateway used to look up user metadata
 | %%NEXT_PRODUCTION_VERSION%%
+| CLIENTLOG_REVA_GATEWAY removed for simplicity.
 
 | xref:{s-path}/frontend.adoc[Frontend]
 | FRONTEND_OCS_ADDITIONAL_INFO_ATTRIBUTE
 | Additional information attribute for the user like {{.Mail}}.
 | %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
 
 | 
 | FRONTEND_OCS_ENABLE_DENIALS
 | EXPERIMENTAL: enable the feature to deny access on folders.
 | %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
 
 | 
 | FRONTEND_OCS_INCLUDE_OCM_SHAREES
 | Include OCM sharees when listing sharees.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_INCLUDE_OCM_SHAREES, the OCS API is deprecated
 
 | 
 | FRONTEND_OCS_LIST_OCM_SHARES
 | Include OCM shares when listing shares. See the OCM service documentation for more details.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_LIST_OCM_SHARES, the OCS API is deprecated
 
 | 
 | FRONTEND_OCS_PERSONAL_NAMESPACE
 | Home namespace identifier.
 | %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
 
 | 
 | FRONTEND_OCS_PREFIX
 | URL path prefix for the OCS service. Note that the string must not start with '/'.
 | %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
 
 | 
 | FRONTEND_OCS_SHARE_PREFIX
 | Path prefix for shares as part of an ocis resource. Note that the path must start with '/'.
 | %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
 
 | 
 | FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD
 | The password to use for authentication. Only applies when using the 'nats-js-kv' store type.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD, the OCS API is deprecated
 
 | 
 | FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME
 | The username to use for authentication. Only applies when using the 'nats-js-kv' store type.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME, the OCS API is deprecated
 
 | 
 | FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE
 | Disable persistence of the cache. Only applies when using the 'nats-js-kv' store type. Defaults to false.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE, the OCS API is deprecated
 
 | 
 | FRONTEND_OCS_STAT_CACHE_STORE
 | The type of the cache store. Supported values are: 'memory', 'redis-sentinel', 'nats-js-kv', 'noop'. See the text description for details.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_STORE, the OCS API is deprecated
 
 | 
 | FRONTEND_OCS_STAT_CACHE_STORE_NODES
 | A list of nodes to access the configured store. This has no effect when 'memory' store is configured. Note that the behaviour how nodes are used is dependent on the library of the configured store. See the Environment Variable Types description for more details.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_STORE_NODES, the OCS API is deprecated
 
 | 
 | FRONTEND_OCS_STAT_CACHE_TABLE
 | The database table the store should use.
 | %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
 
 | 
 | FRONTEND_OCS_STAT_CACHE_TTL
 | Default time to live for user info in the cache. Only applied when access tokens has no expiration. See the Environment Variable Types description for more details.
 | %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_TTL, the OCS API is deprecated
 
 |===
 

--- a/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-removed.adoc
+++ b/docs/services/general-info/env-var-deltas/5.0.0-7.0.0-removed.adoc
@@ -6,7 +6,7 @@
 
 [width="100%",cols="~,~,~,~",options="header"]
 |===
-| Service| Variable| Description| Default
+| Service | Variable | Description | Default
 
 | xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
 | OCIS_CACHE_SIZE


### PR DESCRIPTION
The table containing deprecations did not contain additional info like the reason for the deprecation (deprecationInfo). This is now fixed and the table updated.