### PR TITLE
feat: allow scaling of the search service

### DIFF
--- a/services/search/pkg/config/engine.go
+++ b/services/search/pkg/config/engine.go
@@ -9,5 +9,5 @@ type Engine struct {
 // EngineBleve configures the bleve engine
 type EngineBleve struct {
 	Datapath string `yaml:"data_path" env:"SEARCH_ENGINE_BLEVE_DATA_PATH" desc:"The directory where the filesystem will store search data. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/search." introductionVersion:"pre5.0"`
-	Scale    bool   `yaml:"scale" env:"SEARCH_ENGINE_BLEVE_SCALE" desc:"Enable scaling of the bleve index. If set to false, the service will have exclusive write access to the index as long as the service is running, locking out other processes. Defaults to false." introductionVersion:"%%NEXT%%"`
+	Scale    bool   `yaml:"scale" env:"SEARCH_ENGINE_BLEVE_SCALE" desc:"Enable scaling of the search index (bleve). If set to 'true', the instance of the search service will no longer have exclusive write access to the index. Note when scaling search, all instances of the search service must be set to true! For 'false', which is the default, the running search service will lock out other processes trying to access the index as long it is running." introductionVersion:"%%NEXT%%"`
 }

--- a/services/search/pkg/config/engine.go
+++ b/services/search/pkg/config/engine.go
@@ -9,4 +9,5 @@ type Engine struct {
 // EngineBleve configures the bleve engine
 type EngineBleve struct {
 	Datapath string `yaml:"data_path" env:"SEARCH_ENGINE_BLEVE_DATA_PATH" desc:"The directory where the filesystem will store search data. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/search." introductionVersion:"pre5.0"`
+	Scale    bool   `yaml:"scale" env:"SEARCH_ENGINE_BLEVE_SCALE" desc:"Enable scaling of the bleve index. If set to false, the service will have exclusive write access to the index as long as the service is running, locking out other processes. Defaults to false." introductionVersion:"%%NEXT%%"`
 }

--- a/services/search/pkg/config/engine.go
+++ b/services/search/pkg/config/engine.go
@@ -9,5 +9,5 @@ type Engine struct {
 // EngineBleve configures the bleve engine
 type EngineBleve struct {
 	Datapath string `yaml:"data_path" env:"SEARCH_ENGINE_BLEVE_DATA_PATH" desc:"The directory where the filesystem will store search data. If not defined, the root directory derives from $OCIS_BASE_DATA_PATH/search." introductionVersion:"pre5.0"`
-	Scale    bool   `yaml:"scale" env:"SEARCH_ENGINE_BLEVE_SCALE" desc:"Enable scaling of the search index (bleve). If set to 'true', the instance of the search service will no longer have exclusive write access to the index. Note when scaling search, all instances of the search service must be set to true! For 'false', which is the default, the running search service will lock out other processes trying to access the index as long it is running." introductionVersion:"%%NEXT%%"`
+	Scale    bool   `yaml:"scale" env:"SEARCH_ENGINE_BLEVE_SCALE" desc:"Enable scaling of the search index (bleve). If set to 'true', the instance of the search service will no longer have exclusive write access to the index. Note when scaling search, all instances of the search service must be set to true! For 'false', which is the default, the running search service has exclusive access to the index as long it is running. This locks out other search processes tying to access the index." introductionVersion:"%%NEXT%%"`
 }

--- a/services/search/pkg/engine/bleve/index.go
+++ b/services/search/pkg/engine/bleve/index.go
@@ -1,0 +1,150 @@
+package bleve
+
+import (
+	"errors"
+	"path/filepath"
+
+	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/mapping"
+)
+
+// IndexGetter is an interface that provides a way to get an index.
+// Implementations might differ in how the index is created and how the
+// index is gotten (reused, created on the fly, etc).
+//
+// Some implementations might require the index to be kept opened, meaning
+// the index should be closed only when the application is shutting down. In
+// this case, IndexCanBeClosed should return false. If the index can be
+// closed and reopened safely at any time, IndexCanBeClosed should
+// return true.
+type IndexGetter interface {
+	GetIndex(opts ...GetIndexOption) (bleve.Index, error)
+	IndexCanBeClosed() bool
+}
+
+type IndexGetterMemory struct {
+	mapping mapping.IndexMapping
+	index   bleve.Index
+}
+
+// NewIndexGetterMemory creates a new IndexGetterMemory. This implementation
+// creates a new in-memory index every time GetIndex is called. As such, the
+// index must be kept opened. Closing the index will result in wiping the
+// data.
+func NewIndexGetterMemory(mapping mapping.IndexMapping) *IndexGetterMemory {
+	return &IndexGetterMemory{
+		mapping: mapping,
+	}
+}
+
+// GetIndex creates a new in-memory index every time it is called.
+// The options are ignored in this implementation.
+func (i *IndexGetterMemory) GetIndex(opts ...GetIndexOption) (bleve.Index, error) {
+	if i.index != nil {
+		return i.index, nil
+	}
+
+	index, err := bleve.NewMemOnly(i.mapping)
+	if err != nil {
+		return nil, err
+	}
+
+	i.index = index
+	return i.index, nil
+}
+
+// IndexCanBeClosed returns false, meaning the index must be kept opened.
+func (i *IndexGetterMemory) IndexCanBeClosed() bool {
+	return false
+}
+
+type IndexGetterPersistent struct {
+	rootDir string
+	mapping mapping.IndexMapping
+	index   bleve.Index
+}
+
+// NewIndexGetterPersistent creates a new IndexGetterPersistent. The index
+// will be persisted on the FS. If the index does not exist, it will be
+// created. If the index exists, it will be opened.
+//
+// The index will be cached and reused every time GetIndex is called. You
+// should not close the index unless you are shutting down the application.
+func NewIndexGetterPersistent(rootDir string, mapping mapping.IndexMapping) *IndexGetterPersistent {
+	return &IndexGetterPersistent{
+		rootDir: rootDir,
+		mapping: mapping,
+	}
+}
+
+// GetIndex returns the cached index. The options are ignored in this
+// implementation.
+func (i *IndexGetterPersistent) GetIndex(opts ...GetIndexOption) (bleve.Index, error) {
+	if i.index != nil {
+		return i.index, nil
+	}
+
+	destination := filepath.Join(i.rootDir, "bleve")
+	index, err := bleve.Open(destination)
+	if errors.Is(bleve.ErrorIndexPathDoesNotExist, err) {
+		index, err = bleve.New(destination, i.mapping)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	i.index = index
+	return i.index, nil
+}
+
+// IndexCanBeClosed returns false, meaning the index must be kept opened.
+func (i *IndexGetterPersistent) IndexCanBeClosed() bool {
+	return false
+}
+
+type IndexGetterPersistentScale struct {
+	rootDir string
+	mapping mapping.IndexMapping
+}
+
+// NewIndexGetterPersistentScale creates a new IndexGetterPersistentScale.
+// The index will be persisted on the FS. If the index does not exist, it will
+// be created. If the index exists, it will be opened.
+// The GetIndex method will create a new connection to the index every time
+// it is called. That connection must be closed after use.
+func NewIndexGetterPersistentScale(rootDir string, mapping mapping.IndexMapping) *IndexGetterPersistentScale {
+	return &IndexGetterPersistentScale{
+		rootDir: rootDir,
+		mapping: mapping,
+	}
+}
+
+// GetIndex creates a new connection to the index every time it is called.
+// You can use the ReadOnly option to open the index in read-only mode. This
+// allow read-only operations to be performed in parallel.
+// In order to avoid blocking write operations, you should close the index
+// as soon as you are done with it.
+func (i *IndexGetterPersistentScale) GetIndex(opts ...GetIndexOption) (bleve.Index, error) {
+	options := newGetIndexOptions(opts...)
+	destination := filepath.Join(i.rootDir, "bleve")
+	params := map[string]interface{}{
+		"read_only": options.ReadOnly,
+	}
+	index, err := bleve.OpenUsing(destination, params)
+	if errors.Is(bleve.ErrorIndexPathDoesNotExist, err) {
+		index, err = bleve.New(destination, i.mapping)
+		if err != nil {
+			return nil, err
+		}
+
+		return index, nil
+	}
+
+	return index, err
+}
+
+// IndexCanBeClosed returns true, meaning the index can be closed and
+// reopened. You should close the index as soon as you are done with it.
+func (i *IndexGetterPersistentScale) IndexCanBeClosed() bool {
+	return true
+}

--- a/services/search/pkg/engine/bleve/option.go
+++ b/services/search/pkg/engine/bleve/option.go
@@ -1,0 +1,21 @@
+package bleve
+
+type GetIndexOption func(o *GetIndexOptions)
+
+type GetIndexOptions struct {
+	ReadOnly bool
+}
+
+func ReadOnly(b bool) GetIndexOption {
+	return func(o *GetIndexOptions) {
+		o.ReadOnly = b
+	}
+}
+
+func newGetIndexOptions(opts ...GetIndexOption) GetIndexOptions {
+	o := GetIndexOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}

--- a/services/search/pkg/engine/bleve/option.go
+++ b/services/search/pkg/engine/bleve/option.go
@@ -1,17 +1,23 @@
 package bleve
 
+// GetIndexOption is a function that sets some option for the GetIndex method.
 type GetIndexOption func(o *GetIndexOptions)
 
+// GetIndexOptions contains the options for the GetIndex method.
 type GetIndexOptions struct {
 	ReadOnly bool
 }
 
+// ReadOnly is an option to opens the index in read-only mode.
+// This option should allow running multiple read-only operations in parallel.
+// The behavior of write operations is not defined when this option is used.
 func ReadOnly(b bool) GetIndexOption {
 	return func(o *GetIndexOptions) {
 		o.ReadOnly = b
 	}
 }
 
+// newGetIndexOptions creates a new GetIndexOptions with the given options.
 func newGetIndexOptions(opts ...GetIndexOption) GetIndexOptions {
 	o := GetIndexOptions{}
 	for _, opt := range opts {

--- a/services/search/pkg/engine/bleve_test.go
+++ b/services/search/pkg/engine/bleve_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Bleve", func() {
 
 		indexGetter := bleveEngine.NewIndexGetterMemory(mapping)
 
-		idx, err = indexGetter.GetIndex()
+		idx, _, err = indexGetter.GetIndex() // IndexGetterMemory ignores closeFn
 		Expect(err).ToNot(HaveOccurred())
 
 		eng = engine.NewBleveEngine(indexGetter, bleve.DefaultCreator)

--- a/services/search/pkg/engine/bleve_test.go
+++ b/services/search/pkg/engine/bleve_test.go
@@ -15,6 +15,7 @@ import (
 	searchsvc "github.com/owncloud/ocis/v2/protogen/gen/ocis/services/search/v0"
 	"github.com/owncloud/ocis/v2/services/search/pkg/content"
 	"github.com/owncloud/ocis/v2/services/search/pkg/engine"
+	bleveEngine "github.com/owncloud/ocis/v2/services/search/pkg/engine/bleve"
 	"github.com/owncloud/ocis/v2/services/search/pkg/query/bleve"
 )
 
@@ -59,10 +60,12 @@ var _ = Describe("Bleve", func() {
 		mapping, err := engine.BuildBleveMapping()
 		Expect(err).ToNot(HaveOccurred())
 
-		idx, err = bleveSearch.NewMemOnly(mapping)
+		indexGetter := bleveEngine.NewIndexGetterMemory(mapping)
+
+		idx, err = indexGetter.GetIndex()
 		Expect(err).ToNot(HaveOccurred())
 
-		eng = engine.NewBleveEngine(idx, bleve.DefaultCreator)
+		eng = engine.NewBleveEngine(indexGetter, bleve.DefaultCreator)
 		Expect(err).ToNot(HaveOccurred())
 
 		rootResource = engine.Resource{
@@ -89,13 +92,6 @@ var _ = Describe("Bleve", func() {
 			Type:     uint64(sprovider.ResourceType_RESOURCE_TYPE_FILE),
 			Document: content.Document{Name: "child.pdf"},
 		}
-	})
-
-	Describe("New", func() {
-		It("returns a new index instance", func() {
-			b := engine.NewBleveEngine(idx, bleve.DefaultCreator)
-			Expect(b).ToNot(BeNil())
-		})
 	})
 
 	Describe("Search", func() {

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -45,16 +45,16 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error)
 	var eng engine.Engine
 	switch cfg.Engine.Type {
 	case "bleve":
-		idx, err := engine.NewBleveIndex(cfg.Engine.Bleve.Datapath)
+		bleveEngine, err := engine.NewBleveEngine(cfg.Engine.Bleve.Datapath, bleve.DefaultCreator, cfg.Engine.Bleve.Scale)
 		if err != nil {
 			return nil, teardown, err
 		}
 
 		teardown = func() {
-			_ = idx.Close()
+			_ = bleveEngine.Close()
 		}
+		eng = bleveEngine
 
-		eng = engine.NewBleveEngine(idx, bleve.DefaultCreator)
 	default:
 		return nil, teardown, fmt.Errorf("unknown search engine: %s", cfg.Engine.Type)
 	}

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/owncloud/ocis/v2/services/search/pkg/config"
 	"github.com/owncloud/ocis/v2/services/search/pkg/content"
 	"github.com/owncloud/ocis/v2/services/search/pkg/engine"
+	bleveEngine "github.com/owncloud/ocis/v2/services/search/pkg/engine/bleve"
 	"github.com/owncloud/ocis/v2/services/search/pkg/query/bleve"
 	"github.com/owncloud/ocis/v2/services/search/pkg/search"
 )
@@ -45,10 +46,18 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error)
 	var eng engine.Engine
 	switch cfg.Engine.Type {
 	case "bleve":
-		bleveEngine, err := engine.NewBleveEngine(cfg.Engine.Bleve.Datapath, bleve.DefaultCreator, cfg.Engine.Bleve.Scale)
+		bleveMapping, err := engine.BuildBleveMapping()
 		if err != nil {
 			return nil, teardown, err
 		}
+
+		var indexGetter bleveEngine.IndexGetter
+		indexGetter = bleveEngine.NewIndexGetterPersistent(cfg.Engine.Bleve.Datapath, bleveMapping)
+		if cfg.Engine.Bleve.Scale {
+			indexGetter = bleveEngine.NewIndexGetterPersistentScale(cfg.Engine.Bleve.Datapath, bleveMapping)
+		}
+
+		bleveEngine := engine.NewBleveEngine(indexGetter, bleve.DefaultCreator)
 
 		teardown = func() {
 			_ = bleveEngine.Close()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Previously, the search service opened a write connection to the bleve index and kept that connection opened as long as the service was running. This means that the search service was locking out other processes from accessing the index, including the bleve cli and other replicas of the search service. Replicas of the service can't be spawned because they won't be able to access the index.

We've added a new flag to the search service in order to scale the service.

For environments where scaling isn't needed, it's recommended to set the `SEARCH_ENGINE_BLEVE_SCALE` as false (default value). This will keep the current behavior of locking the bleve index for exclusive access. This is expected to have a better performance because we won't create new connections every time, and the load in the index should be reduced due to less locking overhead.

Setting the `SEARCH_ENGINE_BLEVE_SCALE` to true will cause connections to be opened per "engine operation" (search, index, delete, prune...). Those connections will be closed as soon as the operation finishes.
Concurrency control is delegated to the bleve index, which will need to handle the operations concurrently from multiple replicas.
On heavy workloads, it's expected operations to have delays because they'll have to wait for other operations to finish and release the lock. Read-only operations (search and count) are expected to run through the index in parallel as long as there is no other write operation on going.

## Related Issue
https://github.com/owncloud/ocis/issues/11008

## Motivation and Context
Scaling the service should be possible regardless of the specific setup. 

## How Has This Been Tested?
1. Exclude the search service from running in the "main" oCIS server
2. Setup the search service replicas to use debug log level, and use the new `SEARCH_ENGINE_BLEVE_SCALE=true` on all of them.
3. Spawn 3 search service replicas (note that all the replicas must access to the same index files)
4. Index some files and run some searches

You'll see logs coming from different replicas, and the UX isn't impacted in any way (all the replicas are being used and returning results).
In addition, it's possible to run the bleve cli against the index oCIS is using. Previously, the cli waited indefinitely.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
