### PR TITLE
[tests-only][full-ci] use store for drives

### DIFF
--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -1051,7 +1051,8 @@ class GraphHelper {
 		array  $body = [],
 		array  $headers = []
 	): ResponseInterface {
-		$url = self::getFullUrl($baseUrl, 'me/drives' . $urlArguments);
+		$urlArguments = $urlArguments ? "?$urlArguments" : "";
+		$url = self::getFullUrl($baseUrl, "me/drives$urlArguments");
 
 		return HttpRequestHelper::get($url, $xRequestId, $user, $password, $headers, $body);
 	}
@@ -1080,7 +1081,8 @@ class GraphHelper {
 		array  $body = [],
 		array  $headers = []
 	): ResponseInterface {
-		$url = self::getFullUrl($baseUrl, 'drives/' . $urlArguments);
+		$urlArguments = $urlArguments ? "?$urlArguments" : "";
+		$url = self::getFullUrl($baseUrl, "drives$urlArguments");
 
 		return HttpRequestHelper::get($url, $xRequestId, $user, $password, $headers, $body);
 	}

--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -1052,7 +1052,7 @@ class GraphHelper {
 		array  $headers = []
 	): ResponseInterface {
 		$urlArguments = $urlArguments ? "?$urlArguments" : "";
-		$url = self::getFullUrl($baseUrl, "me/drives$urlArguments");
+		$url = self::getFullUrl($baseUrl, "me/drives" . $urlArguments);
 
 		return HttpRequestHelper::get($url, $xRequestId, $user, $password, $headers, $body);
 	}
@@ -1082,7 +1082,7 @@ class GraphHelper {
 		array  $headers = []
 	): ResponseInterface {
 		$urlArguments = $urlArguments ? "?$urlArguments" : "";
-		$url = self::getFullUrl($baseUrl, "drives$urlArguments");
+		$url = self::getFullUrl($baseUrl, "drives" . $urlArguments);
 
 		return HttpRequestHelper::get($url, $xRequestId, $user, $password, $headers, $body);
 	}

--- a/tests/acceptance/TestHelpers/HttpRequestHelper.php
+++ b/tests/acceptance/TestHelpers/HttpRequestHelper.php
@@ -55,7 +55,7 @@ class HttpRequestHelper {
 	 *
 	 * @return int
 	 */
-	public static function numRetriesOnHttpTooEarly(): int {
+	public static function maxHTTPRequestRetries(): int {
 		// Currently reva and oCIS may return HTTP_TOO_EARLY
 		// So try up to 10 times before giving up.
 		return 10;
@@ -203,7 +203,7 @@ class HttpRequestHelper {
 			$debugResponses = false;
 		}
 
-		$sendRetryLimit = self::numRetriesOnHttpTooEarly();
+		$sendRetryLimit = self::maxHTTPRequestRetries();
 		$sendCount = 0;
 		$sendExceptionHappened = false;
 		do {

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -1787,8 +1787,6 @@ class FeatureContext extends BehatVariablesContext {
 			return $this->getAdminPassword();
 		} elseif (\array_key_exists($username, $this->createdUsers)) {
 			return (string)$this->createdUsers[$username]['password'];
-		} elseif (\array_key_exists($username, $this->createdRemoteUsers)) {
-			return (string)$this->createdRemoteUsers[$username]['password'];
 		}
 
 		// The user has not been created yet, see if there is a replacement
@@ -1863,12 +1861,6 @@ class FeatureContext extends BehatVariablesContext {
 			}
 			return $userName;
 		}
-		if (\array_key_exists($username, $this->createdRemoteUsers)) {
-			if (isset($this->createdRemoteUsers[$username]['displayname'])) {
-				return (string)$this->createdRemoteUsers[$username]['displayname'];
-			}
-			return $userName;
-		}
 
 		// The user has not been created yet, see if there is a replacement
 		// defined for the user.
@@ -1923,9 +1915,6 @@ class FeatureContext extends BehatVariablesContext {
 		$username = $this->getActualUsername($userNameNormalized);
 		if (\array_key_exists($username, $this->createdUsers)) {
 			return (string)$this->createdUsers[$username]['email'];
-		}
-		if (\array_key_exists($username, $this->createdRemoteUsers)) {
-			return (string)$this->createdRemoteUsers[$username]['email'];
 		}
 
 		// The user has not been created yet, see if there is a replacement
@@ -2977,8 +2966,6 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws Exception
 	 */
 	public static function checkScenario(AfterScenarioScope $scope): void {
-		var_dump("Before running...");
-		var_dump($this->personalSpaces);
 		if (($scope->getTestResult()->getResultCode() !== 0)
 			&& (!self::isExpectedToFail(self::getScenarioLine($scope)))
 		) {

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -2977,6 +2977,8 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws Exception
 	 */
 	public static function checkScenario(AfterScenarioScope $scope): void {
+		var_dump("Before running...");
+		var_dump($this->personalSpaces);
 		if (($scope->getTestResult()->getResultCode() !== 0)
 			&& (!self::isExpectedToFail(self::getScenarioLine($scope)))
 		) {

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -96,7 +96,7 @@ class GraphContext implements Context {
 	 *
 	 * @param string $byUser
 	 * @param string $user
-	 * @param string $userName
+	 * @param string $newUsername
 	 *
 	 * @return void
 	 * @throws GuzzleException
@@ -105,13 +105,18 @@ class GraphContext implements Context {
 	public function theUserChangesTheUserNameOfUserToUsingTheGraphApi(
 		string $byUser,
 		string $user,
-		string $userName
+		string $newUsername
 	): void {
-		$response = $this->editUserUsingTheGraphApi($byUser, $user, $userName);
+		$response = $this->editUserUsingTheGraphApi($byUser, $user, $newUsername);
 		$this->featureContext->setResponse($response);
-		// need to add user to list to delete him after test
-		if (!empty($userName) && $this->featureContext->getAttributeOfCreatedUser($userName, 'id')) {
-			$this->featureContext->addUserToCreatedUsersList($userName, $this->featureContext->getUserPassword($user));
+
+		// save the updated user
+		if (!empty($newUsername) && $response->getStatusCode() === 200) {
+			$this->featureContext->rememberThatUserIsNotExpectedToExist($user);
+			$this->featureContext->addUserToCreatedUsersList(
+				$newUsername,
+				$this->featureContext->getUserPassword($user)
+			);
 		}
 	}
 
@@ -291,13 +296,17 @@ class GraphContext implements Context {
 	 */
 	public function adminDeletesUserUsingTheGraphApi(string $user, ?string $byUser = null): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($byUser);
-		return GraphHelper::deleteUser(
+		$response = GraphHelper::deleteUser(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
 			$credentials["username"],
 			$credentials["password"],
 			$user
 		);
+		if ($response->getStatusCode() === 204) {
+			$this->featureContext->rememberThatUserIsNotExpectedToExist($user);
+		}
+		return $response;
 	}
 
 	/**
@@ -327,21 +336,30 @@ class GraphContext implements Context {
 	/**
 	 * sends a request to delete a user with the help of userID using the Graph API
 	 *
-	 * @param string $userId
+	 * @param string $user
 	 * @param string $byUser
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public function deleteUserByUserIdUsingTheGraphApi(string $userId, string $byUser): ResponseInterface {
+	public function deleteUserByUserId(string $user, string $byUser): ResponseInterface {
+		if ($user === "nonexistent") {
+			$userId = WebDavHelper::generateUUIDv4();
+		} else {
+			$userId = $this->featureContext->getUserIdByUserName($user);
+		}
 		$credentials = $this->getAdminOrUserCredentials($byUser);
-		return GraphHelper::deleteUserByUserId(
+		$response = GraphHelper::deleteUserByUserId(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
 			$credentials["username"],
 			$credentials["password"],
 			$userId
 		);
+		if ($response->getStatusCode() === 204) {
+			$this->featureContext->rememberThatUserIsNotExpectedToExist($user);
+		}
+		return $response;
 	}
 
 	/**
@@ -355,8 +373,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function theUserDeletesAUserUsingTheGraphAPI(string $byUser, string $user): void {
-		$userId = $this->featureContext->getUserIdByUserName($user);
-		$this->featureContext->setResponse($this->deleteUserByUserIdUsingTheGraphApi($userId, $byUser));
+		$this->featureContext->setResponse($this->deleteUserByUserId($user, $byUser));
 	}
 
 	/**
@@ -369,8 +386,7 @@ class GraphContext implements Context {
 	 * @throws Exception
 	 */
 	public function theUserTriesToDeleteNonExistingUser(string $byUser): void {
-		$userId = WebDavHelper::generateUUIDv4();
-		$this->featureContext->setResponse($this->deleteUserByUserIdUsingTheGraphApi($userId, $byUser));
+		$this->featureContext->setResponse($this->deleteUserByUserId("nonexistent", $byUser));
 	}
 
 	/**
@@ -689,11 +705,12 @@ class GraphContext implements Context {
 			$rows["email"],
 			$rows["displayName"]
 		);
+		$this->featureContext->setResponse($response);
 
 		// add created user to list except for the user with an empty name
 		// because request /graph/v1.0/users/emptyUserName exits with 200
 		// and we cannot check that the user with empty name doesn't exist
-		if (!empty($rows["userName"])) {
+		if (!empty($rows["userName"]) && $response->getStatusCode() === 201) {
 			$this->featureContext->addUserToCreatedUsersList(
 				$rows["userName"],
 				$rows["password"],
@@ -701,7 +718,6 @@ class GraphContext implements Context {
 				$rows["email"]
 			);
 		}
-		$this->featureContext->setResponse($response);
 	}
 
 	/**
@@ -2994,7 +3010,7 @@ class GraphContext implements Context {
 	 * @return void
 	 */
 	public function userListsTheActivitiesOfSpaceUsingTheGraphApi(string $user, string $spaceName): void {
-		$spaceId = ($this->spacesContext->getSpaceByName($user, $spaceName))->id;
+		$spaceId = ($this->spacesContext->getSpaceByName($user, $spaceName))["id"];
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -2674,7 +2674,7 @@ class GraphContext implements Context {
 					$autoSync = $this->featureContext->getUserAutoSyncSetting($credentials['username']);
 					$tryAgain = !$share->{'@client.synchronize'}
 					&& $autoSync
-					&& $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
+					&& $retried < HttpRequestHelper::maxHTTPRequestRetries();
 
 					if ($tryAgain) {
 						$retried += 1;
@@ -2918,7 +2918,7 @@ class GraphContext implements Context {
 		string $resource,
 		string $spaceName
 	): void {
-		$resourceId = $this->featureContext->spacesContext->getResourceId($user, $spaceName, $resource);
+		$resourceId = $this->spacesContext->getResourceId($user, $spaceName, $resource);
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
@@ -2974,7 +2974,7 @@ class GraphContext implements Context {
 		string $owner,
 		string $spaceName
 	): void {
-		$resourceId = $this->featureContext->spacesContext->getResourceId($owner, $spaceName, $file);
+		$resourceId = $this->spacesContext->getResourceId($owner, $spaceName, $file);
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
@@ -2994,7 +2994,7 @@ class GraphContext implements Context {
 	 * @return void
 	 */
 	public function userListsTheActivitiesOfSpaceUsingTheGraphApi(string $user, string $spaceName): void {
-		$spaceId = ($this->featureContext->spacesContext->getSpaceByName($user, $spaceName))["id"];
+		$spaceId = ($this->spacesContext->getSpaceByName($user, $spaceName))->id;
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),
@@ -3073,7 +3073,7 @@ class GraphContext implements Context {
 		string $filterType,
 		string $filterValue
 	): void {
-		$resourceId = $this->featureContext->spacesContext->getResourceId($user, $spaceName, $resource);
+		$resourceId = $this->spacesContext->getResourceId($user, $spaceName, $resource);
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),

--- a/tests/acceptance/bootstrap/NotificationContext.php
+++ b/tests/acceptance/bootstrap/NotificationContext.php
@@ -75,7 +75,7 @@ class NotificationContext implements Context {
 	 */
 	public function clearAllEmails(): void {
 		try {
-			$usersList = $this->featureContext->getAllCreatedUsers();
+			$usersList = $this->featureContext->getCreatedUsers();
 			foreach ($usersList as $emailRecipient) {
 				EmailHelper::deleteAllEmailsForAMailbox(
 					EmailHelper::getLocalEmailUrl(),

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -41,12 +41,6 @@ trait Provisioning {
 	 * key is the lowercase username, value is an array of user attributes
 	 */
 	private array $createdUsers = [];
-
-	/**
-	 * list of users that were created on the remote server during test runs
-	 * key is the lowercase username, value is an array of user attributes
-	 */
-	private array $createdRemoteUsers = [];
 	private array $startingGroups = [];
 	private array $createdRemoteGroups = [];
 	private array $createdGroups = [];
@@ -86,13 +80,6 @@ trait Provisioning {
 	/**
 	 * @return array
 	 */
-	public function getAllCreatedUsers(): array {
-		return array_merge($this->createdUsers, $this->createdRemoteUsers);
-	}
-
-	/**
-	 * @return array
-	 */
 	public function getCreatedGroups(): array {
 		return $this->createdGroups;
 	}
@@ -107,7 +94,7 @@ trait Provisioning {
 	 */
 	public function getUserDisplayName(string $username): string {
 		$normalizedUsername = $this->normalizeUsername($username);
-		$users = $this->getAllCreatedUsers();
+		$users = $this->getCreatedUsers();
 		if (isset($users[$normalizedUsername]['displayname'])) {
 			$displayName = (string) $users[$normalizedUsername]['displayname'];
 			if ($displayName !== '') {
@@ -125,7 +112,7 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function getAttributeOfCreatedUser(string $user, string $attribute) {
-		$usersList = $this->getAllCreatedUsers();
+		$usersList = $this->getCreatedUsers();
 		$normalizedUsername = $this->normalizeUsername($user);
 		if (\array_key_exists($normalizedUsername, $usersList)) {
 			if (\array_key_exists($attribute, $usersList[$normalizedUsername])) {
@@ -175,8 +162,6 @@ trait Provisioning {
 			$password = $this->getAdminPassword();
 		} elseif (\array_key_exists($normalizedUsername, $this->createdUsers)) {
 			$password = $this->createdUsers[$normalizedUsername]['password'];
-		} elseif (\array_key_exists($normalizedUsername, $this->createdRemoteUsers)) {
-			$password = $this->createdRemoteUsers[$normalizedUsername]['password'];
 		} else {
 			throw new Exception(
 				"user '$username' was not created by this test run"
@@ -768,7 +753,6 @@ trait Provisioning {
 			$this->userExists($user),
 			"User '$user' should not exist but does exist"
 		);
-		$this->rememberThatUserIsNotExpectedToExist($user);
 	}
 
 	/**
@@ -855,7 +839,6 @@ trait Provisioning {
 			$this->userExists($user),
 			"User '$user' should not exist but does exist"
 		);
-		$this->rememberThatUserIsNotExpectedToExist($user);
 	}
 
 	/**
@@ -977,8 +960,8 @@ trait Provisioning {
 	 * makes it possible to use this list in other test steps
 	 * or to delete them at the end of the test
 	 *
-	 * @param string|null $user
-	 * @param string|null $password
+	 * @param string $user
+	 * @param string $password
 	 * @param string|null $displayName
 	 * @param string|null $email
 	 * @param string|null $userId only set for the users created using the Graph API
@@ -988,8 +971,8 @@ trait Provisioning {
 	 * @throws JsonException
 	 */
 	public function addUserToCreatedUsersList(
-		?string $user,
-		?string $password,
+		string $user,
+		string $password,
 		?string $displayName = null,
 		?string $email = null,
 		?string $userId = null,
@@ -997,30 +980,17 @@ trait Provisioning {
 	): void {
 		$user = $this->getActualUsername($user);
 		$normalizedUsername = $this->normalizeUsername($user);
-		$userData = [
-			"password" => $password,
-			"displayname" => $displayName,
-			"email" => $email,
-			"shouldExist" => $shouldExist,
-			"actualUsername" => $user,
-			"id" => $userId
-		];
 
-		if ($this->currentServer === 'LOCAL') {
-			// Only remember this user creation if it was expected to have been successful
-			// or the user has not been processed before. Some tests create a user the
-			// first time (successfully) and then purposely try to create the user again.
-			// The 2nd user creation is expected to fail, and in that case we want to
-			// still remember the details of the first user creation.
-			if ($shouldExist || !\array_key_exists($normalizedUsername, $this->createdUsers)) {
-				$this->createdUsers[$normalizedUsername] = $userData;
-			}
-		} elseif ($this->currentServer === 'REMOTE') {
-			// See comment above about the LOCAL case. The logic is the same for the remote case.
-			if ($shouldExist || !\array_key_exists($normalizedUsername, $this->createdRemoteUsers)) {
-				$this->createdRemoteUsers[$normalizedUsername] = $userData;
-				$this->createdUsers[$normalizedUsername] = $userData;
-			}
+		if ($shouldExist || !\array_key_exists($normalizedUsername, $this->createdUsers)) {
+			$this->createdUsers[$normalizedUsername] = [
+				"password" => $password,
+				"displayname" => $displayName,
+				"email" => $email,
+				"shouldExist" => $shouldExist,
+				"actualUsername" => $user,
+				"id" => $userId,
+				"serverType" => $this->currentServer
+			];
 		}
 	}
 
@@ -1038,14 +1008,8 @@ trait Provisioning {
 		string $password
 	): void {
 		$normalizedUsername = $this->normalizeUsername($user);
-		if ($this->currentServer === 'LOCAL') {
-			if (\array_key_exists($normalizedUsername, $this->createdUsers)) {
-				$this->createdUsers[$normalizedUsername]['password'] = $password;
-			}
-		} elseif ($this->currentServer === 'REMOTE') {
-			if (\array_key_exists($normalizedUsername, $this->createdRemoteUsers)) {
-				$this->createdRemoteUsers[$user]['password'] = $password;
-			}
+		if (\array_key_exists($normalizedUsername, $this->createdUsers)) {
+			$this->createdUsers[$normalizedUsername]['password'] = $password;
 		}
 	}
 
@@ -1792,6 +1756,9 @@ trait Provisioning {
 			// users can be deleted using the username in the GraphApi too
 			$response = $this->graphContext->adminDeletesUserUsingTheGraphApi($user);
 		}
+		if ($response->getStatusCode() === 204) {
+			$this->rememberThatUserIsNotExpectedToExist($user);
+		}
 		return $response;
 	}
 
@@ -1998,8 +1965,13 @@ trait Provisioning {
 	 */
 	public function cleanupDatabaseUsers(): void {
 		$previousServer = $this->currentServer;
-		$this->usingServer('LOCAL');
 		foreach ($this->createdUsers as $userData) {
+			// do not try to delete if user doesn't exist
+			if (!$userData["shouldExist"]) {
+				continue;
+			}
+			$this->usingServer($userData["serverType"]);
+
 			$user = $userData['actualUsername'];
 			$response = $this->deleteUser($user);
 			$this->theHTTPStatusCodeShouldBe(204, "Failed to delete user '$user'", $response);
@@ -2007,18 +1979,6 @@ trait Provisioning {
 				$this->userExists($user),
 				"User '$user' should not exist but does exist"
 			);
-			$this->rememberThatUserIsNotExpectedToExist($user);
-		}
-		$this->usingServer('REMOTE');
-		foreach ($this->createdRemoteUsers as $userData) {
-			$user = $userData['actualUsername'];
-			$response = $this->deleteUser($user);
-			$this->theHTTPStatusCodeShouldBe(204, "Failed to delete user '$user'", $response);
-			Assert::assertFalse(
-				$this->userExists($user),
-				"User '$user' should not exist but does exist"
-			);
-			$this->rememberThatUserIsNotExpectedToExist($user);
 		}
 		$this->usingServer($previousServer);
 	}

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -951,7 +951,8 @@ trait Provisioning {
 		}
 
 		// initialize user by requesting drives
-		// saves the Personal drive id
+		// NOTE: this should not be removed,
+		// as it will save the Personal and Shares drives information
 		$this->spacesContext->getSpaceByName($user, 'Personal');
 	}
 

--- a/tests/acceptance/bootstrap/SettingsContext.php
+++ b/tests/acceptance/bootstrap/SettingsContext.php
@@ -186,7 +186,7 @@ class SettingsContext implements Context {
 				$decodedBody = \json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
 				$tryAgain = false;
 			} catch (Exception $e) {
-				$tryAgain = $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
+				$tryAgain = $retried < HttpRequestHelper::maxHTTPRequestRetries();
 
 				if (!$tryAgain) {
 					throw $e;

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -72,11 +72,7 @@ class SharingNgContext implements Context {
 		$bodyRows = $body->getRowsHash();
 		$resource = $bodyRows['resource'] ?? "";
 
-		if ($bodyRows['space'] === 'Personal' || $bodyRows['space'] === 'Shares') {
-			$space = $this->spacesContext->getSpaceByName($user, $bodyRows['space']);
-		} else {
-			$space = $this->spacesContext->getCreatedSpace($bodyRows['space']);
-		}
+		$space = $this->spacesContext->getSpaceByName($user, $bodyRows['space']);
 		$spaceId = $space['id'];
 
 		if ($resource === '' && !\in_array($bodyRows['space'], ['Personal', 'Shares'])) {
@@ -280,11 +276,7 @@ class SharingNgContext implements Context {
 		string $fileId = null,
 		bool $federatedShare = false
 	): ResponseInterface {
-		if ($shareInfo['space'] === 'Personal' || $shareInfo['space'] === 'Shares') {
-			$space = $this->spacesContext->getSpaceByName($user, $shareInfo['space']);
-		} else {
-			$space = $this->spacesContext->getCreatedSpace($shareInfo['space']);
-		}
+		$space = $this->spacesContext->getSpaceByName($user, $shareInfo['space']);
 		$spaceId = $space['id'];
 
 		// $fileId is used for trying to share deleted files
@@ -374,11 +366,7 @@ class SharingNgContext implements Context {
 	): ResponseInterface {
 		$shareeIds = [];
 		$rows = $table->getRowsHash();
-		if ($rows['space'] === 'Personal' || $rows['space'] === 'Shares') {
-			$space = $this->spacesContext->getSpaceByName($user, $rows['space']);
-		} else {
-			$space = $this->spacesContext->getCreatedSpace($rows['space']);
-		}
+		$space = $this->spacesContext->getSpaceByName($user, $rows['space']);
 		$spaceId = $space['id'];
 
 		$sharees = array_map('trim', explode(',', $rows['sharee']));
@@ -664,11 +652,7 @@ class SharingNgContext implements Context {
 	 */
 	public function updateResourceShare(string $user, TableNode  $body, string $permissionID): ResponseInterface {
 		$bodyRows = $body->getRowsHash();
-		if ($bodyRows['space'] === 'Personal' || $bodyRows['space'] === 'Shares') {
-			$space = $this->spacesContext->getSpaceByName($user, $bodyRows['space']);
-		} else {
-			$space = $this->spacesContext->getCreatedSpace($bodyRows['space']);
-		}
+		$space = $this->spacesContext->getSpaceByName($user, $bodyRows['space']);
 		$spaceId = $space["id"];
 		// for updating role of project space shared, we do not need to provide resource
 		$resource = $bodyRows['resource'] ?? '';
@@ -1494,7 +1478,7 @@ class SharingNgContext implements Context {
 				return;
 			}
 
-			$tryAgain = !$shareSynced && $retried < HttpRequestHelper::numRetriesOnHttpTooEarly();
+			$tryAgain = !$shareSynced && $retried < HttpRequestHelper::maxHTTPRequestRetries();
 			if ($tryAgain) {
 				$retried += 1;
 				echo "[INFO] Wait for share sync status...";

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -1623,8 +1623,7 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has changed the quota of the personal space of "([^"]*)" space to "([^"]*)"$/
-	 * @Given /^user "([^"]*)" has changed the quota of the "([^"]*)" space to "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has changed the quota of space "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -223,7 +223,7 @@ class SpacesContext implements Context {
 				$this->featureContext->getStepLineRef()
 			);
 			// NOTE: user can be created with empty password
-			// so if that's the case, the user won't be able request using empty password
+			// so if that's the case, the user won't be able to request using empty password
 			// and user won't have personal space.
 			if ($response->getStatusCode() === 401 && !$password) {
 				return [];
@@ -237,16 +237,25 @@ class SpacesContext implements Context {
 
 			$found = false;
 			$foundSpace = [];
-			foreach ($spaces as $space) {
-				if ($space->name === "Shares" && !\array_key_exists("Shares", $allSpaces)) {
-					$this->addPersonalSpaceForUser("Shares", $space);
+
+			// update the Shares space with other properties
+			// NOTE: the order of drives list can be different
+			// so this extra loop is needed to find and update the Shares space properties
+			if ($allSpaces["Shares"]->name !== "Shares") {
+				foreach ($spaces as $space) {
+					if ($space->name === "Shares") {
+						$this->addPersonalSpaceForUser("Shares", $space);
+						break;
+					}
 				}
+			}
+			foreach ($spaces as $space) {
 				if ($space->name === $spaceName) {
 					$found = true;
 					$foundSpace = $space;
 					if ($space->driveType === "project") {
 						$this->addToCreatedSpace($user, $space);
-					} else {
+					} elseif (!($space->name === "Shares" && $space->driveType === "virtual")) {
 						$this->addPersonalSpaceForUser($user, $space);
 					}
 					break;
@@ -488,6 +497,18 @@ class SpacesContext implements Context {
 		$this->checksumContext = BehatHelper::getContext($scope, $environment, 'ChecksumContext');
 		$this->filesVersionsContext = BehatHelper::getContext($scope, $environment, 'FilesVersionsContext');
 		$this->archiverContext = BehatHelper::getContext($scope, $environment, 'ArchiverContext');
+
+		// add Shares space as its drive-id is known
+		// NOTE: this cannot be moved into a constructor method
+		// because it uses the $this->featureContext object
+		$this->personalSpaces = [
+			"Shares" => (object)[
+				"id" => GraphHelper::SHARES_SPACE_ID,
+				// let 'name' be empty, it is used to update the shares space later on
+				"name" => "",
+				"serverType" => $this->featureContext->getCurrentServer()
+			]
+		];
 	}
 
 	/**

--- a/tests/acceptance/features/apiArchiver/downloadByPath.feature
+++ b/tests/acceptance/features/apiArchiver/downloadByPath.feature
@@ -13,7 +13,7 @@ Feature: download multiple resources bundled into an archive
   @issue-4637
   Scenario Outline: download a single file
     Given user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
-    When user "Alice" downloads the <archive-type> archive of "/home/textfile0.txt" using the resource path and setting these headers:
+    When user "Alice" downloads the <archive-type> archive of "textfile0.txt" using the resource path and setting these headers:
       | header     | value        |
       | User-Agent | <user-agent> |
     Then the HTTP status code should be "200"
@@ -30,7 +30,7 @@ Feature: download multiple resources bundled into an archive
     Given user "Alice" has created folder "my_data"
     And user "Alice" has uploaded file with content "some data" to "/my_data/textfile0.txt"
     And user "Alice" has uploaded file with content "more data" to "/my_data/an_other_file.txt"
-    When user "Alice" downloads the <archive-type> archive of "/home/my_data" using the resource path and setting these headers:
+    When user "Alice" downloads the <archive-type> archive of "my_data" using the resource path and setting these headers:
       | header     | value        |
       | User-Agent | <user-agent> |
     Then the HTTP status code should be "200"
@@ -52,10 +52,10 @@ Feature: download multiple resources bundled into an archive
     And user "Alice" has created folder "more_data"
     And user "Alice" has uploaded file with content "more data" to "/more_data/an_other_file.txt"
     When user "Alice" downloads the archive of these items using the resource paths
-      | /home/textfile0.txt |
-      | /home/textfile1.txt |
-      | /home/my_data       |
-      | /home/more_data     |
+      | textfile0.txt |
+      | textfile1.txt |
+      | my_data       |
+      | more_data     |
     Then the HTTP status code should be "200"
     And the downloaded tar archive should contain these files:
       | name                        | content    |
@@ -107,10 +107,10 @@ Feature: download multiple resources bundled into an archive
       | permissionsRole | Viewer    |
     And user "Brian" has a share "more_data" synced
     When user "Brian" downloads the archive of these items using the resource path
-      | /home/Shares/textfile0.txt |
-      | /home/Shares/textfile1.txt |
-      | /home/Shares/my_data       |
-      | /home/Shares/more_data     |
+      | Shares/textfile0.txt |
+      | Shares/textfile1.txt |
+      | Shares/my_data       |
+      | Shares/more_data     |
     Then the HTTP status code should be "200"
     And the downloaded tar archive should contain these files:
       | name                        | content    |
@@ -156,7 +156,7 @@ Feature: download multiple resources bundled into an archive
       | shareType       | user      |
       | permissionsRole | Viewer    |
     And user "Brian" has a share "more_data" synced
-    When user "Brian" downloads the <archive-type> archive of "/home/Shares" using the resource path and setting these headers:
+    When user "Brian" downloads the <archive-type> archive of "Shares" using the resource path and setting these headers:
       | header     | value        |
       | User-Agent | <user-agent> |
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiGraph/userGDPRExport.feature
+++ b/tests/acceptance/features/apiGraph/userGDPRExport.feature
@@ -411,7 +411,7 @@ Feature: user GDPR (General Data Protection Regulation) report
 
 
   Scenario: generate a GDPR report after the admin updates the quota of personal space
-    Given user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10000"
+    Given user "Admin" has changed the quota of space "Alice Hansen" to "10000"
     When user "Alice" exports her GDPR report to "/.personal_data_export.json" using the Graph API
     And user "Alice" downloads the content of GDPR report ".personal_data_export.json"
     Then the HTTP status code of responses on each endpoint should be "202, 200" respectively

--- a/tests/acceptance/features/apiGraphUserGroup/editUser.feature
+++ b/tests/acceptance/features/apiGraphUserGroup/editUser.feature
@@ -37,7 +37,7 @@ Feature: edit user
     Examples:
       | action description           | user    | http-status-code | new-user |
       | change to a valid user name  | Lionel  | 200              | Lionel   |
-      | user name characters         | a*!_+-& | 200              | a*!_+-&  |
+      | user name characters         | a*!_-&  | 200              | a*!_-&   |
       | change to existing user name | Brian   | 409              | Carol    |
       | empty user name              |         | 400              | Carol    |
 

--- a/tests/acceptance/features/apiLocks/lockFiles.feature
+++ b/tests/acceptance/features/apiLocks/lockFiles.feature
@@ -11,7 +11,7 @@ Feature: lock files
 
   Scenario Outline: lock a file
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     When user "Alice" locks file "textfile.txt" using the WebDAV API setting the following properties
       | lockscope | exclusive |
     Then the HTTP status code should be "200"
@@ -32,7 +32,7 @@ Feature: lock files
 
   Scenario Outline: lock a file with a timeout
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     When user "Alice" locks file "textfile.txt" using the WebDAV API setting the following properties
       | lockscope | exclusive   |
       | timeout   | Second-5000 |
@@ -54,7 +54,7 @@ Feature: lock files
 
   Scenario: lock a file using file-id
     Given using spaces DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
     When user "Alice" locks file "textfile.txt" using file-id "<<FILEID>>" using the WebDAV API setting the following properties
       | lockscope | exclusive   |
@@ -72,7 +72,7 @@ Feature: lock files
 
   Scenario Outline: user cannot lock file twice
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And user "Alice" has locked file "textfile.txt" setting the following properties
       | lockscope | exclusive |
     When user "Alice" tries to lock file "textfile.txt" using the WebDAV API setting the following properties
@@ -163,7 +163,7 @@ Feature: lock files
   @issue-7599
   Scenario Outline: lock a file in the shares
     Given using <dav-path-version> DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
       | space           | Personal     |
@@ -189,7 +189,7 @@ Feature: lock files
 
   Scenario: lock a file in the shares using file-id
     Given using spaces DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
@@ -213,7 +213,7 @@ Feature: lock files
   Scenario Outline: viewer cannot lock a file in the shares using file-id
     Given using spaces DAV path
     And the administrator has enabled the permissions role "Secure Viewer"
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt       |
@@ -233,7 +233,7 @@ Feature: lock files
 
   Scenario: sharee cannot lock a resource exclusively locked by a sharer
     Given using spaces DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |
@@ -258,7 +258,7 @@ Feature: lock files
 
   Scenario: sharer cannot lock a resource exclusively locked by a sharee
     Given using spaces DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |

--- a/tests/acceptance/features/apiLocks/unlockFiles.feature
+++ b/tests/acceptance/features/apiLocks/unlockFiles.feature
@@ -249,7 +249,7 @@ Feature: unlock locked items
 
   Scenario: unlock a file using file-id
     Given using spaces DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
     And user "Alice" has locked file "textfile.txt" using file-id "<<FILEID>>" setting the following properties
       | lockscope | exclusive   |
@@ -278,7 +278,7 @@ Feature: unlock locked items
   Scenario: unlock a file in the shares using file-id
     Given user "Brian" has been created with default attributes
     And using spaces DAV path
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "textfile.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "textfile.txt"
     And we save it into "FILEID"
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile.txt |

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -519,7 +519,7 @@ Feature: Change data of space
 
   Scenario Outline: user can't upload resource greater than set quota
     Given the administrator has assigned the role "<user-role>" to user "Alice" using the Graph API
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "15"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "15"
     When user "Alice" uploads a file inside space "Alice Hansen" with content "file is more than 15 bytes" to "file.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And for user "Alice" the space "Personal" should not contain these entries:

--- a/tests/acceptance/features/apiSpaces/quota.feature
+++ b/tests/acceptance/features/apiSpaces/quota.feature
@@ -108,7 +108,7 @@ Feature: State of the quota
 
 
   Scenario Outline: check the relative amount of quota of personal space
-    Given user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10000"
+    Given user "Admin" has changed the quota of space "Alice Hansen" to "10000"
     And user "Alice" has uploaded file "<file-upload>" to "/demo.txt"
     When the user "Alice" requests these endpoints with "GET" with basic auth
       | endpoint    |
@@ -141,7 +141,7 @@ Feature: State of the quota
 
 
   Scenario: user can restore a file version even if there is not enough quota to do so
-    Given user "Admin" has changed the quota of the "Alice Hansen" space to "30"
+    Given user "Admin" has changed the quota of space "Alice Hansen" to "30"
     And user "Alice" has uploaded file with content "file is less than 30 bytes" to "/file.txt"
     And user "Alice" has uploaded file with content "reduceContent" to "/file.txt"
     And user "Alice" has uploaded file with content "some content" to "newFile.txt"

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -57,7 +57,7 @@ Feature: Tag
 
   Scenario: user creates tags for resources in the personal space
     Given user "Alice" has created a folder "folderMain" in space "Alice Hansen"
-    And user "Alice" has uploaded a file inside space "Alice Hansen" with content "some content" to "file.txt"
+    And user "Alice" has uploaded a file inside space "Personal" with content "some content" to "file.txt"
     When user "Alice" creates the following tags for folder "folderMain" of space "Alice Hansen":
       | my tag    |
       | important |

--- a/tests/acceptance/features/apiSpacesShares/shareOperations.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareOperations.feature
@@ -331,7 +331,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When user "Brian" uploads a file inside space "Shares" with content "new description" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
@@ -348,7 +348,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When user "Brian" uploads a file inside space "Shares" with content "new description" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
@@ -363,7 +363,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When user "Brian" uploads a file inside space "Shares" with content "new description" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
@@ -380,7 +380,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "10"
     When user "Brian" uploads a file inside space "Shares" with content "new descriptionfgshsywhhh" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist

--- a/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/coreApiShareOperationsToShares2/uploadToShare.feature
@@ -167,7 +167,7 @@ Feature: sharing
   Scenario Outline: check quota of owners parent directory of a shared file
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes
-    And user "Admin" has changed the quota of the personal space of "Brian Murphy" space to "0"
+    And user "Admin" has changed the quota of space "Brian Murphy" to "0"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/myfile.txt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | myfile.txt  |
@@ -204,7 +204,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
@@ -228,7 +228,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Editor   |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
@@ -250,7 +250,7 @@ Feature: sharing
       | shareType       | user     |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
@@ -274,7 +274,7 @@ Feature: sharing
       | shareType       | group    |
       | permissionsRole | Uploader |
     And user "Brian" has a share "FOLDER" synced
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist

--- a/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -86,7 +86,7 @@ Feature: upload to a public link share
       | space           | Personal |
       | permissionsRole | Edit     |
       | password        | %public% |
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the public WebDAV API
     Then the HTTP status code should be "507"
 
@@ -98,7 +98,7 @@ Feature: upload to a public link share
       | space           | Personal   |
       | permissionsRole | File Drop  |
       | password        | %public%   |
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "1"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "1"
     When the public uploads file "test.txt" with password "%public%" and content "test2" using the public WebDAV API
     Then the HTTP status code should be "507"
 

--- a/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/coreApiWebdavProperties/getQuota.feature
@@ -36,8 +36,8 @@ Feature: get quota
   Scenario Outline: retrieving folder quota of shared folder with quota when no quota is set for recipient
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "0"
-    And user "Admin" has changed the quota of the personal space of "Brian Murphy" space to "10000"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "0"
+    And user "Admin" has changed the quota of space "Brian Murphy" to "10000"
     And user "Brian" has created folder "/testquota"
     And user "Brian" has uploaded file "/testquota/Brian.txt" of size 1000 bytes
     And user "Brian" has sent the following resource share invitation:
@@ -61,7 +61,7 @@ Feature: get quota
   @issue-8197
   Scenario Outline: retrieving folder quota when quota is set and a file was uploaded
     Given using <dav-path-version> DAV path
-    And user "Admin" has changed the quota of the personal space of "Alice Hansen" space to "10000"
+    And user "Admin" has changed the quota of space "Alice Hansen" to "10000"
     And user "Alice" has uploaded file "/prueba.txt" of size 1000 bytes
     When user "Alice" gets the following properties of folder "/" using the WebDAV API
       | propertyName            |
@@ -78,7 +78,7 @@ Feature: get quota
   Scenario Outline: retrieving folder quota when quota is set and a file was received
     Given using <dav-path-version> DAV path
     And user "Brian" has been created with default attributes
-    And user "Admin" has changed the quota of the personal space of "Brian Murphy" space to "10000"
+    And user "Admin" has changed the quota of space "Brian Murphy" to "10000"
     And user "Alice" has uploaded file "/Alice.txt" of size 93 bytes
     And user "Alice" has sent the following resource share invitation:
       | resource        | Alice.txt   |


### PR DESCRIPTION
## Description
I have added a store to save all drives (`personal`, `shares` and `project`) and use it to get the necessary properties. If the requested drive is unavailable in the store then a request to `me/drives` is made to get the drives.

I have also made the changes to the user store and user deletion flow. These stores should work with the local and remote server setup.

## Related Issue
- Fix for https://github.com/owncloud/ocis/issues/10603


## How Has This Been Tested?
- test environment: :robot: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
