### PR TITLE
Allow Multiple Spaceclaims

### DIFF
--- a/changelog/unreleased/claim-managed-spaces.md
+++ b/changelog/unreleased/claim-managed-spaces.md
@@ -3,3 +3,4 @@ Enhancement: Claim managed spaces
 Allow managing spaces from oidc claims
 
 https://github.com/owncloud/ocis/pull/11280
+https://github.com/owncloud/ocis/pull/11291


### PR DESCRIPTION
When using claim managed spaces, this will allow having multiple claims for the same space. The system will automatically use the one with the highest permission
