### PR TITLE
[test-ony][full-ci] add test for list single permission for resources

### DIFF
--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -1604,6 +1604,35 @@ class GraphHelper {
 	}
 
 	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $spaceId
+	 * @param string $itemId
+	 * @param string $permssionId
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	public static function getSinglePermissionList(
+		string $baseUrl,
+		string $user,
+		string $password,
+		string $spaceId,
+		string $itemId,
+		string $permssionId
+	): ResponseInterface {
+		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permssionId");
+
+		return HttpRequestHelper::get(
+			$url,
+			$user,
+			$password,
+			self::getRequestHeaders()
+		);
+	}
+
+	/**
 	 * Get the role id by name
 	 *
 	 * @param string $permissionsRole

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -205,6 +205,43 @@ class SharingNgContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" (?:tries to list|lists) the permission for (?:folder|file) "([^"]*)" of the space "([^"]*)" shared via (link|invitation) using the Graph API$/
+	 *
+	 * @param string $user
+	 * @param string $resource
+	 * @param string $space
+	 * @param string $shareMethods
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userGetsPermissionListForResourceOfTheSpaceUsingTheGraphAPI(
+		string $user,
+		string $resource,
+		string $space,
+		string $shareMethods
+	): void {
+		if ($shareMethods === 'link') {
+			$permissionId = $this->featureContext->shareNgGetLastCreatedLinkShareID();
+		} else {
+			$permissionId = $this->featureContext->shareNgGetLastCreatedUserGroupShareID();
+		}
+		$spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
+		$itemId = $this->spacesContext->getResourceId($user, $space, $resource);
+
+		$response = GraphHelper::getSinglePermissionList(
+			$this->featureContext->getBaseUrl(),
+			$user,
+			$this->featureContext->getPasswordForUser($user),
+			$spaceId,
+			$itemId,
+			$permissionId
+		);
+
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" lists the permissions of space "([^"]*)" using permissions endpoint of the Graph API$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -393,5 +393,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSharingNgShares/sharedWithMe.feature:5410](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5410)
 - [apiSharingNgShares/sharedWithMe.feature:5411](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgShares/sharedWithMe.feature#L5411)
 
+### [[Sharing NG] Implement https://owncloud.dev/libre-graph-api/#/drives.permissions/GetPermission](https://github.com/owncloud/ocis/issues/8616)
+- [apiSharingNgPermissions/listPermissions.feature:2585](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature#L2585)
+- [apiSharingNgPermissions/listPermissions.feature:2631](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature#L2631)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR has added tests for listing single sharing permission for resources using [/v1beta1/drives/{drive-id}/items/{item-id}/permissions/{perm-id}](https://owncloud.dev/libre-graph-api/#/drives.permissions/GetPermission
) api endpoint.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/8616
- part of https://github.com/owncloud/ocis/issues/9524


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
