### PR TITLE
[tests-only][full-ci]Hard code setting id's to avoid flakiness in tests

### DIFF
--- a/tests/acceptance/TestHelpers/SettingsHelper.php
+++ b/tests/acceptance/TestHelpers/SettingsHelper.php
@@ -32,6 +32,39 @@ use PHPUnit\Framework\Assert;
 class SettingsHelper {
 	private static string $settingsEndpoint = '/api/v0/settings/';
 
+	private const BUNDLE_ID = "2a506de7-99bd-4f0d-994e-c38e72c28fd9";
+
+	private const DEFAULT_SETTING_EVENTS = [
+		'Disable Email Notifications' => '33ffb5d6-cd07-4dc0-afb0-84f7559ae438',
+		'Auto Accept Shares' => 'ec3ed4a3-3946-4efc-8f9f-76d38b12d3a9',
+		'File Rejected' => 'fe0a3011-d886-49c8-b797-33d02fa426ef',
+		'Email Sending Interval' => '08dec2fe-3f97-42a9-9d1b-500855e92f25',
+		'Share Received' => '872d8ef6-6f2a-42ab-af7d-f53cc81d7046',
+		'Share Removed' => 'd7484394-8321-4c84-9677-741ba71e1f80',
+		'Share Expired' => 'e1aa0b7c-1b0f-4072-9325-c643c89fee4e',
+		'Added As Space Member' => '694d5ee1-a41c-448c-8d14-396b95d2a918',
+		'Removed As Space Member' => '26c20e0e-98df-4483-8a77-759b3a766af0',
+		'Space Deleted' => '094ceca9-5a00-40ba-bb1a-bbc7bccd39ee',
+		'Space Disabled' => 'eb5c716e-03be-42c6-9ed1-1105d24e109f',
+		'Space Membership Expired' => '7275921e-b737-4074-ba91-3c2983be3edd'
+	];
+
+	/**
+	 * @return string
+	 */
+	public static function getBundleId(): string {
+		return self::BUNDLE_ID;
+	}
+
+	/**
+	 * @param string $event
+	 *
+	 * @return string
+	 */
+	public static function getSettingIdUsingEventName(string $event): string {
+		return self::DEFAULT_SETTING_EVENTS[$event];
+	}
+
 	/**
 	 * @param string $baseUrl
 	 * @param string $path

--- a/tests/acceptance/features/apiAntivirus/antivirus.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirus.feature
@@ -1,4 +1,4 @@
-@antivirus @skipOnReva @notification
+@antivirus @notification
 Feature: antivirus
   As a system administrator and user
   I want to protect myself and others from known viruses

--- a/tests/acceptance/features/apiAntivirus/enableDisableNotification.feature
+++ b/tests/acceptance/features/apiAntivirus/enableDisableNotification.feature
@@ -1,0 +1,174 @@
+@antivirus @notification
+Feature: enable/disable malware related notification
+  As a system administrator and user
+  I want to get notifications related to malware
+  So that I can quickly detect and analyze security threats
+
+  Background:
+    Given these users have been created with default attributes:
+      | username |
+      | Alice    |
+      | Brian    |
+
+
+  Scenario Outline: disable in-app notification for "File rejected" event
+    Given using <dav-path-version> DAV path
+    When user "Brian" disables notification for the following events using the settings API:
+      | File Rejected | in-app |
+    Then the HTTP status code should be "201"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "object",
+            "required": ["identifier","value"],
+            "properties": {
+              "identifier":{
+                "type": "object",
+                "required": ["extension","bundle","setting"],
+                "properties": {
+                  "extension":{ "const": "ocis-accounts" },
+                  "bundle":{ "const": "profile" },
+                  "setting":{ "const": "event-postprocessing-step-finished-options" }
+                }
+              },
+              "value":{
+                "type": "object",
+                "required": ["id","bundleId","settingId","accountUuid","resource","collectionValue"],
+                "properties":{
+                  "id":{ "pattern":"%uuidv4_pattern%" },
+                  "bundleId":{ "pattern":"%uuidv4_pattern%" },
+                  "settingId":{ "pattern":"%uuidv4_pattern%" },
+                  "accountUuid":{ "pattern":"%uuidv4_pattern%" },
+                  "resource":{
+                    "type": "object",
+                    "required":["type"],
+                    "properties": {
+                      "type":{ "const": "TYPE_USER" }
+                    }
+                  },
+                  "collectionValue":{
+                    "type": "object",
+                    "required":["values"],
+                    "properties": {
+                      "values":{
+                        "type": "array",
+                        "maxItems": 1,
+                        "minItems": 1,
+                        "uniqueItems": true,
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": ["key","boolValue"],
+                              "properties": {
+                                "key":{ "const": "in-app" },
+                                "boolValue":{ "const": false }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And user "Brian" has uploaded file "filesForUpload/filesWithVirus/<file-name>" to "<new-file-name>"
+    And user "Brian" should not have any notification
+    Examples:
+      | dav-path-version | file-name     | new-file-name  |
+      | old              | eicar.com     | virusFile1.txt |
+      | new              | eicar.com     | virusFile1.txt |
+      | spaces           | eicar.com     | virusFile1.txt |
+
+
+  Scenario: disable in-app notification for "File rejected" event (Project space)
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "newSpace" with the default quota using the Graph API
+    And user "Alice" has sent the following space share invitation:
+      | space           | newSpace     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Editor |
+    When user "Brian" disables notification for the following events using the settings API:
+      | File Rejected | in-app |
+    Then the HTTP status code should be "201"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "object",
+            "required": ["identifier","value"],
+            "properties": {
+              "identifier":{
+                "type": "object",
+                "required": ["extension","bundle","setting"],
+                "properties": {
+                  "extension":{ "const": "ocis-accounts" },
+                  "bundle":{ "const": "profile" },
+                  "setting":{ "const": "event-postprocessing-step-finished-options" }
+                }
+              },
+              "value":{
+                "type": "object",
+                "required": ["id","bundleId","settingId","accountUuid","resource","collectionValue"],
+                "properties":{
+                  "id":{ "pattern":"%uuidv4_pattern%" },
+                  "bundleId":{ "pattern":"%uuidv4_pattern%" },
+                  "settingId":{ "pattern":"%uuidv4_pattern%" },
+                  "accountUuid":{ "pattern":"%uuidv4_pattern%" },
+                  "resource":{
+                    "type": "object",
+                    "required":["type"],
+                    "properties": {
+                      "type":{ "const": "TYPE_USER" }
+                    }
+                  },
+                  "collectionValue":{
+                    "type": "object",
+                    "required":["values"],
+                    "properties": {
+                      "values":{
+                        "type": "array",
+                        "maxItems": 1,
+                        "minItems": 1,
+                        "uniqueItems": true,
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": ["key","boolValue"],
+                              "properties": {
+                                "key":{ "const": "in-app" },
+                                "boolValue":{ "const": false }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And user "Brian" has uploaded a file "filesForUpload/filesWithVirus/eicar.com" to "virusFile.txt" in space "newSpace"
+    And user "Brian" should get a notification with subject "Space shared" and message:
+      | message                                  |
+      | Alice Hansen added you to Space newSpace |
+    But user "Brian" should not have a notification related to resource "virusFile.txt" with subject "Virus found"

--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -339,169 +339,6 @@ Feature: Notification Settings
       | Alice Hansen shared insideSpace.txt with you |
     But user "Brian" should not have a notification related to resource "insideSpace.txt" with subject "Resource unshared"
 
-  @antivirus
-  Scenario Outline: disable in-app notification for "File rejected" event
-    Given using <dav-path-version> DAV path
-    When user "Brian" disables notification for the following events using the settings API:
-      | File rejected | in-app |
-    Then the HTTP status code should be "201"
-    And the JSON data of the response should match
-      """
-      {
-        "type": "object",
-        "required": ["value"],
-        "properties": {
-          "value": {
-            "type": "object",
-            "required": ["identifier","value"],
-            "properties": {
-              "identifier":{
-                "type": "object",
-                "required": ["extension","bundle","setting"],
-                "properties": {
-                  "extension":{ "const": "ocis-accounts" },
-                  "bundle":{ "const": "profile" },
-                  "setting":{ "const": "event-postprocessing-step-finished-options" }
-                }
-              },
-              "value":{
-                "type": "object",
-                "required": ["id","bundleId","settingId","accountUuid","resource","collectionValue"],
-                "properties":{
-                  "id":{ "pattern":"%uuidv4_pattern%" },
-                  "bundleId":{ "pattern":"%uuidv4_pattern%" },
-                  "settingId":{ "pattern":"%uuidv4_pattern%" },
-                  "accountUuid":{ "pattern":"%uuidv4_pattern%" },
-                  "resource":{
-                    "type": "object",
-                    "required":["type"],
-                    "properties": {
-                      "type":{ "const": "TYPE_USER" }
-                    }
-                  },
-                  "collectionValue":{
-                    "type": "object",
-                    "required":["values"],
-                    "properties": {
-                      "values":{
-                        "type": "array",
-                        "maxItems": 1,
-                        "minItems": 1,
-                        "uniqueItems": true,
-                        "items": {
-                          "oneOf": [
-                            {
-                              "type": "object",
-                              "required": ["key","boolValue"],
-                              "properties": {
-                                "key":{ "const": "in-app" },
-                                "boolValue":{ "const": false }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      """
-    And user "Brian" has uploaded file "filesForUpload/filesWithVirus/<file-name>" to "<new-file-name>"
-    And user "Brian" should not have any notification
-    Examples:
-      | dav-path-version | file-name     | new-file-name  |
-      | old              | eicar.com     | virusFile1.txt |
-      | new              | eicar.com     | virusFile1.txt |
-      | spaces           | eicar.com     | virusFile1.txt |
-
-  @antivirus
-  Scenario: disable in-app notification for "File rejected" event (Project space)
-    Given using spaces DAV path
-    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
-    And user "Alice" has created a space "newSpace" with the default quota using the Graph API
-    And user "Alice" has sent the following space share invitation:
-      | space           | newSpace     |
-      | sharee          | Brian        |
-      | shareType       | user         |
-      | permissionsRole | Space Editor |
-    When user "Brian" disables notification for the following events using the settings API:
-      | File rejected | in-app |
-    Then the HTTP status code should be "201"
-    And the JSON data of the response should match
-      """
-      {
-        "type": "object",
-        "required": ["value"],
-        "properties": {
-          "value": {
-            "type": "object",
-            "required": ["identifier","value"],
-            "properties": {
-              "identifier":{
-                "type": "object",
-                "required": ["extension","bundle","setting"],
-                "properties": {
-                  "extension":{ "const": "ocis-accounts" },
-                  "bundle":{ "const": "profile" },
-                  "setting":{ "const": "event-postprocessing-step-finished-options" }
-                }
-              },
-              "value":{
-                "type": "object",
-                "required": ["id","bundleId","settingId","accountUuid","resource","collectionValue"],
-                "properties":{
-                  "id":{ "pattern":"%uuidv4_pattern%" },
-                  "bundleId":{ "pattern":"%uuidv4_pattern%" },
-                  "settingId":{ "pattern":"%uuidv4_pattern%" },
-                  "accountUuid":{ "pattern":"%uuidv4_pattern%" },
-                  "resource":{
-                    "type": "object",
-                    "required":["type"],
-                    "properties": {
-                      "type":{ "const": "TYPE_USER" }
-                    }
-                  },
-                  "collectionValue":{
-                    "type": "object",
-                    "required":["values"],
-                    "properties": {
-                      "values":{
-                        "type": "array",
-                        "maxItems": 1,
-                        "minItems": 1,
-                        "uniqueItems": true,
-                        "items": {
-                          "oneOf": [
-                            {
-                              "type": "object",
-                              "required": ["key","boolValue"],
-                              "properties": {
-                                "key":{ "const": "in-app" },
-                                "boolValue":{ "const": false }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      """
-    And user "Brian" has uploaded a file "filesForUpload/filesWithVirus/eicar.com" to "virusFile.txt" in space "newSpace"
-    And user "Brian" should get a notification with subject "Space shared" and message:
-      | message                                  |
-      | Alice Hansen added you to Space newSpace |
-    But user "Brian" should not have a notification related to resource "virusFile.txt" with subject "Virus found"
-
 
   Scenario: disable in-app notification for "Space disabled" event
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
@@ -512,7 +349,7 @@ Feature: Notification Settings
       | shareType       | user         |
       | permissionsRole | Space Viewer |
     When user "Brian" disables notification for the following events using the settings API:
-      | Space disabled | in-app |
+      | Space Disabled | in-app |
     Then the HTTP status code should be "201"
     And the JSON data of the response should match
       """
@@ -660,7 +497,7 @@ Feature: Notification Settings
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "newSpace" with the default quota using the Graph API
     When user "Brian" disables notification for the following events using the settings API:
-      | Added as space member | mail,in-app |
+      | Added As Space Member | mail,in-app |
     Then the HTTP status code should be "201"
     And the JSON data of the response should match
       """
@@ -813,7 +650,7 @@ Feature: Notification Settings
       | shareType       | user         |
       | permissionsRole | Space Viewer |
     When user "Brian" disables notification for the following events using the settings API:
-      | Removed as space member | mail,in-app |
+      | Removed As Space Member | mail,in-app |
     Then the HTTP status code should be "201"
     And the JSON data of the response should match
       """


### PR DESCRIPTION
## Description
Sometimes setting related tests fails when getting bundles list. To avoid such flakiness setting id has been hard coded. 
Shifted two scenarios to antivirus suite so that tests run when antivirus service is setup

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/11088

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
