### PR TITLE
[docs-only] Update ocis_full image versions

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -97,7 +97,10 @@ MINIO_DOMAIN=
 # Define SMPT settings if you would like to send Infinite Scale email notifications.
 # For more details see:
 # https://doc.owncloud.com/ocis/latest/deployment/services/s-list/notifications.html
-# NOTE: when configuring mail server (i.e., Mailpit), these settings have no effect, see mailserver.yml for details.
+#
+# Note: When configuring a mail server for testing purposes, such as Mailpit,
+# these settings will have no effect. See 'mailserver.yml' for details.
+#
 # SMTP host to connect to.
 SMTP_HOST=
 # Port of the SMTP host to connect to.

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -51,7 +51,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.1.1.1
+    image: collabora/code:25.04.2.2.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       ocis-net:

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   traefik:
-    image: traefik:v3.4.0
+    image: traefik:v3.4.1
     # release notes: https://github.com/traefik/traefik/releases
     networks:
       ocis-net:

--- a/deployments/examples/ocis_full/mailserver.yml
+++ b/deployments/examples/ocis_full/mailserver.yml
@@ -8,7 +8,7 @@ services:
       NOTIFICATIONS_SMTP_INSECURE: "true"
 
   mailserver:
-    image: axllent/mailpit:v1.22.3
+    image: axllent/mailpit:v1.26
     networks:
       - ocis-net
     ports:


### PR DESCRIPTION
This PR updates the image version of the `ocis_full` deployment example.

Tested on Hetzner with master, works.

Should be merged before Addams so it is part of the derived docs.