### PR TITLE
[tests-only][full-ci] Fix notification cleanup and retry

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -1,4 +1,4 @@
-@antivirus @skipOnReva
+@antivirus @skipOnReva @notification
 Feature: antivirus
   As a system administrator and user
   I want to protect myself and others from known viruses

--- a/tests/acceptance/features/apiNotification/deleteNotification.feature
+++ b/tests/acceptance/features/apiNotification/deleteNotification.feature
@@ -1,3 +1,4 @@
+@notification
 Feature: Delete notification
   As a user
   I want to delete notifications

--- a/tests/acceptance/features/apiNotification/deprovisioningNotification.feature
+++ b/tests/acceptance/features/apiNotification/deprovisioningNotification.feature
@@ -1,4 +1,4 @@
-@skipOnStable3.0
+@notification
 Feature: Deprovisioning notification
   As a user admin
   I want to inform users about shutting down and deprovisioning the instance

--- a/tests/acceptance/features/apiNotification/emailNotification.feature
+++ b/tests/acceptance/features/apiNotification/emailNotification.feature
@@ -1,4 +1,4 @@
-@email
+@notification @email
 Feature: Email notification
   As a user
   I want to get email notification of events related to me
@@ -130,7 +130,7 @@ Feature: Email notification
       Zum Ansehen hier klicken: %base_url%/files/shares/with-me
       """
 
-  @skipOnStable3.0
+
   Scenario: group members get an email notification in their respective languages when someone shares a space with the group
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Carol" has been created with default attributes

--- a/tests/acceptance/features/apiNotification/notification.feature
+++ b/tests/acceptance/features/apiNotification/notification.feature
@@ -1,3 +1,4 @@
+@notification
 Feature: Notification
   As a user
   I want to be notified of various events

--- a/tests/acceptance/features/apiNotification/serviceAvailabilityCheck.feature
+++ b/tests/acceptance/features/apiNotification/serviceAvailabilityCheck.feature
@@ -1,3 +1,4 @@
+@notification
 Feature: service health check
 
 

--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -1,3 +1,4 @@
+@notification
 Feature: Notification
   As a user
   I want to be notified of actions related to space

--- a/tests/acceptance/features/apiOcm/createInvitation.feature
+++ b/tests/acceptance/features/apiOcm/createInvitation.feature
@@ -76,7 +76,7 @@ Feature: create invitation
       | @domain.com                       | 400  |
       | user@domain..com                  | 400  |
 
-  @email @issue-10059
+  @issue-10059 @notification @email
   Scenario: federated user gets an email notification if their email was specified when creating the federation share invitation
     Given using server "REMOTE"
     And user "David" has been created with default attributes

--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -1,4 +1,4 @@
-@email
+@notification
 Feature: Notification Settings
   As a user
   I want to manage my notification settings
@@ -11,7 +11,7 @@ Feature: Notification Settings
       | Brian    |
     And user "Alice" has uploaded file with content "some data" to "lorem.txt"
 
-
+  @email
   Scenario: disable email notification
     When user "Brian" disables email notification using the settings API
     Then the HTTP status code should be "201"
@@ -64,7 +64,7 @@ Feature: Notification Settings
       | permissionsRole | Viewer    |
     And user "Brian" should have "0" emails
 
-
+  @email
   Scenario: disable mail and in-app notification for "Share Received" event
     When user "Brian" disables notification for the following events using the settings API:
       | Share Received | mail,in-app |
@@ -153,7 +153,7 @@ Feature: Notification Settings
     Then the HTTP status code should be "200"
     And the notifications should be empty
 
-
+  @email
   Scenario: disable mail and in-app notification for "Share Removed" event
     Given user "Alice" has sent the following resource share invitation:
       | resource        | lorem.txt |
@@ -244,7 +244,7 @@ Feature: Notification Settings
       | Alice Hansen shared lorem.txt with you |
     But user "Brian" should not have a notification related to resource "lorem.txt" with subject "Resource unshared"
 
-
+  @email
   Scenario: disable mail and in-app notification for "Share Removed" event (Project space)
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
@@ -654,7 +654,7 @@ Feature: Notification Settings
       | Alice Hansen shared lorem.txt with you |
     And user "Brian" should have "0" emails
 
-
+  @email
   Scenario: disable mail and in-app notification for "Added as space member" event
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
@@ -802,7 +802,7 @@ Feature: Notification Settings
       | Alice Hansen shared lorem.txt with you |
     And user "Brian" should have "0" emails
 
-
+  @email
   Scenario: disable mail and in-app notification for "Removed as space member" event
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API


### PR DESCRIPTION
## Description
This PR fix notification retry test code and cleanup mail and in-app after every notification-related scenario
A new tag @notification has been introduced, which does in-app and mail notification cleanup in the after hook.
@email will be used for specifying email-related tests scenario 

- Removed **@skipOnStable3.0** tag because there is no used of it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/10802

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
