### PR TITLE
[full-ci] fix: test, file postprocessing flakyness

### DIFF
--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -3029,4 +3029,15 @@ class FeatureContext extends BehatVariablesContext {
 		}
 		return false;
 	}
+
+	/**
+	 * @Given the system waits for :arg1 seconds
+	 *
+	 * @param string $seconds
+	 *
+	 * @return void
+	 */
+	public function theSystemWaitsForSeconds(string $seconds): void {
+		\sleep((int)$seconds);
+	}
 }

--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -29,6 +29,7 @@ Feature: List upload sessions via CLI command
       | ANTIVIRUS_INFECTED_FILE_HANDLING | abort     |
     And user "Alice" has uploaded file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt"
     And the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And the system waits for "5" seconds
     And user "Alice" has uploaded file with content "uploaded content" to "/file1.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/file2.txt"
     When the administrator lists all the upload sessions with flag "processing"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->


Hypothesis:
- The file post processing logic for virusscan seems correct. Test seems to have correct expectations.
- The reason for random fails can be timing of results propagation.
- The is some small wait time added after requests 

Potential fix:
 - explicitly wait a bit longer for the processing results to propagate, there is 10s window set with delay

Test CI output spotted in https://drone.owncloud.com/owncloud/ocis/44766/37/10
```
Scenario: list all upload sessions that are currently in postprocessing                            # /drone/src/tests/acceptance/features/cliCommands/uploadSessions.feature:25
    Given the following configs have been set:                                                       # OcisConfigContext::theConfigHasBeenSetToValue()
      | config                           | value     |
      | POSTPROCESSING_STEPS             | virusscan |
      | ANTIVIRUS_INFECTED_FILE_HANDLING | abort     |
    And user "Alice" has uploaded file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt" # FeatureContext::userHasUploadedAFileTo()
    And the config "POSTPROCESSING_DELAY" has been set to "10s"                                      # OcisConfigContext::theConfigHasBeenSetTo()
    And user "Alice" has uploaded file with content "uploaded content" to "/file1.txt"               # FeatureContext::userHasUploadedAFileWithContentTo()
    And user "Alice" has uploaded file with content "uploaded content" to "/file2.txt"               # FeatureContext::userHasUploadedAFileWithContentTo()
    When the administrator lists all the upload sessions with flag "processing"                      # CliContext::theAdministratorListsAllTheUploadSessions()
    Then the command should be successful                                                            # CliContext::theCommandShouldBeSuccessful()
    And the CLI response should contain these entries:                                               # CliContext::theCLIResponseShouldContainTheseEntries()
      | file1.txt |
      | file2.txt |
    And the CLI response should not contain these entries:                                           # CliContext::theCLIResponseShouldContainTheseEntries()
      | virusFile.txt |
      The resource 'virusFile.txt' was found in the response.
      Failed asserting that true is not true.
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Test CI output spotted in https://drone.owncloud.com/owncloud/ocis/44766/37/10

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
