### PR TITLE
[tests-only][full-ci] Tests for sharing resource with Denied role in Personal and Project space

### DIFF
--- a/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
@@ -5232,3 +5232,45 @@ Feature: an user gets the resources shared to them
     And the json response should contain the following shares:
       | textfile.txt  |
       | FolderToShare |
+
+  @env-config
+  Scenario Outline: check the permission access while sharing a resource with denied permission role (Personal Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "personal space" to "/textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Denied     |
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And user "Brian" should not have a share "<resource>" shared by user "Alice"
+    Examples:
+      | resource      |
+      | FolderToShare |
+      | textfile.txt  |
+
+  @env-config
+  Scenario Outline: check the response while sharing a resource with denied permission role (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "project space" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource> |
+      | space           | NewSpace   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Denied     |
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And user "Brian" should not have a share "<resource>" shared by user "Alice"
+    Examples:
+      | resource      |
+      | FolderToShare |
+      | textfile.txt  |

--- a/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
@@ -5234,43 +5234,37 @@ Feature: an user gets the resources shared to them
       | FolderToShare |
 
   @env-config
-  Scenario Outline: check the permission access while sharing a resource with denied permission role (Personal Space)
+  Scenario: share a folder with denied permission role (Personal Space)
     Given using spaces DAV path
     And the administrator has enabled the permissions role "Denied"
     And user "Alice" has created folder "FolderToShare"
-    And user "Alice" has uploaded file with content "personal space" to "/textfile.txt"
+    And user "Alice" has uploaded file with content "hello world" to "FolderToShare/lorem.txt"
     And user "Alice" has sent the following resource share invitation:
-      | resource        | <resource> |
-      | space           | Personal   |
-      | sharee          | Brian      |
-      | shareType       | user       |
-      | permissionsRole | Denied     |
+      | resource        | FolderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Denied        |
     When user "Brian" lists the shares shared with him using the Graph API
     Then the HTTP status code should be "200"
-    And user "Brian" should not have a share "<resource>" shared by user "Alice"
-    Examples:
-      | resource      |
-      | FolderToShare |
-      | textfile.txt  |
+    And user "Brian" should not have a share "FolderToShare" shared by user "Alice" from space "Personal"
+    And user "Brian" should not be able to download file "FolderToShare/lorem.txt" from space "Shares"
 
   @env-config
-  Scenario Outline: check the response while sharing a resource with denied permission role (Project Space)
+  Scenario: share a folder with denied permission role (Project Space)
     Given using spaces DAV path
     And the administrator has enabled the permissions role "Denied"
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
-    And user "Alice" has uploaded a file inside space "NewSpace" with content "project space" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "FolderToShare/lorem.txt"
     And user "Alice" has sent the following resource share invitation:
-      | resource        | <resource> |
-      | space           | NewSpace   |
-      | sharee          | Brian      |
-      | shareType       | user       |
-      | permissionsRole | Denied     |
+      | resource        | FolderToShare |
+      | space           | NewSpace      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Denied        |
     When user "Brian" lists the shares shared with him using the Graph API
     Then the HTTP status code should be "200"
-    And user "Brian" should not have a share "<resource>" shared by user "Alice"
-    Examples:
-      | resource      |
-      | FolderToShare |
-      | textfile.txt  |
+    And user "Brian" should not have a share "FolderToShare" shared by user "Alice" from space "NewSpace"
+    And user "Brian" should not be able to download file "FolderToShare/lorem.txt" from space "Shares"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
In this PR: 
-  Added the "Denied" role to the list of additional permissions.
- Updated methods to handle the "Denied" role and added assertions to check the presence or absence of shares based on the role.
- Added new scenarios to validate the "Denied" role for both folders and files across Personal and Project spaces.
 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to: https://github.com/owncloud/ocis/issues/10656

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
