### PR TITLE
[tests-only][full-ci] Extend notification tests for `User Light` role

### DIFF
--- a/tests/acceptance/features/apiNotification/notification.feature
+++ b/tests/acceptance/features/apiNotification/notification.feature
@@ -13,9 +13,10 @@ Feature: Notification
     And user "Alice" has uploaded file with content "other data" to "/textfile1.txt"
     And user "Alice" has created folder "my_data"
 
-  @email
+  @issue-10937 @email
   Scenario Outline: user gets in-app and mail notifications of resource sharing
-    Given user "Alice" has sent the following resource share invitation:
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -85,13 +86,16 @@ Feature: Notification
       Click here to view it: %base_url%/files/shares/with-me
       """
     Examples:
-      | resource      |
-      | textfile1.txt |
-      | my_data       |
+      | user-role     | resource      |
+      | User          | textfile1.txt |
+      | User          | my_data       |
+      | User Light    | textfile1.txt |
+      | User Light    | my_data       |
 
-
-  Scenario Outline: get a notification about a file share in various languages
-    Given user "Brian" has switched the system language to "<language>" using the <api> API
+  @issue-10937 @email
+  Scenario Outline: user gets a notification about a file share in various languages
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    And user "Brian" has switched the system language to "<language>" using the <api> API
     And user "Alice" has sent the following resource share invitation:
       | resource        | textfile1.txt |
       | space           | Personal      |
@@ -118,11 +122,15 @@ Feature: Notification
       }
       """
     Examples:
-      | language | subject            | message                                          | api      |
-      | de       | Neue Freigabe      | Alice Hansen hat textfile1.txt mit Ihnen geteilt | Graph    |
-      | de       | Neue Freigabe      | Alice Hansen hat textfile1.txt mit Ihnen geteilt | settings |
-      | es       | Recurso compartido | Alice Hansen compartió textfile1.txt contigo     | Graph    |
-      | es       | Recurso compartido | Alice Hansen compartió textfile1.txt contigo     | settings |
+      | user-role     | language | subject            | message                                          | api      |
+      | User          | de       | Neue Freigabe      | Alice Hansen hat textfile1.txt mit Ihnen geteilt | Graph    |
+      | User          | de       | Neue Freigabe      | Alice Hansen hat textfile1.txt mit Ihnen geteilt | settings |
+      | User          | es       | Recurso compartido | Alice Hansen compartió textfile1.txt contigo     | Graph    |
+      | User          | es       | Recurso compartido | Alice Hansen compartió textfile1.txt contigo     | settings |
+      | User Light    | de       | Neue Freigabe      | Alice Hansen hat textfile1.txt mit Ihnen geteilt | Graph    |
+      | User Light    | de       | Neue Freigabe      | Alice Hansen hat textfile1.txt mit Ihnen geteilt | settings |
+      | User Light    | es       | Recurso compartido | Alice Hansen compartió textfile1.txt contigo     | Graph    |
+      | User Light    | es       | Recurso compartido | Alice Hansen compartió textfile1.txt contigo     | settings |
 
   @env-config
   Scenario: get a notification about a file share in default languages
@@ -171,9 +179,10 @@ Feature: Notification
       | textfile1.txt |
       | my_data       |
 
-  @issue-10966 @email
-  Scenario: check share expired in-app and mail notifications for Personal space file
+  @issue-10937 @issue-10966 @email
+  Scenario Outline: check share expired in-app and mail notifications for Personal space file
     Given using SharingNG
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | testfile.txt |
@@ -195,10 +204,15 @@ Feature: Notification
 
       Even though this share has been revoked you still might have access through other shares and/or space memberships.
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-  @issue-10966 @email
-  Scenario: check share expired in-app and mail notifications for Personal space folder
+  @issue-10937 @issue-10966 @email
+  Scenario Outline: check share expired in-app and mail notifications for Personal space folder
     Given using SharingNG
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has created folder "folderToShare"
     And user "Alice" has sent the following resource share invitation:
       | resource        | folderToShare |
@@ -220,10 +234,15 @@ Feature: Notification
 
       Even though this share has been revoked you still might have access through other shares and/or space memberships.
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-  @issue-10904 @email
+  @issue-10904 @issue-10937 @email
   Scenario Outline: user gets an in-app and mail notifications of unsharing resource
-    Given user "Alice" has sent the following resource share invitation:
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    And user "Alice" has sent the following resource share invitation:
       | resource        | <resource> |
       | space           | Personal   |
       | sharee          | Brian      |
@@ -243,17 +262,20 @@ Feature: Notification
       Even though this share has been revoked you still might have access through other shares and/or space memberships.
       """
     Examples:
-      | resource      |
-      | textfile1.txt |
-      | my_data       |
+      | user-role  | resource      |
+      | User       | textfile1.txt |
+      | User       | my_data       |
+      | User Light | textfile1.txt |
+      | User Light | my_data       |
 
-  @issue-10904 @email
+  @issue-10904 @issue-10937 @email
   Scenario Outline: user gets in-app and mail notifications when a resource is unshared (Project Space)
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "shared-space" with the default quota using the Graph API
     And user "Alice" has created a folder "SHARED-FOLDER" in space "shared-space"
     And user "Alice" has uploaded a file inside space "shared-space" with content "Sample data" to "file-to-share.txt"
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has sent the following resource share invitation:
       | resource        | <resource>   |
       | space           | shared-space |
@@ -274,9 +296,11 @@ Feature: Notification
       Even though this share has been revoked you still might have access through other shares and/or space memberships.
       """
     Examples:
-      | resource          |
-      | file-to-share.txt |
-      | SHARED-FOLDER     |
+      | user-role  | resource          |
+      | User       | file-to-share.txt |
+      | User       | SHARED-FOLDER     |
+      | User Light | file-to-share.txt |
+      | User Light | SHARED-FOLDER     |
 
   @issue-9530 @email
   Scenario: user gets an in-app and mail notifications when someone with comma in display name shares a file

--- a/tests/acceptance/features/apiNotification/spaceNotification.feature
+++ b/tests/acceptance/features/apiNotification/spaceNotification.feature
@@ -18,8 +18,9 @@ Feature: Notification
       | shareType       | user                  |
       | permissionsRole | Space Editor          |
 
-  @email
-  Scenario: user gets in-app and mail notifications of space shared
+  @issue-10937 @email
+  Scenario Outline: user gets in-app and mail notifications of space shared
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     When user "Brian" lists all notifications
     Then the HTTP status code should be "200"
     And the JSON response should contain a notification message with the subject "Space shared" and the message-details should match
@@ -83,9 +84,14 @@ Feature: Notification
 
       Click here to view it: %base_url%/f/%space_id%
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-  @email
-  Scenario: gets in-app and mail notification of space unshared
+  @issue-10937 @email
+  Scenario Outline: gets in-app and mail notification of space unshared
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     When user "Alice" removes the access of user "Brian" from space "notification checking" using root endpoint of the Graph API
     Then the HTTP status code should be "204"
     And user "Brian" should get a notification with subject "Removed from Space" and message:
@@ -101,10 +107,15 @@ Feature: Notification
 
       Click here to check it: %base_url%/f/%space_id%
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-
-  Scenario: user gets in-app notification of space disabled (note: no mail notification)
-    Given user "Alice" has disabled a space "notification checking"
+  @issue-10937
+  Scenario Outline: user gets in-app notification of "Space disabled" event (note: no mail notification)
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    And user "Alice" has disabled a space "notification checking"
     When user "Brian" lists all notifications
     Then the HTTP status code should be "200"
     And there should be "2" notifications
@@ -161,6 +172,10 @@ Feature: Notification
         }
       }
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
 
   Scenario Outline: get in-app notification about a space share in various languages
@@ -191,15 +206,20 @@ Feature: Notification
     Then the HTTP status code should be "200"
     And the notifications should be empty
 
-  @email
-  Scenario: user doesn't get any notification after being removed from space(note: no mail notification)
-    Given user "Alice" has removed the access of user "Brian" from space "notification checking"
+  @issue-10937 @email
+  Scenario Outline: user doesn't get any notification after being removed from space (note: no mail notification)
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    And user "Alice" has removed the access of user "Brian" from space "notification checking"
     And user "Alice" has disabled a space "notification checking"
     When user "Brian" lists all notifications
     Then the HTTP status code should be "200"
     And there should be "2" notifications
     And user "Brian" should have "2" emails
     But user "Brian" should not have a notification related to space "notification checking" with subject "Space disabled"
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
   @email
   Scenario: group members get in-app and email notifications when someone shares a project space with the group
@@ -275,8 +295,9 @@ Feature: Notification
       Zum Ansehen hier klicken: %base_url%/f/%space_id%
       """
 
-  @issue-10882 @email
-  Scenario: user gets in-app and email notifications when space membership expires
+  @issue-10937 @issue-10882 @email
+  Scenario Outline: user gets in-app and email notifications when space membership expires
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     When user "Alice" has expired the membership of user "Brian" from space "notification checking"
     Then the HTTP status code should be "200"
     And user "Brian" should get a notification with subject "Membership expired" and message:
@@ -290,3 +311,7 @@ Feature: Notification
 
       Even though this membership has expired you still might have access through other shares and/or space memberships
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |

--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -64,8 +64,9 @@ Feature: Notification Settings
       | permissionsRole | Viewer    |
     And user "Brian" should have "0" emails
 
-  @email
-  Scenario: disable mail and in-app notification for "Share Received" event
+  @issue-10937 @email
+  Scenario Outline: disable mail and in-app notification for "Share Received" event
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     When user "Brian" disables notification for the following event using the settings API:
       | event             | Share Received |
       | notificationTypes | mail,in-app    |
@@ -153,10 +154,15 @@ Feature: Notification Settings
     When user "Brian" lists all notifications
     Then the HTTP status code should be "200"
     And the notifications should be empty
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-  @email
-  Scenario: disable mail and in-app notification for "Share Removed" event
-    Given user "Alice" has sent the following resource share invitation:
+  @issue-10937 @email
+  Scenario Outline: disable mail and in-app notification for "Share Removed" event
+    Given the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
+    And user "Alice" has sent the following resource share invitation:
       | resource        | lorem.txt |
       | space           | Personal  |
       | sharee          | Brian     |
@@ -245,13 +251,18 @@ Feature: Notification Settings
       | message                                |
       | Alice Hansen shared lorem.txt with you |
     But user "Brian" should not have a notification related to resource "lorem.txt" with subject "Resource unshared"
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-  @email
-  Scenario: disable mail and in-app notification for "Share Removed" event (Project space)
+  @issue-10937 @email
+  Scenario Outline: disable mail and in-app notification for "Share Removed" event (Project space)
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "newSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "newSpace" with content "some content" to "insideSpace.txt"
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has sent the following resource share invitation:
       | resource        | insideSpace.txt |
       | space           | newSpace        |
@@ -341,11 +352,16 @@ Feature: Notification Settings
       | message                                      |
       | Alice Hansen shared insideSpace.txt with you |
     But user "Brian" should not have a notification related to resource "insideSpace.txt" with subject "Resource unshared"
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-
-  Scenario: disable in-app notification for "Space disabled" event
+  @issue-10937
+  Scenario Outline: disable in-app notification for "Space disabled" event (note: no mail notification)
     Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has sent the following space share invitation:
       | space           | new-space    |
       | sharee          | Brian        |
@@ -437,9 +453,13 @@ Feature: Notification Settings
       | message                                   |
       | Alice Hansen added you to Space new-space |
     But user "Brian" should not have a notification related to space "new-space" with subject "Space disabled"
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
   @issue-10864 @email
-  Scenario: disable email notification for user light
+  Scenario: disable email notification for User Light mode
     Given the administrator has assigned the role "User Light" to user "Brian" using the Graph API
     When user "Brian" disables email notification using the settings API
     Then the HTTP status code should be "201"
@@ -495,11 +515,12 @@ Feature: Notification Settings
       | Alice Hansen shared lorem.txt with you |
     And user "Brian" should have "0" emails
 
-  @email
-  Scenario: disable mail and in-app notification for "Added as space member" event
+  @issue-10937 @email
+  Scenario Outline: disable mail and in-app notification for "Added as space member" event
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "newSpace" with the default quota using the Graph API
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     When user "Brian" disables notification for the following event using the settings API:
       | event             | Added As Space Member |
       | notificationTypes | mail,in-app           |
@@ -586,6 +607,10 @@ Feature: Notification Settings
     Then the HTTP status code should be "200"
     And the notifications should be empty
     And user "Brian" should have "0" emails
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
   @email
   Scenario: no email should be received when email sending interval is set to never
@@ -644,11 +669,12 @@ Feature: Notification Settings
       | Alice Hansen shared lorem.txt with you |
     And user "Brian" should have "0" emails
 
-  @email
-  Scenario: disable mail and in-app notification for "Removed as space member" event
+  @issue-10937 @email
+  Scenario Outline: disable mail and in-app notification for "Removed as space member" event
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "newSpace" with the default quota using the Graph API
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has sent the following space share invitation:
       | space           | newSpace     |
       | sharee          | Brian        |
@@ -745,11 +771,16 @@ Feature: Notification Settings
 
       Click here to view it: %base_url%/f/%space_id%
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-  @email
-  Scenario: disable mail and in-app notification for "Space Membership Expired" event
+  @issue-10937 @email
+  Scenario Outline: disable mail and in-app notification for "Space Membership Expired" event
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has created a space "newSpace" with the default quota using the Graph API
     And user "Alice" has sent the following space share invitation:
       | space           | newSpace     |
@@ -848,11 +879,16 @@ Feature: Notification Settings
 
       Click here to view it: %base_url%/f/%space_id%
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-
-  Scenario: disable share expired in-app and mail notification
+  @issue-10937 @email
+  Scenario Outline: disable mail and in-app notification for "Share Expired" event
     Given using SharingNG
     And user "Alice" has uploaded file with content "hello world" to "testfile.txt"
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     When user "Brian" disables notification for the following event using the settings API:
       | event             | Share Expired |
       | notificationTypes | mail,in-app   |
@@ -932,10 +968,15 @@ Feature: Notification Settings
         }
       }
       """
+    Examples:
+      | user-role  |
+      | User       |
+      | User Light |
 
-  @email
-  Scenario Outline: no in-app and mail notification should appear when Share Expired notification is disabled (Personal space)
+  @issue-10937 @email
+  Scenario Outline: no in-app and mail notification should appear when "Share Expired" event is disabled (Personal space)
     Given using SharingNG
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has created folder "my_data"
     And user "Alice" has uploaded file with content "hello world" to "lorem.txt"
     And user "Brian" has disabled notification for the following event using the settings API:
@@ -963,15 +1004,18 @@ Feature: Notification Settings
       | Alice Hansen shared <resource> with you |
     But user "Brian" should not have a notification related to space "Alice Hansen" with subject "Share expired"
     Examples:
-      | resource  |
-      | lorem.txt |
-      | my_data   |
+      | resource  | user-role  |
+      | lorem.txt | User       |
+      | lorem.txt | User Light |
+      | my_data   | User       |
+      | my_data   | User Light |
 
-  @email
-  Scenario Outline: no in-app and mail notification should appear when Share Expired notification is disabled (Project space)
+  @issue-10937 @email
+  Scenario Outline: no in-app and mail notification should appear when "Share Expired" event is disabled (Project space)
     Given using spaces DAV path
     And using SharingNG
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has assigned the role "<user-role>" to user "Brian" using the Graph API
     And user "Alice" has created a space "NewSpace" with the default quota using the Graph API
     And user "Alice" has created a folder "uploadFolder" in space "NewSpace"
     And user "Alice" has uploaded a file inside space "NewSpace" with content "share space items" to "lorem.txt"
@@ -1000,6 +1044,8 @@ Feature: Notification Settings
       | Alice Hansen shared <resource> with you |
     But user "Brian" should not have a notification related to space "NewSpace" with subject "Share expired"
     Examples:
-      | resource     |
-      | lorem.txt    |
-      | uploadFolder |
+      | resource     | user-role  |
+      | lorem.txt    | User       |
+      | lorem.txt    | User Light |
+      | uploadFolder | User       |
+      | uploadFolder | User Light |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR introduces updates for some of the API acceptance tests by adding a new initial step, which configures the user role.
Adding this step allows the examples to set a new user role - `User Light`.
Examples data for the modified scenarios are also extended to cover the `User Light` role.
Covering the following scenarios for in-app and email notifications:

- Share Received
--> notificationSetting.feature (Line 68)-> disable mail and in-app notification for "Share Received" event
- Share Removed
--> notificationSetting.feature (Line 163) -> disable mail and in-app notification for "Share Removed" event
--> notificationSetting.feature (Line 260) -> disable mail and in-app notification for "Share Removed" event (Project space)
- Share Expired
--> notificationSetting.feature (Line 884) -> disable mail and in-app notification for "Share Expired" event
--> notificationSetting.feature (Line 972) -> no in-app and mail notification should appear when "Share Expired" event is disabled (Personal space)
--> notificationSetting.feature (line 1009) -> no in-app and mail notification should appear when "Share Expired" event is disabled (Project space)
- Added as space member
--> notificationSetting.feature (Line 519) -> disable mail and in-app notification for "Added as space member" event
- Removed as space member
--> notificationSetting.feature (Line 673) -> disable mail and in-app notification for "Removed as space member" event
- Space membership expired 
--> notificationSetting.feature (Line 780) -> disable mail and in-app notification for "Space Membership Expired" event
- Space disabled
--> spaceNotification.feature (Line 116) -> user gets in-app notification of "Space disabled" event (note: no mail notification)
--> notificationSetting.feature (Line 361) -> disable in-app notification for "Space disabled" event (note: no mail notification)
- Space deleted
- File rejected `(to be done)`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/10937

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test locally only

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
