### PR TITLE
[full-ci][tests-only]Add tests for restoring specific and all trashed resources of specific space at once

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -289,6 +289,20 @@ class SpacesContext implements Context {
 	}
 
 	/**
+	 * finds available spaces to the user and returns the owner userId by spaceName
+	 *
+	 * @param string $user
+	 * @param string $spaceName
+	 *
+	 * @return string
+	 * @throws GuzzleException
+	 */
+	public function getSpaceOwnerUserIdByName(string $user, string $spaceName): string {
+		$space = $this->getSpaceByName($user, $spaceName);
+		return $space["owner"]["user"]["id"];
+	}
+
+	/**
 	 * @param string $user
 	 * @param string $share
 	 *

--- a/tests/acceptance/features/cliCommands/trashBin.feature
+++ b/tests/acceptance/features/cliCommands/trashBin.feature
@@ -46,3 +46,49 @@ Feature: trashbin
       | /folder-to-delete  | folder |
       | /folder-to-restore | folder |
       | /testfile.txt      | file   |
+
+
+  Scenario: restore all trashed resource at once
+    Given user "Brian" has been created with default attributes
+    And user "Alice" has created the following folders
+      | path              |
+      | folder-to-delete  |
+      | folder-to-restore |
+    And user "Alice" has uploaded file with content "test file" to "testfile.txt"
+    And user "Alice" has deleted the following resources
+      | path              |
+      | folder-to-delete  |
+      | folder-to-restore |
+      | testfile.txt      |
+    And user "Brian" has created folder "BrianFolder"
+    And user "Brian" has deleted folder "BrianFolder"
+    When the administrator restores all the trashed resources of space "Personal" owned by user "Alice"
+    Then the command should be successful
+    And there should be no trashed resources of space "Personal" owned by user "Alice"
+    And user "Alice" should see the following elements
+      | /folder-to-delete  |
+      | /folder-to-restore |
+      | /testfile.txt      |
+    And there should be "1" trashed resources of space "Personal" owned by user "Brian":
+      | resource     | type   |
+      | /BrianFolder | folder |
+
+
+  Scenario: restore specific trashed resource at once
+    Given user "Brian" has been created with default attributes
+    And user "Alice" has created the following folders
+      | path              |
+      | folder-to-delete  |
+      | folder-to-restore |
+    And user "Alice" has uploaded file with content "test file" to "testfile.txt"
+    And user "Alice" has deleted the following resources
+      | path              |
+      | folder-to-delete  |
+      | folder-to-restore |
+      | testfile.txt      |
+    When the administrator restores the trashed resources "/folder-to-restore" of space "Personal" owned by user "Alice"
+    Then the command should be successful
+    And there should be "2" trashed resources of space "Personal" owned by user "Alice":
+      | resource          | type   |
+      | /testfile.txt     | file   |
+      | /folder-to-delete | folder |


### PR DESCRIPTION
## Description
This PR adds cli tests for restoring trashed resources 
- specific item
- all item of specific space at once


## Related Issue
- https://github.com/owncloud/ocis/issues/11248

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
