### PR TITLE
[tests-only][full-ci] Add tests for share expiry

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2700,8 +2700,7 @@ class SpacesContext implements Context {
 		string $resource,
 		string $spaceName
 	): void {
-		$dateTime = new DateTime('yesterday');
-		$rows['expireDate'] = $dateTime->format('Y-m-d\\TH:i:sP');
+		$rows['expireDate'] = $this->featureContext->formatExpiryDateTime('Y-m-d\\TH:i:sP');
 		if ($this->featureContext->isUsingSharingNG()) {
 			$space = $this->getSpaceByName($user, $spaceName);
 			$itemId = $this->getResourceId($user, $spaceName, $resource);

--- a/tests/acceptance/features/apiNotification/notification.feature
+++ b/tests/acceptance/features/apiNotification/notification.feature
@@ -331,3 +331,53 @@ Feature: Notification
       | resource      |
       | textfile1.txt |
       | my_data       |
+
+  @issue-10966
+  Scenario: check share expired in-app and mail notifications for Personal space file
+    Given using SharingNG
+    And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    When user "Alice" expires the last share of resource "testfile.txt" inside of the space "Personal"
+    Then the HTTP status code should be "200"
+    And as "Brian" file "Shares/testfile.txt" should not exist
+    And user "Brian" should get a notification with subject "Share expired" and message:
+      | message                        |
+      | Access to testfile.txt expired |
+    And user "Brian" should have received the following email from user "Alice"
+      """
+      Hello Brian Murphy,
+
+      Your share to testfile.txt has expired at %expiry_date_in_mail%
+
+      Even though this share has been revoked you still might have access through other shares and/or space memberships.
+      """
+
+  @issue-10966
+  Scenario: check share expired in-app and mail notifications for Personal space folder
+    Given using SharingNG
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    When user "Alice" expires the last share of resource "folderToShare" inside of the space "Personal"
+    Then the HTTP status code should be "200"
+    And as "Brian" file "Shares/folderToShare" should not exist
+    And user "Brian" should get a notification with subject "Share expired" and message:
+      | message                         |
+      | Access to folderToShare expired |
+    And user "Brian" should have received the following email from user "Alice"
+      """
+      Hello Brian Murphy,
+
+      Your share to folderToShare has expired at %expiry_date_in_mail%
+
+      Even though this share has been revoked you still might have access through other shares and/or space memberships.
+      """


### PR DESCRIPTION
## Description
This PR add tests for checking in-app and mail notification alert for resource share expiry of personal .
- Project drive have bug i.e generate 2 notification for share expire event (partially fixed)

## Flakiness Alert
-  Don't use the list all notification step in this scenario; it may gives flakiness

## Related Issue
Bug coverage of - https://github.com/owncloud/ocis/issues/10966
- Part of https://github.com/owncloud/ocis/issues/10937

## How Has This Been Tested?
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
