### PR TITLE
[full-ci] chore: bump Web to 11.3.2

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=1d1e9bb9cc6128a706aa4e2d4fddcb967f7a727a
+WEB_COMMITID=4de74fe05f111a7c6dfa93b17c423861fb14ad88
 WEB_BRANCH=stable-11.0

--- a/changelog/unreleased/bump-web-to-11.3.2.md
+++ b/changelog/unreleased/bump-web-to-11.3.2.md
@@ -1,0 +1,8 @@
+Enhancement: Bump Web to 11.3.2
+
+- Bugfix [owncloud/web#12460](https://github.com/owncloud/web/pull/12460): Add missing dependencies to markdown editor
+- Bugfix [owncloud/web#12460](https://github.com/owncloud/web/pull/12460): Hide image upload in markdown editor
+- Bugfix [owncloud/web#12460](https://github.com/owncloud/web/pull/12460): Hide save in markdown editor
+
+https://github.com/owncloud/ocis/pull/11330
+https://github.com/owncloud/web/releases/tag/v11.3.2

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v11.3.1
+WEB_ASSETS_VERSION = v11.3.2
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
This update brings markdown editor fixes based on user feedback.