### PR TITLE
[k6-test][full-ci]Debug k6 failure on nightly 

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -479,7 +479,7 @@ def testOcisAndUploadResults(ctx):
     # The triggers have been disabled for now, since the govulncheck can #
     # not silence single, acceptable vulnerabilities.                    #
     # See https://github.com/owncloud/ocis/issues/9527 for more details. #
-    # FIXME: RE-ENABLE THIS ASAP!!!                                      #
+    # FIXME: RE-ENABLE THIS ASAP!!!!                                      #
     ######################################################################
 
     scan_result_upload = uploadScanResults(ctx)


### PR DESCRIPTION
## Description
This PR initiates k6 load testing to determine if the failures observed in the nightly build are flaky. [Link to build](https://drone.owncloud.com/owncloud/ocis/42073/67/1). The build cannot be restarted due to changelog constraints. Additionally, if a PR is merged after the nightly run, restarting the nightly CI build results in failure.
