### PR TITLE
[tests-only][full-ci] fix tests for reva

### DIFF
--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -45,6 +45,8 @@ class GraphHelper {
 		'Space Editor Without Versions' => '3284f2d5-0070-4ad8-ac40-c247f7c1fb27',
 	];
 
+	public const SHARES_SPACE_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668';
+
 	/**
 	 * @return string[]
 	 */

--- a/tests/acceptance/TestHelpers/WebDavHelper.php
+++ b/tests/acceptance/TestHelpers/WebDavHelper.php
@@ -520,30 +520,25 @@ class WebDavHelper {
 		if (\array_key_exists($user, self::$spacesIdRef) && \array_key_exists("personal", self::$spacesIdRef[$user])) {
 			return self::$spacesIdRef[$user]["personal"];
 		}
-		$trimmedBaseUrl = \trim($baseUrl, "/");
-		$drivesPath = '/graph/v1.0/me/drives';
-		$fullUrl = $trimmedBaseUrl . $drivesPath;
-		$response = HttpRequestHelper::get(
-			$fullUrl,
-			$xRequestId,
-			$user,
-			$password
-		);
-		Assert::assertEquals(200, $response->getStatusCode(), "Cannot list drives for user '$user'");
 
 		$personalSpaceId = '';
-		$drives = HttpRequestHelper::getJsonDecodedResponseBodyContent($response);
-		foreach ($drives->value as $drive) {
-			if ($drive->driveType === "personal") {
-				$personalSpaceId = $drive->id;
-				break;
+		if (!OcisHelper::isTestingOnReva()) {
+			$response = GraphHelper::getMySpaces($baseUrl, $user, $password, '', $xRequestId);
+			Assert::assertEquals(200, $response->getStatusCode(), "Cannot list drives for user '$user'");
+
+			$drives = HttpRequestHelper::getJsonDecodedResponseBodyContent($response);
+			foreach ($drives->value as $drive) {
+				if ($drive->driveType === "personal") {
+					$personalSpaceId = $drive->id;
+					break;
+				}
 			}
 		}
 
 		if (!$personalSpaceId) {
 			// the graph endpoint did not give a useful answer
 			// try getting the information from the webdav endpoint
-			$fullUrl = "$trimmedBaseUrl/" . self::getDavPath(self::DAV_VERSION_NEW, $user);
+			$fullUrl = "$baseUrl/" . self::getDavPath(self::DAV_VERSION_NEW, $user);
 			$response = HttpRequestHelper::sendRequest(
 				$fullUrl,
 				$xRequestId,

--- a/tests/acceptance/bootstrap/AuthContext.php
+++ b/tests/acceptance/bootstrap/AuthContext.php
@@ -24,7 +24,6 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
-use TestHelpers\SetupHelper;
 use TestHelpers\BehatHelper;
 use TestHelpers\WebDavHelper;
 
@@ -596,12 +595,12 @@ class AuthContext implements Context {
 		$headers = [];
 		if ($method === 'MOVE' || $method === 'COPY') {
 			$baseUrl = $this->featureContext->getBaseUrl();
-			$suffix = "";
+			$suffix = $user;
 			if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
-				$suffix = $this->featureContext->spacesContext->getSpaceIdByName($user, "Personal");
+				$suffix = $this->featureContext->getPersonalSpaceIdForUser($user);
 			}
-			$davPath = WebDavHelper::getDavPath($this->featureContext->getDavPathVersion(), $user);
-			$headers['Destination'] = "$baseUrl/$davPath/$suffix/moved";
+			$davPath = WebDavHelper::getDavPath($this->featureContext->getDavPathVersion(), $suffix);
+			$headers['Destination'] = "$baseUrl/$davPath/moved";
 		}
 
 		foreach ($table->getHash() as $row) {

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -207,7 +207,6 @@ class FeatureContext extends BehatVariablesContext {
 		$this->autoSyncSettings[$user] = $value;
 	}
 
-	public const SHARES_SPACE_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668';
 	private bool $useSharingNG = false;
 
 	/**

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -1794,31 +1794,18 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then user :sharee should have a share :share shared by user :sharer from space :space
+	 * @Then /^user "([^"]*)" (should|should not) have a share "([^"]*)" shared by user "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $sharee
+	 * @param string $shouldOrNot
 	 * @param string $share
 	 * @param string $sharer
 	 * @param string $space
 	 *
 	 * @return void
 	 */
-	public function userShouldHaveShareSharedByUserFromSpace(string $sharee, string $share, string $sharer, string $space): void {
-		$this->checkIfShareExists($share, $sharee, $sharer, $space);
-	}
-
-	/**
-	 * @Then user :sharee should not have a share :share shared by user :sharer from space :space
-	 *
-	 * @param string $sharee
-	 * @param string $share
-	 * @param string $sharer
-	 * @param string $space
-	 *
-	 * @return void
-	 */
-	public function userShouldNotHaveShareSharedByUserFromSpace(string $sharee, string $share, string $sharer, string $space): void {
-		$this->checkIfShareExists($share, $sharee, $sharer, $space, false);
+	public function userShouldHaveShareSharedByUserFromSpace(string $sharee, string $shouldOrNot, string $share, string $sharer, string $space): void {
+		$this->checkIfShareExists($share, $sharee, $sharer, $space, $shouldOrNot === "should");
 	}
 
 	/**

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -1139,36 +1139,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then /^for user "([^"]*)" the space Shares should (not|)\s?contain these (files|entries):$/
-	 *
-	 * @param string $user
-	 * @param string $shouldOrNot
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function forUserTheSpaceSharesShouldContainTheseEntries(string $user, string $shouldOrNot, TableNode $table): void {
-		$should = $shouldOrNot !== 'not';
-		$rows = $table->getRows();
-		$response = GraphHelper::getSharesSharedWithMe(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getStepLineRef(),
-			$user,
-			$this->featureContext->getPasswordForUser($user)
-		);
-		$contents = \json_decode($response->getBody()->getContents(), true);
-
-		$fileFound = empty(array_diff(array_map(fn ($row) => trim($row[0], '/'), $rows), array_column($contents['value'], 'name')));
-
-		$assertMessage = $should
-			? "Response does not contain the entry."
-			: "Response does contain the entry but should not.";
-
-		Assert::assertSame($should, $fileFound, $assertMessage);
-	}
-
-	/**
 	 * @Given user :user has disabled sync of last shared resource
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -22,7 +22,7 @@ Feature: Send a sharing invitations
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "<resource>" shared by user "Alice"
+    And user "Brian" should have a share "<resource>" shared by user "Alice" from space "Personal"
     And the JSON data of the response should match
       """
       {
@@ -111,9 +111,8 @@ Feature: Send a sharing invitations
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "<resource>" shared by user "Alice"
-    And for user "Carol" the space Shares should contain these entries:
-      | <resource> |
+    And user "Brian" should have a share "<resource>" shared by user "Alice" from space "Personal"
+    And user "Carol" should have a share "<resource>" shared by user "Alice" from space "Personal"
     And the JSON data of the response should match
       """
       {
@@ -1901,8 +1900,7 @@ Feature: Send a sharing invitations
       | shareType       | user     |
       | permissionsRole | Viewer   |
     Then the HTTP status code should be "404"
-    And for user "Brian" the space Shares should not contain these entries:
-      | textfile1.txt |
+    And user "Brian" should not have a share "textfile1.txt" shared by user "Alice" from space "Personal"
     And the JSON data of the response should match
       """
       {
@@ -1947,10 +1945,8 @@ Feature: Send a sharing invitations
       | shareType       | group    |
       | permissionsRole | Viewer   |
     Then the HTTP status code should be "404"
-    And for user "Brian" the space Shares should not contain these entries:
-      | textfile1.txt |
-    And for user "Carol" the space Shares should not contain these entries:
-      | textfile1.txt |
+    And user "Brian" should not have a share "textfile1.txt" shared by user "Alice" from space "Personal"
+    And user "Carol" should not have a share "textfile1.txt" shared by user "Alice" from space "Personal"
     And the JSON data of the response should match
       """
       {
@@ -1992,7 +1988,7 @@ Feature: Send a sharing invitations
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "<resource>" shared by user "Alice"
+    And user "Brian" should have a share "<resource>" shared by user "Alice" from space "NewSpace"
     And the JSON data of the response should match
       """
       {
@@ -2079,9 +2075,8 @@ Feature: Send a sharing invitations
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "<resource>" shared by user "Alice"
-    And for user "Carol" the space Shares should contain these entries:
-      | <resource> |
+    And user "Brian" should have a share "<resource>" shared by user "Alice" from space "NewSpace"
+    And user "Carol" should have a share "<resource>" shared by user "Alice" from space "NewSpace"
     And the JSON data of the response should match
       """
       {
@@ -2240,10 +2235,10 @@ Feature: Send a sharing invitations
       }
       """
     Examples:
-      | permissions-role | error-message                                                                                      |
-      | Space Viewer     | role not applicable to this resource                                                               |
-      | Space Editor     | role not applicable to this resource                                                               |
-      | Manager          | role not applicable to this resource                                                               |
+      | permissions-role | error-message                        |
+      | Space Viewer     | role not applicable to this resource |
+      | Space Editor     | role not applicable to this resource |
+      | Manager          | role not applicable to this resource |
 
 
   Scenario Outline: try to send share invitation with different re-sharing permissions
@@ -3115,7 +3110,7 @@ Feature: Send a sharing invitations
       | shareType       | user         |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "<resource>" shared by user "Alice"
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "Personal"
     When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | Personal     |
@@ -3123,8 +3118,7 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And for user "Carol" the space Shares should contain these entries:
-      | textfile.txt |
+    And user "Carol" should have a share "textfile.txt" shared by user "Alice" from space "Personal"
 
 
   Scenario: share a file to group containing special characters in name (Personal space)
@@ -3140,7 +3134,7 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "textfile.txt" shared by user "Alice"
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "Personal"
 
 
   Scenario: share a file to user and group having same name (Project space)
@@ -3160,7 +3154,7 @@ Feature: Send a sharing invitations
       | shareType       | user         |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "textfile.txt" shared by user "Alice"
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "NewSpace"
     When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | NewSpace     |
@@ -3168,8 +3162,7 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And for user "Carol" the space Shares should contain these entries:
-      | textfile.txt |
+    And user "Carol" should have a share "textfile.txt" shared by user "Alice" from space "NewSpace"
 
 
   Scenario: share a file to group containing special characters in name (Project space)
@@ -3188,4 +3181,4 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "textfile.txt" shared by user "Alice"
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "NewSpace"

--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -22,8 +22,7 @@ Feature: Send a sharing invitations
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | <resource> |
+    And user "Brian" should have a share "<resource>" shared by user "Alice"
     And the JSON data of the response should match
       """
       {
@@ -112,8 +111,7 @@ Feature: Send a sharing invitations
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | <resource> |
+    And user "Brian" should have a share "<resource>" shared by user "Alice"
     And for user "Carol" the space Shares should contain these entries:
       | <resource> |
     And the JSON data of the response should match
@@ -1994,8 +1992,7 @@ Feature: Send a sharing invitations
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | <resource> |
+    And user "Brian" should have a share "<resource>" shared by user "Alice"
     And the JSON data of the response should match
       """
       {
@@ -2082,8 +2079,7 @@ Feature: Send a sharing invitations
       | shareType       | group              |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | <resource> |
+    And user "Brian" should have a share "<resource>" shared by user "Alice"
     And for user "Carol" the space Shares should contain these entries:
       | <resource> |
     And the JSON data of the response should match
@@ -3119,8 +3115,7 @@ Feature: Send a sharing invitations
       | shareType       | user         |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | textfile.txt |
+    And user "Brian" should have a share "<resource>" shared by user "Alice"
     When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | Personal     |
@@ -3145,8 +3140,7 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | textfile.txt |
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice"
 
 
   Scenario: share a file to user and group having same name (Project space)
@@ -3166,8 +3160,7 @@ Feature: Send a sharing invitations
       | shareType       | user         |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | textfile.txt |
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice"
     When user "Alice" sends the following resource share invitation using the Graph API:
       | resource        | textfile.txt |
       | space           | NewSpace     |
@@ -3195,5 +3188,4 @@ Feature: Send a sharing invitations
       | shareType       | group        |
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
-    And for user "Brian" the space Shares should contain these entries:
-      | textfile.txt |
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice"

--- a/tests/acceptance/features/apiSpacesShares/copySpaces.feature
+++ b/tests/acceptance/features/apiSpacesShares/copySpaces.feature
@@ -714,7 +714,7 @@ Feature: copy file
     And as "Brian" folder "BRIAN-Folder/sample-folder" should exist
     But as "Alice" file "Shares/BRIAN-Folder" should not exist
     And as "Alice" file "Shares/textfile1.txt" should not exist
-    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian"
+    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian" from space "Personal"
 
   @issue-7208
   Scenario: copy a folder over the top of an existing file received as a user share
@@ -734,7 +734,7 @@ Feature: copy file
     And for user "Alice" the content of the file "sharedfile1.txt" of the space "Shares" should be "file to share"
     And for user "Brian" the content of the file "sharedfile1.txt" of the space "Personal" should be "file to share"
     But as "Alice" folder "Shares/FOLDER/sample-folder" should not exist
-    And user "Alice" should have a share "sharedfile1.txt" shared by user "Brian"
+    And user "Alice" should have a share "sharedfile1.txt" shared by user "Brian" from space "Personal"
 
 
   Scenario: copy a folder into another folder at different level which is received as a user share

--- a/tests/acceptance/features/coreApiAuth/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/coreApiAuth/webDavMKCOLAuth.feature
@@ -71,7 +71,7 @@ Feature: create folder using MKCOL
       | /dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
-  @issue-5049  @issue-1347 @issue-1292
+  @issue-5049 @issue-1347 @issue-1292
   Scenario: send MKCOL requests to non-existent user's webDav endpoints as normal user using the spaces WebDAV API
     Given user "Brian" has been created with default attributes
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "non-existent-user"

--- a/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature
@@ -218,7 +218,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @issue-3561
   Scenario Outline: listing non-existent user's trashbin is prohibited
     Given using <dav-path-version> DAV path
-    When user "Alice" tries to list the trashbin content for user "testtrashbinnotauser"
+    When user "Alice" tries to list the trashbin content for user "nonexistent"
     Then the HTTP status code should be "404"
     Examples:
       | dav-path-version |

--- a/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/copyFile.feature
@@ -233,7 +233,7 @@ Feature: copy file
     Then the HTTP status code should be "400"
     And as "Alice" folder "/Shares/BRIAN-Folder/sample-folder" should exist
     And as "Alice" file "/Shares/BRIAN-Folder" should not exist
-    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian"
+    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian" from space "Personal"
     And as "Brian" folder "BRIAN-Folder" should exist
     Examples:
       | dav-path-version |
@@ -257,7 +257,7 @@ Feature: copy file
     When user "Alice" copies file "copy.txt" to "Shares/lorem.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "Shares/lorem.txt" for user "Alice" should be "file to copy"
-    And user "Alice" should have a share "lorem.txt" shared by user "Brian"
+    And user "Alice" should have a share "lorem.txt" shared by user "Brian" from space "Personal"
     And the content of file "lorem.txt" for user "Brian" should be "file to copy"
     Examples:
       | dav-path-version |
@@ -282,7 +282,7 @@ Feature: copy file
     Then the HTTP status code should be "400"
     And the content of file "Shares/sharedfile1.txt" for user "Alice" should be "file to share"
     And as "Alice" folder "/Shares/sharedfile1.txt" should not exist
-    And user "Alice" should have a share "sharedfile1.txt" shared by user "Brian"
+    And user "Alice" should have a share "sharedfile1.txt" shared by user "Brian" from space "Personal"
     And the content of file "sharedfile1.txt" for user "Brian" should be "file to share"
     Examples:
       | dav-path-version |
@@ -308,7 +308,7 @@ Feature: copy file
     Then the HTTP status code should be "400"
     And as "Alice" folder "Shares/BRIAN-Folder/brian-folder" should exist
     And as "Alice" folder "Shares/BRIAN-Folder/alice-folder" should not exist
-    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian"
+    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian" from space "Personal"
     And as "Brian" folder "BRIAN-Folder" should exist
     Examples:
       | dav-path-version |
@@ -460,7 +460,7 @@ Feature: copy file
     Then the HTTP status code should be "400"
     And as "Alice" folder "/Shares/BRIAN-Folder/sample-folder" should exist
     And as "Alice" file "/Shares/BRIAN-Folder" should not exist
-    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian"
+    And user "Alice" should have a share "BRIAN-Folder" shared by user "Brian" from space "Personal"
     And as "Brian" folder "BRIAN-Folder/sample-folder" should exist
     Examples:
       | dav-path-version |
@@ -488,7 +488,7 @@ Feature: copy file
     Then the HTTP status code should be "400"
     And as "Alice" file "/Shares/sharedfile1.txt" should exist
     And as "Alice" folder "/Shares/sharedfile1.txt" should not exist
-    And user "Alice" should have a share "sharedfile1.txt" shared by user "Brian"
+    And user "Alice" should have a share "sharedfile1.txt" shared by user "Brian" from space "Personal"
     And as "Brian" file "sharedfile1.txt" should exist
     Examples:
       | dav-path-version |

--- a/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/setFileProperties.feature
@@ -61,7 +61,7 @@ Feature: set file properties
       | new              |
       | spaces           |
 
-  @issue-1297
+  @skipOnReva @issue-1297
   Scenario Outline: setting custom DAV property on a shared file as an owner and reading as a recipient
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes

--- a/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
@@ -372,7 +372,7 @@ Feature: upload file
     And for user "Brian" the content of the file "/textfile.txt" of the space "new-space" should be ""
     And for user "Alice" the content of the file "/textfile.txt" of the space "new-space" should be ""
 
-  @issue-8699 @issue-10331
+  @skipOnReva @issue-8699 @issue-10331
   Scenario: user updates a file inside a link shared space with empty content
     Given using SharingNG
     And user "Brian" has been created with default attributes


### PR DESCRIPTION
## Description
- removed duplicate step
  ```diff
  -Then for user :sharee the space Shares should contain these files
  +Then user :sharee should have a share :share shared by user :sharer from space :space
  +Then user :sharee should not have a share :share shared by user :sharer from space :space
  ```
- fixed tests for reva (https://drone.owncloud.com/cs3org/reva/5743/15/6)
  ```
  Syntax error (JsonException)
  ...
  Type error: FeatureContext::getJsonDecodedResponse(): Return value must be of type array, null returned (Behat\Testwork\Call\Exception\FatalThrowableError)
  ```
- skipped sharing tests for reva

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
