### PR TITLE
[tests-only][full-ci]Support services rollback in ociswrapper

### DIFF
--- a/tests/acceptance/TestHelpers/OcisConfigHelper.php
+++ b/tests/acceptance/TestHelpers/OcisConfigHelper.php
@@ -135,4 +135,13 @@ class OcisConfigHelper {
 		$url = self::getWrapperUrl() . "/services/" . $service;
 		return self::sendRequest($url, "POST", \json_encode($envs));
 	}
+
+	/**
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function rollbackServices(): ResponseInterface {
+		$url = self::getWrapperUrl() . "/services/rollback";
+		return self::sendRequest($url, "DELETE");
+	}
 }

--- a/tests/acceptance/bootstrap/OcisConfigContext.php
+++ b/tests/acceptance/bootstrap/OcisConfigContext.php
@@ -221,6 +221,16 @@ class OcisConfigContext implements Context {
 	 * @AfterScenario @env-config
 	 *
 	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function rollback(): void {
+		$this->rollbackServices();
+		$this->rollbackOcis();
+	}
+
+	/**
+	 * @return void
+	 * @throws GuzzleException
 	 */
 	public function rollbackOcis(): void {
 		$response = OcisConfigHelper::rollbackOcis();
@@ -228,6 +238,19 @@ class OcisConfigContext implements Context {
 			200,
 			$response->getStatusCode(),
 			"Failed to rollback ocis server. Check if oCIS is started with ociswrapper."
+		);
+	}
+
+	/**
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function rollbackServices(): void {
+		$response = OcisConfigHelper::rollbackServices();
+		Assert::assertEquals(
+			200,
+			$response->getStatusCode(),
+			"Failed to rollback services."
 		);
 	}
 }

--- a/tests/ociswrapper/README.md
+++ b/tests/ociswrapper/README.md
@@ -177,3 +177,12 @@ Also, see `./bin/ociswrapper help` for more information.
 
     - `200 OK` - service is successfully reconfigured
     - `500 Internal Server Error` - service is not running
+
+9. `DELETE /services/rollback`
+
+    Stop and rollback all service configurations to the starting point.
+
+    Returns:
+
+    - `200 OK` - rollback is successful
+    - `500 Internal Server Error` - oCIS server is not running

--- a/tests/ociswrapper/wrapper/wrapper.go
+++ b/tests/ociswrapper/wrapper/wrapper.go
@@ -28,6 +28,7 @@ func Start(port string) {
 	mux.HandleFunc("/stop", handlers.StopOcisHandler)
 	mux.HandleFunc("/start", handlers.StartOcisHandler)
 	mux.HandleFunc("/services/{service}", handlers.OcisServiceHandler)
+	mux.HandleFunc("/services/rollback", handlers.RollbackServicesHandler)
 
 	httpServer.Handler = mux
 


### PR DESCRIPTION
## Description
After each scenario, we need to reset the oCIS state, terminate all services, and remove the stored service environment variable configuration for each service. Added **rollback** endpoint for terminating all services and removing the stored service
environment variable configuration  

## Tests plan 
1. run oCIS  and start oCIS service 
2. run oCIS and update oCIS env with PUT method 
    - `curl -XPUT 'http://localhost:5200/config' -d'{"OCIS_EXCLUDE_RUN_SERVICES":"storage-users"}'`
3. run multiple ocis service
   - `curl -XPOST 'http://localhost:5200/services/audit' -d'{"OCIS_LOG_LEVEL":"info"}'` 
   - `curl -XPOST 'http://localhost:5200/services/storage-users' -d'{"OCIS_LOG_LEVEL":"info"}'` 
4. update running service 
   - `curl -XPATCH 'http://localhost:5200/services/storage-users' -d'{"OCIS_LOG_LEVEL":"warn"}'`
5. rollback all services
   - `curl -XDELETE http://localhost:5200/services/rollback `
  all services should be stopped and stored env should be cleared

## Related Issue
- https://github.com/owncloud/ocis/issues/10715

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
