### PR TITLE
[tests-only][full-ci] use displayname of permissions role in resource link share creation step

### DIFF
--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -46,6 +46,15 @@ class GraphHelper {
 		'Denied' => '63e64e19-8d43-42ec-a738-2b6af2610efa',
 	];
 
+	public const SHARING_LINK_TYPE_MAPPINGS = [
+		'View' => 'view',
+		'Internal' => 'internal',
+		'Edit' => 'edit',
+		'Upload' => 'upload',
+		'File Drop' => 'createOnly',
+		'Secure View' => 'blocksDownload',
+	];
+
 	public const SHARES_SPACE_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668';
 
 	/**

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -90,8 +90,11 @@ class SharingNgContext implements Context {
 		$bodyRows['expirationDateTime'] = \array_key_exists('expirationDateTime', $bodyRows)
 		? \date('Y-m-d', \strtotime($bodyRows['expirationDateTime'])) . 'T14:00:00.000Z' : null;
 		$bodyRows['password'] = $bodyRows['password'] ?? null;
+		$permissionsRole = $bodyRows['permissionsRole'];
+
+		$type = GraphHelper::SHARING_LINK_TYPE_MAPPINGS[$permissionsRole] ?? $permissionsRole;
 		$body = [
-			'type' => $bodyRows['permissionsRole'],
+			'type' => $type,
 			"@libre.graph.quickLink" => filter_var($bodyRows['quickLink'], FILTER_VALIDATE_BOOLEAN),
 			'displayName' => $bodyRows['displayName'],
 			'expirationDateTime' => $bodyRows['expirationDateTime'],
@@ -842,7 +845,7 @@ class SharingNgContext implements Context {
 		$body = [];
 
 		if (\array_key_exists('permissionsRole', $bodyRows)) {
-			$body['link']['type'] = $bodyRows['permissionsRole'];
+			$body['link']['type'] = GraphHelper::SHARING_LINK_TYPE_MAPPINGS[$bodyRows['permissionsRole']];
 		}
 
 		if (\array_key_exists('expirationDateTime', $bodyRows)) {

--- a/tests/acceptance/features/apiActivities/shareActivities.feature
+++ b/tests/acceptance/features/apiActivities/shareActivities.feature
@@ -273,7 +273,7 @@ Feature: check share activity
     Given user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     When user "Alice" lists the activities of file "textfile.txt" from space "Personal" using the Graph API
     Then the HTTP status code should be "200"
@@ -378,7 +378,7 @@ Feature: check share activity
     Given user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     And user "Alice" has removed the last link share of file "textfile.txt" from space "Personal"
     When user "Alice" lists the activities of file "textfile.txt" from space "Personal" using the Graph API
@@ -1071,7 +1071,7 @@ Feature: check share activity
       | password        | %public%  |
     And user "Alice" has updated the last resource link share with
       | space              | new-space                |
-      | permissionsRole    | edit                     |
+      | permissionsRole    | Edit                     |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     And user "Alice" has set the following password for the last link share:
       | resource |               |
@@ -1543,12 +1543,12 @@ Feature: check share activity
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | new-space    |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     And user "Alice" has updated the last resource link share with
       | resource           | textfile.txt             |
       | space              | new-space                |
-      | permissionsRole    | edit                     |
+      | permissionsRole    | Edit                     |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     And user "Alice" has set the following password for the last link share:
       | resource | textfile.txt  |
@@ -1853,7 +1853,7 @@ Feature: check share activity
       | password        | %public%  |
     And user "Alice" has updated the last resource link share with
       | space              | new-space                |
-      | permissionsRole    | edit                     |
+      | permissionsRole    | Edit                     |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     And user "Alice" has set the following password for the last link share:
       | resource |               |
@@ -1871,12 +1871,12 @@ Feature: check share activity
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | new-space    |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     And user "Alice" has updated the last resource link share with
       | resource           | textfile.txt             |
       | space              | new-space                |
-      | permissionsRole    | edit                     |
+      | permissionsRole    | Edit                     |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     And user "Alice" has set the following password for the last link share:
       | resource | textfile.txt  |
@@ -1894,12 +1894,12 @@ Feature: check share activity
     And user "Alice" has created the following resource link share:
       | resource        | project-folder |
       | space           | new-space      |
-      | permissionsRole | view           |
+      | permissionsRole | View           |
       | password        | %public%       |
     And user "Alice" has updated the last resource link share with
       | resource           | project-folder           |
       | space              | new-space                |
-      | permissionsRole    | edit                     |
+      | permissionsRole    | Edit                     |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     And user "Alice" has set the following password for the last link share:
       | resource | project-folder |
@@ -1958,7 +1958,7 @@ Feature: check share activity
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | edit         |
+      | permissionsRole | Edit         |
       | password        | %public%     |
     And the public has uploaded file "textfile.txt" with content "public test" and password "%public%" to the last link share using the public WebDAV API
     When user "Alice" lists the activities of file "textfile.txt" from space "Personal" using the Graph API
@@ -2098,7 +2098,7 @@ Feature: check share activity
     And user "Alice" has created the following resource link share:
       | resource        | /FOLDER  |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And the public has uploaded file "text.txt" with content "added by public user" and password "%public%" to the last link share using the public WebDAV API
     And the public has uploaded file "text.txt" with content "updated by public user" and password "%public%" to the last link share using the public WebDAV API

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -101,7 +101,7 @@ Feature: antivirus
     And user "Alice" has created the following resource link share:
       | resource           | uploadFolder             |
       | space              | Personal                 |
-      | permissionsRole    | edit                     |
+      | permissionsRole    | Edit                     |
       | expirationDateTime | 2040-01-01T23:59:59.000Z |
     When the public uploads file "filesForUpload/filesWithVirus/<file-name>" to "<new-file-name>" inside last link shared folder using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -126,7 +126,7 @@ Feature: antivirus
     And user "Alice" has created the following resource link share:
       | resource           | uploadFolder             |
       | space              | Personal                 |
-      | permissionsRole    | edit                     |
+      | permissionsRole    | Edit                     |
       | password           | %public%                 |
       | expirationDateTime | 2040-01-01T23:59:59.000Z |
     When the public uploads file "filesForUpload/filesWithVirus/<file-name>" to "<new-file-name>" inside last link shared folder with password "%public%" using the public WebDAV API
@@ -344,7 +344,7 @@ Feature: antivirus
     And user "Alice" has created the following resource link share:
       | resource        | test.txt |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public overwrites file "test.txt" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" using the public WebDAV API
     Then the HTTP status code should be "204"
     And user "Alice" should get a notification with subject "Virus found" and message:

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -181,7 +181,7 @@ Feature: collaboration (wopi)
     And user "Alice" has created the following resource link share:
       | resource        | simple.odt |
       | space           | Personal   |
-      | permissionsRole | view       |
+      | permissionsRole | View       |
       | password        | %public%   |
     When the public sends HTTP method "POST" to URL "<app-endpoint>" with password "%public%"
     Then the HTTP status code should be "200"
@@ -411,7 +411,7 @@ Feature: collaboration (wopi)
     And user "Alice" has created the following resource link share:
       | resource        | simple.odt |
       | space           | Personal   |
-      | permissionsRole | view       |
+      | permissionsRole | View       |
       | password        | %public%   |
     When the public sends HTTP method "POST" to URL "<app-endpoint>" with password "%public%"
     Then the HTTP status code should be "200"
@@ -953,9 +953,9 @@ Feature: collaboration (wopi)
     And as "Alice" file "publicFolder/simple.odt" should exist
     Examples:
       | permissions-role |
-      | edit             |
-      | upload           |
-      | createOnly       |
+      | Edit             |
+      | Upload           |
+      | File Drop        |
 
   @issue-10126 @issue-10331
   Scenario: public user with permission view tries to creates odt file inside public folder using wopi endpoint
@@ -963,7 +963,7 @@ Feature: collaboration (wopi)
     And user "Alice" has created the following resource link share:
       | resource        | publicFolder |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     When the public tries to create a file "simple.odt" inside the last shared public link folder with password "%public%" using wopi endpoint
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiDepthInfinity/propfind.feature
+++ b/tests/acceptance/features/apiDepthInfinity/propfind.feature
@@ -80,7 +80,7 @@ Feature: PROPFIND with depth:infinity
     And user "Alice" has created the following resource link share:
       | resource        | simple-folder |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
     When the public lists the resources in the last created public link with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last public link DAV response should contain these nodes
@@ -130,7 +130,7 @@ Feature: PROPFIND with depth:infinity
     And user "Alice" has created the following resource link share:
       | resource        | simple-folder |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
     When the public lists the resources in the last created public link with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "400"
 

--- a/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/apiGraph/enforcePasswordPublicLink.feature
@@ -64,7 +64,7 @@ Feature: enforce password on public link
     And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3        |
       | password    | %public% |
@@ -156,7 +156,7 @@ Feature: enforce password on public link
     And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3             |
       | password    | 6a0Q;A3 +i^m[ |
@@ -189,7 +189,7 @@ Feature: enforce password on public link
     And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3    |
       | password    | Pws^ |
@@ -264,7 +264,7 @@ Feature: enforce password on public link
     And user "Alice" has created the following resource link share:
       | resource        | testfile.txt |
       | space           | Personal     |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 3          |
       | password    | <password> |

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -719,7 +719,7 @@ Feature: user GDPR (General Data Protection Regulation) report
     And user "Alice" has created the following resource link share:
       | resource        | folderMain |
       | space           | Personal   |
-      | permissionsRole | view       |
+      | permissionsRole | View       |
       | password        | %public%   |
       | displayName     | sharedlink |
     When user "Alice" exports her GDPR report to "/.personal_data_export.json" using the Graph API

--- a/tests/acceptance/features/apiLocks/lockFiles.feature
+++ b/tests/acceptance/features/apiLocks/lockFiles.feature
@@ -475,7 +475,7 @@ Feature: lock files
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public locks "textfile0.txt" in the last public link shared folder using the public WebDAV API setting the following properties
       | lockscope | <lock-scope> |
@@ -498,7 +498,7 @@ Feature: lock files
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When the public tries to lock "textfile0.txt" in the last public link shared folder using the public WebDAV API setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiLocks/unlockFiles.feature
+++ b/tests/acceptance/features/apiLocks/unlockFiles.feature
@@ -307,7 +307,7 @@ Feature: unlock locked items
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And the public has locked "textfile0.txt" in the last public link shared folder setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiSharingNg1/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg1/listPermissions.feature
@@ -1748,7 +1748,7 @@ Feature: List a sharing permissions
     And user "Alice" has created the following resource link share:
       | resource        | folder   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When user "Alice" gets permissions list for folder "folder" of the space "Personal" using the Graph API
     Then the HTTP status code should be "200"
@@ -1853,7 +1853,7 @@ Feature: List a sharing permissions
     And user "Alice" has created the following resource link share:
       | resource        | textfile0.txt |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | %public%      |
     When user "Alice" gets permissions list for file "textfile0.txt" of the space "Personal" using the Graph API
     Then the HTTP status code should be "200"
@@ -1957,7 +1957,7 @@ Feature: List a sharing permissions
     And user "Alice" has created the following resource link share:
       | resource        | folder    |
       | space           | new-space |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
       | password        | %public%  |
     When user "Alice" gets permissions list for folder "folder" of the space "new-space" using the Graph API
     Then the HTTP status code should be "200"
@@ -2065,7 +2065,7 @@ Feature: List a sharing permissions
     And user "Alice" has created the following resource link share:
       | resource        | textfile0.txt |
       | space           | new-space     |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | %public%      |
     When user "Alice" gets permissions list for file "textfile0.txt" of the space "new-space" using the Graph API
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSharingNg1/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg1/sharedByMe.feature
@@ -1973,7 +1973,7 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -2082,7 +2082,7 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | Personal      |
-      | permissionsRole | edit          |
+      | permissionsRole | Edit          |
       | password        | %public%      |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -2192,12 +2192,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | edit         |
+      | permissionsRole | Edit         |
       | password        | %public%     |
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare/textfile.txt |
       | space           | Personal                   |
-      | permissionsRole | view                       |
+      | permissionsRole | View                       |
       | password        | %public%                   |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -2344,12 +2344,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | Personal      |
-      | permissionsRole | edit          |
+      | permissionsRole | Edit          |
       | password        | %public%      |
     And user "Alice" has created the following resource link share:
       | resource        | parent/FolderToShare |
       | space           | Personal             |
-      | permissionsRole | view                 |
+      | permissionsRole | View                 |
       | password        | %public%             |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -2493,12 +2493,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | edit         |
+      | permissionsRole | Edit         |
       | password        | %public%     |
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     And user "Alice" has removed the last link share of file "textfile.txt" from space "Personal"
     When user "Alice" lists the shares shared by her using the Graph API
@@ -2566,12 +2566,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | Personal      |
-      | permissionsRole | edit          |
+      | permissionsRole | Edit          |
       | password        | %public%      |
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | %public%      |
     And user "Alice" has removed the last link share of folder "FolderToShare" from space "Personal"
     When user "Alice" lists the shares shared by her using the Graph API
@@ -2642,7 +2642,7 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | NewSpace     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -2754,7 +2754,7 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | NewSpace      |
-      | permissionsRole | edit          |
+      | permissionsRole | Edit          |
       | password        | %public%      |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -2867,12 +2867,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | NewSpace     |
-      | permissionsRole | edit         |
+      | permissionsRole | Edit         |
       | password        | %public%     |
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare/textfile.txt |
       | space           | NewSpace                   |
-      | permissionsRole | view                       |
+      | permissionsRole | View                       |
       | password        | %public%                   |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -3021,12 +3021,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | NewSpace      |
-      | permissionsRole | edit          |
+      | permissionsRole | Edit          |
       | password        | %public%      |
     And user "Alice" has created the following resource link share:
       | resource        | parent/FolderToShare |
       | space           | NewSpace             |
-      | permissionsRole | view                 |
+      | permissionsRole | View                 |
       | password        | %public%             |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"
@@ -3173,12 +3173,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | NewSpace     |
-      | permissionsRole | edit         |
+      | permissionsRole | Edit         |
       | password        | %public%     |
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | NewSpace     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     And user "Alice" has removed the last link share of file "textfile.txt" from space "NewSpace"
     When user "Alice" lists the shares shared by her using the Graph API
@@ -3249,12 +3249,12 @@ Feature: resources shared by user
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | NewSpace      |
-      | permissionsRole | edit          |
+      | permissionsRole | Edit          |
       | password        | %public%      |
     And user "Alice" has created the following resource link share:
       | resource        | FolderToShare |
       | space           | NewSpace      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | %public%      |
     And user "Alice" has removed the last link share of folder "FolderToShare" from space "NewSpace"
     When user "Alice" lists the shares shared by her using the Graph API

--- a/tests/acceptance/features/apiSharingNg2/removeAccessToDriveItemInLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNg2/removeAccessToDriveItemInLinkShare.feature
@@ -20,11 +20,11 @@ Feature: Remove access to a drive item
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Upload           |
+      | File Drop        |
+      | Secure View      |
 
 
   Scenario Outline: user removes access to a file in link share
@@ -38,9 +38,9 @@ Feature: Remove access to a drive item
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Secure View      |
 
 
   Scenario Outline: user removes access to a folder in project space in link share
@@ -56,11 +56,11 @@ Feature: Remove access to a drive item
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Upload           |
+      | File Drop        |
+      | Secure View      |
 
 
   Scenario Outline: user removes access to a file in project space in link share
@@ -76,6 +76,6 @@ Feature: Remove access to a drive item
     Then the HTTP status code should be "204"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Secure View      |

--- a/tests/acceptance/features/apiSharingNgLinkSharePermission/createLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkSharePermission/createLinkShare.feature
@@ -52,7 +52,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -64,12 +64,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
   @issue-8619
   Scenario: create an internal link share of a folder using permissions endpoint
@@ -77,7 +77,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folder   |
       | space           | Personal |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -134,7 +134,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folder   |
       | space           | Personal |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
       | password        | %public% |
     Then the HTTP status code should be "400"
 
@@ -184,7 +184,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -196,10 +196,10 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Secure View      | blocksDownload         |
 
   @issue-8619
   Scenario: create an internal link share of a file using permissions endpoint
@@ -207,7 +207,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile1.txt |
       | space           | Personal      |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -264,7 +264,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile1.txt |
       | space           | Personal      |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
       | password        | %public%      |
     Then the HTTP status code should be "400"
 
@@ -320,7 +320,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -332,12 +332,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
   @issue-7879
   Scenario Outline: create a link share of a file with display name and expiry date using permissions endpoint
@@ -391,7 +391,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -403,10 +403,10 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Secure View      | blocksDownload         |
 
   @env-config @issue-7879
   Scenario Outline: create a link share of a file without password using permissions endpoint
@@ -456,7 +456,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -468,11 +468,11 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | internal         |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Internal         | internal               |
+      | Secure View      | blocksDownload         |
 
   @env-config @issue-9724 @issue-10331
   Scenario: set password on a file's link share using permissions endpoint
@@ -483,7 +483,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created the following resource link share:
       | resource        | textfile1.txt |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
     When user "Alice" sets the following password for the last link share using the Graph API:
       | resource | textfile1.txt |
       | space    | Personal      |
@@ -512,7 +512,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | text.txt          |
       | space           | Personal          |
-      | permissionsRole | view              |
+      | permissionsRole | View              |
       | password        | <banned-password> |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match
@@ -597,7 +597,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -609,12 +609,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario: create an internal link share of a folder inside project-space using permissions endpoint
@@ -625,7 +625,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare |
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -684,7 +684,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare |
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
       | password        | %public%      |
     Then the HTTP status code should be "400"
 
@@ -743,7 +743,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -755,12 +755,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario Outline: create a link share of a folder inside project-space with a password that is listed in the Banned-Password-List using permissions endpoint
@@ -804,21 +804,21 @@ Feature: Create a link share for a resource
       """
     Examples:
       | banned-password | permissions-role |
-      | 123             | view             |
-      | password        | view             |
-      | ownCloud        | view             |
-      | 123             | edit             |
-      | password        | edit             |
-      | ownCloud        | edit             |
-      | 123             | upload           |
-      | password        | upload           |
-      | ownCloud        | upload           |
-      | 123             | createOnly       |
-      | password        | createOnly       |
-      | ownCloud        | createOnly       |
-      | 123             | blocksDownload   |
-      | password        | blocksDownload   |
-      | ownCloud        | blocksDownload   |
+      | 123             | View             |
+      | password        | View             |
+      | ownCloud        | View             |
+      | 123             | Edit             |
+      | password        | Edit             |
+      | ownCloud        | Edit             |
+      | 123             | Upload           |
+      | password        | Upload           |
+      | ownCloud        | Upload           |
+      | 123             | File Drop        |
+      | password        | File Drop        |
+      | ownCloud        | File Drop        |
+      | 123             | Secure View      |
+      | password        | Secure View      |
+      | ownCloud        | Secure View      |
 
   @env-config @issue-7879
   Scenario Outline: create a link share of a file inside project-space without password using permissions endpoint
@@ -871,7 +871,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -883,12 +883,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
   @issue-7879
   Scenario Outline: create a link share of a file inside project-space using permissions endpoint
@@ -939,7 +939,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -951,10 +951,10 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Secure View      | blocksDownload         |
 
   @issue-8619
   Scenario: create an internal link share of a file inside project-space using permissions endpoint
@@ -965,7 +965,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt |
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -1025,7 +1025,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt |
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
       | password        | %public%     |
     Then the HTTP status code should be "400"
 
@@ -1084,7 +1084,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "pattern": "^%base_url%/s/[a-zA-Z]{15}$"
@@ -1095,10 +1095,10 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Secure View      | blocksDownload         |
 
   @env-config @issue-7879
   Scenario Outline: create a link share of a file inside project-space without password using permissions endpoint
@@ -1151,7 +1151,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -1163,11 +1163,11 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | internal         |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Internal         | internal               |
+      | Secure View      | blocksDownload         |
 
 
   Scenario Outline: create a link share of a file inside project-space with a password that is listed in the Banned-Password-List using permissions endpoint
@@ -1211,15 +1211,15 @@ Feature: Create a link share for a resource
       """
     Examples:
       | banned-password | permissions-role |
-      | 123             | view             |
-      | password        | view             |
-      | ownCloud        | view             |
-      | 123             | edit             |
-      | password        | edit             |
-      | ownCloud        | edit             |
-      | 123             | blocksDownload   |
-      | password        | blocksDownload   |
-      | ownCloud        | blocksDownload   |
+      | 123             | View             |
+      | password        | View             |
+      | ownCloud        | View             |
+      | 123             | Edit             |
+      | password        | Edit             |
+      | ownCloud        | Edit             |
+      | 123             | Secure View      |
+      | password        | Secure View      |
+      | ownCloud        | Secure View      |
 
   @env-config @issue-9724 @issue-10331
   Scenario: set password on a existing link share of a file inside project-space using permissions endpoint
@@ -1233,7 +1233,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | projectSpace |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
     When user "Alice" sets the following password for the last link share using the Graph API:
       | resource | textfile.txt |
       | space    | projectSpace |
@@ -1296,16 +1296,16 @@ Feature: Create a link share for a resource
       """
     Examples:
       | permissions-role | drive    | message                                   |
-      | view             | Shares   | no share permission                       |
-      | edit             | Shares   | no share permission                       |
-      | upload           | Shares   | no share permission                       |
-      | createOnly       | Shares   | no share permission                       |
-      | blocksDownload   | Shares   | invalid link type                         |
-      | view             | Personal | cannot create link on personal space root |
-      | edit             | Personal | cannot create link on personal space root |
-      | upload           | Personal | cannot create link on personal space root |
-      | createOnly       | Personal | cannot create link on personal space root |
-      | blocksDownload   | Personal | invalid link type                         |
+      | View             | Shares   | no share permission                       |
+      | Edit             | Shares   | no share permission                       |
+      | Upload           | Shares   | no share permission                       |
+      | File Drop        | Shares   | no share permission                       |
+      | Secure View      | Shares   | invalid link type                         |
+      | View             | Personal | cannot create link on personal space root |
+      | Edit             | Personal | cannot create link on personal space root |
+      | Upload           | Personal | cannot create link on personal space root |
+      | File Drop        | Personal | cannot create link on personal space root |
+      | Secure View      | Personal | invalid link type                         |
 
   @issue-7879
   Scenario Outline: create a link share of a project-space drive using permissions endpoint
@@ -1354,7 +1354,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -1366,18 +1366,18 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario Outline: try to create an internal link share of a Personal and Shares drives using permissions endpoint
     When user "Alice" tries to create the following space link share using permissions endpoint of the Graph API:
       | space           | <drive>  |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match
       """
@@ -1419,7 +1419,7 @@ Feature: Create a link share for a resource
   Scenario Outline: try to create an internal link share with password of a Personal and Shares drives using permissions endpoint
     When user "Alice" tries to create the following space link share using permissions endpoint of the Graph API:
       | space           | <drive>  |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
       | password        | %public% |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match
@@ -1466,7 +1466,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     When user "Alice" creates the following space link share using permissions endpoint of the Graph API:
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -1523,7 +1523,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     When user "Alice" creates the following space link share using permissions endpoint of the Graph API:
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
       | password        | %public%      |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match
@@ -1612,7 +1612,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -1624,12 +1624,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario Outline: try to create a link share of a project-space with a password that is listed in the Banned-Password-List using permissions endpoint
@@ -1671,21 +1671,21 @@ Feature: Create a link share for a resource
       """
     Examples:
       | banned-password | permissions-role |
-      | 123             | view             |
-      | password        | view             |
-      | ownCloud        | view             |
-      | 123             | edit             |
-      | password        | edit             |
-      | ownCloud        | edit             |
-      | 123             | upload           |
-      | password        | upload           |
-      | ownCloud        | upload           |
-      | 123             | createOnly       |
-      | password        | createOnly       |
-      | ownCloud        | createOnly       |
-      | 123             | blocksDownload   |
-      | password        | blocksDownload   |
-      | ownCloud        | blocksDownload   |
+      | 123             | View             |
+      | password        | View             |
+      | ownCloud        | View             |
+      | 123             | Edit             |
+      | password        | Edit             |
+      | ownCloud        | Edit             |
+      | 123             | Upload           |
+      | password        | Upload           |
+      | ownCloud        | Upload           |
+      | 123             | File Drop        |
+      | password        | File Drop        |
+      | ownCloud        | File Drop        |
+      | 123             | Secure View      |
+      | password        | Secure View      |
+      | ownCloud        | Secure View      |
 
 
   Scenario Outline: create a link share of a project-space without password using permissions endpoint
@@ -1736,7 +1736,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -1748,12 +1748,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario Outline: create a quick link share of a folder using permissions endpoint
@@ -1802,7 +1802,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -1814,12 +1814,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario: create an internal quick link share of a folder using permissions endpoint
@@ -1827,7 +1827,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folder   |
       | space           | Personal |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
       | quickLink       | true     |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -1926,7 +1926,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -1938,10 +1938,10 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Secure View      | blocksDownload         |
 
 
   Scenario: create an internal quick link share of a file using permissions endpoint
@@ -1949,7 +1949,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile1.txt |
       | space           | Personal      |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
       | quickLink       | true          |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -2051,7 +2051,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -2063,12 +2063,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario: create an internal quick link share of a folder inside project-space using permissions endpoint
@@ -2079,7 +2079,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | folderToShare |
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
       | quickLink       | true          |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -2180,7 +2180,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -2192,10 +2192,10 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Secure View      | blocksDownload         |
 
   @issue-8619
   Scenario: create an internal quick link share of a file inside project-space using permissions endpoint
@@ -2206,7 +2206,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | textfile.txt |
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
       | quickLink       | true         |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -2306,7 +2306,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -2318,12 +2318,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario: create an internal quick link share of a project-space using permissions endpoint
@@ -2332,7 +2332,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     When user "Alice" creates the following space link share using permissions endpoint of the Graph API:
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
       | quickLink       | true          |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -2466,7 +2466,7 @@ Feature: Create a link share for a resource
       | permissionsRole | <permissions-role> |
     When user "Brian" creates the following space link share using permissions endpoint of the Graph API:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -2607,7 +2607,7 @@ Feature: Create a link share for a resource
       | quickLink       | true               |
     When user "Brian" creates the following space link share using permissions endpoint of the Graph API:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
       | quickLink       | true         |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -2728,7 +2728,7 @@ Feature: Create a link share for a resource
       | permissionsRole | <permissions-role> |
     When user "Brian" creates the following space link share using permissions endpoint of the Graph API:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
       | quickLink       | true         |
       | password        | %public%     |
     Then the HTTP status code should be "400"
@@ -2773,7 +2773,7 @@ Feature: Create a link share for a resource
     When user "Alice" creates the following resource link share using the Graph API:
       | resource        | FolderToShare |
       | space           | Personal      |
-      | permissionsRole | denied        |
+      | permissionsRole | Denied        |
       | password        | %public%      |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match

--- a/tests/acceptance/features/apiSharingNgLinkSharePermission/updateLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkSharePermission/updateLinkShare.feature
@@ -56,7 +56,7 @@ Feature: Update a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<new-permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -68,13 +68,13 @@ Feature: Update a link share for a resource
       }
       """
     Examples:
-      | permissions-role | new-permissions-role |
-      | view             | edit                 |
-      | view             | blocksDownload       |
-      | edit             | view                 |
-      | edit             | blocksDownload       |
-      | blocksDownload   | edit                 |
-      | blocksDownload   | blocksDownload       |
+      | permissions-role | new-permissions-role | permissions-role-value |
+      | View             | Edit                 | edit                   |
+      | View             | Secure View          | blocksDownload         |
+      | Edit             | View                 | view                   |
+      | Edit             | Secure View          | blocksDownload         |
+      | Secure View      | Edit                 | edit                   |
+      | Secure View      | Secure View          | blocksDownload         |
 
   @issue-8619
   Scenario Outline: update role of a file's to internal link share using permissions endpoint
@@ -87,7 +87,7 @@ Feature: Update a link share for a resource
     When user "Alice" updates the last public link share using the permissions endpoint of the Graph API:
       | resource        | textfile1.txt |
       | space           | Personal      |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -138,9 +138,9 @@ Feature: Update a link share for a resource
       """
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Secure View      |
 
 
   Scenario: update expiration date of a file's link share using permissions endpoint
@@ -148,7 +148,7 @@ Feature: Update a link share for a resource
     And user "Alice" has created the following resource link share:
       | resource           | textfile1.txt            |
       | space              | Personal                 |
-      | permissionsRole    | view                     |
+      | permissionsRole    | View                     |
       | password           | %public%                 |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     When user "Alice" updates the last public link share using the permissions endpoint of the Graph API:
@@ -211,7 +211,7 @@ Feature: Update a link share for a resource
     And user "Alice" has created the following resource link share:
       | resource        | textfile1.txt |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | $heLlo*1234*  |
     When user "Alice" sets the following password for the last link share using the Graph API:
       | resource | textfile1.txt |
@@ -242,12 +242,12 @@ Feature: Update a link share for a resource
     And user "Alice" has created the following resource link share:
       | resource        | text.txt |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When user "Alice" sets the following password for the last link share using the Graph API:
       | resource        | text.txt          |
       | space           | Personal          |
-      | permissionsRole | view              |
+      | permissionsRole | View              |
       | password        | <banned-password> |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match
@@ -296,7 +296,7 @@ Feature: Update a link share for a resource
     And user "Alice" has created the following resource link share:
       | resource        | folderToShare |
       | space           | projectSpace  |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
     When user "Alice" sets the following password for the last link share using the Graph API:
       | resource | folderToShare |
       | space    | projectSpace  |
@@ -377,7 +377,7 @@ Feature: Update a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<new-permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -389,20 +389,20 @@ Feature: Update a link share for a resource
       }
       """
     Examples:
-      | permissions-role | new-permissions-role |
-      | view             | edit                 |
-      | view             | upload               |
-      | view             | createOnly           |
-      | edit             | view                 |
-      | edit             | upload               |
-      | edit             | createOnly           |
-      | upload           | view                 |
-      | upload           | edit                 |
-      | upload           | createOnly           |
-      | createOnly       | view                 |
-      | createOnly       | edit                 |
-      | createOnly       | upload               |
-      | blocksDownload   | blocksDownload       |
+      | permissions-role | new-permissions-role | permissions-role-value |
+      | view             | Edit                 | edit                   |
+      | view             | Upload               | upload                 |
+      | view             | File Drop            | createOnly             |
+      | edit             | View                 | view                   |
+      | edit             | Upload               | upload                 |
+      | edit             | File Drop            | createOnly             |
+      | upload           | View                 | view                   |
+      | upload           | Edit                 | edit                   |
+      | upload           | File Drop            | createOnly             |
+      | createOnly       | View                 | view                   |
+      | createOnly       | Edit                 | edit                   |
+      | createOnly       | Upload               | upload                 |
+      | blocksDownload   | Secure View          | blocksDownload         |
 
 
   Scenario Outline: update role of a folder's link share inside project-space using permissions endpoint
@@ -462,7 +462,7 @@ Feature: Update a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<new-permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -474,19 +474,19 @@ Feature: Update a link share for a resource
       }
       """
     Examples:
-      | permissions-role | new-permissions-role |
-      | view             | edit                 |
-      | view             | upload               |
-      | view             | createOnly           |
-      | edit             | view                 |
-      | edit             | upload               |
-      | edit             | createOnly           |
-      | upload           | view                 |
-      | upload           | edit                 |
-      | upload           | createOnly           |
-      | createOnly       | view                 |
-      | createOnly       | edit                 |
-      | createOnly       | upload               |
+      | permissions-role | new-permissions-role | permissions-role-value |
+      | View             | Edit                 | edit                   |
+      | View             | Upload               | upload                 |
+      | View             | File Drop            | createOnly             |
+      | Edit             | View                 | view                   |
+      | Edit             | Upload               | upload                 |
+      | Edit             | File Drop            | createOnly             |
+      | Upload           | View                 | view                   |
+      | Upload           | Edit                 | edit                   |
+      | Upload           | File Drop            | createOnly             |
+      | File Drop        | View                 | view                   |
+      | File Drop        | Edit                 | edit                   |
+      | File Drop        | Upload               | upload                 |
 
 
   Scenario Outline: update role of a file's link share inside a project-space using permissions endpoint
@@ -543,7 +543,7 @@ Feature: Update a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<new-permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -555,9 +555,9 @@ Feature: Update a link share for a resource
       }
       """
     Examples:
-      | permissions-role | new-permissions-role |
-      | view             | edit                 |
-      | edit             | view                 |
+      | permissions-role | new-permissions-role | permissions-role-value |
+      | View             | Edit                 | edit                   |
+      | Edit             | View                 | view                   |
 
 
   Scenario Outline: update role of a file's link share to internal inside a project-space using permissions endpoint
@@ -614,7 +614,7 @@ Feature: Update a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<new-permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -626,9 +626,9 @@ Feature: Update a link share for a resource
       }
       """
     Examples:
-      | permissions-role | new-permissions-role |
-      | view             | internal             |
-      | edit             | internal             |
+      | permissions-role | new-permissions-role | permissions-role-value |
+      | View             | Internal             | internal               |
+      | Edit             | Internal             | internal               |
 
 
   Scenario Outline: update role of a folder's link share to internal inside project-space using permissions endpoint
@@ -688,7 +688,7 @@ Feature: Update a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<new-permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -700,11 +700,11 @@ Feature: Update a link share for a resource
       }
       """
     Examples:
-      | permissions-role | new-permissions-role |
-      | view             | internal             |
-      | edit             | internal             |
-      | upload           | internal             |
-      | createOnly       | internal             |
+      | permissions-role | new-permissions-role | permissions-role-value |
+      | View             | Internal             | internal               |
+      | Edit             | Internal             | internal               |
+      | Upload           | Internal             | internal               |
+      | File Drop        | Internal             | internal               |
 
 
   Scenario Outline: update link share of a folder inside personal drive using permissions endpoint
@@ -764,7 +764,7 @@ Feature: Update a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<new-permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -776,20 +776,20 @@ Feature: Update a link share for a resource
       }
       """
     Examples:
-      | permissions-role | new-permissions-role |
-      | view             | edit                 |
-      | view             | upload               |
-      | view             | createOnly           |
-      | edit             | view                 |
-      | edit             | upload               |
-      | edit             | createOnly           |
-      | upload           | view                 |
-      | upload           | edit                 |
-      | upload           | createOnly           |
-      | createOnly       | view                 |
-      | createOnly       | edit                 |
-      | createOnly       | upload               |
-      | blocksDownload   | blocksDownload       |
+      | permissions-role | new-permissions-role | permissions-role-value |
+      | View             | Edit                 | edit                   |
+      | View             | Upload               | upload                 |
+      | View             | File Drop            | createOnly             |
+      | Edit             | View                 | view                   |
+      | Edit             | Upload               | upload                 |
+      | Edit             | File Drop            | createOnly             |
+      | Upload           | View                 | view                   |
+      | Upload           | Edit                 | edit                   |
+      | Upload           | File Drop            | createOnly             |
+      | File Drop        | View                 | view                   |
+      | File Drop        | Edit                 | edit                   |
+      | File Drop        | Upload               | upload                 |
+      | Secure View      | Secure View          | blocksDownload         |
 
   @issues-8405
   Scenario Outline: remove expiration date of a resource link share using permissions endpoint
@@ -798,7 +798,7 @@ Feature: Update a link share for a resource
     And user "Alice" has created the following resource link share:
       | resource           | <resource>               |
       | space              | Personal                 |
-      | permissionsRole    | view                     |
+      | permissionsRole    | View                     |
       | password           | %public%                 |
       | expirationDateTime | 2200-07-15T14:00:00.000Z |
     When user "Alice" updates the last public link share using the permissions endpoint of the Graph API:

--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -101,7 +101,7 @@ Feature: Upload files into a space
     And user "Alice" has created the following resource link share:
       | resource        | uploadFolder |
       | space           | Personal     |
-      | permissionsRole | createOnly   |
+      | permissionsRole | File Drop    |
       | password        | %public%     |
     When the public uploads file "filesForUpload/zerobyte.txt" to "textfile.txt" inside last link shared folder with password "%public%" using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -118,7 +118,7 @@ Feature: Upload files into a space
     And user "Alice" has created the following resource link share:
       | resource        | uploadFolder  |
       | space           | Project Ceres |
-      | permissionsRole | createOnly    |
+      | permissionsRole | File Drop     |
       | password        | %public%      |
     When the public uploads file "filesForUpload/zerobyte.txt" to "textfile.txt" inside last link shared folder with password "%public%" using the public WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
@@ -205,5 +205,5 @@ Feature: checking file versions using file id
     Then the HTTP status code should be "401"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
+      | View             |
+      | Edit             |

--- a/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
+++ b/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
@@ -39,7 +39,7 @@ Feature: Public can download folders from project space public link
       | resource        | NewFolder   |
       | space           | new-space   |
       | displayName     | public link |
-      | permissionsRole | view        |
+      | permissionsRole | View        |
     When public downloads the folder "folder" from the last created public link using the public files API
     Then the HTTP status code should be "200"
     And the downloaded zip archive should contain these files:

--- a/tests/acceptance/features/apiSpacesShares/shareOperations.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareOperations.feature
@@ -456,10 +456,10 @@ Feature: sharing
     And the OCS status message should be "missing required password"
     Examples:
       | ocs-api-version | permissions-role | permissions | http-status-code |
-      | 1               | edit             | change      | 200              |
-      | 2               | edit             | change      | 400              |
-      | 1               | createOnly       | create      | 200              |
-      | 2               | createOnly       | create      | 400              |
+      | 1               | Edit             | change      | 200              |
+      | 2               | Edit             | change      | 400              |
+      | 1               | File Drop        | create      | 200              |
+      | 2               | File Drop        | create      | 400              |
 
 
   Scenario Outline: space admin removes password of a public link share (read permission)
@@ -471,7 +471,7 @@ Feature: sharing
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When user "Alice" updates the last public link share using the sharing API with
       | path        | /FOLDER |

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesPendingFiltered.feature
@@ -33,7 +33,7 @@ Feature: get the pending shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithUser.txt |
@@ -52,7 +52,7 @@ Feature: get the pending shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
 
 

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
@@ -32,7 +32,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithUser.txt |
@@ -49,7 +49,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
 
 

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
@@ -30,7 +30,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithGroup.txt |
@@ -41,7 +41,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
     When user "Brian" gets the user shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
@@ -64,7 +64,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithUser.txt |
@@ -75,7 +75,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
     When user "Brian" gets the group shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
@@ -107,7 +107,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithUser.txt |
@@ -124,7 +124,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
     When user "Brian" gets the public link shares shared with him using the sharing API
     Then the OCS status code should be "<ocs-status-code>"

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFiltered.feature
@@ -32,7 +32,7 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithUser.txt |
@@ -49,7 +49,7 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
 
 

--- a/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
@@ -30,7 +30,7 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithGroup.txt |
@@ -41,7 +41,7 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
     When user "Alice" gets the user shares shared by her using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
@@ -64,7 +64,7 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | folderToShareWithPublic |
       | space           | Personal                |
-      | permissionsRole | view                    |
+      | permissionsRole | View                    |
       | password        | %public%                |
     And user "Alice" has sent the following resource share invitation:
       | resource        | fileToShareWithUser.txt |
@@ -75,7 +75,7 @@ Feature: get shares filtered by type (user, group etc)
     And user "Alice" has created the following resource link share:
       | resource        | fileToShareWithPublic.txt |
       | space           | Personal                  |
-      | permissionsRole | view                      |
+      | permissionsRole | View                      |
       | password        | %public%                  |
     When user "Alice" gets the group shares shared by her using the sharing API
     Then the OCS status code should be "<ocs-status-code>"

--- a/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/changingPublicLinkShare.feature
@@ -24,10 +24,10 @@ Feature: changing a public link share
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
     Examples:
       | permissions-role | http-status-code | should-or-not |
-      | view             | 403              | should        |
-      | upload           | 403              | should        |
-      | createOnly       | 403              | should        |
-      | edit             | 204              | should not    |
+      | View             | 403              | should        |
+      | Upload           | 403              | should        |
+      | File Drop        | 403              | should        |
+      | Edit             | 204              | should not    |
 
   @issue-10331
   Scenario: public link share permissions work correctly for renaming and share permissions edit using the public WebDAV API
@@ -35,7 +35,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the public WebDAV API
     Then the HTTP status code should be "201"
@@ -48,7 +48,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public uploads file "lorem.txt" with password "%public%" and content "test" using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -60,7 +60,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public deletes file "parent.txt" from the last link share with password "invalid" using the public WebDAV API
     Then the HTTP status code should be "401"
@@ -72,7 +72,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public deletes file "parent.txt" from the last link share with password "%public%" using the public WebDAV API
     Then the HTTP status code should be "204"
@@ -84,7 +84,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "invalid" and the public WebDAV API
     Then the HTTP status code should be "401"
@@ -97,7 +97,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the public WebDAV API
     Then the HTTP status code should be "201"
@@ -110,7 +110,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public uploads file "lorem.txt" with password "invalid" and content "test" using the public WebDAV API
     Then the HTTP status code should be "401"
@@ -122,7 +122,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public uploads file "lorem.txt" with password "%public%" and content "test" using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -134,7 +134,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "%public%" and the public WebDAV API
     Then the HTTP status code should be "403"
@@ -147,7 +147,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     When the public deletes file "parent.txt" from the last link share with password "%public%" using the public WebDAV API
     Then the HTTP status code should be "403"
@@ -171,10 +171,10 @@ Feature: changing a public link share
     And the OCS status message should be "missing required password"
     Examples:
       | ocs-api-version | permissions | permissions-role | http-status-code |
-      | 1               | change      | edit             | 200              |
-      | 2               | change      | edit             | 400              |
-      | 1               | create      | createOnly       | 200              |
-      | 2               | create      | createOnly       | 400              |
+      | 1               | change      | Edit             | 200              |
+      | 2               | change      | Edit             | 400              |
+      | 1               | create      | File Drop        | 200              |
+      | 2               | create      | File Drop        | 400              |
 
   @issue-7821
   Scenario Outline: normal user tries to remove password of a public link (update without sending permissions)
@@ -183,7 +183,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When user "Alice" updates the last public link share using the sharing API with
       | path     | /PARENT |
@@ -205,7 +205,7 @@ Feature: changing a public link share
     And user "Admin" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When user "Admin" updates the last public link share using the sharing API with
       | path        | /PARENT |
@@ -238,10 +238,10 @@ Feature: changing a public link share
     And the OCS status message should be "missing required password"
     Examples:
       | ocs-api-version | permissions | permissions-role | http-status-code |
-      | 1               | change      | edit             | 200              |
-      | 2               | change      | edit             | 400              |
-      | 1               | create      | createOnly       | 200              |
-      | 2               | create      | createOnly       | 400              |
+      | 1               | change      | Edit             | 200              |
+      | 2               | change      | Edit             | 400              |
+      | 1               | create      | File Drop        | 200              |
+      | 2               | create      | File Drop        | 400              |
 
   @issue-web-10473
   Scenario: user tries to download public link file using own basic auth
@@ -251,7 +251,7 @@ Feature: changing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When user "Alice" tries to download file "textfile.txt" from the last public link using own basic auth and public WebDAV API
     Then the HTTP status code should be "401"

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -281,7 +281,7 @@ Feature: create a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
     And the public tries to download file "/parent.txt" from inside the last public link shared folder with password "%public%" using the public WebDAV API
@@ -295,7 +295,7 @@ Feature: create a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     When the public tries to download file "/parent.txt" from inside the last public link shared folder with password "%public%" using the public WebDAV API
     Then the HTTP status code should be "403"
@@ -308,7 +308,7 @@ Feature: create a public link share
     And user "Alice" has created the following resource link share:
       | resource        | test-file.txt |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
     When the public gets the size of the last shared public link using the WebDAV API
     Then the HTTP status code should be "207"
     And the size of the file should be "19"
@@ -352,7 +352,7 @@ Feature: create a public link share
     And user "Alice" has created the following resource link share:
       | resource        | testFolder |
       | space           | Personal   |
-      | permissionsRole | edit       |
+      | permissionsRole | Edit       |
     When the public uploads file "file.txt" to the last public link shared folder with password "%public%" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "testFolder/file.txt" should exist
@@ -382,7 +382,7 @@ Feature: create a public link share
     And user "Alice" has created the following resource link share:
       | resource        | file.txt |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
     When the public lists the resources in the last created public link with depth "1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the value of the item "//d:response[2]//d:href" in the response should match "/\/dav\/public-files\/%public_token%\/file.txt$/"
@@ -400,7 +400,7 @@ Feature: create a public link share
     And user "Alice" has created the following resource link share:
       | resource        | test.txt |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     And user "Alice" has deleted file "test.txt"
     When user "Alice" updates the last public link share using the sharing API with

--- a/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/deletePublicLinkShare.feature
@@ -14,7 +14,7 @@ Feature: delete a public link share
     And user "Alice" has created the following resource link share:
       | resource        | test-file.txt |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | %public%      |
       | displayName     | sharedlink    |
     When user "Alice" deletes public link share named "sharedlink" in file "test-file.txt" using the sharing API
@@ -33,7 +33,7 @@ Feature: delete a public link share
     And user "Alice" has created the following resource link share:
       | resource        | test-file.txt |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | %public%      |
       | displayName     | sharedlink    |
     And user "Alice" has moved file "/test-file.txt" to "/renamed-test-file.txt"
@@ -53,7 +53,7 @@ Feature: delete a public link share
     And user "Alice" has created the following resource link share:
       | resource        | test-folder |
       | space           | Personal    |
-      | permissionsRole | view        |
+      | permissionsRole | View        |
       | password        | %public%    |
       | displayName     | sharedlink  |
     When user "Alice" deletes public link share named "sharedlink" in folder "test-folder" using the sharing API
@@ -73,7 +73,7 @@ Feature: delete a public link share
     And user "Alice" has created the following resource link share:
       | resource        | test-folder/testfile.txt |
       | space           | Personal                 |
-      | permissionsRole | view                     |
+      | permissionsRole | View                     |
       | password        | %public%                 |
       | displayName     | sharedlink               |
     And user "Alice" deletes public link share named "sharedlink" in file "/test-folder/testfile.txt" using the sharing API

--- a/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/copyFromPublicLink.feature
@@ -16,7 +16,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/copy1.txt" using the public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/testfile.txt" should exist
@@ -32,7 +32,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies folder "/testFolder" to "/testFolder-copy" using the public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" folder "/PARENT/testFolder" should exist
@@ -48,7 +48,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/testFolder/copy1.txt" using the public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/testfile.txt" should exist
@@ -64,7 +64,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/copy1.txt" using the public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "/PARENT/testfile.txt" should exist
@@ -80,7 +80,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies folder "/testFolder" to "/copy1.txt" using the public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/PARENT/testFolder" should exist
@@ -95,7 +95,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/copy1.txt" using the public WebDAV API
     And user "Alice" deletes file "/PARENT/copy1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -110,7 +110,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/new-folder" using the public WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/PARENT/testfile.txt" for user "Alice" should be "some data"
@@ -125,7 +125,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/<file-name>" to "/copy1.txt" using the public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/<file-name>" should exist
@@ -146,7 +146,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/<destination-file-name>" using the public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/testfile.txt" should exist
@@ -168,7 +168,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/<destination-folder-name>/copy1.txt" using the public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/testfile.txt" should exist
@@ -189,7 +189,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/testfile.txt" using the public WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/PARENT/testfile.txt" for user "Alice" should be "some data"
@@ -202,7 +202,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies folder "/testFolder" to "/testFolder" using the public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/PARENT/testFolder" should exist
@@ -215,7 +215,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies file "/testfile.txt" to "/" using the public WebDAV API
     Then the HTTP status code should be "409"
     And as "Alice" file "/PARENT/testfile.txt" should exist
@@ -229,7 +229,7 @@ Feature: copying from public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public copies folder "/testFolder" to "/" using the public WebDAV API
     Then the HTTP status code should be "409"
     And as "Alice" folder "/PARENT/testFolder" should exist

--- a/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/multilinkSharing.feature
@@ -15,21 +15,21 @@ Feature: multi-link sharing
     And user "Alice" has created the following resource link share:
       | resource           | FOLDER      |
       | space              | Personal    |
-      | permissionsRole    | edit        |
+      | permissionsRole    | Edit        |
       | expirationDateTime | +3 days     |
       | displayName        | sharedlink1 |
       | password           | %public%    |
     And user "Alice" has created the following resource link share:
       | resource           | FOLDER      |
       | space              | Personal    |
-      | permissionsRole    | edit        |
+      | permissionsRole    | Edit        |
       | expirationDateTime | +3 days     |
       | displayName        | sharedlink2 |
       | password           | %public%    |
     And user "Alice" has created the following resource link share:
       | resource           | FOLDER      |
       | space              | Personal    |
-      | permissionsRole    | edit        |
+      | permissionsRole    | Edit        |
       | expirationDateTime | +3 days     |
       | displayName        | sharedlink3 |
       | password           | %public%    |
@@ -55,21 +55,21 @@ Feature: multi-link sharing
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink1   |
       | password           | %public%      |
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink2   |
       | password           | %public%      |
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink3   |
       | password           | %public%      |
@@ -95,14 +95,14 @@ Feature: multi-link sharing
     And user "Alice" has created the following resource link share:
       | resource           | FOLDER      |
       | space              | Personal    |
-      | permissionsRole    | edit        |
+      | permissionsRole    | Edit        |
       | expirationDateTime | +3 days     |
       | displayName        | sharedlink1 |
       | password           | %public%    |
     And user "Alice" has created the following resource link share:
       | resource           | FOLDER      |
       | space              | Personal    |
-      | permissionsRole    | edit        |
+      | permissionsRole    | Edit        |
       | expirationDateTime | +3 days     |
       | displayName        | sharedlink2 |
       | password           | %public%    |
@@ -127,14 +127,14 @@ Feature: multi-link sharing
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink1   |
       | password           | %public%      |
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink2   |
       | password           | %public%      |
@@ -155,21 +155,21 @@ Feature: multi-link sharing
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink1   |
       | password           | %public%      |
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink2   |
       | password           | %public%      |
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink3   |
       | password           | %public%      |
@@ -193,14 +193,14 @@ Feature: multi-link sharing
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink1   |
       | password           | %public%      |
     And user "Alice" has created the following resource link share:
       | resource           | textfile0.txt |
       | space              | Personal      |
-      | permissionsRole    | view          |
+      | permissionsRole    | View          |
       | expirationDateTime | +3 days       |
       | displayName        | sharedlink2   |
       | password           | %public%      |
@@ -224,14 +224,14 @@ Feature: multi-link sharing
     And user "Alice" has created the following resource link share:
       | resource           | FOLDER      |
       | space              | Personal    |
-      | permissionsRole    | edit        |
+      | permissionsRole    | Edit        |
       | expirationDateTime | +3 days     |
       | displayName        | sharedlink1 |
       | password           | %public%    |
     And user "Alice" has created the following resource link share:
       | resource           | FOLDER      |
       | space              | Personal    |
-      | permissionsRole    | edit        |
+      | permissionsRole    | Edit        |
       | expirationDateTime | +3 days     |
       | displayName        | sharedlink2 |
       | password           | %public%    |

--- a/tests/acceptance/features/coreApiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/updatePublicLinkShare.feature
@@ -16,7 +16,7 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When user "Alice" updates the last public link share using the sharing API with
       | expireDate | 2040-01-01T23:59:59+0100 |
@@ -60,7 +60,7 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     And user "Alice" has updated the last resource link share with
       | resource           | FOLDER                   |
@@ -99,7 +99,7 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | randomfile.txt |
       | space           | Personal       |
-      | permissionsRole | view           |
+      | permissionsRole | View           |
       | password        | %public%       |
     When user "Alice" updates the last public link share using the sharing API with
       | expireDate | 2040-01-01T23:59:59+0100 |
@@ -119,7 +119,7 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     And user "Alice" has set the following password for the last link share:
       | resource | FOLDER   |
@@ -157,12 +157,12 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     And user "Alice" has updated the last resource link share with
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -195,12 +195,12 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     And user "Alice" has updated the last resource link share with
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | upload   |
+      | permissionsRole | Upload   |
     When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "200"
@@ -235,12 +235,12 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And user "Alice" has updated the last resource link share with
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
     When the public deletes file "CHILD/child.txt" from the last link share with password "%public%" using the public WebDAV API
     Then the HTTP status code of responses on all endpoints should be "403"
     And as "Alice" file "PARENT/CHILD/child.txt" should exist
@@ -260,12 +260,12 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     And user "Alice" has updated the last resource link share with
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public deletes file "CHILD/child.txt" from the last link share with password "%public%" using the public WebDAV API
     And the public deletes file "parent.txt" from the last link share with password "%public%" using the public WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
@@ -285,7 +285,7 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     And user "Alice" has moved folder "/FOLDER" to "/RENAMED_FOLDER"
     When user "Alice" gets the info of the last public link share using the sharing API
@@ -331,7 +331,7 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | lorem.txt |
       | space           | Personal  |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
       | password        | %public%  |
     And user "Alice" has moved file "/lorem.txt" to "/new-lorem.txt"
     When user "Alice" gets the info of the last public link share using the sharing API
@@ -377,7 +377,7 @@ Feature: update a public link share
     And user "Alice" has created the following resource link share:
       | resource        | textfile.txt |
       | space           | Personal     |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | %public%     |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 0 |

--- a/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -16,7 +16,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     And user "Alice" has deleted folder "/FOLDER"
     When the public uploads file "test.txt" with password "%public%" and content "test-file" using the public WebDAV API
@@ -35,7 +35,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When the public uploads file "test.txt" with password "%public%" and content "test-file" using the public WebDAV API
     And the HTTP status code should be "403"
@@ -46,7 +46,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     When the public uploads file "test.txt" with password "%public%" and content "test-file" using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -60,7 +60,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     When the public uploads file "test.txt" with password "%public%" and content "test-file" using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -72,7 +72,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public uploads file "test.txt" with password "%public%" and content "test-file" using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -84,7 +84,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the public WebDAV API
@@ -96,7 +96,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the public WebDAV API
@@ -108,7 +108,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the public WebDAV API
     Then the HTTP status code should be "201"
@@ -120,7 +120,7 @@ Feature: upload to a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     When the public uploads file "test.txt" with password "%public%" and content "test" using the public WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -223,7 +223,7 @@ Feature: propagation of etags when deleting a file or folder
     And user "Alice" has created the following resource link share:
       | resource        | upload   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
@@ -247,7 +247,7 @@ Feature: propagation of etags when deleting a file or folder
     And user "Alice" has created the following resource link share:
       | resource        | upload   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation1/moveFileFolder.feature
@@ -293,7 +293,7 @@ Feature: propagation of etags when moving files or folders
     And user "Alice" has created the following resource link share:
       | resource        | upload   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
@@ -318,7 +318,7 @@ Feature: propagation of etags when moving files or folders
     And user "Alice" has created the following resource link share:
       | resource        | upload   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/copyFileFolder.feature
@@ -114,7 +114,7 @@ Feature: propagation of etags when copying files or folders
     And user "Alice" has created the following resource link share:
       | resource        | upload   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/createFolder.feature
@@ -115,7 +115,7 @@ Feature: propagation of etags when creating folders
     And user "Alice" has created the following resource link share:
       | resource        | folder     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/folder"
     When the public creates folder "created-by-public" using the public WebDAV API

--- a/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/coreApiWebdavEtagPropagation2/upload.feature
@@ -173,7 +173,7 @@ Feature: propagation of etags when uploading data
     And user "Alice" has created the following resource link share:
       | resource        | upload     |
       | space           | Personal   |
-      | permissionsRole | createOnly |
+      | permissionsRole | File Drop  |
       | password        | %public%   |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"

--- a/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/listFiles.feature
@@ -120,7 +120,7 @@ Feature: list files
     And user "Alice" has created the following resource link share:
       | resource        | simple-folder |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
     When the public lists the resources in the last created public link with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last public link DAV response should not contain these nodes
@@ -148,7 +148,7 @@ Feature: list files
     And user "Alice" has created the following resource link share:
       | resource        | simple-folder |
       | space           | Personal      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
     When the public lists the resources in the last created public link with depth "1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last public link DAV response should contain these nodes

--- a/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/coreApiWebdavOperations/propfind.feature
@@ -44,7 +44,7 @@ Feature: PROPFIND
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When the public sends "PROPFIND" request to the last public link share using the public WebDAV API with password "%public%"
     Then the HTTP status code should be "207"
@@ -59,7 +59,7 @@ Feature: PROPFIND
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When the public sends "PROPFIND" request to the last public link share using the public WebDAV API
     Then the HTTP status code should be "401"
@@ -73,7 +73,7 @@ Feature: PROPFIND
     And user "Alice" has created the following resource link share:
       | resource        | PARENT   |
       | space           | Personal |
-      | permissionsRole | view     |
+      | permissionsRole | View     |
       | password        | %public% |
     When the public sends "PROPFIND" request to the last public link share using the public WebDAV API with password "1234"
     Then the HTTP status code should be "401"

--- a/tests/acceptance/features/coreApiWebdavPreviews/linkSharePreviews.feature
+++ b/tests/acceptance/features/coreApiWebdavPreviews/linkSharePreviews.feature
@@ -16,7 +16,7 @@ Feature: accessing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | testavatar.jpg |
       | space           | Personal       |
-      | permissionsRole | edit           |
+      | permissionsRole | Edit           |
       | password        | %public%       |
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "404"
@@ -29,7 +29,7 @@ Feature: accessing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | testavatar.jpg |
       | space           | Personal       |
-      | permissionsRole | edit           |
+      | permissionsRole | Edit           |
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "200"
 
@@ -42,7 +42,7 @@ Feature: accessing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
       | password        | %public% |
     When the public accesses the preview of the following files from the last shared public link using the sharing API
       | path           |
@@ -60,7 +60,7 @@ Feature: accessing a public link share
     And user "Alice" has created the following resource link share:
       | resource        | FOLDER   |
       | space           | Personal |
-      | permissionsRole | edit     |
+      | permissionsRole | Edit     |
     When the public accesses the preview of the following files from the last shared public link using the sharing API
       | path           |
       | testavatar.jpg |

--- a/tests/acceptance/features/coreApiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/getFileProperties.feature
@@ -205,7 +205,7 @@ Feature: get file properties
     And user "Alice" has created the following resource link share:
       | resource        | <resource> |
       | space           | Personal   |
-      | permissionsRole | edit       |
+      | permissionsRole | Edit       |
       | password        | %public%   |
     When user "Alice" gets the following properties of folder "<resource>" using the WebDAV API
       | propertyName   |
@@ -244,7 +244,7 @@ Feature: get file properties
     And user "Alice" has created the following resource link share:
       | resource        | <resource> |
       | space           | Personal   |
-      | permissionsRole | edit       |
+      | permissionsRole | Edit       |
       | password        | %public%   |
     When user "Alice" gets the following properties of folder "<resource>" using the WebDAV API
       | propertyName   |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR refactors the resource link share creation steps such that the datatable uses permissions roles `displayName`. Previously, permissions role `value` was used.

In this PR following are the changes made in datatable:

from `view` => to `View`
from `internal` => to `Internal`
from `edit` => to `Edit`
from `upload` => to `Upload`
from `createOnly` => to `File Drop`
from `blocksDownload` => to `Secure View`

 See: https://owncloud.dev/libre-graph-api/#/drives.permissions/CreateLink

Refactored steps:
``` feature
Given user "Alice" has created the following resource link share:

And user "Alice" has updated the last resource link share with

When user "Alice" updates the last public link share using the permissions endpoint of the Graph API:
```

		
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Originated from: https://github.com/owncloud/ocis/pull/10839#discussion_r1909859637

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
