### PR TITLE
[docs-only] Add new tables for added/deprecated/removed envvars for 7.1 

### DIFF
--- a/docs/helpers/changed_envvars.py
+++ b/docs/helpers/changed_envvars.py
@@ -22,21 +22,21 @@ from urllib.request import urlopen
 # new is the target version to compare to
 # tagged versions must be of format: 'tags/v6.0.0'
 # master is different, it must be:   'heads/master'
-versionOld = 'tags/v6.0.0'
+versionOld = 'tags/v7.0.0'
 versionNew = 'heads/master'
 
 # CHANGE according your needs
-from_version = '5.0.0'
-to_version = '7.0.0'
+from_version = '7.0.0'
+to_version = '7.1.0'
 
 # CHANGE according your needs
 # this will create files like 5.0.0-7.0.0-added and 5.0.0-7.0.0-removed
 # this should match which versions you compare. master is ok if that is the base for a named release
-nameComponent = '5.0.0-7.0.0'
+nameComponent = '7.0.0-7.1.0'
 
 # ADD new elements when a new version has been published so that it gets excluded
 # array of version patterns to be excluded for added items. we dont need patch versions
-excludePattern = ['pre5.0', '5.0', '6.0']
+excludePattern = ['pre5.0', '5.0', '6.0', '6.0.0', '6.0.1', '6.1.0', '6.7', '7.0', '7.0.0']
 
 # DO NOT CHANGE
 # this is the path the added/removed result is written to

--- a/docs/services/general-info/env-var-deltas/7.0.0-7.1.0-added.adoc
+++ b/docs/services/general-info/env-var-deltas/7.0.0-7.1.0-added.adoc
@@ -1,0 +1,57 @@
+// # Added Variables between oCIS 7.0.0 and oCIS 7.1.0
+// commenting the headline to make it better includable
+
+// table created per 2025.01.10
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+| xref:{s-path}/frontend.adoc[Fontend]
+| FRONTEND_CONFIGURABLE_NOTIFICATIONS
+| Allow configuring notifications via web client.
+| false
+
+| xref:{s-path}/notifications.adoc[Notifications]
+| NOTIFICATIONS_STORE
+| The type of the store. Supported values are: 'memory', 'nats-js-kv', 'redis-sentinel', 'noop'. See the text description for details.
+| nats-js-kv
+
+| 
+| NOTIFICATIONS_STORE_AUTH_PASSWORD
+| The password to authenticate with the store. Only applies when store type 'nats-js-kv' is configured.
+| 
+
+| 
+| NOTIFICATIONS_STORE_AUTH_USERNAME
+| The username to authenticate with the store. Only applies when store type 'nats-js-kv' is configured.
+| 
+
+| 
+| NOTIFICATIONS_STORE_DATABASE
+| The database name the configured store should use.
+| notifications
+
+| 
+| NOTIFICATIONS_STORE_NODES
+| A list of nodes to access the configured store. This has no effect when 'memory' store is configured. Note that the behaviour how nodes are used is dependent on the library of the configured store. See the Environment Variable Types description for more details.
+| [127.0.0.1:9233]
+
+| 
+| NOTIFICATIONS_STORE_TABLE
+| The database table the store should use.
+| 
+
+| 
+| NOTIFICATIONS_STORE_TTL
+| Time to live for notifications in the store. Defaults to '336h' (2 weeks). See the Environment Variable Types description for more details.
+| 336h0m0s
+
+| xref:{s-path}/settings.adoc[Settings]
+| SETTINGS_TRANSLATION_PATH
+| (optional) Set this to a path with custom translations to overwrite the builtin translations. Note that file and folder naming rules apply, see the documentation for more details.
+| 
+
+|===
+

--- a/docs/services/general-info/env-var-deltas/7.0.0-7.1.0-deprecated.adoc
+++ b/docs/services/general-info/env-var-deltas/7.0.0-7.1.0-deprecated.adoc
@@ -1,0 +1,105 @@
+// # Deprecated Variables between oCIS 7.0.0 and oCIS 7.1.0
+// commenting the headline to make it better includable
+
+// table created per 2025.01.10
+// the table should be recreated/updated on source () changes
+
+Note that these environment variables were listed for deprecation in 7.0.0 already. Removal has been delayed for an upcoming production version. They are listed here for consistency.
+
+
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Removal Version | Deprecation Info
+
+| xref:{s-path}/clientlog.adoc[Clientlog]
+| CLIENTLOG_REVA_GATEWAY
+| CS3 gateway used to look up user metadata
+| %%NEXT_PRODUCTION_VERSION%%
+| CLIENTLOG_REVA_GATEWAY removed for simplicity.
+
+| xref:{s-path}/frontend.adoc[Frontend]
+| FRONTEND_OCS_ADDITIONAL_INFO_ATTRIBUTE
+| Additional information attribute for the user like {{.Mail}}.
+| %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
+
+| 
+| FRONTEND_OCS_ENABLE_DENIALS
+| EXPERIMENTAL: enable the feature to deny access on folders.
+| %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
+
+| 
+| FRONTEND_OCS_INCLUDE_OCM_SHAREES
+| Include OCM sharees when listing sharees.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_INCLUDE_OCM_SHAREES, the OCS API is deprecated
+
+| 
+| FRONTEND_OCS_LIST_OCM_SHARES
+| Include OCM shares when listing shares. See the OCM service documentation for more details.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_LIST_OCM_SHARES, the OCS API is deprecated
+
+| 
+| FRONTEND_OCS_PERSONAL_NAMESPACE
+| Home namespace identifier.
+| %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
+
+| 
+| FRONTEND_OCS_PREFIX
+| URL path prefix for the OCS service. Note that the string must not start with '/'.
+| %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
+
+| 
+| FRONTEND_OCS_SHARE_PREFIX
+| Path prefix for shares as part of an ocis resource. Note that the path must start with '/'.
+| %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
+
+| 
+| FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD
+| The password to use for authentication. Only applies when using the 'nats-js-kv' store type.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD, the OCS API is deprecated
+
+| 
+| FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME
+| The username to use for authentication. Only applies when using the 'nats-js-kv' store type.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME, the OCS API is deprecated
+
+| 
+| FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE
+| Disable persistence of the cache. Only applies when using the 'nats-js-kv' store type. Defaults to false.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE, the OCS API is deprecated
+
+| 
+| FRONTEND_OCS_STAT_CACHE_STORE
+| The type of the cache store. Supported values are: 'memory', 'redis-sentinel', 'nats-js-kv', 'noop'. See the text description for details.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_STORE, the OCS API is deprecated
+
+| 
+| FRONTEND_OCS_STAT_CACHE_STORE_NODES
+| A list of nodes to access the configured store. This has no effect when 'memory' store is configured. Note that the behaviour how nodes are used is dependent on the library of the configured store. See the Environment Variable Types description for more details.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_STORE_NODES, the OCS API is deprecated
+
+| 
+| FRONTEND_OCS_STAT_CACHE_TABLE
+| The database table the store should use.
+| %%NEXT_PRODUCTION_VERSION%%
+| The OCS API is deprecated
+
+| 
+| FRONTEND_OCS_STAT_CACHE_TTL
+| Default time to live for user info in the cache. Only applied when access tokens has no expiration. See the Environment Variable Types description for more details.
+| %%NEXT_PRODUCTION_VERSION%%
+| FRONTEND_OCS_STAT_CACHE_TTL, the OCS API is deprecated
+
+|===
+

--- a/docs/services/general-info/env-var-deltas/7.0.0-7.1.0-removed.adoc
+++ b/docs/services/general-info/env-var-deltas/7.0.0-7.1.0-removed.adoc
@@ -1,0 +1,12 @@
+// # Removed Variables between oCIS 7.0.0 and oCIS 7.1.0
+// commenting the headline to make it better includable
+
+// table created per 2025.01.10
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+|===
+


### PR DESCRIPTION
This PR adds new tables for added/deprecated and removed envvars for 7.1

As we integrate 7.1 into 7.0, we need to backport this into 7.0