### PR TITLE
[tests-only][full-ci] add test to disable mail and in-app notifications for `Space membership expired` event

### DIFF
--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -739,3 +739,105 @@ Feature: Notification Settings
 
       Click here to view it: %base_url%/f/%space_id%
       """
+
+  @email
+  Scenario: disable mail and in-app notification for "Space Membership Expired" event
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "newSpace" with the default quota using the Graph API
+    And user "Alice" has sent the following space share invitation:
+      | space           | newSpace     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Viewer |
+    When user "Brian" disables notification for the following events using the settings API:
+      | Space Membership Expired | mail,in-app |
+    Then the HTTP status code should be "201"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "object",
+            "required": ["identifier","value"],
+            "properties": {
+              "identifier":{
+                "type": "object",
+                "required": ["extension","bundle","setting"],
+                "properties": {
+                  "extension":{ "const": "ocis-accounts" },
+                  "bundle":{ "const": "profile" },
+                  "setting":{ "const": "event-space-membership-expired-options" }
+                }
+              },
+              "value":{
+                "type": "object",
+                "required": ["id","bundleId","settingId","accountUuid","resource","collectionValue"],
+                "properties":{
+                  "id":{ "pattern":"%uuidv4_pattern%" },
+                  "bundleId":{ "pattern":"%uuidv4_pattern%" },
+                  "settingId":{ "pattern":"%uuidv4_pattern%" },
+                  "accountUuid":{ "pattern":"%uuidv4_pattern%" },
+                  "resource":{
+                    "type": "object",
+                    "required":["type"],
+                    "properties": {
+                      "type":{ "const": "TYPE_USER" }
+                    }
+                  },
+                  "collectionValue":{
+                    "type": "object",
+                    "required":["values"],
+                    "properties": {
+                      "values":{
+                        "type": "array",
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "uniqueItems": true,
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": ["key","boolValue"],
+                              "properties": {
+                                "key":{ "const": "mail" },
+                                "boolValue":{ "const": false }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "required": ["key","boolValue"],
+                              "properties": {
+                                "key":{ "const": "in-app" },
+                                "boolValue":{ "const": false }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    When user "Alice" expires the user share of space "newSpace" for user "Brian"
+    Then the HTTP status code should be "200"
+    And user "Brian" should get a notification with subject "Space shared" and message:
+      | message                                  |
+      | Alice Hansen added you to Space newSpace |
+    But user "Brian" should not have a notification related to space "newSpace" with subject "Membership expired"
+    And user "Brian" should have "1" emails
+    And user "Brian" should have received the following email from user "Alice" about the share of project space "newSpace"
+      """
+      Hello Brian Murphy,
+
+      %displayname% has invited you to join "newSpace".
+
+      Click here to view it: %base_url%/f/%space_id%
+      """


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds test for disabling in-app and mail notifications for `Space membership expired` event.
``` feature
Scenario: disable mail and in-app notification for "Space Membership Expired" event
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Bug report: https://github.com/owncloud/ocis/issues/10882
- Part of: https://github.com/owncloud/ocis/issues/10802

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
