### PR TITLE
feat: userlog, delete notification by id

### DIFF
--- a/changelog/unreleased/update-delete-notification-by-id.md
+++ b/changelog/unreleased/update-delete-notification-by-id.md
@@ -1,0 +1,7 @@
+Enhancement: Delete notification by ID
+
+It is possible now to delete single notification by ID:
+DELETE /ocs/v2.php/apps/notifications/api/v1/notifications/:id
+
+https://github.com/owncloud/ocis/pull/11203
+https://github.com/owncloud/enterprise/issues/6307

--- a/changelog/unreleased/update-delete-notification-by-id.md
+++ b/changelog/unreleased/update-delete-notification-by-id.md
@@ -1,6 +1,6 @@
 Enhancement: Delete notification by ID
 
-It is possible now to delete single notification by ID:
+It is now possible to delete a single notification by ID:
 DELETE /ocs/v2.php/apps/notifications/api/v1/notifications/:id
 
 https://github.com/owncloud/ocis/pull/11203

--- a/services/userlog/pkg/service/service.go
+++ b/services/userlog/pkg/service/service.go
@@ -87,6 +87,7 @@ func NewUserlogService(opts ...Option) (*UserlogService, error) {
 	ul.m.Route("/ocs/v2.php/apps/notifications/api/v1/notifications", func(r chi.Router) {
 		r.Get("/", ul.HandleGetEvents)
 		r.Delete("/", ul.HandleDeleteEvents)
+		r.Delete("/{id}", ul.HandleDeleteEvent)
 		r.Post("/global", RequireAdminOrSecret(&m, o.Config.GlobalNotificationsSecret)(ul.HandlePostGlobalEvent))
 		r.Delete("/global", RequireAdminOrSecret(&m, o.Config.GlobalNotificationsSecret)(ul.HandleDeleteGlobalEvent))
 	})


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

Ocis shall implement the oc10 delete request for single notifications.
Bulk operation must be done via the ocis style delete request with json body.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes [https://github.com/owncloud/enterprise/issues/6307](https://github.com/owncloud/enterprise/issues/6307)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local test

### Web client: admin created folders a1, a2 and shared them with einstein

List einstein notifications
```bash
curl "https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications?format=json" -u einstein:relativity -k | jq
200 OK
{
  "ocs": {
    "meta": {
      "message": "",
      "status": "",
      "statuscode": 200
    },
    "data": [
      {
        "notification_id": "6b24e986-3cb1-42ef-9e81-3d186eb5a9ae",
        "app": "userlog",
        "user": "admin",
        "datetime": "2025-04-03T11:47:19.023043+02:00",
        "object_id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!0f3a9b09-a6c3-4db2-a7d7-315e211fb809",
        "object_type": "share",
        "subject": "Resource shared",
        "subjectRich": "Resource shared",
        "message": "Admin shared a1 with you",
        "messageRich": "{user} shared {resource} with you",
        "messageRichParameters": {
          "resource": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!0f3a9b09-a6c3-4db2-a7d7-315e211fb809",
            "name": "a1"
          },
          "share": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a:3f2367f5-3749-4b22-a77b-c55a1ee740a3:21315d9e-1f3c-48df-b225-1ad27e3ef40a"
          },
          "user": {
            "displayname": "Admin",
            "id": "3f2367f5-3749-4b22-a77b-c55a1ee740a3",
            "name": "admin"
          }
        }
      },
      {
        "notification_id": "618e019b-25e4-4464-81b7-9b8d9856875c",
        "app": "userlog",
        "user": "admin",
        "datetime": "2025-04-03T11:47:25.118661+02:00",
        "object_id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!23e3227b-6023-4e72-b2c6-c3d3ccbf15df",
        "object_type": "share",
        "subject": "Resource shared",
        "subjectRich": "Resource shared",
        "message": "Admin shared a2 with you",
        "messageRich": "{user} shared {resource} with you",
        "messageRichParameters": {
          "resource": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!23e3227b-6023-4e72-b2c6-c3d3ccbf15df",
            "name": "a2"
          },
          "share": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a:3f2367f5-3749-4b22-a77b-c55a1ee740a3:47c6236c-6b05-46e1-b84e-1d78fb518e41"
          },
          "user": {
            "displayname": "Admin",
            "id": "3f2367f5-3749-4b22-a77b-c55a1ee740a3",
            "name": "admin"
          }
        }
      }
    ]
  }
}
```

### Einstein deletes a1 notification
```bash
curl -X DELETE 'https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/6b24e986-3cb1-42ef-9e81-3d186eb5a9ae' \
  -u einstein:relativity -k | jq
 200 OK
```

List einstein's notifications: a2
```bash
curl 'https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications?format=json' -u einstein:relativity -kv
200 OK
{
  "ocs": {
    "meta": {
      "message": "",
      "status": "",
      "statuscode": 200
    },
    "data": [
      {
        "notification_id": "618e019b-25e4-4464-81b7-9b8d9856875c",
        "app": "userlog",
        "user": "admin",
        "datetime": "2025-04-03T11:47:25.118661+02:00",
        "object_id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!23e3227b-6023-4e72-b2c6-c3d3ccbf15df",
        "object_type": "share",
        "subject": "Resource shared",
        "subjectRich": "Resource shared",
        "message": "Admin shared a2 with you",
        "messageRich": "{user} shared {resource} with you",
        "messageRichParameters": {
          "resource": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!23e3227b-6023-4e72-b2c6-c3d3ccbf15df",
            "name": "a2"
          },
          "share": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a:3f2367f5-3749-4b22-a77b-c55a1ee740a3:47c6236c-6b05-46e1-b84e-1d78fb518e41"
          },
          "user": {
            "displayname": "Admin",
            "id": "3f2367f5-3749-4b22-a77b-c55a1ee740a3",
            "name": "admin"
          }
        }
      }
    ]
  }
}
```

### Edge cases
Edge case: try to delete notification without auth
```bash
curl -X DELETE https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/618e019b-25e4-4464-81b7-9b8d9856875c -kv
...
> DELETE /ocs/v2.php/apps/notifications/api/v1/notifications/618e019b-25e4-4464-81b7-9b8d9856875c HTTP/1.1
...
< HTTP/1.1 401 Unauthorized
```

Edge case: no notification id
```bash
curl -X DELETE 'https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/' -kv -u einstein:relativity
...
* Server auth using Basic with user 'einstein'
> DELETE /ocs/v2.php/apps/notifications/api/v1/notifications/ HTTP/1.1
...
< HTTP/1.1 400 Bad Request
```

Edge case: try to delete non-existent notification
Now OK 200, `func (ul *UserlogService) DeleteEvents(userid string, evids []string) error` would need to detect that the event does not exist.
```bash
curl -X DELETE https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/non-existent-id -u einstein:relativity -kv
...
* Server auth using Basic with user 'einstein'
> DELETE /ocs/v2.php/apps/notifications/api/v1/notifications/non-existent-id HTTP/1.1
...
< HTTP/1.1 200 OK
```

Edge case: admin tries to delete einstein's notification
Now OK 200, `func (ul *UserlogService) DeleteEvents(userid string, evids []string) error` would need to detect that the event does not exist.
```bash
curl -X DELETE https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications/618e019b-25e4-4464-81b7-9b8d9856875c -u admin:admin -kv
...
* Server auth using Basic with user 'admin'
> DELETE /ocs/v2.php/apps/notifications/api/v1/notifications/618e019b-25e4-4464-81b7-9b8d9856875c HTTP/1.1
...
< HTTP/1.1 200 OK
```

Verify notifications still exist
```bash
curl 'https://localhost:9200/ocs/v2.php/apps/notifications/api/v1/notifications?format=json' -u einstein:relativity -kv
200 OK
{
  "ocs": {
    "meta": {
      "message": "",
      "status": "",
      "statuscode": 200
    },
    "data": [
      {
        "notification_id": "618e019b-25e4-4464-81b7-9b8d9856875c",
        "app": "userlog",
        "user": "admin",
        "datetime": "2025-04-03T11:47:25.118661+02:00",
        "object_id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!23e3227b-6023-4e72-b2c6-c3d3ccbf15df",
        "object_type": "share",
        "subject": "Resource shared",
        "subjectRich": "Resource shared",
        "message": "Admin shared a2 with you",
        "messageRich": "{user} shared {resource} with you",
        "messageRichParameters": {
          "resource": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a$3f2367f5-3749-4b22-a77b-c55a1ee740a3!23e3227b-6023-4e72-b2c6-c3d3ccbf15df",
            "name": "a2"
          },
          "share": {
            "id": "f44f9f18-2f57-4213-a82b-0795357bf74a:3f2367f5-3749-4b22-a77b-c55a1ee740a3:47c6236c-6b05-46e1-b84e-1d78fb518e41"
          },
          "user": {
            "displayname": "Admin",
            "id": "3f2367f5-3749-4b22-a77b-c55a1ee740a3",
            "name": "admin"
          }
        }
      }
    ]
  }
}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
