### PR TITLE
fix: Empty email body for grouped email

### DIFF
--- a/changelog/unreleased/fix-grouped-mail-notifications-empty-body.md
+++ b/changelog/unreleased/fix-grouped-mail-notifications-empty-body.md
@@ -1,0 +1,3 @@
+Bugfix: Prevent empty email body for grouped email notifications
+
+https://github.com/owncloud/ocis/pull/10869

--- a/services/notifications/pkg/command/send_email.go
+++ b/services/notifications/pkg/command/send_email.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/stream"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
@@ -51,6 +52,7 @@ func SendEmail(cfg *config.Config) *cli.Command {
 					return err
 				}
 			}
+			fmt.Println("successfully sent SendEmailsEvent")
 			return nil
 		},
 	}

--- a/services/notifications/pkg/service/job.go
+++ b/services/notifications/pkg/service/job.go
@@ -131,6 +131,10 @@ func (s eventsNotifier) createGroupedMail(ctx context.Context, logger zerolog.Lo
 			})
 		}
 	}
+	if len(mts) == 0 && len(mtsVars) == 0 {
+		logger.Error().Msg("no body content for grouped email present")
+		return
+	}
 
 	rendered, err := email.RenderGroupedEmailTemplate(email.Grouped, map[string]string{
 		"DisplayName": userEvents.User.GetDisplayName(),


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Prevent empty email body for grouped email notifications.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Relates to https://github.com/owncloud/ocis/issues/10793
