### PR TITLE
[tests-only][full-ci] refactor scenarios to remove multiple `listAllNotifications` request in steps

### DIFF
--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -239,8 +239,6 @@ Feature: Notification Settings
       """
     And user "Alice" has removed the access of user "Brian" from resource "lorem.txt" of space "Personal"
     And user "Brian" should have "1" emails
-    When user "Brian" lists all notifications
-    Then the HTTP status code should be "200"
     And user "Brian" should get a notification with subject "Resource shared" and message:
       | message                                |
       | Alice Hansen shared lorem.txt with you |
@@ -336,8 +334,6 @@ Feature: Notification Settings
       """
     And user "Alice" has removed the access of user "Brian" from resource "insideSpace.txt" of space "newSpace"
     And user "Brian" should have "1" emails
-    When user "Brian" lists all notifications
-    Then the HTTP status code should be "200"
     And user "Brian" should get a notification with subject "Resource shared" and message:
       | message                                      |
       | Alice Hansen shared insideSpace.txt with you |
@@ -415,8 +411,6 @@ Feature: Notification Settings
       }
       """
     And user "Brian" has uploaded file "filesForUpload/filesWithVirus/<file-name>" to "<new-file-name>"
-    When user "Brian" lists all notifications
-    Then the HTTP status code should be "200"
     And user "Brian" should not have any notification
     Examples:
       | dav-path-version | file-name     | new-file-name  |
@@ -503,8 +497,6 @@ Feature: Notification Settings
       }
       """
     And user "Brian" has uploaded a file "filesForUpload/filesWithVirus/eicar.com" to "virusFile.txt" in space "newSpace"
-    When user "Brian" lists all notifications
-    Then the HTTP status code should be "200"
     And user "Brian" should get a notification with subject "Space shared" and message:
       | message                                  |
       | Alice Hansen added you to Space newSpace |
@@ -600,9 +592,6 @@ Feature: Notification Settings
       }
       """
     And user "Alice" has disabled a space "new-space"
-    When user "Brian" lists all notifications
-    Then the HTTP status code should be "200"
-    And there should be "1" notifications
     And user "Brian" should get a notification with subject "Space shared" and message:
       | message                                   |
       | Alice Hansen added you to Space new-space |
@@ -660,9 +649,6 @@ Feature: Notification Settings
       | sharee          | Brian     |
       | shareType       | user      |
       | permissionsRole | Viewer    |
-    When user "Brian" lists all notifications
-    Then the HTTP status code should be "200"
-    And there should be "1" notifications
     And user "Brian" should get a notification with subject "Resource shared" and message:
       | message                                |
       | Alice Hansen shared lorem.txt with you |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR refactors the notifications test scenarios such that there are no multiple steps that requests to list all the in-app notifications 
Originated from: https://github.com/owncloud/ocis/pull/10928#discussion_r1942218165

In some notification test scenarios, we were using steps like follow:
``` feature
When user "Brian" lists all notifications
Then the HTTP status code should be "200"
And user "Brian" should get a notification with subject "Space shared" and message:
```

In this case, listing all notifications request(`listAllNotifications`) was called twice. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/10802

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
