### PR TITLE
[full-ci][tests-only] refactor(wrapper): handle empty service name

### DIFF
--- a/tests/ociswrapper/wrapper/handlers/handler.go
+++ b/tests/ociswrapper/wrapper/handlers/handler.go
@@ -154,7 +154,7 @@ func StartOcisHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	common.Wg.Add(1)
-	go ocis.Start(nil)
+	go ocis.Start(ocis.ServiceEnvConfigs[ocis.OcisServiceName])
 
 	success, message := ocis.WaitForConnection()
 	if success {


### PR DESCRIPTION
## Description
Handle empty service name when using `StartService`. The default should be `ocis`. Refactored to use the default value.

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
