### PR TITLE
[tests-only][full-ci] added test to enable disable Secure Viewer permissions role for federated shares

### DIFF
--- a/tests/acceptance/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/bootstrap/ArchiverContext.php
@@ -113,7 +113,7 @@ class ArchiverContext implements Context {
 	 *
 	 * @throws Exception
 	 */
-	private function getArchiverQueryString(
+	public function getArchiverQueryString(
 		string $user,
 		string $resource,
 		string $addressType

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -4210,6 +4210,7 @@ class SpacesContext implements Context {
 	 * @param string|null $resource
 	 * @param array|null $headers
 	 * @param string|null $folderDepth
+	 * @param bool $federatedShare
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -4218,12 +4219,20 @@ class SpacesContext implements Context {
 	 */
 	public function sendPropfindRequestToSpace(
 		string $user,
-		string $spaceName,
+		?string $spaceName = "",
 		?string $resource = "",
 		?array $headers = [],
-		?string $folderDepth = "1"
+		?string $folderDepth = "1",
+		bool $federatedShare = false
 	): ResponseInterface {
-		$spaceId = $this->getSpaceIdByName($user, $spaceName);
+		// PROPFIND request to federated share via normal webdav path "remote.php/dav/spaces/{shares-space-id}/{resource}" returns 404 status code
+		// the federated share is only accessible using "remote-item-id", i.e. "remote.php/dav/spaces/{remote-item-id}"
+		if ($federatedShare) {
+			$spaceId = $this->getSharesRemoteItemId($user, $resource);
+			$resource = null;
+		} else {
+			$spaceId = $this->getSpaceIdByName($user, $spaceName);
+		}
 		$properties = [
 			'oc:id',
 			'oc:fileid',

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -336,5 +336,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiOcm/share.feature:1194](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1194)
 - [apiOcm/share.feature:1218](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1218)
 
+#### [[OCM] federated user trying to download file shared with permissions role Secure Viewer returns 500 status code](https://github.com/owncloud/ocis/issues/10822)
+- [apiOcm/enableDisablePermissionsRole.feature:18](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/enableDisablePermissionsRole.feature#L18)
+- [apiOcm/enableDisablePermissionsRole.feature:58](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/enableDisablePermissionsRole.feature#L58)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiOcm/enableDisablePermissionsRole.feature
+++ b/tests/acceptance/features/apiOcm/enableDisablePermissionsRole.feature
@@ -1,0 +1,99 @@
+@ocm @env-config @issue-10824
+Feature: enable/disable permissions role
+  As a user
+  I want to enable/disable permissions role on shared resources
+  So that I can control the accessibility of shared resources to sharee
+
+  Background:
+    Given using spaces DAV path
+    And user "Alice" has been created with default attributes
+    And "Alice" has created the federation share invitation
+    And using server "REMOTE"
+    And user "Brian" has been created with default attributes
+    And "Brian" has accepted invitation
+    And using server "LOCAL"
+    And the administrator has enabled the permissions role "Secure Viewer"
+
+  @issue-10822
+  Scenario: user accesses federated shared file shared with permissions role Secure Viewer after the role is disabled (Personal Space)
+    Given user "Alice" has uploaded file with content "some content" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | textfile.txt  |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And the administrator has disabled the permissions role "Secure Viewer"
+    And using server "REMOTE"
+    When user "Brian" sends PROPFIND request to federated share "textfile.txt" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
+      | key            | value        |
+      | oc:name        | textfile.txt |
+      | oc:permissions |              |
+    And user "Brian" should have a federated share "textfile.txt" shared by user "Alice" from space "Personal"
+    And user "Brian" should be able to download federated shared file "textfile.txt"
+
+
+  Scenario: user accesses federated shared folder shared with permissions role Secure Viewer after the role is disabled (Personal Space)
+    Given user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | folderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And the administrator has disabled the permissions role "Secure Viewer"
+    And using server "REMOTE"
+    When user "Brian" sends PROPFIND request to federated share "folderToShare" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "folderToShare" with these key and value pairs:
+      | key            | value         |
+      | oc:name        | folderToShare |
+      | oc:permissions |               |
+    And user "Brian" should have a federated share "folderToShare" shared by user "Alice" from space "Personal"
+    And user "Brian" should be able to download archive of federated shared folder "folderToShare"
+
+  @issue-10822
+  Scenario: user accesses federated shared file shared with permissions role Secure Viewer after the role is disabled (Project Space)
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | textfile.txt  |
+      | space           | new-space     |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And the administrator has disabled the permissions role "Secure Viewer"
+    And using server "REMOTE"
+    When user "Brian" sends PROPFIND request to federated share "textfile.txt" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
+      | key            | value        |
+      | oc:name        | textfile.txt |
+      | oc:permissions |              |
+    And user "Brian" should have a federated share "textfile.txt" shared by user "Alice" from space "new-space"
+    And user "Brian" should be able to download federated shared file "textfile.txt"
+
+
+  Scenario: user accesses federated shared folder shared with permissions role Secure Viewer after the role is disabled (Project Space)
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | folderToShare |
+      | space           | new-space     |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And the administrator has disabled the permissions role "Secure Viewer"
+    And using server "REMOTE"
+    When user "Brian" sends PROPFIND request to federated share "folderToShare" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "folderToShare" with these key and value pairs:
+      | key            | value         |
+      | oc:name        | folderToShare |
+      | oc:permissions |               |
+    And user "Brian" should have a federated share "folderToShare" shared by user "Alice" from space "new-space"
+    And user "Brian" should be able to download archive of federated shared folder "folderToShare"


### PR DESCRIPTION
## Description
This PR adds tests to enable and disable the share permissions role **Secure VIewer** for federated shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10711

Test Coverage for https://github.com/owncloud/ocis/issues/10824 and https://github.com/owncloud/ocis/issues/10822

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
