### PR TITLE
Cleanup stale shares

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/cs3org/go-cs3apis v0.0.0-20241105092511-3ad35d174fc1
-	github.com/cs3org/reva/v2 v2.26.7
+	github.com/cs3org/reva/v2 v2.26.8-0.20241203081301-17f339546533
 	github.com/davidbyttow/govips/v2 v2.15.0
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20241105092511-3ad35d174fc1 h1:RU6LT6mkD16xZ
 github.com/cs3org/go-cs3apis v0.0.0-20241105092511-3ad35d174fc1/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/cs3org/reva/v2 v2.26.7 h1:E5b1+H5ZsnmDgWWS/u3t4PtdmiMaY1bEEYVI/vE9xo8=
 github.com/cs3org/reva/v2 v2.26.7/go.mod h1:xC5N2XOrCRim/W55uyMsew8RwwFZbQ4hIaKshIbyToo=
+github.com/cs3org/reva/v2 v2.26.8-0.20241203081301-17f339546533 h1:QshDjljk44ASolJwlHxE9e7u+Slgdi/VfPKYvbfFu2g=
+github.com/cs3org/reva/v2 v2.26.8-0.20241203081301-17f339546533/go.mod h1:fJWmn7EkttWOWphZfiKdFOcHuthcUsU55aSN1VeTOhU=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=

--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -519,7 +519,7 @@ func revaShareConfig(cfg *sharing.Config) map[string]interface{} {
 			"machine_auth_apikey": cfg.UserSharingDrivers.CS3.SystemUserAPIKey,
 		},
 		"jsoncs3": map[string]interface{}{
-			"gateway_addr":        cfg.UserSharingDrivers.JSONCS3.ProviderAddr,
+			"gateway_addr":        cfg.Reva.Address,
 			"provider_addr":       cfg.UserSharingDrivers.JSONCS3.ProviderAddr,
 			"service_user_id":     cfg.UserSharingDrivers.JSONCS3.SystemUserID,
 			"service_user_idp":    cfg.UserSharingDrivers.JSONCS3.SystemUserIDP,

--- a/ocis/pkg/command/shares.go
+++ b/ocis/pkg/command/shares.go
@@ -3,6 +3,7 @@ package command
 import (
 	"errors"
 
+	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v2"
 
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
@@ -115,6 +116,11 @@ func cleanup(c *cli.Context, cfg *config.Config) error {
 	if err != nil {
 		return configlog.ReturnError(err)
 	}
+
+	l := logger()
+
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	serviceUserCtx = l.WithContext(serviceUserCtx)
 
 	mgr.(*jsoncs3.Manager).CleanupStaleShares(serviceUserCtx)
 

--- a/ocis/pkg/command/shares.go
+++ b/ocis/pkg/command/shares.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"errors"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3"
+	"github.com/cs3org/reva/v2/pkg/share/manager/registry"
+	"github.com/cs3org/reva/v2/pkg/utils"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	mregistry "github.com/owncloud/ocis/v2/ocis-pkg/registry"
+	"github.com/owncloud/ocis/v2/ocis/pkg/register"
+	sharingparser "github.com/owncloud/ocis/v2/services/sharing/pkg/config/parser"
+)
+
+// SharesCommand is the entrypoint for the groups command.
+func SharesCommand(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:     "shares",
+		Usage:    `cli tools to manage entries in the share manager.`,
+		Category: "maintenance",
+		Before: func(c *cli.Context) error {
+			// Parse base config
+			if err := parser.ParseConfig(cfg, true); err != nil {
+				return configlog.ReturnError(err)
+			}
+
+			// Parse sharing config
+			cfg.Sharing.Commons = cfg.Commons
+			return configlog.ReturnError(sharingparser.ParseConfig(cfg.Sharing))
+		},
+		Subcommands: []*cli.Command{
+			cleanupCmd(cfg),
+		},
+	}
+}
+
+func init() {
+	register.AddCommand(SharesCommand)
+}
+
+func cleanupCmd(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "cleanup",
+		Usage: `clean up stale entries in the share manager.`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "service-account-id",
+				Value:    "",
+				Usage:    "Name of the service account to use for the cleanup",
+				EnvVars:  []string{"OCIS_SERVICE_ACCOUNT_ID"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "service-account-secret",
+				Value:    "",
+				Usage:    "Secret for the service account",
+				EnvVars:  []string{"OCIS_SERVICE_ACCOUNT_SECRET"},
+				Required: true,
+			},
+		},
+		Before: func(c *cli.Context) error {
+			// Parse base config
+			if err := parser.ParseConfig(cfg, true); err != nil {
+				return configlog.ReturnError(err)
+			}
+
+			// Parse sharing config
+			cfg.Sharing.Commons = cfg.Commons
+			return configlog.ReturnError(sharingparser.ParseConfig(cfg.Sharing))
+		},
+		Action: func(c *cli.Context) error {
+			return cleanup(c, cfg)
+		},
+	}
+}
+
+func cleanup(c *cli.Context, cfg *config.Config) error {
+	driver := cfg.Sharing.UserSharingDriver
+	// cleanup is only implemented for the jsoncs3 share manager
+	if driver != "jsoncs3" {
+		return configlog.ReturnError(errors.New("cleanup is only implemented for the jsoncs3 share manager"))
+	}
+
+	rcfg := revaShareConfig(cfg.Sharing)
+	f, ok := registry.NewFuncs[driver]
+	if !ok {
+		return configlog.ReturnError(errors.New("Unknown share manager type '" + driver + "'"))
+	}
+	mgr, err := f(rcfg[driver].(map[string]interface{}))
+	if err != nil {
+		return configlog.ReturnError(err)
+	}
+
+	// Initialize registry to make service lookup work
+	_ = mregistry.GetRegistry()
+
+	// get an authenticated context
+	gatewaySelector, err := pool.GatewaySelector(cfg.Sharing.Reva.Address)
+	if err != nil {
+		return configlog.ReturnError(err)
+	}
+
+	client, err := gatewaySelector.Next()
+	if err != nil {
+		return configlog.ReturnError(err)
+	}
+
+	serviceUserCtx, err := utils.GetServiceUserContext(c.String("service-account-id"), client, c.String("service-account-secret"))
+	if err != nil {
+		return configlog.ReturnError(err)
+	}
+
+	mgr.(*jsoncs3.Manager).CleanupStaleShares(serviceUserCtx)
+
+	return nil
+}

--- a/vendor/github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/vendor/github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/proppatch.go
@@ -133,12 +133,14 @@ func (s *svc) handleProppatch(ctx context.Context, w http.ResponseWriter, r *htt
 	rreq := &provider.UnsetArbitraryMetadataRequest{
 		Ref:                   ref,
 		ArbitraryMetadataKeys: []string{""},
+		LockId:                requestLockToken(r),
 	}
 	sreq := &provider.SetArbitraryMetadataRequest{
 		Ref: ref,
 		ArbitraryMetadata: &provider.ArbitraryMetadata{
 			Metadata: map[string]string{},
 		},
+		LockId: requestLockToken(r),
 	}
 
 	acceptedProps := []xml.Name{}

--- a/vendor/github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -214,6 +214,11 @@ func (c *Cache) Remove(ctx context.Context, userid, shareID string) error {
 			log.Debug().Msg("precondition failed when persisting removed share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+		case errtypes.AlreadyExists:
+			log.Debug().Msg("file already existed when persisting removed share. retrying...")
+			// CS3 uses an already exists error instead of precondition failed when using an If-None-Match=* header / IfExists flag in the InitiateFileUpload call.
+			// Thas happens when the cache thinks there is no file.
+			// continue with sync below
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting removed share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting removed share failed")

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/ocis/ocis.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/ocis/ocis.go
@@ -36,7 +36,7 @@ func init() {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a local filesystem.
-func New(m map[string]interface{}, stream events.Stream, _ *zerolog.Logger) (storage.FS, error) {
+func New(m map[string]interface{}, stream events.Stream, log *zerolog.Logger) (storage.FS, error) {
 	o, err := options.New(m)
 	if err != nil {
 		return nil, err
@@ -47,5 +47,5 @@ func New(m map[string]interface{}, stream events.Stream, _ *zerolog.Logger) (sto
 		return nil, err
 	}
 
-	return decomposedfs.NewDefault(m, bs, stream)
+	return decomposedfs.NewDefault(m, bs, stream, log)
 }

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/posix/posix.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/posix/posix.go
@@ -134,7 +134,7 @@ func New(m map[string]interface{}, stream events.Stream, log *zerolog.Logger) (s
 		Trashbin:          trashbin,
 	}
 
-	dfs, err := decomposedfs.New(&o.Options, aspects)
+	dfs, err := decomposedfs.New(&o.Options, aspects, log)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/posix/tree/tree.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/posix/tree/tree.go
@@ -704,6 +704,8 @@ func (t *Tree) ResolveSpaceIDIndexEntry(spaceid, entry string) (string, string, 
 
 // InitNewNode initializes a new node
 func (t *Tree) InitNewNode(ctx context.Context, n *node.Node, fsize uint64) (metadata.UnlockFunc, error) {
+	_, span := tracer.Start(ctx, "InitNewNode")
+	defer span.End()
 	// create folder structure (if needed)
 	if err := os.MkdirAll(filepath.Dir(n.InternalPath()), 0700); err != nil {
 		return nil, err

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/s3ng/s3ng.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/fs/s3ng/s3ng.go
@@ -35,7 +35,7 @@ func init() {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a local filesystem.
-func New(m map[string]interface{}, stream events.Stream, _ *zerolog.Logger) (storage.FS, error) {
+func New(m map[string]interface{}, stream events.Stream, log *zerolog.Logger) (storage.FS, error) {
 	o, err := parseConfig(m)
 	if err != nil {
 		return nil, err
@@ -59,5 +59,5 @@ func New(m map[string]interface{}, stream events.Stream, _ *zerolog.Logger) (sto
 		return nil, err
 	}
 
-	return decomposedfs.NewDefault(m, bs, stream)
+	return decomposedfs.NewDefault(m, bs, stream, log)
 }

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/grants.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/grants.go
@@ -38,6 +38,8 @@ import (
 
 // DenyGrant denies access to a resource.
 func (fs *Decomposedfs) DenyGrant(ctx context.Context, ref *provider.Reference, grantee *provider.Grantee) error {
+	_, span := tracer.Start(ctx, "DenyGrant")
+	defer span.End()
 	log := appctx.GetLogger(ctx)
 
 	log.Debug().Interface("ref", ref).Interface("grantee", grantee).Msg("DenyGrant()")
@@ -74,6 +76,8 @@ func (fs *Decomposedfs) DenyGrant(ctx context.Context, ref *provider.Reference, 
 
 // AddGrant adds a grant to a resource
 func (fs *Decomposedfs) AddGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) (err error) {
+	_, span := tracer.Start(ctx, "AddGrant")
+	defer span.End()
 	log := appctx.GetLogger(ctx)
 	log.Debug().Interface("ref", ref).Interface("grant", g).Msg("AddGrant()")
 	grantNode, unlockFunc, grant, err := fs.loadGrant(ctx, ref, g)
@@ -119,6 +123,8 @@ func (fs *Decomposedfs) AddGrant(ctx context.Context, ref *provider.Reference, g
 
 // ListGrants lists the grants on the specified resource
 func (fs *Decomposedfs) ListGrants(ctx context.Context, ref *provider.Reference) (grants []*provider.Grant, err error) {
+	_, span := tracer.Start(ctx, "ListGrants")
+	defer span.End()
 	var grantNode *node.Node
 	if grantNode, err = fs.lu.NodeFromResource(ctx, ref); err != nil {
 		return
@@ -174,6 +180,8 @@ func (fs *Decomposedfs) ListGrants(ctx context.Context, ref *provider.Reference)
 
 // RemoveGrant removes a grant from resource
 func (fs *Decomposedfs) RemoveGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) (err error) {
+	_, span := tracer.Start(ctx, "RemoveGrant")
+	defer span.End()
 	grantNode, unlockFunc, grant, err := fs.loadGrant(ctx, ref, g)
 	if err != nil {
 		return err
@@ -235,6 +243,8 @@ func isShareGrant(ctx context.Context) bool {
 // UpdateGrant updates a grant on a resource
 // TODO remove AddGrant or UpdateGrant grant from CS3 api, redundant? tracked in https://github.com/cs3org/cs3apis/issues/92
 func (fs *Decomposedfs) UpdateGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) error {
+	_, span := tracer.Start(ctx, "UpdateGrant")
+	defer span.End()
 	log := appctx.GetLogger(ctx)
 	log.Debug().Interface("ref", ref).Interface("grant", g).Msg("UpdateGrant()")
 
@@ -272,6 +282,8 @@ func (fs *Decomposedfs) UpdateGrant(ctx context.Context, ref *provider.Reference
 
 // checks if the given grant exists and returns it. Nil grant means it doesn't exist
 func (fs *Decomposedfs) loadGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) (*node.Node, metadata.UnlockFunc, *provider.Grant, error) {
+	_, span := tracer.Start(ctx, "loadGrant")
+	defer span.End()
 	n, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
 		return nil, nil, nil, err
@@ -308,6 +320,8 @@ func (fs *Decomposedfs) loadGrant(ctx context.Context, ref *provider.Reference, 
 }
 
 func (fs *Decomposedfs) storeGrant(ctx context.Context, n *node.Node, g *provider.Grant) error {
+	_, span := tracer.Start(ctx, "storeGrant")
+	defer span.End()
 	// if is a grant to a space root, the receiver needs the space type to update the indexes
 	spaceType, ok := storageprovider.SpaceTypeFromContext(ctx)
 	if !ok {

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata.go
@@ -38,6 +38,8 @@ import (
 
 // SetArbitraryMetadata sets the metadata on a resource
 func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.Reference, md *provider.ArbitraryMetadata) (err error) {
+	_, span := tracer.Start(ctx, "SetArbitraryMetadata")
+	defer span.End()
 	n, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
 		return errors.Wrap(err, "Decomposedfs: error resolving ref")
@@ -131,6 +133,8 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 
 // UnsetArbitraryMetadata unsets the metadata on the given resource
 func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provider.Reference, keys []string) (err error) {
+	_, span := tracer.Start(ctx, "UnsetArbitraryMetadata")
+	defer span.End()
 	n, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
 		return errors.Wrap(err, "Decomposedfs: error resolving ref")

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/mtimesyncedcache/map.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/mtimesyncedcache/map.go
@@ -34,3 +34,12 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 }
 
 func (m *Map[K, V]) Store(key K, value V) { m.m.Store(key, value) }
+
+func (m *Map[K, V]) Count() int {
+	l := 0
+	m.Range(func(_ K, _ V) bool {
+		l++
+		return true
+	})
+	return l
+}

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/node.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/node.go
@@ -218,6 +218,8 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 
 // Type returns the node's resource type
 func (n *Node) Type(ctx context.Context) provider.ResourceType {
+	_, span := tracer.Start(ctx, "Type")
+	defer span.End()
 	if n.nodeType != nil {
 		return *n.nodeType
 	}
@@ -446,6 +448,8 @@ func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
 
 // ParentWithReader returns the parent node
 func (n *Node) ParentWithReader(ctx context.Context, r io.Reader) (*Node, error) {
+	_, span := tracer.Start(ctx, "ParentWithReader")
+	defer span.End()
 	if n.ParentID == "" {
 		return nil, fmt.Errorf("decomposedfs: root has no parent")
 	}
@@ -1261,8 +1265,7 @@ func (n *Node) ProcessingID(ctx context.Context) (string, error) {
 
 // IsSpaceRoot checks if the node is a space root
 func (n *Node) IsSpaceRoot(ctx context.Context) bool {
-	_, err := n.Xattr(ctx, prefixes.SpaceNameAttr)
-	return err == nil
+	return n.ID == n.SpaceID
 }
 
 // SetScanData sets the virus scan info to the node

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -68,6 +68,8 @@ func (md Attributes) Time(key string) (time.Time, error) {
 
 // SetXattrs sets multiple extended attributes on the write-through cache/node
 func (n *Node) SetXattrsWithContext(ctx context.Context, attribs map[string][]byte, acquireLock bool) (err error) {
+	_, span := tracer.Start(ctx, "SetXattrsWithContext")
+	defer span.End()
 	if n.xattrsCache != nil {
 		for k, v := range attribs {
 			n.xattrsCache[k] = v

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/permissions/spacepermissions.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/permissions/spacepermissions.go
@@ -60,6 +60,8 @@ func (p Permissions) AssemblePermissions(ctx context.Context, n *node.Node) (*pr
 
 // AssembleTrashPermissions is used to assemble file permissions
 func (p Permissions) AssembleTrashPermissions(ctx context.Context, n *node.Node) (*provider.ResourcePermissions, error) {
+	_, span := tracer.Start(ctx, "AssembleTrashPermissions")
+	defer span.End()
 	return p.item.AssembleTrashPermissions(ctx, n)
 }
 

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/recycle.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/recycle.go
@@ -64,7 +64,8 @@ func (tb *DecomposedfsTrashbin) Setup(fs storage.FS) error {
 // ListRecycle returns the list of available recycle items
 // ref -> the space (= resourceid), key -> deleted node id, relativePath = relative to key
 func (tb *DecomposedfsTrashbin) ListRecycle(ctx context.Context, ref *provider.Reference, key, relativePath string) ([]*provider.RecycleItem, error) {
-
+	_, span := tracer.Start(ctx, "ListRecycle")
+	defer span.End()
 	if ref == nil || ref.ResourceId == nil || ref.ResourceId.OpaqueId == "" {
 		return nil, errtypes.BadRequest("spaceid required")
 	}
@@ -346,6 +347,8 @@ func (tb *DecomposedfsTrashbin) listTrashRoot(ctx context.Context, spaceID strin
 
 // RestoreRecycleItem restores the specified item
 func (tb *DecomposedfsTrashbin) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+	_, span := tracer.Start(ctx, "RestoreRecycleItem")
+	defer span.End()
 	if ref == nil {
 		return errtypes.BadRequest("missing reference, needs a space id")
 	}
@@ -399,6 +402,8 @@ func (tb *DecomposedfsTrashbin) RestoreRecycleItem(ctx context.Context, ref *pro
 
 // PurgeRecycleItem purges the specified item, all its children and all their revisions
 func (tb *DecomposedfsTrashbin) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
+	_, span := tracer.Start(ctx, "PurgeRecycleItem")
+	defer span.End()
 	if ref == nil {
 		return errtypes.BadRequest("missing reference, needs a space id")
 	}
@@ -429,6 +434,8 @@ func (tb *DecomposedfsTrashbin) PurgeRecycleItem(ctx context.Context, ref *provi
 
 // EmptyRecycle empties the trash
 func (tb *DecomposedfsTrashbin) EmptyRecycle(ctx context.Context, ref *provider.Reference) error {
+	_, span := tracer.Start(ctx, "EmptyRecycle")
+	defer span.End()
 	if ref == nil || ref.ResourceId == nil || ref.ResourceId.OpaqueId == "" {
 		return errtypes.BadRequest("spaceid must be set")
 	}

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/revisions.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/revisions.go
@@ -48,6 +48,8 @@ import (
 
 // ListRevisions lists the revisions of the given resource
 func (fs *Decomposedfs) ListRevisions(ctx context.Context, ref *provider.Reference) (revisions []*provider.FileVersion, err error) {
+	_, span := tracer.Start(ctx, "ListRevisions")
+	defer span.End()
 	var n *node.Node
 	if n, err = fs.lu.NodeFromResource(ctx, ref); err != nil {
 		return
@@ -115,6 +117,8 @@ func (fs *Decomposedfs) ListRevisions(ctx context.Context, ref *provider.Referen
 // DownloadRevision returns a reader for the specified revision
 // FIXME the CS3 api should explicitly allow initiating revision and trash download, a related issue is https://github.com/cs3org/reva/issues/1813
 func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Reference, revisionKey string, openReaderFunc func(md *provider.ResourceInfo) bool) (*provider.ResourceInfo, io.ReadCloser, error) {
+	_, span := tracer.Start(ctx, "DownloadRevision")
+	defer span.End()
 	log := appctx.GetLogger(ctx)
 
 	// verify revision key format
@@ -186,6 +190,8 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 
 // RestoreRevision restores the specified revision of the resource
 func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (returnErr error) {
+	_, span := tracer.Start(ctx, "RestoreRevision")
+	defer span.End()
 	log := appctx.GetLogger(ctx)
 
 	// verify revision key format
@@ -330,6 +336,8 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 
 // DeleteRevision deletes the specified revision of the resource
 func (fs *Decomposedfs) DeleteRevision(ctx context.Context, ref *provider.Reference, revisionKey string) error {
+	_, span := tracer.Start(ctx, "DeleteRevision")
+	defer span.End()
 	n, err := fs.getRevisionNode(ctx, ref, revisionKey, func(rp *provider.ResourcePermissions) bool {
 		return rp.RestoreFileVersion
 	})
@@ -345,6 +353,8 @@ func (fs *Decomposedfs) DeleteRevision(ctx context.Context, ref *provider.Refere
 }
 
 func (fs *Decomposedfs) getRevisionNode(ctx context.Context, ref *provider.Reference, revisionKey string, hasPermission func(*provider.ResourcePermissions) bool) (*node.Node, error) {
+	_, span := tracer.Start(ctx, "getRevisionNode")
+	defer span.End()
 	log := appctx.GetLogger(ctx)
 
 	// verify revision key format

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -183,7 +183,7 @@ func (p AsyncPropagator) queuePropagation(ctx context.Context, spaceID, nodeID s
 			ready = true
 			break
 		}
-		log.Error().Err(err).Msg("failed to write Change to disk (retrying)")
+		log.Debug().Err(err).Msg("failed to write Change to disk (retrying)")
 		err = os.Mkdir(filepath.Dir(changePath), 0700)
 		triggerPropagation = err == nil || os.IsExist(err) // only the first goroutine, which succeeds to create the directory, is supposed to actually trigger the propagation
 	}
@@ -386,7 +386,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, spaceID, nodeID string, 
 			// a negative new treesize. Something must have gone wrong with the accounting.
 			// Reset the current treesize to 0.
 			log.Error().Uint64("treeSize", treeSize).Int64("sizeDiff", pc.SizeDiff).
-				Msg("Error when updating treesize of node. Updated treesize < 0. Reestting to 0")
+				Msg("Error when updating treesize of node. Updated treesize < 0. Resetting to 0")
 			newSize = 0
 		default:
 			newSize = treeSize - uint64(-pc.SizeDiff)
@@ -414,7 +414,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, spaceID, nodeID string, 
 	log.Info().Msg("Propagation done. cleaning up")
 	cleanup()
 
-	if !n.IsSpaceRoot(ctx) { // This does not seem robust as it checks the space name property
+	if !n.IsSpaceRoot(ctx) {
 		p.queuePropagation(ctx, n.SpaceID, n.ParentID, pc, log)
 	}
 

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload.go
@@ -47,6 +47,8 @@ import (
 // TODO Upload (and InitiateUpload) needs a way to receive the expected checksum.
 // Maybe in metadata as 'checksum' => 'sha1 aeosvp45w5xaeoe' = lowercase, space separated?
 func (fs *Decomposedfs) Upload(ctx context.Context, req storage.UploadRequest, uff storage.UploadFinishedFunc) (*provider.ResourceInfo, error) {
+	_, span := tracer.Start(ctx, "Upload")
+	defer span.End()
 	up, err := fs.GetUpload(ctx, req.Ref.GetPath())
 	if err != nil {
 		return &provider.ResourceInfo{}, errors.Wrap(err, "Decomposedfs: error retrieving upload")
@@ -130,6 +132,8 @@ func (fs *Decomposedfs) Upload(ctx context.Context, req storage.UploadRequest, u
 // TODO read optional content for small files in this request
 // TODO InitiateUpload (and Upload) needs a way to receive the expected checksum. Maybe in metadata as 'checksum' => 'sha1 aeosvp45w5xaeoe' = lowercase, space separated?
 func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error) {
+	_, span := tracer.Start(ctx, "InitiateUpload")
+	defer span.End()
 	log := appctx.GetLogger(ctx)
 
 	// remember the path from the reference

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload/session.go
@@ -81,6 +81,8 @@ func (s *OcisSession) executantUser() *userpb.User {
 
 // Purge deletes the upload session metadata and written binary data
 func (s *OcisSession) Purge(ctx context.Context) error {
+	_, span := tracer.Start(ctx, "Purge")
+	defer span.End()
 	sessionPath := sessionPath(s.store.root, s.info.ID)
 	f, err := lockedfile.OpenFile(sessionPath+".lock", os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0600)
 	if err != nil {
@@ -112,6 +114,8 @@ func (s *OcisSession) TouchBin() error {
 // events can update the scan outcome and the finished event might read an empty file because of race conditions
 // so we need to lock the file while writing and use atomic writes
 func (s *OcisSession) Persist(ctx context.Context) error {
+	_, span := tracer.Start(ctx, "Persist")
+	defer span.End()
 	sessionPath := sessionPath(s.store.root, s.info.ID)
 	// create folder structure (if needed)
 	if err := os.MkdirAll(filepath.Dir(sessionPath), 0700); err != nil {

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -184,7 +184,7 @@ func (session *OcisSession) FinishUploadDecomposed(ctx context.Context) error {
 		}
 	}
 
-	n, err := session.store.CreateNodeForUpload(session, attrs)
+	n, err := session.store.CreateNodeForUpload(ctx, session, attrs)
 	if err != nil {
 		return err
 	}
@@ -226,7 +226,7 @@ func (session *OcisSession) FinishUploadDecomposed(ctx context.Context) error {
 	// for 0-byte uploads we take a shortcut and finalize isn't called elsewhere
 	if !session.store.async || session.info.Size == 0 {
 		// handle postprocessing synchronously
-		err = session.Finalize()
+		err = session.Finalize(ctx)
 		session.store.Cleanup(ctx, session, err != nil, false, err == nil)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to upload")
@@ -279,8 +279,8 @@ func (session *OcisSession) ConcatUploads(_ context.Context, uploads []tusd.Uplo
 }
 
 // Finalize finalizes the upload (eg moves the file to the internal destination)
-func (session *OcisSession) Finalize() (err error) {
-	ctx, span := tracer.Start(session.Context(context.Background()), "Finalize")
+func (session *OcisSession) Finalize(ctx context.Context) (err error) {
+	ctx, span := tracer.Start(session.Context(ctx), "Finalize")
 	defer span.End()
 
 	revisionNode := node.New(session.SpaceID(), session.NodeID(), "", "", session.Size(), session.ID(),

--- a/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/metadata/cs3.go
+++ b/vendor/github.com/cs3org/reva/v2/pkg/storage/utils/metadata/cs3.go
@@ -552,7 +552,11 @@ func (cs3 *CS3) getAuthContext(ctx context.Context) (context.Context, error) {
 	authCtx, span := tracer.Start(authCtx, "getAuthContext", trace.WithLinks(trace.LinkFromContext(ctx)))
 	defer span.End()
 
-	client, err := pool.GetGatewayServiceClient(cs3.gatewayAddr)
+	selector, err := pool.GatewaySelector(cs3.gatewayAddr)
+	if err != nil {
+		return nil, err
+	}
+	client, err := selector.Next()
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -367,7 +367,7 @@ github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1
 github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1
 github.com/cs3org/go-cs3apis/cs3/tx/v1beta1
 github.com/cs3org/go-cs3apis/cs3/types/v1beta1
-# github.com/cs3org/reva/v2 v2.26.7
+# github.com/cs3org/reva/v2 v2.26.8-0.20241203081301-17f339546533
 ## explicit; go 1.22.0
 github.com/cs3org/reva/v2/cmd/revad/internal/grace
 github.com/cs3org/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
Add a `ocis shares cleanup` command to ocis for cleanup up stale shares (i.e. shares where there shared resource does no longer exist.

Depends on https://github.com/cs3org/reva/pull/4983

Fixes #10645