### PR TITLE
[tests-only][full-ci] skip spaces that are marked as deleted

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -250,7 +250,7 @@ class SpacesContext implements Context {
 				}
 			}
 			foreach ($spaces as $space) {
-				if ($space->name === $spaceName) {
+				if ($space->name === $spaceName && !isset($space->root->deleted)) {
 					$found = true;
 					$foundSpace = $space;
 					if ($space->driveType === "project") {


### PR DESCRIPTION
## Description
Do not try to store spaces that have the `deleted` property. This property can sometimes appear on deleted spaces, but the deletion was partial or something else happened during the process.
See https://github.com/owncloud/ocis/issues/10603#issuecomment-2668380050

## Related Issue
- Follow up: https://github.com/owncloud/ocis/pull/11000


## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
