### PR TITLE
[tests-only][full-ci]Add tests for filtering permission of project resource

### DIFF
--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -2112,31 +2112,6 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the allowed roles for federated user of (folder|file) "([^"]*)" from the space "([^"]*)" using the Graph API$/
-	 *
-	 * @param string $user
-	 * @param string $fileOrFolder (file|folder)
-	 * @param string $resource
-	 * @param string $space
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userGetsFederatedPermissionsListForFileOfTheSpaceUsingTheGraphApi(
-		string $user,
-		string $fileOrFolder,
-		string $resource,
-		string $space
-	): void {
-		$query = '$filter=@libre.graph.permissions.roles.allowedValues'
-			. '/rolePermissions/any(p:contains(p/condition,+\'@Subject.UserType=="Federated"\'))'
-			. '&$select=@libre.graph.permissions.roles.allowedValues';
-		$this->featureContext->setResponse(
-			$this->getPermissionsList($user, $fileOrFolder, $space, $resource, $query)
-		);
-	}
-
-	/**
 	 * @When /^user "([^"]*)" lists permissions with following filters for (folder|file) "([^"]*)" of the space "([^"]*)" using the Graph API:$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/apiOcm/listPermissions.feature
+++ b/tests/acceptance/features/apiOcm/listPermissions.feature
@@ -1,4 +1,4 @@
-@ocm
+@ocm @issue-9898
 Feature: List a federated sharing permissions
   As a user
   I want to list the permissions for federated share
@@ -7,7 +7,7 @@ Feature: List a federated sharing permissions
   Background:
     Given user "Alice" has been created with default attributes
 
-  @issue-9898
+
   Scenario: user lists permissions of a resource shared to a federated user
     Given using server "LOCAL"
     And "Alice" has created the federation share invitation
@@ -121,71 +121,110 @@ Feature: List a federated sharing permissions
       }
       """
 
-  @issue-9745 @env-config
-  Scenario: user lists allowed file permissions for federated user
+
+  Scenario: user lists permissions of a resource shared to a federated user
     Given using server "LOCAL"
-    And the administrator has enabled the permissions role "Secure Viewer"
-    And user "Alice" has uploaded file with content "ocm test" to "/textfile.txt"
-    When user "Alice" gets the allowed roles for federated user of file "textfile.txt" from the space "Personal" using the Graph API
+    And "Alice" has created the federation share invitation
+    And using server "REMOTE"
+    And user "Brian" has been created with default attributes
+    And "Brian" has accepted invitation
+    And using server "LOCAL"
+    And user "Alice" has created folder "/uploadFolder"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | uploadFolder |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Editor       |
+    When user "Alice" gets permissions list for folder "uploadFolder" of the space "Personal" using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
       {
         "type": "object",
-          "required": [
-            "@libre.graph.permissions.roles.allowedValues"
-          ],
-          "properties": {
-            "@libre.graph.permissions.roles.allowedValues": {
-              "type": "array",
-              "minItems": 2,
-              "maxItems": 2,
-              "uniqueItems": true,
-              "items": {
-                "oneOf":[
+        "required": [
+          "@libre.graph.permissions.actions.allowedValues",
+          "@libre.graph.permissions.roles.allowedValues",
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "oneOf":[
                 {
                   "type": "object",
                   "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
+                    "grantedToV2",
+                    "id",
+                    "roles"
                   ],
                   "properties": {
-                    "@libre.graph.weight": {
-                      "const": 1
-                    },
-                    "description": {
-                      "const": "View and download."
-                    },
-                    "displayName": {
-                      "const": "Can view"
-                    },
-                    "id": {
-                      "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
-                  "properties": {
-                    "@libre.graph.weight": {
-                      "const": 2
-                    },
-                    "description": {
-                      "const": "View, download and edit."
-                    },
-                    "displayName": {
-                      "const": "Can edit"
+                    "grantedToV2": {
+                      "type": "object",
+                      "required": ["user"],
+                      "properties": {
+                        "user": {
+                          "type": "object",
+                          "required": ["@libre.graph.userType","displayName","id"],
+                          "properties": {
+                            "@libre.graph.userType": {
+                              "const": "Federated"
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^%federated_user_id_pattern%$"
+                            },
+                            "displayName": {
+                              "const": "Brian Murphy"
+                            }
+                          }
+                        }
+                      }
                     },
                     "id": {
-                      "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
+                      "type": "string",
+                      "pattern": "^%user_id_pattern%$"
+                    },
+                    "invitation": {
+                      "type": "object",
+                      "required": ["invitedBy"],
+                      "properties": {
+                        "invitedBy": {
+                          "type": "object",
+                          "required": ["user"],
+                          "properties": {
+                            "user": {
+                              "type": "object",
+                              "required": ["@libre.graph.userType", "displayName", "id"],
+                              "properties": {
+                                "@libre.graph.userType": {
+                                  "const": "Member"
+                                },
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%user_id_pattern%$"
+                                },
+                                "displayName": {
+                                  "const": "Alice Hansen"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "roles": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "string",
+                        "pattern": "^%role_id_pattern%$"
+                      }
                     }
                   }
                 }
@@ -196,71 +235,108 @@ Feature: List a federated sharing permissions
       }
       """
 
-  @issue-9745
-  Scenario: user lists allowed folder permissions for federated user
+
+  Scenario: user lists permissions of a project resource shared to a federated user
     Given using server "LOCAL"
-    And the administrator has enabled the permissions role "Secure Viewer"
-    And user "Alice" has created folder "folderToShare"
-    When user "Alice" gets the allowed roles for federated user of folder "folderToShare" from the space "Personal" using the Graph API
+    And "Alice" has created the federation share invitation
+    And using server "REMOTE"
+    And user "Brian" has been created with default attributes
+    And "Brian" has accepted invitation
+    And using server "LOCAL"
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "projectSpace"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | folderToShare |
+      | space           | projectSpace  |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    When user "Alice" gets permissions list for folder "folderToShare" of the space "projectSpace" using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
       {
         "type": "object",
-          "required": [
-            "@libre.graph.permissions.roles.allowedValues"
-          ],
-          "properties": {
-            "@libre.graph.permissions.roles.allowedValues": {
-              "type": "array",
-              "minItems": 2,
-              "maxItems": 2,
-              "uniqueItems": true,
-              "items": {
-                "oneOf":[
+        "required": [
+          "@libre.graph.permissions.actions.allowedValues",
+          "@libre.graph.permissions.roles.allowedValues",
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "oneOf":[
                 {
                   "type": "object",
                   "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
+                    "grantedToV2",
+                    "id",
+                    "roles"
                   ],
                   "properties": {
-                    "@libre.graph.weight": {
-                      "const": 1
-                    },
-                    "description": {
-                      "const": "View and download."
-                    },
-                    "displayName": {
-                      "const": "Can view"
-                    },
-                    "id": {
-                      "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
-                  "properties": {
-                    "@libre.graph.weight": {
-                      "const": 2
-                    },
-                    "description": {
-                      "const": "View, download, upload, edit, add and delete."
-                    },
-                    "displayName": {
-                      "const": "Can edit"
+                    "grantedToV2": {
+                      "type": "object",
+                      "required": ["user"],
+                      "properties": {
+                        "user": {
+                          "type": "object",
+                          "required": ["@libre.graph.userType","displayName","id"],
+                          "properties": {
+                            "@libre.graph.userType": {
+                              "const": "Federated"
+                            },
+                            "id": {
+                              "type": "string",
+                              "pattern": "^%federated_user_id_pattern%$"
+                            },
+                            "displayName": {
+                              "const": "Brian Murphy"
+                            }
+                          }
+                        }
+                      }
                     },
                     "id": {
-                      "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
+                      "type": "string",
+                      "pattern": "^%user_id_pattern%$"
+                    },
+                    "invitation": {
+                      "type": "object",
+                      "required": ["invitedBy"],
+                      "properties": {
+                        "invitedBy": {
+                          "type": "object",
+                          "required": ["user"],
+                          "properties": {
+                            "user": {
+                              "type": "object",
+                              "required": ["@libre.graph.userType", "displayName", "id"],
+                              "properties": {
+                                "@libre.graph.userType": {
+                                  "const": "Member"
+                                },
+                                "id": {
+                                  "type": "string",
+                                  "pattern": "^%user_id_pattern%$"
+                                },
+                                "displayName": { "const": "Alice Hansen" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "roles": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": { "pattern": "^%role_id_pattern%$" }
                     }
                   }
                 }
@@ -270,3 +346,97 @@ Feature: List a federated sharing permissions
         }
       }
       """
+
+
+  Scenario: user lists permissions of a project resource shared to a federated user
+    Given using server "LOCAL"
+    And "Alice" has created the federation share invitation
+    And using server "REMOTE"
+    And user "Brian" has been created with default attributes
+    And "Brian" has accepted invitation
+    And using server "LOCAL"
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "projectSpace" with content "some content" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | textfile.txt |
+      | space           | projectSpace |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    When user "Alice" gets permissions list for file "textfile.txt" of the space "projectSpace" using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": [
+          "@libre.graph.permissions.actions.allowedValues",
+          "@libre.graph.permissions.roles.allowedValues",
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "oneOf":[
+                {
+                  "type": "object",
+                  "required": ["grantedToV2", "id", "roles"],
+                  "properties": {
+                    "grantedToV2": {
+                      "type": "object",
+                      "required": ["user"],
+                      "properties": {
+                        "user": {
+                          "type": "object",
+                          "required": ["@libre.graph.userType","displayName","id"],
+                          "properties": {
+                            "@libre.graph.userType": { "const": "Federated" },
+                            "id": { "pattern": "^%federated_user_id_pattern%$" },
+                            "displayName": { "const": "Brian Murphy" }
+                          }
+                        }
+                      }
+                    },
+                    "id": { "pattern": "^%user_id_pattern%$" },
+                    "invitation": {
+                      "type": "object",
+                      "required": ["invitedBy"],
+                      "properties": {
+                        "invitedBy": {
+                          "type": "object",
+                          "required": ["user"],
+                          "properties": {
+                            "user": {
+                              "type": "object",
+                              "required": ["@libre.graph.userType", "displayName", "id"],
+                              "properties": {
+                                "@libre.graph.userType": { "const": "Member" },
+                                "id": { "pattern": "^%user_id_pattern%$" },
+                                "displayName": { "const": "Alice Hansen" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "roles": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": { "pattern": "^%role_id_pattern%$" }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+

--- a/tests/acceptance/features/apiOcm/listPermissions.feature
+++ b/tests/acceptance/features/apiOcm/listPermissions.feature
@@ -6,15 +6,14 @@ Feature: List a federated sharing permissions
 
   Background:
     Given user "Alice" has been created with default attributes
-
-
-  Scenario: user lists permissions of a resource shared to a federated user
-    Given using server "LOCAL"
     And "Alice" has created the federation share invitation
     And using server "REMOTE"
     And user "Brian" has been created with default attributes
     And "Brian" has accepted invitation
-    And using server "LOCAL"
+
+
+  Scenario: user lists permissions of a resource shared to a federated user
+    Given using server "LOCAL"
     And user "Alice" has uploaded file with content "ocm test" to "/textfile.txt"
     And user "Alice" has sent the following resource share invitation to federated user:
       | resource        | textfile.txt |
@@ -43,11 +42,7 @@ Feature: List a federated sharing permissions
               "oneOf":[
                 {
                   "type": "object",
-                  "required": [
-                    "grantedToV2",
-                    "id",
-                    "roles"
-                  ],
+                  "required": ["grantedToV2","id","roles"],
                   "properties": {
                     "grantedToV2": {
                       "type": "object",
@@ -57,24 +52,14 @@ Feature: List a federated sharing permissions
                           "type": "object",
                           "required": ["@libre.graph.userType","displayName","id"],
                           "properties": {
-                            "@libre.graph.userType": {
-                              "const": "Federated"
-                            },
-                            "id": {
-                              "type": "string",
-                              "pattern": "^%federated_user_id_pattern%$"
-                            },
-                            "displayName": {
-                              "const": "Brian Murphy"
-                            }
+                            "@libre.graph.userType": {"const": "Federated"},
+                            "id": {"pattern": "^%federated_user_id_pattern%$"},
+                            "displayName": {"const": "Brian Murphy"}
                           }
                         }
                       }
                     },
-                    "id": {
-                      "type": "string",
-                      "pattern": "^%user_id_pattern%$"
-                    },
+                    "id": {"pattern": "^%user_id_pattern%$"},
                     "invitation": {
                       "type": "object",
                       "required": ["invitedBy"],
@@ -87,16 +72,9 @@ Feature: List a federated sharing permissions
                               "type": "object",
                               "required": ["@libre.graph.userType", "displayName", "id"],
                               "properties": {
-                                "@libre.graph.userType": {
-                                  "const": "Member"
-                                },
-                                "id": {
-                                  "type": "string",
-                                  "pattern": "^%user_id_pattern%$"
-                                },
-                                "displayName": {
-                                  "const": "Alice Hansen"
-                                }
+                                "@libre.graph.userType": {"const": "Member"},
+                                "id": {"pattern": "^%user_id_pattern%$"},
+                                "displayName": {"const": "Alice Hansen"}
                               }
                             }
                           }
@@ -107,124 +85,7 @@ Feature: List a federated sharing permissions
                       "type": "array",
                       "minItems": 1,
                       "maxItems": 1,
-                      "items": {
-                        "type": "string",
-                        "pattern": "^%role_id_pattern%$"
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      }
-      """
-
-
-  Scenario: user lists permissions of a resource shared to a federated user
-    Given using server "LOCAL"
-    And "Alice" has created the federation share invitation
-    And using server "REMOTE"
-    And user "Brian" has been created with default attributes
-    And "Brian" has accepted invitation
-    And using server "LOCAL"
-    And user "Alice" has created folder "/uploadFolder"
-    And user "Alice" has sent the following resource share invitation to federated user:
-      | resource        | uploadFolder |
-      | space           | Personal     |
-      | sharee          | Brian        |
-      | shareType       | user         |
-      | permissionsRole | Editor       |
-    When user "Alice" gets permissions list for folder "uploadFolder" of the space "Personal" using the Graph API
-    Then the HTTP status code should be "200"
-    And the JSON data of the response should match
-      """
-      {
-        "type": "object",
-        "required": [
-          "@libre.graph.permissions.actions.allowedValues",
-          "@libre.graph.permissions.roles.allowedValues",
-          "value"
-        ],
-        "properties": {
-          "value": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
-            "uniqueItems": true,
-            "items": {
-              "oneOf":[
-                {
-                  "type": "object",
-                  "required": [
-                    "grantedToV2",
-                    "id",
-                    "roles"
-                  ],
-                  "properties": {
-                    "grantedToV2": {
-                      "type": "object",
-                      "required": ["user"],
-                      "properties": {
-                        "user": {
-                          "type": "object",
-                          "required": ["@libre.graph.userType","displayName","id"],
-                          "properties": {
-                            "@libre.graph.userType": {
-                              "const": "Federated"
-                            },
-                            "id": {
-                              "type": "string",
-                              "pattern": "^%federated_user_id_pattern%$"
-                            },
-                            "displayName": {
-                              "const": "Brian Murphy"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "id": {
-                      "type": "string",
-                      "pattern": "^%user_id_pattern%$"
-                    },
-                    "invitation": {
-                      "type": "object",
-                      "required": ["invitedBy"],
-                      "properties": {
-                        "invitedBy": {
-                          "type": "object",
-                          "required": ["user"],
-                          "properties": {
-                            "user": {
-                              "type": "object",
-                              "required": ["@libre.graph.userType", "displayName", "id"],
-                              "properties": {
-                                "@libre.graph.userType": {
-                                  "const": "Member"
-                                },
-                                "id": {
-                                  "type": "string",
-                                  "pattern": "^%user_id_pattern%$"
-                                },
-                                "displayName": {
-                                  "const": "Alice Hansen"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "roles": {
-                      "type": "array",
-                      "minItems": 1,
-                      "maxItems": 1,
-                      "items": {
-                        "type": "string",
-                        "pattern": "^%role_id_pattern%$"
-                      }
+                      "items": {"pattern": "^%role_id_pattern%$"}
                     }
                   }
                 }
@@ -238,11 +99,6 @@ Feature: List a federated sharing permissions
 
   Scenario: user lists permissions of a project resource shared to a federated user
     Given using server "LOCAL"
-    And "Alice" has created the federation share invitation
-    And using server "REMOTE"
-    And user "Brian" has been created with default attributes
-    And "Brian" has accepted invitation
-    And using server "LOCAL"
     And using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
@@ -288,24 +144,14 @@ Feature: List a federated sharing permissions
                           "type": "object",
                           "required": ["@libre.graph.userType","displayName","id"],
                           "properties": {
-                            "@libre.graph.userType": {
-                              "const": "Federated"
-                            },
-                            "id": {
-                              "type": "string",
-                              "pattern": "^%federated_user_id_pattern%$"
-                            },
-                            "displayName": {
-                              "const": "Brian Murphy"
-                            }
+                            "@libre.graph.userType": {"const": "Federated"},
+                            "id": {"pattern": "^%federated_user_id_pattern%$"},
+                            "displayName": {"const": "Brian Murphy"}
                           }
                         }
                       }
                     },
-                    "id": {
-                      "type": "string",
-                      "pattern": "^%user_id_pattern%$"
-                    },
+                    "id": { "pattern": "^%user_id_pattern%$" },
                     "invitation": {
                       "type": "object",
                       "required": ["invitedBy"],
@@ -318,14 +164,9 @@ Feature: List a federated sharing permissions
                               "type": "object",
                               "required": ["@libre.graph.userType", "displayName", "id"],
                               "properties": {
-                                "@libre.graph.userType": {
-                                  "const": "Member"
-                                },
-                                "id": {
-                                  "type": "string",
-                                  "pattern": "^%user_id_pattern%$"
-                                },
-                                "displayName": { "const": "Alice Hansen" }
+                                "@libre.graph.userType": {"const": "Member"},
+                                "id": {"pattern": "^%user_id_pattern%$"},
+                                "displayName": {"const": "Alice Hansen"}
                               }
                             }
                           }
@@ -336,7 +177,7 @@ Feature: List a federated sharing permissions
                       "type": "array",
                       "minItems": 1,
                       "maxItems": 1,
-                      "items": { "pattern": "^%role_id_pattern%$" }
+                      "items": {"pattern": "^%role_id_pattern%$"}
                     }
                   }
                 }
@@ -350,11 +191,6 @@ Feature: List a federated sharing permissions
 
   Scenario: user lists permissions of a project resource shared to a federated user
     Given using server "LOCAL"
-    And "Alice" has created the federation share invitation
-    And using server "REMOTE"
-    And user "Brian" has been created with default attributes
-    And "Brian" has accepted invitation
-    And using server "LOCAL"
     And using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "projectSpace" with the default quota using the Graph API
@@ -386,7 +222,7 @@ Feature: List a federated sharing permissions
               "oneOf":[
                 {
                   "type": "object",
-                  "required": ["grantedToV2", "id", "roles"],
+                  "required": ["grantedToV2","id","roles"],
                   "properties": {
                     "grantedToV2": {
                       "type": "object",
@@ -396,14 +232,14 @@ Feature: List a federated sharing permissions
                           "type": "object",
                           "required": ["@libre.graph.userType","displayName","id"],
                           "properties": {
-                            "@libre.graph.userType": { "const": "Federated" },
-                            "id": { "pattern": "^%federated_user_id_pattern%$" },
-                            "displayName": { "const": "Brian Murphy" }
+                            "@libre.graph.userType": {"const": "Federated"},
+                            "id": {"pattern": "^%federated_user_id_pattern%$"},
+                            "displayName": {"const": "Brian Murphy"}
                           }
                         }
                       }
                     },
-                    "id": { "pattern": "^%user_id_pattern%$" },
+                    "id": {"pattern": "^%user_id_pattern%$"},
                     "invitation": {
                       "type": "object",
                       "required": ["invitedBy"],
@@ -416,9 +252,9 @@ Feature: List a federated sharing permissions
                               "type": "object",
                               "required": ["@libre.graph.userType", "displayName", "id"],
                               "properties": {
-                                "@libre.graph.userType": { "const": "Member" },
-                                "id": { "pattern": "^%user_id_pattern%$" },
-                                "displayName": { "const": "Alice Hansen" }
+                                "@libre.graph.userType": {"const": "Member"},
+                                "id": {"pattern": "^%user_id_pattern%$"},
+                                "displayName": {"const": "Alice Hansen"}
                               }
                             }
                           }
@@ -429,7 +265,7 @@ Feature: List a federated sharing permissions
                       "type": "array",
                       "minItems": 1,
                       "maxItems": 1,
-                      "items": { "pattern": "^%role_id_pattern%$" }
+                      "items": {"pattern": "^%role_id_pattern%$"}
                     }
                   }
                 }

--- a/tests/acceptance/features/apiSharingNg1/filterPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg1/filterPermissions.feature
@@ -1192,32 +1192,22 @@ Feature: filter sharing permissions
                 "oneOf":[
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 1 },
-                    "description": { "const": "View and download." },
-                    "displayName": { "const": "Can view" },
-                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                    "@libre.graph.weight": {"const": 1},
+                    "description": {"const": "View and download."},
+                    "displayName": {"const": "Can view"},
+                    "id": {"const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"}
                   }
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 2 },
-                    "description": { "const": "View, download and edit." },
-                    "displayName": { "const": "Can edit" },
-                    "id": { "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"  }
+                    "@libre.graph.weight": {"const": 2},
+                    "description": {"const": "View, download and edit."},
+                    "displayName": {"const": "Can edit"},
+                    "id": {"const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a" }
                   }
                 }
               ]
@@ -1252,32 +1242,22 @@ Feature: filter sharing permissions
                 "oneOf":[
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 1 },
-                    "description": { "const": "View and download." },
-                    "displayName": { "const": "Can view" },
-                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                    "@libre.graph.weight": {"const": 1},
+                    "description": {"const": "View and download."},
+                    "displayName": {"const": "Can view"},
+                    "id": {"const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"}
                   }
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 2 },
-                    "description": { "const": "View, download, upload, edit, add and delete." },
-                    "displayName": { "const": "Can edit" },
-                    "id": { "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21" }
+                    "@libre.graph.weight": {"const": 2},
+                    "description": {"const": "View, download, upload, edit, add and delete."},
+                    "displayName": {"const": "Can edit"},
+                    "id": {"const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"}
                   }
                 }
               ]
@@ -1315,32 +1295,22 @@ Feature: filter sharing permissions
                 "oneOf":[
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 1 },
-                    "description": { "const": "View and download." },
-                    "displayName": { "const": "Can view" },
-                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                    "@libre.graph.weight": {"const": 1},
+                    "description": {"const": "View and download."},
+                    "displayName": {"const": "Can view"},
+                    "id": {"const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"}
                   }
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 2 },
-                    "description": { "const": "View, download and edit." },
-                    "displayName": { "const": "Can edit" },
-                    "id": { "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a" }
+                    "@libre.graph.weight": {"const": 2},
+                    "description": {"const": "View, download and edit."},
+                    "displayName": {"const": "Can edit"},
+                    "id": {"const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"}
                   }
                 }
               ]
@@ -1378,32 +1348,22 @@ Feature: filter sharing permissions
                 "oneOf":[
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 1 },
-                    "description": { "const": "View and download." },
-                    "displayName": { "const": "Can view" },
-                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                    "@libre.graph.weight": {"const": 1},
+                    "description": {"const": "View and download."},
+                    "displayName": {"const": "Can view"},
+                    "id": {"const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"}
                   }
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "@libre.graph.weight",
-                    "description",
-                    "displayName",
-                    "id"
-                  ],
+                  "required": ["@libre.graph.weight","description","displayName","id"],
                   "properties": {
-                    "@libre.graph.weight": { "const": 2 },
-                    "description": { "const": "View, download, upload, edit, add and delete." },
-                    "displayName": { "const": "Can edit" },
-                    "id": { "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21" }
+                    "@libre.graph.weight": {"const": 2},
+                    "description": {"const": "View, download, upload, edit, add and delete."},
+                    "displayName": {"const": "Can edit"},
+                    "id": {"const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"}
                   }
                 }
               ]

--- a/tests/acceptance/features/apiSharingNg1/filterPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg1/filterPermissions.feature
@@ -1166,3 +1166,249 @@ Feature: filter sharing permissions
         }
       }
       """
+
+  @issue-9745 @env-config
+  Scenario: user lists allowed file permissions for federated user
+    Given the administrator has enabled the permissions role "Secure Viewer"
+    And user "Alice" has uploaded file with content "ocm test" to "/textfile.txt"
+    When user "Alice" lists permissions with following filters for file "textfile.txt" of the space "Personal" using the Graph API:
+      | $filter=@libre.graph.permissions.roles.allowedValues/rolePermissions/any(p:contains(p/condition,+'@Subject.UserType=="Federated"')) |
+      | $select=@libre.graph.permissions.roles.allowedValue                                                                                 |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+          "required": [
+            "@libre.graph.permissions.roles.allowedValues"
+          ],
+          "properties": {
+            "@libre.graph.permissions.roles.allowedValues": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "oneOf":[
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 1 },
+                    "description": { "const": "View and download." },
+                    "displayName": { "const": "Can view" },
+                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 2 },
+                    "description": { "const": "View, download and edit." },
+                    "displayName": { "const": "Can edit" },
+                    "id": { "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"  }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+
+  @issue-9745 @env-config
+  Scenario: user lists allowed folder permissions for federated user
+    Given the administrator has enabled the permissions role "Denied"
+    And user "Alice" has created folder "folderToShare"
+    When user "Alice" lists permissions with following filters for folder "folderToShare" of the space "Personal" using the Graph API:
+      | $filter=@libre.graph.permissions.roles.allowedValues/rolePermissions/any(p:contains(p/condition,+'@Subject.UserType=="Federated"')) |
+      | $select=@libre.graph.permissions.roles.allowedValue                                                                                 |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+          "required": [
+            "@libre.graph.permissions.roles.allowedValues"
+          ],
+          "properties": {
+            "@libre.graph.permissions.roles.allowedValues": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "oneOf":[
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 1 },
+                    "description": { "const": "View and download." },
+                    "displayName": { "const": "Can view" },
+                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 2 },
+                    "description": { "const": "View, download, upload, edit, add and delete." },
+                    "displayName": { "const": "Can edit" },
+                    "id": { "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+
+  @issue-9745 @env-config
+  Scenario: user lists allowed file permissions for federated user (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Secure Viewer"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
+    When user "Alice" lists permissions with following filters for file "textfile.txt" of the space "new-space" using the Graph API:
+      | $filter=@libre.graph.permissions.roles.allowedValues/rolePermissions/any(p:contains(p/condition,+'@Subject.UserType=="Federated"')) |
+      | $select=@libre.graph.permissions.roles.allowedValue                                                                                 |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+          "required": [
+            "@libre.graph.permissions.roles.allowedValues"
+          ],
+          "properties": {
+            "@libre.graph.permissions.roles.allowedValues": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "oneOf":[
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 1 },
+                    "description": { "const": "View and download." },
+                    "displayName": { "const": "Can view" },
+                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 2 },
+                    "description": { "const": "View, download and edit." },
+                    "displayName": { "const": "Can edit" },
+                    "id": { "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+
+  @issue-9745 @env-config
+  Scenario: user lists allowed folder permissions for federated user (Project Space)
+    Given using spaces DAV path
+    And the administrator has enabled the permissions role "Denied"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    When user "Alice" lists permissions with following filters for folder "folderToShare" of the space "new-space" using the Graph API:
+      | $filter=@libre.graph.permissions.roles.allowedValues/rolePermissions/any(p:contains(p/condition,+'@Subject.UserType=="Federated"')) |
+      | $select=@libre.graph.permissions.roles.allowedValue                                                                                 |
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+          "required": [
+            "@libre.graph.permissions.roles.allowedValues"
+          ],
+          "properties": {
+            "@libre.graph.permissions.roles.allowedValues": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "oneOf":[
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 1 },
+                    "description": { "const": "View and download." },
+                    "displayName": { "const": "Can view" },
+                    "id": { "const": "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5" }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "@libre.graph.weight",
+                    "description",
+                    "displayName",
+                    "id"
+                  ],
+                  "properties": {
+                    "@libre.graph.weight": { "const": 2 },
+                    "description": { "const": "View, download, upload, edit, add and delete." },
+                    "displayName": { "const": "Can edit" },
+                    "id": { "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """


### PR DESCRIPTION
## Description
This PR shifts and adds test coverage for filtering permission for federated user.
Also add some tests related to listing permission after resource share to check roles 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of  https://github.com/owncloud/ocis/issues/10728

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
