### PR TITLE
[tests-only][full-ci] add API test to enable share sync after disabling

### DIFF
--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -2009,7 +2009,6 @@ class GraphHelper {
 	 * @param string $user
 	 * @param string $password
 	 * @param string $itemId
-	 * @param string $shareSpaceId
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -2019,14 +2018,13 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $itemId,
-		string $shareSpaceId,
 	): ResponseInterface {
 		$body = [
 			"remoteItem" => [
 				"id" => $itemId,
 			],
 		];
-		$url = self::getBetaFullUrl($baseUrl, "drives/$shareSpaceId/root/children");
+		$url = self::getBetaFullUrl($baseUrl, "drives/" . GraphHelper::SHARES_SPACE_ID . "/root/children");
 		return HttpRequestHelper::post(
 			$url,
 			$user,

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -1512,13 +1512,11 @@ class SharingNgContext implements Context {
 	): void {
 		$share = ltrim($share, '/');
 		$itemId = $this->spacesContext->getResourceId($offeredBy, $space, $share);
-		$shareSpaceId = GraphHelper::SHARES_SPACE_ID;
 		$response = GraphHelper::enableShareSync(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$itemId,
-			$shareSpaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1542,7 +1540,6 @@ class SharingNgContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$remoteItemId,
-			GraphHelper::SHARES_SPACE_ID,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1560,7 +1557,6 @@ class SharingNgContext implements Context {
 	 * @throws Exception|GuzzleException
 	 */
 	public function userTriesToEnableShareSyncOfResourceUsingTheGraphApi(string $user, string $resource): void {
-		$shareSpaceId = GraphHelper::SHARES_SPACE_ID;
 		$itemId = ($resource === 'nonexistent') ? WebDavHelper::generateUUIDv4() : $resource;
 
 		$response = GraphHelper::enableShareSync(
@@ -1568,7 +1564,6 @@ class SharingNgContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$itemId,
-			$shareSpaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -21,9 +21,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [Settings service user can list other peoples assignments](https://github.com/owncloud/ocis/issues/5032)
 
-- [apiSettings/settings.feature:125](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L125)
-- [apiSettings/settings.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L126)
-- [apiSettings/settings.feature:127](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L127)
+- [apiSettings/settings.feature:182](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L182)
+- [apiSettings/settings.feature:183](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L183)
+- [apiSettings/settings.feature:184](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L184)
 
 #### [A User can get information of another user with Graph API](https://github.com/owncloud/ocis/issues/5125)
 

--- a/tests/acceptance/features/apiSettings/settings.feature
+++ b/tests/acceptance/features/apiSettings/settings.feature
@@ -66,6 +66,62 @@ Feature: settings api
       | permissionsRole | Viewer       |
     Then user "Brian" should have sync disabled for share "textfile.txt"
 
+  @issue-11335
+  Scenario: enable auto-sync-shares after disabling it
+    And user "Brian" has disabled the auto-sync share
+    When user "Brian" enables the auto-sync share using the settings API
+    Then the HTTP status code should be "201"
+    And the JSON data of the response should match
+      """
+      {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value" : {
+            "type": "object",
+            "required": ["identifier","value"],
+            "properties": {
+              "identifier": {
+                "type": "object",
+                "required": ["extension", "bundle", "setting"],
+                "properties": {
+                  "extension": { "const": "ocis-accounts" },
+                  "bundle": { "const": "profile" },
+                  "setting": { "const": "auto-accept-shares" }
+                }
+              },
+              "value": {
+                "type": "object",
+                "required": ["id", "bundleId", "settingId", "accountUuid", "resource", "boolValue"],
+                "properties": {
+                  "id": { "pattern": "^%user_id_pattern%$" },
+                  "bundleId": { "pattern": "^%user_id_pattern%$" },
+                  "settingId": { "pattern": "^%user_id_pattern%$" },
+                  "accountUuid": { "pattern": "^%user_id_pattern%$" },
+                  "resource": {
+                    "type": "object",
+                    "required": ["type"],
+                    "properties": {
+                      "type": { "const": "TYPE_USER" }
+                    }
+                  },
+                  "boolValue": { "const": true }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    And for user "Brian" setting "auto-accept-shares" should have value "true"
+    Given user "Alice" has sent the following resource share invitation:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    Then user "Brian" should have sync enabled for share "textfile.txt"
+
 
   Scenario: assign role to user
     When user "Admin" assigns the role "Admin" to user "Alice" using the settings API

--- a/tests/acceptance/features/apiSettings/settings.feature
+++ b/tests/acceptance/features/apiSettings/settings.feature
@@ -68,6 +68,7 @@ Feature: settings api
 
   @issue-11335
   Scenario: enable auto-sync-shares after disabling it
+    Given user "Alice" has uploaded file with content "lorem epsum" to "textfile.txt"
     And user "Brian" has disabled the auto-sync share
     When user "Brian" enables the auto-sync share using the settings API
     Then the HTTP status code should be "201"


### PR DESCRIPTION
## Description
Added test scenarios to enable share sync after disabling it
```feature
Scenario: enable auto-sync-shares after disabling it
```

## Related Issue
- Coverage for: https://github.com/owncloud/ocis/issues/11335


## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
