### PR TITLE
[docs-only] Update the Python script which creates adoc delta envvar tables

### DIFF
--- a/docs/helpers/changed_envvars.py
+++ b/docs/helpers/changed_envvars.py
@@ -13,7 +13,7 @@ from urllib.request import urlopen
 ## when the files got created, you MUST do some post work manually like referencing services with xref:
 ## when running, files get recreated, existing content gets overwritten!!
 
-## you MUST run this script from the local ocis repo root !!
+## !! you MUST run this script from the local ocis repo root !!
 ## like: python3 docs/helpers/changed_envvars.py
 ## create a branch to prepare the changes
 
@@ -22,44 +22,40 @@ from urllib.request import urlopen
 # new is the target version to compare to
 # tagged versions must be of format: 'tags/v6.0.0'
 # master is different, it must be:   'heads/master'
-versionOld = 'tags/v7.0.0'
-versionNew = 'heads/master'
+versionOld: str = 'tags/v7.1.0'
+versionNew: str = 'heads/master'
 
 # CHANGE according your needs
-from_version = '7.0.0'
-to_version = '7.1.0'
+from_version: str = '7.1.0'
+to_version: str = '7.2.0'
 
 # CHANGE according your needs
 # this will create files like 5.0.0-7.0.0-added and 5.0.0-7.0.0-removed
 # this should match which versions you compare. master is ok if that is the base for a named release
-nameComponent = '7.0.0-7.1.0'
+nameComponent: str = '7.1.0-7.2.0'
 
 # ADD new elements when a new version has been published so that it gets excluded
 # array of version patterns to be excluded for added items. we dont need patch versions
-excludePattern = ['pre5.0', '5.0', '6.0', '6.0.0', '6.0.1', '6.1.0', '6.7', '7.0', '7.0.0']
+excludePattern: list[str] = ['pre5.0', '5.0', '6.0', '6.0.0', '6.0.1', '6.1.0', '6.7', '7.0', '7.0.0', '7.1.0']
 
 # DO NOT CHANGE
 # this is the path the added/removed result is written to
-adocWritePath = 'docs/services/general-info/env-var-deltas'
+adocWritePath: str = 'docs/services/general-info/env-var-deltas'
 
-addedWith = {}
-removedWith = {}
-deprecatedWith = {}
+# define root sources from github
+git_left_dir: str = 'https://raw.githubusercontent.com/owncloud/ocis/refs/'
+git_right_dir: str ='/docs/helpers/env_vars.yaml'
 
-def check_path():
+def check_path() -> None:
 	# check which path the script started. we can do this because the target path must be present
 	# exit if not present
 	if not os.path.exists(adocWritePath):
 		print('Path not found: ' + adocWritePath)
 		sys.exit()
 
-def get_sources(versionOld, versionNew):
-	# get the sources from github
-	git_bleft_dir = 'https://raw.githubusercontent.com/owncloud/ocis/refs/'
-	git_right_dir ='/docs/helpers/env_vars.yaml'
-
-	urlOld = git_bleft_dir + versionOld + git_right_dir
-	urlNew = git_bleft_dir + versionNew + git_right_dir
+def get_sources(versionOld: str, versionNew: str) -> (str, str):
+	urlOld = git_left_dir + versionOld + git_right_dir
+	urlNew = git_left_dir + versionNew + git_right_dir
 
 	try:
 		fileOld = urlopen(urlOld).read().decode('utf-8')
@@ -70,34 +66,34 @@ def get_sources(versionOld, versionNew):
 		print(e)
 		sys.exit()
 
-def get_added(fileNew, excludePattern):
+def get_added(fileNew: str, excludePattern: list[str]) -> set[str]:
 	# create dict with added items
-	addedWith = {}
+	addedWith: set[str] = {}
 	for key, value in fileNew.items():
 		if not fileNew[key]['introductionVersion'] in str(excludePattern):
 			addedWith[key] = value
 	return addedWith
 
-def get_removed(fileOld, fileNew):
+def get_removed(fileOld: str, fileNew: str) -> set[str]:
 	# create dict with removed items
-	removedWith = {}
+	removedWith: set[str] = {}
 	for key, value in fileOld.items():
 		if not key in fileNew:
 			removedWith[key] = value
 	return removedWith
 
-def get_deprecated(fileNew):
+def get_deprecated(fileNew: str) -> set[str]:
 	# create dict with deprecated items
-	deprecatedWith = {}
+	deprecatedWith: set[str] = {}
 	for key, value in fileNew.items():
 		if value['removalVersion']:
 			deprecatedWith[key] = value
 	return deprecatedWith
 
-def create_adoc_start(type_text, from_version, to_version, creation_date, columns, closing):
+def create_adoc_start(type_text: str, from_version: str, to_version: str, creation_date: str, columns: str, closing: str) -> str:
 	# create the page/table header
 	# 'closing' contains variable column names dependen if added/removed ir deprecated
-	a = '''// # {ftype} Variables between oCIS {ffrom} and oCIS {fto}
+	a: str = '''// # {ftype} Variables between oCIS {ffrom} and oCIS {fto}
 // commenting the headline to make it better includable
 
 // table created per {fdate}
@@ -110,17 +106,17 @@ def create_adoc_start(type_text, from_version, to_version, creation_date, column
 '''.format(ftype = type_text, ffrom = from_version, fto = to_version, fdate = creation_date, fcolumns = columns, fclosing = closing)
 	return a
 
-def create_adoc_end():
+def create_adoc_end() -> str:
 	# close the table
-	a = '''|===
+	a: str = '''|===
 
 '''
 	return a
 
-def add_adoc_line_1(service, variable, description, value):
+def add_adoc_line_1(service: str, variable: str, description: str, value: str) -> str:
 	# add a table line for added/removed
 	# the dummy values are only here to have the same number of parameters as add_adoc_line_2
-	a = '''| {fservice}
+	a: str = '''| {fservice}
 | {fvariable}
 | {fdescription}
 | {fvalue}
@@ -130,7 +126,7 @@ def add_adoc_line_1(service, variable, description, value):
 
 def add_adoc_line_2(service, variable, description, removalVersion, deprecationInfo):
 	# add a table line for deprecated, this has different columns
-	a = '''| {fservice}
+	a: str = '''| {fservice}
 | {fvariable}
 | {fdescription}
 | {fremovalVersion}
@@ -139,11 +135,11 @@ def add_adoc_line_2(service, variable, description, removalVersion, deprecationI
 '''.format(fservice = service, fvariable = variable, fdescription = description, fremovalVersion = removalVersion, fdeprecationInfo = deprecationInfo)
 	return a
 
-def create_table(type_text, source_dict, from_version, to_version, date_today, type = False):
+def create_table(type_text: str, source_dict: set[str], from_version: str, to_version: str, date_today: str, type: bool = False) -> str:
 	# get the table header
-	columns = '~,~,~,~' if type == False else '~,~,~,~,~'
-	closing = 'Default' if type == False else 'Removal Version | Deprecation Info'
-	a = create_adoc_start(type_text, from_version, to_version, date_today, columns, closing)
+	columns: str = '~,~,~,~' if type == False else '~,~,~,~,~'
+	closing: str = 'Default' if type == False else 'Removal Version | Deprecation Info'
+	a: str = create_adoc_start(type_text, from_version, to_version, date_today, columns, closing)
 
 	if not type:
 	# added and removed envvars
@@ -192,7 +188,7 @@ def create_table(type_text, source_dict, from_version, to_version, date_today, t
 	a += create_adoc_end()
 	return a
 
-def write_output(a, type_text):
+def write_output(a: str, type_text: str) -> None:
 	# write the content to a file
 	try:
 		with open(adocWritePath + '/' + nameComponent + '-' + type_text + '.adoc', 'w') as file:
@@ -202,20 +198,30 @@ def write_output(a, type_text):
 		print(e)
 		sys.exit()
 
-## here are the tasks in sequence
+def main() -> None:
+	## here are the tasks in sequence
 
-check_path()
-fileOld, fileNew = get_sources(versionOld, versionNew)
-addedWith = get_added(fileNew, excludePattern)
-removedWith = get_removed(fileOld, fileNew)
-deprecatedWith = get_deprecated(fileNew)
+	fileOld: str = ''
+	fileNew: str = ''
+	addedWith: set[str] = {}
+	removedWith: set[str] = {}
+	deprecatedWith: set[str] = {}
 
-a = create_table('Added', addedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'))
-r = create_table('Removed', removedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'))
-d = create_table('Deprecated', deprecatedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'), True)
+	check_path()
+	fileOld, fileNew = get_sources(versionOld, versionNew)
+	addedWith = get_added(fileNew, excludePattern)
+	removedWith = get_removed(fileOld, fileNew)
+	deprecatedWith = get_deprecated(fileNew)
 
-write_output(a, 'added')
-write_output(r, 'removed')
-write_output(d, 'deprecated')
+	a: str = create_table('Added', addedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'))
+	r: str = create_table('Removed', removedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'))
+	d: str = create_table('Deprecated', deprecatedWith, from_version, to_version, date.today().strftime('%Y.%m.%d'), True)
 
-print('Success, see files created in: ' + adocWritePath)
+	write_output(a, 'added')
+	write_output(r, 'removed')
+	write_output(d, 'deprecated')
+
+	print('Success, see files created in: ' + adocWritePath)
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
This PR updates the python script we use to automatically create added/deprecated and removed envvar tables required for the documentation. The changes are for improved maintainability and updated versions.

* Add good practices for Python code 
  * Use variable and return value type annotations
  * Use a main definition
* Update the versions to what I think will come next (`stable-7.2`)
(Can be adapted if needed later on, does no harm if we use a name instead a semver, because it is only a filename component)

A local testrun returned expected results