### PR TITLE
[tests-only][full-ci] Add test to receive an email notification when space membership expire

### DIFF
--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -284,7 +284,6 @@ Feature: Notification
       | sharee             | Brian                    |
       | shareType          | user                     |
       | permissionsRole    | Space Viewer             |
-      | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" has expired the membership of user "Brian" from space "new-space"
     Then user "Brian" should have received the following email from user "Alice" about the share of project space "new-space"
       """

--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -274,3 +274,23 @@ Feature: Notification
 
       Zum Ansehen hier klicken: %base_url%/f/%space_id%
       """
+
+  @email @issue-10882
+  Scenario: user gets an email notification when space membership expires
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has sent the following space share invitation:
+      | space              | new-space                |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
+      | permissionsRole    | Space Viewer             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
+    When user "Alice" has expired the membership of user "Brian" from space "new-space"
+    Then user "Brian" should have received the following email from user "Alice" about the share of project space "new-space"
+      """
+      Hello Brian Murphy,
+
+      Your membership of space new-space has expired at %expiry_date_in_mail%
+
+      Even though this membership has expired you still might have access through other shares and/or space memberships
+      """

--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -276,7 +276,7 @@ Feature: Notification
       """
 
   @issue-10882 @email
-  Scenario: user gets an email notification when space membership expires
+  Scenario: user gets in-app and email notifications when space membership expires
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" has sent the following space share invitation:
@@ -286,65 +286,14 @@ Feature: Notification
       | permissionsRole    | Space Viewer             |
     When user "Alice" has expired the membership of user "Brian" from space "new-space"
     Then the HTTP status code should be "200"
-    # And user "Brian" should have received the following email from user "Alice" about the share of project space "new-space"
-    #   """
-    #   Hello Brian Murphy,
-
-    #   Your membership of space new-space has expired at %expiry_date_in_mail%
-
-    #   Even though this membership has expired you still might have access through other shares and/or space memberships
-    #   """
-    And the JSON response should contain a notification message with the subject "Neue Freigabe" and the message-details should match
+    And user "Brian" should get a notification with subject "Membership expired" and message:
+      | message                        |
+      | Access to Space new-space lost |
+    And user "Brian" should have received the following email from user "Alice" about the share of project space "new-space"
       """
-      {
-      "type": "object",
-        "required": [
-          "app",
-          "datetime",
-          "message",
-          "messageRich",
-          "messageRichParameters",
-          "notification_id",
-          "object_id",
-          "object_type",
-          "subject",
-          "subjectRich",
-          "user"
-        ],
-        "properties": {
-          "app": {"const": "userlog"},
-          "message": {"const": "Alice Hansen shared <resource> with you"},
-          "messageRich": {"const": "{user} shared {resource} with you"},
-          "messageRichParameters": {
-            "type": "object",
-            "required": ["resource","user"],
-            "properties": {
-              "resource": {
-                "type": "object",
-                "required": ["id","name"],
-                "properties": {
-                  "id": {"pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\\$[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}![a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"},
-                  "name": {"const": "<resource>"}
-                }
-              },
-              "user": {
-                "type": "object",
-                "required": ["displayname","id","name"],
-                "properties": {
-                  "displayname": {"const": "Alice Hansen"},
-                  "id": {"pattern": "^%user_id_pattern%$"},
-                  "name": {"const": "Alice"}
-                }
-              }
-            }
-          },
-          "notification_id": {"type": "string"},
-          "object_id": {"type": "string"},
-          "object_type": {"const": "share"},
-          "subject": {"const": "Resource shared"},
-          "subjectRich": {"const": "Resource shared"},
-          "user": {"const": "Alice"}
-        }
-      }
+      Hello Brian Murphy,
+
+      Your membership of space new-space has expired at %expiry_date_in_mail%
+
+      Even though this membership has expired you still might have access through other shares and/or space memberships
       """
-      

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -191,10 +191,10 @@ Feature: Space management
   Scenario: user gets an email notification when space membership expires
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" shares a space "new-space" with settings:
-      | shareWith          | Brian                    |
+    And user "Alice" has sent the following space share invitation:
       | space              | new-space                |
-      | role               | viewer                   |
+      | sharee             | Brian                    |
+      | shareType          | user                     |
       | permissionsRole    | Space Viewer             |
       | expirationDateTime | 2042-03-25T23:59:59.000Z |
     When user "Alice" has expired the membership of user "Brian" from space "new-space"

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -186,24 +186,3 @@ Feature: Space management
     When user "Carol" tries to restore a disabled space "Project" owned by user "Alice"
     Then the HTTP status code should be "404"
     And the user "Alice" should have a space "Project" in the disable state
-
-  @issue-10882
-  Scenario: user gets an email notification when space membership expires
-    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
-    And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has sent the following space share invitation:
-      | space              | new-space                |
-      | sharee             | Brian                    |
-      | shareType          | user                     |
-      | permissionsRole    | Space Viewer             |
-      | expirationDateTime | 2042-03-25T23:59:59.000Z |
-    When user "Alice" has expired the membership of user "Brian" from space "new-space"
-    Then user "Brian" should have received the following email from user "Alice" about the share of project space "new-space"
-      """
-      Hello Brian Murphy,
-
-      Your membership of space new-space has expired at %expiry_date_in_mail%
-
-      Even though this membership has expired you still might have access through other shares and/or space memberships
-      """
-

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -188,7 +188,7 @@ Feature: Space management
     And the user "Alice" should have a space "Project" in the disable state
 
   @issue-10882
-  Scenario: user gets an email notification when space membership expire
+  Scenario: user gets an email notification when space membership expires
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
     And user "Alice" shares a space "new-space" with settings:

--- a/tests/acceptance/features/apiSpaces/spaceManagement.feature
+++ b/tests/acceptance/features/apiSpaces/spaceManagement.feature
@@ -186,3 +186,24 @@ Feature: Space management
     When user "Carol" tries to restore a disabled space "Project" owned by user "Alice"
     Then the HTTP status code should be "404"
     And the user "Alice" should have a space "Project" in the disable state
+
+  @issue-10882
+  Scenario: user gets an email notification when space membership expire
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" shares a space "new-space" with settings:
+      | shareWith          | Brian                    |
+      | space              | new-space                |
+      | role               | viewer                   |
+      | permissionsRole    | Space Viewer             |
+      | expirationDateTime | 2042-03-25T23:59:59.000Z |
+    When user "Alice" has expired the membership of user "Brian" from space "new-space"
+    Then user "Brian" should have received the following email from user "Alice" about the share of project space "new-space"
+      """
+      Hello Brian Murphy,
+
+      Your membership of space new-space has expired at %expiry_date_in_mail%
+
+      Even though this membership has expired you still might have access through other shares and/or space memberships
+      """
+


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds only one scenario to check if an user receives an email notification when the space membership expire. 

## Related Issue
- https://github.com/owncloud/ocis/issues/10882
- https://github.com/owncloud/ocis/issues/10937

## Motivation and Context

## How Has This Been Tested?
- Locally

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
