### PR TITLE
[tests-only][full-ci]Add tests for exceeding tags amount

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -46,6 +46,7 @@ default:
         - OcisConfigContext:
         - WebDavLockingContext:
         - SharingNgContext:
+        - SearchContext:
 
     apiSpacesShares:
       paths:

--- a/tests/acceptance/expected-failures-without-remotephp.md
+++ b/tests/acceptance/expected-failures-without-remotephp.md
@@ -121,6 +121,7 @@
 - [apiSearchContent/contentSearch.feature:238](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/contentSearch.feature#L238)
 - [apiSearchContent/contentSearch.feature:239](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/contentSearch.feature#L239)
 - [apiSearchContent/contentSearch.feature:268](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/contentSearch.feature#L268)
+- [apiSpaces/tag.feature:369](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/tag.feature#L369)
 - [cliCommands/searchReIndex.feature:15](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/cliCommands/searchReIndex.feature#L15)
 - [coreApiWebdavOperations/search.feature:44](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L44)
 - [coreApiWebdavOperations/search.feature:62](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L62)

--- a/tests/acceptance/features/apiSpaces/tag.feature
+++ b/tests/acceptance/features/apiSpaces/tag.feature
@@ -364,3 +364,17 @@ Feature: Tag
       | my tag                                                                                                    |
       | Loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliqua,qa |
     Then the HTTP status code should be "200"
+
+
+  Scenario: user tries to create tags above 100, only first 100 tags will be created
+    Given the config "OCIS_MAX_TAG_LENGTH" has been set to "100"
+    And user "Alice" has created a folder "folderMain" in space "Alice Hansen"
+    When user "Alice" creates "200" tags for folder "folderMain" of space "Alice Hansen"
+    Then the HTTP status code should be "200"
+    When user "Alice" searches for "Tags:testTag100" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these files:
+      | folderMain |
+    When user "Alice" searches for "Tags:testTag101" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result should contain "0" entries


### PR DESCRIPTION
## Description
This PR add tests related to exceeding amount of tag (> 100) . 
Expected behaviour : only first 100 tags should be created and return 200 status code.

Discussion done here : https://github.com/owncloud/enterprise/issues/7180
> Yes, this seems to be expected behaviour for now. Compare this comment: 
> https://github.com/owncloud/reva/blob/main/pkg/tags/tags.go#L116

## Related Issue
- https://github.com/owncloud/ocis/issues/11243

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
