### PR TITLE
[tests-only][full-ci] use displayname of permissions role in space link share creation step

### DIFF
--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -127,12 +127,14 @@ class SharingNgContext implements Context {
 		$space = $bodyRows['space'];
 
 		$spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
+		$permissionsRole = $bodyRows['permissionsRole'];
 		$bodyRows['quickLink'] = $bodyRows['quickLink'] ?? false;
 		$bodyRows['displayName'] = $bodyRows['displayName'] ?? null;
 		$bodyRows['expirationDateTime'] = $bodyRows['expirationDateTime'] ?? null;
 		$bodyRows['password'] = $bodyRows['password'] ?? null;
+		$type = GraphHelper::SHARING_LINK_TYPE_MAPPINGS[$permissionsRole] ?? $permissionsRole;
 		$body = [
-			'type' => $bodyRows['permissionsRole'],
+			'type' => $type,
 			"@libre.graph.quickLink" => filter_var($bodyRows['quickLink'], FILTER_VALIDATE_BOOLEAN),
 			'displayName' => $bodyRows['displayName'],
 			'expirationDateTime' => $bodyRows['expirationDateTime'],

--- a/tests/acceptance/features/apiActivities/shareActivities.feature
+++ b/tests/acceptance/features/apiActivities/shareActivities.feature
@@ -1067,7 +1067,7 @@ Feature: check share activity
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | new-space |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
       | password        | %public%  |
     And user "Alice" has updated the last resource link share with
       | space              | new-space                |
@@ -1849,7 +1849,7 @@ Feature: check share activity
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | new-space |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
       | password        | %public%  |
     And user "Alice" has updated the last resource link share with
       | space              | new-space                |

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -1044,9 +1044,9 @@ Feature: collaboration (wopi)
       | simple.odt |
     Examples:
       | permissions-role |
-      | edit             |
-      | upload           |
-      | createOnly       |
+      | Edit             |
+      | Upload           |
+      | File Drop        |
 
   @issue-8691 @issue-10126 @issue-10331
   Scenario: public user with permission view tries to create odt file inside folder of public space using wopi endpoint
@@ -1056,7 +1056,7 @@ Feature: collaboration (wopi)
     And user "Alice" has created a folder "testFolder" in space "new-space"
     And user "Alice" has created the following space link share:
       | space           | new-space |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
       | password        | %public%  |
     When the public tries to create a file "simple.odt" inside folder "testFolder" in the last shared public link space with password "%public%" using wopi endpoint
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiSharingNg1/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg1/listPermissions.feature
@@ -262,7 +262,7 @@ Feature: List a sharing permissions
       | permissionsRole | <permissions-role> |
     And user "Alice" has created the following space link share:
       | space           | new-space |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
       | password        | %public%  |
     When user "Alice" lists the permissions of space "new-space" using permissions endpoint of the Graph API
     Then the HTTP status code should be "200"
@@ -1276,7 +1276,7 @@ Feature: List a sharing permissions
       | permissionsRole | <permissions-role> |
     And user "Alice" has created the following space link share:
       | space           | new-space |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
       | password        | %public%  |
     When user "Alice" lists the permissions of space "new-space" using root endpoint of the Graph API
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSharingNg1/removeAccessToDrive.feature
+++ b/tests/acceptance/features/apiSharingNg1/removeAccessToDrive.feature
@@ -170,11 +170,11 @@ Feature: Remove access to a drive
     And user "Alice" should not have any "link" permissions on space "NewSpace"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Upload           |
+      | File Drop        |
+      | Secure View      |
 
 
   Scenario: user removes internal link share from project space using root endpoint
@@ -182,7 +182,7 @@ Feature: Remove access to a drive
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | NewSpace |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
     When user "Alice" removes the link from space "NewSpace" using root endpoint of the Graph API
     Then the HTTP status code should be "204"
     And user "Alice" should not have any "link" permissions on space "NewSpace"
@@ -199,11 +199,11 @@ Feature: Remove access to a drive
     Then the HTTP status code should be "404"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Upload           |
+      | File Drop        |
+      | Secure View      |
 
 
   Scenario: user tries to remove internal link share of project space owned by next user using root endpoint
@@ -211,7 +211,7 @@ Feature: Remove access to a drive
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | NewSpace |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
     When user "Brian" tries to remove the link from space "NewSpace" owned by "Alice" using root endpoint of the Graph API
     Then the HTTP status code should be "404"
 
@@ -229,11 +229,11 @@ Feature: Remove access to a drive
     And user "Alice" should not have any "link" permissions on space "projectSpace"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | View             |
+      | Edit             |
+      | Upload           |
+      | File Drop        |
+      | Secure View      |
 
 
   Scenario: user removes internal link share of a project drive using permissions endpoint
@@ -242,7 +242,7 @@ Feature: Remove access to a drive
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
     When user "Alice" removes the last link share of space "projectSpace" using permissions endpoint of the Graph API
     Then the HTTP status code should be "204"
     And user "Alice" should not have any "link" permissions on space "projectSpace"

--- a/tests/acceptance/features/apiSharingNg1/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNg1/sharedByMe.feature
@@ -3323,7 +3323,7 @@ Feature: resources shared by user
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | NewSpace      |
-      | permissionsRole | view          |
+      | permissionsRole | View          |
       | password        | %public%      |
     When user "Alice" lists the shares shared by her using the Graph API
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSharingNgLinkSharePermission/createLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkSharePermission/createLinkShare.feature
@@ -2397,7 +2397,7 @@ Feature: Create a link share for a resource
       | permissionsRole | <permissions-role> |
     When user "Brian" creates the following space link share using root endpoint of the Graph API:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -2536,7 +2536,7 @@ Feature: Create a link share for a resource
       | quickLink       | true               |
     When user "Brian" creates the following space link share using root endpoint of the Graph API:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
       | quickLink       | true         |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
@@ -2677,7 +2677,7 @@ Feature: Create a link share for a resource
       | permissionsRole | <permissions-role> |
     When user "Brian" creates the following space link share using root endpoint of the Graph API:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
       | quickLink       | true         |
       | password        | %public%     |
     Then the HTTP status code should be "400"

--- a/tests/acceptance/features/apiSharingNgLinkSharePermission/updateLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkSharePermission/updateLinkShare.feature
@@ -390,19 +390,19 @@ Feature: Update a link share for a resource
       """
     Examples:
       | permissions-role | new-permissions-role | permissions-role-value |
-      | view             | Edit                 | edit                   |
-      | view             | Upload               | upload                 |
-      | view             | File Drop            | createOnly             |
-      | edit             | View                 | view                   |
-      | edit             | Upload               | upload                 |
-      | edit             | File Drop            | createOnly             |
-      | upload           | View                 | view                   |
-      | upload           | Edit                 | edit                   |
-      | upload           | File Drop            | createOnly             |
-      | createOnly       | View                 | view                   |
-      | createOnly       | Edit                 | edit                   |
-      | createOnly       | Upload               | upload                 |
-      | blocksDownload   | Secure View          | blocksDownload         |
+      | View             | Edit                 | edit                   |
+      | View             | Upload               | upload                 |
+      | View             | File Drop            | createOnly             |
+      | Edit             | View                 | view                   |
+      | Edit             | Upload               | upload                 |
+      | Edit             | File Drop            | createOnly             |
+      | Upload           | View                 | view                   |
+      | Upload           | Edit                 | edit                   |
+      | Upload           | File Drop            | createOnly             |
+      | File Drop        | View                 | view                   |
+      | File Drop        | Edit                 | edit                   |
+      | File Drop        | Upload               | upload                 |
+      | Secure View      | Secure View          | blocksDownload         |
 
 
   Scenario Outline: update role of a folder's link share inside project-space using permissions endpoint

--- a/tests/acceptance/features/apiSharingNgLinkShareRoot/createLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkShareRoot/createLinkShare.feature
@@ -47,22 +47,22 @@ Feature: Create a link share for a resource
       """
     Examples:
       | permissions-role | drive    |
-      | view             | Shares   |
-      | edit             | Shares   |
-      | upload           | Shares   |
-      | createOnly       | Shares   |
-      | blocksDownload   | Shares   |
-      | view             | Personal |
-      | edit             | Personal |
-      | upload           | Personal |
-      | createOnly       | Personal |
-      | blocksDownload   | Personal |
+      | View             | Shares   |
+      | Edit             | Shares   |
+      | Upload           | Shares   |
+      | File Drop        | Shares   |
+      | Secure View      | Shares   |
+      | View             | Personal |
+      | Edit             | Personal |
+      | Upload           | Personal |
+      | File Drop        | Personal |
+      | Secure View      | Personal |
 
 
   Scenario Outline: try to create an internal link share of a Personal and Share drives using root endpoint
     When user "Alice" tries to create the following space link share using root endpoint of the Graph API:
       | space           | <drive>  |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match
       """
@@ -105,7 +105,7 @@ Feature: Create a link share for a resource
   Scenario Outline: try to create an internal link share with password of a Personal and Share drive using root endpoint
     When user "Alice" tries to create the following space link share using root endpoint of the Graph API:
       | space           | <drive>  |
-      | permissionsRole | internal |
+      | permissionsRole | Internal |
       | password        | %public% |
     Then the HTTP status code should be "400"
     And the JSON data of the response should match
@@ -192,7 +192,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -204,12 +204,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario: create an internal link share of a project-space using root endpoint
@@ -218,7 +218,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     When user "Alice" creates the following space link share using root endpoint of the Graph API:
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
@@ -275,7 +275,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     When user "Alice" tries to create the following space link share using root endpoint of the Graph API:
       | space           | projectSpace  |
-      | permissionsRole | internal      |
+      | permissionsRole | Internal      |
       | password        | %public%      |
     Then the HTTP status code should be "400"
 
@@ -332,7 +332,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -344,12 +344,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
   @issue-7879
   Scenario Outline: try to create a link share of a project-space drive with a password that is listed in the Banned-Password-List using root endpoint
@@ -391,21 +391,21 @@ Feature: Create a link share for a resource
       """
     Examples:
       | banned-password | permissions-role |
-      | 123             | view             |
-      | password        | view             |
-      | ownCloud        | view             |
-      | 123             | edit             |
-      | password        | edit             |
-      | ownCloud        | edit             |
-      | 123             | upload           |
-      | password        | upload           |
-      | ownCloud        | upload           |
-      | 123             | createOnly       |
-      | password        | createOnly       |
-      | ownCloud        | createOnly       |
-      | 123             | blocksDownload   |
-      | password        | blocksDownload   |
-      | ownCloud        | blocksDownload   |
+      | 123             | View             |
+      | password        | View             |
+      | ownCloud        | View             |
+      | 123             | Edit             |
+      | password        | Edit             |
+      | ownCloud        | Edit             |
+      | 123             | Upload           |
+      | password        | Upload           |
+      | ownCloud        | Upload           |
+      | 123             | File Drop        |
+      | password        | File Drop        |
+      | ownCloud        | File Drop        |
+      | 123             | Secure View      |
+      | password        | Secure View      |
+      | ownCloud        | Secure View      |
 
   @env-config @issue-7879
   Scenario Outline: create a link share of a project-space drive without password using root endpoint
@@ -456,7 +456,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -468,12 +468,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
   @issue-7879
   Scenario Outline: create a link share of a project-space drive with display name using root endpoint
@@ -523,7 +523,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -535,12 +535,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
   @issue-7879
   Scenario Outline: create a link share of a project-space drive with expiry date using root endpoint
@@ -594,7 +594,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -606,12 +606,12 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | edit             |
-      | upload           |
-      | createOnly       |
-      | blocksDownload   |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Edit             | edit                   |
+      | Upload           | upload                 |
+      | File Drop        | createOnly             |
+      | Secure View      | blocksDownload         |
 
 
   Scenario Outline: create quick link share of a project space drive using root endpoint
@@ -661,7 +661,7 @@ Feature: Create a link share for a resource
                 "const": false
               },
               "type": {
-                "const": "<permissions-role>"
+                "const": "<permissions-role-value>"
               },
               "webUrl": {
                 "type": "string",
@@ -673,11 +673,11 @@ Feature: Create a link share for a resource
       }
       """
     Examples:
-      | permissions-role |
-      | view             |
-      | upload           |
-      | edit             |
-      | createOnly       |
+      | permissions-role | permissions-role-value |
+      | View             | view                   |
+      | Upload           | upload                 |
+      | Edit             | edit                   |
+      | File Drop        | createOnly             |
 
 
   Scenario: create an internal quick link share of a project space drive using root endpoint
@@ -686,7 +686,7 @@ Feature: Create a link share for a resource
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
     When user "Alice" creates the following space link share using root endpoint of the Graph API:
       | space           | projectSpace |
-      | permissionsRole | internal     |
+      | permissionsRole | Internal     |
       | displayName     | Link         |
       | quickLink       | true         |
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSharingNgLinkShareRoot/updateLinkShare.feature
+++ b/tests/acceptance/features/apiSharingNgLinkShareRoot/updateLinkShare.feature
@@ -17,7 +17,7 @@ Feature: Update a link share for a resource
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
     And user "Alice" has created the following space link share:
       | space           | projectSpace |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
     When user "Alice" sets the following password for the last space link share using root endpoint of the Graph API:
       | space    | projectSpace |
       | password | %public%     |
@@ -46,7 +46,7 @@ Feature: Update a link share for a resource
     And user "Alice" has uploaded a file inside space "projectSpace" with content "to share" to "textfile.txt"
     And user "Alice" has created the following space link share:
       | space           | projectSpace |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
       | password        | $heLlo*1234* |
     When user "Alice" sets the following password for the last space link share using root endpoint of the Graph API:
       | space    | projectSpace |

--- a/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
+++ b/tests/acceptance/features/apiSpaces/editPublicLinkOfSpace.feature
@@ -18,7 +18,7 @@ Feature: A manager of the space can edit public link
     And user "Alice" has created a space "edit space" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space              | edit space               |
-      | permissionsRole    | view                     |
+      | permissionsRole    | View                     |
       | password           | %public%                 |
       | expirationDateTime | 2040-01-01T23:59:59.000Z |
       | displayName        | someName                 |

--- a/tests/acceptance/features/apiSpaces/publicLink.feature
+++ b/tests/acceptance/features/apiSpaces/publicLink.feature
@@ -11,7 +11,7 @@ Feature: public link for a space
     And user "Alice" has created a space "public space" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | public space |
-      | permissionsRole | view         |
+      | permissionsRole | View         |
     And using SharingNG
 
   @issue-10331

--- a/tests/acceptance/features/apiSpaces/uploadSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/uploadSpaces.feature
@@ -133,7 +133,7 @@ Feature: Upload files into a space
     Given using SharingNG
     And user "Alice" has created the following space link share:
       | space           | Project Ceres |
-      | permissionsRole | createOnly    |
+      | permissionsRole | File Drop     |
       | password        | %public%      |
     When the public uploads file "filesForUpload/zerobyte.txt" to "textfile.txt" inside last link shared folder with password "%public%" using the public WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
+++ b/tests/acceptance/features/apiSpacesDavOperation/fileVersionByFileID.feature
@@ -187,8 +187,8 @@ Feature: checking file versions using file id
     Then the HTTP status code should be "401"
     Examples:
       | permissions-role |
-      | view             |
-      | edit             |
+      | View             |
+      | Edit             |
 
 
   Scenario Outline: public tries to check the versions of a file in a personal space shared via link as viewer/editor

--- a/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
+++ b/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
@@ -21,7 +21,7 @@ Feature: Public can download folders from project space public link
     And user "Alice" has created the following space link share:
       | space           | new-space |
       | displayName     | someName  |
-      | permissionsRole | view      |
+      | permissionsRole | View      |
     When public downloads the folder "NewFolder" from the last created public link using the public files API
     Then the HTTP status code should be "200"
     And the downloaded zip archive should contain these files:

--- a/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareSpacesViaLink.feature
@@ -139,7 +139,7 @@ Feature: Share spaces via link
     And using SharingNG
     And user "Alice" has created the following space link share:
       | space           | share space |
-      | permissionsRole | view        |
+      | permissionsRole | View        |
       | password        | %public%    |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 1 |
@@ -168,12 +168,12 @@ Feature: Share spaces via link
     And the OCS status message should be "missing required password"
     Examples:
       | ocs-api-version | permissions | http-status-code | permissions-role |
-      | 1               | 5           | 200              | upload           |
-      | 2               | 5           | 400              | upload           |
-      | 1               | 15          | 200              | edit             |
-      | 2               | 15          | 400              | edit             |
-      | 1               | 4           | 200              | createOnly       |
-      | 2               | 4           | 400              | createOnly       |
+      | 1               | 5           | 200              | Upload           |
+      | 2               | 5           | 400              | Upload           |
+      | 1               | 15          | 200              | Edit             |
+      | 2               | 15          | 400              | Edit             |
+      | 1               | 4           | 200              | File Drop        |
+      | 2               | 4           | 400              | File Drop        |
 
 
   Scenario Outline: space admin removes password of a public link share of a space (invite permission)
@@ -181,7 +181,7 @@ Feature: Share spaces via link
     And using SharingNG
     And user "Alice" has created the following space link share:
       | space           | share space |
-      | permissionsRole | view        |
+      | permissionsRole | View        |
       | password        | %public%    |
     When user "Alice" updates the last public link share using the sharing API with
       | permissions | 0 |
@@ -205,7 +205,7 @@ Feature: Share spaces via link
       | permissionsRole | Manager     |
     And user "Brian" has created the following space link share:
       | space           | share space |
-      | permissionsRole | view        |
+      | permissionsRole | View        |
       | password        | %public%    |
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | 1 |
@@ -239,12 +239,12 @@ Feature: Share spaces via link
     And the OCS status message should be "missing required password"
     Examples:
       | ocs-api-version | permissions | http-status-code | permissions-role |
-      | 1               | 5           | 200              | upload           |
-      | 2               | 5           | 400              | upload           |
-      | 1               | 15          | 200              | edit             |
-      | 2               | 15          | 400              | edit             |
-      | 1               | 4           | 200              | createOnly       |
-      | 2               | 4           | 400              | createOnly       |
+      | 1               | 5           | 200              | Upload           |
+      | 2               | 5           | 400              | Upload           |
+      | 1               | 15          | 200              | Edit             |
+      | 2               | 15          | 400              | Edit             |
+      | 1               | 4           | 200              | File Drop        |
+      | 2               | 4           | 400              | File Drop        |
 
 
   Scenario Outline: space manager removes password of a public link share of a space (invite permission)
@@ -257,7 +257,7 @@ Feature: Share spaces via link
       | permissionsRole | Manager     |
     And user "Brian" has created the following space link share:
       | space           | share space |
-      | permissionsRole | view        |
+      | permissionsRole | View        |
       | password        | %public%    |
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | 0 |
@@ -291,19 +291,19 @@ Feature: Share spaces via link
     And the OCS status message should be "missing permissions to update share"
     Examples:
       | ocs-api-version | http-status-code | space-role   | permissions | permissions-role |
-      | 1               | 200              | Space Viewer | 1           | view             |
-      | 2               | 401              | Space Viewer | 1           | view             |
-      | 1               | 200              | Space Viewer | 5           | upload           |
-      | 2               | 401              | Space Viewer | 5           | upload           |
-      | 1               | 200              | Space Viewer | 15          | edit             |
-      | 2               | 401              | Space Viewer | 15          | edit             |
-      | 1               | 200              | Space Viewer | 4           | createOnly       |
-      | 2               | 401              | Space Viewer | 4           | createOnly       |
-      | 1               | 200              | Space Editor | 1           | view             |
-      | 2               | 401              | Space Editor | 1           | view             |
-      | 1               | 200              | Space Editor | 5           | upload           |
-      | 2               | 401              | Space Editor | 5           | upload           |
-      | 1               | 200              | Space Editor | 15          | edit             |
-      | 2               | 401              | Space Editor | 15          | edit             |
-      | 1               | 200              | Space Editor | 4           | createOnly       |
-      | 2               | 401              | Space Editor | 4           | createOnly       |
+      | 1               | 200              | Space Viewer | 1           | View             |
+      | 2               | 401              | Space Viewer | 1           | View             |
+      | 1               | 200              | Space Viewer | 5           | Upload           |
+      | 2               | 401              | Space Viewer | 5           | Upload           |
+      | 1               | 200              | Space Viewer | 15          | Edit             |
+      | 2               | 401              | Space Viewer | 15          | Edit             |
+      | 1               | 200              | Space Viewer | 4           | File Drop        |
+      | 2               | 401              | Space Viewer | 4           | File Drop        |
+      | 1               | 200              | Space Editor | 1           | View             |
+      | 2               | 401              | Space Editor | 1           | View             |
+      | 1               | 200              | Space Editor | 5           | Upload           |
+      | 2               | 401              | Space Editor | 5           | Upload           |
+      | 1               | 200              | Space Editor | 15          | Edit             |
+      | 2               | 401              | Space Editor | 15          | Edit             |
+      | 1               | 200              | Space Editor | 4           | File Drop        |
+      | 2               | 401              | Space Editor | 4           | File Drop        |

--- a/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
+++ b/tests/acceptance/features/coreApiWebdavUpload/uploadFile.feature
@@ -380,7 +380,7 @@ Feature: upload file
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has created the following space link share:
       | space           | new-space |
-      | permissionsRole | edit      |
+      | permissionsRole | Edit      |
       | password        | %public%  |
     When the public uploads file "test.txt" with password "%public%" and content "test-file" using the public WebDAV API
     Then the HTTP status code should be "201"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Similar to PR: https://github.com/owncloud/ocis/pull/10850
This PR refactors the `space link share` creation steps such that the datatable uses permissions roles `displayName`. Previously, permissions role value was used.

In this PR following are the changes made in datatable:

from `view` => to `View`
from `internal` => to `Internal`
from `edit` => to `Edit`
from `upload` => to `Upload`
from `createOnly` => to `File Drop`
from `blocksDownload` => to `Secure View`
See: https://owncloud.dev/libre-graph-api/#/drives.root/CreateLinkSpaceRoot

Refactored steps:
``` feature
Given user "Alice" has created the following space link share:

When user "Brian" creates the following space link share using root endpoint of the Graph API:

When user "Alice" tries to create the following space link share using root endpoint of the Graph API:
```
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Originated from: https://github.com/owncloud/ocis/pull/10850#issuecomment-2601418720
- Original discussion: https://github.com/owncloud/ocis/pull/10839#discussion_r1909859637

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
