### PR TITLE
[tests-only][full-ci] Tests for checking share access after changing share role to and from "Denied"

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2058,15 +2058,18 @@ class SpacesContext implements Context {
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function userShouldNotBeAbleToDownloadFileInsideSpace(
+	public function userShouldOrShouldNotBeAbleToDownloadFileFromSpace(
 		string $user,
 		string $fileName,
 		string $spaceName
 	): void {
+		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$response = $this->featureContext->downloadFileAsUserUsingPassword(
 			$user,
 			$fileName,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
+			null,
+			$spaceId
 		);
 		Assert::assertGreaterThanOrEqual(
 			400,

--- a/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNg1/sharedWithMe.feature
@@ -5268,3 +5268,110 @@ Feature: an user gets the resources shared to them
     Then the HTTP status code should be "200"
     And user "Brian" should not have a share "FolderToShare" shared by user "Alice" from space "NewSpace"
     And user "Brian" should not be able to download file "FolderToShare/lorem.txt" from space "Shares"
+
+  @env-config
+  Scenario Outline: check share access after updating the permission role of a shared folder from other roles to Denied (Personal Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "hello world" to "FolderToShare/lorem.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | FolderToShare      |
+      | space           | Personal           |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+    And user "Alice" has updated the last resource share with the following properties:
+      | permissionsRole | Denied        |
+      | space           | Personal      |
+      | resource        | FolderToShare |
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And user "Brian" should not have a share "FolderToShare" shared by user "Alice" from space "Personal"
+    And user "Brian" should not be able to download file "FolderToShare/lorem.txt" from space "Shares"
+    Examples:
+      | permissions-role |
+      | Editor           |
+      | Viewer           |
+      | Uploader         |
+
+  @env-config
+  Scenario Outline: check share access after updating the permission role of a shared folder from Denied to other roles (Personal Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "hello world" to "FolderToShare/lorem.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | FolderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Denied        |
+    And user "Alice" has updated the last resource share with the following properties:
+      | permissionsRole | <permissions-role> |
+      | space           | Personal           |
+      | resource        | FolderToShare      |
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And user "Brian" should have a share "FolderToShare" shared by user "Alice" from space "Personal"
+    And for user "Brian" the content of the file "FolderToShare/lorem.txt" of the space "Shares" should be "hello world"
+    Examples:
+      | permissions-role |
+      | Editor           |
+      | Viewer           |
+      | Uploader         |
+
+  @env-config
+  Scenario Outline: check share access after updating the permission role of a shared folder from other roles to Denied (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "FolderToShare/lorem.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | FolderToShare      |
+      | space           | NewSpace           |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+    And user "Alice" has updated the last resource share with the following properties:
+      | permissionsRole | Denied        |
+      | space           | NewSpace      |
+      | resource        | FolderToShare |
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And user "Brian" should not have a share "FolderToShare" shared by user "Alice" from space "NewSpace"
+    Examples:
+      | permissions-role |
+      | Editor           |
+      | Viewer           |
+      | Uploader         |
+
+  @env-config
+  Scenario Outline: check share access after updating the permission role of a shared folder from Denied to other roles (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "hello world" to "FolderToShare/lorem.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | FolderToShare |
+      | space           | NewSpace      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Denied        |
+    And user "Alice" has updated the last resource share with the following properties:
+      | permissionsRole | <permissions-role> |
+      | space           | NewSpace           |
+      | resource        | FolderToShare      |
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And user "Brian" should have a share "FolderToShare" shared by user "Alice" from space "NewSpace"
+    And for user "Brian" the content of the file "FolderToShare/lorem.txt" of the space "Shares" should be "hello world"
+    Examples:
+      | permissions-role |
+      | Editor           |
+      | Viewer           |
+      | Uploader         |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
- Added new scenarios to check the share access before and after changing permission role the "Denied" role across Personal and Project spaces.
- Used the `$spaceName`  variable properly inside the function `userShouldOrShouldNotBeAbleToDownloadFileFromSpace` which was unused (was just placed in the params list) previously.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to: https://github.com/owncloud/ocis/issues/10656

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- CI 
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
