### PR TITLE
[tests-only][full-ci] added test to list shares sharedByMe after the share role has been disabled

### DIFF
--- a/tests/acceptance/features/apiSharingNg1/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg1/sharedByMe.feature
@@ -3863,3 +3863,217 @@ Feature: resources shared by user
         }
       }
       """
+
+  @env-config
+  Scenario Outline: sharer lists the shares shared with Secure Viewer after the role is disabled (Personal Space)
+    Given the administrator has enabled the permissions role "Secure Viewer"
+    And user "Alice" has uploaded file with content "some content" to "textfile.txt"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource>    |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And user "Brian" has a share "<resource>" synced
+    And the administrator has disabled the permissions role "Secure Viewer"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "<resource>" with the following data:
+      """
+      {
+        "type": "object",
+        "required": [
+          "parentReference",
+          "permissions",
+          "name"
+        ],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "@libre.graph.permissions.actions",
+                "grantedToV2",
+                "id",
+                "invitation"
+              ],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": [
+                      "libre.graph/driveItem/path/read",
+                      "libre.graph/driveItem/children/read",
+                      "libre.graph/driveItem/basic/read"
+                  ]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | resource      |
+      | textfile.txt  |
+      | folderToShare |
+
+  @env-config
+  Scenario: sharer lists the shares shared with Denied after the role is disabled (Personal Space)
+    Given the administrator has enabled the permissions role "Denied"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Denied        |
+    And the administrator has disabled the permissions role "Denied"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "folderToShare" with the following data:
+      """
+      {
+        "type": "object",
+        "required": [
+          "parentReference",
+          "permissions",
+          "name"
+        ],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "@libre.graph.permissions.actions",
+                "grantedToV2",
+                "id",
+                "invitation"
+              ],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": ["none"]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """
+
+  @env-config
+  Scenario Outline: sharer lists the shares shared with Secure Viewer after the role is disabled (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Secure Viewer"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource>    |
+      | space           | new-space     |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And user "Brian" has a share "<resource>" synced
+    And the administrator has disabled the permissions role "Secure Viewer"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "<resource>" with the following data:
+      """
+      {
+        "type": "object",
+        "required": [
+          "parentReference",
+          "permissions",
+          "name"
+        ],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "@libre.graph.permissions.actions",
+                "grantedToV2",
+                "id",
+                "invitation"
+              ],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": [
+                      "libre.graph/driveItem/path/read",
+                      "libre.graph/driveItem/children/read",
+                      "libre.graph/driveItem/basic/read"
+                  ]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | resource      |
+      | textfile.txt  |
+      | folderToShare |
+
+  @env-config
+  Scenario: sharer lists the shares shared with Denied after the role is disabled (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | new-space     |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Denied        |
+    And the administrator has disabled the permissions role "Denied"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "folderToShare" with the following data:
+      """
+      {
+        "type": "object",
+        "required": [
+          "parentReference",
+          "permissions",
+          "name"
+        ],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "@libre.graph.permissions.actions",
+                "grantedToV2",
+                "id",
+                "invitation"
+              ],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": ["none"]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the test to list shares `sharedByMe` after the share role has been disabled, with precondition 
`enable role` -> `share` -> `disable role`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10711

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
