### PR TITLE
[tests-only][full-ci] fix typo in `Then` scenario steps

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -1026,7 +1026,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the json responded should not contain a space with name "([^"]*)"$/
+	 * @Then /^the json response should not contain a space with name "([^"]*)"$/
 	 *
 	 * @param string $spaceName
 	 *
@@ -1103,7 +1103,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Then /^the json responded should (not|only|)\s?contain spaces of type "([^"]*)"$/
+	 * @Then /^the json response should (not|only|)\s?contain spaces of type "([^"]*)"$/
 	 *
 	 * @param string $onlyOrNot (not|only|)
 	 * @param string $type

--- a/tests/acceptance/features/apiGraphUserGroup/deleteUser.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/deleteUser.feature
@@ -150,7 +150,7 @@ Feature: delete user
     When the user "Alice" deletes a user "Brian" using the Graph API
     Then the HTTP status code should be "204"
     When user "Alice" lists all spaces via the Graph API with query "$filter=driveType eq 'personal'"
-    Then the json responded should not contain a space with name "Brian Murphy"
+    Then the json response should not contain a space with name "Brian Murphy"
 
 
   Scenario: accepted share is deleted automatically when the user is deleted

--- a/tests/acceptance/features/apiOcm/share.feature
+++ b/tests/acceptance/features/apiOcm/share.feature
@@ -1272,7 +1272,7 @@ Feature: an user shares resources using ScienceMesh application
     And using server "REMOTE"
     When user "Brian" lists all available spaces via the Graph API
     Then the HTTP status code should be "200"
-    And the json responded should not contain a space with name "folderToShare"
+    And the json response should not contain a space with name "folderToShare"
 
   @issue-10213
   Scenario Outline: local user removes access of federated user from a resource

--- a/tests/acceptance/features/apiSpaces/listSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/listSpaces.feature
@@ -149,8 +149,8 @@ Feature: List and create spaces
         }
       }
       """
-    And the json responded should not contain a space with name "Shares"
-    And the json responded should only contain spaces of type "personal"
+    And the json response should not contain a space with name "Shares"
+    And the json response should only contain spaces of type "personal"
 
 
   Scenario: ordinary user will not see any space when using a filter for project
@@ -183,7 +183,7 @@ Feature: List and create spaces
         }
       }
       """
-    And the json responded should not contain a space with name "Alice Hansen"
+    And the json response should not contain a space with name "Alice Hansen"
 
 
   Scenario: ordinary user can access their space via the webDav API
@@ -435,7 +435,7 @@ Feature: List and create spaces
     And user "Admin" has created a space "Project Venus" with the default quota using the Graph API
     When user "Alice" tries to look up the single space "Project Venus" owned by the user "Admin" by using its id
     Then the HTTP status code should be "404"
-    And the json responded should not contain a space with name "Project Venus"
+    And the json response should not contain a space with name "Project Venus"
     Examples:
       | user-role  |
       | User       |

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -49,7 +49,7 @@ Feature: Space management
         }
       }
       """
-    And the json responded should not contain a space with name "Alice Hansen"
+    And the json response should not contain a space with name "Alice Hansen"
 
 
   Scenario: space admin user can see another personal spaces
@@ -80,14 +80,14 @@ Feature: Space management
         }
       }
       """
-    And the json responded should not contain a space with name "Project"
+    And the json response should not contain a space with name "Project"
 
 
   Scenario: user without space admin permission cannot see another spaces
     When user "Carol" tries to list all spaces via the Graph API
     Then the HTTP status code should be "200"
-    And the json responded should not contain a space with name "Project"
-    And the json responded should not contain a space with name "Alice Hansen"
+    And the json response should not contain a space with name "Project"
+    And the json response should not contain a space with name "Alice Hansen"
 
 
   Scenario: space admin user changes the name of the project space


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR fixes typo in following then steps:
``` feature
And the json responded should not contain a space with name "Shares"
And the json responded should only contain spaces of type "personal"
````

Updated to:
``` feature
And the json response should not contain a space with name "Shares"
And the json response should only contain spaces of type "personal"
````

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Originated from: https://github.com/owncloud/ocis/pull/10753#discussion_r1886620122

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
