### PR TITLE
[tests-only][full-ci] add test to disable in-app notification for share removed event by federated user

### DIFF
--- a/tests/acceptance/features/apiOcm/ocmNotifications.feature
+++ b/tests/acceptance/features/apiOcm/ocmNotifications.feature
@@ -120,3 +120,94 @@ Feature: ocm notifications
         Token: %fed_invitation_token%
         ProviderDomain: %local_base_url%
       """
+
+  @issue-11042
+  Scenario: no in-app notification should pop-up for unshared resource when "Share Removed" event is disabled
+    Given using server "REMOTE"
+    And user "Brian" has been created with default attributes
+    And "Brian" has created the federation share invitation
+    And using server "LOCAL"
+    And "Alice" has accepted invitation
+    And user "Alice" has uploaded file with content "ocm test" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation to federated user:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    And using server "REMOTE"
+    When user "Brian" disables notification for the following event using the settings API:
+      | event             | Share Removed |
+      | notificationTypes | in-app        |
+    Then the HTTP status code should be "201"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "object",
+            "required": ["identifier","value"],
+            "properties": {
+              "identifier":{
+                "type": "object",
+                "required": ["extension","bundle","setting"],
+                "properties": {
+                  "extension":{ "const": "ocis-accounts" },
+                  "bundle":{ "const": "profile" },
+                  "setting":{ "const": "event-share-removed-options" }
+                }
+              },
+              "value":{
+                "type": "object",
+                "required": ["id","bundleId","settingId","accountUuid","resource","collectionValue"],
+                "properties":{
+                  "id":{ "pattern":"%uuidv4_pattern%" },
+                  "bundleId":{ "pattern":"%uuidv4_pattern%" },
+                  "settingId":{ "pattern":"%uuidv4_pattern%" },
+                  "accountUuid":{ "pattern":"%uuidv4_pattern%" },
+                  "resource":{
+                    "type": "object",
+                    "required":["type"],
+                    "properties": {
+                      "type":{ "const": "TYPE_USER" }
+                    }
+                  },
+                  "collectionValue":{
+                    "type": "object",
+                    "required":["values"],
+                    "properties": {
+                      "values":{
+                        "type": "array",
+                        "maxItems": 1,
+                        "minItems": 1,
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": ["key","boolValue"],
+                              "properties": {
+                                "key":{ "const": "in-app" },
+                                "boolValue":{ "const": false }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And using server "LOCAL"
+    And user "Alice" has removed the access of user "Brian" from resource "textfile.txt" of space "Personal"
+    And using server "REMOTE"
+    And user "Brian" should get a notification with subject "Resource shared" and message:
+      | message                                   |
+      | Alice Hansen shared textfile.txt with you |
+    And user "Brian" should not have a notification related to resource "textfile.txt" with subject "Resource unshared"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds test to disable in-app notification for `Share Removed` event by federated user(OCM).
NOTE :exclamation: => Email notifications are not implemented yet for OCM
``` feature
Scenario: federated user disables in-app notification for "Share Removed" event
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/11062
- Bug report: https://github.com/owncloud/ocis/issues/11042

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
