### PR TITLE
feat: add SpaceEditorWithoutTrashbin role

### DIFF
--- a/changelog/unreleased/add-space-editor-without-trashbin-role.md
+++ b/changelog/unreleased/add-space-editor-without-trashbin-role.md
@@ -1,0 +1,7 @@
+Enhancement: Add SpaceEditorWithoutTrashbin Role
+
+Added a new built-in role: `SpaceEditorWithoutTrashbin`.
+This role is a subset of the `SpaceEditor` role, but it does not have list/restore resources in trashbin permissions.
+
+https://github.com/owncloud/ocis/pull/11391
+https://github.com/owncloud/ocis/issues/11206

--- a/services/graph/README.md
+++ b/services/graph/README.md
@@ -151,6 +151,7 @@ The following roles are **enabled** by default:
 The following role is **disabled** by default:
 
 - `UnifiedRoleSecureViewer`
+- `UnifiedRoleSpaceEditorWithoutTrashbin`
 
 To enable disabled roles like the `UnifiedRoleSecureViewer`, you must provide the UID(s) by one of the following methods:
 

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -18,6 +18,7 @@ var (
 	_disabledByDefaultUnifiedRoleRoleIDs = []string{
 		unifiedrole.UnifiedRoleSecureViewerID,
 		unifiedrole.UnifiedRoleSpaceEditorWithoutVersionsID,
+		unifiedrole.UnifiedRoleSpaceEditorWithoutTrashbinID,
 		unifiedrole.UnifiedRoleViewerListGrantsID,
 		unifiedrole.UnifiedRoleEditorListGrantsID,
 		unifiedrole.UnifiedRoleEditorListGrantsWithVersionsID,

--- a/services/graph/pkg/unifiedrole/conversion.go
+++ b/services/graph/pkg/unifiedrole/conversion.go
@@ -218,6 +218,8 @@ func cs3RoleToDisplayName(role *conversions.Role) string {
 		return _spaceEditorUnifiedRoleDisplayName
 	case conversions.RoleSpaceEditorWithoutVersions:
 		return _spaceEditorWithoutVersionsUnifiedRoleDisplayName
+	case conversions.RoleSpaceEditorWithoutTrashbin:
+		return _spaceEditorWithoutTrashbinUnifiedRoleDisplayName
 	case conversions.RoleFileEditor:
 		return _fileEditorUnifiedRoleDisplayName
 	case conversions.RoleFileEditorListGrants:

--- a/services/graph/pkg/unifiedrole/export_test.go
+++ b/services/graph/pkg/unifiedrole/export_test.go
@@ -9,6 +9,7 @@ var (
 	RoleEditorListGrantsWithVersions     = roleEditorListGrantsWithVersions
 	RoleSpaceEditor                      = roleSpaceEditor
 	RoleSpaceEditorWithoutVersions       = roleSpaceEditorWithoutVersions
+	RoleSpaceEditorWithoutTrashbin       = roleSpaceEditorWithoutTrashbin
 	RoleFileEditor                       = roleFileEditor
 	RoleFileEditorListGrants             = roleFileEditorListGrants
 	RoleFileEditorListGrantsWithVersions = roleFileEditorListGrantsWithVersions

--- a/services/graph/pkg/unifiedrole/filter.go
+++ b/services/graph/pkg/unifiedrole/filter.go
@@ -53,6 +53,7 @@ func buildInRoles() []*libregraph.UnifiedRoleDefinition {
 		roleEditorListGrantsWithVersions(),
 		roleSpaceEditor(),
 		roleSpaceEditorWithoutVersions(),
+		roleSpaceEditorWithoutTrashbin(),
 		roleFileEditor(),
 		roleFileEditorListGrants(),
 		roleFileEditorListGrantsWithVersions(),

--- a/services/graph/pkg/unifiedrole/roles.go
+++ b/services/graph/pkg/unifiedrole/roles.go
@@ -30,6 +30,8 @@ const (
 	UnifiedRoleSpaceEditorID = "58c63c02-1d89-4572-916a-870abc5a1b7d"
 	// UnifiedRoleSpaceEditorWithoutVersionsID Unified role space editor without list/restore versions id.
 	UnifiedRoleSpaceEditorWithoutVersionsID = "3284f2d5-0070-4ad8-ac40-c247f7c1fb27"
+	// UnifiedRoleSpaceEditorWithoutTrashbinID Unified role space editor without list/restore resources in trashbin id.
+	UnifiedRoleSpaceEditorWithoutTrashbinID = "8f4701d9-c68f-4109-a482-88e22ee32805"
 	// UnifiedRoleFileEditorID Unified role file editor id.
 	UnifiedRoleFileEditorID = "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
 	// UnifiedRoleFileEditorListGrantsID Unified role file editor id.
@@ -142,6 +144,12 @@ var (
 
 	// UnifiedRole SpaseEditorWithoutVersions, Role DisplayName (resolves directly)
 	_spaceEditorWithoutVersionsUnifiedRoleDisplayName = l10n.Template("Can edit without versions")
+
+	// UnifiedRole SpaceEditorWithoutTrashbin, Role DisplayName (resolves directly)
+	_spaceEditorWithoutTrashbinUnifiedRoleDisplayName = l10n.Template("Can edit without trashbin")
+
+	// UnifiedRole SpaceEditorWithoutTrashbin, Role Description (resolves directly)
+	_spaceEditorWithoutTrashbinUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add and delete.")
 
 	// UnifiedRole FileEditor, Role Description (resolves directly)
 	_fileEditorUnifiedRoleDescription = l10n.Template("View, download and edit.")
@@ -363,6 +371,22 @@ var (
 		return &libregraph.UnifiedRoleDefinition{
 			Id:          proto.String(UnifiedRoleSpaceEditorWithoutVersionsID),
 			Description: proto.String(_spaceEditorWithoutVersionsUnifiedRoleDescription),
+			DisplayName: proto.String(cs3RoleToDisplayName(r)),
+			RolePermissions: []libregraph.UnifiedRolePermission{
+				{
+					AllowedResourceActions: CS3ResourcePermissionsToLibregraphActions(r.CS3ResourcePermissions()),
+					Condition:              proto.String(UnifiedRoleConditionDrive),
+				},
+			},
+			LibreGraphWeight: proto.Int32(0),
+		}
+	}
+
+	roleSpaceEditorWithoutTrashbin = func() *libregraph.UnifiedRoleDefinition {
+		r := conversions.NewSpaceEditorWithoutTrashbinRole()
+		return &libregraph.UnifiedRoleDefinition{
+			Id:          proto.String(UnifiedRoleSpaceEditorWithoutTrashbinID),
+			Description: proto.String(_spaceEditorWithoutTrashbinUnifiedRoleDescription),
 			DisplayName: proto.String(cs3RoleToDisplayName(r)),
 			RolePermissions: []libregraph.UnifiedRolePermission{
 				{

--- a/services/graph/pkg/unifiedrole/roles_test.go
+++ b/services/graph/pkg/unifiedrole/roles_test.go
@@ -189,6 +189,7 @@ func TestGetRolesByPermissions(t *testing.T) {
 			unifiedRoleDefinition: []*libregraph.UnifiedRoleDefinition{
 				unifiedrole.RoleSpaceViewer(),
 				unifiedrole.RoleSpaceEditorWithoutVersions(),
+				unifiedrole.RoleSpaceEditorWithoutTrashbin(),
 				unifiedrole.RoleSpaceEditor(),
 				unifiedrole.RoleManager(),
 			},

--- a/services/web/pkg/theme/theme.go
+++ b/services/web/pkg/theme/theme.go
@@ -61,6 +61,10 @@ var themeDefaults = KV{
 				"label":    "UnifiedRoleSpaceEditorWithoutVersions",
 				"iconName": "pencil",
 			},
+			unifiedrole.UnifiedRoleSpaceEditorWithoutTrashbinID: KV{
+				"label":    "UnifiedRoleSpaceEditorWithoutTrashbin",
+				"iconName": "pencil",
+			},
 			unifiedrole.UnifiedRoleManagerID: KV{
 				"label":    "UnifiedRoleManager",
 				"iconName": "user-star",


### PR DESCRIPTION
## Description

Added a new built-in role: `SpaceEditorWithoutTrashbin`. This role is a subset of the `SpaceEditor` role, but it does not have list/restore resources in trashbin permissions.

## Related Issue

- resolves https://github.com/owncloud/ocis/issues/11206

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Open tasks

- [ ] bump reva once the role is merged and tagged
