### PR TITLE
[tests-only][full-ci]added test to check share-types property by sharer after sharee is deleted

### DIFF
--- a/tests/acceptance/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/bootstrap/WebDavPropertiesContext.php
@@ -515,9 +515,10 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
-	 * @Then the single response should contain a property :property with a child property :childProperty
+	 * @Then /^the single response should contain a property "([^"]*)" (with|without) a child property "([^"]*)"$/
 	 *
 	 * @param string $property
+	 * @param string $withOrWithout
 	 * @param string $childProperty
 	 *
 	 * @return void
@@ -526,15 +527,23 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function theSingleResponseShouldContainAPropertyWithChildProperty(
 		string $property,
+		string $withOrWithout,
 		string $childProperty
 	): void {
 		$xmlPart = HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath(
 			"//d:prop/$property/$childProperty"
 		);
-		Assert::assertTrue(
-			isset($xmlPart[0]),
-			"Cannot find property \"$property/$childProperty\""
-		);
+		if ($withOrWithout === "with") {
+			Assert::assertTrue(
+				isset($xmlPart[0]),
+				"Cannot find property \"$property/$childProperty\""
+			);
+		} else {
+			Assert::assertFalse(
+				isset($xmlPart[0]),
+				"Found property \"$property/$childProperty\""
+			);
+		}
 	}
 
 	/**

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -357,5 +357,15 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiContract/propfindShares.feature:171](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L171)
 - [apiContract/propfindShares.feature:172](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L172)
 
+#### [PROPFIND request to resource shared with user when deleted retains it's <oc:share-type> property](https://github.com/owncloud/ocis/issues/9463)
+- [apiContract/propfindShares.feature:194](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L194)
+- [apiContract/propfindShares.feature:195](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L195)
+- [apiContract/propfindShares.feature:196](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L196)
+- [apiContract/propfindShares.feature:197](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L197)
+- [apiContract/propfindShares.feature:198](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L198)
+- [apiContract/propfindShares.feature:199](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L199)
+- [apiContract/propfindShares.feature:223](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L223)
+- [apiContract/propfindShares.feature:224](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L224)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiContract/propfindShares.feature
+++ b/tests/acceptance/features/apiContract/propfindShares.feature
@@ -170,3 +170,55 @@ Feature: propfind a shares
       | old              |
       | new              |
       | spaces           |
+
+  @issue-9463
+  Scenario Outline: sharer checks share-types property after sharee is deleted (Personal Space)
+    Given using <dav-path-version> DAV path
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "some content" to "testfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource> |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    And user "Brian" has a share "<resource>" synced
+    And the user "Admin" has deleted a user "Brian"
+    When user "Alice" gets the following properties of resource "<resource>" inside space "Personal" using the WebDAV API
+      | propertyName   |
+      | oc:share-types |
+    Then the HTTP status code should be "207"
+    And the single response should contain a property "oc:share-types" without a child property "oc:share-type"
+    Examples:
+      | dav-path-version | resource      |
+      | old              | folderToShare |
+      | old              | testfile.txt  |
+      | new              | folderToShare |
+      | new              | testfile.txt  |
+      | spaces           | folderToShare |
+      | spaces           | testfile.txt  |
+
+  @issue-9463
+  Scenario Outline: sharer checks share-types property after sharee is deleted (Project Space)
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
+    And user "Alice" has created a folder "folderToShare" in space "NewSpace"
+    And user "Alice" has uploaded a file inside space "NewSpace" with content "some content" to "testfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | <resource> |
+      | space           | NewSpace   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    And user "Brian" has a share "<resource>" synced
+    And the user "Admin" has deleted a user "Brian"
+    When user "Alice" gets the following properties of resource "<resource>" inside space "NewSpace" using the WebDAV API
+      | propertyName   |
+      | oc:share-types |
+    Then the HTTP status code should be "207"
+    And the single response should contain a property "oc:share-types" without a child property "oc:share-type"
+    Examples:
+      | resource      |
+      | folderToShare |
+      | testfile.txt  |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Added test to check `oc:share-types` property by sharer after the sharee is deleted.

The current behavior contains `<oc:share-types><oc:share-type>0</oc:share-type></oc:share-types>` in the response.
The `oc:share-types` property should be empty after the sharee is deleted.

#### Expected response
```xml
<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
    <d:response>
        <d:href>/remote.php/dav/spaces/a9439309-d04d-4855-8e66-aade543fa429$78d13b96-8de1-4dfa-8886-c932831e6c04/testFolder/</d:href>
        <d:propstat>
            <d:prop>
                <oc:share-types></oc:share-types>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/10830
- Bug report: https://github.com/owncloud/ocis/issues/9463

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
