### PR TITLE
[tests-only] [full-ci]Add tests for project drive resource share expiry notification

### DIFF
--- a/tests/acceptance/features/apiNotification/shareExpireNotification.feature
+++ b/tests/acceptance/features/apiNotification/shareExpireNotification.feature
@@ -1,0 +1,32 @@
+@notification @email
+Feature: Share Expiry Notification
+  As a user
+  I want to be notified when share expires
+  So that I can stay updated about the share
+
+  Background:
+    Given these users have been created with default attributes:
+      | username |
+      | Alice    |
+      | Brian    |
+
+  @issue-10966
+  Scenario: check share expired in-app and mail notification for Project space resource
+    Given using spaces DAV path
+    And using SharingNG
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "testfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource           | testfile.txt         |
+      | space              | NewSpace             |
+      | sharee             | Brian                |
+      | shareType          | user                 |
+      | permissionsRole    | Viewer               |
+      | expirationDateTime | 2025-07-15T14:00:00Z |
+    When user "Alice" expires the last share of resource "testfile.txt" inside of the space "NewSpace"
+    Then the HTTP status code should be "200"
+    And user "Brian" should get a notification with subject "Membership expired" and message:
+      | message                       |
+      | Access to Space NewSpace lost |
+    And user "Brian" should have "2" emails


### PR DESCRIPTION
|Status| Reason|
|------|-------
|Blocked| Flaky feature|

## Description
This PR adds tests related to the share expiry notification of resource inside project drive.
It seems like there is a bug which make this scenario flaky. Sometime we get single notification, sometime we get 2 notification for share expiry.

Below you can see mail we get when test is flaky

```
    And user "Brian" should have "2" emails                                                                         # NotificationContext::userShouldHaveEmail()
      │ array(3) {
      │   [0]=>
      │   object(stdClass)#3127 (9) {
      │     ["mailbox"]=>
      │     string(5) "brian"
      │     ["id"]=>
      │     string(20) "20250211T050947-0027"
      │     ["from"]=>
      │     string(47) "Alice Hansen via owncloud <noreply@example.com>"
      │     ["to"]=>
      │     array(1) {
      │       [0]=>
      │       string(19) "<brian@example.org>"
      │     }
      │     ["subject"]=>
      │     string(43) "Alice Hansen shared 'testfile.txt' with you"
      │     ["date"]=>
      │     string(30) "2025-02-11T05:09:47.884899228Z"
      │     ["posix-millis"]=>
      │     int(1739250587884)
      │     ["size"]=>
      │     int(2591)
      │     ["seen"]=>
      │     bool(false)
      │   }
      │   [1]=>
      │   object(stdClass)#3130 (9) {
      │     ["mailbox"]=>
      │     string(5) "brian"
      │     ["id"]=>
      │     string(20) "20250211T050948-0028"
      │     ["from"]=>
      │     string(47) "Alice Hansen via owncloud <noreply@example.com>"
      │     ["to"]=>
      │     array(1) {
      │       [0]=>
      │       string(19) "<brian@example.org>"
      │     }
      │     ["subject"]=>
      │     string(55) "Membership of 'NewSpace' expired at 2025-02-11 10:49:47"
      │     ["date"]=>
      │     string(30) "2025-02-11T05:09:48.068341429Z"
      │     ["posix-millis"]=>
      │     int(1739250588068)
      │     ["size"]=>
      │     int(2633)
      │     ["seen"]=>
      │     bool(false)
      │   }
      │   [2]=>
      │   object(stdClass)#3131 (9) {
      │     ["mailbox"]=>
      │     string(5) "brian"
      │     ["id"]=>
      │     string(20) "20250211T050948-0029"
      │     ["from"]=>
      │     string(47) "Alice Hansen via owncloud <noreply@example.com>"
      │     ["to"]=>
      │     array(1) {
      │       [0]=>
      │       string(19) "<brian@example.org>"
      │     }
      │     ["subject"]=>
      │     string(55) "Membership of 'NewSpace' expired at 2025-02-11 10:49:47"
      │     ["date"]=>
      │     string(30) "2025-02-11T05:09:48.069781255Z"
      │     ["posix-millis"]=>
      │     int(1739250588069)
      │     ["size"]=>
      │     int(2633)
      │     ["seen"]=>
      │     bool(false)
      │   }
      │ }
      │ 
      Failed asserting that actual size 3 matches expected size 2.

```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/10802
- Bug coverage of https://github.com/owncloud/ocis/issues/10936

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
