### PR TITLE
[tests-only] test: rename step name

### DIFF
--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -2331,7 +2331,7 @@ class SharingNgContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should have the following shares of the (?:folder|file) "([^"]*)":$/
+	 * @Then for user :user file/folder :resource should have the following shares:
 	 *
 	 * @param string $user
 	 * @param string $resource

--- a/tests/acceptance/features/apiSharingNgAdditionalShareRole/listGrantsShareRole.feature
+++ b/tests/acceptance/features/apiSharingNgAdditionalShareRole/listGrantsShareRole.feature
@@ -62,7 +62,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the file "textfile1.txt":
+    And for user "Brian" file "textfile1.txt" should have the following shares:
       | sharee | shareType | permissionsRole    |
       | Brian  | user      | <permissions-role> |
     Examples:
@@ -122,7 +122,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the folder "FolderToShare":
+    And for user "Brian" folder "FolderToShare" should have the following shares:
       | sharee | shareType | permissionsRole    |
       | Brian  | user      | <permissions-role> |
     Examples:
@@ -185,7 +185,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the file "textfile1.txt":
+    And for user "Brian" file "textfile1.txt" should have the following shares:
       | sharee | shareType | permissionsRole    |
       | Brian  | user      | <permissions-role> |
     Examples:
@@ -248,7 +248,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the folder "FolderToShare":
+    And for user "Brian" folder "FolderToShare" should have the following shares:
       | sharee | shareType | permissionsRole    |
       | Brian  | user      | <permissions-role> |
     Examples:
@@ -301,7 +301,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the file "textfile1.txt":
+    And for user "Brian" file "textfile1.txt" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -356,7 +356,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the folder "FolderToShare":
+    And for user "Brian" folder "FolderToShare" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -416,7 +416,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the file "textfile1.txt":
+    And for user "Brian" file "textfile1.txt" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -474,7 +474,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the folder "FolderToShare":
+    And for user "Brian" folder "FolderToShare" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -531,7 +531,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the file "textfile1.txt":
+    And for user "Brian" file "textfile1.txt" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -586,7 +586,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the folder "FolderToShare":
+    And for user "Brian" folder "FolderToShare" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -646,7 +646,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the file "textfile1.txt":
+    And for user "Brian" file "textfile1.txt" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -704,7 +704,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the folder "FolderToShare":
+    And for user "Brian" folder "FolderToShare" should have the following shares:
       | sharee | shareType | permissionsRole        |
       | Brian  | user      | <new-permissions-role> |
     Examples:
@@ -1302,7 +1302,7 @@ Feature: ListGrants role
         }
       }
       """
-    And user "Brian" should have the following shares of the folder "folder":
+    And for user "Brian" folder "folder" should have the following shares:
       | sharee | shareType | permissionsRole    |
       | Brian  | user      | Viewer             |
       | grp1   | group     | <permissions-role> |


### PR DESCRIPTION
## Description
Shares are linked to the resources. user is the owner of the resources. So it is better to write `resource has a share` if mentioning multiple shares of same resource.

Renamed
```feature
Then user "Brian" should have the following shares of the file "textfile1.txt":
```
to
```feature
Then for user "Brian" file "textfile1.txt" should have the following shares:
```

## Related Issue

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
