### PR TITLE
graph skip fetching members

### DIFF
--- a/changelog/unreleased/graph-skip-fetching-members.md
+++ b/changelog/unreleased/graph-skip-fetching-members.md
@@ -1,0 +1,5 @@
+Bugfix: Skip fetching members
+
+We now skip fetching group members when they are not needed.
+
+https://github.com/owncloud/ocis/pull/10701

--- a/services/graph/pkg/identity/cache.go
+++ b/services/graph/pkg/identity/cache.go
@@ -149,7 +149,8 @@ func (cache IdentityCache) GetGroup(ctx context.Context, groupID string) (libreg
 			OpaqueId: groupID,
 		}
 		req := cs3Group.GetGroupRequest{
-			GroupId: cs3GroupID,
+			GroupId:             cs3GroupID,
+			SkipFetchingMembers: true,
 		}
 		res, err := gatewayClient.GetGroup(ctx, &req)
 		if err != nil {


### PR DESCRIPTION
We now skip fetching group members when they are not needed.

related: https://github.com/owncloud/ocis/issues/10692#issuecomment-2510840046