### PR TITLE
[docs-only] Add a minimalistic docker run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Before starting to set up an instance, we **highly** recommend reading the [Prer
 
 ### Use the Official Documentation
 
-See the [Quick Guide](https://doc.owncloud.com/ocis/next/quickguide/quickguide.html) or the [Binary Setup](https://doc.owncloud.com/ocis/next/deployment/binary/binary-setup.html) for a single-node bare-metal deployment starting with a Raspberry Pi or single server, the [Container Setup](https://doc.owncloud.com/ocis/next/deployment/container/container-setup.html) for classic container environments like docker or learn how to [deploy to Kubernetes](https://doc.owncloud.com/ocis/next/deployment/container/orchestration/orchestration.html).
+See the [Install Infinite Scale on a Server](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html) for a production ready deployment starting with a Raspberry Pi, a single server or VM. Also see the [Developer Deployment Guides](https://owncloud.dev/ocis/guides/) for a brief preview.
 
 ### Use the ocis Repo as Source
 
-Use this method to run an instance with the latest code. This is only recommended for development purposes. The minimum go version required is 1.22. Note that you need, as a prerequisite, a C compile environment installed because some dependencies like reva have components that require c-go libraries/tool-chains. The command installing for debian based systems is: `sudo apt install build-essentials`. To build and run a local instance with demo users:
+Use this method to run an instance with the latest code. This is only recommended for development purposes. The minimum go version required is 1.22. Note that you need, as a prerequisite, a C compile environment installed because some dependencies like reva have components that require c-go libraries/tool-chains. The command installing for debian based systems is: `sudo apt install build-essential`. To build and run a local instance with demo users:
 
 ```console
 # get the source

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 *   [Introduction](#introduction)
+*   [Quickstart](#quickstart)
 *   [Overview](#overview)
     * [Clients](#clients)
     * [Web Office Applications](#web-office-applications)
@@ -33,6 +34,33 @@
 ownCloud Infinite Scale (oCIS) is the new file sync & share platform that will be the foundation of your data management platform.
 
 Make sure to download the [latest released version](https://download.owncloud.com/ocis/ocis/stable/?sort=time&order=desc) today!
+
+## Quickstart
+
+For details of the commands used see the [Minimalistic Evaluation Guide for oCIS with Docker](https://owncloud.dev/ocis/guides/ocis-mini-eval/).
+
+```bash
+mkdir -p $HOME/ocis/ocis-config \
+mkdir -p $HOME/ocis/ocis-data
+sudo chown -Rfv 1000:1000 $HOME/ocis/
+docker pull owncloud/ocis
+docker run --rm -it \
+    --mount type=bind,source=$HOME/ocis/ocis-config,target=/etc/ocis \
+    --mount type=bind,source=$HOME/ocis/ocis-data,target=/var/lib/ocis \
+    owncloud/ocis init --insecure yes
+docker run \
+    --name ocis_runtime \
+    --rm \
+    -it \
+    -p 9200:9200 \
+    --mount type=bind,source=$HOME/ocis/ocis-config,target=/etc/ocis \
+    --mount type=bind,source=$HOME/ocis/ocis-data,target=/var/lib/ocis \
+    -e OCIS_INSECURE=true \
+    -e PROXY_HTTP_ADDR=0.0.0.0:9200 \
+    -e OCIS_URL=https://localhost:9200 \
+    owncloud/ocis
+```
+Use as URL `localhost:9200` and the user/password printed.
 
 ## Overview
 
@@ -73,7 +101,7 @@ Before starting to set up an instance, we **highly** recommend reading the [Prer
 
 ### Use the Official Documentation
 
-See the [Install Infinite Scale on a Server](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html) for a production ready deployment starting with a Raspberry Pi, a single server or VM. Also see the [Developer Deployment Guides](https://owncloud.dev/ocis/guides/) for a brief preview.
+See the [Install Infinite Scale on a Server](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html) for a production ready deployment starting with a Raspberry Pi, a single server or VM.
 
 ### Use the ocis Repo as Source
 

--- a/docs/ocis/guides/_index.md
+++ b/docs/ocis/guides/_index.md
@@ -18,5 +18,6 @@ These guides should extend the generic documentation and help admins to learn In
 
 oCIS deployments are super simple, yet there are many configurations possible for advanced setups.
 
+- {{< icon "docker" >}} [Minimalistic Evaluation Guide for oCIS with Docker]({{< ref "ocis-mini-eval" >}}) - minimalistic evaluation
 - {{< icon "docker" >}} [Discover oCIS with Docker]({{< ref "ocis-local-docker" >}}) - configure domain, certificates and port
 - {{< icon "person-walking-luggage" >}} [Migrate data to Infinite Scale]({{< ref "migrate-data-rclone" >}})

--- a/docs/ocis/guides/migrate-data-rclone.md
+++ b/docs/ocis/guides/migrate-data-rclone.md
@@ -2,7 +2,7 @@
 ---
 title: "Migrate Data using rclone"
 date: 2020-06-12T14:35:00+01:00
-weight: 8
+weight: 10
 geekdocRepo: https://github.com/owncloud/ocis
 geekdocEditPath: edit/master/docs/ocis/guides
 geekdocFilePath: migrate-data-rclone.md

--- a/docs/ocis/guides/ocis-mini-eval.md
+++ b/docs/ocis/guides/ocis-mini-eval.md
@@ -51,15 +51,12 @@ docker pull owncloud/ocis
 docker run --rm -it \
     --mount type=bind,source=$HOME/ocis/ocis-config,target=/etc/ocis \
     --mount type=bind,source=$HOME/ocis/ocis-data,target=/var/lib/ocis \
-    owncloud/ocis init
+    owncloud/ocis init --insecure yes
 ```
 
-You will get an output like the following, answer with `yes`:
+You will get an output like the following:
 
-```txt {hl_lines=[9]}
-Do you want to configure Infinite Scale with certificate checking disabled?
- This is not recommended for public instances! [yes | no = default] yes
-
+```txt {hl_lines=[6]}
 =========================================
  generated OCIS Config
 =========================================

--- a/docs/ocis/guides/ocis-mini-eval.md
+++ b/docs/ocis/guides/ocis-mini-eval.md
@@ -1,0 +1,106 @@
+---
+title: "Minimalistic Evaluation Guide for oCIS with Docker"
+date: 2025-05-08T16:00:00+02:00
+weight: 7
+geekdocRepo: https://github.com/owncloud/ocis
+geekdocEditPath: edit/master/docs/ocis/guides
+geekdocFilePath: ocis-mini-eval.md
+geekdocCollapseSection: true
+---
+
+{{< toc >}}
+
+**IMPORTANT** This type of installation is **ONLY** intended for a quick evaluation and to access the instance from your local machine using internal certificates only. We recommend using test data only for this evaluation.
+
+## Prerequisites
+
+As a prerequisite, we assume you have Docker installed locally on a machine that has a GUI. A headless one will not work. You know how to use Docker commands and what they mean. This guide is not intended to be a detailed explanation.
+
+## What you can Expect
+
+By passing the commands as described, you will be able to get a very first look and feel of Infinite Scale, which can be accessed from your browser using `localhost`.
+
+## Setup Procedure
+
+The setup process is quite simple and is done from a terminal.
+
+### Prepare Paths
+
+Create directories if not exists:
+
+```bash
+mkdir -p $HOME/ocis/ocis-config \
+mkdir -p $HOME/ocis/ocis-data
+```
+
+Set the user for the directories to be the same as the user inside the container:
+
+```bash
+sudo chown -Rfv 1000:1000 $HOME/ocis/
+```
+
+### Pull the Image
+
+```bash
+docker pull owncloud/ocis
+```
+
+### First Time Initialisation
+
+```bash
+docker run --rm -it \
+    --mount type=bind,source=$HOME/ocis/ocis-config,target=/etc/ocis \
+    --mount type=bind,source=$HOME/ocis/ocis-data,target=/var/lib/ocis \
+    owncloud/ocis init
+```
+
+You will get an output like the following, answer with `yes`:
+
+```txt {hl_lines=[9]}
+Do you want to configure Infinite Scale with certificate checking disabled?
+ This is not recommended for public instances! [yes | no = default] yes
+
+=========================================
+ generated OCIS Config
+=========================================
+ configpath : /etc/ocis/ocis.yaml
+ user       : admin
+ password   : t3p4N0jJ47LbhpQ04s9W%u1$d2uE3Y.3
+```
+
+Note that the password displayed is the one that will be used when you first log in or until it is changed.
+
+### Recurring Start of Infinite Scale
+
+```bash
+docker run \
+    --name ocis_runtime \
+    --rm \
+    -it \
+    -p 9200:9200 \
+    --mount type=bind,source=$HOME/ocis/ocis-config,target=/etc/ocis \
+    --mount type=bind,source=$HOME/ocis/ocis-data,target=/var/lib/ocis \
+    -e OCIS_INSECURE=true \
+    -e PROXY_HTTP_ADDR=0.0.0.0:9200 \
+    -e OCIS_URL=https://localhost:9200 \
+    owncloud/ocis
+```
+
+## Access Infinite Scale with the Browser
+
+To access Infinite Scale, open your browser and type as url:
+
+```
+https://localhost:9200
+```
+
+## Remove the Evaluation
+
+```bash
+sudo docker rmi owncloud/ocis \
+sudo rm -r $HOME/ocis
+```
+
+## Next Steps
+
+After evaluation, we strongly recommend that you use the [Install Infinite Scale on a Server](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html) documentation which is ready for production and remove this evaluation setup completely.


### PR DESCRIPTION
This PR adds a minimalistic guide to run ocis based on `docker run` (not compose !) - for eval only !

To have a local rendering, check out and run `make -C docs docs-serve` and open a browser with URL:
`http://localhost:1313/ocis/guides/ocis-mini-eval/`

