### PR TITLE
[tests-only][full-ci]added test to download archive of folder shared with Secure Viewer role

### DIFF
--- a/tests/acceptance/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/bootstrap/ArchiverContext.php
@@ -228,6 +228,7 @@ class ArchiverContext implements Context {
 
 	/**
 	 * @When user :user downloads the archive of these items using the resource :addressType
+	 * @When user :user tries to download the archive of these items using the resource :addressType
 	 *
 	 * @param string $user
 	 * @param string $addressType ids|paths

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -357,6 +357,10 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiContract/propfindShares.feature:171](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L171)
 - [apiContract/propfindShares.feature:172](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L172)
 
+#### [Folder shared with Secure view can be downloaded.](https://github.com/owncloud/ocis/issues/9369)
+- [apiSpacesShares/shareOperations.feature:488](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareOperations.feature#L488)
+- [apiSpacesShares/shareOperations.feature:503](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/shareOperations.feature#L503)
+
 #### [PROPFIND request to resource shared with user when deleted retains it's <oc:share-type> property](https://github.com/owncloud/ocis/issues/9463)
 - [apiContract/propfindShares.feature:194](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L194)
 - [apiContract/propfindShares.feature:195](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L195)

--- a/tests/acceptance/features/apiSpacesShares/shareOperations.feature
+++ b/tests/acceptance/features/apiSpacesShares/shareOperations.feature
@@ -483,3 +483,34 @@ Feature: sharing
       | ocs-api-version | ocs-status-code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @issue-9369 @env-config
+  Scenario: sharee cannot download empty folder shared with Secure Viewer permission
+    Given the administrator has enabled the permissions role "Secure Viewer"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And user "Brian" has a share "folderToShare" synced
+    When user "Brian" tries to download the archive of these items using the resource ids
+      | Shares/folderToShare |
+    Then the HTTP status code should be "403"
+
+  @issue-9369 @env-config
+  Scenario: sharee cannot download non-empty folder shared with Secure Viewer permission
+    Given the administrator has enabled the permissions role "Secure Viewer"
+    And user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "some content" to "folderToShare/testfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | folderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Secure Viewer |
+    And user "Brian" has a share "folderToShare" synced
+    When user "Brian" tries to download the archive of these items using the resource ids
+      | Shares/folderToShare |
+    Then the HTTP status code should be "403"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds test for share receiver trying to download the folder shared with Secure Viewer role.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/10830
- Bug Report: https://github.com/owncloud/ocis/issues/9369

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
