### PR TITLE
fix: app-auth, REST user not found code

### DIFF
--- a/changelog/unreleased/fix-app-auth-rest-status.md
+++ b/changelog/unreleased/fix-app-auth-rest-status.md
@@ -1,0 +1,6 @@
+Bugfix: Fix app-auth, REST status code
+
+Now app-auth REST returns status code 404 when creating token for non-existent user (Impersonation)
+
+https://github.com/owncloud/ocis/pull/11190
+https://github.com/owncloud/ocis/issues/10815


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Bugfix: Fix app-auth, REST status code when creating token for non-existent user (Impersonation)
Now app-auth REST returns status code 404 when creating token for non-existent user (Impersonation)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #10815

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: same as in the issue

```
➜  curl -kv -XPOST 'https://localhost:9200/auth-app/tokens?expiry=72h&userName=mosss' -uadmin:admin
* Host localhost:9200 was resolved.
...
* Server auth using Basic with user 'admin'
...
< HTTP/1.1 404 Not Found
< Content-Length: 15
< Content-Security-Policy: child-src 'self'; connect-src 'self' blob: https://raw.githubusercontent.com/owncloud/awesome-ocis/; default-src 'none'; font-src 'self'; frame-ancestors 'self'; frame-src 'self' blob: https://embed.diagrams.net/; img-src 'self' data: blob: https://raw.githubusercontent.com/owncloud/awesome-ocis/; manifest-src 'self'; media-src 'self'; object-src 'self' blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'
< Content-Type: text/plain; charset=utf-8
< Date: Tue, 01 Apr 2025 15:05:53 GMT
< Referrer-Policy: strict-origin-when-cross-origin
< Strict-Transport-Security: max-age=315360000; preload
< Vary: Origin
< X-Auth-App-Version: 7.1.2+3f4c3bee5fb
< X-Content-Type-Options: nosniff
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Permitted-Cross-Domain-Policies: none
< X-Request-Id: MacBookPro/XGhF2QoMH8-000021
< X-Robots-Tag: none
< X-Xss-Protection: 1; mode=block
<
user not found
* Connection #0 to host localhost left intact
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
