### PR TITLE
fix: Email templates to not contain white spaces / new lines

### DIFF
--- a/changelog/unreleased/fix-email-templates.md
+++ b/changelog/unreleased/fix-email-templates.md
@@ -1,0 +1,5 @@
+Bugfix: Fix email templates white spaces & new lines
+
+Email templates now contain no unwanted white spaces & new lines if .CallToAction is nil
+
+https://github.com/owncloud/ocis/pull/10884

--- a/services/notifications/pkg/email/templates/html/email.html.tmpl
+++ b/services/notifications/pkg/email/templates/html/email.html.tmpl
@@ -11,8 +11,10 @@
                         {{ .Greeting }}
                         <br><br>
                         {{ .MessageBody }}
-                        {{if ne .CallToAction "" }}<br><br>
-                        {{ .CallToAction }}{{end}}
+                        {{- if .CallToAction }}
+                        <br><br>
+                        {{ .CallToAction }}
+                        {{- end }}
                     </td>
                 </tr>
                 <tr>

--- a/services/notifications/pkg/email/templates/text/email.text.tmpl
+++ b/services/notifications/pkg/email/templates/text/email.text.tmpl
@@ -1,9 +1,11 @@
 {{ .Greeting }}
 
 {{ .MessageBody }}
-{{if ne .CallToAction "" }}
+{{- if .CallToAction }}
+
 {{ .CallToAction }}
-{{end}}
+{{- end }}
+
 
 ---
 ownCloud - Store. Share. Work.


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Fix email templates to not contain white spaces / new lines if .CallToAction is nil

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Relates to https://github.com/owncloud/ocis/issues/10793
