### PR TITLE
[tests-only][full-ci] Add cli test for deleting stale uploads

### DIFF
--- a/tests/acceptance/features/cliCommands/staleUpload.feature
+++ b/tests/acceptance/features/cliCommands/staleUpload.feature
@@ -1,0 +1,82 @@
+@env-config @cli-stale-uploads
+Feature: stale upload via CLI command
+  As a user
+  I want to manage stale uploads
+  So that I clean up stale uploads from storage
+
+  Background:
+    Given user "Alice" has been created with default attributes
+    And user "Brian" has been created with default attributes
+
+
+  Scenario: list and delete all stale uploads
+    Given the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "staleuploads" with the default quota using the Graph API
+    And user "Alice" has uploaded a file "filesForUpload/testavatar.jpg" to "/testavatar.jpg" in space "staleuploads"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile.txt"
+    And the administrator has stopped the server
+    And the administrator has created stale upload
+    And the administrator has started the server
+    When the administrator lists all the stale uploads
+    Then the command should be successful
+    And the CLI response should contain the following message:
+      """
+      Scanning all spaces for stale processing nodes...
+      Total stale nodes: 2
+      """
+    When the administrator deletes all the stale uploads
+    Then the command should be successful
+    And the CLI response should contain the following message:
+      """
+      Scanning all spaces for stale processing nodes...
+      Total stale nodes: 2
+      """
+    And there should be "0" stale uploads
+
+
+  Scenario: list and delete all stale uploads of a specific space
+    Given user "Alice" has created folder "FolderToShare"
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "staleuploads" with the default quota using the Graph API
+    And using SharingNG
+    And the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | FolderToShare |
+      | space           | Personal      |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | Uploader      |
+    And user "Brian" has uploaded a file "filesForUpload/testavatar.png" to "FolderToShare/testavatar.png" in space "Shares"
+    And user "Alice" has uploaded file "filesForUpload/testavatar.png" to "testavatar.png"
+    And user "Alice" has uploaded a file "filesForUpload/testavatar.jpg" to "/testavatar.jpg" in space "staleuploads"
+    And the administrator has stopped the server
+    And the administrator has created stale upload
+    And the administrator has started the server
+    When the administrator lists all the stale uploads of space "Personal" owned by user "Alice"
+    Then the command should be successful
+    And the CLI response should contain the following message:
+      """
+      Total stale nodes: 2
+      """
+    When the administrator lists all the stale uploads of space "staleuploads" owned by user "Alice"
+    Then the command should be successful
+    And the CLI response should contain the following message:
+      """
+      Total stale nodes: 1
+      """
+    When the administrator deletes all the stale uploads of space "Personal" owned by user "Alice"
+    Then the command should be successful
+    And the CLI response should contain the following message:
+      """
+      Total stale nodes: 2
+      """
+    And there should be "0" stale uploads of space "Personal" owned by user "Alice"
+    When the administrator deletes all the stale uploads of space "staleuploads" owned by user "Alice"
+    Then the command should be successful
+    And the CLI response should contain the following message:
+      """
+      Total stale nodes: 1
+      """
+    And there should be "0" stale uploads of space "Personal" owned by user "Alice"


### PR DESCRIPTION
## Description
This PR adds tests for listing and deleting stale uploads. 
To create stale upload `POSTPROCESSING_DELAY` env has been used to start processing after some time so that we can stop ocis and delete ***.info** file inside `.ocis/storage/users/uploads`

Scenario covered
- list and delete all stale uploads (which list and delete  every user stale upload)
-  list and delete stale upload of specific space (which list and delete stale upload of specific user specific space)

## Related Issue
- https://github.com/owncloud/ocis/issues/11246

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
