### PR TITLE
[full-ci] fix: test, handler flakyness 

### DIFF
--- a/tests/ociswrapper/wrapper/handlers/handler.go
+++ b/tests/ociswrapper/wrapper/handlers/handler.go
@@ -210,7 +210,6 @@ func OcisServiceHandler(res http.ResponseWriter, req *http.Request) {
 	serviceName := req.PathValue("service")
 
     var envBody map[string]interface{}
-    var serviceEnvMap []string
 
 	if req.Body != nil && req.ContentLength > 0 {
 		var err error
@@ -223,7 +222,7 @@ func OcisServiceHandler(res http.ResponseWriter, req *http.Request) {
 
 	if req.Method == http.MethodPost {
 		for key, value := range envBody {
-			ocis.ServiceEnvConfigs[serviceName] = append(serviceEnvMap, fmt.Sprintf("%s=%v", key, value))
+			ocis.ServiceEnvConfigs[serviceName] = append(ocis.ServiceEnvConfigs[serviceName], fmt.Sprintf("%s=%v", key, value))
 			if strings.HasSuffix(key, "DEBUG_ADDR") {
 				address := strings.Split(value.(string), ":")
 				port, _ := strconv.Atoi(address[1])
@@ -254,6 +253,7 @@ func OcisServiceHandler(res http.ResponseWriter, req *http.Request) {
 	} else if req.Method == http.MethodPatch {
 		success, message := ocis.StopService(serviceName)
 		if success {
+			var serviceEnvMap []string
 			for key, value := range envBody {
 				serviceEnvMap = append(serviceEnvMap, fmt.Sprintf("%s=%v", key, value))
 				if strings.HasSuffix(key, "DEBUG_ADDR") {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

Hypothesis:
- In handler Post: service was started with ocis.ServiceEnvConfigs containing only last env key-value
- In test: possible that test was ok when server was started with default config due to timing

Potential fix:
 - use ocis.ServiceEnvConfigs in MethodPost to persist the env config and scope serviceEnvMap only to MethodPatch
 
 Note:
  - ~~the timing issue may still not be fixed properly - haven't found it yet.~~
  - by using persistant ocis.ServiceEnvConfigs[serviceName] the env variables persist correctly across the requests

Found in: https://drone.owncloud.com/owncloud/ocis/44783/20/6
```
 @env-config
  Scenario: check services health and readiness while running separately                     # /drone/src/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature:142
    Given the following configs have been set:                                               # OcisConfigContext::theConfigHasBeenSetToValue()
      | config                    | value |
      | OCIS_EXCLUDE_RUN_SERVICES | audit |
    And the administrator has started service "audit" separately with the following configs: # OcisConfigContext::theAdministratorHasStartedServiceSeparatelyWithTheFollowingConfig()
      | config           | value        |
      | OCIS_LOG_LEVEL   | info         |
      | AUDIT_DEBUG_ADDR | 0.0.0.0:9229 |
    When a user requests these URLs with "GET" and no authentication                         # AuthContext::aUserRequestsTheseUrlsWithAndNoAuthentication()
      | endpoint                                | service |
      | http://%base_url_hostname%:9229/healthz | audit   |
      | http://%base_url_hostname%:9229/readyz  | audit   |
      cURL error 7: Failed to connect to ocis-server port 9229: Connection refused (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://ocis-server:9229/healthz (GuzzleHttp\Exception\ConnectException)
    Then the HTTP status code of responses on all endpoints should be "200"                  # FeatureContext::theHTTPStatusCodeOfResponsesOnAllEndpointsShouldBe()

```
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Found in: https://drone.owncloud.com/owncloud/ocis/44783/20/6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
