### PR TITLE
feat: container signals will reach ocis

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/docker-compose.yml
+++ b/deployments/examples/oc10_ocis_parallel/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     # run ocis init to initialize a configuration file with random secrets
     # it will fail on subsequent runs, because the config file already exists
     # therefore we ignore the error and then start the ocis server
-    command: ["-c", "ocis init || true; ocis server"]
+    command: ["-c", "ocis init || true; exec ocis server"]
     #entrypoint:
     #  - /bin/sh
     #  - /entrypoint-override.sh

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -21,9 +21,7 @@ services:
         condition: service_started
       collabora:
         condition: service_healthy
-    entrypoint:
-      - /bin/sh
-    command: [ "-c", "ocis collaboration server" ]
+    command: ["ocis", "collaboration", "server"]
     environment:
       COLLABORATION_GRPC_ADDR: 0.0.0.0:9301
       COLLABORATION_HTTP_ADDR: 0.0.0.0:9300

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -16,7 +16,7 @@ services:
     # run ocis init to initialize a configuration file with random secrets
     # it will fail on subsequent runs, because the config file already exists
     # therefore we ignore the error and then start the ocis server
-    command: ["-c", "ocis init || true; ocis server"]
+    command: ["-c", "ocis init || true; exec ocis server"]
     environment:
       # enable services that are not started automatically
       OCIS_ADD_RUN_SERVICES: ${START_ADDITIONAL_SERVICES}

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -16,9 +16,7 @@ services:
         condition: service_started
       onlyoffice:
         condition: service_healthy
-    entrypoint:
-      - /bin/sh
-    command: [ "-c", "ocis collaboration server" ]
+    command: ["ocis", "collaboration", "server"]
     environment:
       COLLABORATION_GRPC_ADDR: 0.0.0.0:9301
       COLLABORATION_HTTP_ADDR: 0.0.0.0:9300

--- a/deployments/examples/ocis_hello/docker-compose.yml
+++ b/deployments/examples/ocis_hello/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     # run ocis init to initialize a configuration file with random secrets
     # it will fail on subsequent runs, because the config file already exists
     # therefore we ignore the error and then start the ocis server
-    command: ["-c", "ocis init || true; ocis server"]
+    command: ["-c", "ocis init || true; exec ocis server"]
     environment:
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-info}

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     # run ocis init to initialize a configuration file with random secrets
     # it will fail on subsequent runs, because the config file already exists
     # therefore we ignore the error and then start the ocis server
-    command: ["-c", "ocis init || true; ocis server"]
+    command: ["-c", "ocis init || true; exec ocis server"]
     environment:
       # Keycloak IDP specific configuration
       PROXY_AUTOPROVISION_ACCOUNTS: "true"

--- a/deployments/examples/ocis_ldap/docker-compose.yml
+++ b/deployments/examples/ocis_ldap/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     # run ocis init to initialize a configuration file with random secrets
     # it will fail on subsequent runs, because the config file already exists
     # therefore we ignore the error and then start the ocis server
-    command: [ "-c", "ocis init || true; ocis server" ]
+    command: [ "-c", "ocis init || true; exec ocis server" ]
     environment:
       # users/groups from ldap
       OCIS_LDAP_URI: ldaps://ldap-server:1636

--- a/deployments/examples/ocis_ocm/ocis.yml
+++ b/deployments/examples/ocis_ocm/ocis.yml
@@ -16,7 +16,7 @@ services:
     # run ocis init to initialize a configuration file with random secrets
     # it will fail on subsequent runs, because the config file already exists
     # therefore we ignore the error and then start the ocis server
-    command: ["-c", "ocis init || true; ocis server"]
+    command: ["-c", "ocis init || true; exec ocis server"]
     environment:
       # enable services that are not started automatically
       OCIS_ADD_RUN_SERVICES: ${START_ADDITIONAL_SERVICES}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Fix signal delivery in the docker containers for the deployment examples. This will allow a clean shutdown process in the oCIS containers.

## Related Issue
https://github.com/owncloud/ocis/issues/11399

## Motivation and Context
Signals weren't being delivered to oCIS. Docker needed to kill the containers because they didn't stop.

## How Has This Been Tested?
Manually tested. Just start the containers and stop them after a while. Shutting down the whole docker stack takes around 3 seconds, so docker doesn't need to kill the containers.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
