### PR TITLE
Maintenance example

### DIFF
--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -76,6 +76,7 @@ services:
       - "traefik.http.routers.collabora.rule=Host(`${COLLABORA_DOMAIN:-collabora.owncloud.test}`)"
       - "traefik.http.routers.collabora.tls.certresolver=http"
       - "traefik.http.routers.collabora.service=collabora"
+      - "traefik.http.routers.collabora.middlewares=maintenance"
       - "traefik.http.services.collabora.loadbalancer.server.port=9980"
     logging:
       driver: ${LOG_DRIVER:-local}

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
       - "--certificatesResolvers.http.acme.caserver=${TRAEFIK_ACME_CASERVER:-https://acme-v02.api.letsencrypt.org/directory}"
       # enable dashboard
-      - "--api.dashboard=true"
+      - "--api.dashboard=${TRAEFIK_DASHBOARD:-false}"
       # define entrypoints
       - "--entryPoints.http.address=:80"
       - "--entryPoints.http.http.redirections.entryPoint.to=https"
@@ -41,7 +41,7 @@ services:
       - "${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock:ro"
       - "certs:/certs"
     labels:
-      - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
+      - "traefik.enable=true"
        # defaults to admin:admin
       - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$$apr1$$4vqie50r$$YQAmQdtmz5n9rEALhxJ4l.}"
       - "traefik.http.routers.traefik.entrypoints=https"

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - "--accessLog=true"
       - "--accessLog.format=json"
       - "--accessLog.fields.headers.names.X-Request-Id=keep"
+      # maintenance page
+      - "--experimental.plugins.traefik-maintenance.modulename=github.com/TRIMM/traefik-maintenance"
+      - "--experimental.plugins.traefik-maintenance.version=v1.0.1"
     ports:
       - "80:80"
       - "443:443"
@@ -46,6 +49,12 @@ services:
       - "traefik.http.routers.traefik.middlewares=traefik-auth"
       - "traefik.http.routers.traefik.tls.certresolver=http"
       - "traefik.http.routers.traefik.service=api@internal"
+      # maintenance configuration
+      - "traefik.http.middlewares.maintenance.plugin.traefik-maintenance.enabled=true"
+      - "traefik.http.middlewares.maintenance.plugin.traefik-maintenance.httpResponseCode=503"
+      - "traefik.http.middlewares.maintenance.plugin.traefik-maintenance.filename=/maintenance/content.txt"
+      - "traefik.http.middlewares.maintenance.plugin.traefik-maintenance.triggerFilename=/maintenance/content.txt.trigger"
+      - "traefik.http.middlewares.maintenance.plugin.traefik-maintenance.httpContentType=text/plain; charset=utf-8"
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -66,6 +66,7 @@ services:
       - "traefik.http.routers.ocis.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
       - "traefik.http.routers.ocis.tls.certresolver=http"
       - "traefik.http.routers.ocis.service=ocis"
+      - "traefik.http.routers.ocis.middlewares=maintenance"
       - "traefik.http.services.ocis.loadbalancer.server.port=9200"
     logging:
       driver: ${LOG_DRIVER:-local}

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -78,7 +78,7 @@ services:
       - "traefik.http.services.onlyoffice.loadbalancer.server.port=80"
       # websockets can't be opened when this is omitted
       - "traefik.http.middlewares.onlyoffice.headers.customrequestheaders.X-Forwarded-Proto=https"
-      - "traefik.http.routers.onlyoffice.middlewares=onlyoffice"
+      - "traefik.http.routers.onlyoffice.middlewares=onlyoffice,maintenance"
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Add maintenance page to the ocis_full deployment.

In order to switch on the maintenance mode:
1. Enter the traefik container
2. Create the `/maintenance/content.txt` file inside the traefik container if it doesn't exist. Write any type of plain text content in the file (just an "Under maintenance" is good enough)
3. Create an empty file `/maintenance/content.txt.trigger`. This will switch on the maintenance mode
4. In order to switch off the maintenance mode, just remove the `/maintenance/content.txt.trigger` file.

For convenience:
* Switch on -> `docker exec -ti ocis_full-traefik-1 sh -c 'mkdir -p /maintenance && echo "Under maintenance" > /maintenance/content.txt && touch /maintenance/content.txt.trigger'`
* Switch off -> `docker exec -ti ocis_full-traefik-1 sh -c 'rm /maintenance/content.txt.trigger'`

Note that the maintenance mode will be "active" for the ocis, collabora and onlyoffice containers, which are expected to be exposed to the outside. The rest of the containers, which should only be accessed internally, will be accessible as usual. They might not work properly though because they might need to access to the ocis container.

## Related Issue
Part of https://github.com/owncloud/web/issues/10260

## Motivation and Context
The maintenance page is expected to be handled by traefik in this case. This PR just adds the proposed configuration.

## How Has This Been Tested?
Manually tested. Enabling the maintenance mode makes the server responses to start sending 503 codes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

Note that the dashboard has been slightly touched.
The `traefik.enable=true` is required so other containers can see the maintenance plugin configuration, otherwise the "ocis" and "collabora" containers won't be able to find the maintenance plugin.
In that regard, the dashboard will only be enabled if `TRAEFIK_DASHBOARD=true`, as intended.
