### PR TITLE
[docs-only] Update images for ocis_full deployment example

### DIFF
--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -53,7 +53,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:24.04.11.3.1
+    image: collabora/code:24.04.12.3.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       ocis-net:

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   traefik:
-    image: traefik:v3.3.1
+    image: traefik:v3.3.3
     # release notes: https://github.com/traefik/traefik/releases
     networks:
       ocis-net:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -51,7 +51,7 @@ services:
   onlyoffice:
     # if you want to use oo enterprise edition, use: onlyoffice/documentserver-ee:<version>
     # note, you also need to add a volume, see below
-    image: onlyoffice/documentserver:8.2.2
+    image: onlyoffice/documentserver:8.3.0
     # changelog https://github.com/ONLYOFFICE/DocumentServer/releases
     networks:
       ocis-net:


### PR DESCRIPTION
This PR updates images of the `ocis_full` deploment examples.

Tested locally, works without issues.

Needs backport to 7.0 (to be available for 7.1)
