### PR TITLE
chore: mark 7 production release

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -5,7 +5,7 @@
 # NOTE: need to be updated if new production releases are determined
 # - follow semver
 # - omit 'v' prefix
-PRODUCTION_RELEASE_TAGS = ["5.0", "7.0"]
+PRODUCTION_RELEASE_TAGS = ["5.0", "7"]
 
 # images
 ALPINE_GIT = "alpine/git:latest"

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -8,6 +8,7 @@
 * [ ] DEV/QA: Check new strings and align with clients
 * [ ] DEV/DOCS: Create list of pending docs tasks 
 * [ ] DEV: Create branch `release-x.x.x-rc.x` -> CODEFREEZE
+  * [ ] DEV: specify if it is a production release in [.drone.star](https://github.com/owncloud/ocis/blob/b4cf38fa1ba180c58519026dfe762b7c45695466/.drone.star#L8) (if needed)
   * [ ] DEV: bump ocis version in necessary files
   * [ ] DEV: `changelog/CHANGELOG.tmpl`
   * [ ] DEV: `ocis-pkg/version/version.go`


### PR DESCRIPTION
## Description
- Marked ocis 7 as production release - respective tags: 7.1, 7.1.0-rc.1 ... will be marked as production
- Updated the release template to check the above point

## Related Issue
Part of https://github.com/owncloud/ocis/issues/10851

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: <link> 
