### PR TITLE
[tests-only][full-ci]added test to share resources after the permissions role is disabled

### DIFF
--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -3238,3 +3238,127 @@ Feature: Send a sharing invitations
       | resource      |
       | FolderToShare |
       | lorem.txt     |
+
+  @env-config
+  Scenario Outline: try to share resource after disabling the role (Personal Space)
+    Given the administrator has disabled the permissions role "<permissions-role>"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "some content" to "textfile.txt"
+    When user "Alice" sends the following resource share invitation using the Graph API:
+      | resource        | <resource>         |
+      | space           | Personal           |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+    Then the HTTP status code should be "400"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "innererror", "message"],
+            "properties": {
+              "code": { "const": "invalidRequest" },
+              "innererror": {
+                "type": "object",
+                "required": ["date", "request-id"]
+              },
+              "message": { "const": "Key: 'DriveItemInvite.Roles' Error:Field validation for 'Roles' failed on the 'available_role' tag" }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | resource      | permissions-role |
+      | folderToShare | Viewer           |
+      | folderToShare | Editor           |
+      | folderToShare | Uploader         |
+      | textfile.txt  | Viewer           |
+      | textfile.txt  | File Editor      |
+
+  @env-config
+  Scenario Outline: try to share resource after disabling the role (Project Space)
+    Given the administrator has disabled the permissions role "<permissions-role>"
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "new-space"
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content" to "textfile.txt"
+    When user "Alice" sends the following resource share invitation using the Graph API:
+      | resource        | <resource>         |
+      | space           | new-space          |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+    Then the HTTP status code should be "400"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "innererror", "message"],
+            "properties": {
+              "code": { "const": "invalidRequest" },
+              "innererror": {
+                "type": "object",
+                "required": ["date", "request-id"]
+              },
+              "message": { "const": "Key: 'DriveItemInvite.Roles' Error:Field validation for 'Roles' failed on the 'available_role' tag" }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | resource      | permissions-role |
+      | folderToShare | Viewer           |
+      | folderToShare | Editor           |
+      | folderToShare | Uploader         |
+      | textfile.txt  | Viewer           |
+      | textfile.txt  | File Editor      |
+
+  @env-config
+  Scenario Outline: try to invite to the project space after disabling the role
+    Given the administrator has disabled the permissions role "<permissions-role>"
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    When user "Alice" sends the following space share invitation using permissions endpoint of the Graph API:
+      | space           | new-space          |
+      | sharee          | Brian              |
+      | shareType       | user               |
+      | permissionsRole | <permissions-role> |
+    Then the HTTP status code should be "400"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "innererror", "message"],
+            "properties": {
+              "code": { "const": "invalidRequest" },
+              "innererror": {
+                "type": "object",
+                "required": ["date", "request-id"]
+              },
+              "message": { "const": "Key: 'DriveItemInvite.Roles' Error:Field validation for 'Roles' failed on the 'available_role' tag" }
+            }
+          }
+        }
+      }
+      """
+    Examples:
+      | permissions-role |
+      | Space Viewer     |
+      | Space Editor     |
+      | Manager          |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the test for sharing resources after disabling the permissions role.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/10711

Originated from comment: https://github.com/owncloud/ocis/pull/11057#discussion_r1972832365

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
