### PR TITLE
[full-ci][tests-only] check personal settings value after update

### DIFF
--- a/tests/acceptance/TestHelpers/SettingsHelper.php
+++ b/tests/acceptance/TestHelpers/SettingsHelper.php
@@ -33,7 +33,10 @@ class SettingsHelper {
 	private static string $settingsEndpoint = '/api/v0/settings/';
 
 	private const BUNDLE_ID = "2a506de7-99bd-4f0d-994e-c38e72c28fd9";
-	private const PROFILE_LANGUAGE_ID = "aa8cfbe5-95d4-4f7e-a032-c3c01f5f062f";
+	public const PROFILE_SETTINGS = [
+		'language' => 'aa8cfbe5-95d4-4f7e-a032-c3c01f5f062f',
+		'auto-accept-shares' => 'ec3ed4a3-3946-4efc-8f9f-76d38b12d3a9',
+	];
 
 	private const DEFAULT_SETTING_EVENTS = [
 		'Disable Email Notifications' => '33ffb5d6-cd07-4dc0-afb0-84f7559ae438',
@@ -259,7 +262,7 @@ class SettingsHelper {
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
-	public static function getAutoAcceptSharesSettingValue(
+	public static function getAutoAcceptSharesDefaultValue(
 		string $baseUrl,
 		string $user,
 		string $password,
@@ -299,7 +302,7 @@ class SettingsHelper {
 	): string {
 		$response = self::getValuesBySettingID(
 			$baseUrl,
-			self::PROFILE_LANGUAGE_ID,
+			self::PROFILE_SETTINGS['language'],
 			$user,
 			$password,
 		);

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -179,7 +179,7 @@ class FeatureContext extends BehatVariablesContext {
 		if (\array_key_exists($user, $this->autoSyncSettings)) {
 			return $this->autoSyncSettings[$user];
 		}
-		$autoSyncSetting = SettingsHelper::getAutoAcceptSharesSettingValue(
+		$autoSyncSetting = SettingsHelper::getAutoAcceptSharesDefaultValue(
 			$this->baseUrl,
 			$user,
 			$this->getPasswordForUser($user),

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -21,9 +21,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [Settings service user can list other peoples assignments](https://github.com/owncloud/ocis/issues/5032)
 
-- [apiSettings/settings.feature:116](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L116)
-- [apiSettings/settings.feature:117](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L117)
-- [apiSettings/settings.feature:118](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L118)
+- [apiSettings/settings.feature:125](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L125)
+- [apiSettings/settings.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L126)
+- [apiSettings/settings.feature:127](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSettings/settings.feature#L127)
 
 #### [A User can get information of another user with Graph API](https://github.com/owncloud/ocis/issues/5125)
 

--- a/tests/acceptance/features/apiSettings/settings.feature
+++ b/tests/acceptance/features/apiSettings/settings.feature
@@ -12,6 +12,7 @@ Feature: settings api
 
 
   Scenario: disable auto-sync share
+    Given user "Alice" has uploaded file with content "lorem epsum" to "textfile.txt"
     When user "Brian" disables the auto-sync share using the settings API
     Then the HTTP status code should be "201"
     And the JSON data of the response should match
@@ -56,6 +57,14 @@ Feature: settings api
         }
       }
       """
+    And for user "Brian" setting "auto-accept-shares" should have value "false"
+    Given user "Alice" has sent the following resource share invitation:
+      | resource        | textfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    Then user "Brian" should have sync disabled for share "textfile.txt"
 
 
   Scenario: assign role to user
@@ -180,6 +189,7 @@ Feature: settings api
         }
       }
       """
+    And for user "Alice" setting "language" should have value "de"
 
   @issue-5079
   Scenario Outline: user lists existing roles


### PR DESCRIPTION
## Description
Check the personal bundle settings value after an update.
Currently, we have test scenarios to change `auto-accept-shares` and `language` settings. PR adds the checks for them.


## Related Issue
- taken from https://github.com/owncloud/ocis/pull/11336
- related https://github.com/owncloud/ocis/issues/11335


## How Has This Been Tested?
- test environment: :raised_back_of_hand: 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
