### PR TITLE
[full-ci][tests-only] read concurrently from command running in pseudo-terminal

### DIFF
--- a/tests/acceptance/bootstrap/EmailContext.php
+++ b/tests/acceptance/bootstrap/EmailContext.php
@@ -41,23 +41,17 @@ class EmailContext implements Context {
 		// if oCIS has been setup with notification configuration
 		// event related step generates emails
 		// so deleting all email
-		$this->clearAllEmails();
 	}
 
 	/**
+	 * @BeforeScenario @email
 	 * @AfterScenario @email
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
 	public function clearAllEmails(): void {
-		try {
-			EmailHelper::deleteAllEmails();
-		} catch (Exception $e) {
-			echo __METHOD__ .
-				" could not delete email messages?\n" .
-				$e->getMessage();
-		}
+		EmailHelper::deleteAllEmails();
 	}
 
 	/**

--- a/tests/acceptance/bootstrap/EmailContext.php
+++ b/tests/acceptance/bootstrap/EmailContext.php
@@ -38,9 +38,6 @@ class EmailContext implements Context {
 		// Get all the contexts you need in this context
 		$this->featureContext = BehatHelper::getContext($scope, $environment, 'FeatureContext');
 		$this->spacesContext = BehatHelper::getContext($scope, $environment, 'SpacesContext');
-		// if oCIS has been setup with notification configuration
-		// event related step generates emails
-		// so deleting all email
 	}
 
 	/**

--- a/tests/acceptance/features/apiSettings/notificationSetting.feature
+++ b/tests/acceptance/features/apiSettings/notificationSetting.feature
@@ -933,7 +933,7 @@ Feature: Notification Settings
       }
       """
 
-
+  @email
   Scenario Outline: no in-app and mail notification should appear when Share Expired notification is disabled (Personal space)
     Given using SharingNG
     And user "Alice" has created folder "my_data"
@@ -967,7 +967,7 @@ Feature: Notification Settings
       | lorem.txt |
       | my_data   |
 
-
+  @email
   Scenario Outline: no in-app and mail notification should appear when Share Expired notification is disabled (Project space)
     Given using spaces DAV path
     And using SharingNG


### PR DESCRIPTION
## Description
concurrently read from command running in pseudo-terminal instead of reading at the end. This helps to preserve the output from the command.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/11201

## Motivation and Context
Run CLI tests in MacOS

## How Has This Been Tested?
- test environment:
  - [x] Linux
  - [x] MacOS


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
