### PR TITLE
[tests-only][full-ci] Add tests related to purge expired trash resources

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -894,4 +894,17 @@ class CliContext implements Context {
 		];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}
+
+	/**
+	 * @When the administrator purges the expired trash resources
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorPurgesTheExpiredTrashResources(): void {
+		$body = [
+			"command" => "storage-users trash-bin purge-expired"
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
 }

--- a/tests/acceptance/features/cliCommands/trashBin.feature
+++ b/tests/acceptance/features/cliCommands/trashBin.feature
@@ -92,3 +92,47 @@ Feature: trashbin
       | resource          | type   |
       | /testfile.txt     | file   |
       | /folder-to-delete | folder |
+
+
+  Scenario: purge expired trashed resources of Personal space
+    Given the following configs have been set:
+      | config                                               | value |
+      | STORAGE_USERS_PURGE_TRASH_BIN_PERSONAL_DELETE_BEFORE | 1s    |
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created the following folders
+      | path              |
+      | folder-to-delete  |
+    And user "Alice" has deleted folder "/folder-to-delete"
+    And user "Alice" has created a space "Newspace" with the default quota using the Graph API
+    And user "Alice" has created a folder "uploadFolder" in space "Newspace"
+    And user "Alice" has uploaded a file inside space "Newspace" with content "hello world" to "text.txt"
+    And user "Alice" has removed the file "text.txt" from space "Newspace"
+    And the system waits for "1" seconds
+    When the administrator purges the expired trash resources
+    Then there should be no trashed resources of space "Personal" owned by user "Alice"
+    And there should be "1" trashed resources of space "Newspace" owned by user "Alice":
+      | resource  | type   |
+      | /text.txt | file |
+
+
+  Scenario: purge expired trashed resources of project space
+    Given the following configs have been set:
+      | config                                              | value |
+      | STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE | 1s    |
+    And using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created the following folders
+      | path              |
+      | folder-to-delete  |
+    And user "Alice" has deleted folder "/folder-to-delete"
+    And user "Alice" has created a space "Newspace" with the default quota using the Graph API
+    And user "Alice" has created a folder "uploadFolder" in space "Newspace"
+    And user "Alice" has uploaded a file inside space "Newspace" with content "hello world" to "text.txt"
+    And user "Alice" has removed the file "text.txt" from space "Newspace"
+    And the system waits for "1" seconds
+    When the administrator purges the expired trash resources
+    Then there should be no trashed resources of space "Newspace" owned by user "Alice"
+    And there should be "1" trashed resources of space "Personal" owned by user "Alice":
+      | resource          | type   |
+      | /folder-to-delete | folder |


### PR DESCRIPTION
## Description
This PR adds tests for purging trashed resources resources
 used ocis env to set expiration time interval 
- STORAGE_USERS_PURGE_TRASH_BIN_PERSONAL_DELETE_BEFORE
- STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE

## Related Issue
- https://github.com/owncloud/ocis/issues/11248

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
