### PR TITLE
[tests-only][full-ci]Remove notification and email tag from unrelated scenario

### DIFF
--- a/tests/acceptance/features/apiNotification/emailNotification.feature
+++ b/tests/acceptance/features/apiNotification/emailNotification.feature
@@ -1,4 +1,4 @@
-@notification @email
+@email
 Feature: Email notification
   As a user
   I want to get email notification of events related to me

--- a/tests/acceptance/features/apiNotification/serviceAvailabilityCheck.feature
+++ b/tests/acceptance/features/apiNotification/serviceAvailabilityCheck.feature
@@ -1,4 +1,3 @@
-@notification
 Feature: service health check
 
 

--- a/tests/acceptance/features/apiOcm/acceptInvitation.feature
+++ b/tests/acceptance/features/apiOcm/acceptInvitation.feature
@@ -1,4 +1,4 @@
-@ocm @notification
+@ocm
 Feature: accepting invitation
   As a user
   I can accept invitations from users of other ocis instances

--- a/tests/acceptance/features/apiOcm/createInvitation.feature
+++ b/tests/acceptance/features/apiOcm/createInvitation.feature
@@ -76,23 +76,6 @@ Feature: create invitation
       | @domain.com                       | 400  |
       | user@domain..com                  | 400  |
 
-  @issue-10059 @notification @email
-  Scenario: federated user gets an email notification if their email was specified when creating the federation share invitation
-    Given using server "REMOTE"
-    And user "David" has been created with default attributes
-    And using server "LOCAL"
-    When "Alice" has created the federation share invitation with email "david@example.org" and description "a share invitation from Alice"
-    And user "David" should have received the following email from user "Alice" ignoring whitespaces
-      """
-      Hi,
-
-      Alice Hansen (alice@example.org) wants to start sharing collaboration resources with you.
-
-      Please visit your federation settings and use the following details:
-        Token: %fed_invitation_token%
-        ProviderDomain: %local_base_url%
-      """
-
   @env-config
   Scenario: user cannot see expired invitation tokens
     Given using server "LOCAL"

--- a/tests/acceptance/features/apiOcm/deleteFederatedConnections.feature
+++ b/tests/acceptance/features/apiOcm/deleteFederatedConnections.feature
@@ -1,4 +1,4 @@
-@ocm @notification
+@ocm
 Feature: delete federated connections
   As a user
   I want to delete federated connections if they are no longer needed

--- a/tests/acceptance/features/apiOcm/listPermissions.feature
+++ b/tests/acceptance/features/apiOcm/listPermissions.feature
@@ -1,4 +1,4 @@
-@ocm @notification @issue-9898
+@ocm @issue-9898
 Feature: List a federated sharing permissions
   As a user
   I want to list the permissions for federated share

--- a/tests/acceptance/features/apiOcm/ocmNotifications.feature
+++ b/tests/acceptance/features/apiOcm/ocmNotifications.feature
@@ -4,10 +4,12 @@ Feature: ocm notifications
   I want to manage my notification settings
   So that I do not get notified of unimportant events
 
+  Background:
+    Given user "Alice" has been created with default attributes
+
 
   Scenario: federated user disables mail and in-app notification for "Share Received" event
-    Given user "Alice" has been created with default attributes
-    And user "Alice" has uploaded file with content "ocm test" to "textfile.txt"
+    Given user "Alice" has uploaded file with content "ocm test" to "textfile.txt"
     And "Alice" has created the federation share invitation
     And using server "REMOTE"
     And user "Brian" has been created with default attributes
@@ -100,3 +102,20 @@ Feature: ocm notifications
     Then the HTTP status code should be "200"
     And the notifications should be empty
     And user "Brian" should have "0" emails
+
+  @issue-10059
+  Scenario: federated user gets an email notification if their email was specified when creating the federation share invitation
+    Given using server "REMOTE"
+    And user "David" has been created with default attributes
+    And using server "LOCAL"
+    When "Alice" has created the federation share invitation with email "david@example.org" and description "a share invitation from Alice"
+    And user "David" should have received the following email from user "Alice" ignoring whitespaces
+      """
+      Hi,
+
+      Alice Hansen (alice@example.org) wants to start sharing collaboration resources with you.
+
+      Please visit your federation settings and use the following details:
+        Token: %fed_invitation_token%
+        ProviderDomain: %local_base_url%
+      """

--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -597,7 +597,7 @@ Feature: Notification Settings
       | Alice Hansen added you to Space new-space |
     But user "Brian" should not have a notification related to space "new-space" with subject "Space disabled"
 
-  @issue-10864
+  @issue-10864 @email
   Scenario: disable email notification for user light
     Given the administrator has assigned the role "User Light" to user "Brian" using the Graph API
     When user "Brian" disables email notification using the settings API
@@ -745,7 +745,7 @@ Feature: Notification Settings
     And the notifications should be empty
     And user "Brian" should have "0" emails
 
-
+  @email
   Scenario: no email should be received when email sending interval is set to never
     When user "Brian" sets the email sending interval to "never" using the settings API
     Then the HTTP status code should be "201"


### PR DESCRIPTION
## Description
This PR removes notification and email tag from unrelated scenarios and moved 
`Scenario: federated user gets an email notification if their email was specified when creating the federation share invitation` scenario from `tests/acceptance/features/apiOcm/createInvitation.feature` to `tests/acceptance/features/apiOcm/ocmNotifications.feature`

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/11020

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
