### PR TITLE
[full-ci][tests-only] Refactor service health and ready url in tests

### DIFF
--- a/tests/acceptance/bootstrap/AuthContext.php
+++ b/tests/acceptance/bootstrap/AuthContext.php
@@ -213,11 +213,34 @@ class AuthContext implements Context {
 	 * @throws Exception
 	 */
 	public function userRequestsEndpointsWithNoAuthentication(string $method, TableNode $table): void {
-		$this->featureContext->verifyTableNodeColumns($table, ['endpoint'], ['service']);
+		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 		foreach ($table->getHash() as $row) {
 			$this->featureContext->setResponse(
 				$this->sendRequest(
 					$this->featureContext->substituteInLineCodes($row['endpoint']),
+					$method
+				)
+			);
+			$this->featureContext->pushToLastStatusCodesArrays();
+		}
+	}
+
+	/**
+	 * @When a user requests these URLs with :method and no authentication
+	 *
+	 * @param $method
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function aUserRequestsTheseUrlsWithAndNoAuthentication($method, TableNode $table): void {
+		$this->featureContext->verifyTableNodeColumns($table, ['endpoint'], ['service']);
+		foreach ($table->getHash() as $row) {
+			$this->featureContext->setResponse(
+				HttpRequestHelper::sendRequest(
+					$this->featureContext->substituteInLineCodes($row['endpoint']),
+					$this->featureContext->getStepLineRef(),
 					$method
 				)
 			);

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -322,5 +322,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 - [apiSharingNg1/propfindShares.feature:149](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNg1/propfindShares.feature#L149)
 
+#### [Readiness check for some services returns 500 status code](https://github.com/owncloud/ocis/issues/10661)
+- [apiServiceAvailability/serviceAvailabilityCheck.feature:116](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L116)
+- [apiServiceAvailability/serviceAvailabilityCheck.feature:125](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L125)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiAntivirus/serviceAvailabilityCheck.feature
+++ b/tests/acceptance/features/apiAntivirus/serviceAvailabilityCheck.feature
@@ -2,14 +2,14 @@ Feature: service health check
 
 
   Scenario: check service health
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                         | service   |
-      | %base_url_hostname%:9297/healthz | antivirus |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                                | service   |
+      | http://%base_url_hostname%:9297/healthz | antivirus |
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
   Scenario: check service readiness
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                        | service   |
-      | %base_url_hostname%:9297/readyz | antivirus |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                               | service   |
+      | http://%base_url_hostname%:9297/readyz | antivirus |
     Then the HTTP status code of responses on all endpoints should be "200"

--- a/tests/acceptance/features/apiCollaboration/serviceAvailabilityCheck.feature
+++ b/tests/acceptance/features/apiCollaboration/serviceAvailabilityCheck.feature
@@ -2,14 +2,14 @@ Feature: service health check
 
 
   Scenario: check service health
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                              | service       |
-      | %collaboration_hostname%:9304/healthz | collaboration |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                                     | service       |
+      | http://%collaboration_hostname%:9304/healthz | collaboration |
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
   Scenario: check service readiness
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                             | service       |
-      | %collaboration_hostname%:9304/readyz | collaboration |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                                    | service       |
+      | http://%collaboration_hostname%:9304/readyz | collaboration |
     Then the HTTP status code of responses on all endpoints should be "200"

--- a/tests/acceptance/features/apiNotification/serviceAvailabilityCheck.feature
+++ b/tests/acceptance/features/apiNotification/serviceAvailabilityCheck.feature
@@ -2,14 +2,14 @@ Feature: service health check
 
 
   Scenario: check service health
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                         | service      |
-      | %base_url_hostname%:9174/healthz | notification |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                                | service      |
+      | http://%base_url_hostname%:9174/healthz | notification |
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
   Scenario: check service readiness
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                        | service      |
-      | %base_url_hostname%:9174/readyz | notification |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                               | service      |
+      | http://%base_url_hostname%:9174/readyz | notification |
     Then the HTTP status code of responses on all endpoints should be "200"

--- a/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature
+++ b/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature
@@ -2,42 +2,42 @@ Feature: service health check
 
 
   Scenario: check default services health
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                         | service            |
-      | %base_url_hostname%:9197/healthz | activitylog        |
-      | %base_url_hostname%:9165/healthz | app-provider       |
-      | %base_url_hostname%:9243/healthz | app-registry       |
-      | %base_url_hostname%:9147/healthz | auth-basic         |
-      | %base_url_hostname%:9167/healthz | auth-machine       |
-      | %base_url_hostname%:9198/healthz | auth-service       |
-      | %base_url_hostname%:9260/healthz | clientlog          |
-      | %base_url_hostname%:9270/healthz | eventhistory       |
-      | %base_url_hostname%:9141/healthz | frontend           |
-      | %base_url_hostname%:9143/healthz | gateway            |
-      | %base_url_hostname%:9124/healthz | graph              |
-      | %base_url_hostname%:9161/healthz | groups             |
-      | %base_url_hostname%:9239/healthz | idm                |
-      | %base_url_hostname%:9134/healthz | idp                |
-      | %base_url_hostname%:9234/healthz | nats               |
-      | %base_url_hostname%:9163/healthz | ocdav              |
-      | %base_url_hostname%:9281/healthz | ocm                |
-      | %base_url_hostname%:9114/healthz | ocs                |
-      | %base_url_hostname%:9255/healthz | postprocessing     |
-      | %base_url_hostname%:9205/healthz | proxy              |
-      | %base_url_hostname%:9224/healthz | search             |
-      | %base_url_hostname%:9194/healthz | settings           |
-      | %base_url_hostname%:9151/healthz | sharing            |
-      | %base_url_hostname%:9139/healthz | sse                |
-      | %base_url_hostname%:9179/healthz | storage-publiclink |
-      | %base_url_hostname%:9156/healthz | storage-shares     |
-      | %base_url_hostname%:9217/healthz | storage-system     |
-      | %base_url_hostname%:9159/healthz | storage-users      |
-      | %base_url_hostname%:9189/healthz | thumbnails         |
-      | %base_url_hostname%:9214/healthz | userlog            |
-      | %base_url_hostname%:9145/healthz | users              |
-      | %base_url_hostname%:9104/healthz | web                |
-      | %base_url_hostname%:9119/healthz | webdav             |
-      | %base_url_hostname%:9279/healthz | webfinger          |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                                | service            |
+      | http://%base_url_hostname%:9197/healthz | activitylog        |
+      | http://%base_url_hostname%:9165/healthz | app-provider       |
+      | http://%base_url_hostname%:9243/healthz | app-registry       |
+      | http://%base_url_hostname%:9147/healthz | auth-basic         |
+      | http://%base_url_hostname%:9167/healthz | auth-machine       |
+      | http://%base_url_hostname%:9198/healthz | auth-service       |
+      | http://%base_url_hostname%:9260/healthz | clientlog          |
+      | http://%base_url_hostname%:9270/healthz | eventhistory       |
+      | http://%base_url_hostname%:9141/healthz | frontend           |
+      | http://%base_url_hostname%:9143/healthz | gateway            |
+      | http://%base_url_hostname%:9124/healthz | graph              |
+      | http://%base_url_hostname%:9161/healthz | groups             |
+      | http://%base_url_hostname%:9239/healthz | idm                |
+      | http://%base_url_hostname%:9134/healthz | idp                |
+      | http://%base_url_hostname%:9234/healthz | nats               |
+      | http://%base_url_hostname%:9163/healthz | ocdav              |
+      | http://%base_url_hostname%:9281/healthz | ocm                |
+      | http://%base_url_hostname%:9114/healthz | ocs                |
+      | http://%base_url_hostname%:9255/healthz | postprocessing     |
+      | http://%base_url_hostname%:9205/healthz | proxy              |
+      | http://%base_url_hostname%:9224/healthz | search             |
+      | http://%base_url_hostname%:9194/healthz | settings           |
+      | http://%base_url_hostname%:9151/healthz | sharing            |
+      | http://%base_url_hostname%:9139/healthz | sse                |
+      | http://%base_url_hostname%:9179/healthz | storage-publiclink |
+      | http://%base_url_hostname%:9156/healthz | storage-shares     |
+      | http://%base_url_hostname%:9217/healthz | storage-system     |
+      | http://%base_url_hostname%:9159/healthz | storage-users      |
+      | http://%base_url_hostname%:9189/healthz | thumbnails         |
+      | http://%base_url_hostname%:9214/healthz | userlog            |
+      | http://%base_url_hostname%:9145/healthz | users              |
+      | http://%base_url_hostname%:9104/healthz | web                |
+      | http://%base_url_hostname%:9119/healthz | webdav             |
+      | http://%base_url_hostname%:9279/healthz | webfinger          |
     Then the HTTP status code of responses on all endpoints should be "200"
 
   @env-config
@@ -47,56 +47,51 @@ Feature: service health check
       | OCIS_ADD_RUN_SERVICES  | audit,auth-app,auth-bearer,policies,invitations |
       | AUDIT_DEBUG_ADDR       | 0.0.0.0:9229                                    |
       | AUTH_APP_DEBUG_ADDR    | 0.0.0.0:9245                                    |
-      | AUTH_BEARER_DEBUG_ADDR | 0.0.0.0:9149                                    |
       | POLICIES_DEBUG_ADDR    | 0.0.0.0:9129                                    |
       | INVITATIONS_DEBUG_ADDR | 0.0.0.0:9269                                    |
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                         | service     |
-      | %base_url_hostname%:9229/healthz | audit       |
-      | %base_url_hostname%:9245/healthz | auth-app    |
-      | %base_url_hostname%:9149/healthz | auth-bearer |
-      | %base_url_hostname%:9269/healthz | invitations |
-      | %base_url_hostname%:9129/healthz | policies    |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                                | service     |
+      | http://%base_url_hostname%:9229/healthz | audit       |
+      | http://%base_url_hostname%:9245/healthz | auth-app    |
+      | http://%base_url_hostname%:9269/healthz | invitations |
+      | http://%base_url_hostname%:9129/healthz | policies    |
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
   Scenario: check default services readiness
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                        | service            |
-      | %base_url_hostname%:9197/readyz | activitylog        |
-      | %base_url_hostname%:9165/readyz | app-provider       |
-      | %base_url_hostname%:9243/readyz | app-registry       |
-      | %base_url_hostname%:9147/readyz | auth-basic         |
-      | %base_url_hostname%:9167/readyz | auth-machine       |
-      | %base_url_hostname%:9198/readyz | auth-service       |
-      | %base_url_hostname%:9260/readyz | clientlog          |
-      | %base_url_hostname%:9270/readyz | eventhistory       |
-      | %base_url_hostname%:9141/readyz | frontend           |
-      | %base_url_hostname%:9143/readyz | gateway            |
-      | %base_url_hostname%:9124/readyz | graph              |
-      | %base_url_hostname%:9161/readyz | groups             |
-      | %base_url_hostname%:9239/readyz | idm                |
-      | %base_url_hostname%:9134/readyz | idp                |
-      | %base_url_hostname%:9234/readyz | nats               |
-      | %base_url_hostname%:9163/readyz | ocdav              |
-      | %base_url_hostname%:9281/readyz | ocm                |
-      | %base_url_hostname%:9114/readyz | ocs                |
-      | %base_url_hostname%:9255/readyz | postprocessing     |
-      | %base_url_hostname%:9205/readyz | proxy              |
-      | %base_url_hostname%:9224/readyz | search             |
-      | %base_url_hostname%:9194/readyz | settings           |
-      | %base_url_hostname%:9151/readyz | sharing            |
-      | %base_url_hostname%:9139/readyz | sse                |
-      | %base_url_hostname%:9179/readyz | storage-publiclink |
-      | %base_url_hostname%:9156/readyz | storage-shares     |
-      | %base_url_hostname%:9217/readyz | storage-system     |
-      | %base_url_hostname%:9159/readyz | storage-users      |
-      | %base_url_hostname%:9189/readyz | thumbnails         |
-      | %base_url_hostname%:9214/readyz | userlog            |
-      | %base_url_hostname%:9145/readyz | users              |
-      | %base_url_hostname%:9104/readyz | web                |
-      | %base_url_hostname%:9119/readyz | webdav             |
-      | %base_url_hostname%:9279/readyz | webfinger          |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                               | service            |
+      | http://%base_url_hostname%:9197/readyz | activitylog        |
+      | http://%base_url_hostname%:9165/readyz | app-provider       |
+      | http://%base_url_hostname%:9243/readyz | app-registry       |
+      | http://%base_url_hostname%:9147/readyz | auth-basic         |
+      | http://%base_url_hostname%:9167/readyz | auth-machine       |
+      | http://%base_url_hostname%:9198/readyz | auth-service       |
+      | http://%base_url_hostname%:9260/readyz | clientlog          |
+      | http://%base_url_hostname%:9270/readyz | eventhistory       |
+      | http://%base_url_hostname%:9141/readyz | frontend           |
+      | http://%base_url_hostname%:9143/readyz | gateway            |
+      | http://%base_url_hostname%:9161/readyz | groups             |
+      | http://%base_url_hostname%:9239/readyz | idm                |
+      | http://%base_url_hostname%:9234/readyz | nats               |
+      | http://%base_url_hostname%:9163/readyz | ocdav              |
+      | http://%base_url_hostname%:9281/readyz | ocm                |
+      | http://%base_url_hostname%:9114/readyz | ocs                |
+      | http://%base_url_hostname%:9255/readyz | postprocessing     |
+      | http://%base_url_hostname%:9224/readyz | search             |
+      | http://%base_url_hostname%:9194/readyz | settings           |
+      | http://%base_url_hostname%:9151/readyz | sharing            |
+      | http://%base_url_hostname%:9139/readyz | sse                |
+      | http://%base_url_hostname%:9179/readyz | storage-publiclink |
+      | http://%base_url_hostname%:9156/readyz | storage-shares     |
+      | http://%base_url_hostname%:9217/readyz | storage-system     |
+      | http://%base_url_hostname%:9159/readyz | storage-users      |
+      | http://%base_url_hostname%:9189/readyz | thumbnails         |
+      | http://%base_url_hostname%:9214/readyz | userlog            |
+      | http://%base_url_hostname%:9145/readyz | users              |
+      | http://%base_url_hostname%:9104/readyz | web                |
+      | http://%base_url_hostname%:9119/readyz | webdav             |
+      | http://%base_url_hostname%:9279/readyz | webfinger          |
     Then the HTTP status code of responses on all endpoints should be "200"
 
   @env-config
@@ -109,11 +104,30 @@ Feature: service health check
       | AUTH_BEARER_DEBUG_ADDR | 0.0.0.0:9149                                    |
       | POLICIES_DEBUG_ADDR    | 0.0.0.0:9129                                    |
       | INVITATIONS_DEBUG_ADDR | 0.0.0.0:9269                                    |
-    When a user requests these endpoints with "GET" and no authentication
-      | endpoint                        | service     |
-      | %base_url_hostname%:9229/readyz | audit       |
-      | %base_url_hostname%:9245/readyz | auth-app    |
-      | %base_url_hostname%:9149/readyz | auth-bearer |
-      | %base_url_hostname%:9269/readyz | invitations |
-      | %base_url_hostname%:9129/readyz | policies    |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                               | service     |
+      | http://%base_url_hostname%:9229/readyz | audit       |
+      | http://%base_url_hostname%:9245/readyz | auth-app    |
+      | http://%base_url_hostname%:9269/readyz | invitations |
+      | http://%base_url_hostname%:9129/readyz | policies    |
+    Then the HTTP status code of responses on all endpoints should be "200"
+
+  @issue-10661
+  Scenario: check default services readiness
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                               | service |
+      | http://%base_url_hostname%:9124/readyz | graph   |
+      | http://%base_url_hostname%:9134/readyz | idp     |
+      | http://%base_url_hostname%:9205/readyz | proxy   |
+    Then the HTTP status code of responses on all endpoints should be "200"
+
+  @env-config @issue-10661
+  Scenario: check extra services readiness
+    Given the following configs have been set:
+      | config                 | value        |
+      | OCIS_ADD_RUN_SERVICES  | auth-bearer  |
+      | AUTH_BEARER_DEBUG_ADDR | 0.0.0.0:9149 |
+    When a user requests these URLs with "GET" and no authentication
+      | endpoint                               | service     |
+      | http://%base_url_hostname%:9149/readyz | auth-bearer |
     Then the HTTP status code of responses on all endpoints should be "200"


### PR DESCRIPTION
## Description
The problem lies in the test code, which is sending requests to the following incorrect URL: https://localhost:9200/ocalhost:9229/healthz and https://localhost:9200/ocalhost:9229/readyz

As a result, the server returns a 200 status code, but the request is not directed to the intended endpoint, causing tests to pass erroneously.

This PR update test code base to send request to proper url

**Note:** This PR isolates the problematic service into a separate scenario for testing. Once issue #10661 is resolved, the scenario separation introduced in this PR should be reverted.
A follow-up QA point has been added in #10316.
![Screenshot from 2024-12-30 09-43-09](https://github.com/user-attachments/assets/9ed78b1d-f064-4610-8a28-b083661d288e)


## Related Issue
Part of 
- https://github.com/owncloud/ocis/issues/10661
- https://github.com/owncloud/ocis/issues/10316
- https://github.com/owncloud/ocis/issues/10715

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
