### PR TITLE
fix: supervisor won't cause data races

### DIFF
--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/runner"
 	authapp "github.com/owncloud/ocis/v2/services/auth-app/pkg/command"
+	"github.com/urfave/cli/v2"
 
 	"github.com/cenkalti/backoff"
 	"github.com/mohae/deepcopy"
@@ -120,6 +121,15 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 		cfg:          opts.Config,
 	}
 
+	// run server command
+	runServerCommand := func(ctx context.Context, server *cli.Command) error {
+		cliCtx := &cli.Context{Context: ctx}
+		if err := server.Before(cliCtx); err != nil {
+			return err
+		}
+		return server.Action(cliCtx)
+	}
+
 	// populate services
 	reg := func(priority int, name string, exec func(context.Context, *ociscfg.Config) error) {
 		if s.Services[priority] == nil {
@@ -132,14 +142,14 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 	reg(0, opts.Config.Nats.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Nats.Context = ctx
 		cfg.Nats.Commons = cfg.Commons
-		return nats.Execute(cfg.Nats)
+		return runServerCommand(ctx, nats.Server(cfg.Nats))
 	})
 
 	// gateway is in priority group 1. It needs to start before the reva services
 	reg(1, opts.Config.Gateway.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Gateway.Context = ctx
 		cfg.Gateway.Commons = cfg.Commons
-		return gateway.Execute(cfg.Gateway)
+		return runServerCommand(ctx, gateway.Server(cfg.Gateway))
 	})
 
 	// priority group 2 is empty for now
@@ -148,157 +158,157 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 	reg(3, opts.Config.Activitylog.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Activitylog.Context = ctx
 		cfg.Activitylog.Commons = cfg.Commons
-		return activitylog.Execute(cfg.Activitylog)
+		return runServerCommand(ctx, activitylog.Server(cfg.Activitylog))
 	})
 	reg(3, opts.Config.AppProvider.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.AppProvider.Context = ctx
 		cfg.AppProvider.Commons = cfg.Commons
-		return appProvider.Execute(cfg.AppProvider)
+		return runServerCommand(ctx, appProvider.Server(cfg.AppProvider))
 	})
 	reg(3, opts.Config.AppRegistry.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.AppRegistry.Context = ctx
 		cfg.AppRegistry.Commons = cfg.Commons
-		return appRegistry.Execute(cfg.AppRegistry)
+		return runServerCommand(ctx, appRegistry.Server(cfg.AppRegistry))
 	})
 	reg(3, opts.Config.AuthBasic.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.AuthBasic.Context = ctx
 		cfg.AuthBasic.Commons = cfg.Commons
-		return authbasic.Execute(cfg.AuthBasic)
+		return runServerCommand(ctx, authbasic.Server(cfg.AuthBasic))
 	})
 	reg(3, opts.Config.AuthMachine.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.AuthMachine.Context = ctx
 		cfg.AuthMachine.Commons = cfg.Commons
-		return authmachine.Execute(cfg.AuthMachine)
+		return runServerCommand(ctx, authmachine.Server(cfg.AuthMachine))
 	})
 	reg(3, opts.Config.AuthService.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.AuthService.Context = ctx
 		cfg.AuthService.Commons = cfg.Commons
-		return authservice.Execute(cfg.AuthService)
+		return runServerCommand(ctx, authservice.Server(cfg.AuthService))
 	})
 	reg(3, opts.Config.Clientlog.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Clientlog.Context = ctx
 		cfg.Clientlog.Commons = cfg.Commons
-		return clientlog.Execute(cfg.Clientlog)
+		return runServerCommand(ctx, clientlog.Server(cfg.Clientlog))
 	})
 	reg(3, opts.Config.EventHistory.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.EventHistory.Context = ctx
 		cfg.EventHistory.Commons = cfg.Commons
-		return eventhistory.Execute(cfg.EventHistory)
+		return runServerCommand(ctx, eventhistory.Server(cfg.EventHistory))
 	})
 	reg(3, opts.Config.Graph.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Graph.Context = ctx
 		cfg.Graph.Commons = cfg.Commons
-		return graph.Execute(cfg.Graph)
+		return runServerCommand(ctx, graph.Server(cfg.Graph))
 	})
 	reg(3, opts.Config.Groups.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Groups.Context = ctx
 		cfg.Groups.Commons = cfg.Commons
-		return groups.Execute(cfg.Groups)
+		return runServerCommand(ctx, groups.Server(cfg.Groups))
 	})
 	reg(3, opts.Config.IDM.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.IDM.Context = ctx
 		cfg.IDM.Commons = cfg.Commons
-		return idm.Execute(cfg.IDM)
+		return runServerCommand(ctx, idm.Server(cfg.IDM))
 	})
 	reg(3, opts.Config.OCDav.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.OCDav.Context = ctx
 		cfg.OCDav.Commons = cfg.Commons
-		return ocdav.Execute(cfg.OCDav)
+		return runServerCommand(ctx, ocdav.Server(cfg.OCDav))
 	})
 	reg(3, opts.Config.OCS.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.OCS.Context = ctx
 		cfg.OCS.Commons = cfg.Commons
-		return ocs.Execute(cfg.OCS)
+		return runServerCommand(ctx, ocs.Server(cfg.OCS))
 	})
 	reg(3, opts.Config.Postprocessing.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Postprocessing.Context = ctx
 		cfg.Postprocessing.Commons = cfg.Commons
-		return postprocessing.Execute(cfg.Postprocessing)
+		return runServerCommand(ctx, postprocessing.Server(cfg.Postprocessing))
 	})
 	reg(3, opts.Config.Search.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Search.Context = ctx
 		cfg.Search.Commons = cfg.Commons
-		return search.Execute(cfg.Search)
+		return runServerCommand(ctx, search.Server(cfg.Search))
 	})
 	reg(3, opts.Config.Settings.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Settings.Context = ctx
 		cfg.Settings.Commons = cfg.Commons
-		return settings.Execute(cfg.Settings)
+		return runServerCommand(ctx, settings.Server(cfg.Settings))
 	})
 	reg(3, opts.Config.StoragePublicLink.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.StoragePublicLink.Context = ctx
 		cfg.StoragePublicLink.Commons = cfg.Commons
-		return storagepublic.Execute(cfg.StoragePublicLink)
+		return runServerCommand(ctx, storagepublic.Server(cfg.StoragePublicLink))
 	})
 	reg(3, opts.Config.StorageShares.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.StorageShares.Context = ctx
 		cfg.StorageShares.Commons = cfg.Commons
-		return storageshares.Execute(cfg.StorageShares)
+		return runServerCommand(ctx, storageshares.Server(cfg.StorageShares))
 	})
 	reg(3, opts.Config.StorageSystem.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.StorageSystem.Context = ctx
 		cfg.StorageSystem.Commons = cfg.Commons
-		return storageSystem.Execute(cfg.StorageSystem)
+		return runServerCommand(ctx, storageSystem.Server(cfg.StorageSystem))
 	})
 	reg(3, opts.Config.StorageUsers.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.StorageUsers.Context = ctx
 		cfg.StorageUsers.Commons = cfg.Commons
-		return storageusers.Execute(cfg.StorageUsers)
+		return runServerCommand(ctx, storageusers.Server(cfg.StorageUsers))
 	})
 	reg(3, opts.Config.Thumbnails.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Thumbnails.Context = ctx
 		cfg.Thumbnails.Commons = cfg.Commons
-		return thumbnails.Execute(cfg.Thumbnails)
+		return runServerCommand(ctx, thumbnails.Server(cfg.Thumbnails))
 	})
 	reg(3, opts.Config.Userlog.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Userlog.Context = ctx
 		cfg.Userlog.Commons = cfg.Commons
-		return userlog.Execute(cfg.Userlog)
+		return runServerCommand(ctx, userlog.Server(cfg.Userlog))
 	})
 	reg(3, opts.Config.Users.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Users.Context = ctx
 		cfg.Users.Commons = cfg.Commons
-		return users.Execute(cfg.Users)
+		return runServerCommand(ctx, users.Server(cfg.Users))
 	})
 	reg(3, opts.Config.Web.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Web.Context = ctx
 		cfg.Web.Commons = cfg.Commons
-		return web.Execute(cfg.Web)
+		return runServerCommand(ctx, web.Server(cfg.Web))
 	})
 	reg(3, opts.Config.WebDAV.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.WebDAV.Context = ctx
 		cfg.WebDAV.Commons = cfg.Commons
-		return webdav.Execute(cfg.WebDAV)
+		return runServerCommand(ctx, webdav.Server(cfg.WebDAV))
 	})
 	reg(3, opts.Config.Webfinger.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Webfinger.Context = ctx
 		cfg.Webfinger.Commons = cfg.Commons
-		return webfinger.Execute(cfg.Webfinger)
+		return runServerCommand(ctx, webfinger.Server(cfg.Webfinger))
 	})
 	reg(3, opts.Config.IDP.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.IDP.Context = ctx
 		cfg.IDP.Commons = cfg.Commons
-		return idp.Execute(cfg.IDP)
+		return runServerCommand(ctx, idp.Server(cfg.IDP))
 	})
 	reg(3, opts.Config.Proxy.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Proxy.Context = ctx
 		cfg.Proxy.Commons = cfg.Commons
-		return proxy.Execute(cfg.Proxy)
+		return runServerCommand(ctx, proxy.Server(cfg.Proxy))
 	})
 	reg(3, opts.Config.Sharing.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Sharing.Context = ctx
 		cfg.Sharing.Commons = cfg.Commons
-		return sharing.Execute(cfg.Sharing)
+		return runServerCommand(ctx, sharing.Server(cfg.Sharing))
 	})
 	reg(3, opts.Config.SSE.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.SSE.Context = ctx
 		cfg.SSE.Commons = cfg.Commons
-		return sse.Execute(cfg.SSE)
+		return runServerCommand(ctx, sse.Server(cfg.SSE))
 	})
 	reg(3, opts.Config.OCM.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.OCM.Context = ctx
 		cfg.OCM.Commons = cfg.Commons
-		return ocm.Execute(cfg.OCM)
+		return runServerCommand(ctx, ocm.Server(cfg.OCM))
 	})
 
 	// out of some unknown reason ci gets angry when frontend service starts in priority group 3
@@ -307,7 +317,7 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 	reg(4, opts.Config.Frontend.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Frontend.Context = ctx
 		cfg.Frontend.Commons = cfg.Commons
-		return frontend.Execute(cfg.Frontend)
+		return runServerCommand(ctx, frontend.Server(cfg.Frontend))
 	})
 
 	// populate optional services
@@ -317,32 +327,32 @@ func NewService(ctx context.Context, options ...Option) (*Service, error) {
 	areg(opts.Config.Antivirus.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Antivirus.Context = ctx
 		// cfg.Antivirus.Commons = cfg.Commons // antivirus holds no Commons atm
-		return antivirus.Execute(cfg.Antivirus)
+		return runServerCommand(ctx, antivirus.Server(cfg.Antivirus))
 	})
 	areg(opts.Config.Audit.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Audit.Context = ctx
 		cfg.Audit.Commons = cfg.Commons
-		return audit.Execute(cfg.Audit)
+		return runServerCommand(ctx, audit.Server(cfg.Audit))
 	})
 	areg(opts.Config.AuthApp.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.AuthApp.Context = ctx
 		cfg.AuthApp.Commons = cfg.Commons
-		return authapp.Execute(cfg.AuthApp)
+		return runServerCommand(ctx, authapp.Server(cfg.AuthApp))
 	})
 	areg(opts.Config.Policies.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Policies.Context = ctx
 		cfg.Policies.Commons = cfg.Commons
-		return policies.Execute(cfg.Policies)
+		return runServerCommand(ctx, policies.Server(cfg.Policies))
 	})
 	areg(opts.Config.Invitations.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Invitations.Context = ctx
 		cfg.Invitations.Commons = cfg.Commons
-		return invitations.Execute(cfg.Invitations)
+		return runServerCommand(ctx, invitations.Server(cfg.Invitations))
 	})
 	areg(opts.Config.Notifications.Service.Name, func(ctx context.Context, cfg *ociscfg.Config) error {
 		cfg.Notifications.Context = ctx
 		cfg.Notifications.Commons = cfg.Commons
-		return notifications.Execute(cfg.Notifications)
+		return runServerCommand(ctx, notifications.Server(cfg.Notifications))
 	})
 
 	return s, nil
@@ -361,7 +371,7 @@ func Start(ctx context.Context, o ...Option) error {
 	}
 
 	// cancel the context when a signal is received.
-	var cancel context.CancelFunc
+	var cancel context.CancelFunc = func() {}
 	if ctx == nil {
 		ctx, cancel = signal.NotifyContext(context.Background(), runner.StopSignals...)
 		defer cancel()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Supervised services will just run the `Server` command directly of the respective services. This won't involve additional parsing of flags that was happening before and was causing a data race.

## Related Issue
https://github.com/owncloud/ocis/issues/11386

## Motivation and Context
Data races can cause unexpected behavior.

## How Has This Been Tested?
Using a custom build with the` -race` option. Without the PR, there are data races happening during the startup. With the PR, the data races don't show.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
