### PR TITLE
refactor: clarify setup for the RPC server

### DIFF
--- a/ocis/pkg/runtime/service/service.go
+++ b/ocis/pkg/runtime/service/service.go
@@ -406,7 +406,7 @@ func Start(ctx context.Context, o ...Option) error {
 	srv, err := newRPCServer(s)
 	if err != nil {
 		s.Log.Fatal().Err(err).Msg("could not create RPC server")
-		// TODO: Should abort? previous code kept going
+		return err
 	}
 
 	// prepare the set of services to run


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Preparing the RPC server is more clear now. There is only one "hidden" interaction with the `http.DefaultServeMux`, which is explained in the code (I don't think there is a way around it), but the rest is pretty explicit.
From the outside it's just create the RPC server and start listening with the resulting instance.

## Related Issue
https://github.com/owncloud/ocis/issues/11376

## Motivation and Context
The code should be easier to read and understand now.

## How Has This Been Tested?
Manually tested. Just start a server and then run `ocis list` to show the running services.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
