### PR TITLE
feat: Add email notification for share removed

### DIFF
--- a/changelog/unreleased/enhancement-share-removed-email.md
+++ b/changelog/unreleased/enhancement-share-removed-email.md
@@ -1,0 +1,4 @@
+Enhancement: Add email notification for share removed event
+
+https://github.com/owncloud/ocis/pull/10915
+https://github.com/owncloud/ocis/issues/10904

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -81,6 +81,7 @@ func Server(cfg *config.Config) *cli.Command {
 			evs := []events.Unmarshaller{
 				events.ShareCreated{},
 				events.ShareExpired{},
+				events.ShareRemoved{},
 				events.SpaceShared{},
 				events.SpaceUnshared{},
 				events.SpaceMembershipExpired{},

--- a/services/notifications/pkg/email/templates.go
+++ b/services/notifications/pkg/email/templates.go
@@ -36,6 +36,19 @@ var (
 Even though this share has been revoked you still might have access through other shares and/or space memberships.`),
 	}
 
+	ShareRemoved = MessageTemplate{
+		textTemplate: _textTemplate,
+		htmlTemplate: _htmlTemplate,
+		// ShareRemoved email template, Subject field (resolves directly)
+		Subject: l10n.Template(`{ShareSharer} unshared '{ShareFolder}' with you`),
+		// ShareRemoved email template, resolves via {{ .Greeting }}
+		Greeting: l10n.Template(`Hello {ShareGrantee},`),
+		// ShareRemoved email template, resolves via {{ .MessageBody }}
+		MessageBody: l10n.Template(`{ShareSharer} has unshared '{ShareFolder}' with you.
+
+Even though this share has been revoked you still might have access through other shares and/or space memberships.`),
+	}
+
 	// Spaces templates
 	SharedSpace = MessageTemplate{
 		textTemplate: _textTemplate,

--- a/services/notifications/pkg/service/job.go
+++ b/services/notifications/pkg/service/job.go
@@ -130,6 +130,24 @@ func (s eventsNotifier) createGroupedMail(ctx context.Context, logger zerolog.Lo
 				"ShareFolder": shareFolder,
 				"ExpiredAt":   te.ExpiredAt.Format("2006-01-02 15:04:05"),
 			})
+		case events.ShareRemoved:
+			logger := logger.With().
+				Str("event", "ShareRemoved").
+				Str("eventId", te.ItemID.OpaqueId).
+				Logger()
+			executant, shareFolder, _, err := s.prepareShareRemoved(logger, te)
+			if err != nil {
+				logger.Error().Err(err).Msg("could not prepare vars for grouped email")
+				continue
+			}
+
+			mts = append(mts, email.ShareRemoved)
+			mtsVars = append(mtsVars, map[string]string{
+				"ShareSharer": executant.GetDisplayName(),
+				"ShareFolder": shareFolder,
+			})
+		default:
+			logger.Error().Str("eventType", e.Type).Msg("unsupported event type for grouped email")
 		}
 	}
 	if len(mts) == 0 && len(mtsVars) == 0 {

--- a/services/notifications/pkg/service/service.go
+++ b/services/notifications/pkg/service/service.go
@@ -117,6 +117,8 @@ func (s eventsNotifier) Run() error {
 					s.handleShareCreated(e, evt.ID)
 				case events.ShareExpired:
 					s.handleShareExpired(e, evt.ID)
+				case events.ShareRemoved:
+					s.handleShareRemoved(e, evt.ID)
 				case events.ScienceMeshInviteTokenGenerated:
 					s.handleScienceMeshInviteTokenGenerated(e)
 				case events.SendEmailsEvent:

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -328,7 +328,7 @@ func generateBundleProfileRequest() *settingsmsg.Bundle {
 					MultiChoiceCollectionValue: &settingsmsg.MultiChoiceCollection{
 						Options: []*settingsmsg.MultiChoiceCollectionOption{
 							&optionInAppTrue,
-							&optionMailFalseDisabled,
+							&optionMailTrue,
 						},
 					},
 				},


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Add email notification for share removed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Closes https://github.com/owncloud/ocis/issues/10904

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: localhost
- test case 1: share removed instant
- test case 2: share removed instant but disabled
- test case 3: share removed instant but disabled
- test case 4: share removed daily
- test case 5: share removed daily but disabled
- test case 6: share removed weekly
- test case 7: share removed weekly but disabled
