### PR TITLE
[tests-only][full-ci] test: check if share creation date is not missing in share invite response

### DIFF
--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -1,3 +1,4 @@
+@issue-10739
 Feature: Send a sharing invitations
   As the owner of a resource
   I want to be able to send invitations to other users
@@ -38,6 +39,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "roles",
                 "grantedToV2"
@@ -128,6 +130,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "roles",
                 "grantedToV2"
@@ -209,6 +212,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "@libre.graph.permissions.actions",
                 "grantedToV2"
@@ -297,6 +301,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "@libre.graph.permissions.actions",
                 "grantedToV2"
@@ -394,6 +399,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "@libre.graph.permissions.actions",
                 "grantedToV2"
@@ -488,6 +494,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "@libre.graph.permissions.actions",
                 "grantedToV2"
@@ -581,6 +588,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "roles",
                 "grantedToV2",
@@ -677,6 +685,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "roles",
                 "grantedToV2",
@@ -767,6 +776,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "roles",
                 "grantedToV2"
@@ -2004,6 +2014,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "grantedToV2",
                 "roles"
               ],
@@ -2092,6 +2103,7 @@ Feature: Send a sharing invitations
             "items": {
               "type": "object",
               "required": [
+                "createdDateTime",
                 "id",
                 "roles",
                 "grantedToV2"


### PR DESCRIPTION
## Description
This PR confirms that `createdDateTime` is not missing in the response while sharing the items via `.../invite` endpoint.

Bug report has been done for drive invitation so this PR only touches resource invitation
- https://github.com/owncloud/ocis/issues/10077

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to: https://github.com/owncloud/ocis/issues/8428
- https://github.com/owncloud/ocis/issues/10739

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
