### PR TITLE
Translation fix

### DIFF
--- a/changelog/unreleased/Fix-Role-Names.md
+++ b/changelog/unreleased/Fix-Role-Names.md
@@ -1,0 +1,5 @@
+Bugfix: Fix translations of editor roles
+
+Uses the correct translations strings for ocis roles
+
+https://github.com/owncloud/ocis/pull/11098

--- a/services/graph/pkg/unifiedrole/roles.go
+++ b/services/graph/pkg/unifiedrole/roles.go
@@ -104,7 +104,7 @@ var (
 	// UnifiedRole ViewerListGrants, Role Description (resolves directly)
 	_viewerListGrantsUnifiedRoleDescription = l10n.Template("View, download and show all invited people.")
 
-	// UnifiedRole Viewer, Role DisplayName (resolves directly)
+	// UnifiedRole ViewerListGrants, Role DisplayName (resolves directly)
 	_viewerListGrantsUnifiedRoleDisplayName = l10n.Template("Can view")
 
 	// UnifiedRole SpaceViewer, Role Description (resolves directly)
@@ -117,18 +117,18 @@ var (
 	_editorUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add and delete.")
 
 	// UnifiedRole Editor, Role DisplayName (resolves directly)
-	_editorUnifiedRoleDisplayName = l10n.Template("Can edit")
+	_editorUnifiedRoleDisplayName = l10n.Template("Can edit without versions")
 
-	// UnifiedRoleListGrants Editor, Role Description (resolves directly)
+	// UnifiedRole EditorListGrants Editor, Role Description (resolves directly)
 	_editorListGrantsUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add, delete and show all invited people.")
 
 	// UnifiedRole EditorListGrants, Role DisplayName (resolves directly)
-	_editorListGrantsUnifiedRoleDisplayName = l10n.Template("Can edit")
+	_editorListGrantsUnifiedRoleDisplayName = l10n.Template("Can edit without versions")
 
-	// UnifiedRoleListGrants Editor, Role Description (resolves directly)
+	// UnifiedRole EditorListGrantsWithVersions, Role Description (resolves directly)
 	_editorListGrantsWithVersionsUnifiedRoleDescription = l10n.Template("View, download, upload, edit, delete and show all invited people, show all versions.")
 
-	// UnifiedRole EditorListGrants, Role DisplayName (resolves directly)
+	// UnifiedRole EditorListGrantsWithVersions, Role DisplayName (resolves directly)
 	_editorListGrantsWithVersionsUnifiedRoleDisplayName = l10n.Template("Can edit")
 
 	// UnifiedRole SpaseEditor, Role Description (resolves directly)
@@ -147,13 +147,13 @@ var (
 	_fileEditorUnifiedRoleDescription = l10n.Template("View, download and edit.")
 
 	// UnifiedRole FileEditor, Role DisplayName (resolves directly)
-	_fileEditorUnifiedRoleDisplayName = l10n.Template("Can edit")
+	_fileEditorUnifiedRoleDisplayName = l10n.Template("Can edit without versions")
 
 	// UnifiedRole FileEditorListGrants, Role Description (resolves directly)
 	_fileEditorListGrantsUnifiedRoleDescription = l10n.Template("View, download, edit and show all invited people.")
 
 	// UnifiedRole FileEditorListGrants, Role DisplayName (resolves directly)
-	_fileEditorListGrantsUnifiedRoleDisplayName = l10n.Template("Can edit")
+	_fileEditorListGrantsUnifiedRoleDisplayName = l10n.Template("Can edit without versions")
 
 	// UnifiedRole FileEditorListGrants, Role Description (resolves directly)
 	_fileEditorListGrantsWithVersionsUnifiedRoleDescription = l10n.Template("View, download, edit and show all invited people, show all versions.")
@@ -336,9 +336,11 @@ var (
 		}
 	}()
 
-	// roleEditorListGrantsWithVersions creates an editor role.
+	// roleEditorListGrantsWithVersions creates an editor-list-grants-with-versions role.
 	roleEditorListGrantsWithVersions = func() *libregraph.UnifiedRoleDefinition {
 		r := conversions.NewEditorListGrantsWithVersionsRole()
+		// TODO: Workaround to avoid reva bump - fix in reva
+		r.Name = conversions.RoleEditorListGrantsWithVersions
 		return &libregraph.UnifiedRoleDefinition{
 			Id:          proto.String(UnifiedRoleEditorListGrantsWithVersionsID),
 			Description: proto.String(_editorListGrantsWithVersionsUnifiedRoleDescription),
@@ -436,6 +438,8 @@ var (
 	// roleFileEditorListGrantsWithVersions creates a file-editor role
 	roleFileEditorListGrantsWithVersions = func() *libregraph.UnifiedRoleDefinition {
 		r := conversions.NewFileEditorListGrantsWithVersionsRole()
+		// TODO: Workaround to avoid reva bump - fix in reva
+		r.Name = conversions.RoleFileEditorListGrantsWithVersions
 		return &libregraph.UnifiedRoleDefinition{
 			Id:          proto.String(UnifiedRoleFileEditorListGrantsWithVersionsID),
 			Description: proto.String(_fileEditorListGrantsWithVersionsUnifiedRoleDescription),

--- a/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
+++ b/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
@@ -211,7 +211,7 @@ Feature: permissions role definitions
                   "const": "View, download, upload, edit, add and delete."
                 },
                 "displayName": {
-                  "const": "Can edit"
+                  "const": "Can edit without versions"
                 },
                 "id": {
                   "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -359,7 +359,7 @@ Feature: permissions role definitions
                   "const": "View, download and edit."
                 },
                 "displayName": {
-                  "const": "Can edit"
+                  "const": "Can edit without versions"
                 },
                 "id": {
                   "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"

--- a/tests/acceptance/features/apiSharingNg1/filterPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg1/filterPermissions.feature
@@ -90,7 +90,7 @@ Feature: filter sharing permissions
                       "const": "View, download, upload, edit, add and delete."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -189,7 +189,7 @@ Feature: filter sharing permissions
                       "const": "View, download and edit."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
@@ -334,7 +334,7 @@ Feature: filter sharing permissions
                       "const": "View, download, upload, edit, add and delete."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -456,7 +456,7 @@ Feature: filter sharing permissions
                       "const": "View, download and edit."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
@@ -554,7 +554,7 @@ Feature: filter sharing permissions
                       "const": "View, download, upload, edit, add and delete."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -653,7 +653,7 @@ Feature: filter sharing permissions
                       "const": "View, download and edit."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
@@ -778,7 +778,7 @@ Feature: filter sharing permissions
                       "const": "View, download and edit."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
@@ -926,7 +926,7 @@ Feature: filter sharing permissions
                       "const": "View, download, upload, edit, add and delete."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -1051,7 +1051,7 @@ Feature: filter sharing permissions
                       "const": "View, download, upload, edit, add and delete."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -1153,7 +1153,7 @@ Feature: filter sharing permissions
                       "const": "View, download and edit."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
@@ -1206,7 +1206,7 @@ Feature: filter sharing permissions
                   "properties": {
                     "@libre.graph.weight": {"const": 2},
                     "description": {"const": "View, download and edit."},
-                    "displayName": {"const": "Can edit"},
+                    "displayName": {"const": "Can edit without versions"},
                     "id": {"const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a" }
                   }
                 }
@@ -1256,7 +1256,7 @@ Feature: filter sharing permissions
                   "properties": {
                     "@libre.graph.weight": {"const": 2},
                     "description": {"const": "View, download, upload, edit, add and delete."},
-                    "displayName": {"const": "Can edit"},
+                    "displayName": {"const": "Can edit without versions"},
                     "id": {"const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"}
                   }
                 }
@@ -1309,7 +1309,7 @@ Feature: filter sharing permissions
                   "properties": {
                     "@libre.graph.weight": {"const": 2},
                     "description": {"const": "View, download and edit."},
-                    "displayName": {"const": "Can edit"},
+                    "displayName": {"const": "Can edit without versions"},
                     "id": {"const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"}
                   }
                 }
@@ -1362,7 +1362,7 @@ Feature: filter sharing permissions
                   "properties": {
                     "@libre.graph.weight": {"const": 2},
                     "description": {"const": "View, download, upload, edit, add and delete."},
-                    "displayName": {"const": "Can edit"},
+                    "displayName": {"const": "Can edit without versions"},
                     "id": {"const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"}
                   }
                 }

--- a/tests/acceptance/features/apiSharingNg1/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNg1/listPermissions.feature
@@ -112,7 +112,7 @@ Feature: List a sharing permissions
                       "const": "View, download, upload, edit, add and delete."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -609,7 +609,7 @@ Feature: List a sharing permissions
                       "const": "View, download and edit."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
@@ -732,7 +732,7 @@ Feature: List a sharing permissions
                       "const": "View, download, upload, edit, add and delete."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "fb6c3e19-e378-47e5-b277-9732f9de6e21"
@@ -832,7 +832,7 @@ Feature: List a sharing permissions
                       "const": "View, download and edit."
                     },
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     },
                     "id": {
                       "const": "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
@@ -2239,7 +2239,7 @@ Feature: List a sharing permissions
                   ],
                   "properties": {
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     }
                   }
                 }
@@ -2428,7 +2428,7 @@ Feature: List a sharing permissions
                   ],
                   "properties": {
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     }
                   }
                 }
@@ -2525,7 +2525,7 @@ Feature: List a sharing permissions
                   ],
                   "properties": {
                     "displayName": {
-                      "const": "Can edit"
+                      "const": "Can edit without versions"
                     }
                   }
                 }


### PR DESCRIPTION
Fixes the translation of the editor roles. Old roles are now named "can edit without versions" to be in sync with space logic

Relates to https://github.com/owncloud/ocis/issues/11104 (needs masterport for closing)