### PR TITLE
[tests-only][full-ci] add test to check oc:shareid on propfind response on the sharejail root

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -352,5 +352,10 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSharingNgShares/sharedByMe.feature:3320](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedByMe.feature#L3320)
 - [apiSharingNgShares/sharedByMe.feature:3868](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedByMe.feature#L3868)
 
+#### [Missing shareid on response of a PROPFIND on the sharejail root](https://github.com/owncloud/ocis/issues/8510)
+- [apiContract/propfindShares.feature:170](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L170)
+- [apiContract/propfindShares.feature:171](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L171)
+- [apiContract/propfindShares.feature:172](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L172)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiContract/propfindShares.feature
+++ b/tests/acceptance/features/apiContract/propfindShares.feature
@@ -147,3 +147,26 @@ Feature: propfind a shares
       | old              | %file_id_pattern%  |
       | new              | %file_id_pattern%  |
       | spaces           | %share_id_pattern% |
+
+  @issue-8510
+  Scenario Outline: check share-id from PROPFIND request to shared items
+    Given using <dav-path-version> DAV path
+    And using SharingNG
+    And user "Alice" has uploaded file with content "some content" to "testfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    And user "Brian" has a share "testfile.txt" synced
+    When user "Brian" sends PROPFIND request from the space "Shares" to the resource "/" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Brian" the PROPFIND response should contain a resource "testfile.txt" with these key and value pairs:
+      | key        | value           |
+      | oc:shareid | %last_share_id% |
+    Examples:
+      | dav-path-version |
+      | old              |
+      | new              |
+      | spaces           |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added test to check `oc:shareid` on propfind response on the sharejail root.

Current, behavior using `spaces` dav path the `oc:shareid` property is empty and for `old` and `new` dav paths the `oc:shareid` property is not available in the response.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/10830
- Bug report: https://github.com/owncloud/ocis/issues/8510

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
