### PR TITLE
Reduce memory footprint in test runner

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -206,11 +206,7 @@ function run_behat_tests() {
 	BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
 
 	# remove nullbytes from the test log
-	TEMP_CONTENT=$(tr < ${TEST_LOG_FILE} -d '\000')
-	OLD_IFS="${IFS}"
-	IFS=""
-	echo ${TEMP_CONTENT} > ${TEST_LOG_FILE}
-	IFS="${OLD_IFS}"
+	sed -i 's/\x0//g' ${TEST_LOG_FILE}
 
 	# Find the count of scenarios that passed
 	SCENARIO_RESULTS_COLORED=`grep -Ea '^[0-9]+[[:space:]]scenario(|s)[[:space:]]\(' ${TEST_LOG_FILE}`


### PR DESCRIPTION
`run.sh` could cause bash running into memory issue when the loading a large log file. When running the test with  `DEBUG_ACCEPTANCE_API_CALLS=1` the bash process executing `run.sh` used so much memory (>25GB) that is was finally getting OOM killed.

I was able to track this down to the `echo ${TEMP_CONTENT} > ${TEST_LOG_FILE}` call that rewrites the log file with `null` bytes being removed. I don't quite understand why, but there seems to be an issue with ${} expansion with IFS is set to `""`. Anyway. I've just replaced the code with an `sed` call doing the `null` byte removal inplace now. Should be a lot more efficient as well.