### PR TITLE
[tests-only][full-ci]Add test cases to validate JSON response for shared resource activity listing (list grant roles)

### DIFF
--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -2934,7 +2934,11 @@ class GraphContext implements Context {
 		string $resource,
 		string $spaceName
 	): void {
-		$resourceId = $this->spacesContext->getResourceId($user, $spaceName, $resource);
+		if ($spaceName === "Shares") {
+			$resourceId = $this->spacesContext->getSharesRemoteItemId($user, $resource);
+		} else {
+			$resourceId = $this->spacesContext->getResourceId($user, $spaceName, $resource);
+		}
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getStepLineRef(),


### PR DESCRIPTION
## Description
This PR only adds one scenario which checks JSON response of the share received resource. Other activities related tests cases will be covered in next PR without using JSON scheme 

## Related Issue
- https://github.com/owncloud/ocis/issues/10951

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
