### PR TITLE
[docs-only] Create Added/Removed/Deprecated envvars between 7.1.0 and 7.2.0

### DIFF
--- a/docs/services/general-info/env-var-deltas/7.1.0-7.2.0-added.adoc
+++ b/docs/services/general-info/env-var-deltas/7.1.0-7.2.0-added.adoc
@@ -1,0 +1,42 @@
+// # Added Variables between oCIS 7.1.0 and oCIS 7.2.0
+// commenting the headline to make it better includable
+
+// table created per 2025.06.13
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+| xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
+| OCIS_CLAIM_MANAGED_SPACES_CLAIMNAME
+| The name of the claim used to manage Spaces.
+| 
+
+| 
+| OCIS_CLAIM_MANAGED_SPACES_ENABLED
+| Enables Space management through OIDC claims. See the text description for more details.
+| false
+
+| 
+| OCIS_CLAIM_MANAGED_SPACES_MAPPING
+| (Optional) Mapping of OIDC roles to ocis Space roles. Example: 'oidcroleA:viewer,oidcroleB:manager'
+| []
+
+| 
+| OCIS_CLAIM_MANAGED_SPACES_REGEXP
+| The regular expression that extracts Space IDs and roles from a claim.
+| 
+
+| 
+| OCIS_MAX_TAG_LENGTH
+| Define the maximum tag length. Defaults to 100 if not set. Set to 0 to not limit the tag length. Changes only impact the validation of new tags.
+| 100
+
+| xref:{s-path}/search.adoc[search]
+| SEARCH_ENGINE_BLEVE_SCALE
+| Enable scaling of the search index (bleve). If set to 'true', the instance of the search service will no longer have exclusive write access to the index. Note when scaling search, all instances of the search service must be set to true! For 'false', which is the default, the running search service has exclusive access to the index as long it is running. This locks out other search processes tying to access the index.
+| false
+
+|===
+

--- a/docs/services/general-info/env-var-deltas/7.1.0-7.2.0-deprecated.adoc
+++ b/docs/services/general-info/env-var-deltas/7.1.0-7.2.0-deprecated.adoc
@@ -1,0 +1,12 @@
+// # Deprecated Variables between oCIS 7.1.0 and oCIS 7.2.0
+// commenting the headline to make it better includable
+
+// table created per 2025.06.13
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Removal Version | Deprecation Info
+
+|===
+

--- a/docs/services/general-info/env-var-deltas/7.1.0-7.2.0-removed.adoc
+++ b/docs/services/general-info/env-var-deltas/7.1.0-7.2.0-removed.adoc
@@ -1,0 +1,97 @@
+// # Removed Variables between oCIS 7.1.0 and oCIS 7.2.0
+// commenting the headline to make it better includable
+
+// table created per 2025.06.13
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+| xref:{s-path}/clientlog.adoc[clientlog]
+| CLIENTLOG_REVA_GATEWAY
+| CS3 gateway used to look up user metadata
+| com.owncloud.api.gateway
+
+| xref:{s-path}/frontend.adoc[frontend]
+| FRONTEND_OCS_ADDITIONAL_INFO_ATTRIBUTE
+| Additional information attribute for the user like {{.Mail}}.
+| {{.Mail}}
+
+| 
+| FRONTEND_OCS_ENABLE_DENIALS
+| EXPERIMENTAL: enable the feature to deny access on folders.
+| false
+
+| 
+| FRONTEND_OCS_INCLUDE_OCM_SHAREES
+| Include OCM sharees when listing sharees.
+| false
+
+| 
+| FRONTEND_OCS_LIST_OCM_SHARES
+| Include OCM shares when listing shares. See the OCM service documentation for more details.
+| true
+
+| 
+| FRONTEND_OCS_PERSONAL_NAMESPACE
+| Home namespace identifier.
+| /users/{{.Id.OpaqueId}}
+
+| 
+| FRONTEND_OCS_PREFIX
+| URL path prefix for the OCS service. Note that the string must not start with '/'.
+| ocs
+
+| 
+| FRONTEND_OCS_PUBLIC_SHARE_MUST_HAVE_PASSWORD
+| Set this to true if you want to enforce passwords on all public shares.
+| true
+
+| 
+| FRONTEND_OCS_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD
+| Set this to true if you want to enforce passwords for writable shares. Only effective if the setting for 'passwords on all public shares' is set to false.
+| false
+
+| 
+| FRONTEND_OCS_SHARE_PREFIX
+| Path prefix for shares as part of an ocis resource. Note that the path must start with '/'.
+| /Shares
+
+| 
+| FRONTEND_OCS_STAT_CACHE_AUTH_PASSWORD
+| The password to use for authentication. Only applies when using the 'nats-js-kv' store type.
+| 
+
+| 
+| FRONTEND_OCS_STAT_CACHE_AUTH_USERNAME
+| The username to use for authentication. Only applies when using the 'nats-js-kv' store type.
+| 
+
+| 
+| FRONTEND_OCS_STAT_CACHE_DISABLE_PERSISTENCE
+| Disable persistence of the cache. Only applies when using the 'nats-js-kv' store type. Defaults to false.
+| false
+
+| 
+| FRONTEND_OCS_STAT_CACHE_STORE
+| The type of the cache store. Supported values are: 'memory', 'redis-sentinel', 'nats-js-kv', 'noop'. See the text description for details.
+| memory
+
+| 
+| FRONTEND_OCS_STAT_CACHE_STORE_NODES
+| A list of nodes to access the configured store. This has no effect when 'memory' store is configured. Note that the behaviour how nodes are used is dependent on the library of the configured store. See the Environment Variable Types description for more details.
+| [127.0.0.1:9233]
+
+| 
+| FRONTEND_OCS_STAT_CACHE_TABLE
+| The database table the store should use.
+| 
+
+| 
+| FRONTEND_OCS_STAT_CACHE_TTL
+| Default time to live for user info in the cache. Only applied when access tokens has no expiration. See the Environment Variable Types description for more details.
+| 5m0s
+
+|===
+


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/11432 ([docs-only] Update env_vars.yaml with latest changes)

This PR creates the required .adoc tables for the admin docs for Addams for Added/Removed/Deprecated envvars between 7.1.0 and 7.2.0