### PR TITLE
[tests-only][full-ci] added test to restart and resume all stale uploads

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -907,4 +907,21 @@ class CliContext implements Context {
 		];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}
+
+	/**
+	 * @When /^the administrator (resumes|restarts) all the stale uploads$/
+	 *
+	 * @param string $flag
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorResumesOrRestartsAllTheStaleUploads(string $flag): void {
+		$flag = rtrim($flag, "s");
+		$command = "storage-users uploads sessions --$flag --json";
+		$body = [
+			"command" => $command
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
 }

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -406,5 +406,10 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 #### [Activity. no event for deleting a file using file-id](https://github.com/owncloud/ocis/issues/10328)
 - [apiActivities/activitiesByFileId.feature:2017](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiActivities/activitiesByFileId.feature#L2017)
 
+#### [[CLI]Restart and Resume stale uploads returns empty list](https://github.com/owncloud/ocis/issues/11296)
+
+- [cliCommands/staleUpload.feature:85](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/cliCommands/staleUpload.feature#L85)
+- [cliCommands/staleUpload.feature:97](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/cliCommands/staleUpload.feature#L97)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/cliCommands/staleUpload.feature
+++ b/tests/acceptance/features/cliCommands/staleUpload.feature
@@ -80,3 +80,27 @@ Feature: stale upload via CLI command
       Total stale nodes: 1
       """
     And there should be "0" stale uploads of space "Personal" owned by user "Alice"
+
+  @issue-11296
+  Scenario: resume all stale uploads
+    Given the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And user "Alice" has uploaded file with content "some content" to "textfile.txt"
+    And the administrator has stopped the server
+    And the administrator has created stale upload
+    And the administrator has started the server
+    When the administrator resumes all the stale uploads
+    Then the command should be successful
+    And the CLI response should contain these entries:
+      | textfile.txt |
+
+  @issue-11296
+  Scenario: restart all stale uploads
+    Given the config "POSTPROCESSING_DELAY" has been set to "10s"
+    And user "Alice" has uploaded file with content "some content" to "textfile.txt"
+    And the administrator has stopped the server
+    And the administrator has created stale upload
+    And the administrator has started the server
+    When the administrator restarts all the stale uploads
+    Then the command should be successful
+    And the CLI response should contain these entries:
+      | textfile.txt |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds test to restart and resume all the stale uploads using the CLI commands.
```bash
ocis storage-users uploads sessions --resume
ocis storage-users uploads sessions --restart
```

Currently the CLI command does not restart or resume any uploads are returns empty list, reported in https://github.com/owncloud/ocis/issues/11296.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/11274
- Bug Report: https://github.com/owncloud/ocis/issues/11296

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
