### PR TITLE
fix(graph): Don't return OCM shares in the drives list

### DIFF
--- a/changelog/unreleased/me_drives_ocm_shares.md
+++ b/changelog/unreleased/me_drives_ocm_shares.md
@@ -1,0 +1,7 @@
+Bugfix: Fix graph drives response for federated shares
+
+Federated shares where erroneously showing up in the /me/drives response
+on the graph API.
+
+https://github.com/owncloud/ocis/pull/10730
+https://github.com/owncloud/ocis/issues/10689


### PR DESCRIPTION
OCM shares don't have mountpoints currently. So they're no supposed to show up in the drives list on the graph service.

Fixes: #10689
