### PR TITLE
fix: Filtering of PostprocessingStepFinished events

### DIFF
--- a/changelog/unreleased/fix-in-app-notifications-filtering.md
+++ b/changelog/unreleased/fix-in-app-notifications-filtering.md
@@ -1,0 +1,4 @@
+Bugfix: Fix filtering of PostprocessingStepFinished events
+
+https://github.com/owncloud/ocis/pull/10868
+https://github.com/owncloud/ocis/issues/10867

--- a/services/userlog/pkg/service/filter.go
+++ b/services/userlog/pkg/service/filter.go
@@ -60,6 +60,8 @@ func (ulf userlogFilter) filterUsersBySettings(ctx context.Context, users []stri
 		settingId = defaults.SettingUUIDProfileEventSpaceDisabled
 	case events.SpaceDeleted:
 		settingId = defaults.SettingUUIDProfileEventSpaceDeleted
+	case events.PostprocessingStepFinished:
+		settingId = defaults.SettingUUIDProfileEventPostprocessingStepFinished
 	default:
 		// event that cannot be disabled
 		return users

--- a/services/userlog/pkg/service/filter_test.go
+++ b/services/userlog/pkg/service/filter_test.go
@@ -53,6 +53,7 @@ func TestUserlogFilter_execute(t *testing.T) {
 		{"SpaceMembershipExpired enabled", setupMockValueService(true), args{users: []string{"foo"}, event: events.Event{Event: events.SpaceMembershipExpired{}}, ctx: context.TODO()}, []string{"foo"}},
 		{"SpaceDisabled enabled", setupMockValueService(true), args{users: []string{"foo"}, event: events.Event{Event: events.SpaceDisabled{}}, ctx: context.TODO()}, []string{"foo"}},
 		{"SpaceDeleted enabled", setupMockValueService(true), args{users: []string{"foo"}, event: events.Event{Event: events.SpaceDeleted{}}, ctx: context.TODO()}, []string{"foo"}},
+		{"PostprocessingStepFinished enabled", setupMockValueService(true), args{users: []string{"foo"}, event: events.Event{Event: events.PostprocessingStepFinished{}}, ctx: context.TODO()}, []string{"foo"}},
 		{"ShareCreated disabled", setupMockValueService(false), args{users: []string{"foo"}, event: events.Event{Event: events.ShareCreated{}}, ctx: context.TODO()}, []string(nil)},
 		{"ShareRemoved disabled", setupMockValueService(false), args{users: []string{"foo"}, event: events.Event{Event: events.ShareRemoved{}}, ctx: context.TODO()}, []string(nil)},
 		{"ShareExpired disabled", setupMockValueService(false), args{users: []string{"foo"}, event: events.Event{Event: events.ShareExpired{}}, ctx: context.TODO()}, []string(nil)},
@@ -61,6 +62,7 @@ func TestUserlogFilter_execute(t *testing.T) {
 		{"SpaceMembershipExpired disabled", setupMockValueService(false), args{users: []string{"foo"}, event: events.Event{Event: events.SpaceMembershipExpired{}}, ctx: context.TODO()}, []string(nil)},
 		{"SpaceDisabled disabled", setupMockValueService(false), args{users: []string{"foo"}, event: events.Event{Event: events.SpaceDisabled{}}, ctx: context.TODO()}, []string(nil)},
 		{"SpaceDeleted disabled", setupMockValueService(false), args{users: []string{"foo"}, event: events.Event{Event: events.SpaceDeleted{}}, ctx: context.TODO()}, []string(nil)},
+		{"PostprocessingStepFinished disabled", setupMockValueService(false), args{users: []string{"foo"}, event: events.Event{Event: events.PostprocessingStepFinished{}}, ctx: context.TODO()}, []string(nil)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Adjust userlogFilter to also filter PostprocessingStepFinished events

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/10867
