### PR TITLE
[tests-only][full-ci] fix search reindexing cli tests

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -54,6 +54,16 @@ class CliContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has cleaned the search service data
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasCleanedTheSearchServiceData(): void {
+		$dataPath = $this->featureContext->getOcisDataPath() . "/search";
+		\exec("rm -rf $dataPath");
+	}
+
+	/**
 	 * @Given the administrator has stopped the server
 	 *
 	 * @return void

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -731,8 +731,16 @@ class FeatureContext extends BehatVariablesContext {
 	/**
 	 * @return string
 	 */
-	public function getStorageUsersRoot(): string {
+	public function getOcisDataPath(): string {
 		$ocisDataPath = getenv("OCIS_BASE_DATA_PATH") ? getenv("OCIS_BASE_DATA_PATH") : getenv("HOME") . '/.ocis';
+		return $ocisDataPath;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getStorageUsersRoot(): string {
+		$ocisDataPath = $this->getOcisDataPath();
 		return getenv("STORAGE_USERS_OCIS_ROOT") ? getenv("STORAGE_USERS_OCIS_ROOT") : $ocisDataPath . "/storage/users";
 	}
 

--- a/tests/acceptance/features/cliCommands/searchReIndex.feature
+++ b/tests/acceptance/features/cliCommands/searchReIndex.feature
@@ -5,7 +5,8 @@ Feature: reindex space via CLI command
     So that I can improve search performance by ensuring that the index is up-to-date
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given the administrator has cleaned the search service data
+    And user "Alice" has been created with default attributes
     And using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "new-space" with the default quota using the Graph API


### PR DESCRIPTION
## Description
Delete previous search service data on the search re-indexing scenarios.
This deletes the `<ocis-data>/search` folder where search indexes are store. Deleting the previous index data and running reindexing scenarios on clean data makes the tests more stable.

## Related Issue


## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
