### PR TITLE
[docs-only] Update the ocis_full example for new image versions

### DIFF
--- a/changelog/unreleased/update-ocis_full_images.md
+++ b/changelog/unreleased/update-ocis_full_images.md
@@ -3,4 +3,4 @@ Enhancement: Update ocis_full deployment example images
 The ocis_full deployment example got updated images.
 Additionally a fix has been implemented for collabora.yml to be compliant with new releases. 
 
-https://github.com/owncloud/ocis/pull/
+https://github.com/owncloud/ocis/pull/11319

--- a/changelog/unreleased/update-ocis_full_images.md
+++ b/changelog/unreleased/update-ocis_full_images.md
@@ -1,0 +1,6 @@
+Enhancement: Update ocis_full deployment example images
+
+The ocis_full deployment example got updated images.
+Additionally a fix has been implemented for collabora.yml to be compliant with new releases. 
+
+https://github.com/owncloud/ocis/pull/

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -53,7 +53,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:24.04.12.3.1
+    image: collabora/code:25.04.1.1.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       ocis-net:
@@ -80,6 +80,7 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
-    command: ["bash", "-c", "coolconfig generate-proof-key ; /start-collabora-online.sh"]
+    entrypoint: ['/bin/bash', '-c']
+    command: ['coolconfig generate-proof-key && /start-collabora-online.sh']
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9980/hosting/discovery" ]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/9980 && echo -e 'GET /hosting/discovery HTTP/1.1\r\nHost: localhost:9980\r\n\r\n' >&3 && head -n 1 <&3 | grep '200 OK'"]

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   traefik:
-    image: traefik:v3.3.3
+    image: traefik:v3.4.0
     # release notes: https://github.com/traefik/traefik/releases
     networks:
       ocis-net:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -51,7 +51,7 @@ services:
   onlyoffice:
     # if you want to use oo enterprise edition, use: onlyoffice/documentserver-ee:<version>
     # note, you also need to add a volume, see below
-    image: onlyoffice/documentserver:8.3.0
+    image: onlyoffice/documentserver:8.3.3
     # changelog https://github.com/ONLYOFFICE/DocumentServer/releases
     networks:
       ocis-net:


### PR DESCRIPTION
Fixes: #11066 (ocis_full update collabora image results in startup failure)
References: #11109 (Maintenance example)

The images for `collabora`, `onlyoffice` and `traefik` got updated.
Additionally, the startup in `collabora.yml` is fixed. It starts now as expected and is healthy.

Note the changelog, because this update needs to be part of the upgrade process/documentation due to the changed collabora.yml file.

Tested locally, an office file was editable with both web apps.

When merged, #11109 must be rebased.