### PR TITLE
[docs-only] Update ocis_full collabora image version

### DIFF
--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -53,7 +53,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:24.04.11.1.1
+    image: collabora/code:24.04.11.3.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       ocis-net:


### PR DESCRIPTION
Update the collabora image.

Backport to 7.0

Tested with my Hetzer deployment, no issues found.