### PR TITLE
[tests-only][full-ci] When file or folder is unshared user received an email notification

### DIFF
--- a/tests/acceptance/features/apiNotification/emailNotification.feature
+++ b/tests/acceptance/features/apiNotification/emailNotification.feature
@@ -183,6 +183,92 @@ Feature: Email notification
       Click here to check it: %base_url%/f/%space_id%
       """
 
+  @issue-10904
+  Scenario: user gets an email notification when a folder is unshared (Personal Space)
+    Given user "Alice" has created folder "SHARED-FOLDER"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | SHARED-FOLDER |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    When user "Alice" removes the access of user "Brian" from resource "SHARED-FOLDER" of space "Personal" using the Graph API
+    Then the HTTP status code should be "204"
+    And user "Brian" should have received the following email from user "Alice" about the share of project space "SHARED-FOLDER"
+      """
+      Hello Brian Murphy,
+
+      %displayname% has unshared 'SHARED-FOLDER' with you.
+
+      Even though this share has been revoked you still might have access through other shares and/or space memberships.
+      """
+
+  @issue-10904
+  Scenario: user gets an email notification when a folder is unshared (Project Space)
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "shared-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "SHARED-FOLDER" in space "shared-space"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | SHARED-FOLDER |
+      | space           | shared-space  |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Viewer        |
+    When user "Alice" removes the access of user "Brian" from resource "SHARED-FOLDER" of space "shared-space" using the Graph API
+    Then the HTTP status code should be "204"
+    And user "Brian" should have received the following email from user "Alice" about the share of project space "shared-space"
+      """
+      Hello Brian Murphy,
+
+      %displayname% has unshared 'SHARED-FOLDER' with you.
+
+      Even though this share has been revoked you still might have access through other shares and/or space memberships.
+      """
+
+  @issue-10904
+  Scenario: user gets an email notification when a file is unshared (Personal Space)
+    Given user "Alice" has uploaded file with content "Sample data" to "file-to-share.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | file-to-share.txt  |
+      | space           | Personal           |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | Viewer             |
+    When user "Alice" removes the access of user "Brian" from resource "file-to-share.txt" of space "Personal" using the Graph API
+    Then the HTTP status code should be "204"
+    And user "Brian" should have received the following email from user "Alice" about the share of project space "file-to-share.txt"
+      """
+      Hello Brian Murphy,
+
+      %displayname% has unshared 'file-to-share.txt' with you.
+
+      Even though this share has been revoked you still might have access through other shares and/or space memberships.
+      """
+
+  @issue-10904
+  Scenario: user gets an email notification when a file is unshared (Project Space)
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "shared-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "shared-space" with content "Sample data" to "file-to-share.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | file-to-share.txt |
+      | space           | shared-space      |
+      | sharee          | Brian             |
+      | shareType       | user              |
+      | permissionsRole | Viewer            |
+    When user "Alice" removes the access of user "Brian" from resource "file-to-share.txt" of space "shared-space" using the Graph API
+    Then the HTTP status code should be "204"
+    And user "Brian" should have received the following email from user "Alice" about the share of project space "file-to-share.txt"
+      """
+      Hello Brian Murphy,
+
+      %displayname% has unshared 'file-to-share.txt' with you.
+
+      Even though this share has been revoked you still might have access through other shares and/or space memberships.
+      """
+
   @env-config
   Scenario: group members get an email notification in default language when someone shares a file with the group
     Given the config "OCIS_DEFAULT_LANGUAGE" has been set to "de"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds 4 tests for checking mail notification alert for file and folder, which have been unshared.
Add the following scenarios:
 - user gets an email notification when a folder is unshared
 - user gets an email notification when space admin unshares a folder
 - user gets an email notification when a file is unshared
 - user gets an email notification when space admin unshares a file

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/10937
- Test coverage for https://github.com/owncloud/ocis/issues/10904

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- extend notification tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
