### PR TITLE
feat: Improve logging in the postprocessing service

### DIFF
--- a/changelog/unreleased/update-postprocessing-logs.md
+++ b/changelog/unreleased/update-postprocessing-logs.md
@@ -1,0 +1,6 @@
+Enhancement: Improve postprocessing logs
+
+Improve postprocessing logs to easily trace successful and failing uploads/
+
+https://github.com/owncloud/ocis/pull/11108
+https://github.com/owncloud/ocis/issues/10998


### PR DESCRIPTION
## Description
- log each incoming event (debug level)
- log events that instruct the service to retry an event on info level
- log errors it encounters on error level
- log postprocessing restart events
- log the outcome of all operations even if they were successful
- make sure all postprocessing steps are tracked in the logs

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes: #10998 

## Motivation and Context
User Story: The postprocessing service is the center piece of uploads in ocis. Unfortunately logging is scarce. We need to improve logging so we can easily trace failing uploads

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: 
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
