### PR TITLE
[tests-only][full-ci] Tests for availability of resources shared with Denied role while listing all drives

### DIFF
--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -2067,13 +2067,17 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then the json response should contain the following shares:
+	 * @Then /^the json response (should|should not) contain the following shares:$/
 	 *
+	 * @param string $shouldOrNot
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
-	public function theJsonResponseShouldContainTheFollowingShares(TableNode $table): void {
+	public function theJsonResponseShouldOrShouldNotContainTheFollowingShares(
+		string $shouldOrNot,
+		TableNode $table
+	): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent();
 
 		$resourceNames = [];
@@ -2088,10 +2092,17 @@ class SharingNgContext implements Context {
 		$expectedShares = $table->getColumn(0);
 
 		foreach ($expectedShares as $expectedShare) {
-			Assert::assertTrue(
-				\in_array($expectedShare, $resourceNames),
-				"The share '$expectedShare' was not found in the response."
-			);
+			if ($shouldOrNot === "should not") {
+				Assert::assertFalse(
+					\in_array($expectedShare, $resourceNames),
+					"The share '$expectedShare' was found in the response."
+				);
+			} else {
+				Assert::assertTrue(
+					\in_array($expectedShare, $resourceNames),
+					"The share '$expectedShare' was not found in the response."
+				);
+			}
 		}
 	}
 

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -371,6 +371,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - SpacesContext:
         - SharingNgContext:
+        - OcisConfigContext:
 
     apiSharingNgLinkSharePermission:
       paths:

--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -3194,3 +3194,47 @@ Feature: Send a sharing invitations
       | permissionsRole | Viewer       |
     Then the HTTP status code should be "200"
     And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "NewSpace"
+
+  @env-config
+  Scenario Outline: resource shared with denied permission role should not be visible when the sharee lists all drives (Personal space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "personal space" to "lorem.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Denied     |
+    When user "Brian" lists all spaces via the Graph API
+    Then the HTTP status code should be "200"
+    And the json response should not contain the following shares:
+      | <resource> |
+    Examples:
+      | resource      |
+      | FolderToShare |
+      | lorem.txt     |
+
+  @env-config
+  Scenario Outline: resource shared with denied permission role should not be visible when the sharee lists all drives (Project space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has created a folder "FolderToShare" in space "NewSpace"
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "lorem" to "lorem.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource> |
+      | space           | NewSpace   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Denied     |
+    When user "Brian" lists all spaces via the Graph API
+    Then the HTTP status code should be "200"
+    And the json response should not contain the following shares:
+      | <resource> |
+    Examples:
+      | resource      |
+      | FolderToShare |
+      | lorem.txt     |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR 
 - verifies that the resources, in both personal and project spaces, shared with denied permission roles don't appear while sharee lists all drives. 
 -  Adds  `OcisConfigContext` context  for the suite `apiSharingNgShareInvitation`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to: https://github.com/owncloud/ocis/issues/10656

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
