### PR TITLE
[docs-only][stable-7.0] ocis_full: point ocis to production and not to rolling

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -39,7 +39,7 @@ OCIS=:ocis.yml
 # For production releases: "owncloud/ocis"
 # For rolling releases:    "owncloud/ocis-rolling"
 # Defaults to production if not set otherwise
-OCIS_DOCKER_IMAGE=owncloud/ocis-rolling
+OCIS_DOCKER_IMAGE=
 # The oCIS container version.
 # Defaults to "latest" and points to the latest stable tag.
 OCIS_DOCKER_TAG=


### PR DESCRIPTION
The image needs to be set to production and not to rolling in stable 7.
(empty = production...)

Missed to update this...