### PR TITLE
[tests-only][full-ci]added test to list drives after the share role has been disabled

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2049,9 +2049,10 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to download file "([^"]*)" from space "([^"]*)"$/
+	 * @Then /^user "([^"]*)" (should|should not) be able to download file "([^"]*)" from space "([^"]*)"$/
 	 *
 	 * @param string $user
+	 * @param string $shouldOrNot
 	 * @param string $fileName
 	 * @param string $spaceName
 	 *
@@ -2060,6 +2061,7 @@ class SpacesContext implements Context {
 	 */
 	public function userShouldOrShouldNotBeAbleToDownloadFileFromSpace(
 		string $user,
+		string $shouldOrNot,
 		string $fileName,
 		string $spaceName
 	): void {
@@ -2071,19 +2073,27 @@ class SpacesContext implements Context {
 			null,
 			$spaceId
 		);
-		Assert::assertGreaterThanOrEqual(
-			400,
-			$response->getStatusCode(),
-			__METHOD__
-			. ' download must fail'
-		);
-		Assert::assertLessThanOrEqual(
-			499,
-			$response->getStatusCode(),
-			__METHOD__
-			. ' 4xx error expected but got status code "'
-			. $response->getStatusCode() . '"'
-		);
+		if ($shouldOrNot === 'should') {
+			$this->featureContext->theHTTPStatusCodeShouldBe(
+				200,
+				__METHOD__ . "Expected response status code is 200 but got " . $response->getStatusCode(),
+				$response
+			);
+		} else {
+			Assert::assertGreaterThanOrEqual(
+				400,
+				$response->getStatusCode(),
+				__METHOD__
+				. ' download must fail'
+			);
+			Assert::assertLessThanOrEqual(
+				499,
+				$response->getStatusCode(),
+				__METHOD__
+				. ' 4xx error expected but got status code "'
+				. $response->getStatusCode() . '"'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the test to list the available drives after the share role has been disabled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10711


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
