### PR TITLE
fix: no acme on services not exposed to the outside

### DIFF
--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -40,9 +40,8 @@ services:
       - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.collaboration.entrypoints=https"
+      - "traefik.http.routers.collaboration.entrypoints=http"
       - "traefik.http.routers.collaboration.rule=Host(`collaboration`)"
-      - "traefik.http.routers.collaboration.tls.certresolver=http"
       - "traefik.http.routers.collaboration.service=collaboration"
       - "traefik.http.services.collaboration.loadbalancer.server.port=9300"
     logging:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -35,9 +35,8 @@ services:
       - ${OCIS_CONFIG_DIR:-ocis-config}:/etc/ocis
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.collaboration-oo.entrypoints=https"
+      - "traefik.http.routers.collaboration-oo.entrypoints=http"
       - "traefik.http.routers.collaboration-oo.rule=Host(`collaboration-oo`)"
-      - "traefik.http.routers.collaboration-oo.tls.certresolver=http"
       - "traefik.http.routers.collaboration-oo.service=collaboration-oo"
       - "traefik.http.services.collaboration-oo.loadbalancer.server.port=9300"
     logging:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Recent changes in the ocis_full example have moved the collaboration services (for both OnlyOffice and Collabora) inside the docker network. The hostnames used should be resolvable only within the docker network. This is causing some problems with the SSL certificates because the services can't be accessed from the outside, so it isn't possible for let'sencrypt (and any other certificate authority) to verify and generate proper certificates via ACME protocol.

The following changes will fix the problem by not requesting certificates for those services. As said, those services are inside the docker network and won't be exposed to the outside.

## Related Issue
Notice some ACME errors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
