### PR TITLE
[docs-only] Add a note to translation docs how to manual start syncing.

### DIFF
--- a/docs/services/general-info/add-translations.md
+++ b/docs/services/general-info/add-translations.md
@@ -17,7 +17,12 @@ Services can have texts that need to be translated. These translations will be s
 The process for _synchronisation_ with Transifex is already setup and nothing needs to be done here. For any translation, it is necessary to set it up in the respective service and tell to sync it.
 
 **IMPORTANT**\
-Translations are automatically synced on a daily basis in the night. To do so, there is an own repo that covers the process for ALL translations from all configured repos: [translation-sync](https://github.com/owncloud/translation-sync). If there is a manual "emergency" sync necessary, you only need to trigger [drone](https://drone.owncloud.com/owncloud/translation-sync). Note that you need drone write access to do that.
+Translations are automatically synced on a daily basis in the night. To do so, there is an own repo that covers the process for ALL translations from all configured repos: [translation-sync](https://github.com/owncloud/translation-sync). If there is a manual "emergency" sync necessary, you only need to trigger [drone](https://drone.owncloud.com/owncloud/translation-sync) via cli
+
+```bash
+drone cron exec owncloud/translation-sync nightly
+```
+Note that you need to be logged on in drone to execute the command.
 
 ## Implementing ocis Translations
 

--- a/docs/services/general-info/add-translations.md
+++ b/docs/services/general-info/add-translations.md
@@ -16,7 +16,8 @@ Services can have texts that need to be translated. These translations will be s
 
 The process for _synchronisation_ with Transifex is already setup and nothing needs to be done here. For any translation, it is necessary to set it up in the respective service and tell to sync it.
 
-Translations are automatically synced on a daily basis in the night.
+**IMPORTANT**\
+Translations are automatically synced on a daily basis in the night. To do so, there is an own repo that covers the process for ALL translations from all configured repos: [translation-sync](https://github.com/owncloud/translation-sync). If there is a manual "emergency" sync necessary, you only need to trigger [drone](https://drone.owncloud.com/owncloud/translation-sync). Note that you need drone write access to do that.
 
 ## Implementing ocis Translations
 


### PR DESCRIPTION
The translation docs missed a note how and where to manually start a sync process - fixed.