### PR TITLE
[tests-only][full-ci] added test to resume all uploads sessions

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -917,4 +917,18 @@ class CliContext implements Context {
 		];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}
+
+	/**
+	 * @When the administrator resumes all the upload sessions using the CLI
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorResumesAllTheUploadSessionsUsingTheCLI(): void {
+		$command = "storage-users uploads sessions --resume --json";
+		$body = [
+			"command" => $command
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
 }

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -392,5 +392,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 - [apiSharingNgDriveLinkShare/createInternalLinkShare.feature:339](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgDriveLinkShare/createInternalLinkShare.feature#L339)
 
+#### [[CLI] Error while resuming an upload](https://github.com/owncloud/ocis/issues/11290)
+
+- [cliCommands/uploadSessions.feature:156](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/cliCommands/uploadSessions.feature#L156)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -151,3 +151,14 @@ Feature: List upload sessions via CLI command
     And the CLI response should not contain these entries:
       | file1.txt     |
       | virusFile.txt |
+
+  @issue-11290
+  Scenario: resume all upload sessions
+    Given the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And user "Alice" has uploaded file with content "upload content" to "file.txt"
+    And the administrator has stopped the server
+    And the administrator has started the server
+    When the administrator resumes all the upload sessions using the CLI
+    Then the command should be successful
+    And the CLI response should contain these entries:
+      | file.txt |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds test to resume all the uploads sessions using the CLI command. 
```bash
ocis storage-users uploads sessions --resume
```

While resuming the upload sessions, currently it returns an error, reported in https://github.com/owncloud/ocis/issues/11290.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/11274
- Bug Report: https://github.com/owncloud/ocis/issues/11290

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
