### PR TITLE
[tests-only][full-ci] adding test for disabling in-app notifications for space deleted event

### DIFF
--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -1049,3 +1049,82 @@ Feature: Notification Settings
       | lorem.txt    | User Light |
       | uploadFolder | User       |
       | uploadFolder | User Light |
+
+  @issue-10941
+  Scenario: disable in-app notification for "Space Deleted" event
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has sent the following space share invitation:
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Viewer |
+    And user "Brian" disables notification for the following event using the settings API:
+      | event             | Space Deleted |
+      | notificationTypes | in-app        |
+    Then the HTTP status code should be "201"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "object",
+            "required": ["identifier", "value"],
+            "properties": {
+              "identifier": {
+                "type": "object",
+                "required": ["extension", "bundle", "setting"],
+                "properties": {
+                  "extension": { "const": "ocis-accounts" },
+                  "bundle": { "const": "profile" },
+                  "setting": { "const": "event-space-deleted-options" }
+                }
+              },
+              "value": {
+                "type": "object",
+                "required": ["id", "bundleId", "settingId", "accountUuid", "resource", "collectionValue"],
+                "properties": {
+                  "id": { "pattern": "%user_id_pattern%" },
+                  "bundleId": { "pattern": "%user_id_pattern%" },
+                  "settingId": { "pattern": "%user_id_pattern%" },
+                  "accountUuid": { "pattern": "%user_id_pattern%" },
+                  "resource": {
+                    "type": "object",
+                    "required": ["type"],
+                    "properties": {
+                      "type": { "const": "TYPE_USER" }
+                    }
+                  },
+                  "collectionValue": {
+                    "type": "object",
+                    "required": ["values"],
+                    "properties": {
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 1,
+                        "items": {
+                          "type": "object",
+                          "required": ["key", "boolValue"],
+                          "properties": {
+                            "key": { "const": "in-app" },
+                            "boolValue": { "const": false }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And user "Alice" has disabled a space "new-space"
+    And user "Alice" has deleted a space "new-space"
+    When user "Brian" lists all notifications
+    Then the HTTP status code should be "200"
+    And user "Brian" should not have any notification

--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -1059,7 +1059,7 @@ Feature: Notification Settings
       | sharee          | Brian        |
       | shareType       | user         |
       | permissionsRole | Space Viewer |
-    And user "Brian" disables notification for the following event using the settings API:
+    When user "Brian" disables notification for the following event using the settings API:
       | event             | Space Deleted |
       | notificationTypes | in-app        |
     Then the HTTP status code should be "201"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds test for disabling in-app notifications for space deleted event.
enabling or disabling notification for email is not available for this event.
>Note: All notifications related to a space will be deleted when the space is deleted, which is to be expected for now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/10802
- https://github.com/owncloud/ocis/issues/10941

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1: locally
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
