### PR TITLE
Rename role for consistency (leftover from change in v3)

### DIFF
--- a/changelog/unreleased/consistenly-name-roles.md
+++ b/changelog/unreleased/consistenly-name-roles.md
@@ -1,0 +1,5 @@
+Bugfix: Consistently name roles
+
+BundleUUIDRoleGuest has been renamed to BundleUUIDRoleUserLight for consistency reasons
+
+https://github.com/owncloud/ocis/pull/10871

--- a/services/proxy/pkg/userroles/defaultrole.go
+++ b/services/proxy/pkg/userroles/defaultrole.go
@@ -46,7 +46,7 @@ func (d defaultRoleAssigner) UpdateUserRoleAssignment(ctx context.Context, user 
 			if user.Id.Type == cs3.UserType_USER_TYPE_PRIMARY || user.Id.Type == cs3.UserType_USER_TYPE_GUEST {
 				roleId := settingsService.BundleUUIDRoleUser
 				if user.Id.Type == cs3.UserType_USER_TYPE_GUEST {
-					roleId = settingsService.BundleUUIDRoleGuest
+					roleId = settingsService.BundleUUIDRoleUserLight
 				}
 				d.logger.Info().Str("userid", user.Id.OpaqueId).Msg("user has no role assigned, assigning default user role")
 				ctx = metadata.Set(ctx, middleware.AccountID, user.Id.OpaqueId)

--- a/services/settings/pkg/service/v0/settings.go
+++ b/services/settings/pkg/service/v0/settings.go
@@ -10,8 +10,9 @@ const (
 	// BundleUUIDRoleUser represents the user role.
 	BundleUUIDRoleUser = "d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11"
 
-	// BundleUUIDRoleGuest represents the guest role.
-	BundleUUIDRoleGuest = "38071a68-456a-4553-846a-fa67bf5596cc"
+	// BundleUUIDRoleUserLight represents the light role.
+	// BundleUUIDRoleGuest has been renamed to BundleUUIDRoleUserLight for consistency reasons
+	BundleUUIDRoleUserLight = "38071a68-456a-4553-846a-fa67bf5596cc"
 
 	// RoleManagementPermissionID is the hardcoded setting UUID for the role management permission
 	RoleManagementPermissionID string = "a53e601e-571f-4f86-8fec-d4576ef49c62"

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -13,6 +13,7 @@ const (
 	// BundleUUIDRoleUser represents the user role.
 	BundleUUIDRoleUser = "d7beeea8-8ff4-406b-8fb6-ab2dd81e6b11"
 	// BundleUUIDRoleUserLight represents the user light role.
+	// BundleUUIDRoleGuest has been renamed to BundleUUIDRoleUserLight for consistency reasons
 	BundleUUIDRoleUserLight = "38071a68-456a-4553-846a-fa67bf5596cc"
 	// BundleUUIDProfile represents the user profile.
 	BundleUUIDProfile = "2a506de7-99bd-4f0d-994e-c38e72c28fd9"


### PR DESCRIPTION
References: #10870 (Transition from 'Guest' user to 'User Light' was incomplete in terms of translatable strings)

This PR does most likely not fix the issue completely, but contributes to make things consistable and understandable.

The change was defined in: https://github.com/owncloud/ocis/blob/9e1fe81069b526d76ed4da5d8044cb03ca3e1a4c/changelog/3.0.0_2023-06-06/rename-guest-role.md?plain=1

Note that the UUID's of the roles are the same.

* Changing:
`roleId = settingsService.BundleUUIDRoleGuest` --> `roleId = settingsService.BundleUUIDRoleUserLight`
* Replacing
`BundleUUIDRoleGuest` with `BundleUUIDRoleUserLight` in `services/settings/pkg/service/v0/settings.go`
* Adding comments