### PR TITLE
[tests-only][full-ci]ci: run k6 only for master branch nightly unless specified in PR title

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -3277,9 +3277,11 @@ def k6LoadTests(ctx):
     script_link = "%s/%s/tests/config/drone/run_k6_tests.sh" % (ocis_git_base_url, ctx.build.commit)
 
     event_array = ["cron"]
+    trigger_ref = ["refs/heads/master"]
 
     if "k6-test" in ctx.build.title.lower():
         event_array.append("pull_request")
+        trigger_ref.append("refs/pull/**")
 
     return [{
         "kind": "pipeline",
@@ -3332,6 +3334,7 @@ def k6LoadTests(ctx):
         "depends_on": [],
         "trigger": {
             "event": event_array,
+            "ref": trigger_ref,
         },
     }]
 


### PR DESCRIPTION
## Description
Currently, we are running k6 pipeline on both the master and stable branches' nightlies. Since the k6 test runner server is the same for both, the pipeline cannot pass.
Example builds:
- https://drone.owncloud.com/owncloud/ocis/44556/63/1
- https://drone.owncloud.com/owncloud/ocis/44557/67/1 

Run k6-tests daily basis for the master branch only. If `k6-test` is specified in the PR title, then the tests should run on the PR as well no matter the branch name. Meaning you can run k6 tests in other branches if necessary by adding `k6-test` in the PR title.

Only the nightly build of master branch will have the k6 pipeline running. This prevents the failures caused by the many k6 nightly pipelines running together.

## Related Issue
- resolves https://github.com/owncloud/ocis/issues/11141

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
