### PR TITLE
fix: list shares, handle reva errors more gracefully

### DIFF
--- a/changelog/unreleased/fix-error-on-listing-space-members.md
+++ b/changelog/unreleased/fix-error-on-listing-space-members.md
@@ -1,0 +1,6 @@
+Bugfix: Fix error on listing space members
+
+Now the members list will still show grantees even with there is any invalid share after the upgrade.
+
+https://github.com/owncloud/ocis/pull/11245
+https://github.com/owncloud/ocis/issues/11119


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Handle gracefully the error mentioned by the issues. Unblock the space members API by recognizing the reva 'AlreadyExists'. Return HTTP OK 200 with remaining shares instead of HTTP Internal Server Error 5XX.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [#11119](https://github.com/owncloud/ocis/issues/11119)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: [gist with scripts for upgrade and listing members](https://gist.github.com/mklos-kw/0ea8b208a77ebc19246389c19c8588e6)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
