### PR TITLE
fix: [WIP] fix data race during startup

### DIFF
--- a/ocis-pkg/clihelper/app.go
+++ b/ocis-pkg/clihelper/app.go
@@ -21,6 +21,7 @@ func DefaultApp(app *cli.App) *cli.App {
 	// disable global version flag
 	// instead we provide the version command
 	app.HideVersion = true
+	app.HideHelp = true
 
 	return app
 }

--- a/ocis/pkg/command/backup.go
+++ b/ocis/pkg/command/backup.go
@@ -17,8 +17,9 @@ import (
 // BackupCommand is the entrypoint for the backup command
 func BackupCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "backup",
-		Usage: "ocis backup functionality",
+		HideHelp: true,
+		Name:     "backup",
+		Usage:    "ocis backup functionality",
 		Subcommands: []*cli.Command{
 			ConsistencyCommand(cfg),
 		},
@@ -35,8 +36,9 @@ func BackupCommand(cfg *config.Config) *cli.Command {
 // ConsistencyCommand is the entrypoint for the consistency Command
 func ConsistencyCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "consistency",
-		Usage: "check backup consistency",
+		HideHelp: true,
+		Name:     "consistency",
+		Usage:    "check backup consistency",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "basepath",

--- a/ocis/pkg/command/benchmark.go
+++ b/ocis/pkg/command/benchmark.go
@@ -26,6 +26,7 @@ import (
 // BenchmarkCommand is the entrypoint for the benchmark commands.
 func BenchmarkCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp:    true,
 		Name:        "benchmark",
 		Usage:       "cli tools to test low and high level performance",
 		Category:    "benchmark",
@@ -36,7 +37,8 @@ func BenchmarkCommand(cfg *config.Config) *cli.Command {
 // BenchmarkClientCommand is the entrypoint for the benchmark client command.
 func BenchmarkClientCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name: "client",
+		HideHelp: true,
+		Name:     "client",
 
 		Usage: "Start a client that continuously makes web requests and prints stats. The options mimic curl, but URL must be at the end.",
 		Flags: []cli.Flag{
@@ -281,8 +283,9 @@ func client(o clientOptions) error {
 // BenchmarkSyscallsCommand is the entrypoint for the benchmark syscalls command.
 func BenchmarkSyscallsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "syscalls",
-		Usage: "test the performance of syscalls",
+		HideHelp: true,
+		Name:     "syscalls",
+		Usage:    "test the performance of syscalls",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "path",

--- a/ocis/pkg/command/decomposedfs.go
+++ b/ocis/pkg/command/decomposedfs.go
@@ -31,6 +31,7 @@ import (
 // DecomposedfsCommand is the entrypoint for the groups command.
 func DecomposedfsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "decomposedfs",
 		Usage:    `cli tools to inspect and manipulate a decomposedfs storage.`,
 		Category: "maintenance",
@@ -47,8 +48,9 @@ func init() {
 
 func checkCmd(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "check-treesize",
-		Usage: `cli tool to check the treesize metadata of a Space`,
+		HideHelp: true,
+		Name:     "check-treesize",
+		Usage:    `cli tool to check the treesize metadata of a Space`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "root",
@@ -186,8 +188,9 @@ func walkTree(ctx context.Context, tree *tree.Tree, lu *lookup.Lookup, root *nod
 
 func metadataCmd(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "metadata",
-		Usage: `cli tools to inspect and manipulate node metadata`,
+		HideHelp: true,
+		Name:     "metadata",
+		Usage:    `cli tools to inspect and manipulate node metadata`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "root",
@@ -208,8 +211,9 @@ func metadataCmd(cfg *config.Config) *cli.Command {
 
 func dumpCmd(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "dump",
-		Usage: `print the metadata of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.`,
+		HideHelp: true,
+		Name:     "dump",
+		Usage:    `print the metadata of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.`,
 		Action: func(c *cli.Context) error {
 			lu, backend := getBackend(c)
 			path, err := getPath(c, lu)
@@ -230,8 +234,9 @@ func dumpCmd(cfg *config.Config) *cli.Command {
 
 func getCmd(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "get",
-		Usage: `print a specific attribute of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.`,
+		HideHelp: true,
+		Name:     "get",
+		Usage:    `print a specific attribute of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "attribute",
@@ -259,8 +264,9 @@ func getCmd(cfg *config.Config) *cli.Command {
 
 func setCmd(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "set",
-		Usage: `manipulate metadata of the given node. Binary attributes can be given hex encoded (prefix by '0x') or base64 encoded (prefix by '0s').`,
+		HideHelp: true,
+		Name:     "set",
+		Usage:    `manipulate metadata of the given node. Binary attributes can be given hex encoded (prefix by '0x') or base64 encoded (prefix by '0s').`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "attribute",

--- a/ocis/pkg/command/init.go
+++ b/ocis/pkg/command/init.go
@@ -17,8 +17,9 @@ import (
 // InitCommand is the entrypoint for the init command
 func InitCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "init",
-		Usage: "initialise an ocis config",
+		HideHelp: true,
+		Name:     "init",
+		Usage:    "initialise an ocis config",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "insecure",

--- a/ocis/pkg/command/list.go
+++ b/ocis/pkg/command/list.go
@@ -14,6 +14,7 @@ import (
 // ListCommand is the entrypoint for the list command.
 func ListCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "list",
 		Usage:    "list oCIS services running in the runtime (supervised mode)",
 		Category: "runtime",

--- a/ocis/pkg/command/migrate.go
+++ b/ocis/pkg/command/migrate.go
@@ -44,6 +44,7 @@ import (
 // Migrate is the entrypoint for the Migrate command.
 func Migrate(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "migrate",
 		Usage:    "migrate data from an existing to another instance",
 		Category: "migration",
@@ -63,6 +64,7 @@ func init() {
 // RebuildJSONCS3Indexes rebuilds the share indexes from the shares json
 func RebuildJSONCS3Indexes(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp:    true,
 		Name:        "rebuild-jsoncs3-indexes",
 		Usage:       "rebuild the share indexes from the shares json",
 		Subcommands: []*cli.Command{},
@@ -203,8 +205,9 @@ func RebuildJSONCS3Indexes(cfg *config.Config) *cli.Command {
 // MigrateDecomposedfs is the entrypoint for the decomposedfs migrate command
 func MigrateDecomposedfs(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "decomposedfs",
-		Usage: "run a decomposedfs migration",
+		HideHelp: true,
+		Name:     "decomposedfs",
+		Usage:    "run a decomposedfs migration",
 		Subcommands: []*cli.Command{
 			ListDecomposedfsMigrations(cfg),
 		},
@@ -261,8 +264,9 @@ func MigrateDecomposedfs(cfg *config.Config) *cli.Command {
 // ListDecomposedfsMigrations is the entrypoint for the decomposedfs list migrations command
 func ListDecomposedfsMigrations(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "list",
-		Usage: "list decomposedfs migrations",
+		HideHelp: true,
+		Name:     "list",
+		Usage:    "list decomposedfs migrations",
 		Action: func(c *cli.Context) error {
 			rootFlag := c.String("root")
 			bod := lookup.DetectBackendOnDisk(rootFlag)
@@ -299,8 +303,9 @@ func ListDecomposedfsMigrations(cfg *config.Config) *cli.Command {
 
 func MigrateShares(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "shares",
-		Usage: "migrates shares from the previous to the new share manager",
+		HideHelp: true,
+		Name:     "shares",
+		Usage:    "migrates shares from the previous to the new share manager",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "from",
@@ -394,8 +399,9 @@ func MigrateShares(cfg *config.Config) *cli.Command {
 
 func MigratePublicShares(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "publicshares",
-		Usage: "migrates public shares from the previous to the new public share manager",
+		HideHelp: true,
+		Name:     "publicshares",
+		Usage:    "migrates public shares from the previous to the new public share manager",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "from",

--- a/ocis/pkg/command/revisions.go
+++ b/ocis/pkg/command/revisions.go
@@ -26,8 +26,9 @@ var (
 // RevisionsCommand is the entrypoint for the revisions command.
 func RevisionsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "revisions",
-		Usage: "ocis revisions functionality",
+		HideHelp: true,
+		Name:     "revisions",
+		Usage:    "ocis revisions functionality",
 		Subcommands: []*cli.Command{
 			PurgeRevisionsCommand(cfg),
 		},
@@ -44,8 +45,9 @@ func RevisionsCommand(cfg *config.Config) *cli.Command {
 // PurgeRevisionsCommand allows removing all revisions from a storage provider.
 func PurgeRevisionsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "purge",
-		Usage: "purge revisions",
+		HideHelp: true,
+		Name:     "purge",
+		Usage:    "purge revisions",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "basepath",

--- a/ocis/pkg/command/server.go
+++ b/ocis/pkg/command/server.go
@@ -12,6 +12,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    "start a fullstack server (runtime and all services in supervised mode)",
 		Category: "fullstack",

--- a/ocis/pkg/command/services.go
+++ b/ocis/pkg/command/services.go
@@ -268,6 +268,7 @@ var svccmds = []register.Command{
 // ServiceCommand is the entry point for the all service commands.
 func ServiceCommand(cfg *config.Config, serviceName string, subcommands []*cli.Command, f func(*config.Config)) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     serviceName,
 		Usage:    helper.SubcommandDescription(serviceName),
 		Category: "services",

--- a/ocis/pkg/command/shares.go
+++ b/ocis/pkg/command/shares.go
@@ -22,6 +22,7 @@ import (
 // SharesCommand is the entrypoint for the groups command.
 func SharesCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "shares",
 		Usage:    `cli tools to manage entries in the share manager.`,
 		Category: "maintenance",
@@ -47,8 +48,9 @@ func init() {
 
 func cleanupCmd(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "cleanup",
-		Usage: `clean up stale entries in the share manager.`,
+		HideHelp: true,
+		Name:     "cleanup",
+		Usage:    `clean up stale entries in the share manager.`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "service-account-id",

--- a/ocis/pkg/command/trash.go
+++ b/ocis/pkg/command/trash.go
@@ -13,8 +13,9 @@ import (
 
 func TrashCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "trash",
-		Usage: "ocis trash functionality",
+		HideHelp: true,
+		Name:     "trash",
+		Usage:    "ocis trash functionality",
 		Subcommands: []*cli.Command{
 			TrashPurgeEmptyDirsCommand(cfg),
 		},
@@ -30,8 +31,9 @@ func TrashCommand(cfg *config.Config) *cli.Command {
 
 func TrashPurgeEmptyDirsCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "purge-empty-dirs",
-		Usage: "purge empty directories",
+		HideHelp: true,
+		Name:     "purge-empty-dirs",
+		Usage:    "purge empty directories",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "basepath",

--- a/ocis/pkg/command/version.go
+++ b/ocis/pkg/command/version.go
@@ -21,8 +21,9 @@ const (
 // VersionCommand is the entrypoint for the version command.
 func VersionCommand(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "version",
-		Usage: "print the version of this binary and all running service instances",
+		HideHelp: true,
+		Name:     "version",
+		Usage:    "print the version of this binary and all running service instances",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  _skipServiceListingFlagName,

--- a/services/activitylog/pkg/command/health.go
+++ b/services/activitylog/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/activitylog/pkg/command/server.go
+++ b/services/activitylog/pkg/command/server.go
@@ -49,6 +49,7 @@ var _registeredEvents = []events.Unmarshaller{
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/activitylog/pkg/command/version.go
+++ b/services/activitylog/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/antivirus/pkg/command/health.go
+++ b/services/antivirus/pkg/command/health.go
@@ -15,6 +15,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/antivirus/pkg/command/server.go
+++ b/services/antivirus/pkg/command/server.go
@@ -20,6 +20,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/antivirus/pkg/command/version.go
+++ b/services/antivirus/pkg/command/version.go
@@ -12,6 +12,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/app-provider/pkg/command/health.go
+++ b/services/app-provider/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/app-provider/pkg/command/server.go
+++ b/services/app-provider/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/app-provider/pkg/command/version.go
+++ b/services/app-provider/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/app-registry/pkg/command/health.go
+++ b/services/app-registry/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/app-registry/pkg/command/server.go
+++ b/services/app-registry/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/app-registry/pkg/command/version.go
+++ b/services/app-registry/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/audit/pkg/command/health.go
+++ b/services/audit/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/audit/pkg/command/server.go
+++ b/services/audit/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/audit/pkg/command/version.go
+++ b/services/audit/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/auth-app/pkg/command/create.go
+++ b/services/auth-app/pkg/command/create.go
@@ -28,6 +28,7 @@ import (
 // Create is the entrypoint for the app auth create command
 func Create(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "create",
 		Usage:    "create an app auth token for a user",
 		Category: "maintenance",

--- a/services/auth-app/pkg/command/health.go
+++ b/services/auth-app/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/auth-app/pkg/command/server.go
+++ b/services/auth-app/pkg/command/server.go
@@ -26,6 +26,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/auth-app/pkg/command/version.go
+++ b/services/auth-app/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/auth-basic/pkg/command/health.go
+++ b/services/auth-basic/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/auth-basic/pkg/command/server.go
+++ b/services/auth-basic/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/auth-basic/pkg/command/version.go
+++ b/services/auth-basic/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/auth-bearer/pkg/command/health.go
+++ b/services/auth-bearer/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/auth-bearer/pkg/command/server.go
+++ b/services/auth-bearer/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/auth-bearer/pkg/command/version.go
+++ b/services/auth-bearer/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running services instances",
 		Category: "info",

--- a/services/auth-machine/pkg/command/health.go
+++ b/services/auth-machine/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/auth-machine/pkg/command/server.go
+++ b/services/auth-machine/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/auth-machine/pkg/command/version.go
+++ b/services/auth-machine/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/auth-service/pkg/command/health.go
+++ b/services/auth-service/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/auth-service/pkg/command/server.go
+++ b/services/auth-service/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/auth-service/pkg/command/version.go
+++ b/services/auth-service/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/clientlog/pkg/command/health.go
+++ b/services/clientlog/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/clientlog/pkg/command/server.go
+++ b/services/clientlog/pkg/command/server.go
@@ -49,6 +49,7 @@ var _registeredEvents = []events.Unmarshaller{
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/clientlog/pkg/command/version.go
+++ b/services/clientlog/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/collaboration/pkg/command/health.go
+++ b/services/collaboration/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/collaboration/pkg/command/server.go
+++ b/services/collaboration/pkg/command/server.go
@@ -27,6 +27,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/collaboration/pkg/command/version.go
+++ b/services/collaboration/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/eventhistory/pkg/command/health.go
+++ b/services/eventhistory/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/eventhistory/pkg/command/server.go
+++ b/services/eventhistory/pkg/command/server.go
@@ -27,6 +27,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/eventhistory/pkg/command/version.go
+++ b/services/eventhistory/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/frontend/pkg/command/health.go
+++ b/services/frontend/pkg/command/health.go
@@ -16,6 +16,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/frontend/pkg/command/server.go
+++ b/services/frontend/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/frontend/pkg/command/version.go
+++ b/services/frontend/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/gateway/pkg/command/health.go
+++ b/services/gateway/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/gateway/pkg/command/server.go
+++ b/services/gateway/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/gateway/pkg/command/version.go
+++ b/services/gateway/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/graph/pkg/command/health.go
+++ b/services/graph/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/graph/pkg/command/server.go
+++ b/services/graph/pkg/command/server.go
@@ -21,6 +21,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/graph/pkg/command/unified_roles.go
+++ b/services/graph/pkg/command/unified_roles.go
@@ -51,8 +51,9 @@ func UnifiedRoles(cfg *config.Config) cli.Commands {
 // unifiedRolesStatus lists available unified roles, it contains an indicator to show if the role is enabled or not
 func listUnifiedRoles(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "list",
-		Usage: "list available unified roles",
+		HideHelp: true,
+		Name:     "list",
+		Usage:    "list available unified roles",
 		Action: func(c *cli.Context) error {
 			tbl := tablewriter.NewWriter(os.Stdout)
 			tbl.SetRowLine(true)

--- a/services/graph/pkg/command/version.go
+++ b/services/graph/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/groups/pkg/command/health.go
+++ b/services/groups/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/groups/pkg/command/server.go
+++ b/services/groups/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/groups/pkg/command/version.go
+++ b/services/groups/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/idm/pkg/command/health.go
+++ b/services/idm/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/idm/pkg/command/resetpw.go
+++ b/services/idm/pkg/command/resetpw.go
@@ -24,6 +24,7 @@ import (
 // ResetPassword is the entrypoint for the resetpassword command
 func ResetPassword(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "resetpassword",
 		Usage:    "Reset user password",
 		Category: "password reset",

--- a/services/idm/pkg/command/server.go
+++ b/services/idm/pkg/command/server.go
@@ -30,6 +30,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/idm/pkg/command/version.go
+++ b/services/idm/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/idp/pkg/command/health.go
+++ b/services/idp/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/idp/pkg/command/server.go
+++ b/services/idp/pkg/command/server.go
@@ -33,6 +33,7 @@ const _rsaKeySize = 4096
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/idp/pkg/command/version.go
+++ b/services/idp/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/invitations/pkg/command/health.go
+++ b/services/invitations/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/invitations/pkg/command/server.go
+++ b/services/invitations/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/invitations/pkg/command/version.go
+++ b/services/invitations/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/nats/pkg/command/health.go
+++ b/services/nats/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/nats/pkg/command/server.go
+++ b/services/nats/pkg/command/server.go
@@ -21,6 +21,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/nats/pkg/command/version.go
+++ b/services/nats/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/notifications/pkg/command/health.go
+++ b/services/notifications/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/notifications/pkg/command/send_email.go
+++ b/services/notifications/pkg/command/send_email.go
@@ -14,8 +14,9 @@ import (
 // SendEmail triggers the sending of grouped email notifications for daily or weekly emails.
 func SendEmail(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "send-email",
-		Usage: "Send grouped email notifications with daily or weekly interval. Specify at least one of the flags '--daily' or '--weekly'.",
+		HideHelp: true,
+		Name:     "send-email",
+		Usage:    "Send grouped email notifications with daily or weekly interval. Specify at least one of the flags '--daily' or '--weekly'.",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "daily",

--- a/services/notifications/pkg/command/server.go
+++ b/services/notifications/pkg/command/server.go
@@ -34,6 +34,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/notifications/pkg/command/version.go
+++ b/services/notifications/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/ocdav/pkg/command/health.go
+++ b/services/ocdav/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/ocdav/pkg/command/server.go
+++ b/services/ocdav/pkg/command/server.go
@@ -24,6 +24,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/ocdav/pkg/command/version.go
+++ b/services/ocdav/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/ocm/pkg/command/health.go
+++ b/services/ocm/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/ocm/pkg/command/server.go
+++ b/services/ocm/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/ocm/pkg/command/version.go
+++ b/services/ocm/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/ocs/pkg/command/health.go
+++ b/services/ocs/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/ocs/pkg/command/server.go
+++ b/services/ocs/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/ocs/pkg/command/version.go
+++ b/services/ocs/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/policies/pkg/command/health.go
+++ b/services/policies/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/policies/pkg/command/server.go
+++ b/services/policies/pkg/command/server.go
@@ -27,6 +27,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", "authz"),
 		Category: "server",

--- a/services/policies/pkg/command/version.go
+++ b/services/policies/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/postprocessing/pkg/command/health.go
+++ b/services/postprocessing/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/postprocessing/pkg/command/postprocessing.go
+++ b/services/postprocessing/pkg/command/postprocessing.go
@@ -16,9 +16,10 @@ import (
 // RestartPostprocessing cli command to restart postprocessing
 func RestartPostprocessing(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:    "resume",
-		Aliases: []string{"restart"},
-		Usage:   "resume postprocessing for an uploadID",
+		HideHelp: true,
+		Name:     "resume",
+		Aliases:  []string{"restart"},
+		Usage:    "resume postprocessing for an uploadID",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "upload-id",

--- a/services/postprocessing/pkg/command/server.go
+++ b/services/postprocessing/pkg/command/server.go
@@ -24,6 +24,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/postprocessing/pkg/command/version.go
+++ b/services/postprocessing/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running extension instances",
 		Category: "info",

--- a/services/proxy/pkg/command/health.go
+++ b/services/proxy/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -50,6 +50,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/proxy/pkg/command/version.go
+++ b/services/proxy/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "Print the version of this binary and the running service instances",
 		Category: "Version",

--- a/services/search/pkg/command/health.go
+++ b/services/search/pkg/command/health.go
@@ -13,6 +13,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/search/pkg/command/index.go
+++ b/services/search/pkg/command/index.go
@@ -20,6 +20,7 @@ import (
 // Index is the entrypoint for the server command.
 func Index(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "index",
 		Usage:    "index the files for one one more users",
 		Category: "index management",

--- a/services/search/pkg/command/server.go
+++ b/services/search/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/search/pkg/command/version.go
+++ b/services/search/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/settings/pkg/command/health.go
+++ b/services/settings/pkg/command/health.go
@@ -14,8 +14,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Before: func(c *cli.Context) error {
 			return configlog.ReturnError(parser.ParseConfig(cfg))
 		},

--- a/services/settings/pkg/command/server.go
+++ b/services/settings/pkg/command/server.go
@@ -24,6 +24,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/settings/pkg/command/version.go
+++ b/services/settings/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/sharing/pkg/command/health.go
+++ b/services/sharing/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/sharing/pkg/command/server.go
+++ b/services/sharing/pkg/command/server.go
@@ -24,6 +24,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/sharing/pkg/command/version.go
+++ b/services/sharing/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/sse/pkg/command/health.go
+++ b/services/sse/pkg/command/health.go
@@ -16,6 +16,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/sse/pkg/command/server.go
+++ b/services/sse/pkg/command/server.go
@@ -28,6 +28,7 @@ var _registeredEvents = []events.Unmarshaller{
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/sse/pkg/command/version.go
+++ b/services/sse/pkg/command/version.go
@@ -13,6 +13,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/storage-publiclink/pkg/command/health.go
+++ b/services/storage-publiclink/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/storage-publiclink/pkg/command/server.go
+++ b/services/storage-publiclink/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/storage-publiclink/pkg/command/version.go
+++ b/services/storage-publiclink/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/storage-shares/pkg/command/health.go
+++ b/services/storage-shares/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/storage-shares/pkg/command/server.go
+++ b/services/storage-shares/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/storage-shares/pkg/command/version.go
+++ b/services/storage-shares/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/storage-system/pkg/command/health.go
+++ b/services/storage-system/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/storage-system/pkg/command/server.go
+++ b/services/storage-system/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/storage-system/pkg/command/version.go
+++ b/services/storage-system/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/storage-users/pkg/command/health.go
+++ b/services/storage-users/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -24,6 +24,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/storage-users/pkg/command/trash_bin.go
+++ b/services/storage-users/pkg/command/trash_bin.go
@@ -57,8 +57,9 @@ var _applyYesFlagTmpl = cli.BoolFlag{
 // TrashBin wraps trash-bin related sub-commands.
 func TrashBin(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "trash-bin",
-		Usage: "manage trash-bin's",
+		HideHelp: true,
+		Name:     "trash-bin",
+		Usage:    "manage trash-bin's",
 		Subcommands: []*cli.Command{
 			PurgeExpiredResources(cfg),
 			listTrashBinItems(cfg),
@@ -71,9 +72,10 @@ func TrashBin(cfg *config.Config) *cli.Command {
 // PurgeExpiredResources cli command removes old trash-bin items.
 func PurgeExpiredResources(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "purge-expired",
-		Usage: "Purge expired trash-bin items",
-		Flags: []cli.Flag{},
+		HideHelp: true,
+		Name:     "purge-expired",
+		Usage:    "Purge expired trash-bin items",
+		Flags:    []cli.Flag{},
 		Before: func(c *cli.Context) error {
 			return configlog.ReturnFatal(parser.ParseConfig(cfg))
 		},
@@ -105,6 +107,7 @@ func listTrashBinItems(cfg *config.Config) *cli.Command {
 	verboseFlag := _verboseFlagTmpl
 	verboseFlag.Destination = &verboseVal
 	return &cli.Command{
+		HideHelp:  true,
 		Name:      "list",
 		Usage:     "Print a list of all trash-bin items of a space.",
 		ArgsUsage: "['spaceID' required]",
@@ -166,6 +169,7 @@ func restoreAllTrashBinItems(cfg *config.Config) *cli.Command {
 	applyYesFlag := _applyYesFlagTmpl
 	applyYesFlag.Destination = &applyYesVal
 	return &cli.Command{
+		HideHelp:  true,
 		Name:      "restore-all",
 		Usage:     "Restore all trash-bin items for a space.",
 		ArgsUsage: "['spaceID' required]",
@@ -264,6 +268,7 @@ func restoreTrashBindItem(cfg *config.Config) *cli.Command {
 	verboseFlag := _verboseFlagTmpl
 	verboseFlag.Destination = &verboseVal
 	return &cli.Command{
+		HideHelp:  true,
 		Name:      "restore",
 		Usage:     "Restore a trash-bin item by ID.",
 		ArgsUsage: "['spaceID' required] ['itemID' required]",

--- a/services/storage-users/pkg/command/uploads.go
+++ b/services/storage-users/pkg/command/uploads.go
@@ -56,8 +56,9 @@ type Session struct {
 // Uploads is the entry point for the uploads command
 func Uploads(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "uploads",
-		Usage: "manage unfinished uploads",
+		HideHelp: true,
+		Name:     "uploads",
+		Usage:    "manage unfinished uploads",
 		Subcommands: []*cli.Command{
 			ListUploadSessions(cfg),
 			DeleteStaleProcessingNodes(cfg),
@@ -68,8 +69,9 @@ func Uploads(cfg *config.Config) *cli.Command {
 // ListUploadSessions prints a list of upload sessiens
 func ListUploadSessions(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "sessions",
-		Usage: "Print a list of upload sessions",
+		HideHelp: true,
+		Name:     "sessions",
+		Usage:    "Print a list of upload sessions",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "id",
@@ -329,8 +331,9 @@ func buildInfo(filter storage.UploadSessionFilter) string {
 // DeleteStaleProcessingNodes is the entry point for the delete-stale-nodes command
 func DeleteStaleProcessingNodes(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "delete-stale-nodes",
-		Usage: "Delete all nodes in processing state that are not referenced by any upload session",
+		HideHelp: true,
+		Name:     "delete-stale-nodes",
+		Usage:    "Delete all nodes in processing state that are not referenced by any upload session",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "spaceid",

--- a/services/storage-users/pkg/command/version.go
+++ b/services/storage-users/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/thumbnails/pkg/command/health.go
+++ b/services/thumbnails/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/thumbnails/pkg/command/server.go
+++ b/services/thumbnails/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/thumbnails/pkg/command/version.go
+++ b/services/thumbnails/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/userlog/pkg/command/health.go
+++ b/services/userlog/pkg/command/health.go
@@ -8,8 +8,9 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:  "health",
-		Usage: "Check health status",
+		HideHelp: true,
+		Name:     "health",
+		Usage:    "Check health status",
 		Action: func(c *cli.Context) error {
 			// Not implemented
 			return nil

--- a/services/userlog/pkg/command/server.go
+++ b/services/userlog/pkg/command/server.go
@@ -52,6 +52,7 @@ var _registeredEvents = []events.Unmarshaller{
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/userlog/pkg/command/version.go
+++ b/services/userlog/pkg/command/version.go
@@ -8,6 +8,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/users/pkg/command/health.go
+++ b/services/users/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/users/pkg/command/server.go
+++ b/services/users/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entry point for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/users/pkg/command/version.go
+++ b/services/users/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/web/pkg/command/health.go
+++ b/services/web/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/web/pkg/command/server.go
+++ b/services/web/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/web/pkg/command/version.go
+++ b/services/web/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/webdav/pkg/command/health.go
+++ b/services/webdav/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/webdav/pkg/command/server.go
+++ b/services/webdav/pkg/command/server.go
@@ -22,6 +22,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/webdav/pkg/command/version.go
+++ b/services/webdav/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",

--- a/services/webfinger/pkg/command/health.go
+++ b/services/webfinger/pkg/command/health.go
@@ -14,6 +14,7 @@ import (
 // Health is the entrypoint for the health command.
 func Health(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "health",
 		Usage:    "check health status",
 		Category: "info",

--- a/services/webfinger/pkg/command/server.go
+++ b/services/webfinger/pkg/command/server.go
@@ -23,6 +23,7 @@ import (
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "server",
 		Usage:    fmt.Sprintf("start the %s service without runtime (unsupervised mode)", cfg.Service.Name),
 		Category: "server",

--- a/services/webfinger/pkg/command/version.go
+++ b/services/webfinger/pkg/command/version.go
@@ -15,6 +15,7 @@ import (
 // Version prints the service versions of all running instances.
 func Version(cfg *config.Config) *cli.Command {
 	return &cli.Command{
+		HideHelp: true,
 		Name:     "version",
 		Usage:    "print the version of this binary and the running service instances",
 		Category: "info",


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Data race seems to happen due to the shared "help" flag that all ocis commands use. The supervisor starts commands in different goroutines that will try to modify the same shared "help" flag.

Removing the "help" flag from the commands fixes the problem, but I don't think it's a good idea because we'll lose an important feature.

## Related Issue
https://github.com/owncloud/ocis/issues/11386

## Motivation and Context
Data races can cause unexpected behavior.

## How Has This Been Tested?
Using a custom build with the `-race` option. Without the PR, there are data races happening during the startup. With the PR, the data races don't show.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Note
Leaving as a draft for now because we don't want to lose the "help" flag. Need to look into alternatives.