### PR TITLE
[tests-only][full-ci]Refactor step  related to sharee access to expired shared resource

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -328,13 +328,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 #### [[OCM] Users can invite themselves to their own federated connection](https://github.com/owncloud/ocis/issues/11004)
 - [apiOcm/acceptInvitation.feature:148](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/acceptInvitation.feature#L148)
 
-#### [[OCM] Sharee can access expired federated share](https://github.com/owncloud/ocis/issues/11033)
-- [apiOcm/share.feature:1158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1158)
-- [apiOcm/share.feature:1178](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1178)
-
 #### [[OCM] Hide & Enable Sync fail with received federated shares](https://github.com/owncloud/ocis/issues/10719)
-- [apiOcm/share.feature:1198](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1198)
-- [apiOcm/share.feature:1222](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1222)
+- [apiOcm/share.feature:1190](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1190)
+- [apiOcm/share.feature:1214](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/share.feature#L1214)
 
 #### [[OCM] federated user trying to download file shared with permissions role Secure Viewer returns 500 status code](https://github.com/owncloud/ocis/issues/10822)
 - [apiOcm/enableDisablePermissionsRole.feature:18](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiOcm/enableDisablePermissionsRole.feature#L18)

--- a/tests/acceptance/features/apiOcm/share.feature
+++ b/tests/acceptance/features/apiOcm/share.feature
@@ -1168,11 +1168,7 @@ Feature: an user shares resources using ScienceMesh application
     When user "Alice" expires the last share of resource "textfile.txt" inside of the space "Personal"
     Then the HTTP status code should be "200"
     And using server "REMOTE"
-    When user "Brian" updates the content of federated share "textfile.txt" with "this is a new content" using the WebDAV API
-    Then the HTTP status code should be "404"
     And user "Brian" should not have a federated share "textfile.txt" shared by user "Alice" from space "Personal"
-    And using server "LOCAL"
-    And for user "Alice" the content of the file "textfile.txt" of the space "Personal" should be "ocm test"
 
   @issue-11033
   Scenario: external sharee shouldn't be able to the access folder when federated share expires
@@ -1188,11 +1184,7 @@ Feature: an user shares resources using ScienceMesh application
     When user "Alice" expires the last share of resource "folderToShare" inside of the space "Personal"
     Then the HTTP status code should be "200"
     And using server "REMOTE"
-    When user "Brian" uploads a file with content "lorem" to "file.txt" inside federated share "folderToShare" via TUS using the WebDAV API
-    Then the HTTP status code should be "404"
     And user "Brian" should not have a federated share "folderToShare" shared by user "Alice" from space "Personal"
-    And using server "LOCAL"
-    And as "Alice" file "folderToShare/file.txt" should not exist
 
   @issue-10719
   Scenario: federated user hides the file shared by local user


### PR DESCRIPTION
## Description
This PR has removed steps which seems impossible to occur after the bug gets fixed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-  https://github.com/owncloud/ocis/issues/11033

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
