### PR TITLE
[tests-only][full-ci] restart upload sessions of unfinished uploads

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -931,4 +931,18 @@ class CliContext implements Context {
 		];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}
+
+	/**
+	 * @When the administrator restarts the expired upload sessions using the CLI
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorRestartsTheExpiredUploadSessionsUsingTheCLI(): void {
+		$command = "storage-users uploads sessions --expired --restart --json";
+		$body = [
+			"command" => $command,
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
 }

--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -177,3 +177,16 @@ Feature: List upload sessions via CLI command
       | file.txt |
     When the administrator waits for "3" seconds
     Then the content of file "file.txt" for user "Alice" should be "upload content"
+
+
+  Scenario: restart expired upload sessions
+    Given a file "large.zip" with the size of "2GB" has been created locally
+    And the config "STORAGE_USERS_UPLOAD_EXPIRATION" has been set to "1"
+    And user "Alice" has uploaded a file from "filesForUpload/textfile.txt" to "file.txt" via TUS inside of the space "Personal" using the WebDAV API
+    And user "Alice" has tried to upload file "filesForUpload/large.zip" to "large.zip" inside space "Personal" via TUS
+    When the administrator restarts the expired upload sessions using the CLI
+    Then the command should be successful
+    And the CLI response should contain these entries:
+      | large.zip |
+    And the CLI response should not contain these entries:
+      | file.txt |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR covers test scenario for restarting the upload sessions that are expired and after restarting the ocis service.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/11274

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
