### PR TITLE
[tests-only][full-ci]added test to delete share access from group after the share role has been disabled

### DIFF
--- a/tests/acceptance/features/apiSharingNg1/removeAccessToDrive.feature
+++ b/tests/acceptance/features/apiSharingNg1/removeAccessToDrive.feature
@@ -262,3 +262,21 @@ Feature: Remove access to a drive
     When user "Alice" removes the access of user "Brian" from space "new-space" using root endpoint of the Graph API
     Then the HTTP status code should be "204"
     And the user "Brian" should not have a space called "NewSpace"
+
+  @env-config
+  Scenario: remove space share from group after the share role Space Editor Without Versions has been disabled
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Space Editor Without Versions"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has sent the following space share invitation:
+      | space           | new-space                     |
+      | sharee          | group1                        |
+      | shareType       | group                         |
+      | permissionsRole | Space Editor Without Versions |
+    And the administrator has disabled the permissions role "Space Editor Without Versions"
+    When user "Alice" removes the access of group "group1" from space "new-space" using root endpoint of the Graph API
+    Then the HTTP status code should be "204"
+    And the user "Brian" should not have a space called "new-space"

--- a/tests/acceptance/features/apiSharingNg1/removeAccessToDriveItem.feature
+++ b/tests/acceptance/features/apiSharingNg1/removeAccessToDriveItem.feature
@@ -223,3 +223,91 @@ Feature: Remove access to a drive item
     Then the HTTP status code should be "204"
     And for user "Brian" the space "Shares" should not contain these entries:
       | folderToShare |
+
+  @env-config
+  Scenario Outline: remove share from group after the share role Secure Viewer has been disabled (Personal Space)
+    Given the administrator has enabled the permissions role "Secure Viewer"
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has uploaded file with content "some content" to "textfile.txt"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource>    |
+      | space           | Personal      |
+      | sharee          | group1        |
+      | shareType       | group         |
+      | permissionsRole | Secure Viewer |
+    And the administrator has disabled the permissions role "Secure Viewer"
+    When user "Alice" removes the access of group "group1" from resource "<resource>" of space "Personal" using the Graph API
+    Then the HTTP status code should be "204"
+    And for user "Brian" the space "Shares" should not contain these entries:
+      | <resource> |
+    Examples:
+      | resource      |
+      | textfile.txt  |
+      | folderToShare |
+
+  @env-config
+  Scenario: remove share from group after the share role Denied has been disabled (Personal Space)
+    Given the administrator has enabled the permissions role "Denied"
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | Personal      |
+      | sharee          | group1        |
+      | shareType       | group         |
+      | permissionsRole | Denied        |
+    And the administrator has disabled the permissions role "Denied"
+    When user "Alice" removes the access of group "group1" from resource "folderToShare" of space "Personal" using the Graph API
+    Then the HTTP status code should be "204"
+    And for user "Brian" the space "Shares" should not contain these entries:
+      | folderToShare |
+
+  @env-config
+  Scenario Outline: remove share from group after the share role Secure Viewer has been disabled (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Secure Viewer"
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource>    |
+      | space           | new-space     |
+      | sharee          | group1        |
+      | shareType       | group         |
+      | permissionsRole | Secure Viewer |
+    And the administrator has disabled the permissions role "Secure Viewer"
+    When user "Alice" removes the access of group "group1" from resource "<resource>" of space "new-space" using the Graph API
+    Then the HTTP status code should be "204"
+    And for user "Brian" the space "Shares" should not contain these entries:
+      | <resource> |
+    Examples:
+      | resource      |
+      | textfile.txt  |
+      | folderToShare |
+
+  @env-config
+  Scenario: remove share from group after the share role Denied has been disabled (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And group "group1" has been created
+    And user "Brian" has been added to group "group1"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | new-space     |
+      | sharee          | group1        |
+      | shareType       | group         |
+      | permissionsRole | Denied        |
+    And the administrator has disabled the permissions role "Denied"
+    When user "Alice" removes the access of group "group1" from resource "folderToShare" of space "new-space" using the Graph API
+    Then the HTTP status code should be "204"
+    And for user "Brian" the space "Shares" should not contain these entries:
+      | folderToShare |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the test to remove access to group share after the share role has been disabled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10711

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
