### PR TITLE
[full-ci][tests-only] chore: port skip k6 and web bump

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=fcad45acafde55a14c2b285bd4a373e113893bb7
+WEB_COMMITID=23f03afdfd592a6300e72477d8d52c6b00d98ca6
 WEB_BRANCH=stable-11.0-correct

--- a/.drone.star
+++ b/.drone.star
@@ -3250,9 +3250,11 @@ def k6LoadTests(ctx):
     script_link = "%s/%s/tests/config/drone/run_k6_tests.sh" % (ocis_git_base_url, ctx.build.commit)
 
     event_array = ["cron"]
+    trigger_ref = ["refs/heads/master"]
 
     if "k6-test" in ctx.build.title.lower():
         event_array.append("pull_request")
+        trigger_ref.append("refs/pull/**")
 
     return [{
         "kind": "pipeline",
@@ -3305,6 +3307,7 @@ def k6LoadTests(ctx):
         "depends_on": [],
         "trigger": {
             "event": event_array,
+            "ref": trigger_ref,
         },
     }]
 


### PR DESCRIPTION
## Description
Port PR https://github.com/owncloud/ocis/pull/11172 and bump web commit id

## Related Issue
Part of https://github.com/owncloud/web/issues/12436

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
