### PR TITLE
[tests-only][full-ci] check resource creation with share creation

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -390,9 +390,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [Lost permission when received multiple shares on the same resource](https://github.com/owncloud/ocis/issues/8464)
 
-- [apiSharingNgShares/sharedWithMe.feature:5406](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5406)
-- [apiSharingNgShares/sharedWithMe.feature:5407](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5407)
-- [apiSharingNgShares/sharedWithMe.feature:5408](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5408)
+- [apiSharingNgShares/sharedWithMe.feature:5410](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5410)
+- [apiSharingNgShares/sharedWithMe.feature:5411](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5411)
+- [apiSharingNgShares/sharedWithMe.feature:5412](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5412)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature
+++ b/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature
@@ -5391,16 +5391,20 @@ Feature: an user gets the resources shared to them
       | sharee          | Brian    |
       | shareType       | user     |
       | permissionsRole | Editor   |
-    And user "Alice" has sent the following resource share invitation:
+    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "Shares/Folder/lorem1.txt"
+    And user "Brian" should be able to create folder "Shares/Folder/testFolder1"
+    And as "Alice" file "Folder/lorem1.txt" should exist
+    And as "Alice" folder "Folder/testFolder1" should exist
+    Given user "Alice" has sent the following resource share invitation:
       | resource        | Folder   |
       | space           | Personal |
       | sharee          | grp1     |
       | shareType       | group    |
       | permissionsRole | Viewer   |
-    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "Shares/Folder/lorem.txt"
-    And user "Brian" should be able to create folder "Shares/Folder/testFolder"
-    And as "Alice" file "Folder/lorem.txt" should exist
-    And as "Alice" folder "Folder/testFolder" should exist
+    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "Shares/Folder/lorem2.txt"
+    And user "Brian" should be able to create folder "Shares/Folder/testFolder2"
+    And as "Alice" file "Folder/lorem2.txt" should exist
+    And as "Alice" folder "Folder/testFolder2" should exist
     Examples:
       | dav-path-version |
       | old              |


### PR DESCRIPTION
## Description
check file actions after share creation. This is to prevent possible flakiness that can occur due to existing issue https://github.com/owncloud/ocis/issues/8464

Note: if this becomes flaky again then maybe we should skip this test

## Related Issue


## How Has This Been Tested?
- test environment:
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
