### PR TITLE
[tests-only][full-ci] added test to list shares after disabling Editor role

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2104,6 +2104,11 @@ class SpacesContext implements Context {
 		string $spaceName
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
+		if ($spaceName === "Shares"
+			&& $this->featureContext->getDavPathVersion() !== WebDavHelper::DAV_VERSION_SPACES
+		) {
+			$fileName = "Shares/$fileName";
+		}
 		$response = $this->featureContext->downloadFileAsUserUsingPassword(
 			$user,
 			$fileName,

--- a/tests/acceptance/features/apiSharingNg1/enableDisablePermissionsRole.feature
+++ b/tests/acceptance/features/apiSharingNg1/enableDisablePermissionsRole.feature
@@ -715,3 +715,461 @@ Feature: enable disable permissions role
       | Space Viewer     |             | a8d5fe5e-96e3-418d-825b-534dbdf22b99 |
       | Space Editor     | DNVCK       | 58c63c02-1d89-4572-916a-870abc5a1b7d |
       | Manager          | RDNVCKZP    | 312c0871-5ef7-4b3a-85b6-0e4074c64049 |
+
+
+  Scenario: users list the folder shares shared with Editor role after the role is disabled (Personal Space)
+    Given using spaces DAV path
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "hello world" to "folderToShare/textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Editor        |
+    And user "Brian" has a share "folderToShare" synced
+    And the administrator has disabled the permissions role "Editor"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "folderToShare" with the following data:
+      """
+      {
+        "type": "object",
+        "required": ["parentReference", "permissions", "name"],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": [
+                    "libre.graph/driveItem/children/create",
+                    "libre.graph/driveItem/standard/delete",
+                    "libre.graph/driveItem/path/read",
+                    "libre.graph/driveItem/quota/read",
+                    "libre.graph/driveItem/content/read",
+                    "libre.graph/driveItem/upload/create",
+                    "libre.graph/driveItem/children/read",
+                    "libre.graph/driveItem/deleted/read",
+                    "libre.graph/driveItem/path/update",
+                    "libre.graph/driveItem/deleted/update",
+                    "libre.graph/driveItem/basic/read"
+                  ]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@UI.Hidden", "@client.synchronize", "createdBy", "eTag", "folder", "id", "lastModifiedDateTime", "name", "parentReference", "remoteItem"],
+              "properties": {
+                "remoteItem": {
+                  "type": "object",
+                  "required": ["createdBy", "eTag", "folder", "id", "lastModifiedDateTime", "name", "parentReference", "permissions"],
+                  "properties": {
+                    "name": { "const": "folderToShare" },
+                    "permissions": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "object",
+                        "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+                        "properties": {
+                          "@libre.graph.permissions.actions": {
+                            "const": [
+                              "libre.graph/driveItem/children/create",
+                              "libre.graph/driveItem/standard/delete",
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/path/update",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "roles": { "const": null }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And user "Brian" should have a share "folderToShare" shared by user "Alice" from space "Personal"
+    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "folderToShare" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "folderToShare" with these key and value pairs:
+      | key            | value         |
+      | oc:name        | folderToShare |
+      | oc:permissions | SDNVCK        |
+    And user "Brian" should be able to upload file "filesForUpload/davtest.txt" to "Shares/folderToShare/textfile.txt"
+    And for user "Alice" the content of the file "folderToShare/textfile.txt" of the space "Personal" should be "Dav-Test"
+
+
+  Scenario: users list the folder shares shared with Editor role after the role is disabled (Project Space)
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    And user "Alice" has uploaded a file inside space "new-space" with content "hello world" to "folderToShare/textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | new-space     |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Editor        |
+    And user "Brian" has a share "folderToShare" synced
+    And the administrator has disabled the permissions role "Editor"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "folderToShare" with the following data:
+      """
+      {
+        "type": "object",
+        "required": ["parentReference", "permissions", "name"],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": [
+                    "libre.graph/driveItem/children/create",
+                    "libre.graph/driveItem/standard/delete",
+                    "libre.graph/driveItem/path/read",
+                    "libre.graph/driveItem/quota/read",
+                    "libre.graph/driveItem/content/read",
+                    "libre.graph/driveItem/upload/create",
+                    "libre.graph/driveItem/children/read",
+                    "libre.graph/driveItem/deleted/read",
+                    "libre.graph/driveItem/path/update",
+                    "libre.graph/driveItem/deleted/update",
+                    "libre.graph/driveItem/basic/read"
+                  ]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@UI.Hidden", "@client.synchronize", "eTag", "folder", "id", "lastModifiedDateTime", "name", "parentReference", "remoteItem"],
+              "properties": {
+                "remoteItem": {
+                  "type": "object",
+                  "required": ["eTag", "folder", "id", "lastModifiedDateTime", "name", "parentReference", "permissions"],
+                  "properties": {
+                    "name": { "const": "folderToShare" },
+                    "permissions": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "object",
+                        "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+                        "properties": {
+                          "@libre.graph.permissions.actions": {
+                            "const": [
+                              "libre.graph/driveItem/children/create",
+                              "libre.graph/driveItem/standard/delete",
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/path/update",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "roles": { "const": null }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And user "Brian" should have a share "folderToShare" shared by user "Alice" from space "new-space"
+    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "folderToShare" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "folderToShare" with these key and value pairs:
+      | key            | value         |
+      | oc:name        | folderToShare |
+      | oc:permissions | SDNVCK        |
+    And user "Brian" should be able to upload file "filesForUpload/davtest.txt" to "Shares/folderToShare/textfile.txt"
+    And for user "Alice" the content of the file "folderToShare/textfile.txt" of the space "new-space" should be "Dav-Test"
+
+
+  Scenario: users list the file shares shared with Editor role after the role is disabled (Personal Space)
+    Given using spaces DAV path
+    And user "Alice" has uploaded file with content "some content" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | File Editor  |
+    And user "Brian" has a share "textfile.txt" synced
+    And the administrator has disabled the permissions role "File Editor"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "textfile.txt" with the following data:
+      """
+      {
+        "type": "object",
+        "required": ["parentReference", "permissions", "name"],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": [
+                    "libre.graph/driveItem/path/read",
+                    "libre.graph/driveItem/quota/read",
+                    "libre.graph/driveItem/content/read",
+                    "libre.graph/driveItem/upload/create",
+                    "libre.graph/driveItem/children/read",
+                    "libre.graph/driveItem/deleted/read",
+                    "libre.graph/driveItem/deleted/update",
+                    "libre.graph/driveItem/basic/read"
+                  ]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@UI.Hidden", "@client.synchronize", "createdBy", "eTag", "file", "id", "lastModifiedDateTime", "name", "parentReference", "remoteItem", "size"],
+              "properties": {
+                "remoteItem": {
+                  "type": "object",
+                  "required": ["createdBy", "eTag", "file", "id", "lastModifiedDateTime", "name", "parentReference", "permissions"],
+                  "properties": {
+                    "name": { "const": "textfile.txt" },
+                    "permissions": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "object",
+                        "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+                        "properties": {
+                          "@libre.graph.permissions.actions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "roles": { "const": null }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "Personal"
+    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "textfile.txt" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
+      | key            | value        |
+      | oc:name        | textfile.txt |
+      | oc:permissions | SNVW         |
+    And user "Brian" should be able to upload file "filesForUpload/davtest.txt" to "Shares/textfile.txt"
+    And for user "Alice" the content of the file "textfile.txt" of the space "Personal" should be "Dav-Test"
+
+
+  Scenario: users list the file shares shared with Editor role after the role is disabled (Project Space)
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | textfile.txt |
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | File Editor  |
+    And user "Brian" has a share "textfile.txt" synced
+    And the administrator has disabled the permissions role "File Editor"
+    When user "Alice" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "textfile.txt" with the following data:
+      """
+      {
+        "type": "object",
+        "required": ["parentReference", "permissions", "name"],
+        "properties": {
+          "permissions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+              "properties": {
+                "@libre.graph.permissions.actions": {
+                  "const": [
+                    "libre.graph/driveItem/path/read",
+                    "libre.graph/driveItem/quota/read",
+                    "libre.graph/driveItem/content/read",
+                    "libre.graph/driveItem/upload/create",
+                    "libre.graph/driveItem/children/read",
+                    "libre.graph/driveItem/deleted/read",
+                    "libre.graph/driveItem/deleted/update",
+                    "libre.graph/driveItem/basic/read"
+                  ]
+                },
+                "roles": { "const": null }
+              }
+            }
+          }
+        }
+      }
+      """
+    When user "Brian" lists the shares shared with him using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["@UI.Hidden", "@client.synchronize", "eTag", "file", "id", "lastModifiedDateTime", "name", "parentReference", "remoteItem", "size"],
+              "properties": {
+                "remoteItem": {
+                  "type": "object",
+                  "required": ["eTag", "file", "id", "lastModifiedDateTime", "name", "parentReference", "permissions"],
+                  "properties": {
+                    "name": { "const": "textfile.txt" },
+                    "permissions": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "type": "object",
+                        "required": ["@libre.graph.permissions.actions", "grantedToV2", "id", "invitation"],
+                        "properties": {
+                          "@libre.graph.permissions.actions": {
+                            "const": [
+                              "libre.graph/driveItem/path/read",
+                              "libre.graph/driveItem/quota/read",
+                              "libre.graph/driveItem/content/read",
+                              "libre.graph/driveItem/upload/create",
+                              "libre.graph/driveItem/children/read",
+                              "libre.graph/driveItem/deleted/read",
+                              "libre.graph/driveItem/deleted/update",
+                              "libre.graph/driveItem/basic/read"
+                            ]
+                          },
+                          "roles": { "const": null }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And user "Brian" should have a share "textfile.txt" shared by user "Alice" from space "new-space"
+    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "textfile.txt" with depth "0" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "textfile.txt" with these key and value pairs:
+      | key            | value        |
+      | oc:name        | textfile.txt |
+      | oc:permissions | SNVW         |
+    And user "Brian" should be able to upload file "filesForUpload/davtest.txt" to "Shares/textfile.txt"
+    And for user "Alice" the content of the file "textfile.txt" of the space "new-space" should be "Dav-Test"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the test to share resource with Editor role, disabling the Editor role and users listing the shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10711

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
