### PR TITLE
[tests-only][full-ci] backport skip changelog pipeline in nightly ci run

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2135,6 +2135,11 @@ def changelog():
                 "refs/heads/stable-*",
                 "refs/pull/**",
             ],
+            "event": {
+                "exclude": [
+                    "cron",
+                ],
+            },
         },
     }]
 


### PR DESCRIPTION
## Description
Skip change log pipeline for nightly

backport of PR: https://github.com/owncloud/ocis/pull/10960