### PR TITLE
[tests-only][full-ci] add missing property createdDateTime while listing permissions of space using root endpoint

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -371,5 +371,12 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiContract/propfindShares.feature:223](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L223)
 - [apiContract/propfindShares.feature:224](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiContract/propfindShares.feature#L224)
 
+#### [Creation date is missing for space members](https://github.com/owncloud/ocis/issues/10077)
+- [apiSharingNgPermissions/listPermissions.feature:874](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature#L874)
+- [apiSharingNgPermissions/listPermissions.feature:1548](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature#L1548)
+- [apiSharingNgPermissions/listPermissions.feature:1549](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature#L1549)
+- [apiSharingNgPermissions/listPermissions.feature:1550](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature#L1550)
+- [apiSharingNgPermissions/listPermissions.feature:2263](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature#L2263)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature
@@ -870,7 +870,7 @@ Feature: List a sharing permissions
       | sharee       | Brian    |
       | shareType    | user     |
 
-  @issues-8351
+  @issues-8351 @issue-10077
   Scenario: user lists permissions of a project space using root endpoint
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
@@ -922,7 +922,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "@libre.graph.weight": {
@@ -945,7 +946,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "@libre.graph.weight": {
@@ -968,7 +970,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "@libre.graph.weight": {
@@ -1263,7 +1266,7 @@ Feature: List a sharing permissions
       }
       """
 
-
+  @issue-10077
   Scenario Outline: sharer lists permissions of a shared project space using root endpoint
     Given using spaces DAV path
     And user "Brian" has been created with default attributes
@@ -1326,7 +1329,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "@libre.graph.weight": {
@@ -1349,7 +1353,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "@libre.graph.weight": {
@@ -1372,7 +1377,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "@libre.graph.weight": {
@@ -1404,7 +1410,8 @@ Feature: List a sharing permissions
                   "required": [
                     "grantedToV2",
                     "id",
-                    "roles"
+                    "roles",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "grantedToV2": {
@@ -1446,7 +1453,8 @@ Feature: List a sharing permissions
                   "required": [
                     "grantedToV2",
                     "id",
-                    "roles"
+                    "roles",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "grantedToV2": {
@@ -1488,7 +1496,8 @@ Feature: List a sharing permissions
                   "required": [
                     "hasPassword",
                     "id",
-                    "link"
+                    "link",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "hasPassword": {
@@ -2250,7 +2259,7 @@ Feature: List a sharing permissions
       }
       """
 
-
+  @env-config @issue-10077
   Scenario: user lists permissions of a space after enabling 'Space Editor Without Versions' role
     Given the administrator has enabled the permissions role "Space Editor Without Versions"
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
@@ -2279,7 +2288,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "displayName": {
@@ -2293,7 +2303,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "@libre.graph.weight": {
@@ -2316,7 +2327,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "displayName": {
@@ -2330,7 +2342,8 @@ Feature: List a sharing permissions
                     "@libre.graph.weight",
                     "description",
                     "displayName",
-                    "id"
+                    "id",
+                    "createdDateTime"
                   ],
                   "properties": {
                     "displayName": {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the missing property `cretaedDateTime` property while requesting members of project space using root endpoint `/graph/v1beta1/drives/{driveId}/root/permissions`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/10830
- Bug Report: https://github.com/owncloud/ocis/issues/10077

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
