### PR TITLE
fix: use a tmp file and rename to prevent a possible race condition

### DIFF
--- a/changelog/unreleased/thumbnail-create-and-rename.md
+++ b/changelog/unreleased/thumbnail-create-and-rename.md
@@ -1,0 +1,8 @@
+Bugfix: Fix possible race condition when a thumbnails is stored in the FS
+
+A race condition could cause the thumbnail service to return a thumbnail
+with 0 bytes or with partial content. In order to fix this, the service will
+create a temporary file with the contents and then rename that file to its
+final location.
+
+https://github.com/owncloud/ocis/pull/10693

--- a/services/thumbnails/pkg/thumbnail/storage/filesystem.go
+++ b/services/thumbnails/pkg/thumbnail/storage/filesystem.go
@@ -62,14 +62,29 @@ func (s FileSystem) Put(key string, img []byte) error {
 	}
 
 	if _, err := os.Stat(imgPath); os.IsNotExist(err) {
-		f, err := os.Create(imgPath)
+		f, err := os.CreateTemp(dir, "tmpthumb")
 		if err != nil {
-			return errors.Wrapf(err, "could not create file \"%s\"", key)
+			return errors.Wrapf(err, "could not create temporary file for \"%s\"", key)
 		}
-		defer f.Close()
 
-		if _, err = f.Write(img); err != nil {
-			return errors.Wrapf(err, "could not write to file \"%s\"", key)
+		_, writeErr := f.Write(img) // write the thumbnail in the temporary file
+		f.Close()                   // close the file regardless of the error
+
+		// if there was a problem writing, remove the temporary file
+		if writeErr != nil {
+			if remErr := os.Remove(f.Name()); remErr != nil {
+				return errors.Wrapf(remErr, "could not cleanup temporary file for \"%s\"", key)
+			}
+			return errors.Wrapf(writeErr, "could not write to temporary file for \"%s\"", key)
+		}
+
+		// rename the temporary file to the final file
+		if renErr := os.Rename(f.Name(), imgPath); renErr != nil {
+			// if we couldn't rename, remove the temporary file
+			if remErr := os.Remove(f.Name()); remErr != nil {
+				return errors.Wrapf(remErr, "rename failed and could not cleanup temporary file for \"%s\"", key)
+			}
+			return errors.Wrapf(err, "could not rename temporary file to \"%s\"", key)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Use a temporary file and then rename in order to prevent a race condition. This should help to prevent getting thumbnails with 0 byte content or with partial content.
According to the documentation, the won't be name collisions in the FS with the temporary files, so every thumbnail will be written into a unique file before trying to rename it to the final file (0 byte or partial content shouldn't happen).

**NOTE:** The previous `os.Create` call creates a file with 0666 permissions. The new `os.CreateTemp` creates the file with 0600 permissions, so the new thumbnails will have different permissions on the FS. This shouldn't cause problems though.

## Related Issue
https://github.com/owncloud/ocis/issues/10684

## Motivation and Context
This increases the stability of the system by preventing the error from happening.

## How Has This Been Tested?
Basic case has been tested manually to ensure the code doesn't break anything.
Error reproduction is very difficult because it's a race condition, but the error message should clarify what's happening.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
