### PR TITLE
Nats connection names

### DIFF
--- a/ocis-pkg/generators/natsnames.go
+++ b/ocis-pkg/generators/natsnames.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 )
 
+// NType is an enum type for the different types of NATS connections
 type NType int
 
 const (
@@ -17,6 +18,8 @@ func (n NType) String() string {
 	return []string{"bus", "kv", "reg"}[n]
 }
 
+// GenerateConnectionName generates a connection name for a NATS connection
+// The connection name will be formatted as follows: "hostname:pid:service:type"
 func GenerateConnectionName(service string, ntype NType) string {
 	host, err := os.Hostname()
 	if err != nil {
@@ -26,6 +29,7 @@ func GenerateConnectionName(service string, ntype NType) string {
 	return firstNRunes(host, 5) + ":" + strconv.Itoa(os.Getpid()) + ":" + service + ":" + ntype.String()
 }
 
+// firstNRunes returns the first n runes of a string
 func firstNRunes(s string, n int) string {
 	i := 0
 	for j := range s {

--- a/ocis-pkg/generators/natsnames.go
+++ b/ocis-pkg/generators/natsnames.go
@@ -8,12 +8,14 @@ import (
 // NType is an enum type for the different types of NATS connections
 type NType int
 
+// Enum values for NType
 const (
 	NTypeBus NType = iota
 	NTypeKeyValue
 	NTypeRegistry
 )
 
+// String returns the string representation of a NType
 func (n NType) String() string {
 	return []string{"bus", "kv", "reg"}[n]
 }

--- a/ocis-pkg/generators/natsnames.go
+++ b/ocis-pkg/generators/natsnames.go
@@ -1,0 +1,38 @@
+package generators
+
+import (
+	"os"
+	"strconv"
+)
+
+type NType int
+
+const (
+	NTYPE_BUS NType = iota
+	NTYPE_KEYVALUE
+	NTYPE_REGISTRY
+)
+
+func (n NType) String() string {
+	return []string{"bus", "kv", "reg"}[n]
+}
+
+func GenerateConnectionName(service string, ntype NType) string {
+	host, err := os.Hostname()
+	if err != nil {
+		host = ""
+	}
+
+	return firstNRunes(host, 5) + ":" + strconv.Itoa(os.Getpid()) + ":" + service + ":" + ntype.String()
+}
+
+func firstNRunes(s string, n int) string {
+	i := 0
+	for j := range s {
+		if i == n {
+			return s[:j]
+		}
+		i++
+	}
+	return s
+}

--- a/ocis-pkg/generators/natsnames.go
+++ b/ocis-pkg/generators/natsnames.go
@@ -9,9 +9,9 @@ import (
 type NType int
 
 const (
-	NTYPE_BUS NType = iota
-	NTYPE_KEYVALUE
-	NTYPE_REGISTRY
+	NTypeBus NType = iota
+	NTypeKeyValue
+	NTypeRegistry
 )
 
 func (n NType) String() string {

--- a/ocis-pkg/natsjsregistry/options.go
+++ b/ocis-pkg/natsjsregistry/options.go
@@ -10,6 +10,7 @@ import (
 
 type storeOptionsKey struct{}
 type defaultTTLKey struct{}
+type serviceNameKey struct{}
 
 // StoreOptions sets the options for the underlying store
 func StoreOptions(opts []store.Option) registry.Option {
@@ -28,5 +29,16 @@ func DefaultTTL(t time.Duration) registry.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, defaultTTLKey{}, t)
+	}
+}
+
+// ServiceName links the service name to the registry if possible.
+// The name will be part of the connection name to the Nats registry
+func ServiceName(name string) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, serviceNameKey{}, name)
 	}
 }

--- a/ocis-pkg/natsjsregistry/registry.go
+++ b/ocis-pkg/natsjsregistry/registry.go
@@ -201,7 +201,7 @@ func (n *storeregistry) storeOptions(opts registry.Options) []store.Option {
 	storeoptions = append(storeoptions, store.Nodes(addr...))
 
 	natsOptions := nats.GetDefaultOptions()
-	natsOptions.Name = generators.GenerateConnectionName(serviceName, generators.NTYPE_REGISTRY)
+	natsOptions.Name = generators.GenerateConnectionName(serviceName, generators.NTypeRegistry)
 	natsOptions.User, natsOptions.Password = getAuth()
 	natsOptions.ReconnectedCB = func(_ *nats.Conn) {
 		if err := n.Init(); err != nil {

--- a/ocis-pkg/natsjsregistry/registry.go
+++ b/ocis-pkg/natsjsregistry/registry.go
@@ -13,6 +13,7 @@ import (
 
 	natsjskv "github.com/go-micro/plugins/v4/store/nats-js-kv"
 	"github.com/nats-io/nats.go"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"go-micro.dev/v4/registry"
 	"go-micro.dev/v4/server"
 	"go-micro.dev/v4/store"
@@ -186,6 +187,11 @@ func (n *storeregistry) storeOptions(opts registry.Options) []store.Option {
 		storeoptions = append(storeoptions, natsjskv.DefaultTTL(defaultTTL))
 	}
 
+	serviceName := "_ocis" // use "_ocis" as default service name if nothing else is provided
+	if name, ok := opts.Context.Value(serviceNameKey{}).(string); ok {
+		serviceName = name
+	}
+
 	addr := []string{"127.0.0.1:9233"}
 	if len(opts.Addrs) > 0 {
 		addr = opts.Addrs
@@ -195,7 +201,7 @@ func (n *storeregistry) storeOptions(opts registry.Options) []store.Option {
 	storeoptions = append(storeoptions, store.Nodes(addr...))
 
 	natsOptions := nats.GetDefaultOptions()
-	natsOptions.Name = "nats-js-kv-registry"
+	natsOptions.Name = generators.GenerateConnectionName(serviceName, generators.NTYPE_REGISTRY)
 	natsOptions.User, natsOptions.Password = getAuth()
 	natsOptions.ReconnectedCB = func(_ *nats.Conn) {
 		if err := n.Init(); err != nil {

--- a/ocis-pkg/natsjsregistry/registry.go
+++ b/ocis-pkg/natsjsregistry/registry.go
@@ -30,7 +30,15 @@ var (
 )
 
 func init() {
-	cmd.DefaultRegistries[_registryName] = NewRegistry
+	cmd.DefaultRegistries[_registryName] = NewRegistryMicro
+}
+
+// NewRegistryMicro returns a new natsjs registry, forcing the service name
+// to be "_go-micro". This is the registry that is intended to be used by
+// go-micro
+func NewRegistryMicro(opts ...registry.Option) registry.Registry {
+	overwrittenOpts := append(opts, ServiceName("_go-micro"))
+	return NewRegistry(overwrittenOpts...)
 }
 
 // NewRegistry returns a new natsjs registry
@@ -187,7 +195,7 @@ func (n *storeregistry) storeOptions(opts registry.Options) []store.Option {
 		storeoptions = append(storeoptions, natsjskv.DefaultTTL(defaultTTL))
 	}
 
-	serviceName := "_ocis" // use "_ocis" as default service name if nothing else is provided
+	serviceName := "_unknown" // use "_unknown" as default service name if nothing else is provided
 	if name, ok := opts.Context.Value(serviceNameKey{}).(string); ok {
 		serviceName = name
 	}

--- a/ocis-pkg/registry/registry.go
+++ b/ocis-pkg/registry/registry.go
@@ -59,6 +59,7 @@ func GetRegistry(opts ...Option) mRegistry.Registry {
 			_reg = natsjsregistry.NewRegistry(
 				mRegistry.Addrs(cfg.Addresses...),
 				natsjsregistry.DefaultTTL(cfg.RegisterTTL),
+				natsjsregistry.ServiceName("_ocis"),
 			)
 		case "memory":
 			_reg = memr.NewRegistry()

--- a/services/activitylog/pkg/command/server.go
+++ b/services/activitylog/pkg/command/server.go
@@ -71,7 +71,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			evStream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to initialize event stream")

--- a/services/activitylog/pkg/command/server.go
+++ b/services/activitylog/pkg/command/server.go
@@ -13,6 +13,7 @@ import (
 	microstore "go-micro.dev/v4/store"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
@@ -70,7 +71,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
-			evStream, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			evStream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to initialize event stream")
 				return err

--- a/services/antivirus/pkg/service/service.go
+++ b/services/antivirus/pkg/service/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/owncloud/reva/v2/pkg/rhttp"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/antivirus/pkg/config"
 	"github.com/owncloud/ocis/v2/services/antivirus/pkg/scanners"
@@ -107,7 +108,8 @@ func (av Antivirus) Run() error {
 		av.c.Events.TLSInsecure = false
 	}
 
-	natsStream, err := stream.NatsFromConfig(av.c.Service.Name, false, stream.NatsConfig(av.c.Events))
+	connName := generators.GenerateConnectionName(av.c.Service.Name, generators.NTYPE_BUS)
+	natsStream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(av.c.Events))
 	if err != nil {
 		return err
 	}

--- a/services/antivirus/pkg/service/service.go
+++ b/services/antivirus/pkg/service/service.go
@@ -108,7 +108,7 @@ func (av Antivirus) Run() error {
 		av.c.Events.TLSInsecure = false
 	}
 
-	connName := generators.GenerateConnectionName(av.c.Service.Name, generators.NTYPE_BUS)
+	connName := generators.GenerateConnectionName(av.c.Service.Name, generators.NTypeBus)
 	natsStream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(av.c.Events))
 	if err != nil {
 		return err

--- a/services/audit/pkg/command/server.go
+++ b/services/audit/pkg/command/server.go
@@ -37,7 +37,7 @@ func Server(cfg *config.Config) *cli.Command {
 			)
 			defer cancel()
 
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			client, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err

--- a/services/audit/pkg/command/server.go
+++ b/services/audit/pkg/command/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/services/audit/pkg/config"
 	"github.com/owncloud/ocis/v2/services/audit/pkg/config/parser"
 	"github.com/owncloud/ocis/v2/services/audit/pkg/logging"
@@ -36,7 +37,8 @@ func Server(cfg *config.Config) *cli.Command {
 			)
 			defer cancel()
 
-			client, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			client, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err
 			}

--- a/services/clientlog/pkg/command/server.go
+++ b/services/clientlog/pkg/command/server.go
@@ -69,7 +69,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			s, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err

--- a/services/clientlog/pkg/command/server.go
+++ b/services/clientlog/pkg/command/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -68,7 +69,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
-			s, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			s, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err
 			}

--- a/services/eventhistory/pkg/command/server.go
+++ b/services/eventhistory/pkg/command/server.go
@@ -56,7 +56,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			m.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			consumer, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err

--- a/services/eventhistory/pkg/command/server.go
+++ b/services/eventhistory/pkg/command/server.go
@@ -11,6 +11,7 @@ import (
 	microstore "go-micro.dev/v4/store"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/ocis-pkg/version"
@@ -55,7 +56,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			m.BuildInfo.WithLabelValues(version.GetString()).Set(1)
 
-			consumer, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			consumer, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err
 			}

--- a/services/frontend/pkg/command/events.go
+++ b/services/frontend/pkg/command/events.go
@@ -35,7 +35,7 @@ var _registeredEvents = []events.Unmarshaller{
 
 // ListenForEvents listens for events and acts accordingly
 func ListenForEvents(ctx context.Context, cfg *config.Config, l log.Logger) error {
-	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 	bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 	if err != nil {
 		l.Error().Err(err).Msg("cannot connect to nats")

--- a/services/frontend/pkg/command/events.go
+++ b/services/frontend/pkg/command/events.go
@@ -18,6 +18,7 @@ import (
 	"go-micro.dev/v4/metadata"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
@@ -34,7 +35,8 @@ var _registeredEvents = []events.Unmarshaller{
 
 // ListenForEvents listens for events and acts accordingly
 func ListenForEvents(ctx context.Context, cfg *config.Config, l log.Logger) error {
-	bus, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+	bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 	if err != nil {
 		l.Error().Err(err).Msg("cannot connect to nats")
 		return err

--- a/services/graph/pkg/server/http/server.go
+++ b/services/graph/pkg/server/http/server.go
@@ -54,7 +54,7 @@ func Server(opts ...Option) (http.Service, error) {
 
 	if options.Config.Events.Endpoint != "" {
 		var err error
-		connName := generators.GenerateConnectionName(options.Config.Service.Name, generators.NTYPE_BUS)
+		connName := generators.GenerateConnectionName(options.Config.Service.Name, generators.NTypeBus)
 		eventsStream, err = stream.NatsFromConfig(connName, false, stream.NatsConfig(options.Config.Events))
 		if err != nil {
 			options.Logger.Error().

--- a/services/graph/pkg/server/http/server.go
+++ b/services/graph/pkg/server/http/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/account"
 	"github.com/owncloud/ocis/v2/ocis-pkg/cors"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/keycloak"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
@@ -53,7 +54,8 @@ func Server(opts ...Option) (http.Service, error) {
 
 	if options.Config.Events.Endpoint != "" {
 		var err error
-		eventsStream, err = stream.NatsFromConfig(options.Config.Service.Name, false, stream.NatsConfig(options.Config.Events))
+		connName := generators.GenerateConnectionName(options.Config.Service.Name, generators.NTYPE_BUS)
+		eventsStream, err = stream.NatsFromConfig(connName, false, stream.NatsConfig(options.Config.Events))
 		if err != nil {
 			options.Logger.Error().
 				Err(err).

--- a/services/notifications/pkg/command/send_email.go
+++ b/services/notifications/pkg/command/send_email.go
@@ -34,7 +34,7 @@ func SendEmail(cfg *config.Config) *cli.Command {
 			if !daily && !weekly {
 				return errors.New("at least one of '--daily' or '--weekly' must be set")
 			}
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			s, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Notifications.Events))
 			if err != nil {
 				return err

--- a/services/notifications/pkg/command/send_email.go
+++ b/services/notifications/pkg/command/send_email.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/services/notifications/pkg/config"
 	"github.com/owncloud/reva/v2/pkg/events"
 	"github.com/owncloud/reva/v2/pkg/events/stream"
@@ -33,7 +34,8 @@ func SendEmail(cfg *config.Config) *cli.Command {
 			if !daily && !weekly {
 				return errors.New("at least one of '--daily' or '--weekly' must be set")
 			}
-			s, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Notifications.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			s, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Notifications.Events))
 			if err != nil {
 				return err
 			}

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -96,7 +96,7 @@ func Server(cfg *config.Config) *cli.Command {
 				registeredEvents[typ.String()] = e
 			}
 
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			client, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Notifications.Events))
 			if err != nil {
 				return err

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
@@ -95,7 +96,8 @@ func Server(cfg *config.Config) *cli.Command {
 				registeredEvents[typ.String()] = e
 			}
 
-			client, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Notifications.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			client, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Notifications.Events))
 			if err != nil {
 				return err
 			}

--- a/services/policies/pkg/command/server.go
+++ b/services/policies/pkg/command/server.go
@@ -105,7 +105,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			{
 
-				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 				bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 				if err != nil {
 					return err

--- a/services/policies/pkg/command/server.go
+++ b/services/policies/pkg/command/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
@@ -104,7 +105,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			{
 
-				bus, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 				if err != nil {
 					return err
 				}

--- a/services/postprocessing/pkg/command/postprocessing.go
+++ b/services/postprocessing/pkg/command/postprocessing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/services/postprocessing/pkg/config"
 	"github.com/owncloud/ocis/v2/services/postprocessing/pkg/config/parser"
 	"github.com/owncloud/reva/v2/pkg/events"
@@ -40,7 +41,8 @@ func RestartPostprocessing(cfg *config.Config) *cli.Command {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
 		Action: func(c *cli.Context) error {
-			stream, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Postprocessing.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			stream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Postprocessing.Events))
 			if err != nil {
 				return err
 			}

--- a/services/postprocessing/pkg/command/postprocessing.go
+++ b/services/postprocessing/pkg/command/postprocessing.go
@@ -41,7 +41,7 @@ func RestartPostprocessing(cfg *config.Config) *cli.Command {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
 		Action: func(c *cli.Context) error {
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			stream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Postprocessing.Events))
 			if err != nil {
 				return err

--- a/services/postprocessing/pkg/command/server.go
+++ b/services/postprocessing/pkg/command/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 	microstore "go-micro.dev/v4/store"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/services/postprocessing/pkg/config"
 	"github.com/owncloud/ocis/v2/services/postprocessing/pkg/config/parser"
@@ -47,7 +48,8 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			{
-				bus, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Postprocessing.Events))
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Postprocessing.Events))
 				if err != nil {
 					return err
 				}

--- a/services/postprocessing/pkg/command/server.go
+++ b/services/postprocessing/pkg/command/server.go
@@ -48,7 +48,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			{
-				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 				bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Postprocessing.Events))
 				if err != nil {
 					return err

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -157,7 +157,7 @@ func Server(cfg *config.Config) *cli.Command {
 			var publisher events.Stream
 			if cfg.Events.Endpoint != "" {
 				var err error
-				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 				publisher, err = stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 				if err != nil {
 					logger.Error().

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justinas/alice"
 	"github.com/oklog/run"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	pkgmiddleware "github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
@@ -156,7 +157,8 @@ func Server(cfg *config.Config) *cli.Command {
 			var publisher events.Stream
 			if cfg.Events.Endpoint != "" {
 				var err error
-				publisher, err = stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				publisher, err = stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 				if err != nil {
 					logger.Error().
 						Err(err).

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -80,7 +80,7 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error)
 		return nil, teardown, fmt.Errorf("unknown search extractor: %s", cfg.Extractor.Type)
 	}
 
-	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 	bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig{
 		Endpoint:             cfg.Events.Endpoint,
 		Cluster:              cfg.Events.Cluster,

--- a/services/search/pkg/service/grpc/v0/service.go
+++ b/services/search/pkg/service/grpc/v0/service.go
@@ -22,6 +22,7 @@ import (
 	"go-micro.dev/v4/metadata"
 	grpcmetadata "google.golang.org/grpc/metadata"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	v0 "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/search/v0"
@@ -79,7 +80,8 @@ func NewHandler(opts ...Option) (searchsvc.SearchProviderHandler, func(), error)
 		return nil, teardown, fmt.Errorf("unknown search extractor: %s", cfg.Extractor.Type)
 	}
 
-	bus, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig{
+	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+	bus, err := stream.NatsFromConfig(connName, false, stream.NatsConfig{
 		Endpoint:             cfg.Events.Endpoint,
 		Cluster:              cfg.Events.Cluster,
 		EnableTLS:            cfg.Events.EnableTLS,

--- a/services/sharing/pkg/revaconfig/config.go
+++ b/services/sharing/pkg/revaconfig/config.go
@@ -136,7 +136,7 @@ func SharingConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string]
 					"tls-insecure":     cfg.Events.TLSInsecure,
 					"tls-root-ca-cert": cfg.Events.TLSRootCaCertPath,
 					"enable-tls":       cfg.Events.EnableTLS,
-					"name":             generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS),
+					"name":             generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus),
 					"username":         cfg.Events.AuthUsername,
 					"password":         cfg.Events.AuthPassword,
 				},

--- a/services/sharing/pkg/revaconfig/config.go
+++ b/services/sharing/pkg/revaconfig/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/sharing/pkg/config"
 )
@@ -135,7 +136,7 @@ func SharingConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string]
 					"tls-insecure":     cfg.Events.TLSInsecure,
 					"tls-root-ca-cert": cfg.Events.TLSRootCaCertPath,
 					"enable-tls":       cfg.Events.EnableTLS,
-					"name":             "sharing-eventsmiddleware",
+					"name":             generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS),
 					"username":         cfg.Events.AuthUsername,
 					"password":         cfg.Events.AuthPassword,
 				},

--- a/services/sse/pkg/command/server.go
+++ b/services/sse/pkg/command/server.go
@@ -53,7 +53,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			{
-				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 				natsStream, err := stream.NatsFromConfig(connName, true, stream.NatsConfig(cfg.Events))
 				if err != nil {
 					return err

--- a/services/sse/pkg/command/server.go
+++ b/services/sse/pkg/command/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/services/sse/pkg/config"
@@ -52,7 +53,8 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			{
-				natsStream, err := stream.NatsFromConfig(cfg.Service.Name, true, stream.NatsConfig(cfg.Events))
+				connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+				natsStream, err := stream.NatsFromConfig(connName, true, stream.NatsConfig(cfg.Events))
 				if err != nil {
 					return err
 				}

--- a/services/storage-users/pkg/event/event.go
+++ b/services/storage-users/pkg/event/event.go
@@ -9,7 +9,7 @@ import (
 
 // NewStream prepares the requested nats stream and returns it.
 func NewStream(cfg *config.Config) (events.Stream, error) {
-	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 	return stream.NatsFromConfig(connName, false, stream.NatsConfig{
 		Endpoint:             cfg.Events.Addr,
 		Cluster:              cfg.Events.ClusterID,

--- a/services/storage-users/pkg/event/event.go
+++ b/services/storage-users/pkg/event/event.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config"
 	"github.com/owncloud/reva/v2/pkg/events/stream"
 	"go-micro.dev/v4/events"
@@ -8,7 +9,8 @@ import (
 
 // NewStream prepares the requested nats stream and returns it.
 func NewStream(cfg *config.Config) (events.Stream, error) {
-	return stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig{
+	connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+	return stream.NatsFromConfig(connName, false, stream.NatsConfig{
 		Endpoint:             cfg.Events.Addr,
 		Cluster:              cfg.Events.ClusterID,
 		EnableTLS:            cfg.Events.EnableTLS,

--- a/services/storage-users/pkg/revaconfig/config.go
+++ b/services/storage-users/pkg/revaconfig/config.go
@@ -58,7 +58,7 @@ func StorageUsersConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					"tls-insecure":     cfg.Events.TLSInsecure,
 					"tls-root-ca-cert": cfg.Events.TLSRootCaCertPath,
 					"enable-tls":       cfg.Events.EnableTLS,
-					"name":             generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS),
+					"name":             generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus),
 					"username":         cfg.Events.AuthUsername,
 					"password":         cfg.Events.AuthPassword,
 				},

--- a/services/storage-users/pkg/revaconfig/config.go
+++ b/services/storage-users/pkg/revaconfig/config.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config"
 )
 
@@ -57,7 +58,7 @@ func StorageUsersConfigFromStruct(cfg *config.Config) map[string]interface{} {
 					"tls-insecure":     cfg.Events.TLSInsecure,
 					"tls-root-ca-cert": cfg.Events.TLSRootCaCertPath,
 					"enable-tls":       cfg.Events.EnableTLS,
-					"name":             "storage-users-eventsmiddleware",
+					"name":             generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS),
 					"username":         cfg.Events.AuthUsername,
 					"password":         cfg.Events.AuthPassword,
 				},

--- a/services/userlog/pkg/command/server.go
+++ b/services/userlog/pkg/command/server.go
@@ -13,6 +13,7 @@ import (
 	microstore "go-micro.dev/v4/store"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/generators"
 	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	ogrpc "github.com/owncloud/ocis/v2/ocis-pkg/service/grpc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
@@ -78,7 +79,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
-			stream, err := stream.NatsFromConfig(cfg.Service.Name, false, stream.NatsConfig(cfg.Events))
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			stream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err
 			}

--- a/services/userlog/pkg/command/server.go
+++ b/services/userlog/pkg/command/server.go
@@ -79,7 +79,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
-			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTYPE_BUS)
+			connName := generators.GenerateConnectionName(cfg.Service.Name, generators.NTypeBus)
 			stream, err := stream.NatsFromConfig(connName, false, stream.NatsConfig(cfg.Events))
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Change the connection names according to the format `hostname:pid:service:type`

```
root@f0895c1d67d2:/# nats account report connections

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                  Top 24 Connections out of 24 by subs                                                                                 │
├─────┬──────────────────────────────┬──────────────────────────────────────────────────────────┬──────────────┬──────────────────┬─────────┬────────┬─────────┬──────────┬──────────┬───────────┬──────┤
│ CID │ Name                         │ Server                                                   │ Cluster      │ IP               │ Account │ Uptime │ In Msgs │ Out Msgs │ In Bytes │ Out Bytes │ Subs │
├─────┼──────────────────────────────┼──────────────────────────────────────────────────────────┼──────────────┼──────────────────┼─────────┼────────┼─────────┼──────────┼──────────┼───────────┼──────┤
│ 34  │ initial                      │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53014  │         │ 1m7s   │ 0       │ 0        │ 0 B      │ 0 B       │ 0    │
│ 46  │ f0895:13:proxy:bus           │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53024  │         │ 1m6s   │ 0       │ 0        │ 0 B      │ 0 B       │ 0    │
│ 64  │ f0895:13:sharing:bus         │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53086  │         │ 1m5s   │ 0       │ 0        │ 0 B      │ 0 B       │ 0    │
│ 63  │ f0895:13:storage-users:bus   │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53084  │         │ 1m5s   │ 0       │ 0        │ 0 B      │ 0 B       │ 0    │
│ 62  │ storageprovider              │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53080  │         │ 1m5s   │ 0       │ 0        │ 0 B      │ 0 B       │ 0    │
│ 52  │ sciencemesh-token-handler    │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53042  │         │ 1m6s   │ 0       │ 0        │ 0 B      │ 0 B       │ 0    │
│ 91  │ NATS CLI Version development │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53162  │         │ 0s     │ 1       │ 0        │ 254 B    │ 0 B       │ 1    │
│ 86  │ ffa64:1:_ocis:reg            │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 172.18.0.7:53946 │         │ 36s    │ 3       │ 3        │ 4.0 KiB  │ 1.1 KiB   │ 1    │
│ 51  │ f0895:13:_ocis:reg           │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53040  │         │ 1m6s   │ 4       │ 4        │ 1.5 KiB  │ 1.1 KiB   │ 1    │
│ 56  │ f0895:13:storage-users:bus   │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53064  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 49  │ f0895:13:sse:bus             │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53036  │         │ 1m6s   │ 3       │ 3        │ 283 B    │ 1.6 KiB   │ 2    │
│ 55  │ f0895:13:userlog:bus         │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53054  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 53  │ f0895:13:postprocessing:bus  │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53052  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 59  │ jsoncs3-share-manager        │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53076  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 61  │ dataprovider                 │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53082  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 50  │ f0895:13:graph:bus           │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53038  │         │ 1m6s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 54  │ f0895:13:eventhistory:bus    │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53056  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 47  │ f0895:13:clientlog:bus       │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53028  │         │ 1m6s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 67  │ f0895:13:notifications:bus   │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53100  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 68  │ f0895:13:frontend:bus        │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53102  │         │ 1m5s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 80  │ b27d7:1:_ocis:reg            │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 172.18.0.6:35196 │         │ 36s    │ 10      │ 122      │ 2.9 KiB  │ 79 KiB    │ 2    │
│ 85  │ ffa64:1:search:bus           │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 172.18.0.7:53944 │         │ 36s    │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 45  │ f0895:13:activitylog:bus     │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53026  │         │ 1m6s   │ 3       │ 3        │ 24 B     │ 1.6 KiB   │ 2    │
│ 35  │ f0895:13:_ocis:reg           │ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │ 127.0.0.1:53016  │         │ 1m7s   │ 123     │ 644      │ 102 KiB  │ 419 KiB   │ 6    │
├─────┼──────────────────────────────┼──────────────────────────────────────────────────────────┼──────────────┼──────────────────┼─────────┼────────┼─────────┼──────────┼──────────┼───────────┼──────┤
│     │ TOTALS FOR 24 CONNECTIONS    │                                                          │              │                  │         │        │ 180     │ 812      │ 111 KIB  │ 520 KIB   │ 37   │
╰─────┴──────────────────────────────┴──────────────────────────────────────────────────────────┴──────────────┴──────────────────┴─────────┴────────┴─────────┴──────────┴──────────┴───────────┴──────╯

╭───────────────────────────────────────────────────────────────────────────────────────╮
│                                 Connections per server                                │
├──────────────────────────────────────────────────────────┬──────────────┬─────────────┤
│ Server                                                   │ Cluster      │ Connections │
├──────────────────────────────────────────────────────────┼──────────────┼─────────────┤
│ NDGAWWVGUZNVZPI527FQBXUEEA73PCFLVNTB5LNO7773UKHQMAZJXHFS │ ocis-cluster │          24 │
╰──────────────────────────────────────────────────────────┴──────────────┴─────────────╯

```

There are some exceptions:
* Some reva services generate their own connections and ocis cannot change them:
  * storageprovider
  * sciencemesh-token-handler
  * jsoncs3-share-manager
  * dataprovider
* `initial` connection seems to come from https://github.com/owncloud/ocis/blob/626d78b8b0bf8e96be92fbfc663bd4cafbe4a11e/ocis/pkg/runtime/service/service.go#L523 . It needs further investigation, so no changes for now.
* There are no key-value / store connections. They're expected to be named with `TODO` according to https://github.com/cs3org/reva/blob/edge/pkg/store/store.go#L120-L138 , but they require reva changes in order to be able to change the name from ocis. We can't do anything about it for now.
* `NATS CLI Version development` can be ignored because it comes from the command line executing the actual command.

## Related Issue
https://github.com/owncloud/ocis/issues/9594

## Motivation and Context
It provides easier identification of which services or processes are accessing nats.

## How Has This Been Tested?
Manually tested on an idle environment using the "official" nats client with the command shown above

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

Note: there are 2 `f0895:13:_ocis:reg` connections when there should be only one. We need to check where the other one comes from.