### PR TITLE
[tests-only][full-ci] Update test to receive an email notification when space membership expire

### DIFF
--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -277,23 +277,16 @@ Feature: Notification
 
   @issue-10882 @email
   Scenario: user gets in-app and email notifications when space membership expires
-    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
-    And user "Alice" has created a space "new-space" with the default quota using the Graph API
-    And user "Alice" has sent the following space share invitation:
-      | space              | new-space                |
-      | sharee             | Brian                    |
-      | shareType          | user                     |
-      | permissionsRole    | Space Viewer             |
-    When user "Alice" has expired the membership of user "Brian" from space "new-space"
+    When user "Alice" has expired the membership of user "Brian" from space "notification checking"
     Then the HTTP status code should be "200"
     And user "Brian" should get a notification with subject "Membership expired" and message:
-      | message                        |
-      | Access to Space new-space lost |
-    And user "Brian" should have received the following email from user "Alice" about the share of project space "new-space"
+      | message                                    |
+      | Access to Space notification checking lost |
+    And user "Brian" should have received the following email from user "Alice" about the share of project space "notification checking"
       """
       Hello Brian Murphy,
 
-      Your membership of space new-space has expired at %expiry_date_in_mail%
+      Your membership of space notification checking has expired at %expiry_date_in_mail%
 
       Even though this membership has expired you still might have access through other shares and/or space memberships
       """


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR only updates the scenario, which checks if an user receives an email notification when the space membership expire.
Previous PR https://github.com/owncloud/ocis/pull/11215

## Related Issue
- https://github.com/owncloud/ocis/issues/10882
- Part of https://github.com/owncloud/ocis/issues/10937

## Motivation and Context
Improvements to reduce the steps to execute the given scenario

## How Has This Been Tested?
- tested locally

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
