### PR TITLE
[tests-only][full-ci] check share sync and role

### DIFF
--- a/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
+++ b/tests/acceptance/features/apiSharingNgShareInvitation/shareInvitations.feature
@@ -23,7 +23,6 @@ Feature: Send a sharing invitations
       | shareType       | user               |
       | permissionsRole | <permissions-role> |
     Then the HTTP status code should be "200"
-    And user "Brian" should have a share "<resource>" shared by user "Alice" from space "Personal"
     And the JSON data of the response should match
       """
       {
@@ -88,6 +87,10 @@ Feature: Send a sharing invitations
         }
       }
       """
+    And user "Brian" should have a share "<resource>" synced
+    And user "Brian" should have the following resource shares:
+      | resource   | permissionsRole    | sharer | space    |
+      | <resource> | <permissions-role> | Alice  | Personal |
     Examples:
       | permissions-role | resource       |
       | Viewer           | /textfile1.txt |


### PR DESCRIPTION
## Description
The flaky reported in https://github.com/owncloud/ocis/issues/11126 is probably due to the async server tasks. I have added a share sync check and also checked the shared role. The step that checks the sync status runs with retries until the timeout.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/11126

## Motivation and Context

## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
