### PR TITLE
fix: Missing new lines in grouped email

### DIFF
--- a/changelog/unreleased/fix-grouped-email-missing-newline.md
+++ b/changelog/unreleased/fix-grouped-email-missing-newline.md
@@ -1,0 +1,5 @@
+Bugfix: Fix missing newline in grouped email
+
+`\n` is now replaced by `<br>` in the HTML email body
+
+https://github.com/owncloud/ocis/pull/10883

--- a/services/notifications/pkg/email/composer.go
+++ b/services/notifications/pkg/email/composer.go
@@ -116,7 +116,7 @@ func NewGroupedHTMLTemplate(gmt GroupedMessageTemplate, vars map[string]string, 
 		}
 		bodyParts = append(bodyParts, bodyPart)
 	}
-	gmt.MessageBody = strings.Join(bodyParts, "<br><br><br>")
+	gmt.MessageBody = newlineToBr(strings.Join(bodyParts, "<br><br><br>"))
 
 	return gmt, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Bugfix: Fix missing newline in grouped email

`\n` is now replaced by `<br>` in the HTML email body



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Relates to https://github.com/owncloud/ocis/issues/10793
