### PR TITLE
feat: OCM, share notifications

### DIFF
--- a/changelog/unreleased/fix-ocm-share-notifications.md
+++ b/changelog/unreleased/fix-ocm-share-notifications.md
@@ -1,0 +1,6 @@
+Bugfix: OCM Share Notifications
+
+Fix no OCM sharing notifications, now share and unshare notifications are created
+
+https://github.com/owncloud/ocis/pull/11162
+https://github.com/owncloud/ocis/issues/11042

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/owncloud/ocis/v2
 
-go 1.22.7
+go 1.23.0
+
 toolchain go1.24.1
 
 require (
@@ -66,7 +67,7 @@ require (
 	github.com/open-policy-agent/opa v0.70.0
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20250217093259-fa3804be6c27
-	github.com/owncloud/reva/v2 v2.0.0-20250313103212-d8b4c329554a
+	github.com/owncloud/reva/v2 v2.0.0-20250331084351-00f64db78848
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.10
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -881,8 +881,8 @@ github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CF
 github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20250217093259-fa3804be6c27 h1:ID8s5lGBntmrlI6TbDAjTzRyHucn3bVM2wlW+HBplv4=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20250217093259-fa3804be6c27/go.mod h1:+gT+x62AS9u2Farh9wE2uYmgdvTg0MQgsSI62D+xoRg=
-github.com/owncloud/reva/v2 v2.0.0-20250313103212-d8b4c329554a h1:90QCmxi6n/GkcYbm+zw7Y4HrLcLzqN/ipFfNCOLw3TA=
-github.com/owncloud/reva/v2 v2.0.0-20250313103212-d8b4c329554a/go.mod h1:1QUFTq8Q2tjzwY3g+Y1dHIO4tPYqTovV6ScacW3sTPs=
+github.com/owncloud/reva/v2 v2.0.0-20250331084351-00f64db78848 h1:eWOevrc619bmhJwV9tzT3Ak1oFU9Nx9gufLFiCETN9Q=
+github.com/owncloud/reva/v2 v2.0.0-20250331084351-00f64db78848/go.mod h1:1QUFTq8Q2tjzwY3g+Y1dHIO4tPYqTovV6ScacW3sTPs=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.7 h1:1ii49dGBnRn0t1Sz7RGZS6/NberPEDQprwKHN49Bv6U=

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -168,6 +168,14 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 							"file": cfg.OCMCore.Drivers.JSON.File,
 						},
 					},
+					"events": map[string]interface{}{
+						"natsaddress":          cfg.Events.Endpoint,
+						"natsclusterid":        cfg.Events.Cluster,
+						"tlsinsecure":          cfg.Events.TLSInsecure,
+						"tlsrootcacertificate": cfg.Events.TLSRootCACertificate,
+						"authusername":         cfg.Events.AuthUsername,
+						"authpassword":         cfg.Events.AuthPassword,
+					},
 				},
 				"storageprovider": map[string]interface{}{
 					"driver": "ocmreceived",

--- a/services/userlog/pkg/command/server.go
+++ b/services/userlog/pkg/command/server.go
@@ -43,6 +43,8 @@ var _registeredEvents = []events.Unmarshaller{
 	events.ShareCreated{},
 	events.ShareRemoved{},
 	events.ShareExpired{},
+	events.OCMCoreShareCreated{},
+	events.OCMCoreShareDelete{},
 }
 
 // Server is the entrypoint for the server command.

--- a/services/userlog/pkg/service/filter.go
+++ b/services/userlog/pkg/service/filter.go
@@ -63,6 +63,10 @@ func (ulf userlogFilter) filterUsersBySettings(ctx context.Context, users []stri
 		settingId = defaults.SettingUUIDProfileEventSpaceDeleted
 	case events.PostprocessingStepFinished:
 		settingId = defaults.SettingUUIDProfileEventPostprocessingStepFinished
+	case events.OCMCoreShareCreated:
+		settingId = defaults.SettingUUIDProfileEventShareCreated
+	case events.OCMCoreShareDelete:
+		settingId = defaults.SettingUUIDProfileEventShareRemoved
 	default:
 		// event that cannot be disabled
 		return users

--- a/services/userlog/pkg/service/service.go
+++ b/services/userlog/pkg/service/service.go
@@ -183,8 +183,16 @@ func (ul *UserlogService) processEvent(event events.Event) {
 		users, err = utils.ResolveID(ctx, e.GranteeUserID, e.GranteeGroupID, gwc)
 	case events.ShareExpired:
 		users, err = utils.ResolveID(ctx, e.GranteeUserID, e.GranteeGroupID, gwc)
-	}
 
+	// ocmcore share related
+	case events.OCMCoreShareCreated:
+		executant = e.Sharer
+		users = append(users, e.GranteeUserID.GetOpaqueId())
+	case events.OCMCoreShareDelete:
+		fmt.Println("### userlog processEvent OCMCoreShareDelete", e.Sharer, e.Grantee)
+		executant = e.Sharer
+		users = append(users, e.Grantee.GetOpaqueId())
+	}
 	if err != nil {
 		// TODO: Find out why this errors on ci pipeline
 		ul.log.Debug().Err(err).Interface("event", event).Msg("error gathering members for event")

--- a/vendor/github.com/owncloud/reva/v2/pkg/events/ocmcore.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/events/ocmcore.go
@@ -44,3 +44,19 @@ func (OCMCoreShareCreated) Unmarshal(v []byte) (interface{}, error) {
 	err := json.Unmarshal(v, &e)
 	return e, err
 }
+
+// OCMCoreShareDelete is emitted when an ocm share is requested for delete
+type OCMCoreShareDelete struct {
+	ShareID      string
+	Sharer       *user.UserId
+	Grantee      *user.UserId
+	ResourceName string
+	CTime        *types.Timestamp
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (OCMCoreShareDelete) Unmarshal(v []byte) (interface{}, error) {
+	e := OCMCoreShareDelete{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1219,7 +1219,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20250217093259-fa3804be6c27
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20250313103212-d8b4c329554a
+# github.com/owncloud/reva/v2 v2.0.0-20250331084351-00f64db78848
 ## explicit; go 1.22.7
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
- Subscribe to OCM share events from rava: https://github.com/owncloud/reva/pull/255/files
- Convert to userlog notifications accessible via GET (and visible in web UI)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Resolves [#11042](https://github.com/owncloud/ocis/issues/11042)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- 2 instances: ocm and federated
1. start instances
2. invite federated instance
3. share and unshare directory in ocm instance
4.1. GET endpoint returns notifications
4.2. notice notifications in federated intance

```
curl "https://localhost:10200/ocs/v2.php/apps/notifications/api/v1/notifications?format=json" \
    -u admin:admin -k | jq

{
  "ocs": {
    "meta": {
      "message": "",
      "status": "",
      "statuscode": 200
    },
    "data": [
      {
        "notification_id": "d114d33a-330d-4b3e-8e61-3cc6f24f2dd4",
        "app": "userlog",
        "user": "Albert Einstein",
        "datetime": "2025-03-28T02:39:22.102308+01:00",
        "object_id": "b98bdca3-f011-46c0-8f10-cfccc7ad1b0e",
        "object_type": "share",
        "subject": "Resource shared",
        "subjectRich": "Resource shared",
        "message": "Albert Einstein shared a10 with you",
        "messageRich": "{user} shared {resource} with you",
        "messageRichParameters": {
          "share": {
            "id": "d5a54d1d-2f6a-40b5-992f-2ea30c4a2604"
          },
          "user": {
            "displayname": "Albert Einstein",
            "id": "NGM1MTBhZGEtYzg2Yi00ODE1LTg4MjAtNDJjZGY4MmMzZDUxQGh0dHBzOi8vbG9jYWxob3N0OjkyMDA=",
            "name": ""
          }
        }
      },
      {
        "notification_id": "f537dffe-de19-4308-97d0-1c32b01b588e",
        "app": "userlog",
        "user": "Albert Einstein",
        "datetime": "2025-03-28T02:39:30+01:00",
        "object_id": "b98bdca3-f011-46c0-8f10-cfccc7ad1b0e",
        "object_type": "share",
        "subject": "Resource unshared",
        "subjectRich": "Resource unshared",
        "message": "Albert Einstein unshared a10 with you",
        "messageRich": "{user} unshared {resource} with you",
        "messageRichParameters": {
          "share": {
            "id": "b98bdca3-f011-46c0-8f10-cfccc7ad1b0e"
          },
          "user": {
            "displayname": "Albert Einstein",
            "id": "NGM1MTBhZGEtYzg2Yi00ODE1LTg4MjAtNDJjZGY4MmMzZDUxQGh0dHBzOi8vbG9jYWxob3N0OjkyMDA=",
            "name": ""
          }
        }
      }
    ]
  }
}
```

## Screenshots (if appropriate):
<img width="712" alt="Screenshot 2025-03-28 at 02 39 54" src="https://github.com/user-attachments/assets/9f5e71f4-8127-4038-b35e-5015bd6341d7" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
