### PR TITLE
[tests-only][full-ci] add test for federated user trying to update shared file after local user updates role

### DIFF
--- a/tests/acceptance/features/apiOcm/share.feature
+++ b/tests/acceptance/features/apiOcm/share.feature
@@ -1229,3 +1229,29 @@ Feature: an user shares resources using ScienceMesh application
         }
       }
       """
+
+  @issue-9926
+  Scenario: federated user tries to update a shared file after local user updates role
+    Given using spaces DAV path
+    And using server "LOCAL"
+    And "Alice" has created the federation share invitation
+    And using server "REMOTE"
+    And "Brian" has accepted invitation
+    And using server "LOCAL"
+    And user "Alice" has uploaded file with content "ocm test" to "/textfile.txt"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    And user "Alice" has updated the last resource share with the following properties:
+      | permissionsRole    | File Editor              |
+      | expirationDateTime | 2200-07-15T14:00:00.000Z |
+      | space              | Personal                 |
+      | resource           | textfile.txt             |
+    And using server "REMOTE"
+    When user "Brian" updates the content of federated share "textfile.txt" with "this is a new content" using the WebDAV API
+    Then the HTTP status code should be "500"
+    And using server "LOCAL"
+    And the content of file "textfile.txt" for user "Alice" should be "ocm test"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds test to check if federated user can update a shared file after local user updates the role from `Viewer` to `File Editor`
See: https://github.com/owncloud/web/issues/11991#issuecomment-2513801486
``` feature
Scenario: federated user tries to update a shared file after local user updates role
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/10073
- Bug Report: https://github.com/owncloud/ocis/issues/9926

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
