### PR TITLE
[tests-only][full-ci] add more php lint rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -27,7 +27,9 @@ $config->setFinder($finder)
                 'no_unused_imports' => true,
                 'array_indentation' => true,
                 'method_chaining_indentation' => true,
-                'trailing_comma_in_multiline' => true,
+                'trailing_comma_in_multiline' => [
+                    'elements' => ['arrays', 'arguments', 'parameters'],
+                ],
                 'no_useless_else' => true,
                 'single_line_comment_spacing' => true,
                 'no_trailing_whitespace_in_comment' => true,

--- a/tests/acceptance/TestHelpers/Asserts/WebDav.php
+++ b/tests/acceptance/TestHelpers/Asserts/WebDav.php
@@ -41,7 +41,7 @@ class WebDav extends Assert {
 		?string $element,
 		?string $expectedValue,
 		?array $responseXmlArray,
-		?string $extraErrorText = ''
+		?string $extraErrorText = '',
 	): void {
 		if ($extraErrorText !== '') {
 			$extraErrorText = $extraErrorText . " ";
@@ -49,7 +49,7 @@ class WebDav extends Assert {
 		self::assertArrayHasKey(
 			'value',
 			$responseXmlArray,
-			$extraErrorText . "responseXml does not have key 'value'"
+			$extraErrorText . "responseXml does not have key 'value'",
 		);
 		if ($element === "exception") {
 			$result = $responseXmlArray['value'][0]['value'];
@@ -59,14 +59,14 @@ class WebDav extends Assert {
 			$result = $responseXmlArray['value'][3]['value'];
 		} else {
 			self::fail(
-				__METHOD__ . " element must be one of exception, response or reason. But '$element' was passed in."
+				__METHOD__ . " element must be one of exception, response or reason. But '$element' was passed in.",
 			);
 		}
 
 		self::assertEquals(
 			$expectedValue,
 			$result,
-			__METHOD__ . " " . $extraErrorText . "Expected '$expectedValue' in element $element got '$result'"
+			__METHOD__ . " " . $extraErrorText . "Expected '$expectedValue' in element $element got '$result'",
 		);
 	}
 
@@ -79,15 +79,15 @@ class WebDav extends Assert {
 	 */
 	public static function assertResponseContainsShareTypes(
 		SimpleXMLElement $responseXmlObject,
-		?array $expectedShareTypes
+		?array $expectedShareTypes,
 	): void {
 		foreach ($expectedShareTypes as $row) {
 			$xmlPart = $responseXmlObject->xpath(
-				"//d:prop/oc:share-types/oc:share-type[.=" . $row[0] . "]"
+				"//d:prop/oc:share-types/oc:share-type[.=" . $row[0] . "]",
 			);
 			self::assertNotEmpty(
 				$xmlPart,
-				"cannot find share-type '" . $row[0] . "'"
+				"cannot find share-type '" . $row[0] . "'",
 			);
 		}
 	}

--- a/tests/acceptance/TestHelpers/AuthAppHelper.php
+++ b/tests/acceptance/TestHelpers/AuthAppHelper.php
@@ -45,7 +45,7 @@ class AuthAppHelper {
 	public static function listAllAppAuthTokensForUser(
 		string $baseUrl,
 		string $user,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$url = $baseUrl . self::getAuthAppEndpoint();
 		return HttpRequestHelper::sendRequest(
@@ -92,7 +92,7 @@ class AuthAppHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $token
+		string $token,
 	): ResponseInterface {
 		$url = $baseUrl . self::getAuthAppEndpoint() . "?token=$token";
 		return HttpRequestHelper::sendRequest(

--- a/tests/acceptance/TestHelpers/BehatHelper.php
+++ b/tests/acceptance/TestHelpers/BehatHelper.php
@@ -41,7 +41,7 @@ class BehatHelper {
 	public static function getContext(
 		ScenarioScope $scope,
 		InitializedContextEnvironment $environment,
-		string $class
+		string $class,
 	): Context {
 		try {
 			return $environment->getContext($class);

--- a/tests/acceptance/TestHelpers/CollaborationHelper.php
+++ b/tests/acceptance/TestHelpers/CollaborationHelper.php
@@ -57,7 +57,7 @@ class CollaborationHelper {
 			$url,
 			$username,
 			$password,
-			['Content-Type' => 'application/json']
+			['Content-Type' => 'application/json'],
 		);
 	}
 
@@ -78,14 +78,14 @@ class CollaborationHelper {
 		string $password,
 		string $parentContainerId,
 		string $file,
-		?array $headers = null
+		?array $headers = null,
 	): ResponseInterface {
 		$url = $baseUrl . "/app/new?parent_container_id=$parentContainerId&filename=$file";
 		return HttpRequestHelper::post(
 			$url,
 			$user,
 			$password,
-			$headers
+			$headers,
 		);
 	}
 }

--- a/tests/acceptance/TestHelpers/EmailHelper.php
+++ b/tests/acceptance/TestHelpers/EmailHelper.php
@@ -72,7 +72,7 @@ class EmailHelper {
 			self::getEmailAPIUrl("messages"),
 			null,
 			null,
-			['Content-Type' => 'application/json']
+			['Content-Type' => 'application/json'],
 		);
 	}
 
@@ -91,7 +91,7 @@ class EmailHelper {
 			self::getEmailAPIUrl("message/$id") . "?query=$query",
 			null,
 			null,
-			['Content-Type' => 'application/json']
+			['Content-Type' => 'application/json'],
 		);
 	}
 
@@ -111,7 +111,7 @@ class EmailHelper {
 			$url,
 			null,
 			null,
-			['Content-Type' => 'application/json']
+			['Content-Type' => 'application/json'],
 		);
 	}
 
@@ -126,7 +126,7 @@ class EmailHelper {
 			self::getEmailAPIUrl("messages"),
 			null,
 			null,
-			['Content-Type' => 'application/json']
+			['Content-Type' => 'application/json'],
 		);
 	}
 }

--- a/tests/acceptance/TestHelpers/GraphHelper.php
+++ b/tests/acceptance/TestHelpers/GraphHelper.php
@@ -227,14 +227,14 @@ class GraphHelper {
 		string $method,
 		string $path,
 		?string $body = null,
-		?array $headers = []
+		?array $headers = [],
 	): RequestInterface {
 		$fullUrl = self::getFullUrl($baseUrl, $path);
 		return HttpRequestHelper::createRequest(
 			$fullUrl,
 			$method,
 			$headers,
-			$body
+			$body,
 		);
 	}
 
@@ -257,13 +257,13 @@ class GraphHelper {
 		string $userName,
 		string $password,
 		?string $email = null,
-		?string $displayName = null
+		?string $displayName = null,
 	): ResponseInterface {
 		$payload = self::prepareCreateUserPayload(
 			$userName,
 			$password,
 			$email,
-			$displayName
+			$displayName,
 		);
 
 		$url = self::getFullUrl($baseUrl, 'users');
@@ -272,7 +272,7 @@ class GraphHelper {
 			$adminUser,
 			$adminPassword,
 			self::getRequestHeaders(),
-			$payload
+			$payload,
 		);
 	}
 
@@ -301,14 +301,14 @@ class GraphHelper {
 		?string $password = null,
 		?string $email = null,
 		?string $displayName = null,
-		?bool $accountEnabled = true
+		?bool $accountEnabled = true,
 	): ResponseInterface {
 		$payload = self::preparePatchUserPayload(
 			$userName,
 			$password,
 			$email,
 			$displayName,
-			$accountEnabled
+			$accountEnabled,
 		);
 		$url = self::getFullUrl($baseUrl, 'users/' . $userId);
 		return HttpRequestHelper::sendRequest(
@@ -317,7 +317,7 @@ class GraphHelper {
 			$adminUser,
 			$adminPassword,
 			self::getRequestHeaders(),
-			$payload
+			$payload,
 		);
 	}
 
@@ -334,14 +334,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $userName
+		string $userName,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userName);
 		return HttpRequestHelper::get(
 			$url,
 			$adminUser,
 			$adminPassword,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -357,14 +357,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $searchTerm
+		string $searchTerm,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, "users?\$search=$searchTerm");
 		return HttpRequestHelper::get(
 			$url,
 			$adminUser,
 			$adminPassword,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -380,14 +380,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $searchTerm
+		string $searchTerm,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, "users?\$filter=userType eq 'Federated'&\$search=$searchTerm");
 		return HttpRequestHelper::get(
 			$url,
 			$adminUser,
 			$adminPassword,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -402,14 +402,14 @@ class GraphHelper {
 	public static function getOwnInformationAndGroupMemberships(
 		string $baseUrl,
 		string $user,
-		string $userPassword
+		string $userPassword,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'me/?%24expand=memberOf');
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$userPassword,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -426,7 +426,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $userName
+		string $userName,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userName);
 		return HttpRequestHelper::delete(
@@ -449,7 +449,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $userId
+		string $userId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userId);
 
@@ -473,7 +473,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $byUser,
 		string $userPassword,
-		?string $user = null
+		?string $user = null,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $user . '?%24select=&%24expand=drive');
 		return HttpRequestHelper::get(
@@ -496,13 +496,13 @@ class GraphHelper {
 		string $baseUrl,
 		string $byUser,
 		string $userPassword,
-		string $userId
+		string $userId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/drive');
 		return HttpRequestHelper::get(
 			$url,
 			$byUser,
-			$userPassword
+			$userPassword,
 		);
 	}
 
@@ -519,7 +519,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $byUser,
 		string $userPassword,
-		?string $user = null
+		?string $user = null,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $user . '?%24expand=memberOf');
 		return HttpRequestHelper::get(
@@ -542,7 +542,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $groupName
+		string $groupName,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups');
 		$payload['displayName'] = $groupName;
@@ -552,7 +552,7 @@ class GraphHelper {
 			$adminUser,
 			$adminPassword,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -571,7 +571,7 @@ class GraphHelper {
 		string $adminUser,
 		string $adminPassword,
 		string $groupId,
-		string $displayName
+		string $displayName,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups/' . $groupId);
 		$payload['displayName'] = $displayName;
@@ -581,7 +581,7 @@ class GraphHelper {
 			$adminUser,
 			$adminPassword,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -596,7 +596,7 @@ class GraphHelper {
 	public static function getUsers(
 		string $baseUrl,
 		string $adminUser,
-		string $adminPassword
+		string $adminPassword,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users');
 		return HttpRequestHelper::get(
@@ -618,7 +618,7 @@ class GraphHelper {
 	public static function getGroups(
 		string $baseUrl,
 		string $adminUser,
-		string $adminPassword
+		string $adminPassword,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups');
 		return HttpRequestHelper::get(
@@ -642,14 +642,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $groupName
+		string $groupName,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups/' . $groupName);
 		return HttpRequestHelper::get(
 			$url,
 			$adminUser,
 			$adminPassword,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -665,14 +665,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $searchTerm
+		string $searchTerm,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, "groups?\$search=$searchTerm");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -689,7 +689,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $groupId
+		string $groupId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups/' . $groupId);
 		return HttpRequestHelper::delete(
@@ -716,7 +716,7 @@ class GraphHelper {
 		string $adminUser,
 		string $adminPassword,
 		string $groupId,
-		array $userIds
+		array $userIds,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups/' . $groupId);
 		$payload = [ "members@odata.bind" => [] ];
@@ -729,7 +729,7 @@ class GraphHelper {
 			$adminUser,
 			$adminPassword,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -748,7 +748,7 @@ class GraphHelper {
 		string $adminUser,
 		string $adminPassword,
 		string $userId,
-		string $groupId
+		string $groupId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups/' . $groupId . '/members/$ref');
 		$body = [
@@ -759,7 +759,7 @@ class GraphHelper {
 			$adminUser,
 			$adminPassword,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -778,7 +778,7 @@ class GraphHelper {
 		string $adminUser,
 		string $adminPassword,
 		string $userId,
-		string $groupId
+		string $groupId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups/' . $groupId . '/members/' . $userId . '/$ref');
 		return HttpRequestHelper::delete(
@@ -801,13 +801,13 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		string $groupId
+		string $groupId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'groups/' . $groupId . '/members');
 		return HttpRequestHelper::get(
 			$url,
 			$adminUser,
-			$adminPassword
+			$adminPassword,
 		);
 	}
 
@@ -827,7 +827,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $adminUser,
 		string $adminPassword,
-		?string $groupId = null
+		?string $groupId = null,
 	): ResponseInterface {
 		// we can expand to get list of members for a single group with groupId and also expand to get all groups with all its members
 		$endPath = ($groupId) ? '/' . $groupId . '?$expand=members' : '?$expand=members';
@@ -835,7 +835,7 @@ class GraphHelper {
 		return HttpRequestHelper::get(
 			$url,
 			$adminUser,
-			$adminPassword
+			$adminPassword,
 		);
 	}
 
@@ -853,7 +853,7 @@ class GraphHelper {
 		string $userName,
 		string $password,
 		?string $email,
-		?string $displayName
+		?string $displayName,
 	): string {
 		$payload['onPremisesSamAccountName'] = $userName;
 		$payload['passwordProfile'] = ['password' => $password];
@@ -883,7 +883,7 @@ class GraphHelper {
 		?string $password,
 		?string $email,
 		?string $displayName,
-		?bool $accountEnabled
+		?bool $accountEnabled,
 	): string {
 		$payload = [];
 		if ($userName !== null) {
@@ -923,7 +923,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $body,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'drives');
 
@@ -949,7 +949,7 @@ class GraphHelper {
 		string $password,
 		$body,
 		string $spaceId,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'drives/' . $spaceId);
 
@@ -976,7 +976,7 @@ class GraphHelper {
 		string $password,
 		string $urlArguments = '',
 		array $body = [],
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$urlArguments = $urlArguments ? "?$urlArguments" : "";
 		$url = self::getFullUrl($baseUrl, "me/drives" . $urlArguments);
@@ -1004,7 +1004,7 @@ class GraphHelper {
 		string $password,
 		string $urlArguments = '',
 		array $body = [],
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$urlArguments = $urlArguments ? "?$urlArguments" : "";
 		$url = self::getFullUrl($baseUrl, "drives" . $urlArguments);
@@ -1034,7 +1034,7 @@ class GraphHelper {
 		string $spaceId,
 		string $urlArguments = '',
 		array $body = [],
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'drives/' . $spaceId . "/" . $urlArguments);
 
@@ -1062,7 +1062,7 @@ class GraphHelper {
 		return HttpRequestHelper::delete(
 			$url,
 			$user,
-			$password
+			$password,
 		);
 	}
 
@@ -1090,7 +1090,7 @@ class GraphHelper {
 			$url,
 			$user,
 			$password,
-			$header
+			$header,
 		);
 	}
 
@@ -1133,7 +1133,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $currentPassword,
-		string $newPassword
+		string $newPassword,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'me/changePassword');
 		$payload['currentPassword'] = $currentPassword;
@@ -1145,7 +1145,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -1164,7 +1164,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		array $body = [],
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'extensions/org.libregraph/tags');
 
@@ -1186,7 +1186,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $resourceId,
-		array $tagName
+		array $tagName,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'extensions/org.libregraph/tags');
 		$payload['resourceId'] = $resourceId;
@@ -1198,7 +1198,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -1217,7 +1217,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $resourceId,
-		array $tagName
+		array $tagName,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'extensions/org.libregraph/tags');
 		$payload['resourceId'] = $resourceId;
@@ -1229,7 +1229,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -1244,14 +1244,14 @@ class GraphHelper {
 	public static function getApplications(
 		string $baseUrl,
 		string $user,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'applications');
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1268,14 +1268,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $groupId
+		string $groupId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users?$filter=memberOf/any(m:m/id ' . "eq '$groupId')");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1292,18 +1292,18 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		array $groupIdArray
+		array $groupIdArray,
 	): ResponseInterface {
 		$url = self::getFullUrl(
 			$baseUrl,
 			'users?$filter=memberOf/any(m:m/id ' . "eq '$groupIdArray[0]') "
-			. "and memberOf/any(m:m/id eq '$groupIdArray[1]')"
+			. "and memberOf/any(m:m/id eq '$groupIdArray[1]')",
 		);
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1322,18 +1322,18 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $firstGroup,
-		string $secondGroup
+		string $secondGroup,
 	): ResponseInterface {
 		$url = self::getFullUrl(
 			$baseUrl,
 			'users?$filter=memberOf/any(m:m/id '
-			. "eq '$firstGroup') or memberOf/any(m:m/id eq '$secondGroup')"
+			. "eq '$firstGroup') or memberOf/any(m:m/id eq '$secondGroup')",
 		);
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1350,14 +1350,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $roleId
+		string $roleId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users?$filter=appRoleAssignments/any(m:m/appRoleId ' . "eq '$roleId')");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1376,18 +1376,18 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $roleId,
-		string $groupId
+		string $groupId,
 	): ResponseInterface {
 		$url = self::getFullUrl(
 			$baseUrl,
 			'users?$filter=appRoleAssignments/any(m:m/appRoleId '
-			. "eq '$roleId') and memberOf/any(m:m/id eq '$groupId')"
+			. "eq '$roleId') and memberOf/any(m:m/id eq '$groupId')",
 		);
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1408,7 +1408,7 @@ class GraphHelper {
 		string $password,
 		string $appRoleId,
 		string $applicationId,
-		string $userId
+		string $userId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/appRoleAssignments');
 		$payload['principalId'] = $userId;
@@ -1420,7 +1420,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -1437,14 +1437,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $userId
+		string $userId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/appRoleAssignments');
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1463,7 +1463,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $userId,
-		string $path
+		string $path,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/exportPersonalData');
 		// this payload is the storage location of the report generated
@@ -1474,7 +1474,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -1493,7 +1493,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $appRoleAssignmentId,
-		string $userId
+		string $userId,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'users/' . $userId . '/appRoleAssignments/' . $appRoleAssignmentId);
 		return HttpRequestHelper::sendRequest(
@@ -1519,13 +1519,13 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $path
+		string $path,
 	): string {
 		$response = self::getMySpaces(
 			$baseUrl,
 			$user,
 			$password,
-			''
+			'',
 		);
 		$drives = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
 
@@ -1540,7 +1540,7 @@ class GraphHelper {
 		}
 		throw new \Exception(
 			__METHOD__
-			. " Cannot find share mountpoint id of '$path' for user '$user'"
+			. " Cannot find share mountpoint id of '$path' for user '$user'",
 		);
 	}
 
@@ -1557,7 +1557,7 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $language
+		string $language,
 	): ResponseInterface {
 		$fullUrl = self::getFullUrl($baseUrl, 'me');
 		$payload['preferredLanguage'] = $language;
@@ -1567,7 +1567,7 @@ class GraphHelper {
 			$user,
 			$password,
 			null,
-			\json_encode($payload)
+			\json_encode($payload),
 		);
 	}
 
@@ -1588,7 +1588,7 @@ class GraphHelper {
 		string $password,
 		string $spaceId,
 		string $itemId,
-		?string $query = null
+		?string $query = null,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions");
 		if (!empty($query)) {
@@ -1599,7 +1599,7 @@ class GraphHelper {
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1620,7 +1620,7 @@ class GraphHelper {
 		string $password,
 		string $spaceId,
 		string $itemId,
-		string $permssionId
+		string $permssionId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permssionId");
 
@@ -1628,7 +1628,7 @@ class GraphHelper {
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1683,7 +1683,7 @@ class GraphHelper {
 		array $shareTypes,
 		?string $permissionsRole,
 		?string $permissionsAction,
-		?string $expirationDateTime
+		?string $expirationDateTime,
 	): array {
 		$body = [];
 
@@ -1736,7 +1736,7 @@ class GraphHelper {
 		array $shareTypes,
 		?string $permissionsRole,
 		?string $permissionsAction,
-		?string $expirationDateTime
+		?string $expirationDateTime,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/invite");
 		$body = self::createShareInviteBody(
@@ -1744,14 +1744,14 @@ class GraphHelper {
 			$shareTypes,
 			$permissionsRole,
 			$permissionsAction,
-			$expirationDateTime
+			$expirationDateTime,
 		);
 		return HttpRequestHelper::post(
 			$url,
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -1772,7 +1772,7 @@ class GraphHelper {
 		string $password,
 		string $spaceId,
 		string $itemId,
-		$body
+		$body,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/createLink");
 		return HttpRequestHelper::post(
@@ -1780,7 +1780,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			$body
+			$body,
 		);
 	}
 
@@ -1803,7 +1803,7 @@ class GraphHelper {
 		string $spaceId,
 		string $itemId,
 		$body,
-		string $permissionsId
+		string $permissionsId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permissionsId");
 		return HttpRequestHelper::sendRequestOnce(
@@ -1812,7 +1812,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			$body
+			$body,
 		);
 	}
 
@@ -1835,7 +1835,7 @@ class GraphHelper {
 		string $spaceId,
 		string $itemId,
 		$body,
-		string $permissionsId
+		string $permissionsId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permissionsId/setPassword");
 		return HttpRequestHelper::post(
@@ -1843,7 +1843,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			$body
+			$body,
 		);
 	}
 
@@ -1865,14 +1865,14 @@ class GraphHelper {
 		string $password,
 		string $spaceId,
 		string $itemId,
-		string $permissionId
+		string $permissionId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/items/$itemId/permissions/$permissionId");
 		return HttpRequestHelper::delete(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1892,14 +1892,14 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $spaceId,
-		string $permissionId
+		string $permissionId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/permissions/$permissionId");
 		return HttpRequestHelper::delete(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1914,14 +1914,14 @@ class GraphHelper {
 	public static function getSharesSharedWithMe(
 		string $baseUrl,
 		string $user,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "me/drive/sharedWithMe");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1936,14 +1936,14 @@ class GraphHelper {
 	public static function getSharesSharedByMe(
 		string $baseUrl,
 		string $user,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "me/drive/sharedByMe");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1962,14 +1962,14 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $itemId,
-		string $shareSpaceId
+		string $shareSpaceId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$shareSpaceId/items/$itemId");
 		return HttpRequestHelper::delete(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -1990,7 +1990,7 @@ class GraphHelper {
 		string $password,
 		string $itemId,
 		string $shareSpaceId,
-		array $body
+		array $body,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$shareSpaceId/items/$itemId");
 		return HttpRequestHelper::sendRequest(
@@ -1999,7 +1999,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -2018,7 +2018,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $itemId,
-		string $shareSpaceId
+		string $shareSpaceId,
 	): ResponseInterface {
 		$body = [
 			"remoteItem" => [
@@ -2031,7 +2031,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -2048,14 +2048,14 @@ class GraphHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		string $spaceId
+		string $spaceId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/permissions");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -2074,14 +2074,14 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $spaceId,
-		string $permissionId
+		string $permissionId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/permissions/$permissionId");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -2108,7 +2108,7 @@ class GraphHelper {
 		array $shareTypes,
 		?string $permissionsRole,
 		?string $permissionsAction,
-		?string $expirationDateTime
+		?string $expirationDateTime,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/invite");
 		$body = self::createShareInviteBody(
@@ -2116,7 +2116,7 @@ class GraphHelper {
 			$shareTypes,
 			$permissionsRole,
 			$permissionsAction,
-			$expirationDateTime
+			$expirationDateTime,
 		);
 
 		return HttpRequestHelper::post(
@@ -2124,7 +2124,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -2145,7 +2145,7 @@ class GraphHelper {
 		string $password,
 		string $spaceId,
 		$body,
-		string $permissionsId
+		string $permissionsId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/permissions/$permissionsId");
 
@@ -2155,7 +2155,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			$body
+			$body,
 		);
 	}
 
@@ -2174,7 +2174,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $spaceId,
-		$body
+		$body,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/createLink");
 		return HttpRequestHelper::post(
@@ -2182,7 +2182,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			$body
+			$body,
 		);
 	}
 
@@ -2204,7 +2204,7 @@ class GraphHelper {
 		string $password,
 		string $spaceId,
 		$body,
-		string $permissionsId
+		string $permissionsId,
 	): ResponseInterface {
 		$url = self::getBetaFullUrl($baseUrl, "drives/$spaceId/root/permissions/$permissionsId/setPassword");
 		return HttpRequestHelper::post(
@@ -2212,7 +2212,7 @@ class GraphHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			$body
+			$body,
 		);
 	}
 
@@ -2234,7 +2234,7 @@ class GraphHelper {
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -2259,7 +2259,7 @@ class GraphHelper {
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -2278,7 +2278,7 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $resourceId,
-		?array $filterParams = []
+		?array $filterParams = [],
 	): ResponseInterface {
 		// 'kql=itemId' filter is required for the current implementation but it might change in future
 		// See: https://github.com/owncloud/ocis/issues/9194
@@ -2291,7 +2291,7 @@ class GraphHelper {
 		return HttpRequestHelper::get(
 			$fullUrl,
 			$user,
-			$password
+			$password,
 		);
 	}
 
@@ -2306,14 +2306,14 @@ class GraphHelper {
 	public static function getFederatedUsers(
 		string $baseUrl,
 		string $user,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, "users?\$filter=userType eq 'Federated'");
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -2335,7 +2335,7 @@ class GraphHelper {
 			$url,
 			$adminUser,
 			$adminPassword,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -2354,17 +2354,17 @@ class GraphHelper {
 		string $user,
 		string $password,
 		string $groupId,
-		string $searchTerm
+		string $searchTerm,
 	): ResponseInterface {
 		$url = self::getFullUrl(
 			$baseUrl,
-			'users?$filter=memberOf/any(m:m/id ' . "eq '$groupId')" . '&$search=' . "$searchTerm"
+			'users?$filter=memberOf/any(m:m/id ' . "eq '$groupId')" . '&$search=' . "$searchTerm",
 		);
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 }

--- a/tests/acceptance/TestHelpers/HttpRequestHelper.php
+++ b/tests/acceptance/TestHelpers/HttpRequestHelper.php
@@ -116,7 +116,7 @@ class HttpRequestHelper {
 		?CookieJar $cookies = null,
 		bool $stream = false,
 		?int $timeout = 0,
-		?Client $client = null
+		?Client $client = null,
 	): ResponseInterface {
 		if ($client === null) {
 			$client = self::createClient(
@@ -125,7 +125,7 @@ class HttpRequestHelper {
 				$config,
 				$cookies,
 				$stream,
-				$timeout
+				$timeout,
 			);
 		}
 
@@ -152,7 +152,7 @@ class HttpRequestHelper {
 			$url,
 			$method,
 			$headers,
-			$body
+			$body,
 		);
 
 		if ((\getenv('DEBUG_ACCEPTANCE_REQUESTS') !== false) || (\getenv('DEBUG_ACCEPTANCE_API_CALLS') !== false)) {
@@ -216,7 +216,7 @@ class HttpRequestHelper {
 		bool $stream = false,
 		?int $timeout = 0,
 		?Client $client = null,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): ResponseInterface {
 		if ((\getenv('DEBUG_ACCEPTANCE_RESPONSES') !== false) || (\getenv('DEBUG_ACCEPTANCE_API_CALLS') !== false)) {
 			$debugResponses = true;
@@ -239,7 +239,7 @@ class HttpRequestHelper {
 				$cookies,
 				$stream,
 				$timeout,
-				$client
+				$client,
 			);
 
 			if ($response->getStatusCode() >= 400
@@ -354,7 +354,7 @@ class HttpRequestHelper {
 	 */
 	public static function sendBatchRequest(
 		?array $requests,
-		?Client $client
+		?Client $client,
 	): array {
 		return Pool::batch($client, $requests);
 	}
@@ -379,7 +379,7 @@ class HttpRequestHelper {
 		?array $config = null,
 		?CookieJar $cookies = null,
 		?bool $stream = false,
-		?int $timeout = 0
+		?int $timeout = 0,
 	): Client {
 		$options = [];
 		if ($user !== null) {
@@ -415,7 +415,7 @@ class HttpRequestHelper {
 		?string $url,
 		?string $method = 'GET',
 		?array $headers = null,
-		$body = null
+		$body = null,
 	): RequestInterface {
 		if ($headers === null) {
 			$headers = [];
@@ -434,7 +434,7 @@ class HttpRequestHelper {
 			$method,
 			$url,
 			$headers,
-			$body
+			$body,
 		);
 		HttpLogger::logRequest($request);
 		return $request;
@@ -464,7 +464,7 @@ class HttpRequestHelper {
 		$body = null,
 		?array $config = null,
 		?CookieJar $cookies = null,
-		?bool $stream = false
+		?bool $stream = false,
 	): ResponseInterface {
 		return self::sendRequest(
 			$url,
@@ -475,7 +475,7 @@ class HttpRequestHelper {
 			$body,
 			$config,
 			$cookies,
-			$stream
+			$stream,
 		);
 	}
 
@@ -503,7 +503,7 @@ class HttpRequestHelper {
 		$body = null,
 		?array $config = null,
 		?CookieJar $cookies = null,
-		?bool $stream = false
+		?bool $stream = false,
 	): ResponseInterface {
 		return self::sendRequest(
 			$url,
@@ -514,7 +514,7 @@ class HttpRequestHelper {
 			$body,
 			$config,
 			$cookies,
-			$stream
+			$stream,
 		);
 	}
 
@@ -542,7 +542,7 @@ class HttpRequestHelper {
 		$body = null,
 		?array $config = null,
 		?CookieJar $cookies = null,
-		?bool $stream = false
+		?bool $stream = false,
 	): ResponseInterface {
 		return self::sendRequest(
 			$url,
@@ -553,7 +553,7 @@ class HttpRequestHelper {
 			$body,
 			$config,
 			$cookies,
-			$stream
+			$stream,
 		);
 	}
 
@@ -582,7 +582,7 @@ class HttpRequestHelper {
 		$body = null,
 		?array $config = null,
 		?CookieJar $cookies = null,
-		?bool $stream = false
+		?bool $stream = false,
 	): ResponseInterface {
 		return self::sendRequest(
 			$url,
@@ -593,7 +593,7 @@ class HttpRequestHelper {
 			$body,
 			$config,
 			$cookies,
-			$stream
+			$stream,
 		);
 	}
 
@@ -619,15 +619,15 @@ class HttpRequestHelper {
 			$responseXmlObject = new SimpleXMLElement($contents);
 			$responseXmlObject->registerXPathNamespace(
 				'ocs',
-				'http://open-collaboration-services.org/ns'
+				'http://open-collaboration-services.org/ns',
 			);
 			$responseXmlObject->registerXPathNamespace(
 				'oc',
-				'http://owncloud.org/ns'
+				'http://owncloud.org/ns',
 			);
 			$responseXmlObject->registerXPathNamespace(
 				'd',
-				'DAV:'
+				'DAV:',
 			);
 			return $responseXmlObject;
 		} catch (Exception $e) {

--- a/tests/acceptance/TestHelpers/OcisConfigHelper.php
+++ b/tests/acceptance/TestHelpers/OcisConfigHelper.php
@@ -42,14 +42,14 @@ class OcisConfigHelper {
 	public static function sendRequest(
 		string $url,
 		string $method,
-		?string $body = ""
+		?string $body = "",
 	): ResponseInterface {
 		$client = HttpRequestHelper::createClient();
 		$request = new Request(
 			$method,
 			$url,
 			[],
-			$body
+			$body,
 		);
 
 		try {
@@ -58,7 +58,7 @@ class OcisConfigHelper {
 			throw new \Error(
 				"Cannot connect to the ociswrapper at the moment,"
 				. "make sure that ociswrapper is running before proceeding with the test run.\n"
-				. $e->getMessage()
+				. $e->getMessage(),
 			);
 		} catch (GuzzleException $ex) {
 			$response = $ex->getResponse();

--- a/tests/acceptance/TestHelpers/OcisHelper.php
+++ b/tests/acceptance/TestHelpers/OcisHelper.php
@@ -115,7 +115,7 @@ class OcisHelper {
 		if (!\in_array($storageDriver, self::STORAGE_DRIVERS)) {
 			throw new Exception(
 				"Invalid storage driver. " .
-				"STORAGE_DRIVER must be '" . \join(", ", self::STORAGE_DRIVERS) . "'"
+				"STORAGE_DRIVER must be '" . \join(", ", self::STORAGE_DRIVERS) . "'",
 			);
 		}
 		return $storageDriver;
@@ -148,7 +148,7 @@ class OcisHelper {
 				$deleteCmd = \str_replace(
 					"%s",
 					$user[0] . '/' . $user,
-					$deleteCmd
+					$deleteCmd,
 				);
 			} else {
 				$deleteCmd = \sprintf($deleteCmd, $user);
@@ -308,7 +308,7 @@ class OcisHelper {
 		HttpRequestHelper::get(
 			$baseUrl . "/ocs/v2.php/apps/notifications/api/v1/notifications",
 			$user,
-			$password
+			$password,
 		);
 	}
 }

--- a/tests/acceptance/TestHelpers/OcmHelper.php
+++ b/tests/acceptance/TestHelpers/OcmHelper.php
@@ -68,7 +68,7 @@ class OcmHelper {
 		string $user,
 		string $password,
 		?string $email = null,
-		?string $description = null
+		?string $description = null,
 	): ResponseInterface {
 		$body = [
 			"description" => $description,
@@ -80,7 +80,7 @@ class OcmHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -99,7 +99,7 @@ class OcmHelper {
 		string $user,
 		string $password,
 		string $token,
-		string $providerDomain
+		string $providerDomain,
 	): ResponseInterface {
 		$body = [
 			"token" => $token,
@@ -111,7 +111,7 @@ class OcmHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -126,14 +126,14 @@ class OcmHelper {
 	public static function findAcceptedUsers(
 		string $baseUrl,
 		string $user,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'find-accepted-users');
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -148,14 +148,14 @@ class OcmHelper {
 	public static function listInvite(
 		string $baseUrl,
 		string $user,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'list-invite');
 		return HttpRequestHelper::get(
 			$url,
 			$user,
 			$password,
-			self::getRequestHeaders()
+			self::getRequestHeaders(),
 		);
 	}
 
@@ -174,7 +174,7 @@ class OcmHelper {
 		string $user,
 		string $password,
 		string $userId,
-		string $idp
+		string $idp,
 	): ResponseInterface {
 		$url = self::getFullUrl($baseUrl, 'delete-accepted-user');
 		$body = [
@@ -186,7 +186,7 @@ class OcmHelper {
 			$user,
 			$password,
 			self::getRequestHeaders(),
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 }

--- a/tests/acceptance/TestHelpers/OcsApiHelper.php
+++ b/tests/acceptance/TestHelpers/OcsApiHelper.php
@@ -53,7 +53,7 @@ class OcsApiHelper {
 		?string $path,
 		$body = [],
 		?int $ocsApiVersion = 2,
-		?array $headers = []
+		?array $headers = [],
 	): ResponseInterface {
 		$fullUrl = $baseUrl;
 		if (\substr($fullUrl, -1) !== '/') {
@@ -81,7 +81,7 @@ class OcsApiHelper {
 		?string $path,
 		$body = [],
 		?int $ocsApiVersion = 2,
-		?array $headers = []
+		?array $headers = [],
 	): RequestInterface {
 		$fullUrl = $baseUrl;
 		if (\substr($fullUrl, -1) !== '/') {
@@ -92,7 +92,7 @@ class OcsApiHelper {
 			$fullUrl,
 			$method,
 			$headers,
-			$body
+			$body,
 		);
 	}
 }

--- a/tests/acceptance/TestHelpers/SettingsHelper.php
+++ b/tests/acceptance/TestHelpers/SettingsHelper.php
@@ -94,7 +94,7 @@ class SettingsHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$fullUrl = self::buildFullUrl($baseUrl, "bundles-list");
 		return HttpRequestHelper::post(
@@ -102,7 +102,7 @@ class SettingsHelper {
 			$user,
 			$password,
 			$headers,
-			"{}"
+			"{}",
 		);
 	}
 
@@ -150,7 +150,7 @@ class SettingsHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$fullUrl = self::buildFullUrl($baseUrl, "roles-list");
 		return HttpRequestHelper::post(
@@ -158,7 +158,7 @@ class SettingsHelper {
 			$user,
 			$password,
 			$headers,
-			"{}"
+			"{}",
 		);
 	}
 
@@ -181,7 +181,7 @@ class SettingsHelper {
 		string $password,
 		string $assigneeId,
 		string $roleId,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$fullUrl = self::buildFullUrl($baseUrl, "assignments-add");
 		$body = json_encode(["account_uuid" => $assigneeId, "role_id" => $roleId], JSON_THROW_ON_ERROR);
@@ -190,7 +190,7 @@ class SettingsHelper {
 			$user,
 			$password,
 			$headers,
-			$body
+			$body,
 		);
 	}
 
@@ -211,7 +211,7 @@ class SettingsHelper {
 		string $user,
 		string $password,
 		string $userId,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$fullUrl = self::buildFullUrl($baseUrl, "assignments-list");
 		$body = json_encode(["account_uuid" => $userId], JSON_THROW_ON_ERROR);
@@ -220,7 +220,7 @@ class SettingsHelper {
 			$user,
 			$password,
 			$headers,
-			$body
+			$body,
 		);
 	}
 
@@ -239,7 +239,7 @@ class SettingsHelper {
 		string $baseUrl,
 		string $user,
 		string $password,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$fullUrl = self::buildFullUrl($baseUrl, "values-list");
 		$body = json_encode(["account_uuid" => "me"], JSON_THROW_ON_ERROR);
@@ -248,7 +248,7 @@ class SettingsHelper {
 			$user,
 			$password,
 			$headers,
-			$body
+			$body,
 		);
 	}
 
@@ -338,7 +338,7 @@ class SettingsHelper {
 		string $user,
 		string $password,
 		string $body,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		$fullUrl = self::buildFullUrl($baseUrl, "values-save");
 		return HttpRequestHelper::post(
@@ -346,7 +346,7 @@ class SettingsHelper {
 			$user,
 			$password,
 			$headers,
-			$body
+			$body,
 		);
 	}
 
@@ -373,14 +373,14 @@ class SettingsHelper {
 				"accountUuid" => "me",
 				"settingId" => $settingId,
 			],
-			JSON_THROW_ON_ERROR
+			JSON_THROW_ON_ERROR,
 		);
 		return HttpRequestHelper::post(
 			$fullUrl,
 			$user,
 			$password,
 			[],
-			$body
+			$body,
 		);
 	}
 }

--- a/tests/acceptance/TestHelpers/SetupHelper.php
+++ b/tests/acceptance/TestHelpers/SetupHelper.php
@@ -59,13 +59,13 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 	public static function init(
 		?string $adminUsername,
 		?string $adminPassword,
-		?string $baseUrl
+		?string $baseUrl,
 	): void {
 		foreach (\func_get_args() as $variableToCheck) {
 			if (!\is_string($variableToCheck)) {
 				throw new \InvalidArgumentException(
 					"mandatory argument missing or wrong type ($variableToCheck => "
-					. \gettype($variableToCheck) . ")"
+					. \gettype($variableToCheck) . ")",
 				);
 			}
 		}
@@ -98,7 +98,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		);
 		if ($result->getStatusCode() !== 200) {
 			throw new \Exception(
-				"could not get sysinfo " . $result->getReasonPhrase()
+				"could not get sysinfo " . $result->getReasonPhrase(),
 			);
 		}
 		return HttpRequestHelper::getResponseXml($result, __METHOD__)->data;
@@ -140,7 +140,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			&& $adminUsername === null
 		) {
 			throw new Exception(
-				"$callerName called without adminUsername - pass the username or call SetupHelper::init"
+				"$callerName called without adminUsername - pass the username or call SetupHelper::init",
 			);
 		}
 		if ($adminUsername === null) {
@@ -161,7 +161,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			&& $adminPassword === null
 		) {
 			throw new Exception(
-				"$callerName called without adminPassword - pass the password or call SetupHelper::init"
+				"$callerName called without adminPassword - pass the password or call SetupHelper::init",
 			);
 		}
 		if ($adminPassword === null) {
@@ -182,7 +182,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			&& $baseUrl === null
 		) {
 			throw new Exception(
-				"$callerName called without baseUrl - pass the baseUrl or call SetupHelper::init"
+				"$callerName called without baseUrl - pass the baseUrl or call SetupHelper::init",
 			);
 		}
 		if ($baseUrl === null) {
@@ -206,7 +206,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		?string $dirPathFromServerRoot,
 		?string $baseUrl = null,
 		?string $adminUsername = null,
-		?string $adminPassword = null
+		?string $adminPassword = null,
 	): void {
 		$baseUrl = self::checkBaseUrl($baseUrl, "mkDirOnServer");
 		$adminUsername = self::checkAdminUsername($adminUsername, "mkDirOnServer");
@@ -217,12 +217,12 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			$adminPassword,
 			"POST",
 			"/apps/testing/api/v1/dir",
-			['dir' => $dirPathFromServerRoot]
+			['dir' => $dirPathFromServerRoot],
 		);
 
 		if ($result->getStatusCode() !== 200) {
 			throw new \Exception(
-				"could not create directory $dirPathFromServerRoot " . $result->getReasonPhrase()
+				"could not create directory $dirPathFromServerRoot " . $result->getReasonPhrase(),
 			);
 		}
 	}
@@ -242,7 +242,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		?string $dirPathFromServerRoot,
 		?string $baseUrl = null,
 		?string $adminUsername = null,
-		?string $adminPassword = null
+		?string $adminPassword = null,
 	): void {
 		$baseUrl = self::checkBaseUrl($baseUrl, "rmDirOnServer");
 		$adminUsername = self::checkAdminUsername($adminUsername, "rmDirOnServer");
@@ -253,12 +253,12 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			$adminPassword,
 			"DELETE",
 			"/apps/testing/api/v1/dir",
-			['dir' => $dirPathFromServerRoot]
+			['dir' => $dirPathFromServerRoot],
 		);
 
 		if ($result->getStatusCode() !== 200) {
 			throw new \Exception(
-				"could not delete directory $dirPathFromServerRoot " . $result->getReasonPhrase()
+				"could not delete directory $dirPathFromServerRoot " . $result->getReasonPhrase(),
 			);
 		}
 	}
@@ -280,7 +280,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		?string $content,
 		?string $baseUrl = null,
 		?string $adminUsername = null,
-		?string $adminPassword = null
+		?string $adminPassword = null,
 	): void {
 		$baseUrl = self::checkBaseUrl($baseUrl, "createFileOnServer");
 		$adminUsername = self::checkAdminUsername($adminUsername, "createFileOnServer");
@@ -294,12 +294,12 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			[
 				'file' => $filePathFromServerRoot,
 				'content' => $content,
-			]
+			],
 		);
 
 		if ($result->getStatusCode() !== 200) {
 			throw new \Exception(
-				"could not create file $filePathFromServerRoot " . $result->getReasonPhrase()
+				"could not create file $filePathFromServerRoot " . $result->getReasonPhrase(),
 			);
 		}
 	}
@@ -319,7 +319,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		?string $filePathFromServerRoot,
 		?string $baseUrl = null,
 		?string $adminUsername = null,
-		?string $adminPassword = null
+		?string $adminPassword = null,
 	): void {
 		$baseUrl = self::checkBaseUrl($baseUrl, "deleteFileOnServer");
 		$adminUsername = self::checkAdminUsername($adminUsername, "deleteFileOnServer");
@@ -332,12 +332,12 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			"/apps/testing/api/v1/file",
 			[
 				'file' => $filePathFromServerRoot,
-			]
+			],
 		);
 
 		if ($result->getStatusCode() !== 200) {
 			throw new \Exception(
-				"could not delete file $filePathFromServerRoot " . $result->getReasonPhrase()
+				"could not delete file $filePathFromServerRoot " . $result->getReasonPhrase(),
 			);
 		}
 	}
@@ -356,16 +356,16 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		?string $fileInCore,
 		?string $baseUrl = null,
 		?string $adminUsername = null,
-		?string $adminPassword = null
+		?string $adminPassword = null,
 	): string {
 		$baseUrl = self::checkBaseUrl($baseUrl, "readFile");
 		$adminUsername = self::checkAdminUsername(
 			$adminUsername,
-			"readFile"
+			"readFile",
 		);
 		$adminPassword = self::checkAdminPassword(
 			$adminPassword,
-			"readFile"
+			"readFile",
 		);
 
 		$response = OcsApiHelper::sendRequest(
@@ -378,7 +378,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		self::assertSame(
 			200,
 			$response->getStatusCode(),
-			"Failed to read the file $fileInCore"
+			"Failed to read the file $fileInCore",
 		);
 		$localContent = HttpRequestHelper::getResponseXml($response, __METHOD__);
 		$localContent = (string)$localContent->data->element->contentUrlEncoded;

--- a/tests/acceptance/TestHelpers/SharingHelper.php
+++ b/tests/acceptance/TestHelpers/SharingHelper.php
@@ -106,14 +106,14 @@ class SharingHelper {
 		?string $space_ref = null,
 		int $ocsApiVersion = 1,
 		int $sharingApiVersion = 1,
-		string $sharingApp = 'files_sharing'
+		string $sharingApp = 'files_sharing',
 	): ResponseInterface {
 		$fd = [];
 		foreach ([$path, $baseUrl, $user, $password] as $variableToCheck) {
 			if (!\is_string($variableToCheck)) {
 				throw new InvalidArgumentException(
 					"mandatory argument missing or wrong type ($variableToCheck => "
-					. \gettype($variableToCheck) . ")"
+					. \gettype($variableToCheck) . ")",
 				);
 			}
 		}
@@ -127,12 +127,12 @@ class SharingHelper {
 
 		if (!\in_array($ocsApiVersion, [1, 2], true)) {
 			throw new InvalidArgumentException(
-				"invalid ocsApiVersion ($ocsApiVersion)"
+				"invalid ocsApiVersion ($ocsApiVersion)",
 			);
 		}
 		if (!\in_array($sharingApiVersion, [1, 2], true)) {
 			throw new InvalidArgumentException(
-				"invalid sharingApiVersion ($sharingApiVersion)"
+				"invalid sharingApiVersion ($sharingApiVersion)",
 			);
 		}
 
@@ -169,7 +169,7 @@ class SharingHelper {
 			$user,
 			$password,
 			$headers,
-			$fd
+			$fd,
 		);
 	}
 
@@ -206,13 +206,13 @@ class SharingHelper {
 				$permissionSum += $permission;
 			} else {
 				throw new InvalidArgumentException(
-					"invalid permission type ($permission)"
+					"invalid permission type ($permission)",
 				);
 			}
 		}
 		if ($permissionSum < 0 || $permissionSum > 31) {
 			throw new InvalidArgumentException(
-				"invalid permission total ($permissionSum)"
+				"invalid permission total ($permissionSum)",
 			);
 		}
 		return $permissionSum;
@@ -239,7 +239,7 @@ class SharingHelper {
 			return self::SHARE_TYPES[$key];
 		}
 		throw new InvalidArgumentException(
-			"invalid share type ($shareType)"
+			"invalid share type ($shareType)",
 		);
 	}
 
@@ -254,7 +254,7 @@ class SharingHelper {
 	 */
 	public static function getLastShareIdFromResponse(
 		SimpleXMLElement $responseXmlObject,
-		string $errorMessage = "cannot find share id in response"
+		string $errorMessage = "cannot find share id in response",
 	): string {
 		$xmlPart = $responseXmlObject->xpath("//data/element[last()]/id");
 

--- a/tests/acceptance/TestHelpers/TusClient.php
+++ b/tests/acceptance/TestHelpers/TusClient.php
@@ -72,7 +72,7 @@ class TusClient extends Client {
 				[
 					'body' => $data,
 					'headers' => $headers,
-				]
+				],
 			);
 		} catch (ClientException $e) {
 			$response = $e->getResponse();
@@ -84,9 +84,9 @@ class TusClient extends Client {
 				[
 					'location' => $uploadLocation,
 					'expires_at' => Carbon::now()->addSeconds(
-						$this->getCache()->getTtl()
+						$this->getCache()->getTtl(),
 					)->format($this->getCache()::RFC_7231),
-				]
+				],
 			);
 		}
 		return $response;
@@ -130,7 +130,7 @@ class TusClient extends Client {
 			[
 				'body' => $data,
 				'headers' => $headers,
-			]
+			],
 		);
 		return $response;
 	}

--- a/tests/acceptance/TestHelpers/UploadHelper.php
+++ b/tests/acceptance/TestHelpers/UploadHelper.php
@@ -84,7 +84,7 @@ class UploadHelper extends Assert {
 				null,
 				[],
 				null,
-				$isGivenStep
+				$isGivenStep,
 			);
 		}
 
@@ -114,7 +114,7 @@ class UploadHelper extends Assert {
 				null,
 				[],
 				null,
-				$isGivenStep
+				$isGivenStep,
 			);
 			if ($result->getStatusCode() >= 400) {
 				return $result;
@@ -173,7 +173,7 @@ class UploadHelper extends Assert {
 				return $size;
 			default:
 				throw new \InvalidArgumentException(
-					"Invalid size unit '$sizeUnit' in '$sizeString'. Use GB, MB, KB or no unit for bytes."
+					"Invalid size unit '$sizeUnit' in '$sizeString'. Use GB, MB, KB or no unit for bytes.",
 				);
 		}
 	}
@@ -199,11 +199,11 @@ class UploadHelper extends Assert {
 		\fclose($file);
 		self::assertEquals(
 			1,
-			\file_exists($name)
+			\file_exists($name),
 		);
 		self::assertEquals(
 			$size,
-			\filesize($name)
+			\filesize($name),
 		);
 	}
 
@@ -221,7 +221,7 @@ class UploadHelper extends Assert {
 		\fclose($file);
 		self::assertEquals(
 			1,
-			\file_exists($name)
+			\file_exists($name),
 		);
 	}
 

--- a/tests/acceptance/TestHelpers/UserHelper.php
+++ b/tests/acceptance/TestHelpers/UserHelper.php
@@ -53,7 +53,7 @@ class UserHelper {
 		string $value,
 		string $adminUser,
 		string $adminPassword,
-		?int $ocsApiVersion = 2
+		?int $ocsApiVersion = 2,
 	): ResponseInterface {
 		return OcsApiHelper::sendRequest(
 			$baseUrl,
@@ -62,7 +62,7 @@ class UserHelper {
 			"PUT",
 			"/cloud/users/" . $user,
 			["key" => $key, "value" => $value],
-			$ocsApiVersion
+			$ocsApiVersion,
 		);
 	}
 
@@ -84,12 +84,12 @@ class UserHelper {
 		?array $editData,
 		?string $adminUser,
 		?string $adminPassword,
-		?int $ocsApiVersion = 2
+		?int $ocsApiVersion = 2,
 	): array {
 		$requests = [];
 		$client = HttpRequestHelper::createClient(
 			$adminUser,
-			$adminPassword
+			$adminPassword,
 		);
 
 		foreach ($editData as $data) {
@@ -100,7 +100,7 @@ class UserHelper {
 				$baseUrl,
 				'PUT',
 				$path,
-				$body
+				$body,
 			);
 		}
 		// Send the array of requests at once in parallel.
@@ -111,7 +111,7 @@ class UserHelper {
 				$httpStatusCode = $e->getResponse()->getStatusCode();
 				$reasonPhrase = $e->getResponse()->getReasonPhrase();
 				throw new Exception(
-					"Unexpected failure when editing a user: HTTP status $httpStatusCode HTTP reason $reasonPhrase"
+					"Unexpected failure when editing a user: HTTP status $httpStatusCode HTTP reason $reasonPhrase",
 				);
 			}
 		}
@@ -134,7 +134,7 @@ class UserHelper {
 		?string $userName,
 		?string $adminUser,
 		?string $adminPassword,
-		?int $ocsApiVersion = 2
+		?int $ocsApiVersion = 2,
 	): ResponseInterface {
 		return OcsApiHelper::sendRequest(
 			$baseUrl,
@@ -143,7 +143,7 @@ class UserHelper {
 			"GET",
 			"/cloud/users/" . $userName,
 			[],
-			$ocsApiVersion
+			$ocsApiVersion,
 		);
 	}
 
@@ -163,7 +163,7 @@ class UserHelper {
 		?string $userName,
 		?string $adminUser,
 		?string $adminPassword,
-		?int $ocsApiVersion = 2
+		?int $ocsApiVersion = 2,
 	): ResponseInterface {
 		return OcsApiHelper::sendRequest(
 			$baseUrl,
@@ -172,7 +172,7 @@ class UserHelper {
 			"DELETE",
 			"/cloud/users/" . $userName,
 			[],
-			$ocsApiVersion
+			$ocsApiVersion,
 		);
 	}
 
@@ -194,7 +194,7 @@ class UserHelper {
 		?string $group,
 		?string $adminUser,
 		?string $adminPassword,
-		?int $ocsApiVersion = 2
+		?int $ocsApiVersion = 2,
 	): ResponseInterface {
 		return OcsApiHelper::sendRequest(
 			$baseUrl,
@@ -203,7 +203,7 @@ class UserHelper {
 			"POST",
 			"/cloud/users/" . $user . "/groups",
 			['groupid' => $group],
-			$ocsApiVersion
+			$ocsApiVersion,
 		);
 	}
 
@@ -225,7 +225,7 @@ class UserHelper {
 		?string $group,
 		?string $adminUser,
 		?string $adminPassword,
-		?int $ocsApiVersion = 2
+		?int $ocsApiVersion = 2,
 	): ResponseInterface {
 		return OcsApiHelper::sendRequest(
 			$baseUrl,
@@ -234,7 +234,7 @@ class UserHelper {
 			"DELETE",
 			"/cloud/users/" . $user . "/groups",
 			['groupid' => $group],
-			$ocsApiVersion
+			$ocsApiVersion,
 		);
 	}
 
@@ -252,7 +252,7 @@ class UserHelper {
 		?string $baseUrl,
 		?string $adminUser,
 		?string $adminPassword,
-		?string $search = ""
+		?string $search = "",
 	): ResponseInterface {
 		return OcsApiHelper::sendRequest(
 			$baseUrl,
@@ -277,13 +277,13 @@ class UserHelper {
 		?string $baseUrl,
 		?string $adminUser,
 		?string $adminPassword,
-		?string $search = ""
+		?string $search = "",
 	): array {
 		$result = self::getGroups(
 			$baseUrl,
 			$adminUser,
 			$adminPassword,
-			$search
+			$search,
 		);
 		$groups = HttpRequestHelper::getResponseXml($result, __METHOD__)->xpath(".//groups")[0];
 		$return = [];

--- a/tests/acceptance/TestHelpers/WebDavHelper.php
+++ b/tests/acceptance/TestHelpers/WebDavHelper.php
@@ -85,7 +85,7 @@ class WebDavHelper {
 	 * @throws Exception
 	 */
 	public static function removeSpaceIdReferenceForUser(
-		?string $user
+		?string $user,
 	): void {
 		if (\array_key_exists($user, self::$spacesIdRef)) {
 			unset(self::$spacesIdRef[$user]);
@@ -123,7 +123,7 @@ class WebDavHelper {
 		?string $password,
 		?string $path,
 		?string $spaceId = null,
-		?int $davPathVersionToUse = self::DAV_VERSION_NEW
+		?int $davPathVersionToUse = self::DAV_VERSION_NEW,
 	): string {
 		$body
 			= '<?xml version="1.0"?>
@@ -141,12 +141,12 @@ class WebDavHelper {
 			null,
 			$spaceId,
 			$body,
-			$davPathVersionToUse
+			$davPathVersionToUse,
 		);
 		\preg_match(
 			'/\<oc:fileid\>([^\<]*)\<\/oc:fileid\>/',
 			$response->getBody()->getContents(),
-			$matches
+			$matches,
 		);
 
 		if (!isset($matches[1])) {
@@ -239,7 +239,7 @@ class WebDavHelper {
 		?string $type = "files",
 		?int $davPathVersionToUse = self::DAV_VERSION_NEW,
 		?string $doDavRequestAsUser = null,
-		?array $headers = []
+		?array $headers = [],
 	): ResponseInterface {
 		$body = self::getBodyForPropfind($properties);
 		$folderDepth = (string) $folderDepth;
@@ -267,7 +267,7 @@ class WebDavHelper {
 			null,
 			null,
 			[],
-			$doDavRequestAsUser
+			$doDavRequestAsUser,
 		);
 	}
 
@@ -326,7 +326,7 @@ class WebDavHelper {
 			$spaceId,
 			$body,
 			$davPathVersionToUse,
-			$type
+			$type,
 		);
 	}
 
@@ -384,7 +384,7 @@ class WebDavHelper {
 		?array $propertiesArray,
 		?int $davPathVersion = null,
 		?string $namespaceString = null,
-		?string $type = "files"
+		?string $type = "files",
 	): ResponseInterface {
 		$propertyBody = "";
 		foreach ($propertiesArray as $propertyArray) {
@@ -395,7 +395,7 @@ class WebDavHelper {
 				$matches = [];
 				[$namespacePrefix, $namespace, $property] = self::getPropertyWithNamespaceInfo(
 					$namespaceString,
-					$property
+					$property,
 				);
 				$propertyBody .= "\n\t<$namespacePrefix:$property>" .
 					"$value" .
@@ -422,7 +422,7 @@ class WebDavHelper {
 			null,
 			$body,
 			$davPathVersion,
-			$type
+			$type,
 		);
 	}
 
@@ -451,7 +451,7 @@ class WebDavHelper {
 		?string $spaceId = null,
 		?array $properties = null,
 		?string $type = "files",
-		?int $davPathVersionToUse = self::DAV_VERSION_NEW
+		?int $davPathVersionToUse = self::DAV_VERSION_NEW,
 	): ResponseInterface {
 		if (!$properties) {
 			$properties = [
@@ -467,7 +467,7 @@ class WebDavHelper {
 			$folderDepth,
 			$spaceId,
 			$type,
-			$davPathVersionToUse
+			$davPathVersionToUse,
 		);
 	}
 
@@ -531,22 +531,22 @@ class WebDavHelper {
 				$fullUrl,
 				'PROPFIND',
 				$user,
-				$password
+				$password,
 			);
 			Assert::assertEquals(
 				207,
 				$response->getStatusCode(),
-				"PROPFIND for user '$user' failed so the personal space id cannot be discovered"
+				"PROPFIND for user '$user' failed so the personal space id cannot be discovered",
 			);
 
 			$responseXmlObject = HttpRequestHelper::getResponseXml(
 				$response,
-				__METHOD__
+				__METHOD__,
 			);
 			$xmlPart = $responseXmlObject->xpath("/d:multistatus/d:response[1]/d:propstat/d:prop/oc:spaceid");
 			Assert::assertNotEmpty(
 				$xmlPart,
-				"The 'oc:spaceid' for user '$user' was not found in the PROPFIND response"
+				"The 'oc:spaceid' for user '$user' was not found in the PROPFIND response",
 			);
 
 			$personalSpaceId = $xmlPart[0]->__toString();
@@ -582,7 +582,7 @@ class WebDavHelper {
 		return self::getPersonalSpaceIdForUser(
 			$baseUrl,
 			$user,
-			$password
+			$password,
 		);
 	}
 
@@ -715,7 +715,7 @@ class WebDavHelper {
 					$headers[$key] = \str_replace(
 						$urlSpecialChar[0],
 						$urlSpecialChar[1],
-						$value
+						$value,
 					);
 					break;
 				}
@@ -734,7 +734,7 @@ class WebDavHelper {
 			$stream,
 			$timeout,
 			$client,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -750,7 +750,7 @@ class WebDavHelper {
 	public static function getDavPath(
 		int $davPathVersion,
 		?string $userOrItemIdOrSpaceIdOrToken = null,
-		?string $type = "files"
+		?string $type = "files",
 	): string {
 		switch ($type) {
 			case 'archive':
@@ -830,7 +830,7 @@ class WebDavHelper {
 		?string $baseUrl,
 		?string $fileName,
 		?string $token,
-		?int $davVersionToUse = self::DAV_VERSION_NEW
+		?int $davVersionToUse = self::DAV_VERSION_NEW,
 	): string {
 		$response = self::propfind(
 			$baseUrl,
@@ -841,11 +841,11 @@ class WebDavHelper {
 			'1',
 			null,
 			"public-files",
-			$davVersionToUse
+			$davVersionToUse,
 		);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$response,
-			__METHOD__
+			__METHOD__,
 		);
 		$xmlPart = $responseXmlObject->xpath("//d:getlastmodified");
 
@@ -883,11 +883,11 @@ class WebDavHelper {
 			"0",
 			$spaceId,
 			"files",
-			$davPathVersionToUse
+			$davPathVersionToUse,
 		);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$response,
-			__METHOD__
+			__METHOD__,
 		);
 		$xmlPart = $responseXmlObject->xpath("//d:getlastmodified");
 		Assert::assertArrayHasKey(
@@ -895,7 +895,7 @@ class WebDavHelper {
 			$xmlPart,
 			__METHOD__
 			. " XML part does not have key 0. Expected a value at index 0 of 'xmlPart' but, found: "
-			. json_encode($xmlPart)
+			. json_encode($xmlPart),
 		);
 		$mtime = new DateTime($xmlPart[0]->__toString());
 		return $mtime->format('U');

--- a/tests/acceptance/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/bootstrap/ArchiverContext.php
@@ -114,7 +114,7 @@ class ArchiverContext implements Context {
 	public function getArchiverQueryString(
 		string $user,
 		string $resource,
-		string $addressType
+		string $addressType,
 	): string {
 		switch ($addressType) {
 			case 'id':
@@ -128,7 +128,7 @@ class ArchiverContext implements Context {
 			default:
 				throw new Exception(
 					'"' . $addressType .
-					'" is not a legal value for $addressType, must be id|ids|remoteItemIds|path|paths'
+					'" is not a legal value for $addressType, must be id|ids|remoteItemIds|path|paths',
 				);
 		}
 	}
@@ -152,18 +152,18 @@ class ArchiverContext implements Context {
 		string $archiveType,
 		string $resource,
 		string $addressType,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$headersTable,
-			['header', 'value']
+			['header', 'value'],
 		);
 		$headers = [];
 		foreach ($headersTable as $row) {
 			$headers[$row['header']] = $row ['value'];
 		}
 		$this->featureContext->setResponse(
-			$this->downloadArchive($user, $resource, $addressType, $archiveType, null, $headers)
+			$this->downloadArchive($user, $resource, $addressType, $archiveType, null, $headers),
 		);
 	}
 
@@ -184,7 +184,7 @@ class ArchiverContext implements Context {
 		string $downloader,
 		string $resource,
 		string $owner,
-		string $addressType
+		string $addressType,
 	): void {
 		$this->featureContext->setResponse($this->downloadArchive($downloader, $resource, $addressType, null, $owner));
 	}
@@ -207,7 +207,7 @@ class ArchiverContext implements Context {
 		string $addressType,
 		?string $archiveType = null,
 		?string $owner = null,
-		?array $headers = null
+		?array $headers = null,
 	): ResponseInterface {
 		$owner = $owner ?? $downloader;
 		$downloader = $this->featureContext->getActualUsername($downloader);
@@ -219,7 +219,7 @@ class ArchiverContext implements Context {
 			$this->getArchiverUrl($queryString),
 			$downloader,
 			$this->featureContext->getPasswordForUser($downloader),
-			$headers
+			$headers,
 		);
 	}
 
@@ -238,7 +238,7 @@ class ArchiverContext implements Context {
 	public function userDownloadsTheArchiveOfTheseItems(
 		string $user,
 		string $addressType,
-		TableNode $items
+		TableNode $items,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$queryString = [];
@@ -252,7 +252,7 @@ class ArchiverContext implements Context {
 				$this->getArchiverUrl($queryString),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-			)
+			),
 		);
 	}
 
@@ -302,12 +302,12 @@ class ArchiverContext implements Context {
 							Assert::assertEquals(
 								$expectedItem['content'],
 								$fileContent,
-								__METHOD__ . " content of '" . $expectedPath . "' not as expected"
+								__METHOD__ . " content of '" . $expectedPath . "' not as expected",
 							);
 						} else {
 							Assert::assertFileExists(
 								$fileFullPath,
-								__METHOD__ . " File '" . $expectedPath . "' is not in the downloaded archive."
+								__METHOD__ . " File '" . $expectedPath . "' is not in the downloaded archive.",
 							);
 						}
 					}

--- a/tests/acceptance/bootstrap/AuthAppContext.php
+++ b/tests/acceptance/bootstrap/AuthAppContext.php
@@ -79,7 +79,7 @@ class AuthAppContext implements Context {
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
 				["expiry" => $expiration],
-			)
+			),
 		);
 	}
 
@@ -96,7 +96,7 @@ class AuthAppContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
-			["expiry" => $expiration]
+			["expiry" => $expiration],
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->lastCreatedToken = [
@@ -130,7 +130,7 @@ class AuthAppContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
-			)
+			),
 		);
 	}
 
@@ -161,7 +161,7 @@ class AuthAppContext implements Context {
 			200,
 			"Failed creating auth-app token\n"
 			. "HTTP status code 200 is not the expected value " . $response->getStatusCode(),
-			$response
+			$response,
 		);
 		$this->lastCreatedToken = [
 			"user" => strtolower($impersonatedUser),
@@ -192,7 +192,7 @@ class AuthAppContext implements Context {
 					"expiry" => $expiration,
 					"userName" => $this->featureContext->getActualUsername($impersonatedUser),
 				],
-			)
+			),
 		);
 	}
 
@@ -210,7 +210,7 @@ class AuthAppContext implements Context {
 		$response = AuthAppHelper::listAllAppAuthTokensForUser(
 			$baseUrl,
 			$user,
-			$password
+			$password,
 		);
 		$authAppTokens = json_decode($response->getBody()->getContents());
 		foreach ($authAppTokens as $tokenObj) {
@@ -218,7 +218,7 @@ class AuthAppContext implements Context {
 				$baseUrl,
 				$user,
 				$password,
-				$tokenObj->token
+				$tokenObj->token,
 			);
 			$this->featureContext->setResponse($deleteResponse);
 			$this->featureContext->pushToLastHttpStatusCodesArray((string)$deleteResponse->getStatusCode());
@@ -243,7 +243,7 @@ class AuthAppContext implements Context {
 		Assert::assertCount(
 			$count,
 			$authAppTokens,
-			"Expected the count to be $count but got " . \count($authAppTokens)
+			"Expected the count to be $count but got " . \count($authAppTokens),
 		);
 	}
 
@@ -260,7 +260,7 @@ class AuthAppContext implements Context {
 	public function userCreatesAppTokenWithUserIdForUserWithExpirationTimeUsingTheAuthAppApi(
 		string $user,
 		string $impersonatedUser,
-		string $expiration
+		string $expiration,
 	): void {
 		$this->featureContext->setResponse(
 			AuthAppHelper::createAppAuthToken(
@@ -271,7 +271,7 @@ class AuthAppContext implements Context {
 					"expiry" => $expiration,
 					"userID" => $this->featureContext->getUserIdByUserName($impersonatedUser),
 				],
-			)
+			),
 		);
 	}
 	/**

--- a/tests/acceptance/bootstrap/AuthContext.php
+++ b/tests/acceptance/bootstrap/AuthContext.php
@@ -72,7 +72,7 @@ class AuthContext implements Context {
 		string $url,
 		string $method,
 		?string $body = null,
-		?array $headers = []
+		?array $headers = [],
 	): ResponseInterface {
 		// NOTE: preserving '/' for tests with special cases
 		// E.g: coreApiAuth/webDavSpecialURLs.feature
@@ -110,12 +110,12 @@ class AuthContext implements Context {
 		string $method,
 		?string $body = null,
 		?array $headers = null,
-		?string $property = null
+		?string $property = null,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$url = $this->featureContext->substituteInLineCodes(
 			$url,
-			$user
+			$user,
 		);
 		$authHeader = $this->createBasicAuthHeader($user, $this->featureContext->getPasswordForUser($user));
 		$headers = \array_merge($headers ?? [], $authHeader);
@@ -128,7 +128,7 @@ class AuthContext implements Context {
 			$url,
 			$method,
 			$body,
-			$headers
+			$headers,
 		);
 	}
 
@@ -159,14 +159,14 @@ class AuthContext implements Context {
 		string $method,
 		string $body,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$ofUser = \strtolower($this->featureContext->getActualUsername($ofUser));
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			$response = $this->sendRequest($row['endpoint'], $method, $body);
 			$this->featureContext->setResponse($response);
@@ -187,14 +187,14 @@ class AuthContext implements Context {
 	public function userRequestsEndpointsWithoutBodyAndNoAuthAboutUser(
 		string $method,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$ofUser = \strtolower($this->featureContext->getActualUsername($ofUser));
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			$response = $this->sendRequest($row['endpoint'], $method);
 			$this->featureContext->setResponse($response);
@@ -217,8 +217,8 @@ class AuthContext implements Context {
 			$this->featureContext->setResponse(
 				$this->sendRequest(
 					$this->featureContext->substituteInLineCodes($row['endpoint']),
-					$method
-				)
+					$method,
+				),
 			);
 			$this->featureContext->pushToLastStatusCodesArrays();
 		}
@@ -239,8 +239,8 @@ class AuthContext implements Context {
 			$this->featureContext->setResponse(
 				HttpRequestHelper::sendRequest(
 					$this->featureContext->substituteInLineCodes($row['endpoint']),
-					$method
-				)
+					$method,
+				),
 			);
 			$this->featureContext->pushToLastStatusCodesArrays();
 		}
@@ -282,14 +282,14 @@ class AuthContext implements Context {
 		string $method,
 		string $property,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			$response = $this->requestUrlWithBasicAuth($user, $row['endpoint'], $method, null, null, $property);
 			$this->featureContext->setResponse($response);
@@ -312,7 +312,7 @@ class AuthContext implements Context {
 			$response = $this->requestUrlWithBasicAuth(
 				$this->featureContext->getAdminUsername(),
 				$row['endpoint'],
-				$method
+				$method,
 			);
 			$this->featureContext->setResponse($response);
 			$this->featureContext->pushToLastStatusCodesArrays();
@@ -331,7 +331,7 @@ class AuthContext implements Context {
 	public function userRequestsURLUsingBasicAuth(
 		string $user,
 		string $url,
-		string $method
+		string $method,
 	): void {
 		$response = $this->requestUrlWithBasicAuth($user, $url, $method);
 		$this->featureContext->setResponse($response);
@@ -352,16 +352,16 @@ class AuthContext implements Context {
 		string $user,
 		string $url,
 		string $method,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$url = $this->featureContext->substituteInLineCodes(
 			$url,
-			$user
+			$user,
 		);
 		$this->featureContext->verifyTableNodeColumns(
 			$headersTable,
-			['header', 'value']
+			['header', 'value'],
 		);
 		$headers = [];
 		foreach ($headersTable as $row) {
@@ -373,8 +373,8 @@ class AuthContext implements Context {
 				$url,
 				$method,
 				null,
-				$headers
-			)
+				$headers,
+			),
 		);
 	}
 
@@ -393,7 +393,7 @@ class AuthContext implements Context {
 		string $user,
 		string $method,
 		string $password,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
@@ -424,7 +424,7 @@ class AuthContext implements Context {
 		string $method,
 		string $password,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$ofUser = $this->featureContext->getActualUsername($ofUser);
@@ -435,12 +435,12 @@ class AuthContext implements Context {
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			if (isset($row['destination'])) {
 				$destination = $this->featureContext->substituteInLineCodes(
 					$row['destination'],
-					$ofUser
+					$ofUser,
 				);
 				$headers['Destination'] = $this->featureContext->getBaseUrl()
 				. "/" . WebdavHelper::prefixRemotePhp(\ltrim($destination, "/"));
@@ -449,7 +449,7 @@ class AuthContext implements Context {
 				$row['endpoint'],
 				$method,
 				null,
-				$headers
+				$headers,
 			);
 			$this->featureContext->setResponse($response);
 			$this->featureContext->pushToLastStatusCodesArrays();
@@ -475,7 +475,7 @@ class AuthContext implements Context {
 		string $body,
 		string $password,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$ofUser = $this->featureContext->getActualUsername($ofUser);
@@ -486,12 +486,12 @@ class AuthContext implements Context {
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			if (isset($row['destination'])) {
 				$destination = $this->featureContext->substituteInLineCodes(
 					$row['destination'],
-					$ofUser
+					$ofUser,
 				);
 				$headers['Destination'] = $this->featureContext->getBaseUrl()
 				. "/" . WebdavHelper::prefixRemotePhp(\ltrim($destination, "/"));
@@ -500,7 +500,7 @@ class AuthContext implements Context {
 				$row['endpoint'],
 				$method,
 				$body,
-				$headers
+				$headers,
 			);
 			$this->featureContext->setResponse($response);
 			$this->featureContext->pushToLastStatusCodesArrays();
@@ -524,7 +524,7 @@ class AuthContext implements Context {
 		string $method,
 		string $body,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$ofUser = $this->featureContext->getActualUsername($ofUser);
@@ -538,14 +538,14 @@ class AuthContext implements Context {
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			$response = $this->requestUrlWithBasicAuth(
 				$user,
 				$row['endpoint'],
 				$method,
 				$body,
-				$headers
+				$headers,
 			);
 			$this->featureContext->setResponse($response);
 			$this->featureContext->pushToLastStatusCodesArrays();
@@ -568,7 +568,7 @@ class AuthContext implements Context {
 		string $asUser,
 		string $method,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$asUser = $this->featureContext->getActualUsername($asUser);
 		$ofUser = $this->featureContext->getActualUsername($ofUser);
@@ -580,13 +580,13 @@ class AuthContext implements Context {
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			$response = $this->sendRequest(
 				$row['endpoint'],
 				$method,
 				null,
-				$authHeader
+				$authHeader,
 			);
 			$this->featureContext->setResponse($response);
 			$this->featureContext->pushToLastStatusCodesArrays();
@@ -610,7 +610,7 @@ class AuthContext implements Context {
 		string $method,
 		?string $body,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$asUser = $this->featureContext->getActualUsername($asUser);
 		$ofUser = $this->featureContext->getActualUsername($ofUser);
@@ -622,13 +622,13 @@ class AuthContext implements Context {
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			$response = $this->sendRequest(
 				$row['endpoint'],
 				$method,
 				$body,
-				$authHeader
+				$authHeader,
 			);
 			$this->featureContext->setResponse($response);
 			$this->featureContext->pushToLastStatusCodesArrays();
@@ -650,7 +650,7 @@ class AuthContext implements Context {
 		string $user,
 		string $method,
 		string $ofUser,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$headers = [];
 		if ($method === 'MOVE' || $method === 'COPY') {
@@ -666,14 +666,14 @@ class AuthContext implements Context {
 		foreach ($table->getHash() as $row) {
 			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
 				$row['endpoint'],
-				$ofUser
+				$ofUser,
 			);
 			$response = $this->requestUrlWithBasicAuth(
 				$user,
 				$row['endpoint'],
 				$method,
 				null,
-				$headers
+				$headers,
 			);
 			$this->featureContext->setResponse($response);
 			$this->featureContext->pushToLastStatusCodesArrays();
@@ -692,12 +692,12 @@ class AuthContext implements Context {
 	public function userRequestsURLWithoutRetry(
 		string $user,
 		string $endpoint,
-		string $method
+		string $method,
 	): void {
 		$username = $this->featureContext->getActualUsername($user);
 		$endpoint = $this->featureContext->substituteInLineCodes(
 			$endpoint,
-			$username
+			$username,
 		);
 		$endpoint = \ltrim($endpoint, '/');
 		if (WebdavHelper::isDAVRequest($endpoint)) {
@@ -708,7 +708,7 @@ class AuthContext implements Context {
 			$fullUrl,
 			$method,
 			$username,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/bootstrap/CapabilitiesContext.php
@@ -75,7 +75,7 @@ class CapabilitiesContext implements Context {
 			'GET',
 			'/cloud/capabilities' . ($formatJson ? '?format=json' : ''),
 			[],
-			$this->featureContext->getOcsApiVersion()
+			$this->featureContext->getOcsApiVersion(),
 		);
 	}
 
@@ -110,7 +110,7 @@ class CapabilitiesContext implements Context {
 	public function getParameterValueFromXml(
 		SimpleXMLElement $xml,
 		string $capabilitiesApp,
-		string $capabilitiesPath
+		string $capabilitiesPath,
 	): string {
 		$path_to_element = \explode('@@@', $capabilitiesPath);
 		$answeredValue = $xml->{$capabilitiesApp};
@@ -172,7 +172,7 @@ class CapabilitiesContext implements Context {
 		Assert::assertSame(
 			1,
 			$result,
-			__METHOD__ . " version string '$versionString' does not start with a semver version"
+			__METHOD__ . " version string '$versionString' does not start with a semver version",
 		);
 		// semVerParts should have an array with the 3 semver components of the version, e.g. "1", "9" and "2".
 		$semVerParts = \explode('.', $matches[0]);
@@ -185,17 +185,17 @@ class CapabilitiesContext implements Context {
 		Assert::assertSame(
 			$expectedMajor,
 			$actualMajor,
-			__METHOD__ . "'major' data item does not match with major version in string '$versionString'"
+			__METHOD__ . "'major' data item does not match with major version in string '$versionString'",
 		);
 		Assert::assertSame(
 			$expectedMinor,
 			$actualMinor,
-			__METHOD__ . "'minor' data item does not match with minor version in string '$versionString'"
+			__METHOD__ . "'minor' data item does not match with minor version in string '$versionString'",
 		);
 		Assert::assertSame(
 			$expectedMicro,
 			$actualMicro,
-			__METHOD__ . "'micro' data item does not match with micro (patch) version in string '$versionString'"
+			__METHOD__ . "'micro' data item does not match with micro (patch) version in string '$versionString'",
 		);
 	}
 
@@ -218,35 +218,35 @@ class CapabilitiesContext implements Context {
 		$edition = $this->getParameterValueFromXml(
 			$responseXmlObject,
 			'core',
-			'status@@@edition'
+			'status@@@edition',
 		);
 
 		if (!\strlen($edition)) {
 			Assert::fail(
-				"Cannot get edition from core capabilities"
+				"Cannot get edition from core capabilities",
 			);
 		}
 
 		$product = $this->getParameterValueFromXml(
 			$responseXmlObject,
 			'core',
-			'status@@@product'
+			'status@@@product',
 		);
 		if (!\strlen($product)) {
 			Assert::fail(
-				"Cannot get product from core capabilities"
+				"Cannot get product from core capabilities",
 			);
 		}
 
 		$productName = $this->getParameterValueFromXml(
 			$responseXmlObject,
 			'core',
-			'status@@@productname'
+			'status@@@productname',
 		);
 
 		if (!\strlen($productName)) {
 			Assert::fail(
-				"Cannot get productname from core capabilities"
+				"Cannot get productname from core capabilities",
 			);
 		}
 
@@ -259,24 +259,24 @@ class CapabilitiesContext implements Context {
 		$version = $this->getParameterValueFromXml(
 			$responseXmlObject,
 			'core',
-			'status@@@version'
+			'status@@@version',
 		);
 
 		if (!\strlen($version)) {
 			Assert::fail(
-				"Cannot get version from core capabilities"
+				"Cannot get version from core capabilities",
 			);
 		}
 
 		$versionString = $this->getParameterValueFromXml(
 			$responseXmlObject,
 			'core',
-			'status@@@versionstring'
+			'status@@@versionstring',
 		);
 
 		if (!\strlen($versionString)) {
 			Assert::fail(
-				"Cannot get versionstring from core capabilities"
+				"Cannot get versionstring from core capabilities",
 			);
 		}
 
@@ -306,7 +306,7 @@ class CapabilitiesContext implements Context {
 		Assert::assertMatchesRegularExpression(
 			"/^\d+\.\d+\.\d+\.\d+$/",
 			$version,
-			"version should be in a form like 10.9.8.1 but is $version"
+			"version should be in a form like 10.9.8.1 but is $version",
 		);
 		if (\preg_match("/^(\d+\.\d+\.\d+)\.\d+(-[0-9A-Za-z-]+)?(\+[0-9A-Za-z-]+)?$/", $version, $matches)) {
 			// We should have matched something like 10.9.8 - the first 3 numbers in the version.
@@ -314,7 +314,7 @@ class CapabilitiesContext implements Context {
 			Assert::assertArrayHasKey(
 				1,
 				$matches,
-				"version $version could not match the pattern Major.Minor.Patch"
+				"version $version could not match the pattern Major.Minor.Patch",
 			);
 			$majorMinorPatchVersion = $matches[1];
 		} else {
@@ -323,7 +323,7 @@ class CapabilitiesContext implements Context {
 		Assert::assertStringStartsWith(
 			$majorMinorPatchVersion,
 			$versionString,
-			"version string should start with $majorMinorPatchVersion but is $versionString"
+			"version string should start with $majorMinorPatchVersion but is $versionString",
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/bootstrap/ChecksumContext.php
@@ -46,17 +46,17 @@ class ChecksumContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $checksum
+		string $checksum,
 	): ResponseInterface {
 		$file = \file_get_contents(
-			$this->featureContext->acceptanceTestsDirLocation() . $source
+			$this->featureContext->acceptanceTestsDirLocation() . $source,
 		);
 		return $this->featureContext->makeDavRequest(
 			$user,
 			'PUT',
 			$destination,
 			['OC-Checksum' => $checksum],
-			$file
+			$file,
 		);
 	}
 
@@ -74,10 +74,10 @@ class ChecksumContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $checksum
+		string $checksum,
 	): void {
 		$this->featureContext->setResponse(
-			$this->uploadFileToWithChecksumUsingTheAPI($user, $source, $destination, $checksum)
+			$this->uploadFileToWithChecksumUsingTheAPI($user, $source, $destination, $checksum),
 		);
 	}
 
@@ -95,14 +95,14 @@ class ChecksumContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $checksum
+		string $checksum,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$response = $this->uploadFileToWithChecksumUsingTheAPI(
 			$user,
 			$source,
 			$destination,
-			$checksum
+			$checksum,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe([201,204], '', $response);
 	}
@@ -119,14 +119,14 @@ class ChecksumContext implements Context {
 		string $user,
 		string $content,
 		string $checksum,
-		string $destination
+		string $destination,
 	): ResponseInterface {
 		return $this->featureContext->makeDavRequest(
 			$user,
 			'PUT',
 			$destination,
 			['OC-Checksum' => $checksum],
-			$content
+			$content,
 		);
 	}
 
@@ -144,7 +144,7 @@ class ChecksumContext implements Context {
 		string $user,
 		string $content,
 		string $checksum,
-		string $destination
+		string $destination,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$response = $this->uploadFileWithContentAndChecksumToUsingTheAPI($user, $content, $checksum, $destination);
@@ -188,7 +188,7 @@ class ChecksumContext implements Context {
 			null,
 			$spaceId,
 			$body,
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
 		);
 	}
 
@@ -218,7 +218,7 @@ class ChecksumContext implements Context {
 	public function asUserTheWebdavChecksumOfPathViaPropfindShouldMatch(
 		string $user,
 		string $path,
-		string $expectedChecksum
+		string $expectedChecksum,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$resource = $this->propfindResourceChecksum($user, $path);
@@ -249,72 +249,72 @@ class ChecksumContext implements Context {
 		Assert::assertIsArray(
 			$parsed,
 			__METHOD__
-			. " could not parse response as XML. Expected parsed XML to be an array but found " . $bodyContents
+			. " could not parse response as XML. Expected parsed XML to be an array but found " . $bodyContents,
 		);
 		Assert::assertArrayHasKey(
 			0,
 			$parsed,
-			__METHOD__ . " parsed XML does not have key 0"
+			__METHOD__ . " parsed XML does not have key 0",
 		);
 		$parsed0 = $parsed[0];
 		Assert::assertArrayHasKey(
 			'value',
 			$parsed0,
-			__METHOD__ . " parsed XML parsed0 does not have key value"
+			__METHOD__ . " parsed XML parsed0 does not have key value",
 		);
 		$parsed0Value = $parsed0['value'];
 		Assert::assertArrayHasKey(
 			1,
 			$parsed0Value,
-			__METHOD__ . " parsed XML parsed0Value does not have key 1"
+			__METHOD__ . " parsed XML parsed0Value does not have key 1",
 		);
 		$parsed0Value1 = $parsed0Value[1];
 		Assert::assertArrayHasKey(
 			'value',
 			$parsed0Value1,
-			__METHOD__ . " parsed XML parsed0Value1 does not have key value after key 1"
+			__METHOD__ . " parsed XML parsed0Value1 does not have key value after key 1",
 		);
 		$parsed0Value1Value = $parsed0Value1['value'];
 		Assert::assertArrayHasKey(
 			0,
 			$parsed0Value1Value,
-			__METHOD__ . " parsed XML parsed0Value1Value does not have key 0"
+			__METHOD__ . " parsed XML parsed0Value1Value does not have key 0",
 		);
 		$parsed0Value1Value0 = $parsed0Value1Value[0];
 		Assert::assertArrayHasKey(
 			'value',
 			$parsed0Value1Value0,
-			__METHOD__ . " parsed XML parsed0Value1Value0 does not have key value"
+			__METHOD__ . " parsed XML parsed0Value1Value0 does not have key value",
 		);
 		$parsed0Value1Value0Value = $parsed0Value1Value0['value'];
 		Assert::assertArrayHasKey(
 			0,
 			$parsed0Value1Value0Value,
-			__METHOD__ . " parsed XML parsed0Value1Value0Value does not have key 0"
+			__METHOD__ . " parsed XML parsed0Value1Value0Value does not have key 0",
 		);
 		$checksums = $parsed0Value1Value0Value[0];
 		Assert::assertArrayHasKey(
 			'value',
 			$checksums,
-			__METHOD__ . " parsed XML checksums does not have key value"
+			__METHOD__ . " parsed XML checksums does not have key value",
 		);
 		$checksumsValue = $checksums['value'];
 		Assert::assertArrayHasKey(
 			0,
 			$checksumsValue,
-			__METHOD__ . " parsed XML checksumsValue does not have key 0"
+			__METHOD__ . " parsed XML checksumsValue does not have key 0",
 		);
 		$checksumsValue0 = $checksumsValue[0];
 		Assert::assertArrayHasKey(
 			'value',
 			$checksumsValue0,
-			__METHOD__ . " parsed XML checksumsValue0 does not have key value"
+			__METHOD__ . " parsed XML checksumsValue0 does not have key value",
 		);
 		$actualChecksum = $checksumsValue0['value'];
 		Assert::assertEquals(
 			$expectedChecksum,
 			$actualChecksum,
-			"Expected: webDav checksum should be $expectedChecksum but got $actualChecksum"
+			"Expected: webDav checksum should be $expectedChecksum but got $actualChecksum",
 		);
 	}
 
@@ -332,19 +332,19 @@ class ChecksumContext implements Context {
 
 		Assert::assertIsArray(
 			$headerChecksums,
-			__METHOD__ . " getHeader('OC-Checksum') did not return an array"
+			__METHOD__ . " getHeader('OC-Checksum') did not return an array",
 		);
 
 		Assert::assertNotEmpty(
 			$headerChecksums,
-			__METHOD__ . " getHeader('OC-Checksum') returned an empty array. No checksum header was found."
+			__METHOD__ . " getHeader('OC-Checksum') returned an empty array. No checksum header was found.",
 		);
 
 		$checksumCount = \count($headerChecksums);
 
 		Assert::assertTrue(
 			$checksumCount === 1,
-			__METHOD__ . " Expected 1 checksum in the header but found $checksumCount checksums"
+			__METHOD__ . " Expected 1 checksum in the header but found $checksumCount checksums",
 		);
 
 		$headerChecksum
@@ -352,7 +352,7 @@ class ChecksumContext implements Context {
 		Assert::assertEquals(
 			$expectedChecksum,
 			$headerChecksum,
-			"Expected: header checksum should match $expectedChecksum but got $headerChecksum"
+			"Expected: header checksum should match $expectedChecksum but got $headerChecksum",
 		);
 	}
 
@@ -369,26 +369,26 @@ class ChecksumContext implements Context {
 	public function theHeaderChecksumWhenUserDownloadsFileUsingTheWebdavApiShouldMatch(
 		string $user,
 		string $fileName,
-		string $expectedChecksum
+		string $expectedChecksum,
 	): void {
 		$response = $this->featureContext->downloadFileAsUserUsingPassword($user, $fileName);
 		$headerChecksums = $response->getHeader('OC-Checksum');
 
 		Assert::assertIsArray(
 			$headerChecksums,
-			__METHOD__ . " getHeader('OC-Checksum') did not return an array"
+			__METHOD__ . " getHeader('OC-Checksum') did not return an array",
 		);
 
 		Assert::assertNotEmpty(
 			$headerChecksums,
-			__METHOD__ . " getHeader('OC-Checksum') returned an empty array. No checksum header was found."
+			__METHOD__ . " getHeader('OC-Checksum') returned an empty array. No checksum header was found.",
 		);
 
 		$checksumCount = \count($headerChecksums);
 
 		Assert::assertTrue(
 			$checksumCount === 1,
-			__METHOD__ . " Expected 1 checksum in the header but found $checksumCount checksums"
+			__METHOD__ . " Expected 1 checksum in the header but found $checksumCount checksums",
 		);
 
 		$headerChecksum
@@ -396,7 +396,7 @@ class ChecksumContext implements Context {
 		Assert::assertEquals(
 			$expectedChecksum,
 			$headerChecksum,
-			"Expected: header checksum should match $expectedChecksum but got $headerChecksum"
+			"Expected: header checksum should match $expectedChecksum but got $headerChecksum",
 		);
 	}
 
@@ -416,7 +416,7 @@ class ChecksumContext implements Context {
 		int $total,
 		string $data,
 		string $destination,
-		string $expectedChecksum
+		string $expectedChecksum,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$num -= 1;
@@ -426,7 +426,7 @@ class ChecksumContext implements Context {
 			'PUT',
 			$file,
 			['OC-Checksum' => $expectedChecksum, 'OC-Chunked' => '1'],
-			$data
+			$data,
 		);
 	}
 
@@ -448,7 +448,7 @@ class ChecksumContext implements Context {
 		int $total,
 		string $data,
 		string $destination,
-		string $expectedChecksum
+		string $expectedChecksum,
 	): void {
 		$response = $this->uploadChunkFileOfWithToWithChecksum(
 			$user,
@@ -456,7 +456,7 @@ class ChecksumContext implements Context {
 			$total,
 			$data,
 			$destination,
-			$expectedChecksum
+			$expectedChecksum,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -479,7 +479,7 @@ class ChecksumContext implements Context {
 		int $total,
 		string $data,
 		string $destination,
-		string $expectedChecksum
+		string $expectedChecksum,
 	): void {
 		$response = $this->uploadChunkFileOfWithToWithChecksum(
 			$user,
@@ -487,12 +487,12 @@ class ChecksumContext implements Context {
 			$total,
 			$data,
 			$destination,
-			$expectedChecksum
+			$expectedChecksum,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			[201, 206],
 			'',
-			$response
+			$response,
 		);
 	}
 

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -95,7 +95,7 @@ class CliContext implements Context {
 	public function theAdministratorResetsThePasswordOfUserUsingTheCLI(
 		string $status,
 		string $user,
-		string $password
+		string $password,
 	): void {
 		$command = "idm resetpassword -u $user";
 		$body = [
@@ -149,7 +149,7 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorCreatesAppTokenForUserWithExpirationTimeUsingTheAuthAppCLI(
 		string $user,
-		string $expirationTime
+		string $expirationTime,
 	): void {
 		$user = $this->featureContext->getActualUserName($user);
 		$command = "auth-app create --user-name=$user --expiration=$expirationTime";
@@ -169,7 +169,7 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorHasCreatedAppTokenForUserWithExpirationTimeUsingTheAuthAppCli(
 		$user,
-		$expirationTime
+		$expirationTime,
 	): void {
 		$user = $this->featureContext->getActualUserName($user);
 		$command = "auth-app create --user-name=$user --expiration=$expirationTime";
@@ -183,7 +183,7 @@ class CliContext implements Context {
 		Assert::assertSame(
 			0,
 			$jsonResponse["exitCode"],
-			"Expected exit code to be 0, but got " . $jsonResponse["exitCode"]
+			"Expected exit code to be 0, but got " . $jsonResponse["exitCode"],
 		);
 		$output = $this->featureContext->substituteInLineCodes("App token created for $user");
 		Assert::assertStringContainsString($output, $jsonResponse["message"]);
@@ -199,7 +199,7 @@ class CliContext implements Context {
 	 */
 	public function userHasCreatedAppTokenWithExpirationTimeUsingTheAuthAppCLI(
 		string $user,
-		string $expirationTime
+		string $expirationTime,
 	): void {
 		$user = $this->featureContext->getActualUserName($user);
 		$command = "auth-app create --user-name=$user --expiration=$expirationTime";
@@ -214,7 +214,7 @@ class CliContext implements Context {
 		Assert::assertSame(
 			0,
 			$jsonResponse["exitCode"],
-			"Expected exit code to be 0, but got " . $jsonResponse["exitCode"]
+			"Expected exit code to be 0, but got " . $jsonResponse["exitCode"],
 		);
 	}
 
@@ -320,7 +320,7 @@ class CliContext implements Context {
 		Assert::assertSame(
 			$expectedExitCode,
 			$jsonResponse["exitCode"],
-			"Expected exit code to be 0, but got " . $jsonResponse["exitCode"]
+			"Expected exit code to be 0, but got " . $jsonResponse["exitCode"],
 		);
 	}
 
@@ -446,14 +446,14 @@ class CliContext implements Context {
 			foreach ($expectedFiles as $expectedFile) {
 				Assert::assertNotTrue(
 					\in_array($expectedFile, $resourceNames),
-					"The resource '$expectedFile' was found in the response."
+					"The resource '$expectedFile' was found in the response.",
 				);
 			}
 		} else {
 			foreach ($expectedFiles as $expectedFile) {
 				Assert::assertTrue(
 					\in_array($expectedFile, $resourceNames),
-					"The resource '$expectedFile' was not found in the response."
+					"The resource '$expectedFile' was not found in the response.",
 				);
 			}
 		}
@@ -587,11 +587,11 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorListsTheStaleUploadsOfSpace(
 		string $spaceName,
-		string $user
+		string $user,
 	): void {
 		$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 			$user,
-			$spaceName
+			$spaceName,
 		);
 		$this->featureContext->setResponse($this->listStaleUploads($spaceOwnerId));
 	}
@@ -611,7 +611,7 @@ class CliContext implements Context {
 		Assert::assertSame(
 			$expectedMessage,
 			$actualMessage,
-			"Expected cli output to be $expectedMessage but found $actualMessage"
+			"Expected cli output to be $expectedMessage but found $actualMessage",
 		);
 	}
 
@@ -634,11 +634,11 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorDeletesTheStaleUploadsOfSpaceOwnedByUser(
 		string $spaceName,
-		string $user
+		string $user,
 	): void {
 		$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 			$user,
-			$spaceName
+			$spaceName,
 		);
 		$this->featureContext->setResponse($this->deleteStaleUploads($spaceOwnerId));
 	}
@@ -657,13 +657,13 @@ class CliContext implements Context {
 	public function thereShouldBeStaleUploadsOfSpaceOwnedByUser(
 		int $number,
 		string $spaceName = '',
-		string $user = ''
+		string $user = '',
 	): void {
 		$spaceOwnerId = null;
 		if ($spaceName !== '' && $user !== '') {
 			$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 				$user,
-				$spaceName
+				$spaceName,
 			);
 		}
 
@@ -676,7 +676,7 @@ class CliContext implements Context {
 		Assert::assertStringContainsString(
 			$expectedMessage,
 			$jsonDecodedResponse->message ?? '',
-			"Expected message to contain '$expectedMessage', but got: " . ($jsonDecodedResponse->message ?? 'null')
+			"Expected message to contain '$expectedMessage', but got: " . ($jsonDecodedResponse->message ?? 'null'),
 		);
 
 	}
@@ -691,11 +691,11 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorListsAllTrashedResourceOfSpaceOwnedByUser(
 		string $spaceName,
-		string $user
+		string $user,
 	): void {
 		$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 			$user,
-			$spaceName
+			$spaceName,
 		);
 		$this->featureContext->setResponse($this->listTrashedResource($spaceOwnerId));
 	}
@@ -719,7 +719,7 @@ class CliContext implements Context {
 	 * @return array
 	 */
 	protected function getTrashedResourceFromCliCommandResponse(
-		ResponseInterface $response = null
+		ResponseInterface $response = null,
 	): array {
 		$responseArray = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 		$lines = explode("\n", $responseArray->message);
@@ -729,7 +729,7 @@ class CliContext implements Context {
 			if (preg_match(
 				'/^\s*\|\s*([a-f0-9\-]{36})\s*\|\s*(.*?)\s*\|\s*(file|folder)\s*\|\s*([\d\-T:Z]+)\s*\|/',
 				$line,
-				$matches
+				$matches,
 			)
 			) {
 				$items[] = [
@@ -757,7 +757,7 @@ class CliContext implements Context {
 	 */
 	public function theCommandOutputShouldContainTheFollowingTrashResource(
 		int $count,
-		TableNode $table
+		TableNode $table,
 	): void {
 		[$items, $totalCount] = $this->getTrashedResourceFromCliCommandResponse();
 
@@ -777,7 +777,7 @@ class CliContext implements Context {
 
 			Assert::assertTrue(
 				$matchFound,
-				"Could not find expected resource '{$expectedRow['resource']}' of type '{$expectedRow['type']}'"
+				"Could not find expected resource '{$expectedRow['resource']}' of type '{$expectedRow['type']}'",
 			);
 		}
 	}
@@ -792,11 +792,11 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorRestoresAllTheTrashedResourcesOfSpaceOwnedByUser(
 		string $spaceName,
-		string $user
+		string $user,
 	): void {
 		$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 			$user,
-			$spaceName
+			$spaceName,
 		);
 		$body = [
 			"command" => "storage-users trash-bin restore-all -y $spaceOwnerId",
@@ -815,11 +815,11 @@ class CliContext implements Context {
 	 */
 	public function thereShouldBeNoTrashedResourcesOfSpaceOwnedByUser(
 		string $spaceName,
-		string $user
+		string $user,
 	): void {
 		$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 			$user,
-			$spaceName
+			$spaceName,
 		);
 		$response = $this->listTrashedResource($spaceOwnerId);
 		[$items, $totalCount] = $this->getTrashedResourceFromCliCommandResponse($response);
@@ -842,11 +842,11 @@ class CliContext implements Context {
 		int $number,
 		string $spaceName,
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 			$user,
-			$spaceName
+			$spaceName,
 		);
 		$response = $this->listTrashedResource($spaceOwnerId);
 		[$items, $totalCount] = $this->getTrashedResourceFromCliCommandResponse($response);
@@ -867,7 +867,7 @@ class CliContext implements Context {
 
 			Assert::assertTrue(
 				$matchFound,
-				"Could not find expected resource '{$expectedRow['resource']}' of type '{$expectedRow['type']}'"
+				"Could not find expected resource '{$expectedRow['resource']}' of type '{$expectedRow['type']}'",
 			);
 		}
 	}
@@ -884,11 +884,11 @@ class CliContext implements Context {
 	public function theAdministratorRestoresTheTrashedResourcesOfSpaceOwnedByUser(
 		string $resource,
 		string $spaceName,
-		string $user
+		string $user,
 	): void {
 		$spaceOwnerId = $this->spacesContext->getSpaceOwnerUserIdByName(
 			$user,
-			$spaceName
+			$spaceName,
 		);
 		$response = $this->listTrashedResource($spaceOwnerId);
 		[$items, $totalCount] = $this->getTrashedResourceFromCliCommandResponse($response);

--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -91,7 +91,7 @@ class CollaborationContext implements Context {
 		string $file,
 		string $space,
 		string $app,
-		string $viewMode = null
+		string $viewMode = null,
 	): void {
 		$fileId = $this->spacesContext->getFileId($user, $space, $file);
 		$response = \json_decode(
@@ -101,8 +101,8 @@ class CollaborationContext implements Context {
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
 				$this->featureContext->getBaseUrl(),
-				$viewMode
-			)->getBody()->getContents()
+				$viewMode,
+			)->getBody()->getContents(),
 		);
 
 		$accessToken = $response->form_parameters->access_token;
@@ -115,7 +115,7 @@ class CollaborationContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$wopiSrc . "?access_token=$accessToken",
-			)
+			),
 		);
 	}
 
@@ -135,7 +135,7 @@ class CollaborationContext implements Context {
 		string $user,
 		string $file,
 		string $folder,
-		string $space
+		string $space,
 	): void {
 		$parentContainerId = $this->spacesContext->getResourceId($user, $space, $folder);
 		$this->featureContext->setResponse(
@@ -144,8 +144,8 @@ class CollaborationContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				$parentContainerId,
-				$file
-			)
+				$file,
+			),
 		);
 	}
 
@@ -168,8 +168,8 @@ class CollaborationContext implements Context {
 				"$baseUrl/$davPath/$folder",
 				"PROPFIND",
 				"public",
-				$this->featureContext->getActualPassword($password)
-			)
+				$this->featureContext->getActualPassword($password),
+			),
 		);
 		$xmlPart = $responseXmlObject->xpath("//d:prop/oc:fileid");
 		$parentContainerId = (string) $xmlPart[0];
@@ -184,8 +184,8 @@ class CollaborationContext implements Context {
 				$this->featureContext->getActualPassword($password),
 				$parentContainerId,
 				$file,
-				$headers
-			)
+				$headers,
+			),
 		);
 	}
 
@@ -201,7 +201,7 @@ class CollaborationContext implements Context {
 	 */
 	public function thePublicCreatesAFileInsideTheLastSharedPublicLinkFolderWithPasswordUsingWopiEndpoint(
 		string $file,
-		string $password
+		string $password,
 	): void {
 		$this->createFile($file, $password);
 	}
@@ -220,7 +220,7 @@ class CollaborationContext implements Context {
 	public function thePublicCreatesAFileInsideFolderInTheLastSharedPublicLinkSpaceWithPasswordUsingWopiEndpoint(
 		string $file,
 		string $folder,
-		string $password
+		string $password,
 	): void {
 		$this->createFile($file, $password, $folder);
 	}
@@ -242,7 +242,7 @@ class CollaborationContext implements Context {
 		string $user,
 		string $file,
 		string $space,
-		string $app
+		string $app,
 	): void {
 		$response = \json_decode(
 			CollaborationHelper::sendPOSTRequestToAppOpen(
@@ -251,7 +251,7 @@ class CollaborationContext implements Context {
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
 				$this->featureContext->getBaseUrl(),
-			)->getBody()->getContents()
+			)->getBody()->getContents(),
 		);
 		$accessToken = $response->form_parameters->access_token;
 
@@ -266,7 +266,7 @@ class CollaborationContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$fullUrl . "?access_token=$accessToken",
-			)
+			),
 		);
 	}
 
@@ -287,8 +287,8 @@ class CollaborationContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				$parentContainerId,
-				$file
-			)
+				$file,
+			),
 		);
 	}
 
@@ -335,7 +335,7 @@ class CollaborationContext implements Context {
 		$this->featureContext->setResponse(
 			HttpRequestHelper::get(
 				$wopiSrc . "?access_token=$accessToken",
-			)
+			),
 		);
 	}
 
@@ -351,7 +351,7 @@ class CollaborationContext implements Context {
 	public function theFollowingMimeTypesShouldExistForUser(string $shouldOrNot, TableNode $table): void {
 		$rows = $table->getRows();
 		$responseArray = $this->featureContext->getJsonDecodedResponse(
-			$this->featureContext->getResponse()
+			$this->featureContext->getResponse(),
 		)['mime-types'];
 		$mimeTypes = \array_column($responseArray, 'mime_type');
 		foreach ($rows as $row) {
@@ -359,13 +359,13 @@ class CollaborationContext implements Context {
 				Assert::assertFalse(
 					\in_array($row[0], $mimeTypes),
 					"the response should not contain the mimetype $row[0].\nMime Types found in response:\n"
-					. print_r($mimeTypes, true)
+					. print_r($mimeTypes, true),
 				);
 			} else {
 				Assert::assertTrue(
 					\in_array($row[0], $mimeTypes),
 					"the response does not contain the mimetype $row[0].\nMime Types found in response:\n"
-					. print_r($mimeTypes, true)
+					. print_r($mimeTypes, true),
 				);
 			}
 		}
@@ -381,14 +381,14 @@ class CollaborationContext implements Context {
 	 */
 	public function theAppListResponseShouldContainTheFollowingTemplateInformationForOffice(
 		string $app,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$responseArray = $this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse());
 
 		Assert::assertArrayHasKey(
 			"mime-types",
 			$responseArray,
-			"Expected 'mime-types' in the response but not found.\n" . print_r($responseArray, true)
+			"Expected 'mime-types' in the response but not found.\n" . print_r($responseArray, true),
 		);
 
 		$mimeTypes = $responseArray['mime-types'];
@@ -403,7 +403,7 @@ class CollaborationContext implements Context {
 				$row['mime-type'],
 				$mimeTypeMap,
 				"Expected mime-type '{$row['mime-type']}' to exist in the response but it doesn't.\n"
-				. print_r($mimeTypeMap, true)
+				. print_r($mimeTypeMap, true),
 			);
 
 			$mimeType = $mimeTypeMap[$row['mime-type']];
@@ -415,7 +415,7 @@ class CollaborationContext implements Context {
 						$row['target-extension'],
 						$provider['target_ext'],
 						"Expected 'target_ext' for $app to be '{$row['target-extension']}'"
-						. " but found '{$provider['target_ext']}'"
+						. " but found '{$provider['target_ext']}'",
 					);
 					$found = true;
 					break;
@@ -427,7 +427,7 @@ class CollaborationContext implements Context {
 					"Expected response to contain app-provider '$app' with target-extension "
 					. "'{$row['target-extension']}' for mime-type '{$row['mime-type']}',"
 					. " but no matching provider was found.\n App Providers Found: "
-					. print_r($mimeType['app_providers'], true)
+					. print_r($mimeType['app_providers'], true),
 				);
 			}
 		}
@@ -449,7 +449,7 @@ class CollaborationContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$parentContainerId,
-			$file
+			$file,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 		$decodedResponse = $this->featureContext->getJsonDecodedResponseBodyContent($response);

--- a/tests/acceptance/bootstrap/EmailContext.php
+++ b/tests/acceptance/bootstrap/EmailContext.php
@@ -66,7 +66,7 @@ class EmailContext implements Context {
 		string $user,
 		string $sender,
 		string $spaceName,
-		PyStringNode $content
+		PyStringNode $content,
 	): void {
 		$rawExpectedEmailBodyContent = \str_replace("\r\n", "\n", $content->getRaw());
 		$this->featureContext->setResponse(
@@ -75,7 +75,7 @@ class EmailContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				'',
-			)
+			),
 		);
 		$expectedEmailBodyContent = $this->featureContext->substituteInLineCodes(
 			$rawExpectedEmailBodyContent,
@@ -88,7 +88,7 @@ class EmailContext implements Context {
 						[$this->spacesContext, "getSpaceIdByName"],
 					"parameter" => [$sender, $spaceName],
 				],
-			]
+			],
 		);
 		$this->assertEmailContains($user, $expectedEmailBodyContent);
 	}
@@ -106,12 +106,12 @@ class EmailContext implements Context {
 	public function userShouldHaveReceivedTheFollowingEmailFromUser(
 		string $user,
 		string $sender,
-		PyStringNode $content
+		PyStringNode $content,
 	): void {
 		$rawExpectedEmailBodyContent = \str_replace("\r\n", "\n", $content->getRaw());
 		$expectedEmailBodyContent = $this->featureContext->substituteInLineCodes(
 			$rawExpectedEmailBodyContent,
-			$sender
+			$sender,
 		);
 		$this->assertEmailContains($user, $expectedEmailBodyContent);
 	}
@@ -142,7 +142,7 @@ class EmailContext implements Context {
 		Assert::assertSame(
 			$count,
 			$emails["messages_count"],
-			"Expected '$address' received mail total '$count' email but got " . $emails["messages_count"] . " email"
+			"Expected '$address' received mail total '$count' email but got " . $emails["messages_count"] . " email",
 		);
 	}
 
@@ -159,12 +159,12 @@ class EmailContext implements Context {
 	public function userShouldHaveReceivedTheFollowingEmailFromUserIgnoringWhitespaces(
 		string $user,
 		string $sender,
-		PyStringNode $content
+		PyStringNode $content,
 	): void {
 		$rawExpectedEmailBodyContent = \str_replace("\r\n", "\n", $content->getRaw());
 		$expectedEmailBodyContent = $this->featureContext->substituteInLineCodes(
 			$rawExpectedEmailBodyContent,
-			$sender
+			$sender,
 		);
 		$this->assertEmailContains($user, $expectedEmailBodyContent, true);
 	}
@@ -180,7 +180,7 @@ class EmailContext implements Context {
 	public function assertEmailContains(
 		string $user,
 		string $expectedEmailBodyContent,
-		$ignoreWhiteSpace = false
+		$ignoreWhiteSpace = false,
 	): void {
 		$address = $this->featureContext->getEmailAddressForUser($user);
 		$actualEmailBodyContent = $this->getBodyOfLastEmail($address);
@@ -193,7 +193,7 @@ class EmailContext implements Context {
 			$actualEmailBodyContent,
 			"The email address '$address' should have received an"
 			. "email with the body containing $expectedEmailBodyContent
-			but the received email is $actualEmailBodyContent"
+			but the received email is $actualEmailBodyContent",
 		);
 	}
 
@@ -210,23 +210,23 @@ class EmailContext implements Context {
 	 */
 	public function getBodyOfLastEmail(
 		string $emailAddress,
-		?int $waitTimeSec = EMAIL_WAIT_TIMEOUT_SEC
+		?int $waitTimeSec = EMAIL_WAIT_TIMEOUT_SEC,
 	): string {
 		$currentTime = \time();
 		$endTime = $currentTime + $waitTimeSec;
 		while ($currentTime <= $endTime) {
 			$query = 'to:' . $emailAddress;
 			$mailResponse = $this->featureContext->getJsonDecodedResponse(
-				EmailHelper::searchEmails($query)
+				EmailHelper::searchEmails($query),
 			);
 			if ($mailResponse["messages_count"] > 0) {
 				$lastEmail = $this->featureContext->getJsonDecodedResponse(
-					EmailHelper::getEmailById("latest", $query)
+					EmailHelper::getEmailById("latest", $query),
 				);
 				$body = \str_replace(
 					"\r\n",
 					"\n",
-					\quoted_printable_decode($lastEmail["Text"] . "\n" . $lastEmail["HTML"])
+					\quoted_printable_decode($lastEmail["Text"] . "\n" . $lastEmail["HTML"]),
 				);
 				return $body;
 			}
@@ -247,11 +247,11 @@ class EmailContext implements Context {
 	 */
 	public function userShouldHaveReceivedTheFollowingGroupedEmail(
 		string $user,
-		PyStringNode $content
+		PyStringNode $content,
 	): void {
 		$rawExpectedEmailBodyContent = \str_replace("\r\n", "\n", $content->getRaw());
 		$expectedEmailBodyContent = $this->featureContext->substituteInLineCodes(
-			$rawExpectedEmailBodyContent
+			$rawExpectedEmailBodyContent,
 		);
 		$this->assertEmailContains($user, $expectedEmailBodyContent);
 	}

--- a/tests/acceptance/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/bootstrap/FavoritesContext.php
@@ -48,7 +48,7 @@ class FavoritesContext implements Context {
 			$user,
 			$path,
 			1,
-			$spaceId
+			$spaceId,
 		);
 	}
 
@@ -115,14 +115,14 @@ class FavoritesContext implements Context {
 	public function checkFavoritedElements(
 		string $user,
 		string $shouldOrNot,
-		TableNode $expectedElements
+		TableNode $expectedElements,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->userListsFavorites($user);
 		$this->featureContext->propfindResultShouldContainEntries(
 			$shouldOrNot,
 			$expectedElements,
-			$user
+			$user,
 		);
 	}
 
@@ -160,7 +160,7 @@ class FavoritesContext implements Context {
 			null,
 			null,
 			$body,
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -179,7 +179,7 @@ class FavoritesContext implements Context {
 		string $user,
 		string $path,
 		int $expectedValue = 1,
-		string $spaceId = null
+		string $spaceId = null,
 	): void {
 		$property = "oc:favorite";
 		$this->webDavPropertiesContext->checkPropertyOfAFolder(
@@ -231,7 +231,7 @@ class FavoritesContext implements Context {
 			"oc='http://owncloud.org/ns'",
 			$this->featureContext->getDavPathVersion(),
 			'files',
-			$spaceId
+			$spaceId,
 		);
 	}
 
@@ -253,7 +253,7 @@ class FavoritesContext implements Context {
 		$this->webDavPropertiesContext = BehatHelper::getContext(
 			$scope,
 			$environment,
-			'WebDavPropertiesContext'
+			'WebDavPropertiesContext',
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -259,13 +259,13 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function pushToLastStatusCodesArrays(): void {
 		$this->pushToLastHttpStatusCodesArray(
-			(string)$this->getResponse()->getStatusCode()
+			(string)$this->getResponse()->getStatusCode(),
 		);
 		try {
 			$this->pushToLastOcsCodesArray(
 				$this->ocsContext->getOCSResponseStatusCode(
-					$this->getResponse()
-				)
+					$this->getResponse(),
+				),
 			);
 		} catch (Exception $exception) {
 			// if response couldn't be converted into xml then push "notset" to last ocs status codes array
@@ -402,7 +402,7 @@ class FeatureContext extends BehatVariablesContext {
 		if (($this->userReplacements === null) && $this->isTestingReplacingUsernames()) {
 			$this->userReplacements = \json_decode(
 				\file_get_contents("./tests/acceptance/usernames.json"),
-				true
+				true,
 			);
 			// Loop through the user replacements, and make entries for the lower
 			// and upper case forms. This allows for steps that specifically
@@ -413,14 +413,14 @@ class FeatureContext extends BehatVariablesContext {
 				if ($lowerKey !== $key) {
 					$this->userReplacements[$lowerKey] = $value;
 					$this->userReplacements[$lowerKey]['username'] = \strtolower(
-						$this->userReplacements[$lowerKey]['username']
+						$this->userReplacements[$lowerKey]['username'],
 					);
 				}
 				$upperKey = \strtoupper($key);
 				if ($upperKey !== $key) {
 					$this->userReplacements[$upperKey] = $value;
 					$this->userReplacements[$upperKey]['username'] = \strtoupper(
-						$this->userReplacements[$upperKey]['username']
+						$this->userReplacements[$upperKey]['username'],
 					);
 				}
 			}
@@ -882,7 +882,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function addGuzzleClientHeaders(array $guzzleClientHeaders): void {
 		$this->guzzleClientHeaders = \array_merge(
 			$this->guzzleClientHeaders,
-			$guzzleClientHeaders
+			$guzzleClientHeaders,
 		);
 	}
 
@@ -979,7 +979,7 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function setResponse(
 		?ResponseInterface $response,
-		string $username = ""
+		string $username = "",
 	): void {
 		$this->response = $response;
 		$this->responseUser = $username;
@@ -1023,7 +1023,7 @@ class FeatureContext extends BehatVariablesContext {
 			Assert::assertContains(
 				\ltrim($validator, "$"),
 				$this->jsonSchemaValidators,
-				"Invalid schema validator: '$validator'"
+				"Invalid schema validator: '$validator'",
 			);
 		}
 	}
@@ -1108,7 +1108,7 @@ class FeatureContext extends BehatVariablesContext {
 		Assert::assertEquals(
 			$schemaObj->minItems,
 			$schemaObj->maxItems,
-			"'minItems' and 'maxItems' should be equal for strict assertion"
+			"'minItems' and 'maxItems' should be equal for strict assertion",
 		);
 
 		// check optional validators
@@ -1125,31 +1125,31 @@ class FeatureContext extends BehatVariablesContext {
 							foreach ($value as $element) {
 								Assert::assertNotNull(
 									$element->oneOf,
-									"'oneOf' is required to assert more than one elements"
+									"'oneOf' is required to assert more than one elements",
 								);
 							}
 							Assert::fail("'$validator' should be an object not an array");
 						}
 						Assert::assertFalse(
 							$value->allOf || $value->anyOf,
-							"'allOf' and 'anyOf' are not allowed in array"
+							"'allOf' and 'anyOf' are not allowed in array",
 						);
 						if ($value->oneOf) {
 							Assert::assertNotNull(
 								$value->oneOf,
-								"'oneOf' is required to assert more than one elements"
+								"'oneOf' is required to assert more than one elements",
 							);
 							Assert::assertTrue(\is_array($value->oneOf), "'oneOf' should be an array");
 							Assert::assertEquals(
 								$schemaObj->maxItems,
 								\count($value->oneOf),
-								"Expected " . $schemaObj->maxItems . " 'oneOf' items but got " . \count($value->oneOf)
+								"Expected " . $schemaObj->maxItems . " 'oneOf' items but got " . \count($value->oneOf),
 							);
 						}
 					}
 					Assert::assertTrue(
 						\is_object($value),
-						"'$validator' should be an object when expecting 1 element"
+						"'$validator' should be an object when expecting 1 element",
 					);
 					break;
 				case "uniqueItems":
@@ -1334,8 +1334,8 @@ class FeatureContext extends BehatVariablesContext {
 				$method,
 				"public",
 				$password,
-				$headers
-			)
+				$headers,
+			),
 		);
 	}
 
@@ -1355,11 +1355,11 @@ class FeatureContext extends BehatVariablesContext {
 		string $user,
 		string $verb,
 		string $url,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$this->verifyTableNodeColumns(
 			$headersTable,
-			['header', 'value']
+			['header', 'value'],
 		);
 
 		$user = $this->getActualUsername($user);
@@ -1386,7 +1386,7 @@ class FeatureContext extends BehatVariablesContext {
 			function ($subArray) {
 				return $subArray[0];
 			},
-			$arrayOfArrays
+			$arrayOfArrays,
 		);
 		return $a;
 	}
@@ -1405,7 +1405,7 @@ class FeatureContext extends BehatVariablesContext {
 		string $user,
 		string $method,
 		string $davPath,
-		string $content
+		string $content,
 	): void {
 		$this->setResponse($this->sendingToWithDirectUrl($user, $method, $davPath, $content));
 	}
@@ -1424,7 +1424,7 @@ class FeatureContext extends BehatVariablesContext {
 		string $user,
 		string $verb,
 		string $url,
-		string $password
+		string $password,
 	): void {
 		$this->setResponse($this->sendingToWithDirectUrl($user, $verb, $url, null, $password));
 	}
@@ -1446,7 +1446,7 @@ class FeatureContext extends BehatVariablesContext {
 		string $url,
 		?string $body = null,
 		?string $password = null,
-		?array $headers = null
+		?array $headers = null,
 	): ResponseInterface {
 		$url = \ltrim($url, '/');
 		if (WebdavHelper::isDAVRequest($url)) {
@@ -1490,7 +1490,7 @@ class FeatureContext extends BehatVariablesContext {
 			$reqHeaders,
 			$body,
 			$config,
-			$cookies
+			$cookies,
 		);
 	}
 
@@ -1533,7 +1533,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function theHTTPStatusCodeShouldBe(
 		$expectedStatusCode,
 		?string $message = "",
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): void {
 		$response = $response ?? $this->response;
 		$actualStatusCode = $response->getStatusCode();
@@ -1546,7 +1546,7 @@ class FeatureContext extends BehatVariablesContext {
 			Assert::assertContainsEquals(
 				$actualStatusCode,
 				$expectedStatusCode,
-				$message
+				$message,
 			);
 		} else {
 			if ($message === "") {
@@ -1556,7 +1556,7 @@ class FeatureContext extends BehatVariablesContext {
 			Assert::assertEquals(
 				$expectedStatusCode,
 				$actualStatusCode,
-				$message
+				$message,
 			);
 		}
 	}
@@ -1599,12 +1599,12 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws Exception
 	 */
 	public function theOcsDataOfTheResponseShouldMatch(
-		PyStringNode $schemaString
+		PyStringNode $schemaString,
 	): void {
 		$jsonResponse = $this->getJsonDecodedResponseBodyContent();
 		$this->assertJsonDocumentMatchesSchema(
 			$jsonResponse->ocs->data,
-			$this->getJSONSchema($schemaString)
+			$this->getJSONSchema($schemaString),
 		);
 	}
 
@@ -1620,7 +1620,7 @@ class FeatureContext extends BehatVariablesContext {
 		$responseBody = $this->getJsonDecodedResponseBodyContent();
 		$this->assertJsonDocumentMatchesSchema(
 			$responseBody,
-			$this->getJSONSchema($schemaString)
+			$this->getJSONSchema($schemaString),
 		);
 	}
 
@@ -1645,7 +1645,7 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function theHTTPStatusCodeShouldBeOr($statusCode1, $statusCode2): void {
 		$this->theHTTPStatusCodeShouldBe(
-			[$statusCode1, $statusCode2]
+			[$statusCode1, $statusCode2],
 		);
 	}
 
@@ -1661,7 +1661,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function theHTTPStatusCodeShouldBeBetween(
 		$minStatusCode,
 		$maxStatusCode,
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): void {
 		$response = $response ?? $this->response;
 		$statusCode = $response->getStatusCode();
@@ -1669,12 +1669,12 @@ class FeatureContext extends BehatVariablesContext {
 		Assert::assertGreaterThanOrEqual(
 			$minStatusCode,
 			$statusCode,
-			$message
+			$message,
 		);
 		Assert::assertLessThanOrEqual(
 			$maxStatusCode,
 			$statusCode,
-			$message
+			$message,
 		);
 	}
 
@@ -1692,7 +1692,7 @@ class FeatureContext extends BehatVariablesContext {
 		Assert::assertGreaterThanOrEqual(
 			400,
 			$statusCode,
-			$message
+			$message,
 		);
 	}
 
@@ -1743,7 +1743,7 @@ class FeatureContext extends BehatVariablesContext {
 			$dirPathFromServerRoot,
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
-			$this->getAdminPassword()
+			$this->getAdminPassword(),
 		);
 	}
 
@@ -2027,7 +2027,7 @@ class FeatureContext extends BehatVariablesContext {
 			$this->getAdminPassword(),
 			$this->guzzleClientHeaders,
 			null,
-			$config
+			$config,
 		);
 	}
 
@@ -2042,7 +2042,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 		return \json_decode(
 			(string)$response->getBody(),
-			true
+			true,
 		);
 	}
 
@@ -2052,7 +2052,7 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function getJsonDecodedStatusPhp(): array {
 		return $this->getJsonDecodedResponse(
-			$this->getStatusPhp()
+			$this->getStatusPhp(),
 		);
 	}
 
@@ -2149,7 +2149,7 @@ class FeatureContext extends BehatVariablesContext {
 		?array $functions = [],
 		?array $additionalSubstitutions = [],
 		?string $group = null,
-		?string $userName = null
+		?string $userName = null,
 	): ?string {
 		$substitutions = [
 			[
@@ -2540,7 +2540,7 @@ class FeatureContext extends BehatVariablesContext {
 					"function" =>
 					[$this, "getGroupIdByGroupName"],
 					"parameter" => [$group],
-				]
+				],
 			);
 
 			if (!OcisHelper::isTestingOnReva()) {
@@ -2553,7 +2553,7 @@ class FeatureContext extends BehatVariablesContext {
 							"getSpaceIdByName",
 						],
 						"parameter" => [$user, "Shares"],
-					]
+					],
 				);
 			}
 		}
@@ -2569,7 +2569,7 @@ class FeatureContext extends BehatVariablesContext {
 
 			$replacement = \call_user_func_array(
 				$substitution["function"],
-				$substitution["parameter"]
+				$substitution["parameter"],
 			);
 
 			// do not run functions on regex patterns
@@ -2577,14 +2577,14 @@ class FeatureContext extends BehatVariablesContext {
 				foreach ($functions as $function => $parameters) {
 					$replacement = \call_user_func_array(
 						$function,
-						\array_merge([$replacement], $parameters)
+						\array_merge([$replacement], $parameters),
 					);
 				}
 			}
 			$value = \str_replace(
 				$substitution["code"],
 				$replacement,
-				$value
+				$value,
 			);
 		}
 		return $value;
@@ -2700,7 +2700,7 @@ class FeatureContext extends BehatVariablesContext {
 		if ($this->adminPassword !== $this->originalAdminPassword) {
 			$this->resetUserPasswordAsAdminUsingTheProvisioningApi(
 				$this->getAdminUsername(),
-				$this->originalAdminPassword
+				$this->originalAdminPassword,
 			);
 			$this->adminPassword = $this->originalAdminPassword;
 		}
@@ -2725,7 +2725,7 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function makeTemporaryStorageOnServerBefore(): void {
 		$this->mkDirOnServer(
-			TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER
+			TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER,
 		);
 	}
 
@@ -2738,7 +2738,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function removeTemporaryStorageOnServerAfter(): void {
 		SetupHelper::rmDirOnServer(
 			TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER,
-			HttpRequestHelper::getCurrentScenarioRef()
+			HttpRequestHelper::getCurrentScenarioRef(),
 		);
 	}
 
@@ -2780,7 +2780,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function verifyTableNodeColumns(
 		?TableNode $table,
 		?array $requiredHeader = [],
-		?array $allowedHeader = []
+		?array $allowedHeader = [],
 	): void {
 		if ($table === null || \count($table->getHash()) < 1) {
 			throw new Exception("Table should have at least one row.");
@@ -2897,7 +2897,7 @@ class FeatureContext extends BehatVariablesContext {
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
-			$userName
+			$userName,
 		);
 		$data = \json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
 		if (isset($data["id"])) {
@@ -2919,7 +2919,7 @@ class FeatureContext extends BehatVariablesContext {
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
-			$groupName
+			$groupName,
 		);
 		$data = $this->getJsonDecodedResponse($response);
 		if (isset($data["id"])) {

--- a/tests/acceptance/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/bootstrap/FilesVersionsContext.php
@@ -95,7 +95,7 @@ class FilesVersionsContext implements Context {
 	public function thePublicTriesToGetTheNumberOfVersionsOfFileWithPasswordUsingFileId(
 		string $file,
 		string $password,
-		string $fileId
+		string $fileId,
 	): void {
 		$password = $this->featureContext->getActualPassword($password);
 		$this->featureContext->setResponse(
@@ -109,8 +109,8 @@ class FilesVersionsContext implements Context {
 				"versions",
 				$this->featureContext->getDavPathVersion(),
 				false,
-				$password
-			)
+				$password,
+			),
 		);
 	}
 
@@ -136,7 +136,7 @@ class FilesVersionsContext implements Context {
 		Assert::assertNotNull(
 			$fileId,
 			__METHOD__
-			. " fileid of file $file user $fileOwner not found (the file may not exist)"
+			. " fileid of file $file user $fileOwner not found (the file may not exist)",
 		);
 		return $this->featureContext->makeDavRequest(
 			$user,
@@ -145,7 +145,7 @@ class FilesVersionsContext implements Context {
 			null,
 			null,
 			$spaceId,
-			"versions"
+			"versions",
 		);
 	}
 
@@ -167,8 +167,8 @@ class FilesVersionsContext implements Context {
 				null,
 				null,
 				null,
-				"versions"
-			)
+				"versions",
+			),
 		);
 	}
 
@@ -198,7 +198,7 @@ class FilesVersionsContext implements Context {
 		Assert::assertNotNull(
 			$fileId,
 			__METHOD__
-			. " fileid of file $file user $user not found (the file may not exist)"
+			. " fileid of file $file user $user not found (the file may not exist)",
 		);
 		$body = '<?xml version="1.0"?>
                 <d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
@@ -232,12 +232,12 @@ class FilesVersionsContext implements Context {
 		Assert::assertNotNull(
 			$fileId,
 			__METHOD__
-			. " fileid of file $path user $user not found (the file may not exist)"
+			. " fileid of file $path user $user not found (the file may not exist)",
 		);
 		$response = $this->listVersionFolder($user, $fileId, 1);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$response,
-			__METHOD__
+			__METHOD__,
 		);
 		$xmlPart = $responseXmlObject->xpath("//d:response/d:href");
 		// restoring the version only works with DAV path v2
@@ -250,7 +250,7 @@ class FilesVersionsContext implements Context {
 			'COPY',
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			['Destination' => $destinationUrl]
+			['Destination' => $destinationUrl],
 		);
 	}
 
@@ -298,7 +298,7 @@ class FilesVersionsContext implements Context {
 		$response = $this->listVersionFolder($user, $fileId, 1);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$response,
-			__METHOD__
+			__METHOD__,
 		);
 		$actualCount = \count($responseXmlObject->xpath("//d:prop/d:getetag")) - 1;
 		if ($actualCount === -1) {
@@ -307,7 +307,7 @@ class FilesVersionsContext implements Context {
 		Assert::assertEquals(
 			$expectedCount,
 			$actualCount,
-			"Expected $expectedCount versions but found $actualCount in \n" . $responseXmlObject->asXML()
+			"Expected $expectedCount versions but found $actualCount in \n" . $responseXmlObject->asXML(),
 		);
 	}
 
@@ -324,14 +324,14 @@ class FilesVersionsContext implements Context {
 	public function theVersionFolderOfFileShouldContainElements(
 		string $path,
 		string $user,
-		int $count
+		int $count,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
 		Assert::assertNotNull(
 			$fileId,
 			__METHOD__
-			. ". file '$path' for user '$user' not found (the file may not exist)"
+			. ". file '$path' for user '$user' not found (the file may not exist)",
 		);
 		$this->assertFileVersionsCount($user, $fileId, $count);
 	}
@@ -349,7 +349,7 @@ class FilesVersionsContext implements Context {
 	public function theVersionFolderOfFileIdShouldContainElements(
 		string $fileId,
 		string $user,
-		int $count
+		int $count,
 	): void {
 		$this->assertFileVersionsCount($user, $fileId, $count);
 	}
@@ -369,26 +369,26 @@ class FilesVersionsContext implements Context {
 		string $path,
 		int $index,
 		string $user,
-		int $length
+		int $length,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
 		Assert::assertNotNull(
 			$fileId,
 			__METHOD__
-			. " fileid of file $path user $user not found (the file may not exist)"
+			. " fileid of file $path user $user not found (the file may not exist)",
 		);
 		$response = $this->listVersionFolder($user, $fileId, 1, ['d:getcontentlength']);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$response,
-			__METHOD__
+			__METHOD__,
 		);
 		$xmlPart = $responseXmlObject->xpath("//d:prop/d:getcontentlength");
 		Assert::assertEquals(
 			$length,
 			(int) $xmlPart[$index],
 			"The content length of file $path with version $index for user $user was
-			expected to be $length but the actual content length is $xmlPart[$index]"
+			expected to be $length but the actual content length is $xmlPart[$index]",
 		);
 	}
 
@@ -405,23 +405,23 @@ class FilesVersionsContext implements Context {
 	public function asUsersAuthorsOfVersionsOfFileShouldBe(
 		string $users,
 		string $filename,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$table,
-			['index', 'author']
+			['index', 'author'],
 		);
 		$requiredVersionMetadata = $table->getHash();
 		$usersArray = \explode(",", $users);
 		foreach ($usersArray as $username) {
 			$actualUsername = $this->featureContext->getActualUsername($username);
 			$this->featureContext->setResponse(
-				$this->getFileVersionMetadata($actualUsername, $filename)
+				$this->getFileVersionMetadata($actualUsername, $filename),
 			);
 			foreach ($requiredVersionMetadata as $versionMetadata) {
 				$this->featureContext->checkAuthorOfAVersionOfFile(
 					$versionMetadata['index'],
-					$versionMetadata['author']
+					$versionMetadata['author'],
 				);
 			}
 		}
@@ -440,14 +440,14 @@ class FilesVersionsContext implements Context {
 		string $user,
 		string $path,
 		string $index,
-		?string $spaceId = null
+		?string $spaceId = null,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$fileId = $this->featureContext->getFileIdForPath($user, $path, $spaceId);
 		Assert::assertNotNull(
 			$fileId,
 			__METHOD__
-			. " fileid of file $path user $user not found (the file may not exist)"
+			. " fileid of file $path user $user not found (the file may not exist)",
 		);
 		$index = (int)$index;
 		$response = $this->listVersionFolder($user, $fileId, 1);
@@ -458,17 +458,17 @@ class FilesVersionsContext implements Context {
 		$xmlPart = $responseXmlObject->xpath("//d:response/d:href");
 		if (!isset($xmlPart[$index])) {
 			Assert::fail(
-				'could not find version of path "' . $path . '" with index "' . $index . '"'
+				'could not find version of path "' . $path . '" with index "' . $index . '"',
 			);
 		}
 		// the href already contains the path
 		$url = WebDavHelper::sanitizeUrl(
-			$this->featureContext->getBaseUrlWithoutPath() . $xmlPart[$index]
+			$this->featureContext->getBaseUrlWithoutPath() . $xmlPart[$index],
 		);
 		return HttpRequestHelper::get(
 			$url,
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 	}
 
@@ -501,7 +501,7 @@ class FilesVersionsContext implements Context {
 		string $index,
 		string $path,
 		string $user,
-		string $content
+		string $content,
 	): void {
 		$response = $this->downloadVersion($user, $path, $index);
 		$this->featureContext->theHTTPStatusCodeShouldBe("200", '', $response);
@@ -546,7 +546,7 @@ class FilesVersionsContext implements Context {
 			null,
 			$body,
 			$this->featureContext->getDavPathVersion(),
-			null
+			null,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -567,7 +567,7 @@ class FilesVersionsContext implements Context {
 		string $user,
 		string $fileId,
 		int $folderDepth,
-		?array $properties = null
+		?array $properties = null,
 	): ResponseInterface {
 		if (!$properties) {
 			$properties = [
@@ -584,7 +584,7 @@ class FilesVersionsContext implements Context {
 			$properties,
 			(string) $folderDepth,
 			null,
-			"versions"
+			"versions",
 		);
 		return $response;
 	}
@@ -609,8 +609,8 @@ class FilesVersionsContext implements Context {
 				null,
 				null,
 				null,
-				"versions"
-			)
+				"versions",
+			),
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -84,7 +84,7 @@ class GraphContext implements Context {
 	public function theUserChangesTheDisplayNameOfUserToUsingTheGraphApi(
 		string $byUser,
 		string $user,
-		string $displayName
+		string $displayName,
 	): void {
 		$response = $this->editUserUsingTheGraphApi($byUser, $user, null, null, null, $displayName);
 		$this->featureContext->setResponse($response);
@@ -105,7 +105,7 @@ class GraphContext implements Context {
 	public function theUserChangesTheUserNameOfUserToUsingTheGraphApi(
 		string $byUser,
 		string $user,
-		string $newUsername
+		string $newUsername,
 	): void {
 		$response = $this->editUserUsingTheGraphApi($byUser, $user, $newUsername);
 		$this->featureContext->setResponse($response);
@@ -115,7 +115,7 @@ class GraphContext implements Context {
 			$this->featureContext->rememberThatUserIsNotExpectedToExist($user);
 			$this->featureContext->addUserToCreatedUsersList(
 				$newUsername,
-				$this->featureContext->getUserPassword($user)
+				$this->featureContext->getUserPassword($user),
 			);
 		}
 	}
@@ -183,7 +183,7 @@ class GraphContext implements Context {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$responseBody,
-			$this->featureContext->getJSONSchema($schemaString)
+			$this->featureContext->getJSONSchema($schemaString),
 		);
 	}
 
@@ -210,7 +210,7 @@ class GraphContext implements Context {
 		string $email = null,
 		string $displayName = null,
 		bool $accountEnabled = true,
-		string $method = "PATCH"
+		string $method = "PATCH",
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, 'id') ?: $user;
@@ -224,7 +224,7 @@ class GraphContext implements Context {
 			$password,
 			$email,
 			$displayName,
-			$accountEnabled
+			$accountEnabled,
 		);
 	}
 
@@ -243,7 +243,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
-			$userId
+			$userId,
 		);
 	}
 
@@ -256,7 +256,7 @@ class GraphContext implements Context {
 	 */
 	public function deleteGroupWithId(
 		string $groupId,
-		?string $user = null
+		?string $user = null,
 	): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($user);
 
@@ -264,7 +264,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
 			$credentials["password"],
-			$groupId
+			$groupId,
 		);
 	}
 
@@ -276,7 +276,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function deleteGroupWithName(
-		string $group
+		string $group,
 	): ResponseInterface {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		return $this->deleteGroupWithId($groupId);
@@ -297,7 +297,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
 			$credentials["password"],
-			$user
+			$user,
 		);
 		if ($response->getStatusCode() === 204) {
 			$this->featureContext->rememberThatUserIsNotExpectedToExist($user);
@@ -348,7 +348,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
 			$credentials["password"],
-			$userId
+			$userId,
 		);
 		if ($response->getStatusCode() === 204) {
 			$this->featureContext->rememberThatUserIsNotExpectedToExist($user);
@@ -474,7 +474,7 @@ class GraphContext implements Context {
 	public function adminChangesPasswordOfUserToUsingTheGraphApi(
 		string $user,
 		string $password,
-		?string $byUser = null
+		?string $byUser = null,
 	): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($byUser);
 		$user = $this->featureContext->getActualUsername($user);
@@ -486,7 +486,7 @@ class GraphContext implements Context {
 			$userId,
 			"PATCH",
 			$user,
-			$password
+			$password,
 		);
 	}
 
@@ -503,7 +503,7 @@ class GraphContext implements Context {
 	public function theUserResetsThePasswordOfUserToUsingTheGraphApi(
 		string $byUser,
 		string $user,
-		string $password
+		string $password,
 	): void {
 		$response = $this->adminChangesPasswordOfUserToUsingTheGraphApi($user, $password, $byUser);
 		$this->featureContext->setResponse($response);
@@ -577,7 +577,7 @@ class GraphContext implements Context {
 		return GraphHelper::getGroups(
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
-			$credentials["password"]
+			$credentials["password"],
 		);
 	}
 
@@ -622,7 +622,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
 			$credentials["password"],
-			$this->featureContext->getAttributeOfCreatedGroup($group, 'id')
+			$this->featureContext->getAttributeOfCreatedGroup($group, 'id'),
 		);
 	}
 
@@ -636,7 +636,7 @@ class GraphContext implements Context {
 	 */
 	public function listSingleOrAllGroupsAlongWithAllMemberInformation(
 		string $user,
-		?string $group = null
+		?string $group = null,
 	): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($user);
 
@@ -644,7 +644,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
 			$credentials["password"],
-			($group) ? $this->featureContext->getAttributeOfCreatedGroup($group, 'id') : null
+			($group) ? $this->featureContext->getAttributeOfCreatedGroup($group, 'id') : null,
 		);
 	}
 
@@ -694,7 +694,7 @@ class GraphContext implements Context {
 			$rows["userName"],
 			$rows["password"],
 			$rows["email"],
-			$rows["displayName"]
+			$rows["displayName"],
 		);
 		$this->featureContext->setResponse($response);
 
@@ -706,7 +706,7 @@ class GraphContext implements Context {
 				$rows["userName"],
 				$rows["password"],
 				$rows["displayName"],
-				$rows["email"]
+				$rows["email"],
 			);
 		}
 	}
@@ -739,7 +739,7 @@ class GraphContext implements Context {
 			$credentials['username'],
 			$credentials['password'],
 			$userId,
-			$groupId
+			$groupId,
 		);
 	}
 
@@ -755,7 +755,7 @@ class GraphContext implements Context {
 	 */
 	public function adminHasAddedUserToGroupUsingTheGraphApi(
 		string $user,
-		string $group
+		string $group,
 	): void {
 		$response = $this->addUserToGroup($group, $user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, '', $response);
@@ -789,7 +789,7 @@ class GraphContext implements Context {
 	 */
 	public function theAdministratorTriesToAddNonExistentUserToGroupUsingTheGraphAPI(
 		string $group,
-		?string $byUser = null
+		?string $byUser = null,
 	): void {
 		$this->featureContext->setResponse($this->addUserToGroup($group, "nonexistent", $byUser));
 	}
@@ -807,7 +807,7 @@ class GraphContext implements Context {
 	 */
 	public function theAdministratorTriesToAddUserToNonExistentGroupUsingTheGraphAPI(
 		string $user,
-		?string $byUser = null
+		?string $byUser = null,
 	): void {
 		$this->featureContext->setResponse($this->addUserToGroup("nonexistent", $user, $byUser));
 	}
@@ -836,7 +836,7 @@ class GraphContext implements Context {
 	public function theUserTriesToAddAnotherUserToGroupUsingTheGraphAPI(
 		string $byUser,
 		string $user,
-		string $group
+		string $group,
 	): void {
 		$this->featureContext->setResponse($this->addUserToGroup($group, $user, $byUser));
 	}
@@ -920,14 +920,14 @@ class GraphContext implements Context {
 				. "\n$errorMsg"
 				. "\nHTTP status code: " . $response->getStatusCode()
 				. "\nError code: " . $jsonBody["error"]["code"]
-				. "\nMessage: " . $jsonBody["error"]["message"]
+				. "\nMessage: " . $jsonBody["error"]["message"],
 			);
 		} catch (TypeError $e) {
 			throw new Exception(
 				__METHOD__
 				. "\n$errorMsg"
 				. "\nHTTP status code: " . $response->getStatusCode()
-				. "\nResponse body: " . $response->getBody()
+				. "\nResponse body: " . $response->getBody(),
 			);
 		}
 	}
@@ -959,7 +959,7 @@ class GraphContext implements Context {
 				throw new Exception(
 					__METHOD__
 					. "\nGroup '$groupName' is expected " . ($should ? "" : "not ")
-					. "to exist, but it does" . ($should ? " not" : "") . " exist."
+					. "to exist, but it does" . ($should ? " not" : "") . " exist.",
 				);
 			}
 		}
@@ -982,7 +982,7 @@ class GraphContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$currentPassword,
-			$newPassword
+			$newPassword,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1069,7 +1069,7 @@ class GraphContext implements Context {
 				$exists,
 				__METHOD__
 				. "\nExpected user '" . $userGroup['username'] . "' to be in group '"
-				. $userGroup['groupname'] . "'. But not found."
+				. $userGroup['groupname'] . "'. But not found.",
 			);
 		}
 	}
@@ -1092,7 +1092,7 @@ class GraphContext implements Context {
 			$credentials['username'],
 			$credentials['password'],
 			$oldGroupId,
-			$newGroup
+			$newGroup,
 		);
 	}
 
@@ -1135,14 +1135,14 @@ class GraphContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorRemovesTheFollowingUsersFromTheFollowingGroupsUsingTheGraphApi(
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['username', 'groupname']);
 		$usersGroups = $table->getColumnsHash();
 
 		foreach ($usersGroups as $userGroup) {
 			$this->featureContext->setResponse(
-				$this->removeUserFromGroup($userGroup['groupname'], $userGroup['username'])
+				$this->removeUserFromGroup($userGroup['groupname'], $userGroup['username']),
 			);
 			$this->featureContext->pushToLastHttpStatusCodesArray();
 		}
@@ -1161,7 +1161,7 @@ class GraphContext implements Context {
 	public function theUserTriesToRemoveAnotherUserFromGroupUsingTheGraphAPI(
 		string $user,
 		string $group,
-		?string $byUser = null
+		?string $byUser = null,
 	): void {
 		$this->featureContext->setResponse($this->removeUserFromGroup($group, $user, $byUser));
 	}
@@ -1178,7 +1178,7 @@ class GraphContext implements Context {
 	 */
 	public function theUserTriesToRemoveAnotherUserFromNonExistentGroupUsingTheGraphAPI(
 		string $user,
-		?string $byUser = null
+		?string $byUser = null,
 	): void {
 		$this->featureContext->setResponse($this->removeUserFromGroup('', $user, $byUser));
 	}
@@ -1191,7 +1191,7 @@ class GraphContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function retrieveUserInformationUsingGraphApi(
-		string $user
+		string $user,
 	): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		return GraphHelper::getOwnInformationAndGroupMemberships(
@@ -1210,7 +1210,7 @@ class GraphContext implements Context {
 	 * @throws JsonException
 	 */
 	public function userRetrievesHisOrHerInformationOfUserUsingGraphApi(
-		string $user
+		string $user,
 	): void {
 		$response = $this->retrieveUserInformationUsingGraphApi($user);
 		$this->featureContext->setResponse($response);
@@ -1232,7 +1232,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials['username'],
 			$credentials['password'],
-			$user
+			$user,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1306,7 +1306,7 @@ class GraphContext implements Context {
 	 */
 	public function retrieveUserInformationAlongWithDriveUsingGraphApi(
 		string $byUser,
-		?string $user = null
+		?string $user = null,
 	): ResponseInterface {
 		$user = $user ?? $byUser;
 		$credentials = $this->getAdminOrUserCredentials($user);
@@ -1314,7 +1314,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
 			$credentials["password"],
-			$user
+			$user,
 		);
 	}
 
@@ -1328,7 +1328,7 @@ class GraphContext implements Context {
 	 */
 	public function retrieveUserInformationAlongWithGroupUsingGraphApi(
 		string $byUser,
-		?string $user = null
+		?string $user = null,
 	): ResponseInterface {
 		$user = $user ?? $byUser;
 		$credentials = $this->getAdminOrUserCredentials($user);
@@ -1336,7 +1336,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials["username"],
 			$credentials["password"],
-			$user
+			$user,
 		);
 	}
 
@@ -1393,7 +1393,7 @@ class GraphContext implements Context {
 	public function addMultipleUsersToGroup(
 		string $user,
 		array $userIds,
-		string $groupId
+		string $groupId,
 	): ResponseInterface {
 		$credentials = $this->getAdminOrUserCredentials($user);
 
@@ -1402,7 +1402,7 @@ class GraphContext implements Context {
 			$credentials["username"],
 			$credentials["password"],
 			$groupId,
-			$userIds
+			$userIds,
 		);
 	}
 
@@ -1420,7 +1420,7 @@ class GraphContext implements Context {
 	public function theAdministratorAddsTheFollowingUsersToAGroupInASingleRequestUsingTheGraphApi(
 		string $user,
 		string $group,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$userIds = [];
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
@@ -1446,7 +1446,7 @@ class GraphContext implements Context {
 	public function userTriesToAddTheFollowingUsersToAGroupAtOnceWithInvalidHostUsingTheGraphApi(
 		string $user,
 		string $group,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$userIds = [];
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
@@ -1469,8 +1469,8 @@ class GraphContext implements Context {
 				$credentials["username"],
 				$credentials["password"],
 				['Content-Type' => 'application/json'],
-				\json_encode($payload)
-			)
+				\json_encode($payload),
+			),
 		);
 	}
 
@@ -1488,7 +1488,7 @@ class GraphContext implements Context {
 	public function userTriesToAddUserToGroupWithInvalidHostUsingTheGraphApi(
 		string $adminUser,
 		string $user,
-		string $group
+		string $group,
 	): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$userId = $this->featureContext->getAttributeOfCreatedUser($user, "id");
@@ -1504,8 +1504,8 @@ class GraphContext implements Context {
 				$credentials["username"],
 				$credentials["password"],
 				['Content-Type' => 'application/json'],
-				\json_encode($body)
-			)
+				\json_encode($body),
+			),
 		);
 	}
 
@@ -1521,7 +1521,7 @@ class GraphContext implements Context {
 	 */
 	public function theAdministratorTriesToAddsTheFollowingUsersToANonExistingGroupAtOnceUsingTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$userIds = [];
 		$groupId = WebDavHelper::generateUUIDv4();
@@ -1547,7 +1547,7 @@ class GraphContext implements Context {
 	public function theAdministratorTriesToAddTheFollowingNonExistingUsersToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $group,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$userIds = [];
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
@@ -1574,7 +1574,7 @@ class GraphContext implements Context {
 	public function theAdministratorTriesToAddTheFollowingUsersToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $group,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$userIds = [];
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
@@ -1615,14 +1615,14 @@ class GraphContext implements Context {
 		Assert::assertIsArray(
 			$responseArray = (
 				$this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())
-			)['value'][0]
+			)['value'][0],
 		);
 		foreach ($table->getHash() as $row) {
 			$key = $row["key"];
 			if ($key === 'id') {
 				Assert::assertTrue(
 					GraphHelper::isUUIDv4($responseArray[$key]),
-					__METHOD__ . ' Expected id to have UUIDv4 pattern but found: ' . $row["value"]
+					__METHOD__ . ' Expected id to have UUIDv4 pattern but found: ' . $row["value"],
 				);
 			} else {
 				Assert::assertEquals($responseArray[$key], $row["value"]);
@@ -1641,7 +1641,7 @@ class GraphContext implements Context {
 		Assert::assertIsArray(
 			$responseArray = (
 				$this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())
-			)['value'][0]
+			)['value'][0],
 		);
 		foreach ($table->getRows() as $row) {
 			$foundRoleInResponse = false;
@@ -1670,7 +1670,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$groupId
+			$groupId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1693,7 +1693,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$groupsIdArray
+			$groupsIdArray,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1711,14 +1711,14 @@ class GraphContext implements Context {
 	public function userGetsAllUsersOfFirstGroupOderSecondGroupUsingTheGraphApi(
 		string $user,
 		string $firstGroup,
-		string $secondGroup
+		string $secondGroup,
 	): void {
 		$response = GraphHelper::getUsersFromOneOrOtherGroup(
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$firstGroup,
-			$secondGroup
+			$secondGroup,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1735,7 +1735,7 @@ class GraphContext implements Context {
 		$response = GraphHelper::getApplications(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword()
+			$this->featureContext->getAdminPassword(),
 		);
 		$responseData = \json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
 		if (isset($responseData["value"][0]["appRoles"])) {
@@ -1762,7 +1762,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$this->getRoleIdByRoleName($role)
+			$this->getRoleIdByRoleName($role),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1780,14 +1780,14 @@ class GraphContext implements Context {
 	public function userGetsAllUsersWithRoleAndMemberOfGroupUsingTheGraphApi(
 		string $user,
 		string $role,
-		string $group
+		string $group,
 	): void {
 		$response = GraphHelper::getUsersWithFilterRolesAssignmentAndMemberOf(
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$this->getRoleIdByRoleName($role),
-			$this->featureContext->getGroupIdByGroupName($group)
+			$this->featureContext->getGroupIdByGroupName($group),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1816,13 +1816,13 @@ class GraphContext implements Context {
 			$this->featureContext->getAdminPassword(),
 			$this->appEntity["appRoles"][$role],
 			$this->appEntity["id"],
-			$userId
+			$userId,
 		);
 		Assert::assertEquals(
 			201,
 			$response->getStatusCode(),
 			__METHOD__
-			. "\nExpected status code '200' but got '" . $response->getStatusCode() . "'"
+			. "\nExpected status code '200' but got '" . $response->getStatusCode() . "'",
 		);
 	}
 
@@ -1842,8 +1842,8 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$admin,
 				$this->featureContext->getPasswordForUser($admin),
-				$userId
-			)
+				$userId,
+			),
 		);
 	}
 
@@ -1864,8 +1864,8 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$credentials['username'],
 				$credentials['password'],
-				$userId
-			)
+				$userId,
+			),
 		);
 	}
 
@@ -1882,7 +1882,7 @@ class GraphContext implements Context {
 					$this->featureContext->getBaseUrl(),
 					$this->featureContext->getAdminUsername(),
 					$this->featureContext->getAdminPassword(),
-				)
+				),
 			)
 		)['value'][0];
 		$this->appEntity["id"] = $applicationEntity["id"];
@@ -1910,7 +1910,7 @@ class GraphContext implements Context {
 			$response['appRoleId'],
 			__METHOD__
 			. "\nExpected rolId for role '$role'' to be '" . $this->appEntity["appRoles"][$role]
-			 . "' but got '" . $response['appRoleId'] . "'"
+			 . "' but got '" . $response['appRoleId'] . "'",
 		);
 	}
 
@@ -1924,7 +1924,7 @@ class GraphContext implements Context {
 	public function theGraphApiResponseShouldHaveNoRole(): void {
 		Assert::assertEmpty(
 			$this->featureContext->getJsonDecodedResponse($this->featureContext->getResponse())['value'],
-			"the user has a role, but should not"
+			"the user has a role, but should not",
 		);
 	}
 
@@ -1944,8 +1944,8 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$credentials["username"],
 				$credentials["password"],
-				$groupName
-			)
+				$groupName,
+			),
 		);
 	}
 
@@ -1965,8 +1965,8 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$credentials["username"],
 				$credentials["password"],
-				$searchTerm
-			)
+				$searchTerm,
+			),
 		);
 	}
 
@@ -1984,7 +1984,7 @@ class GraphContext implements Context {
 	public function theJsonDataResponseShouldOrNotContainUserOrGroupAndMatch(
 		string $shouldOrNot,
 		string $userOrGroup,
-		?PyStringNode $schemaString = null
+		?PyStringNode $schemaString = null,
 	): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->value;
 		$userOrGroupFound = false;
@@ -2001,11 +2001,11 @@ class GraphContext implements Context {
 		}
 		Assert::assertFalse(
 			!$shouldContain && $userOrGroupFound,
-			'Response contains user or group "' . $userOrGroup . '" but should not have.'
+			'Response contains user or group "' . $userOrGroup . '" but should not have.',
 		);
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$responseBody,
-			$this->featureContext->getJSONSchema($schemaString)
+			$this->featureContext->getJSONSchema($schemaString),
 		);
 	}
 
@@ -2023,7 +2023,7 @@ class GraphContext implements Context {
 	public function theAdministratorHasAddedTheFollowingUsersToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $group,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$userIds = [];
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
@@ -2049,7 +2049,7 @@ class GraphContext implements Context {
 	public function theAdministratorTriesToAddGroupToAGroupAtOnceUsingTheGraphApi(
 		string $user,
 		string $groupToAdd,
-		string $group
+		string $group,
 	): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$groupIdToAdd = $this->featureContext->getAttributeOfCreatedGroup($groupToAdd, "id");
@@ -2067,8 +2067,8 @@ class GraphContext implements Context {
 				$credentials["username"],
 				$credentials["password"],
 				['Content-Type' => 'application/json'],
-				\json_encode($payload)
-			)
+				\json_encode($payload),
+			),
 		);
 	}
 
@@ -2086,7 +2086,7 @@ class GraphContext implements Context {
 	public function theAdministratorTriesToAddAGroupToAGroupThroughPostRequestUsingTheGraphApi(
 		string $user,
 		string $groupToAdd,
-		string $group
+		string $group,
 	): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$groupIdToAdd = $this->featureContext->getAttributeOfCreatedGroup($groupToAdd, "id");
@@ -2102,8 +2102,8 @@ class GraphContext implements Context {
 				$credentials["username"],
 				$credentials["password"],
 				['Content-Type' => 'application/json'],
-				\json_encode($payload)
-			)
+				\json_encode($payload),
+			),
 		);
 	}
 
@@ -2123,7 +2123,7 @@ class GraphContext implements Context {
 		string $adminUser,
 		string $user,
 		string $group,
-		string $invalidJSON
+		string $invalidJSON,
 	): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$credentials = $this->getAdminOrUserCredentials($adminUser);
@@ -2134,7 +2134,7 @@ class GraphContext implements Context {
 			[],
 			[],
 			null,
-			$user
+			$user,
 		);
 
 		$this->featureContext->setResponse(
@@ -2143,8 +2143,8 @@ class GraphContext implements Context {
 				$credentials["username"],
 				$credentials["password"],
 				['Content-Type' => 'application/json'],
-				\json_encode($invalidJSON)
-			)
+				\json_encode($invalidJSON),
+			),
 		);
 	}
 
@@ -2164,7 +2164,7 @@ class GraphContext implements Context {
 		string $user,
 		string $group,
 		string $invalidJSON,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
 		$credentials = $this->getAdminOrUserCredentials($user);
@@ -2175,7 +2175,7 @@ class GraphContext implements Context {
 				[],
 				[],
 				null,
-				$row['username']
+				$row['username'],
 			);
 		}
 
@@ -2186,8 +2186,8 @@ class GraphContext implements Context {
 				$credentials["username"],
 				$credentials["password"],
 				['Content-Type' => 'application/json'],
-				\json_encode($invalidJSON)
-			)
+				\json_encode($invalidJSON),
+			),
 		);
 	}
 
@@ -2205,7 +2205,7 @@ class GraphContext implements Context {
 	public function theAdministratorTriesToAddTheFollowingUserIdWithInvalidCharacterToAGroup(
 		string $user,
 		string $group,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$userIds = [];
 		$credentials = $this->getAdminOrUserCredentials($user);
@@ -2219,8 +2219,8 @@ class GraphContext implements Context {
 				$credentials["username"],
 				$credentials["password"],
 				$groupId,
-				$userIds
-			)
+				$userIds,
+			),
 		);
 	}
 
@@ -2238,7 +2238,7 @@ class GraphContext implements Context {
 	public function theAdministratorTriesToAddUserIdWithInvalidCharactersToAGroup(
 		string $user,
 		string $userId,
-		string $group
+		string $group,
 	): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$groupId = $this->featureContext->getAttributeOfCreatedGroup($group, "id");
@@ -2248,8 +2248,8 @@ class GraphContext implements Context {
 				$credentials['username'],
 				$credentials['password'],
 				$userId,
-				$groupId
-			)
+				$groupId,
+			),
 		);
 	}
 
@@ -2276,7 +2276,7 @@ class GraphContext implements Context {
 			1,
 			$count,
 			"Expected user '" . $user . "' to be added once to group '"
-			. $group . "' but the user is listed '" . $count . "' times"
+			. $group . "' but the user is listed '" . $count . "' times",
 		);
 	}
 
@@ -2298,8 +2298,8 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$credentials["username"],
 				$credentials["password"],
-				$userId
-			)
+				$userId,
+			),
 		);
 	}
 
@@ -2321,8 +2321,8 @@ class GraphContext implements Context {
 				$credentials['username'],
 				$credentials['password'],
 				$userId,
-				$path
-			)
+				$path,
+			),
 		);
 		$this->featureContext->pushToLastStatusCodesArrays();
 	}
@@ -2342,7 +2342,7 @@ class GraphContext implements Context {
 	public function downloadedJsonContentShouldContainEventTypeInItemAndShouldMatch(
 		string $eventType,
 		?string $spaceType = null,
-		PyStringNode $schemaString = null
+		PyStringNode $schemaString = null,
 	): void {
 		$actualResponseToAssert = null;
 		$events = $this->featureContext->getJsonDecodedResponseBodyContent()->events;
@@ -2361,12 +2361,12 @@ class GraphContext implements Context {
 		}
 		if ($actualResponseToAssert === null) {
 			throw new Error(
-				"Response does not contain event type '" . $eventType . "'."
+				"Response does not contain event type '" . $eventType . "'.",
 			);
 		}
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$actualResponseToAssert,
-			$this->featureContext->getJSONSchema($schemaString)
+			$this->featureContext->getJSONSchema($schemaString),
 		);
 	}
 
@@ -2383,12 +2383,12 @@ class GraphContext implements Context {
 		$actualResponseToAssert = $this->featureContext->getJsonDecodedResponseBodyContent();
 		if (!isset($actualResponseToAssert->user)) {
 			throw new Error(
-				"Response does not contain key 'user'"
+				"Response does not contain key 'user'",
 			);
 		}
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$actualResponseToAssert->user,
-			$this->featureContext->getJSONSchema($schemaString)
+			$this->featureContext->getJSONSchema($schemaString),
 		);
 	}
 
@@ -2405,7 +2405,7 @@ class GraphContext implements Context {
 	public function userTriesToExportGdprReportOfAnotherUserUsingGraphApi(
 		string $user,
 		string $ofUser,
-		string $path
+		string $path,
 	): void {
 		$credentials = $this->getAdminOrUserCredentials($user);
 		$this->featureContext->setResponse(
@@ -2414,8 +2414,8 @@ class GraphContext implements Context {
 				$credentials['username'],
 				$credentials['password'],
 				$this->featureContext->getAttributeOfCreatedUser($ofUser, 'id'),
-				$path
-			)
+				$path,
+			),
 		);
 	}
 
@@ -2433,7 +2433,7 @@ class GraphContext implements Context {
 				$this->featureContext->getBAseUrl(),
 				$this->featureContext->getAdminUsername(),
 				$this->featureContext->getAdminPassword(),
-				$userId
+				$userId,
 			)
 		);
 	}
@@ -2458,7 +2458,7 @@ class GraphContext implements Context {
 			$appRoleAssignmentId = $this->getRoleIdByRoleName("User");
 		} else {
 			$appRoleAssignmentId = $this->featureContext->getJsonDecodedResponse(
-				$this->getAssignedRole($ofUser)
+				$this->getAssignedRole($ofUser),
 			)["value"][0]["id"];
 		}
 
@@ -2470,8 +2470,8 @@ class GraphContext implements Context {
 				$credentials['username'],
 				$credentials['password'],
 				$appRoleAssignmentId,
-				$userId
-			)
+				$userId,
+			),
 		);
 	}
 
@@ -2495,7 +2495,7 @@ class GraphContext implements Context {
 			$jsonDecodedResponse['appRoleId'],
 			__METHOD__
 			. "\nExpected user '$user' to have role '$role' with role id '" . $this->appEntity["appRoles"][$role] .
-			"' but got the role id is '" . $jsonDecodedResponse['appRoleId'] . "'"
+			"' but got the role id is '" . $jsonDecodedResponse['appRoleId'] . "'",
 		);
 	}
 
@@ -2513,7 +2513,7 @@ class GraphContext implements Context {
 		Assert::assertEmpty(
 			$jsonDecodedResponse,
 			__METHOD__
-			. "\nExpected user '$user' to have no roles assigned but got '" . json_encode($jsonDecodedResponse) . "'"
+			. "\nExpected user '$user' to have no roles assigned but got '" . json_encode($jsonDecodedResponse) . "'",
 		);
 	}
 
@@ -2544,8 +2544,8 @@ class GraphContext implements Context {
 				$credentials['password'],
 				$this->appEntity["appRoles"][$role],
 				$this->appEntity["id"],
-				$userId
-			)
+				$userId,
+			),
 		);
 	}
 
@@ -2564,12 +2564,12 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$credentials['username'],
 			$credentials['password'],
-			$language
+			$language,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 	}
 
@@ -2589,8 +2589,8 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$credentials['username'],
 				$credentials['password'],
-				$language
-			)
+				$language,
+			),
 		);
 	}
 
@@ -2607,7 +2607,7 @@ class GraphContext implements Context {
 	public function userListsTheResourcesSharedWithThemUsingGraphApi(
 		string $user,
 		string $cacheStepString,
-		string $retryOption
+		string $retryOption,
 	): void {
 		if ($cacheStepString !== '') {
 			// ENV (GRAPH_SPACES_GROUPS_CACHE_TTL | GRAPH_SPACES_USERS_CACHE_TTL) is set default to 60 sec
@@ -2628,7 +2628,7 @@ class GraphContext implements Context {
 			$response = GraphHelper::getSharesSharedWithMe(
 				$this->featureContext->getBaseUrl(),
 				$credentials['username'],
-				$credentials['password']
+				$credentials['password'],
 			);
 
 			$jsonBody = $this->featureContext->getJsonDecodedResponseBodyContent($response);
@@ -2674,7 +2674,7 @@ class GraphContext implements Context {
 		return GraphHelper::getSharesSharedByMe(
 			$this->featureContext->getBaseUrl(),
 			$credentials['username'],
-			$credentials['password']
+			$credentials['password'],
 		);
 	}
 
@@ -2717,7 +2717,7 @@ class GraphContext implements Context {
 	public function theJsonDataResponseShouldOrNotContainSharedByMeDetails(
 		string $shouldOrNot,
 		string $fileName,
-		PyStringNode $schemaString
+		PyStringNode $schemaString,
 	): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent()->value;
 		$fileOrFolderFound = false;
@@ -2734,11 +2734,11 @@ class GraphContext implements Context {
 		}
 		Assert::assertFalse(
 			!$shouldContain && $fileOrFolderFound,
-			'Response contains file "' . $fileName . '" but should.'
+			'Response contains file "' . $fileName . '" but should.',
 		);
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$responseBody,
-			$this->featureContext->getJSONSchema($schemaString)
+			$this->featureContext->getJSONSchema($schemaString),
 		);
 	}
 
@@ -2761,7 +2761,7 @@ class GraphContext implements Context {
 		}
 		Assert::assertFalse(
 			$mailValueExist,
-			"Response contains email '$email' but should not."
+			"Response contains email '$email' but should not.",
 		);
 	}
 
@@ -2779,20 +2779,20 @@ class GraphContext implements Context {
 	public function userUsingPasswordShouldBeAbleToCreateANewUserWithDefaultAttributes(
 		string $byUser,
 		string $password,
-		string $user
+		string $user,
 	): void {
 		$response = GraphHelper::createUser(
 			$this->featureContext->getBaseUrl(),
 			$byUser,
 			$password,
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 		Assert::assertEquals(
 			201,
 			$response->getStatusCode(),
 			__METHOD__ . " cannot create new user '$user' by user '$byUser'.\nResponse:" .
-			json_encode($this->featureContext->getJsonDecodedResponse($response))
+			json_encode($this->featureContext->getJsonDecodedResponse($response)),
 		);
 		$this->featureContext->addUserToCreatedUsersList($user, $this->featureContext->getPasswordForUser($user));
 	}
@@ -2836,7 +2836,7 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$credentials['username'],
 				$credentials['password'],
-			)
+			),
 		);
 	}
 
@@ -2858,7 +2858,7 @@ class GraphContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$credentials['username'],
 				$credentials['password'],
-			)
+			),
 		);
 	}
 
@@ -2874,7 +2874,7 @@ class GraphContext implements Context {
 	public function getActivities(
 		string $user,
 		string $resource,
-		string $spaceName
+		string $spaceName,
 	): ResponseInterface {
 		if ($spaceName === "Shares") {
 			$resourceId = $this->spacesContext->getSharesRemoteItemId($user, $resource);
@@ -2885,7 +2885,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$resourceId
+			$resourceId,
 		);
 	}
 
@@ -2903,7 +2903,7 @@ class GraphContext implements Context {
 	public function userListsTheActivitiesForResourceOfSpaceUsingTheGraphAPI(
 		string $user,
 		string $resource,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$this->featureContext->setResponse($this->getActivities($user, $resource, $spaceName));
 	}
@@ -2923,11 +2923,11 @@ class GraphContext implements Context {
 		string $user,
 		string $resource,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$unmatchedActivities = [];
 		$activities = $this->featureContext->getJsonDecodedResponse(
-			$this->getActivities($user, $resource, $spaceName)
+			$this->getActivities($user, $resource, $spaceName),
 		);
 		foreach ($table->getRows() as $expectedActivity) {
 			$matched = false;
@@ -2959,7 +2959,7 @@ class GraphContext implements Context {
 	public function forUserFileOfTheSpaceShouldNotHaveAnyActivity(
 		string $user,
 		string $resource,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$activities = $this->getActivities($user, $resource, $spaceName);
 		$responseBody = $activities->getBody()->getContents();
@@ -2967,7 +2967,7 @@ class GraphContext implements Context {
 			$responseBody,
 			__METHOD__
 			. "\nExpected no activity of resource '$resource' for user '$user', but some activities were found\n" .
-			print_r(json_decode($responseBody, true), true)
+			print_r(json_decode($responseBody, true), true),
 		);
 	}
 
@@ -2981,19 +2981,19 @@ class GraphContext implements Context {
 	 */
 	public function userTriesToListTheActivitiesOfFolderWithShareMountIdPointIdUsingTheGraphApi(
 		string $user,
-		string $folder
+		string $folder,
 	): void {
 		$resourceId = GraphHelper::getShareMountId(
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$folder
+			$folder,
 		);
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$resourceId
+			$resourceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3012,14 +3012,14 @@ class GraphContext implements Context {
 		string $user,
 		string $file,
 		string $owner,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$resourceId = $this->spacesContext->getResourceId($owner, $spaceName, $file);
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$resourceId
+			$resourceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3038,7 +3038,7 @@ class GraphContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$spaceId
+			$spaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3055,13 +3055,13 @@ class GraphContext implements Context {
 	public function thePublicTriesToCheckTheActivitiesOfSpaceOwnedByUserWithPasswordUsingGraphApi(
 		string $spaceName,
 		string $user,
-		string $password
+		string $password,
 	): void {
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			"public",
 			$this->featureContext->getActualPassword($password),
-			$this->spacesContext->getSpaceIdByName($user, $spaceName)
+			$this->spacesContext->getSpaceIdByName($user, $spaceName),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3080,13 +3080,13 @@ class GraphContext implements Context {
 		string $resource,
 		string $space,
 		string $owner,
-		string $password
+		string $password,
 	): void {
 		$response = GraphHelper::getActivities(
 			$this->featureContext->getBaseUrl(),
 			"public",
 			$this->featureContext->getPasswordForUser($owner),
-			$this->spacesContext->getResourceId($owner, $space, $resource)
+			$this->spacesContext->getResourceId($owner, $space, $resource),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3107,7 +3107,7 @@ class GraphContext implements Context {
 		string $resource,
 		string $spaceName,
 		string $filterType,
-		string $filterValue
+		string $filterValue,
 	): void {
 		$resourceId = $this->spacesContext->getResourceId($user, $spaceName, $resource);
 		$response = GraphHelper::getActivities(
@@ -3115,7 +3115,7 @@ class GraphContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$resourceId,
-			[$filterType => $filterValue]
+			[$filterType => $filterValue],
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3160,7 +3160,7 @@ class GraphContext implements Context {
 		string $spaceName,
 		string $filterType,
 		string $filterValue,
-		string $sortType
+		string $sortType,
 	): void {
 		$resourceId = $this->spacesContext->getResourceId($user, $spaceName, $resource);
 		$response = GraphHelper::getActivities(
@@ -3187,7 +3187,7 @@ class GraphContext implements Context {
 		$response = GraphHelper::getFederatedUsers(
 			$this->featureContext->getBaseUrl(),
 			$credentials['username'],
-			$credentials['password']
+			$credentials['password'],
 		);
 
 		$this->featureContext->setResponse($response);
@@ -3207,7 +3207,7 @@ class GraphContext implements Context {
 		$response = GraphHelper::getAllUsers(
 			$this->featureContext->getBaseUrl(),
 			$credentials['username'],
-			$credentials['password']
+			$credentials['password'],
 		);
 
 		$this->featureContext->setResponse($response);
@@ -3227,7 +3227,7 @@ class GraphContext implements Context {
 	public function userSearchesForUserOfTheGroupUsingTheGraphApi(
 		string $user,
 		string $searchTerm,
-		string $group
+		string $group,
 	): void {
 		$groupId = $this->featureContext->getGroupIdByGroupName($group);
 		$response = GraphHelper::searchUserWithFilterMemberOf(
@@ -3235,7 +3235,7 @@ class GraphContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$groupId,
-			$searchTerm
+			$searchTerm,
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/bootstrap/NotificationContext.php
+++ b/tests/acceptance/bootstrap/NotificationContext.php
@@ -93,7 +93,7 @@ class NotificationContext implements Context {
 			$this->featureContext->getAdminPassword(),
 			'DELETE',
 			$this->globalNotificationEndpointPath,
-			json_encode($payload)
+			json_encode($payload),
 		);
 	}
 
@@ -118,7 +118,7 @@ class NotificationContext implements Context {
 			$this->notificationEndpointPath,
 			[],
 			2,
-			$headers
+			$headers,
 		);
 	}
 
@@ -218,7 +218,7 @@ class NotificationContext implements Context {
 			'DELETE',
 			$this->notificationEndpointPath,
 			\json_encode($payload),
-			2
+			2,
 		);
 	}
 
@@ -234,7 +234,7 @@ class NotificationContext implements Context {
 			$response = $this->featureContext->getResponse()->getBody()->getContents();
 			throw new \Exception(
 				__METHOD__
-				. " Failed to get user notification list" . $response
+				. " Failed to get user notification list" . $response,
 			);
 		}
 		$notifications = $this->featureContext->getJsonDecodedResponseBodyContent()->ocs->data;
@@ -272,7 +272,7 @@ class NotificationContext implements Context {
 		Assert::assertEquals(
 			$numberOfNotification,
 			$actualNumber,
-			"Expected number of notifications was '$numberOfNotification', but got '$actualNumber'"
+			"Expected number of notifications was '$numberOfNotification', but got '$actualNumber'",
 		);
 	}
 
@@ -287,7 +287,7 @@ class NotificationContext implements Context {
 	 */
 	public function theJsonDataFromLastResponseShouldMatch(
 		string $subject,
-		PyStringNode $schemaString
+		PyStringNode $schemaString,
 	): void {
 		$responseBody = $this->filterResponseAccordingToNotificationSubject($subject);
 		// substitute the value here
@@ -302,7 +302,7 @@ class NotificationContext implements Context {
 		);
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$responseBody,
-			$this->featureContext->getJSONSchema($schemaString)
+			$this->featureContext->getJSONSchema($schemaString),
 		);
 	}
 
@@ -316,7 +316,7 @@ class NotificationContext implements Context {
 	 */
 	public function filterResponseAccordingToNotificationSubject(
 		string $subject,
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): object {
 		$response = $response ?? $this->featureContext->getResponse();
 		if (isset($this->featureContext->getJsonDecodedResponseBodyContent($response)->ocs->data)) {
@@ -344,7 +344,7 @@ class NotificationContext implements Context {
 	public function filterNotificationsBySubjectAndResource(
 		string $subject,
 		string $resource,
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): array {
 		$filteredNotifications = [];
 		$response = $response ?? $this->featureContext->getResponse();
@@ -379,7 +379,7 @@ class NotificationContext implements Context {
 	public function filterNotificationsBySubjectAndSpace(
 		string $subject,
 		string $space,
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): array {
 		$filteredNotifications = [];
 		$response = $response ?? $this->featureContext->getResponse();
@@ -430,7 +430,7 @@ class NotificationContext implements Context {
 			$actualMessage = str_replace(
 				["\r", "\n"],
 				" ",
-				$this->filterResponseAccordingToNotificationSubject($subject, $response)->message
+				$this->filterResponseAccordingToNotificationSubject($subject, $response)->message,
 			);
 		} else {
 			throw new \Exception("Notification was not found even after retrying for 5 seconds.");
@@ -439,7 +439,7 @@ class NotificationContext implements Context {
 		Assert::assertSame(
 			$expectedMessage,
 			$actualMessage,
-			__METHOD__ . "expected message to be '$expectedMessage' but found'$actualMessage'"
+			__METHOD__ . "expected message to be '$expectedMessage' but found'$actualMessage'",
 		);
 	}
 
@@ -458,7 +458,7 @@ class NotificationContext implements Context {
 		string $user,
 		string $resource,
 		string $subject,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->listAllNotifications($user);
 		$notification = $this->filterNotificationsBySubjectAndResource($subject, $resource, $response);
@@ -469,19 +469,19 @@ class NotificationContext implements Context {
 			Assert::assertSame(
 				$expectedMessage,
 				$actualMessage,
-				__METHOD__ . "expected message to be '$expectedMessage' but found'$actualMessage'"
+				__METHOD__ . "expected message to be '$expectedMessage' but found'$actualMessage'",
 			);
 			$response = $this->userDeletesNotification($user);
 			$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 		} elseif (\count($notification) === 0) {
 			throw new \Exception(
 				"Response doesn't contain any notification with resource '$resource' and subject '$subject'.\n"
-				. print_r($notification, true)
+				. print_r($notification, true),
 			);
 		} else {
 			throw new \Exception(
 				"Response contains more than one notification with resource '$resource' and subject '$subject'.\n"
-				. print_r($notification, true)
+				. print_r($notification, true),
 			);
 		}
 	}
@@ -500,7 +500,7 @@ class NotificationContext implements Context {
 		string $user,
 		string $resourceOrSpace,
 		string $resource,
-		string $subject
+		string $subject,
 	): void {
 		$response = $this->listAllNotifications($user);
 		if ($resourceOrSpace === "space") {
@@ -512,7 +512,7 @@ class NotificationContext implements Context {
 			0,
 			$filteredResponse,
 			"Response should not contain notification related to resource '$resource' with subject '$subject' but found"
-			. print_r($filteredResponse, true)
+			. print_r($filteredResponse, true),
 		);
 	}
 
@@ -531,7 +531,7 @@ class NotificationContext implements Context {
 	public function userCreatesDeprovisioningNotification(
 		?string $user = null,
 		?string $deprovision_date = "2043-07-04T11:23:12Z",
-		?string $deprovision_date_format = "2006-01-02T15:04:05Z07:00"
+		?string $deprovision_date_format = "2006-01-02T15:04:05Z07:00",
 	): ResponseInterface {
 		$payload["type"] = "deprovision";
 		$payload["data"] = [
@@ -542,7 +542,7 @@ class NotificationContext implements Context {
 			$user ? $this->featureContext->getPasswordForUser($user) : $this->featureContext->getAdminPassword(),
 			'POST',
 			$this->globalNotificationEndpointPath,
-			json_encode($payload)
+			json_encode($payload),
 		);
 	}
 
@@ -576,7 +576,7 @@ class NotificationContext implements Context {
 	 */
 	public function theAdministratorCreatesADeprovisioningNotificationUsingDateFormat(
 		$deprovision_date,
-		$deprovision_date_format
+		$deprovision_date_format,
 	): void {
 		$response = $this->userCreatesDeprovisioningNotification(null, $deprovision_date, $deprovision_date_format);
 		$this->featureContext->setResponse($response);
@@ -610,7 +610,7 @@ class NotificationContext implements Context {
 			$user ? $this->featureContext->getPasswordForUser($user) : $this->featureContext->getAdminPassword(),
 			'DELETE',
 			$this->globalNotificationEndpointPath,
-			json_encode($payload)
+			json_encode($payload),
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/bootstrap/OCSContext.php
+++ b/tests/acceptance/bootstrap/OCSContext.php
@@ -69,7 +69,7 @@ class OCSContext implements Context {
 			$verb,
 			$url,
 			null,
-			$password
+			$password,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -90,7 +90,7 @@ class OCSContext implements Context {
 		string $url,
 		?TableNode $body = null,
 		?string $password = null,
-		?array $headers = null
+		?array $headers = null,
 	): ResponseInterface {
 		/**
 		 * array of the data to be sent in the body.
@@ -118,7 +118,7 @@ class OCSContext implements Context {
 			$url,
 			$bodyArray,
 			$this->featureContext->getOcsApiVersion(),
-			$headers
+			$headers,
 		);
 	}
 
@@ -132,14 +132,14 @@ class OCSContext implements Context {
 	public function adminSendsHttpMethodToOcsApiEndpointWithBody(
 		string $verb,
 		string $url,
-		?TableNode $body
+		?TableNode $body,
 	): ResponseInterface {
 		$admin = $this->featureContext->getAdminUsername();
 		return $this->sendRequestToOcsEndpoint(
 			$admin,
 			$verb,
 			$url,
-			$body
+			$body,
 		);
 	}
 
@@ -153,13 +153,13 @@ class OCSContext implements Context {
 	public function theUserSendsToOcsApiEndpointWithBody(
 		string $verb,
 		string $url,
-		?TableNode $body = null
+		?TableNode $body = null,
 	): ResponseInterface {
 		return $this->sendRequestToOcsEndpoint(
 			$this->featureContext->getCurrentUser(),
 			$verb,
 			$url,
-			$body
+			$body,
 		);
 	}
 
@@ -179,14 +179,14 @@ class OCSContext implements Context {
 		string $verb,
 		string $url,
 		?TableNode $body = null,
-		?string $password = null
+		?string $password = null,
 	): void {
 		$response = $this->sendRequestToOcsEndpoint(
 			$user,
 			$verb,
 			$url,
 			$body,
-			$password
+			$password,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -204,7 +204,7 @@ class OCSContext implements Context {
 	public function theAdministratorSendsHttpMethodToOcsApiEndpoint(
 		string $verb,
 		string $url,
-		?string $password = null
+		?string $password = null,
 	): void {
 		$this->featureContext->setResponse(
 			$this->sendRequestToOcsEndpoint(
@@ -212,8 +212,8 @@ class OCSContext implements Context {
 				$verb,
 				$url,
 				null,
-				$password
-			)
+				$password,
+			),
 		);
 	}
 
@@ -232,7 +232,7 @@ class OCSContext implements Context {
 		string $user,
 		string $verb,
 		string $url,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$password = $this->featureContext->getPasswordForUser($user);
@@ -243,8 +243,8 @@ class OCSContext implements Context {
 				$url,
 				null,
 				$password,
-				$headersTable->getRowsHash()
-			)
+				$headersTable->getRowsHash(),
+			),
 		);
 	}
 
@@ -261,7 +261,7 @@ class OCSContext implements Context {
 	public function administratorSendsToOcsApiEndpointWithHeaders(
 		string $verb,
 		string $url,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$user = $this->featureContext->getAdminUsername();
 		$password = $this->featureContext->getPasswordForUser($user);
@@ -272,8 +272,8 @@ class OCSContext implements Context {
 				$url,
 				null,
 				$password,
-				$headersTable->getRowsHash()
-			)
+				$headersTable->getRowsHash(),
+			),
 		);
 	}
 
@@ -292,7 +292,7 @@ class OCSContext implements Context {
 		string $verb,
 		string $url,
 		string $password,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$this->featureContext->setResponse(
 			$this->sendRequestToOcsEndpoint(
@@ -301,8 +301,8 @@ class OCSContext implements Context {
 				$url,
 				null,
 				$password,
-				$headersTable->getRowsHash()
-			)
+				$headersTable->getRowsHash(),
+			),
 		);
 	}
 
@@ -318,12 +318,12 @@ class OCSContext implements Context {
 	public function theAdministratorSendsHttpMethodToOcsApiEndpointWithBody(
 		string $verb,
 		string $url,
-		?TableNode $body
+		?TableNode $body,
 	): void {
 		$response = $this->adminSendsHttpMethodToOcsApiEndpointWithBody(
 			$verb,
 			$url,
-			$body
+			$body,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -341,7 +341,7 @@ class OCSContext implements Context {
 		$response = $this->theUserSendsToOcsApiEndpointWithBody(
 			$verb,
 			$url,
-			$body
+			$body,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -360,7 +360,7 @@ class OCSContext implements Context {
 		string $verb,
 		string $url,
 		string $password,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$admin = $this->featureContext->getAdminUsername();
 		$response = $this->sendRequestToOcsEndpoint(
@@ -368,7 +368,7 @@ class OCSContext implements Context {
 			$verb,
 			$url,
 			$body,
-			$password
+			$password,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -389,14 +389,14 @@ class OCSContext implements Context {
 		string $verb,
 		string $url,
 		string $password,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$response = $this->sendRequestToOcsEndpoint(
 			$user,
 			$verb,
 			$url,
 			$body,
-			$password
+			$password,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -414,12 +414,12 @@ class OCSContext implements Context {
 	public function theOCSStatusCodeShouldBe(
 		string $statusCode,
 		string $message = "",
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): void {
 		$statusCodes = explode(",", $statusCode);
 		$response = $response ?? $this->featureContext->getResponse();
 		$responseStatusCode = $this->getOCSResponseStatusCode(
-			$response
+			$response,
 		);
 		if (\is_array($statusCodes)) {
 			if ($message === "") {
@@ -429,7 +429,7 @@ class OCSContext implements Context {
 			Assert::assertContainsEquals(
 				$responseStatusCode,
 				$statusCodes,
-				$message
+				$message,
 			);
 			$this->featureContext->emptyLastOCSStatusCodesArray();
 		} else {
@@ -440,7 +440,7 @@ class OCSContext implements Context {
 			Assert::assertEquals(
 				$statusCodes,
 				$responseStatusCode,
-				$message
+				$message,
 			);
 		}
 	}
@@ -458,13 +458,13 @@ class OCSContext implements Context {
 		$statusCodes = [$statusCode1,$statusCode1];
 		$response = $this->featureContext->getResponse();
 		$responseStatusCode = $this->getOCSResponseStatusCode(
-			$response
+			$response,
 		);
 		Assert::assertContainsEquals(
 			$responseStatusCode,
 			$statusCodes,
 			"OCS status code is not any of the expected values "
-			. \implode(",", $statusCodes) . " got " . $responseStatusCode
+			. \implode(",", $statusCodes) . " got " . $responseStatusCode,
 		);
 		$this->featureContext->emptyLastOCSStatusCodesArray();
 	}
@@ -487,11 +487,11 @@ class OCSContext implements Context {
 		Assert::assertEquals(
 			$statusMessage,
 			$this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
+				$this->featureContext->getResponse(),
 			),
 			'Unexpected OCS status message :"' . $this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
-			) . '" in response'
+				$this->featureContext->getResponse(),
+			) . '" in response',
 		);
 	}
 
@@ -509,16 +509,16 @@ class OCSContext implements Context {
 		$user = \strtolower($this->featureContext->getActualUsername($user));
 		$statusMessage = $this->featureContext->substituteInLineCodes(
 			$statusMessage,
-			$user
+			$user,
 		);
 		Assert::assertEquals(
 			$statusMessage,
 			$this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
+				$this->featureContext->getResponse(),
 			),
 			'Unexpected OCS status message :"' . $this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
-			) . '" in response'
+				$this->featureContext->getResponse(),
+			) . '" in response',
 		);
 	}
 
@@ -541,16 +541,16 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theOCSStatusMessageShouldBePyString(
-		PyStringNode $statusMessage
+		PyStringNode $statusMessage,
 	): void {
 		Assert::assertEquals(
 			$statusMessage->getRaw(),
 			$this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
+				$this->featureContext->getResponse(),
 			),
 			'Unexpected OCS status message: "' . $this->getOCSResponseStatusMessage(
-				$this->featureContext->getResponse()
-			) . '" in response'
+				$this->featureContext->getResponse(),
+			) . '" in response',
 		);
 	}
 
@@ -621,7 +621,7 @@ class OCSContext implements Context {
 		if ($language !== null) {
 			$multiLingualMessage = \json_decode(
 				\file_get_contents(__DIR__ . "/../fixtures/multiLanguageErrors.json"),
-				true
+				true,
 			);
 
 			if (isset($multiLingualMessage[$statusMessage][$language])) {
@@ -643,7 +643,7 @@ class OCSContext implements Context {
 	 */
 	public function assertOCSResponseIndicatesSuccess(
 		?string $message = "",
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): void {
 		$response = $response ?? $this->featureContext->getResponse();
 		$this->featureContext->theHTTPStatusCodeShouldBe('200', $message, $response);

--- a/tests/acceptance/bootstrap/OcisConfigContext.php
+++ b/tests/acceptance/bootstrap/OcisConfigContext.php
@@ -68,7 +68,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to set async upload with delayed post processing"
+			"Failed to set async upload with delayed post processing",
 		);
 	}
 
@@ -90,7 +90,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to set config $configVariable=$configValue"
+			"Failed to set config $configVariable=$configValue",
 		);
 	}
 
@@ -115,7 +115,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to enable role $role"
+			"Failed to enable role $role",
 		);
 		$this->setEnabledPermissionsRoles($defaultRoles);
 	}
@@ -141,7 +141,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to disable role $role"
+			"Failed to disable role $role",
 		);
 		$this->setEnabledPermissionsRoles($availableRoles);
 	}
@@ -160,12 +160,12 @@ class OcisConfigContext implements Context {
 		$response = OcisConfigHelper::reConfigureOcis(
 			[
 				$configVariable => $path,
-			]
+			],
 		);
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to set config $configVariable=$path"
+			"Failed to set config $configVariable=$path",
 		);
 	}
 
@@ -187,7 +187,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to set config"
+			"Failed to set config",
 		);
 	}
 
@@ -202,7 +202,7 @@ class OcisConfigContext implements Context {
 	 */
 	public function theAdministratorHasStartedServiceSeparatelyWithTheFollowingConfig(
 		string $service,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$envs = [];
 		foreach ($table->getHash() as $row) {
@@ -213,7 +213,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to start service $service."
+			"Failed to start service $service.",
 		);
 	}
 
@@ -237,7 +237,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to rollback ocis server. Check if oCIS is started with ociswrapper."
+			"Failed to rollback ocis server. Check if oCIS is started with ociswrapper.",
 		);
 	}
 
@@ -250,7 +250,7 @@ class OcisConfigContext implements Context {
 		Assert::assertEquals(
 			200,
 			$response->getStatusCode(),
-			"Failed to rollback services."
+			"Failed to rollback services.",
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/OcmContext.php
+++ b/tests/acceptance/bootstrap/OcmContext.php
@@ -85,7 +85,7 @@ class OcmContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$email,
-			$description
+			$description,
 		);
 		$responseData = \json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
 		if (isset($responseData["token"])) {
@@ -142,7 +142,7 @@ class OcmContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$token ? $token : $this->getLastFederatedInvitationToken(),
-			$providerDomain
+			$providerDomain,
 		);
 	}
 
@@ -201,8 +201,8 @@ class OcmContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				$token,
-				$providerDomain
-			)
+				$providerDomain,
+			),
 		);
 	}
 
@@ -217,7 +217,7 @@ class OcmContext implements Context {
 		$response = OcmHelper::findAcceptedUsers(
 			$this->featureContext->getBaseUrl(),
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 		if ($response->getStatusCode() === 200) {
 			$users = $this->featureContext->getJsonDecodedResponse($response);
@@ -261,7 +261,7 @@ class OcmContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"failed to list accepted users by '$user'",
-			$response
+			$response,
 		);
 		$users = ($this->featureContext->getJsonDecodedResponse($response));
 		foreach ($users as $acceptedUser) {
@@ -282,7 +282,7 @@ class OcmContext implements Context {
 		return OcmHelper::listInvite(
 			$this->featureContext->getBaseUrl(),
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 	}
 
@@ -338,7 +338,7 @@ class OcmContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"failed while deleting connection with user $ocmUser",
-			$response
+			$response,
 		);
 	}
 
@@ -358,7 +358,7 @@ class OcmContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$ocmUser['user_id'],
-			$ocmUser['idp']
+			$ocmUser['idp'],
 		);
 	}
 
@@ -395,12 +395,12 @@ class OcmContext implements Context {
 		$response = HttpRequestHelper::get(
 			$this->archiverContext->getArchiverUrl($queryString),
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Failed to download archive of resource $resource",
-			$response
+			$response,
 		);
 	}
 
@@ -418,7 +418,7 @@ class OcmContext implements Context {
 	public function userSendsPropfindRequestToFederatedShareWithDepthUsingTheWebdavApi(
 		string $user,
 		string $share,
-		string $folderDepth
+		string $folderDepth,
 	): void {
 		$response = $this->spacesContext->sendPropfindRequestToSpace($user, "", $share, null, $folderDepth, true);
 		$this->featureContext->setResponse($response);
@@ -462,7 +462,7 @@ class OcmContext implements Context {
 	public function userDeletesFederatedConnectionWithUserAndProviderUsingTheGraphApi(
 		string $user,
 		string $ocmUser,
-		string $idp
+		string $idp,
 	): void {
 		$this->featureContext->setResponse($this->deleteConnection($user, $ocmUser, $idp));
 	}

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -119,7 +119,7 @@ trait Provisioning {
 				return $usersList[$normalizedUsername][$attribute];
 			}
 			throw new Exception(
-				__METHOD__ . ": User '$user' has no attribute with name '$attribute'."
+				__METHOD__ . ": User '$user' has no attribute with name '$attribute'.",
 			);
 		}
 		return false;
@@ -139,7 +139,7 @@ trait Provisioning {
 				return $groupsList[$group][$attribute];
 			}
 			throw new Exception(
-				__METHOD__ . ": Group '$group' has no attribute with name '$attribute'."
+				__METHOD__ . ": Group '$group' has no attribute with name '$attribute'.",
 			);
 		}
 		return false;
@@ -160,7 +160,7 @@ trait Provisioning {
 			$password = $this->createdUsers[$normalizedUsername]['password'];
 		} else {
 			throw new Exception(
-				"user '$username' was not created by this test run"
+				"user '$username' was not created by this test run",
 			);
 		}
 
@@ -177,7 +177,7 @@ trait Provisioning {
 	 * @throws Exception|GuzzleException
 	 */
 	public function userHasBeenCreatedWithDefaultAttributes(
-		string $user
+		string $user,
 	): void {
 		$this->userHasBeenCreated(["userName" => $user]);
 	}
@@ -191,7 +191,7 @@ trait Provisioning {
 	 * @throws Exception|GuzzleException
 	 */
 	public function userHasBeenCreatedWithDefaultAttributesAndNotInitialized(
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->usersHaveBeenCreated($table, true, false);
 	}
@@ -223,7 +223,7 @@ trait Provisioning {
 		$rows = $table->getRowsHash();
 		$this->userHasBeenCreated(
 			$rows,
-			$byUser
+			$byUser,
 		);
 	}
 
@@ -245,7 +245,7 @@ trait Provisioning {
 
 		throw new Exception(
 			__METHOD__
-			. " group '$groupname' was not created by this test run"
+			. " group '$groupname' was not created by this test run",
 		);
 	}
 
@@ -439,7 +439,7 @@ trait Provisioning {
 					"uid=" . ldap_escape(
 						$entry['uid'],
 						"",
-						LDAP_ESCAPE_DN
+						LDAP_ESCAPE_DN,
 					) . ",ou=" . $this->ldapUsersOU . "," . $this->ldapBaseDN,
 				);
 				OcisHelper::deleteRevaUserData([$entry['uid']]);
@@ -514,12 +514,12 @@ trait Provisioning {
 			// delete all created ldap users
 			$this->ldap->delete(
 				"ou=" . $this->ldapUsersOU . "," . $this->ldapBaseDN,
-				true
+				true,
 			);
 			// delete all created ldap groups
 			$this->ldap->delete(
 				"ou=" . $this->ldapGroupsOU . "," . $this->ldapBaseDN,
-				true
+				true,
 			);
 		}
 	}
@@ -541,7 +541,7 @@ trait Provisioning {
 	public function usersHaveBeenCreated(
 		TableNode $table,
 		bool $useDefault = true,
-		bool $initialize = true
+		bool $initialize = true,
 	): void {
 		$this->verifyTableNodeColumns($table, ['username'], ['displayname', 'email', 'password']);
 		$table = $table->getColumnsHash();
@@ -550,7 +550,7 @@ trait Provisioning {
 		$requests = [];
 		$client = HttpRequestHelper::createClient(
 			$this->getAdminUsername(),
-			$this->getAdminPassword()
+			$this->getAdminPassword(),
 		);
 
 		foreach ($users as $userAttributes) {
@@ -564,7 +564,7 @@ trait Provisioning {
 					Assert::assertArrayHasKey(
 						'userid',
 						$userAttributes,
-						__METHOD__ . " userAttributes array does not have key 'userid'"
+						__METHOD__ . " userAttributes array does not have key 'userid'",
 					);
 					$attributesToCreateUser['email'] = $userAttributes['userid'] . '@owncloud.com';
 				} else {
@@ -574,7 +574,7 @@ trait Provisioning {
 					$attributesToCreateUser['userid'],
 					$attributesToCreateUser['password'],
 					$attributesToCreateUser['email'],
-					$attributesToCreateUser['displayname']
+					$attributesToCreateUser['displayname'],
 				);
 				$request = GraphHelper::createRequest(
 					$this->getBaseUrl(),
@@ -603,7 +603,7 @@ trait Provisioning {
 						$users[$key]['userid'] . "'" .
 						"\nHTTP status $httpStatusCode " .
 						"\nGraph status $graphStatusCode " .
-						"\nError message $messageText"
+						"\nError message $messageText",
 					);
 				}
 			}
@@ -625,7 +625,7 @@ trait Provisioning {
 				$userAttributes['password'],
 				$userAttributes['displayName'],
 				$userAttributes['email'],
-				$userAttributes['id']
+				$userAttributes['id'],
 			);
 		}
 
@@ -636,7 +636,7 @@ trait Provisioning {
 		foreach ($users as $user) {
 			Assert::assertTrue(
 				$this->userExists($user["userid"]),
-				"User '" . $user["userid"] . "' should exist but does not exist"
+				"User '" . $user["userid"] . "' should exist but does not exist",
 			);
 		}
 
@@ -657,7 +657,7 @@ trait Provisioning {
 		$this->userResetUserPasswordUsingProvisioningApi(
 			$this->getAdminUsername(),
 			$username,
-			$password
+			$password,
 		);
 	}
 
@@ -671,14 +671,14 @@ trait Provisioning {
 	public function userResetUserPasswordUsingProvisioningApi(
 		?string $user,
 		?string $username,
-		?string $password
+		?string $password,
 	): void {
 		$targetUsername = $this->getActualUsername($username);
 		$password = $this->getActualPassword($password);
 		$this->userTriesToResetUserPasswordUsingTheProvisioningApi(
 			$user,
 			$targetUsername,
-			$password
+			$password,
 		);
 		$this->rememberUserPassword($targetUsername, $password);
 	}
@@ -693,7 +693,7 @@ trait Provisioning {
 	public function userTriesToResetUserPasswordUsingTheProvisioningApi(
 		?string $user,
 		?string $username,
-		?string $password
+		?string $password,
 	): void {
 		$password = $this->getActualPassword($password);
 		$bodyTable = new TableNode([['key', 'password'], ['value', $password]]);
@@ -701,7 +701,7 @@ trait Provisioning {
 			$user,
 			"PUT",
 			"/cloud/users/$username",
-			$bodyTable
+			$bodyTable,
 		);
 	}
 
@@ -730,7 +730,7 @@ trait Provisioning {
 	public function userShouldExist(string $user): void {
 		Assert::assertTrue(
 			$this->userExists($user),
-			"User '$user' should exist but does not exist"
+			"User '$user' should exist but does not exist",
 		);
 	}
 
@@ -746,7 +746,7 @@ trait Provisioning {
 		$user = $this->getActualUsername($user);
 		Assert::assertFalse(
 			$this->userExists($user),
-			"User '$user' should not exist but does exist"
+			"User '$user' should not exist but does exist",
 		);
 	}
 
@@ -762,7 +762,7 @@ trait Provisioning {
 	public function groupShouldExist(string $group): void {
 		Assert::assertTrue(
 			$this->groupExists($group),
-			"Group '$group' should exist but does not exist"
+			"Group '$group' should exist but does not exist",
 		);
 	}
 
@@ -778,7 +778,7 @@ trait Provisioning {
 	public function groupShouldNotExist(string $group): void {
 		Assert::assertFalse(
 			$this->groupExists($group),
-			"Group '$group' should not exist but does exist"
+			"Group '$group' should not exist but does exist",
 		);
 	}
 
@@ -802,7 +802,7 @@ trait Provisioning {
 					throw new Exception(
 						"group '" . $row['groupname'] .
 						"' does" . ($should ? " not" : "") .
-						" exist but should" . ($should ? "" : " not")
+						" exist but should" . ($should ? "" : " not"),
 					);
 				}
 			}
@@ -832,7 +832,7 @@ trait Provisioning {
 		}
 		Assert::assertFalse(
 			$this->userExists($user),
-			"User '$user' should not exist but does exist"
+			"User '$user' should not exist but does exist",
 		);
 	}
 
@@ -854,7 +854,7 @@ trait Provisioning {
 			}
 			$this->initializeUser(
 				$row ['username'],
-				$password
+				$password,
 			);
 		}
 	}
@@ -869,7 +869,7 @@ trait Provisioning {
 		return HttpRequestHelper::get(
 			$fullUrl,
 			$this->getAdminUsername(),
-			$this->getAdminPassword()
+			$this->getAdminPassword(),
 		);
 	}
 
@@ -887,7 +887,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl,
 			$actualUser,
-			$actualPassword
+			$actualPassword,
 		);
 	}
 
@@ -901,7 +901,7 @@ trait Provisioning {
 	 */
 	public function userGetsTheListOfAllUsersUsingTheProvisioningApi(string $user): void {
 		$this->featureContext->setResponse(
-			$this->userGetsTheListOfAllUsers($user)
+			$this->userGetsTheListOfAllUsers($user),
 		);
 	}
 
@@ -917,7 +917,7 @@ trait Provisioning {
 		return HttpRequestHelper::get(
 			$fullUrl,
 			$actualUser,
-			$actualPassword
+			$actualPassword,
 		);
 	}
 
@@ -936,7 +936,7 @@ trait Provisioning {
 			HttpRequestHelper::get(
 				$url,
 				$user,
-				$password
+				$password,
 			);
 			return;
 		}
@@ -968,7 +968,7 @@ trait Provisioning {
 		?string $displayName = null,
 		?string $email = null,
 		?string $userId = null,
-		bool $shouldExist = true
+		bool $shouldExist = true,
 	): void {
 		$user = $this->getActualUsername($user);
 		$normalizedUsername = $this->normalizeUsername($user);
@@ -997,7 +997,7 @@ trait Provisioning {
 	 */
 	public function rememberUserPassword(
 		string $user,
-		string $password
+		string $password,
 	): void {
 		$normalizedUsername = $this->normalizeUsername($user);
 		if (\array_key_exists($normalizedUsername, $this->createdUsers)) {
@@ -1055,7 +1055,7 @@ trait Provisioning {
 	 */
 	public function userHasBeenCreated(
 		array $userData,
-		string $byUser = null
+		string $byUser = null,
 	): void {
 		$userId = null;
 
@@ -1095,7 +1095,7 @@ trait Provisioning {
 				$this->createLdapUser($setting);
 			} catch (LdapException $exception) {
 				throw new Exception(
-					__METHOD__ . " cannot create a LDAP user with provided data. Error: $exception"
+					__METHOD__ . " cannot create a LDAP user with provided data. Error: $exception",
 				);
 			}
 		} else {
@@ -1113,7 +1113,7 @@ trait Provisioning {
 				201,
 				$response->getStatusCode(),
 				__METHOD__ . " cannot create user '$user' using Graph API.\nResponse:" .
-				json_encode($this->getJsonDecodedResponse($response))
+				json_encode($this->getJsonDecodedResponse($response)),
 			);
 			$userId = $this->getJsonDecodedResponse($response)['id'];
 		}
@@ -1122,7 +1122,7 @@ trait Provisioning {
 
 		Assert::assertTrue(
 			$this->userExists($user),
-			"User '$user' should exist but does not exist"
+			"User '$user' should exist but does not exist",
 		);
 
 		$this->initializeUser($user, $password);
@@ -1146,14 +1146,14 @@ trait Provisioning {
 				$group,
 				$this->getAdminUsername(),
 				$this->getAdminPassword(),
-				$this->ocsApiVersion
+				$this->ocsApiVersion,
 			);
 		} else {
 			$this->setResponse(
 				$this->graphContext->removeUserFromGroup(
 					$group,
-					$user
-				)
+					$user,
+				),
 			);
 		}
 
@@ -1179,7 +1179,7 @@ trait Provisioning {
 				$expectedGroups,
 				$respondedArray,
 				__METHOD__
-				. " Provided groups do not match the groups returned in the response."
+				. " Provided groups do not match the groups returned in the response.",
 			);
 		} else {
 			$this->graphContext->theseGroupsShouldBeInTheResponse($groupsSimplified);
@@ -1207,7 +1207,7 @@ trait Provisioning {
 		} catch (Exception $e) {
 			\error_log(
 				"INFORMATION: There was an unexpected problem trying to delete group " .
-				"'$group' message '" . $e->getMessage() . "'"
+				"'$group' message '" . $e->getMessage() . "'",
 			);
 		}
 
@@ -1217,7 +1217,7 @@ trait Provisioning {
 			\error_log(
 				"INFORMATION: tried to delete group '$group'" .
 				" at the end of the scenario but it seems to still exist. " .
-				"There might be problems with later scenarios."
+				"There might be problems with later scenarios.",
 			);
 		}
 	}
@@ -1245,7 +1245,7 @@ trait Provisioning {
 		$response = HttpRequestHelper::get(
 			$fullUrl,
 			$requestingUser,
-			$requestingPassword
+			$requestingPassword,
 		);
 		if ($response->getStatusCode() >= 400) {
 			return false;
@@ -1273,7 +1273,7 @@ trait Provisioning {
 				$respondedArray,
 				__METHOD__ . " Group '$group' does not exist in '"
 				. \implode(', ', $respondedArray)
-				. "'"
+				. "'",
 			);
 			Assert::assertEquals(
 				200,
@@ -1281,12 +1281,12 @@ trait Provisioning {
 				__METHOD__
 				. " Expected status code is '200' but got '"
 				. $this->response->getStatusCode()
-				. "'"
+				. "'",
 			);
 		} else {
 			$this->graphContext->userShouldBeMemberInGroupUsingTheGraphApi(
 				$user,
-				$group
+				$group,
 			);
 		}
 	}
@@ -1310,14 +1310,14 @@ trait Provisioning {
 				$response = HttpRequestHelper::get(
 					$fullUrl,
 					$this->getAdminUsername(),
-					$this->getAdminPassword()
+					$this->getAdminPassword(),
 				);
 				$respondedArray = $this->getArrayOfGroupsResponded($response);
 				\sort($respondedArray);
 				Assert::assertNotContains($group, $respondedArray);
 				Assert::assertEquals(
 					200,
-					$response->getStatusCode()
+					$response->getStatusCode(),
 				);
 			} else {
 				$this->graphContext->userShouldNotBeMemberInGroupUsingTheGraphApi($user, $group);
@@ -1339,7 +1339,7 @@ trait Provisioning {
 		$response = HttpRequestHelper::get(
 			$fullUrl,
 			$this->getAdminUsername(),
-			$this->getAdminPassword()
+			$this->getAdminPassword(),
 		);
 		Assert::assertNotContains($username, $this->getArrayOfUsersResponded($response));
 	}
@@ -1373,11 +1373,11 @@ trait Provisioning {
 			try {
 				$this->addUserToLdapGroup(
 					$user,
-					$group
+					$group,
 				);
 			} catch (LdapException $exception) {
 				throw new Exception(
-					"User $user cannot be added to $group Error: $exception"
+					"User $user cannot be added to $group Error: $exception",
 				);
 			}
 		} else {
@@ -1404,11 +1404,11 @@ trait Provisioning {
 				try {
 					$this->addUserToLdapGroup(
 						$user,
-						$group
+						$group,
 					);
 				} catch (LdapException $exception) {
 					throw new Exception(
-						"User $user cannot be added to $group Error: $exception"
+						"User $user cannot be added to $group Error: $exception",
 					);
 				}
 			} else {
@@ -1430,7 +1430,7 @@ trait Provisioning {
 		string $group,
 		bool $shouldExist = true,
 		bool $possibleToDelete = true,
-		?string $id = null
+		?string $id = null,
 	): void {
 		$groupData = [
 			"shouldExist" => $shouldExist,
@@ -1477,7 +1477,7 @@ trait Provisioning {
 		$this->createTheGroup($group);
 		Assert::assertTrue(
 			$this->groupExists($group),
-			"Group '$group' should exist but does not exist"
+			"Group '$group' should exist but does not exist",
 		);
 	}
 
@@ -1523,7 +1523,7 @@ trait Provisioning {
 					$this->createLdapGroup($group);
 				} catch (LdapException $e) {
 					throw new Exception(
-						"could not create group '$group'. Error: $e"
+						"could not create group '$group'. Error: $e",
 					);
 				}
 				break;
@@ -1537,7 +1537,7 @@ trait Provisioning {
 				break;
 			default:
 				throw new InvalidArgumentException(
-					"Invalid method to create group '$group'"
+					"Invalid method to create group '$group'",
 				);
 		}
 
@@ -1557,7 +1557,7 @@ trait Provisioning {
 		string $attribute,
 		string $entry,
 		string $value,
-		bool $append = false
+		bool $append = false,
 	): void {
 		$ldapEntry = $this->ldap->getEntry($entry . "," . $this->ldapBaseDN);
 		Laminas\Ldap\Attribute::setAttribute($ldapEntry, $attribute, $value, $append);
@@ -1588,7 +1588,7 @@ trait Provisioning {
 			$memberAttr,
 			"cn=$group,ou=$ou",
 			$memberValue,
-			true
+			true,
 		);
 	}
 
@@ -1602,7 +1602,7 @@ trait Provisioning {
 	public function deleteValueFromLdapAttribute(string $value, string $attribute, string $entry): void {
 		$this->ldap->deleteAttributes(
 			$entry . "," . $this->ldapBaseDN,
-			[$attribute => [$value]]
+			[$attribute => [$value]],
 		);
 	}
 
@@ -1629,7 +1629,7 @@ trait Provisioning {
 		$this->deleteValueFromLdapAttribute(
 			$memberValue,
 			$memberAttr,
-			"cn=$group,ou=$ou"
+			"cn=$group,ou=$ou",
 		);
 	}
 
@@ -1673,7 +1673,7 @@ trait Provisioning {
 	public function deleteLdapUser(?string $username, ?string $ou = null): void {
 		if (!\in_array($username, $this->ldapCreatedUsers)) {
 			throw new Error(
-				"User " . $username . " was not created using Ldap and does not exist as an Ldap User"
+				"User " . $username . " was not created using Ldap and does not exist as an Ldap User",
 			);
 		}
 		if ($ou === null) {
@@ -1708,7 +1708,7 @@ trait Provisioning {
 				null,
 				null,
 				null,
-				false
+				false,
 			);
 		}
 		Assert::assertEquals(
@@ -1734,7 +1734,7 @@ trait Provisioning {
 				$user,
 				$this->getAdminUsername(),
 				$this->getAdminPassword(),
-				$this->ocsApiVersion
+				$this->ocsApiVersion,
 			);
 		} else {
 			// users can be deleted using the username in the GraphApi too
@@ -1765,7 +1765,7 @@ trait Provisioning {
 		$this->rememberThatGroupIsNotExpectedToExist($group);
 		Assert::assertFalse(
 			$this->groupExists($group),
-			"Group '$group' should not exist but does exist"
+			"Group '$group' should not exist but does exist",
 		);
 	}
 
@@ -1790,7 +1790,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl,
 			$this->getAdminUsername(),
-			$this->getAdminPassword()
+			$this->getAdminPassword(),
 		);
 		if ($this->response->getStatusCode() >= 400) {
 			return false;
@@ -1824,14 +1824,14 @@ trait Provisioning {
 			$response = HttpRequestHelper::get(
 				$fullUrl,
 				$this->getAdminUsername(),
-				$this->getAdminPassword()
+				$this->getAdminPassword(),
 			);
 			$respondedArray = $this->getArrayOfGroupsResponded($response);
 			\sort($respondedArray);
 			Assert::assertNotContains($group, $respondedArray);
 			Assert::assertEquals(
 				200,
-				$response->getStatusCode()
+				$response->getStatusCode(),
 			);
 		} else {
 			$this->graphContext->userShouldNotBeMemberInGroupUsingTheGraphApi($user, $group);
@@ -1853,7 +1853,7 @@ trait Provisioning {
 			function ($user) {
 				return $this->getActualUsername($user);
 			},
-			$this->simplifyArray($users)
+			$this->simplifyArray($users),
 		);
 		if ($this->isTestingWithLdap()) {
 			$respondedArray = $this->getArrayOfUsersResponded($this->response);
@@ -1861,7 +1861,7 @@ trait Provisioning {
 				$usersSimplified,
 				$respondedArray,
 				__METHOD__
-				. " Provided users do not match the users returned in the response."
+				. " Provided users do not match the users returned in the response.",
 			);
 		} else {
 			$this->graphContext->theseUsersShouldBeInTheResponse($usersSimplified);
@@ -1918,7 +1918,7 @@ trait Provisioning {
 		$responseData = HttpRequestHelper::getResponseXml($this->response, __METHOD__)->data[0];
 		Assert::assertEmpty(
 			$responseData,
-			"Response data is not empty but it should be empty"
+			"Response data is not empty but it should be empty",
 		);
 	}
 
@@ -1959,7 +1959,7 @@ trait Provisioning {
 			$this->theHTTPStatusCodeShouldBe(204, "Failed to delete user '$user'", $response);
 			Assert::assertFalse(
 				$this->userExists($user),
-				"User '$user' should not exist but does exist"
+				"User '$user' should not exist but does exist",
 			);
 		}
 		$this->usingServer($previousServer);
@@ -2026,7 +2026,7 @@ trait Provisioning {
 		return HttpRequestHelper::put(
 			$fullUrl,
 			$actualUser,
-			$actualPassword
+			$actualPassword,
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/bootstrap/PublicWebDavContext.php
@@ -56,7 +56,7 @@ class PublicWebDavContext implements Context {
 		return $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
-			$range
+			$range,
 		);
 	}
 
@@ -94,7 +94,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function userTriesToDownloadFileFromPublicLinkUsingBasicAuthAndPublicWebdav(
 		string $user,
-		string $path
+		string $path,
 	): void {
 		$response = $this->downloadFromPublicLinkAsUser($path, $user);
 		$this->featureContext->setResponse($response);
@@ -108,10 +108,10 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicDeletesFileFolderFromTheLastPublicLinkShareUsingThePublicWebdavApi(
-		string $fileName
+		string $fileName,
 	): void {
 		$response = $this->deleteFileFromPublicShare(
-			$fileName
+			$fileName,
 		);
 		$this->featureContext->setResponse($response);
 		$this->featureContext->pushToLastStatusCodesArrays();
@@ -130,13 +130,13 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_NEW,
 			$token,
-			"public-files"
+			"public-files",
 		);
 		$password = $this->featureContext->getActualPassword($password);
 		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath/$fileName";
 		$userName = $this->getUsernameForPublicWebdavApi(
 			$token,
-			$password
+			$password,
 		);
 		$headers = [
 			'X-Requested-With' => 'XMLHttpRequest',
@@ -145,7 +145,7 @@ class PublicWebDavContext implements Context {
 			$fullUrl,
 			$userName,
 			$password,
-			$headers
+			$headers,
 		);
 	}
 
@@ -159,7 +159,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function thePublicHasDeletedFileFromTheLastLinkShareWithPasswordUsingPublicWebdavApi(
 		string $file,
-		string $password
+		string $password,
 	): void {
 		$response = $this->deleteFileFromPublicShare($file, $password);
 		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
@@ -175,10 +175,10 @@ class PublicWebDavContext implements Context {
 	 */
 	public function thePublicDeletesFileFromTheLastLinkShareWithPasswordUsingPublicWebdavApi(
 		string $file,
-		string $password
+		string $password,
 	): void {
 		$this->featureContext->setResponse(
-			$this->deleteFileFromPublicShare($file, $password)
+			$this->deleteFileFromPublicShare($file, $password),
 		);
 		$this->featureContext->pushToLastStatusCodesArrays();
 	}
@@ -193,7 +193,7 @@ class PublicWebDavContext implements Context {
 	public function renameFileFromPublicShare(
 		string $fileName,
 		string $toFileName,
-		?string $password = ""
+		?string $password = "",
 	): ResponseInterface {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -201,14 +201,14 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_NEW,
 			$token,
-			"public-files"
+			"public-files",
 		);
 		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath/$fileName";
 		$password = $this->featureContext->getActualPassword($password);
 		$destination = $this->featureContext->getBaseUrl() . "/$davPath/$toFileName";
 		$userName = $this->getUsernameForPublicWebdavApi(
 			$token,
-			$password
+			$password,
 		);
 		$headers = [
 			'X-Requested-With' => 'XMLHttpRequest',
@@ -219,7 +219,7 @@ class PublicWebDavContext implements Context {
 			"MOVE",
 			$userName,
 			$password,
-			$headers
+			$headers,
 		);
 	}
 
@@ -235,10 +235,10 @@ class PublicWebDavContext implements Context {
 	public function thePublicRenamesFileFromTheLastPublicShareUsingThePasswordPasswordAndOldPublicWebdavApi(
 		string $fileName,
 		string $toName,
-		string $password
+		string $password,
 	): void {
 		$this->featureContext->setResponse(
-			$this->renameFileFromPublicShare($fileName, $toName, $password)
+			$this->renameFileFromPublicShare($fileName, $toName, $password),
 		);
 		$this->featureContext->pushToLastStatusCodesArrays();
 	}
@@ -254,13 +254,13 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publicDownloadsFileFromInsideLastPublicSharedFolderWithPassword(
 		string $path,
-		string $password = ""
+		string $password = "",
 	): void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			"",
-			$this->featureContext->isUsingSharingNG()
+			$this->featureContext->isUsingSharingNG(),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -280,7 +280,7 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			$this->featureContext->getDavPathVersion(),
 			$token,
-			"public-files"
+			"public-files",
 		);
 
 		$username = $this->featureContext->getActualUsername($user);
@@ -290,7 +290,7 @@ class PublicWebDavContext implements Context {
 		return HttpRequestHelper::get(
 			$fullUrl,
 			$username,
-			$password
+			$password,
 		);
 	}
 	/**
@@ -305,7 +305,7 @@ class PublicWebDavContext implements Context {
 		string $path,
 		string $password,
 		string $range,
-		bool $shareNg = false
+		bool $shareNg = false,
 	): ResponseInterface {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
@@ -317,12 +317,12 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_NEW,
 			$token,
-			"public-files"
+			"public-files",
 		);
 		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath/$path";
 		$userName = $this->getUsernameForPublicWebdavApi(
 			$token,
-			$password
+			$password,
 		);
 
 		$headers = [
@@ -335,7 +335,7 @@ class PublicWebDavContext implements Context {
 			$fullUrl,
 			$userName,
 			$password,
-			$headers
+			$headers,
 		);
 	}
 
@@ -348,7 +348,7 @@ class PublicWebDavContext implements Context {
 		return $this->publicUploadContent(
 			\basename($source),
 			'',
-			\file_get_contents($source)
+			\file_get_contents($source),
 		);
 	}
 
@@ -367,11 +367,11 @@ class PublicWebDavContext implements Context {
 	public function publiclyCopyingFile(
 		string $baseUrl,
 		string $source,
-		string $destination
+		string $destination,
 	): ResponseInterface {
 		$fullSourceUrl = "$baseUrl/$source";
 		$fullDestUrl = WebDavHelper::sanitizeUrl(
-			"$baseUrl/$destination"
+			"$baseUrl/$destination",
 		);
 
 		$headers["Destination"] = $fullDestUrl;
@@ -380,7 +380,7 @@ class PublicWebDavContext implements Context {
 			"COPY",
 			null,
 			null,
-			$headers
+			$headers,
 		);
 	}
 
@@ -399,14 +399,14 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_NEW,
 			$token,
-			"public-files"
+			"public-files",
 		);
 		$baseUrl = $this->featureContext->getLocalBaseUrl() . '/' . $davPath;
 
 		$response = $this->publiclyCopyingFile(
 			$baseUrl,
 			$source,
-			$destination
+			$destination,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -447,7 +447,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function thePublicHasUploadedFileWithContentWithAutoRenameMode(
 		string $filename,
-		string $body = 'test'
+		string $body = 'test',
 	): void {
 		$response = $this->publiclyUploadingContentAutoRename($filename, $body);
 		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
@@ -486,7 +486,7 @@ class PublicWebDavContext implements Context {
 	public function thePublicHasUploadedFileWithContentAndPasswordToLastLinkShareUsingPublicWebdavApi(
 		string $filename,
 		string $content = 'test',
-		string $password = ''
+		string $password = '',
 	): void {
 		$response = $this->publiclyUploadingContentWithPassword(
 			$filename,
@@ -513,7 +513,7 @@ class PublicWebDavContext implements Context {
 		$response = $this->publiclyUploadingContentWithPassword(
 			$filename,
 			$password,
-			$body
+			$body,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -541,7 +541,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function thePublicUploadsFileWithContentUsingThePublicWebDavApi(
 		string $filename,
-		string $body = 'test'
+		string $body = 'test',
 	): void {
 		$response = $this->publicUploadContent($filename, '', $body);
 		$this->featureContext->setResponse($response);
@@ -572,11 +572,11 @@ class PublicWebDavContext implements Context {
 	 */
 	public function checkLastPublicSharedFileWithPasswordDownload(
 		string $password,
-		string $expectedContent
+		string $expectedContent,
 	): void {
 		$response = $this->downloadPublicFileWithRange(
 			"",
-			$password
+			$password,
 		);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -584,7 +584,7 @@ class PublicWebDavContext implements Context {
 		$this->featureContext->checkDownloadedContentMatches(
 			$expectedContent,
 			"Checking the content of the last public shared file after downloading with the public WebDAV API",
-			$response
+			$response,
 		);
 	}
 
@@ -599,13 +599,13 @@ class PublicWebDavContext implements Context {
 	 */
 	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolder(
 		string $path,
-		string $expectedHttpCode = "401"
+		string $expectedHttpCode = "401",
 	): void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			"",
 			"",
-			$this->featureContext->isUsingSharingNG()
+			$this->featureContext->isUsingSharingNG(),
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe($expectedHttpCode, "", $response);
 	}
@@ -620,13 +620,13 @@ class PublicWebDavContext implements Context {
 	 */
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
 		string $path,
-		string $password
+		string $password,
 	): void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			"",
-			$this->featureContext->isUsingSharingNG()
+			$this->featureContext->isUsingSharingNG(),
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 	}
@@ -644,7 +644,7 @@ class PublicWebDavContext implements Context {
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordAndContentShouldBe(
 		string $path,
 		string $password,
-		string $content
+		string $content,
 	): void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
@@ -669,13 +669,13 @@ class PublicWebDavContext implements Context {
 	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordForSharingNGAndContentShouldBe(
 		string $path,
 		string $password,
-		string $content
+		string $content,
 	): void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			"",
-			true
+			true,
 		);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -695,13 +695,13 @@ class PublicWebDavContext implements Context {
 	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
 		string $path,
 		string $password,
-		string $expectedHttpCode = "401"
+		string $expectedHttpCode = "401",
 	): void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			"",
-			$this->featureContext->isUsingSharingNG()
+			$this->featureContext->isUsingSharingNG(),
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe($expectedHttpCode, "", $response);
 	}
@@ -718,14 +718,14 @@ class PublicWebDavContext implements Context {
 	public function shouldNotBeAbleToDownloadFileWithPasswordForShareNg(
 		string $path,
 		string $password,
-		string $expectedHttpCode = "401"
+		string $expectedHttpCode = "401",
 	): void {
 		$this->tryingToDownloadUsingWebDAVAPI(
 			$path,
 			"new",
 			$password,
 			$expectedHttpCode,
-			true
+			true,
 		);
 	}
 
@@ -743,13 +743,13 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $range = "",
 		string $expectedHttpCode = "401",
-		bool $shareNg = false
+		bool $shareNg = false,
 	): void {
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
 			$range,
-			$shareNg
+			$shareNg,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe($expectedHttpCode, "", $response);
 	}
@@ -765,13 +765,13 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publiclyUploadingShouldToSharedFileShouldFail(
 		string $password,
-		string $expectedHttpCode
+		string $expectedHttpCode,
 	): void {
 		$filename = (string)$this->featureContext->getLastCreatedPublicShare()->file_target;
 
 		$response = $this->publicUploadContent(
 			$filename,
-			$password
+			$password,
 		);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe($expectedHttpCode, "", $response);
@@ -787,16 +787,16 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publiclyUploadingWithPasswordShouldNotWork(
 		string $password,
-		string $expectedHttpCode = null
+		string $expectedHttpCode = null,
 	): void {
 		$response = $this->publicUploadContent(
 			'whateverfilefortesting.txt',
-			$password
+			$password,
 		);
 		Assert::assertGreaterThanOrEqual(
 			$expectedHttpCode,
 			$response->getStatusCode(),
-			"upload should have failed but passed with code " . $response->getStatusCode()
+			"upload should have failed but passed with code " . $response->getStatusCode(),
 		);
 	}
 
@@ -810,11 +810,11 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publiclyUploadingIntoFolderWithPasswordShouldWork(
 		string $filename,
-		string $password
+		string $password,
 	): void {
 		$response = $this->publicUploadContent(
 			$filename,
-			$password
+			$password,
 		);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe([201, 204], "", $response);
@@ -841,12 +841,12 @@ class PublicWebDavContext implements Context {
 		Assert::assertTrue(
 			($response->getStatusCode() === 201),
 			"upload should have passed but failed with code " .
-			$response->getStatusCode()
+			$response->getStatusCode(),
 		);
 		$response = $this->downloadFileFromPublicFolder(
 			$path,
 			$password,
-			""
+			"",
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->featureContext->checkDownloadedContentMatches($content, "", $response);
@@ -872,31 +872,31 @@ class PublicWebDavContext implements Context {
 		$response = $this->publicUploadContent(
 			$path,
 			$password,
-			$content
+			$content,
 		);
 		if ($should) {
 			Assert::assertTrue(
 				($response->getStatusCode() == 204),
 				"upload should have passed but failed with code " .
-				$response->getStatusCode()
+				$response->getStatusCode(),
 			);
 
 			$response = $this->downloadPublicFileWithRange(
 				"",
-				$password
+				$password,
 			);
 
 			$this->featureContext->checkDownloadedContentMatches(
 				$content,
 				"Checking the content of the last public shared file after downloading with the public WebDAV API",
-				$response
+				$response,
 			);
 		} else {
 			$expectedCode = 403;
 			Assert::assertTrue(
 				($response->getStatusCode() == $expectedCode),
 				"upload should have failed with HTTP status $expectedCode but passed with code " .
-				$response->getStatusCode()
+				$response->getStatusCode(),
 			);
 		}
 	}
@@ -914,12 +914,12 @@ class PublicWebDavContext implements Context {
 		string $destination,
 	): void {
 		$content = \file_get_contents(
-			$this->featureContext->acceptanceTestsDirLocation() . $source
+			$this->featureContext->acceptanceTestsDirLocation() . $source,
 		);
 		$response = $this->publicUploadContent(
 			$destination,
 			'',
-			$content
+			$content,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -937,15 +937,15 @@ class PublicWebDavContext implements Context {
 	public function thePublicUploadsFileToInsideLastLinkSharedFolderWithPasswordUsingThePublicWebdavApi(
 		string $source,
 		string $destination,
-		string $password
+		string $password,
 	): void {
 		$content = \file_get_contents(
-			$this->featureContext->acceptanceTestsDirLocation() . $source
+			$this->featureContext->acceptanceTestsDirLocation() . $source,
 		);
 		$response = $this->publicUploadContent(
 			$destination,
 			$password,
-			$content
+			$content,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -963,7 +963,7 @@ class PublicWebDavContext implements Context {
 	public function thePublicUploadsFileToLastSharedFolderWithMtimeUsingTheWebdavApi(
 		string $fileName,
 		string $password,
-		string $mtime
+		string $mtime,
 	): void {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
@@ -973,7 +973,7 @@ class PublicWebDavContext implements Context {
 			$password,
 			'test',
 			false,
-			["X-OC-Mtime" => $mtime]
+			["X-OC-Mtime" => $mtime],
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -986,7 +986,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publicCreatesFolderUsingPassword(
 		string $destination,
-		string $password
+		string $password,
 	): ResponseInterface {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -994,17 +994,17 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			$this->featureContext->getDavPathVersion(),
 			$token,
-			"public-files"
+			"public-files",
 		);
 		$url = $this->featureContext->getBaseUrl() . "/$davPath/";
 		$password = $this->featureContext->getActualPassword($password);
 		$userName = $this->getUsernameForPublicWebdavApi(
 			$token,
-			$password
+			$password,
 		);
 		$foldername = \implode(
 			'/',
-			\array_map('rawurlencode', \explode('/', $destination))
+			\array_map('rawurlencode', \explode('/', $destination)),
 		);
 		$url .= \ltrim($foldername, '/');
 
@@ -1012,7 +1012,7 @@ class PublicWebDavContext implements Context {
 			$url,
 			'MKCOL',
 			$userName,
-			$password
+			$password,
 		);
 	}
 
@@ -1037,7 +1037,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publicShouldBeAbleToCreateFolderWithPassword(
 		string $foldername,
-		string $password
+		string $password,
 	): void {
 		$response = $this->publicCreatesFolderUsingPassword($foldername, $password);
 		$this->featureContext->theHTTPStatusCodeShouldBe(201, "", $response);
@@ -1055,14 +1055,14 @@ class PublicWebDavContext implements Context {
 	public function publicCreationOfFolderWithPasswordShouldFail(
 		string $foldername,
 		string $password,
-		string $expectedHttpCode
+		string $expectedHttpCode,
 	): void {
 		$response = $this->publicCreatesFolderUsingPassword($foldername, $password);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHttpCode,
 			"creation of $foldername in the last publicly shared folder should have failed with code " .
 			$expectedHttpCode,
-			$response
+			$response,
 		);
 	}
 
@@ -1077,7 +1077,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function theMtimeOfFileInTheLastSharedPublicLinkUsingTheWebdavApiShouldBe(
 		string $fileName,
-		string $mtime
+		string $mtime,
 	): void {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -1092,7 +1092,7 @@ class PublicWebDavContext implements Context {
 				$baseUrl,
 				$fileName,
 				$token,
-			)
+			),
 		);
 	}
 
@@ -1107,7 +1107,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function theMtimeOfFileInTheLastSharedPublicLinkUsingTheWebdavApiShouldNotBe(
 		string $fileName,
-		string $mtime
+		string $mtime,
 	): void {
 		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
@@ -1117,7 +1117,7 @@ class PublicWebDavContext implements Context {
 				$baseUrl,
 				$fileName,
 				$token,
-			)
+			),
 		);
 	}
 
@@ -1148,16 +1148,16 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_NEW,
 			$token,
-			"public-files"
+			"public-files",
 		);
 		$userName = $this->getUsernameForPublicWebdavApi(
 			$token,
-			$password
+			$password,
 		);
 
 		$filename = \implode(
 			'/',
-			\array_map('rawurlencode', \explode('/', $filename))
+			\array_map('rawurlencode', \explode('/', $filename)),
 		);
 		$encodedFilePath = \ltrim($filename, '/');
 		$url = $this->featureContext->getBaseUrl() . "/$davPath/$encodedFilePath";
@@ -1176,7 +1176,7 @@ class PublicWebDavContext implements Context {
 			$userName,
 			$password,
 			$headers,
-			$body
+			$body,
 		);
 	}
 
@@ -1188,7 +1188,7 @@ class PublicWebDavContext implements Context {
 	 */
 	private function getUsernameForPublicWebdavApi(
 		string $token,
-		string $password
+		string $password,
 	): ?string {
 		if ($password !== '') {
 			$userName = 'public';
@@ -1243,12 +1243,12 @@ class PublicWebDavContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_NEW,
 			$token,
-			"public-files"
+			"public-files",
 		);
 		$password = $this->featureContext->getActualPassword($password);
 		$username = $this->getUsernameForPublicWebdavApi(
 			$token,
-			$password
+			$password,
 		);
 		$fullUrl = $this->featureContext->getBaseUrl() . "/$davPath";
 		$response = HttpRequestHelper::sendRequest(
@@ -1257,7 +1257,7 @@ class PublicWebDavContext implements Context {
 			$username,
 			$password,
 			null,
-			$body
+			$body,
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/bootstrap/SearchContext.php
+++ b/tests/acceptance/bootstrap/SearchContext.php
@@ -57,7 +57,7 @@ class SearchContext implements Context {
 		?string $scopeType = null,
 		?string $scope = null,
 		?string $spaceName = null,
-		?TableNode $properties = null
+		?TableNode $properties = null,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
@@ -87,7 +87,7 @@ class SearchContext implements Context {
 				$resourceID = $this->featureContext->spacesContext->getResourceId(
 					$user,
 					$spaceName ?? "Personal",
-					$scope
+					$scope,
 				);
 				$pattern .= " scope:$resourceID";
 			}
@@ -122,7 +122,7 @@ class SearchContext implements Context {
 			$user,
 			$password,
 			null,
-			$body
+			$body,
 		);
 	}
 
@@ -144,7 +144,7 @@ class SearchContext implements Context {
 		string $user,
 		string $pattern,
 		?string $limit = null,
-		?TableNode $properties = null
+		?TableNode $properties = null,
 	): void {
 		// NOTE: because indexing of newly uploaded files or directories with ocis is decoupled and occurs asynchronously
 		// short wait is necessary before searching
@@ -166,28 +166,28 @@ class SearchContext implements Context {
 	public function fileOrFolderInTheSearchResultShouldContainProperties(
 		string $path,
 		string $user,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->featureContext->verifyTableNodeColumns($properties, ['name', 'value']);
 		$properties = $properties->getHash();
 		$fileResult = $this->featureContext->findEntryFromSearchResponse(
-			$path
+			$path,
 		);
 		Assert::assertNotFalse(
 			$fileResult,
-			"could not find file/folder '$path'"
+			"could not find file/folder '$path'",
 		);
 		foreach ($properties as $property) {
 			$property['value'] = $this->featureContext->substituteInLineCodes(
 				$property['value'],
-				$user
+				$user,
 			);
 			$fileResultProperty = $fileResult->xpath("d:propstat//" . $property['name']);
 			if ($fileResultProperty) {
 				Assert::assertMatchesRegularExpression(
 					"/" . $property['value'] . "/",
-					\trim((string)$fileResultProperty[0])
+					\trim((string)$fileResultProperty[0]),
 				);
 				continue;
 			}
@@ -224,13 +224,13 @@ class SearchContext implements Context {
 	 */
 	public function theSearchResultShouldContainEntriesWithHighlight(
 		TableNode $expectedFiles,
-		string $expectedContent
+		string $expectedContent,
 	): void {
 		$this->featureContext->verifyTableNodeColumnsCount($expectedFiles, 1);
 		$elementRows = $expectedFiles->getRows();
 		$foundEntries = $this->featureContext->findEntryFromSearchResponse(
 			null,
-			true
+			true,
 		);
 		foreach ($elementRows as $expectedFile) {
 			$filename = $expectedFile[0];
@@ -244,7 +244,7 @@ class SearchContext implements Context {
 			Assert::assertEquals(
 				$expectedContent,
 				$actualContent,
-				"Expected text highlight to be '$expectedContent' but found '$actualContent'"
+				"Expected text highlight to be '$expectedContent' but found '$actualContent'",
 			);
 		}
 	}

--- a/tests/acceptance/bootstrap/SettingsContext.php
+++ b/tests/acceptance/bootstrap/SettingsContext.php
@@ -57,7 +57,7 @@ class SettingsContext implements Context {
 		return SettingsHelper::getRolesList(
 			$this->featureContext->getBaseUrl(),
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 	}
 
@@ -132,7 +132,7 @@ class SettingsContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201",
-			$response
+			$response,
 		);
 	}
 
@@ -150,12 +150,12 @@ class SettingsContext implements Context {
 	public function userAssignsTheRoleToUserUsingTheSettingsApi(
 		string $assigner,
 		string $role,
-		string $assignee
+		string $assignee,
 	): void {
 		$response = $this->assignRoleToUser(
 			$assigner,
 			$this->featureContext->getAttributeOfCreatedUser($assignee, 'id'),
-			$this->getRoleIdByRoleName($assigner, $role)
+			$this->getRoleIdByRoleName($assigner, $role),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -175,7 +175,7 @@ class SettingsContext implements Context {
 			$this->featureContext->theHTTPStatusCodeShouldBe(
 				201,
 				"Expected response status code should be 201",
-				$response
+				$response,
 			);
 
 			$rawBody = $response->getBody()->getContents();
@@ -201,7 +201,7 @@ class SettingsContext implements Context {
 		Assert::assertArrayHasKey(
 			'bundles',
 			$decodedBody,
-			__METHOD__ . " could not find bundles in body"
+			__METHOD__ . " could not find bundles in body",
 		);
 		$bundles = $decodedBody["bundles"];
 
@@ -287,7 +287,7 @@ class SettingsContext implements Context {
 			Assert::assertEquals(
 				$this->getRoleIdByRoleName($this->featureContext->getAdminUserName(), $role),
 				$actualRoleId,
-				"user $user has no role $role"
+				"user $user has no role $role",
 			);
 		} else {
 			Assert::fail("Response should contain user role but not found.\n" . json_encode($assignmentResponse));
@@ -305,12 +305,12 @@ class SettingsContext implements Context {
 	 */
 	public function theSettingApiResponseShouldHaveTheRole(string $role): void {
 		$assignmentRoleId = $this->featureContext->getJsonDecodedResponse(
-			$this->featureContext->getResponse()
+			$this->featureContext->getResponse(),
 		)["assignments"][0]["roleId"];
 		Assert::assertEquals(
 			$this->getRoleIdByRoleName($this->featureContext->getAdminUserName(), $role),
 			$assignmentRoleId,
-			"user has no role $role"
+			"user has no role $role",
 		);
 	}
 
@@ -362,7 +362,7 @@ class SettingsContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$headers
+			$headers,
 		);
 	}
 
@@ -380,7 +380,7 @@ class SettingsContext implements Context {
 	public function theUserListsAllValuesListWithHeadersUsingSettingsApi(string $user, TableNode $headersTable): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$headersTable,
-			['header', 'value']
+			['header', 'value'],
 		);
 		$headers = [];
 		foreach ($headersTable as $row) {
@@ -431,7 +431,7 @@ class SettingsContext implements Context {
 					"settingId" => $settingId,
 				],
 			],
-			JSON_THROW_ON_ERROR
+			JSON_THROW_ON_ERROR,
 		);
 		return SettingsHelper::updateSettings(
 			$this->featureContext->getBaseUrl(),
@@ -457,7 +457,7 @@ class SettingsContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201",
-			$response
+			$response,
 		);
 	}
 
@@ -499,7 +499,7 @@ class SettingsContext implements Context {
 					"boolValue" => $status,
 				],
 			],
-			JSON_THROW_ON_ERROR
+			JSON_THROW_ON_ERROR,
 		);
 
 		return SettingsHelper::updateSettings(
@@ -526,7 +526,7 @@ class SettingsContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201",
-			$response
+			$response,
 		);
 		$this->featureContext->rememberUserAutoSyncSetting($user, false);
 	}
@@ -590,7 +590,7 @@ class SettingsContext implements Context {
 	public function enableOrDisableNotification(
 		string $user,
 		string $enableOrDisable,
-		array $event
+		array $event,
 	): ResponseInterface {
 		$body = [
 			"value" => [
@@ -638,7 +638,7 @@ class SettingsContext implements Context {
 	public function userHasEnabledOrDisabledNotificationForTheFollowingEventUsingTheSettingsApi(
 		string $user,
 		string $enableOrDisable,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$event = $table->getRowsHash();
 		$response = $this->enableOrDisableNotification($user, $enableOrDisable, $event);
@@ -657,7 +657,7 @@ class SettingsContext implements Context {
 	public function userEnablesOrDisablesNotificationForTheFollowingEventUsingTheSettingsApi(
 		string $user,
 		string $enableOrDisable,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$event = $table->getRowsHash();
 		$response = $this->enableOrDisableNotification($user, $enableOrDisable, $event);
@@ -757,14 +757,14 @@ class SettingsContext implements Context {
 			Assert::fail(
 				"Setting '$settingName' does not have a stringValue, boolValue or listValue."
 				. "\n"
-				. json_encode($setting)
+				. json_encode($setting),
 			);
 		}
 
 		Assert::assertSame(
 			$value,
 			$settingValue,
-			"Expected setting value '$value' but got '$settingValue'"
+			"Expected setting value '$value' but got '$settingValue'",
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/ShareesContext.php
+++ b/tests/acceptance/bootstrap/ShareesContext.php
@@ -50,8 +50,8 @@ class ShareesContext implements Context {
 		$this->featureContext->setResponse(
 			$this->getShareesWithParameters(
 				$this->featureContext->getCurrentUser(),
-				$body
-			)
+				$body,
+			),
 		);
 	}
 
@@ -67,8 +67,8 @@ class ShareesContext implements Context {
 		$this->featureContext->setResponse(
 			$this->getShareesWithParameters(
 				$user,
-				$body
-			)
+				$body,
+			),
 		);
 	}
 
@@ -86,12 +86,12 @@ class ShareesContext implements Context {
 		$sharees = $shareesList->getRows();
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(),
-			$shareeType
+			$shareeType,
 		);
 		Assert::assertEquals(
 			$sharees,
 			$respondedArray,
-			"Returned sharees do not match the expected ones. See the differences below."
+			"Returned sharees do not match the expected ones. See the differences below.",
 		);
 	}
 
@@ -109,13 +109,13 @@ class ShareesContext implements Context {
 		$sharees = $shareesList->getRows();
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(),
-			$shareeType
+			$shareeType,
 		);
 		foreach ($sharees as $sharee) {
 			Assert::assertContains(
 				$sharee,
 				$respondedArray,
-				"Returned sharees do not match the expected ones. See the differences below."
+				"Returned sharees do not match the expected ones. See the differences below.",
 			);
 		}
 	}
@@ -130,7 +130,7 @@ class ShareesContext implements Context {
 	public function theShareesReturnedShouldBeEmpty(string $shareeType): void {
 		$respondedArray = $this->getArrayOfShareesResponded(
 			$this->featureContext->getResponse(),
-			$shareeType
+			$shareeType,
 		);
 		if (isset($respondedArray[0])) {
 			// [0] is display name and [2] is user or group id
@@ -141,7 +141,7 @@ class ShareesContext implements Context {
 
 		Assert::assertEmpty(
 			$respondedArray,
-			"'$shareeType' array should be empty, but it starts with $firstEntry"
+			"'$shareeType' array should be empty, but it starts with $firstEntry",
 		);
 	}
 
@@ -154,7 +154,7 @@ class ShareesContext implements Context {
 	 */
 	public function getArrayOfShareesResponded(
 		ResponseInterface $response,
-		string $shareeType
+		string $shareeType,
 	): array {
 		$elements = HttpRequestHelper::getResponseXml($response, __METHOD__)->data;
 		$elements = \json_decode(\json_encode($elements), true);
@@ -166,7 +166,7 @@ class ShareesContext implements Context {
 		Assert::assertArrayHasKey(
 			$shareeType,
 			$elements,
-			__METHOD__ . " The sharees response does not have key '$shareeType'"
+			__METHOD__ . " The sharees response does not have key '$shareeType'",
 		);
 
 		$sharees = [];
@@ -215,7 +215,7 @@ class ShareesContext implements Context {
 		return $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			'GET',
-			$url
+			$url,
 		);
 	}
 

--- a/tests/acceptance/bootstrap/Sharing.php
+++ b/tests/acceptance/bootstrap/Sharing.php
@@ -223,7 +223,7 @@ trait Sharing {
 			throw new Error(
 				'Response did not contain share id '
 				. $lastResponse['link']['webUrl']
-				. ' for the created public link'
+				. ' for the created public link',
 			);
 		}
 		return substr(strrchr($lastResponse['link']['webUrl'], "/"), 1);
@@ -299,7 +299,7 @@ trait Sharing {
 			$permissions = \array_diff($permissions, ['change']);
 			$permissions = \array_merge(
 				$permissions,
-				['create', 'delete', 'read', 'update']
+				['create', 'delete', 'read', 'update'],
 			);
 		}
 
@@ -377,7 +377,7 @@ trait Sharing {
 		$this->verifyTableNodeRows(
 			$body,
 			['path'],
-			$this->shareFields
+			$this->shareFields,
 		);
 		$bodyRows = $body->getRowsHash();
 		$bodyRows['name'] = \array_key_exists('name', $bodyRows) ? $bodyRows['name'] : null;
@@ -385,11 +385,11 @@ trait Sharing {
 		$bodyRows['shareWith'] = $this->getActualUsername($bodyRows['shareWith']);
 		$bodyRows['publicUpload'] = \array_key_exists(
 			'publicUpload',
-			$bodyRows
+			$bodyRows,
 		) ? $bodyRows['publicUpload'] === 'true' : null;
 		$bodyRows['password'] = \array_key_exists(
 			'password',
-			$bodyRows
+			$bodyRows,
 		) ? $this->getActualPassword($bodyRows['password']) : null;
 
 		if (\array_key_exists('permissions', $bodyRows)) {
@@ -411,7 +411,7 @@ trait Sharing {
 
 		Assert::assertFalse(
 			isset($bodyRows['expireDate'], $bodyRows['expireDateAsString']),
-			'expireDate and expireDateAsString cannot be set at the same time.'
+			'expireDate and expireDateAsString cannot be set at the same time.',
 		);
 		$needToParse = \array_key_exists('expireDate', $bodyRows);
 		$expireDate = $bodyRows['expireDate'] ?? $bodyRows['expireDateAsString'] ?? null;
@@ -425,7 +425,7 @@ trait Sharing {
 			$bodyRows['password'],
 			$bodyRows['permissions'],
 			$bodyRows['name'],
-			$bodyRows['expireDate']
+			$bodyRows['expireDate'],
 		);
 	}
 
@@ -442,7 +442,7 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 		$response = $this->createShareWithSettings(
 			$user,
-			$body
+			$body,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -460,7 +460,7 @@ trait Sharing {
 	public function userHasCreatedAShareWithSettings(string $user, ?TableNode $body): void {
 		$response = $this->createShareWithSettings(
 			$user,
-			$body
+			$body,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
@@ -555,7 +555,7 @@ trait Sharing {
 		string $sharePassword = null,
 		$permissions = null,
 		?string $linkName = null,
-		?string $expireDate = null
+		?string $expireDate = null,
 	): ResponseInterface {
 		return $this->createShare(
 			$user,
@@ -566,7 +566,7 @@ trait Sharing {
 			$sharePassword,
 			$permissions,
 			$linkName,
-			$expireDate
+			$expireDate,
 		);
 	}
 
@@ -609,7 +609,7 @@ trait Sharing {
 	public function userCreatesAPublicLinkShareOfWithPermission(
 		string $user,
 		string $path,
-		$permissions
+		$permissions,
 	): void {
 		$response = $this->createAPublicShare($user, $path, true, null, $permissions);
 		$this->setResponse($response);
@@ -627,7 +627,7 @@ trait Sharing {
 	public function userHasCreatedAPublicLinkShareOfWithPermission(
 		string $user,
 		string $path,
-		$permissions
+		$permissions,
 	): void {
 		$response = $this->createAPublicShare($user, $path, true, null, $permissions);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -644,7 +644,7 @@ trait Sharing {
 	public function createPublicLinkShareOfResourceWithExpiry(
 		string $user,
 		string $path,
-		string $expiryDate
+		string $expiryDate,
 	): void {
 		$this->createAPublicShare(
 			$user,
@@ -653,7 +653,7 @@ trait Sharing {
 			null,
 			null,
 			null,
-			$expiryDate
+			$expiryDate,
 		);
 	}
 
@@ -669,12 +669,12 @@ trait Sharing {
 	public function userCreatesAPublicLinkShareOfWithExpiry(
 		string $user,
 		string $path,
-		string $expiryDate
+		string $expiryDate,
 	): void {
 		$this->createPublicLinkShareOfResourceWithExpiry(
 			$user,
 			$path,
-			$expiryDate
+			$expiryDate,
 		);
 	}
 
@@ -690,12 +690,12 @@ trait Sharing {
 	public function userHasCreatedAPublicLinkShareOfWithExpiry(
 		string $user,
 		string $path,
-		string $expiryDate
+		string $expiryDate,
 	): void {
 		$this->createPublicLinkShareOfResourceWithExpiry(
 			$user,
 			$path,
-			$expiryDate
+			$expiryDate,
 		);
 		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
@@ -717,7 +717,7 @@ trait Sharing {
 			__METHOD__
 			. " Expected response status code is '404' but got '"
 			. $this->ocsContext->getOCSResponseStatusCode($this->response)
-			. "'"
+			. "'",
 		);
 	}
 
@@ -790,7 +790,7 @@ trait Sharing {
 		string $user,
 		?TableNode $body,
 		?string $shareOwner = null,
-		?bool $updateLastPublicLink = false
+		?bool $updateLastPublicLink = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 
@@ -809,7 +809,7 @@ trait Sharing {
 		$this->verifyTableNodeRows(
 			$body,
 			[],
-			$this->shareFields
+			$this->shareFields,
 		);
 		$bodyRows = $body->getRowsHash();
 
@@ -831,7 +831,7 @@ trait Sharing {
 			"PUT",
 			$this->getSharesEndpointPath("/$share_id"),
 			$bodyRows,
-			$this->ocsApiVersion
+			$this->ocsApiVersion,
 		);
 	}
 
@@ -941,7 +941,7 @@ trait Sharing {
 		?string $linkName = null,
 		?string $expireDate = null,
 		?string $space_ref = null,
-		string $sharingApp = 'files_sharing'
+		string $sharingApp = 'files_sharing',
 	): ResponseInterface {
 		$userActual = $this->getActualUsername($user);
 		if (\is_string($permissions) && !\is_numeric($permissions)) {
@@ -963,7 +963,7 @@ trait Sharing {
 			$space_ref,
 			$this->ocsApiVersion,
 			$this->sharingApiVersion,
-			$sharingApp
+			$sharingApp,
 		);
 
 		// save the created share data
@@ -999,7 +999,7 @@ trait Sharing {
 		string $field,
 		string $value,
 		string $contentExpected,
-		bool $expectSuccess = true
+		bool $expectSuccess = true,
 	): bool {
 		if (($contentExpected === "ANY_VALUE")
 			|| (($contentExpected === "A_TOKEN") && (\strlen($value) === 15))
@@ -1032,7 +1032,7 @@ trait Sharing {
 		string $field,
 		?string $contentExpected,
 		bool $expectSuccess = true,
-		?SimpleXMLElement $data = null
+		?SimpleXMLElement $data = null,
 	): bool {
 		if ($data === null) {
 			$data = HttpRequestHelper::getResponseXml($this->response, __METHOD__)->data[0];
@@ -1048,7 +1048,7 @@ trait Sharing {
 				$contentExpected
 					= \date(
 						'Y-m-d',
-						$timestamp
+						$timestamp,
 					) . " 00:00:00";
 			}
 		}
@@ -1069,7 +1069,7 @@ trait Sharing {
 						$field,
 						$value,
 						$contentExpected,
-						$expectSuccess
+						$expectSuccess,
 					)
 					) {
 						return true;
@@ -1084,7 +1084,7 @@ trait Sharing {
 					$field,
 					$value,
 					$contentExpected,
-					$expectSuccess
+					$expectSuccess,
 				)
 				) {
 					return true;
@@ -1138,7 +1138,7 @@ trait Sharing {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertTrue(
 			$this->isFieldInResponse('file_target', "$filename"),
-			"'file_target' value '$filename' was not found in response"
+			"'file_target' value '$filename' was not found in response",
 		);
 	}
 
@@ -1154,7 +1154,7 @@ trait Sharing {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertFalse(
 			$this->isFieldInResponse('file_target', "$filename", false),
-			"'file_target' value '$filename' was unexpectedly found in response"
+			"'file_target' value '$filename' was unexpectedly found in response",
 		);
 	}
 
@@ -1170,7 +1170,7 @@ trait Sharing {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertTrue(
 			$this->isFieldInResponse('path', "$filename"),
-			"'path' value '$filename' was not found in response"
+			"'path' value '$filename' was not found in response",
 		);
 	}
 
@@ -1186,7 +1186,7 @@ trait Sharing {
 		$filename = "/" . \ltrim($filename, '/');
 		Assert::assertFalse(
 			$this->isFieldInResponse('path', "$filename", false),
-			"'path' value '$filename' was unexpectedly found in response"
+			"'path' value '$filename' was unexpectedly found in response",
 		);
 	}
 
@@ -1205,7 +1205,7 @@ trait Sharing {
 		}
 		Assert::assertTrue(
 			$this->isFieldInResponse('share_with', "$user"),
-			"'share_with' value '$user' was not found in response"
+			"'share_with' value '$user' was not found in response",
 		);
 	}
 
@@ -1221,7 +1221,7 @@ trait Sharing {
 	public function checkSharedUserOrGroupNotInResponse(string $userOrGroup): void {
 		Assert::assertFalse(
 			$this->isFieldInResponse('share_with', "$userOrGroup", false),
-			"'share_with' value '$userOrGroup' was unexpectedly found in response"
+			"'share_with' value '$userOrGroup' was unexpectedly found in response",
 		);
 	}
 
@@ -1238,7 +1238,7 @@ trait Sharing {
 		string $sharer,
 		string $filepath,
 		string $sharee,
-		$permissions = null
+		$permissions = null,
 	): ResponseInterface {
 		return $this->createShare(
 			$sharer,
@@ -1247,7 +1247,7 @@ trait Sharing {
 			$this->getActualUsername($sharee),
 			null,
 			null,
-			$permissions
+			$permissions,
 		);
 	}
 
@@ -1266,13 +1266,13 @@ trait Sharing {
 		string $sharer,
 		string $filepath,
 		string $sharee,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$response = $this->createAUserShare(
 			$sharer,
 			$filepath,
 			$this->getActualUsername($sharee),
-			$permissions
+			$permissions,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -1294,7 +1294,7 @@ trait Sharing {
 		string $sharer,
 		string $sharee,
 		TableNode $table,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -1304,7 +1304,7 @@ trait Sharing {
 				$sharer,
 				$filepath["path"],
 				$this->getActualUsername($sharee),
-				$permissions
+				$permissions,
 			);
 			$this->setResponse($response);
 			$this->pushToLastStatusCodesArrays();
@@ -1327,13 +1327,13 @@ trait Sharing {
 		string $sharer,
 		string $filepath,
 		string $sharee,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$response = $this->createAUserShare(
 			$sharer,
 			$filepath,
 			$this->getActualUsername($sharee),
-			$permissions
+			$permissions,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
@@ -1352,14 +1352,14 @@ trait Sharing {
 	public function userHasSharedFileWithTheAdministrator(
 		string $sharer,
 		string $filepath,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$admin = $this->getAdminUsername();
 		$response = $this->createAUserShare(
 			$sharer,
 			$filepath,
 			$this->getActualUsername($admin),
-			$permissions
+			$permissions,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
@@ -1378,13 +1378,13 @@ trait Sharing {
 	public function theUserSharesFileWithUserUsingTheSharingApi(
 		string $filepath,
 		string $user2,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$response = $this->createAUserShare(
 			$this->getCurrentUser(),
 			$filepath["path"],
 			$this->getActualUsername($user2),
-			$permissions
+			$permissions,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -1403,14 +1403,14 @@ trait Sharing {
 	public function theUserHasSharedFileWithUserUsingTheSharingApi(
 		string $filepath,
 		string $user2,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$user2 = $this->getActualUsername($user2);
 		$response = $this->createAUserShare(
 			$this->getCurrentUser(),
 			$filepath,
 			$this->getActualUsername($user2),
-			$permissions
+			$permissions,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
@@ -1429,13 +1429,13 @@ trait Sharing {
 	public function theUserSharesFileWithGroupUsingTheSharingApi(
 		string $filepath,
 		string $group,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$response = $this->createAGroupShare(
 			$this->currentUser,
 			$filepath,
 			$group,
-			$permissions
+			$permissions,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -1454,13 +1454,13 @@ trait Sharing {
 	public function theUserHasSharedFileWithGroupUsingTheSharingApi(
 		string $filepath,
 		string $group,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$response = $this->createAGroupShare(
 			$this->currentUser,
 			$filepath,
 			$group,
-			$permissions
+			$permissions,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
@@ -1479,7 +1479,7 @@ trait Sharing {
 		string $user,
 		string $filepath,
 		string $group,
-		$permissions = null
+		$permissions = null,
 	): ResponseInterface {
 		return $this->createShare(
 			$user,
@@ -1488,7 +1488,7 @@ trait Sharing {
 			$group,
 			null,
 			null,
-			$permissions
+			$permissions,
 		);
 	}
 
@@ -1507,13 +1507,13 @@ trait Sharing {
 		string $user,
 		string $filepath,
 		string $group,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$response = $this->createAGroupShare(
 			$user,
 			$filepath,
 			$group,
-			$permissions
+			$permissions,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -1535,7 +1535,7 @@ trait Sharing {
 		string $user,
 		string $group,
 		TableNode $table,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -1545,7 +1545,7 @@ trait Sharing {
 				$user,
 				$filepath["path"],
 				$group,
-				$permissions
+				$permissions,
 			);
 			$this->setResponse($response);
 			$this->pushToLastStatusCodesArrays();
@@ -1567,13 +1567,13 @@ trait Sharing {
 		string $user,
 		string $filepath,
 		string $group,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$response = $this->createAGroupShare(
 			$user,
 			$filepath,
 			$group,
-			$permissions
+			$permissions,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
@@ -1603,7 +1603,7 @@ trait Sharing {
 	 */
 	public function userTriesToUpdateTheLastPublicLinkShareUsingTheSharingApiWith(
 		string $user,
-		?TableNode $body
+		?TableNode $body,
 	): void {
 		$this->response = $this->updateLastShareWithSettings($user, $body, null, true);
 	}
@@ -1626,7 +1626,7 @@ trait Sharing {
 		string $filepath,
 		string $userOrGroupShareType,
 		string $sharee,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$sharee = $this->getActualUsername($sharee);
 		$response = $this->createShare(
@@ -1636,12 +1636,12 @@ trait Sharing {
 			$sharee,
 			null,
 			null,
-			$permissions
+			$permissions,
 		);
 		$statusCode = $this->ocsContext->getOCSResponseStatusCode($response);
 		Assert::assertTrue(
 			($statusCode == 404) || ($statusCode == 403),
-			"Sharing should have failed with status code 403 or 404 but got status code $statusCode"
+			"Sharing should have failed with status code 403 or 404 but got status code $statusCode",
 		);
 	}
 
@@ -1663,7 +1663,7 @@ trait Sharing {
 		string $filepath,
 		string $userOrGroupShareType,
 		string $sharee,
-		$permissions = null
+		$permissions = null,
 	): void {
 		$sharee = $this->getActualUsername($sharee);
 		$response = $this->createShare(
@@ -1673,13 +1673,13 @@ trait Sharing {
 			$sharee,
 			null,
 			null,
-			$permissions
+			$permissions,
 		);
 
 		$statusCode = $this->ocsContext->getOCSResponseStatusCode($response);
 		Assert::assertTrue(
 			($statusCode == 100) || ($statusCode == 200),
-			"Sharing should be successful but got ocs status code $statusCode"
+			"Sharing should be successful but got ocs status code $statusCode",
 		);
 	}
 
@@ -1712,7 +1712,7 @@ trait Sharing {
 	public function deleteLastShareUsingSharingApi(
 		string $user,
 		string $sharer = null,
-		bool $deleteLastPublicLink = false
+		bool $deleteLastPublicLink = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		if ($deleteLastPublicLink) {
@@ -1730,7 +1730,7 @@ trait Sharing {
 		return $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			"DELETE",
-			$url
+			$url,
 		);
 	}
 
@@ -1810,7 +1810,7 @@ trait Sharing {
 		}
 		if ($shareId === null) {
 			throw new Exception(
-				__METHOD__ . " last public link share data was not found"
+				__METHOD__ . " last public link share data was not found",
 			);
 		}
 		$language = TranslationHelper::getLanguage($language);
@@ -1862,7 +1862,7 @@ trait Sharing {
 		string $requester,
 		string $sharer,
 		string $sharee,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->getLastShareInfo($requester, "user");
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -1892,7 +1892,7 @@ trait Sharing {
 			$url,
 			null,
 			null,
-			$headers
+			$headers,
 		);
 	}
 
@@ -1907,7 +1907,7 @@ trait Sharing {
 		return $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			'GET',
-			$url
+			$url,
 		);
 	}
 
@@ -1941,15 +1941,15 @@ trait Sharing {
 		$this->theHTTPStatusCodeShouldBe(
 			200,
 			"Error getting info of last share for user $user",
-			$response
+			$response,
 		);
 		$this->ocsContext->assertOCSResponseIndicatesSuccess(
 			__METHOD__ .
 			' Error getting info of last share for user $user\n' .
 			$this->ocsContext->getOCSResponseStatusMessage(
-				$response
+				$response,
 			) . '"',
-			$response
+			$response,
 		);
 
 		$this->checkTheFields($user, $table, $response);
@@ -1967,7 +1967,7 @@ trait Sharing {
 	public function userGetsFilteredSharesSharedWithHimUsingTheSharingApi(
 		string $user,
 		string $pending,
-		string $shareType
+		string $shareType,
 	): void {
 		$user = $this->getActualUsername($user);
 		if ($pending === "pending") {
@@ -1987,8 +1987,8 @@ trait Sharing {
 			$user,
 			'GET',
 			$this->getSharesEndpointPath(
-				"?shared_with_me=true" . $pendingClause . "&share_types=" . $rawShareTypes
-			)
+				"?shared_with_me=true" . $pendingClause . "&share_types=" . $rawShareTypes,
+			),
 		);
 		$this->setResponse($response);
 	}
@@ -2003,7 +2003,7 @@ trait Sharing {
 	 */
 	public function userGetsAllSharesSharedWithHimFromFileOrFolderUsingTheProvisioningApi(
 		string $user,
-		string $path
+		string $path,
 	): void {
 		$user = $this->getActualUsername($user);
 		$url = "/apps/files_sharing/api/"
@@ -2011,7 +2011,7 @@ trait Sharing {
 		$response = $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			'GET',
-			$url
+			$url,
 		);
 		$this->setResponse($response);
 	}
@@ -2026,7 +2026,7 @@ trait Sharing {
 	 */
 	public function getAllShares(
 		string $user,
-		?string $endpointPath = null
+		?string $endpointPath = null,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		return OcsApiHelper::sendRequest(
@@ -2036,7 +2036,7 @@ trait Sharing {
 			"GET",
 			$this->getSharesEndpointPath($endpointPath),
 			[],
-			$this->ocsApiVersion
+			$this->ocsApiVersion,
 		);
 	}
 
@@ -2102,7 +2102,7 @@ trait Sharing {
 	 */
 	public function userGetsAllTheSharesWithResharesFromTheFileUsingTheSharingApi(
 		string $user,
-		string $path
+		string $path,
 	): void {
 		$this->setResponse($this->getAllShares($user, "?reshares=true&path=$path"));
 	}
@@ -2130,21 +2130,21 @@ trait Sharing {
 	 */
 	public function theResponseWhenUserGetsInfoOfLastPublicLinkShareShouldInclude(
 		string $user,
-		?TableNode $body
+		?TableNode $body,
 	): void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
 		$this->getShareData($user, (string) $this->getLastCreatedPublicShare()->id);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
-			"Error getting info of last public link share for user $user"
+			"Error getting info of last public link share for user $user",
 		);
 		$this->ocsContext->assertOCSResponseIndicatesSuccess(
 			__METHOD__ .
 			' Error getting info of last public link share for user $user\n' .
 			$this->ocsContext->getOCSResponseStatusMessage(
-				$this->getResponse()
-			) . '"'
+				$this->getResponse(),
+			) . '"',
 		);
 		$this->checkTheFields($user, $body);
 	}
@@ -2160,14 +2160,14 @@ trait Sharing {
 	 */
 	public function informationOfLastShareShouldInclude(
 		string $user,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$user = $this->getActualUsername($user);
 		$shareId = $this->getLastCreatedUserGroupShareId($user);
 		$this->getShareData($user, $shareId);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
-			"Error getting info of last share for user $user with share id $shareId"
+			"Error getting info of last share for user $user with share id $shareId",
 		);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
 		$this->checkTheFields($user, $body);
@@ -2190,7 +2190,7 @@ trait Sharing {
 		string $fileOrFolder,
 		string $fileName,
 		string $type,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeColumnsCount($body, 2);
@@ -2227,7 +2227,7 @@ trait Sharing {
 			$value = $this->replaceValuesFromTable($field, $value);
 			Assert::assertTrue(
 				$this->isFieldInResponse($field, $value),
-				"$field doesn't have value '$value'"
+				"$field doesn't have value '$value'",
 			);
 		}
 	}
@@ -2243,7 +2243,7 @@ trait Sharing {
 		? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
 		if (!$this->isFieldInResponse('id', $shareId)) {
 			Assert::fail(
-				"Share id $shareId not found in response"
+				"Share id $shareId not found in response",
 			);
 		}
 	}
@@ -2259,7 +2259,7 @@ trait Sharing {
 		? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
 		if ($this->isFieldInResponse('id', $shareId, false)) {
 			Assert::fail(
-				"Share id $shareId has been found in response"
+				"Share id $shareId has been found in response",
 			);
 		}
 	}
@@ -2274,7 +2274,7 @@ trait Sharing {
 		$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		if ($this->isFieldInResponse('id', $shareId, false)) {
 			Assert::fail(
-				"Public link share id $shareId has been found in response"
+				"Public link share id $shareId has been found in response",
 			);
 		}
 	}
@@ -2305,7 +2305,7 @@ trait Sharing {
 		}
 		Assert::assertFalse(
 			$fieldIsSet,
-			"response contains $receivedShareCount share ids but should not contain any share ids"
+			"response contains $receivedShareCount share ids but should not contain any share ids",
 		);
 	}
 
@@ -2324,7 +2324,7 @@ trait Sharing {
 		? $this->shareNgGetLastCreatedUserGroupShareID() : $this->getLastCreatedUserGroupShareId();
 		if ($this->isFieldInResponse('id', $shareId, false)) {
 			Assert::fail(
-				"Share id $shareId has been found in response"
+				"Share id $shareId has been found in response",
 			);
 		}
 	}
@@ -2354,7 +2354,7 @@ trait Sharing {
 		Assert::assertEquals(
 			$count,
 			$actualCount,
-			"Expected that the response should contain '$count' entries but got '$actualCount' entries"
+			"Expected that the response should contain '$count' entries but got '$actualCount' entries",
 		);
 	}
 
@@ -2451,7 +2451,7 @@ trait Sharing {
 						],
 					],
 					null,
-					null
+					null,
 				);
 				if ($field === "uid_file_owner") {
 					$value = (explode("$", $value))[1];
@@ -2466,7 +2466,7 @@ trait Sharing {
 
 			Assert::assertTrue(
 				$this->isFieldInResponse($field, $value, true, $this->getLastCreatedPublicShare()),
-				"$field doesn't have value '$value'"
+				"$field doesn't have value '$value'",
 			);
 		}
 	}
@@ -2506,13 +2506,13 @@ trait Sharing {
 					"uid_file_owner",
 					"additional_info_owner",
 					"additional_info_file_owner",
-				]
+				],
 			)
 			) {
 				$value = $this->substituteInLineCodes($value, $sharer);
 			} elseif (\in_array(
 				$field,
-				["share_with", "share_with_displayname", "user", "share_with_additional_info"]
+				["share_with", "share_with_displayname", "user", "share_with_additional_info"],
 			)
 			) {
 				$value = $this->substituteInLineCodes($value, $sharee);
@@ -2520,7 +2520,7 @@ trait Sharing {
 			$value = $this->replaceValuesFromTable($field, $value);
 			Assert::assertTrue(
 				$this->isFieldInResponse($field, $value),
-				"$field doesn't have value '$value'"
+				"$field doesn't have value '$value'",
 			);
 		}
 	}
@@ -2535,7 +2535,7 @@ trait Sharing {
 		Assert::assertEquals(
 			\count($data->element),
 			0,
-			"last response contains data but was expected to be empty"
+			"last response contains data but was expected to be empty",
 		);
 	}
 
@@ -2553,7 +2553,7 @@ trait Sharing {
 			$actualAttributes = (array) $actualAttributesElement[0];
 			if (empty($actualAttributes)) {
 				throw new Exception(
-					"No data inside 'attributes' element in the last response."
+					"No data inside 'attributes' element in the last response.",
 				);
 			}
 			return $actualAttributes[0];
@@ -2587,7 +2587,7 @@ trait Sharing {
 				if ($value === 'false') {
 					$value = false;
 				}
-			}
+			},
 		);
 
 		$actualAttributes = $this->getSharingAttributesFromLastResponse();
@@ -2599,7 +2599,7 @@ trait Sharing {
 			throw new Exception(
 				"JSON decoding failed because of $errMsg in json\n" .
 				'Expected data to be json with array of objects. ' .
-				"\nReceived:\n $actualAttributes"
+				"\nReceived:\n $actualAttributes",
 			);
 		}
 
@@ -2616,7 +2616,7 @@ trait Sharing {
 			}
 			Assert::assertTrue(
 				$foundRow,
-				"Could not find expected attribute with scope '" . $row['scope'] . "' and key '" . $row['key'] . "'"
+				"Could not find expected attribute with scope '" . $row['scope'] . "' and key '" . $row['key'] . "'",
 			);
 		}
 	}
@@ -2640,7 +2640,7 @@ trait Sharing {
 			(string) $receivedErrorMessage[0],
 			"Expected error message was '$errorMessage' but got '"
 			. $receivedErrorMessage[0]
-			. "'"
+			. "'",
 		);
 	}
 
@@ -2660,7 +2660,7 @@ trait Sharing {
 			$value = $this->replaceValuesFromTable($field, $value);
 			Assert::assertFalse(
 				$this->isFieldInResponse($field, $value, false),
-				"$field has value $value but should not"
+				"$field has value $value but should not",
 			);
 		}
 	}
@@ -2688,7 +2688,7 @@ trait Sharing {
 			"GET",
 			$this->getSharesEndpointPath("?path=$path"),
 			[],
-			$this->ocsApiVersion
+			$this->ocsApiVersion,
 		);
 		return HttpRequestHelper::getResponseXml($response, __METHOD__)->data->element;
 	}
@@ -2721,7 +2721,7 @@ trait Sharing {
 							__METHOD__
 							. " Expected '{$expectedElementsArray['path']}' but got '"
 							. $elementResponded->path[0]
-							. "'"
+							. "'",
 						);
 						Assert::assertEquals(
 							$expectedElementsArray['permissions'],
@@ -2729,7 +2729,7 @@ trait Sharing {
 							__METHOD__
 							. " Expected '{$expectedElementsArray['permissions']}' but got '"
 							. $elementResponded->permissions[0]
-							. "'"
+							. "'",
 						);
 						$nameFound = true;
 						break;
@@ -2737,7 +2737,7 @@ trait Sharing {
 				}
 				Assert::assertTrue(
 					$nameFound,
-					"Shared link name {$expectedElementsArray['name']} not found"
+					"Shared link name {$expectedElementsArray['name']} not found",
 				);
 			}
 		}
@@ -2762,7 +2762,7 @@ trait Sharing {
 			__METHOD__
 			. " As '$user', '$path' was expected to have no shares, but got '"
 			. \count($response)
-			. "' shares present"
+			. "' shares present",
 		);
 	}
 
@@ -2793,7 +2793,7 @@ trait Sharing {
 	public function deletePublicLinkShareUsingTheSharingApi(
 		string $user,
 		string $name,
-		string $path
+		string $path,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);
@@ -2801,7 +2801,7 @@ trait Sharing {
 		return $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			"DELETE",
-			$url
+			$url,
 		);
 	}
 
@@ -2817,12 +2817,12 @@ trait Sharing {
 	public function userDeletesPublicLinkShareNamedUsingTheSharingApi(
 		string $user,
 		string $name,
-		string $path
+		string $path,
 	): void {
 		$response = $this->deletePublicLinkShareUsingTheSharingApi(
 			$user,
 			$name,
-			$path
+			$path,
 		);
 		$this->setResponse($response);
 	}
@@ -2839,12 +2839,12 @@ trait Sharing {
 	public function userHasDeletedPublicLinkShareNamedUsingTheSharingApi(
 		string $user,
 		string $name,
-		string $path
+		string $path,
 	): void {
 		$response = $this->deletePublicLinkShareUsingTheSharingApi(
 			$user,
 			$name,
-			$path
+			$path,
 		);
 		$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
@@ -2863,7 +2863,7 @@ trait Sharing {
 		string $action,
 		string $share,
 		string $offeredBy,
-		?string $state = ''
+		?string $state = '',
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$offeredBy = $this->getActualUsername($offeredBy);
@@ -2896,7 +2896,7 @@ trait Sharing {
 		}
 		Assert::assertNotNull(
 			$shareId,
-			__METHOD__ . " could not find share $share, offered by $offeredBy to $user"
+			__METHOD__ . " could not find share $share, offered by $offeredBy to $user",
 		);
 		$url = "/apps/files_sharing/api/v$this->sharingApiVersion" .
 			"/shares/pending/$shareId";
@@ -2910,7 +2910,7 @@ trait Sharing {
 		return $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			$httpRequestMethod,
-			$url
+			$url,
 		);
 	}
 
@@ -2931,13 +2931,13 @@ trait Sharing {
 		string $action,
 		string $share,
 		string $offeredBy,
-		?string $state = ''
+		?string $state = '',
 	): void {
 		$response = $this->reactToShareOfferedBy(
 			$user,
 			$action,
 			$share,
-			$offeredBy
+			$offeredBy,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -2960,13 +2960,13 @@ trait Sharing {
 		string $action,
 		string $share,
 		string $offeredBy,
-		?string $state = ''
+		?string $state = '',
 	): void {
 		$response = $this->reactToShareOfferedBy(
 			$user,
 			$action,
 			"/Shares/" . \trim($share, "/"),
-			$offeredBy
+			$offeredBy,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -2987,7 +2987,7 @@ trait Sharing {
 		string $user,
 		string $action,
 		string $offeredBy,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -2997,7 +2997,7 @@ trait Sharing {
 				$user,
 				$action,
 				$share["path"],
-				$offeredBy
+				$offeredBy,
 			);
 			$this->setResponse($response);
 			$this->pushToLastStatusCodesArrays();
@@ -3032,7 +3032,7 @@ trait Sharing {
 		$response = $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			$httpRequestMethod,
-			$url
+			$url,
 		);
 		$this->setResponse($response);
 	}
@@ -3052,13 +3052,13 @@ trait Sharing {
 		string $user,
 		string $action,
 		string $share,
-		string $offeredBy
+		string $offeredBy,
 	): void {
 		$response = $this->reactToShareOfferedBy(
 			$user,
 			$action,
 			$share,
-			$offeredBy
+			$offeredBy,
 		);
 		if ($action === 'declined') {
 			$actionText = 'decline';
@@ -3068,7 +3068,7 @@ trait Sharing {
 		$this->theHTTPStatusCodeShouldBe(
 			200,
 			__METHOD__ . " could not $actionText share $share to $user by $offeredBy",
-			$response
+			$response,
 		);
 		$this->emptyLastHTTPStatusCodesArray();
 		$this->emptyLastOCSStatusCodesArray();
@@ -3105,7 +3105,7 @@ trait Sharing {
 		$this->theHTTPStatusCodeShouldBe(
 			200,
 			__METHOD__ . " could not accept the pending share $share to $user by $offeredBy",
-			$response
+			$response,
 		);
 		$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
 	}
@@ -3125,14 +3125,14 @@ trait Sharing {
 		string $user,
 		string $action,
 		string $share,
-		string $offeredBy
+		string $offeredBy,
 	): void {
 		if ($action === 'accept') {
 			$response = $this->reactToShareOfferedBy($user, 'accepts', $share, $offeredBy, 'pending');
 			$this->theHTTPStatusCodeShouldBe(
 				200,
 				__METHOD__ . " could not accept the pending share $share to $user by $offeredBy",
-				$response
+				$response,
 			);
 			$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
 			// $this->ocsContext->assertOCSResponseIndicatesSuccess();
@@ -3141,7 +3141,7 @@ trait Sharing {
 			$this->theHTTPStatusCodeShouldBe(
 				200,
 				__METHOD__ . " could not decline share $share to $user by $offeredBy",
-				$response
+				$response,
 			);
 			$this->ocsContext->theOCSStatusCodeShouldBe("100,200", "", $response);
 			// $this->emptyLastHTTPStatusCodesArray();
@@ -3181,7 +3181,7 @@ trait Sharing {
 			if (!$found) {
 				Assert::fail(
 					"could not find the share with this attributes " .
-					\print_r($row, true)
+					\print_r($row, true),
 				);
 			}
 		}
@@ -3201,7 +3201,7 @@ trait Sharing {
 		$usersShares = $this->getAllSharesSharedWithUser($user, $state);
 		Assert::assertEmpty(
 			$usersShares,
-			"user has " . \count($usersShares) . " share(s) in the $state state"
+			"user has " . \count($usersShares) . " share(s) in the $state state",
 		);
 	}
 
@@ -3226,13 +3226,13 @@ trait Sharing {
 		}
 		Assert::assertNotNull(
 			$shareId,
-			__METHOD__ . " could not find share, offered by $sharer to $sharee"
+			__METHOD__ . " could not find share, offered by $sharer to $sharee",
 		);
 
 		return $this->ocsContext->sendRequestToOcsEndpoint(
 			$sharer,
 			'DELETE',
-			'/apps/files_sharing/api/v' . $this->sharingApiVersion . '/shares/' . $shareId
+			'/apps/files_sharing/api/v' . $this->sharingApiVersion . '/shares/' . $shareId,
 		);
 	}
 
@@ -3263,7 +3263,7 @@ trait Sharing {
 		$usersShares = $this->getAllSharesSharedWithUser($user);
 		Assert::assertEmpty(
 			$usersShares,
-			"user has " . \count($usersShares) . " share(s)"
+			"user has " . \count($usersShares) . " share(s)",
 		);
 	}
 
@@ -3277,7 +3277,7 @@ trait Sharing {
 	 */
 	public function userGetsTheLastShareWithTheShareIdUsingTheSharingApi(
 		string $user,
-		string $share_id
+		string $share_id,
 	): ?ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$share_id = $this->substituteInLineCodes($share_id, $user);
@@ -3290,7 +3290,7 @@ trait Sharing {
 			"GET",
 			$url,
 			[],
-			$this->ocsApiVersion
+			$this->ocsApiVersion,
 		);
 		return $this->response;
 	}
@@ -3316,25 +3316,25 @@ trait Sharing {
 				break;
 			default:
 				throw new InvalidArgumentException(
-					__METHOD__ . ' invalid "state" given'
+					__METHOD__ . ' invalid "state" given',
 				);
 		}
 		$url = $this->getSharesEndpointPath("?format=json&shared_with_me=true&state=$stateCode");
 		$response = $this->ocsContext->sendRequestToOcsEndpoint(
 			$user,
 			"GET",
-			$url
+			$url,
 		);
 		if ($response->getStatusCode() !== 200) {
 			throw new Exception(
-				__METHOD__ . " could not retrieve information about shares"
+				__METHOD__ . " could not retrieve information about shares",
 			);
 		}
 		$result = $response->getBody()->getContents();
 		$usersShares = \json_decode($result, true);
 		if (!\is_array($usersShares)) {
 			throw new Exception(
-				__METHOD__ . " API result about shares is not valid JSON"
+				__METHOD__ . " API result about shares is not valid JSON",
 			);
 		}
 		return $usersShares['ocs']['data'];
@@ -3381,7 +3381,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function thePublicAccessesThePreviewOfTheFollowingSharedFileUsingTheSharingApi(
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -3406,7 +3406,7 @@ trait Sharing {
 	public function saveLastSharedPublicLinkShare(
 		string $user,
 		string $shareServer,
-		?string $password = ""
+		?string $password = "",
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$userPassword = $this->getPasswordForUser($user);
@@ -3433,7 +3433,7 @@ trait Sharing {
 
 		Assert::assertNotNull(
 			$token,
-			__METHOD__ . " could not find any public share"
+			__METHOD__ . " could not find any public share",
 		);
 
 		$url = $this->getBaseUrl() . "/index.php/apps/files_sharing/external";
@@ -3443,7 +3443,7 @@ trait Sharing {
 			$user,
 			$userPassword,
 			null,
-			$body
+			$body,
 		);
 		return $response;
 	}
@@ -3473,13 +3473,13 @@ trait Sharing {
 			__METHOD__
 			. " Expected status code is '200' but got '"
 			. $this->response->getStatusCode()
-			. "'"
+			. "'",
 		);
 		Assert::assertNotEquals(
 			'error',
 			$status,
 			__METHOD__
-			. "\nFailed to save public share.\n'$message'"
+			. "\nFailed to save public share.\n'$message'",
 		);
 	}
 
@@ -3495,7 +3495,7 @@ trait Sharing {
 		string $user,
 		string $path,
 		string $type,
-		int $permissions = 1
+		int $permissions = 1,
 	): array {
 		return [
 			"permissions" => $permissions,
@@ -3537,7 +3537,7 @@ trait Sharing {
 			$user,
 			$userPassword,
 			null,
-			$requestPayload
+			$requestPayload,
 		);
 		$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 	}
@@ -3567,24 +3567,24 @@ trait Sharing {
 			$value = \str_replace(
 				"REMOTE",
 				$this->getRemoteBaseUrl(),
-				$value
+				$value,
 			);
 			$value = \str_replace(
 				"LOCAL",
 				$this->getLocalBaseUrl(),
-				$value
+				$value,
 			);
 		}
 		if (\substr($field, 0, 6) === "remote") {
 			$value = \str_replace(
 				"REMOTE",
 				$this->getRemoteBaseUrl(),
-				$value
+				$value,
 			);
 			$value = \str_replace(
 				"LOCAL",
 				$this->getLocalBaseUrl(),
-				$value
+				$value,
 			);
 		}
 		if ($field === "permissions") {

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -102,7 +102,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
 			$itemId,
-			\json_encode($body)
+			\json_encode($body),
 		);
 
 		if ($response->getStatusCode() == 200) {
@@ -146,7 +146,7 @@ class SharingNgContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
-			\json_encode($body)
+			\json_encode($body),
 		);
 	}
 
@@ -163,7 +163,7 @@ class SharingNgContext implements Context {
 		string $user,
 		string $space,
 		?string $resource = '',
-		?string $query = null
+		?string $query = null,
 	): ResponseInterface {
 		if ($space === "Shares") {
 			$spaceId = $this->spacesContext->getSharesRemoteItemParentDriveId($user, $resource);
@@ -179,7 +179,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
 			$itemId,
-			$query
+			$query,
 		);
 	}
 
@@ -196,10 +196,10 @@ class SharingNgContext implements Context {
 	public function userGetsPermissionsListForResourceOfTheSpaceUsingTheGraphAPI(
 		string $user,
 		string $resource,
-		string $space
+		string $space,
 	): void {
 		$this->featureContext->setResponse(
-			$this->getPermissionsList($user, $space, $resource)
+			$this->getPermissionsList($user, $space, $resource),
 		);
 	}
 
@@ -218,7 +218,7 @@ class SharingNgContext implements Context {
 		string $user,
 		string $resource,
 		string $space,
-		string $shareMethods
+		string $shareMethods,
 	): void {
 		if ($shareMethods === 'link') {
 			$permissionId = $this->featureContext->shareNgGetLastCreatedLinkShareID();
@@ -234,7 +234,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
 			$itemId,
-			$permissionId
+			$permissionId,
 		);
 
 		$this->featureContext->setResponse($response);
@@ -259,8 +259,8 @@ class SharingNgContext implements Context {
 				$this->featureContext->getPasswordForUser($user),
 				$spaceId,
 				$itemId,
-				null
-			)
+				null,
+			),
 		);
 	}
 
@@ -277,7 +277,7 @@ class SharingNgContext implements Context {
 	public function userTriesToListThePermissionsOfSpaceUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
 		string $space,
-		string $spaceOwner
+		string $spaceOwner,
 	): void {
 		$spaceId = ($this->spacesContext->getSpaceByName($spaceOwner, $space))["id"];
 		$itemId = $this->spacesContext->getResourceId($spaceOwner, $space, '');
@@ -288,8 +288,8 @@ class SharingNgContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				$spaceId,
-				$itemId
-			)
+				$itemId,
+			),
 		);
 	}
 
@@ -311,7 +311,7 @@ class SharingNgContext implements Context {
 		string $user,
 		array $shareInfo,
 		string $fileId = null,
-		bool $federatedShare = false
+		bool $federatedShare = false,
 	): ResponseInterface {
 		$space = $this->spacesContext->getSpaceByName($user, $shareInfo['space']);
 		$spaceId = $space['id'];
@@ -348,7 +348,7 @@ class SharingNgContext implements Context {
 						$shareeId = (
 							$this->featureContext->ocmContext->getAcceptedUserByName(
 								$user,
-								$sharee
+								$sharee,
 							)
 						)['user_id'];
 					}
@@ -374,7 +374,7 @@ class SharingNgContext implements Context {
 			$shareTypes,
 			$permissionsRole,
 			$permissionsAction,
-			$expirationDateTime
+			$expirationDateTime,
 		);
 		if ($response->getStatusCode() === 200) {
 			$this->featureContext->shareNgAddToCreatedUserGroupShares($response);
@@ -398,7 +398,7 @@ class SharingNgContext implements Context {
 	public function sendDriveShareInvitation(
 		string $user,
 		TableNode $table,
-		bool $federatedShare = false
+		bool $federatedShare = false,
 	): ResponseInterface {
 		$shareeIds = [];
 		$rows = $table->getRowsHash();
@@ -441,7 +441,7 @@ class SharingNgContext implements Context {
 			$shareTypes,
 			$permissionsRole,
 			$permissionsAction,
-			$expirationDateTime
+			$expirationDateTime,
 		);
 	}
 
@@ -460,7 +460,7 @@ class SharingNgContext implements Context {
 		Assert::assertArrayHasKey(
 			"resource",
 			$rows,
-			"'resource' should be provided in the data-table while sharing a resource"
+			"'resource' should be provided in the data-table while sharing a resource",
 		);
 		$response = $this->sendShareInvitation($user, $rows);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -478,13 +478,13 @@ class SharingNgContext implements Context {
 	 */
 	public function userHasSentTheFollowingResourceShareInvitationToFederatedUser(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRowsHash();
 		Assert::assertArrayHasKey(
 			"resource",
 			$rows,
-			"'resource' should be provided in the data-table while sharing a resource"
+			"'resource' should be provided in the data-table while sharing a resource",
 		);
 		$response = $this->sendShareInvitation($user, $rows, null, true);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -505,7 +505,7 @@ class SharingNgContext implements Context {
 		Assert::assertArrayNotHasKey(
 			"resource",
 			$rows,
-			"'resource' should not be provided in the data-table while sharing a space"
+			"'resource' should not be provided in the data-table while sharing a space",
 		);
 		$response = $this->sendDriveShareInvitation($user, $table);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -527,10 +527,10 @@ class SharingNgContext implements Context {
 		Assert::assertArrayHasKey(
 			"resource",
 			$rows,
-			"'resource' should be provided in the data-table while sharing a resource"
+			"'resource' should be provided in the data-table while sharing a resource",
 		);
 		$this->featureContext->setResponse(
-			$this->sendShareInvitation($user, $rows)
+			$this->sendShareInvitation($user, $rows),
 		);
 	}
 
@@ -546,16 +546,16 @@ class SharingNgContext implements Context {
 	 */
 	public function userSendsTheFollowingResourceShareInvitationToFederatedUserUsingTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRowsHash();
 		Assert::assertArrayHasKey(
 			"resource",
 			$rows,
-			"'resource' should be provided in the data-table while sharing a resource"
+			"'resource' should be provided in the data-table while sharing a resource",
 		);
 		$this->featureContext->setResponse(
-			$this->sendShareInvitation($user, $rows, null, true)
+			$this->sendShareInvitation($user, $rows, null, true),
 		);
 	}
 
@@ -569,7 +569,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userSendsTheFollowingResourcesShareInvitationConcurrentlyToFederatedUserUsingTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$results = $this->sendConcurrentShareInvitation($user, $table);
 		foreach ($results as $result) {
@@ -597,7 +597,7 @@ class SharingNgContext implements Context {
 			$shareeId = (
 				$this->featureContext->ocmContext->getAcceptedUserByName(
 					$user,
-					$shareInfo["sharee"]
+					$shareInfo["sharee"],
 				)
 			)['user_id'];
 
@@ -614,21 +614,21 @@ class SharingNgContext implements Context {
 
 			$fullUrl = GraphHelper::getBetaFullUrl(
 				$this->featureContext->getBaseUrl(),
-				"drives/$spaceId/items/$itemId/invite"
+				"drives/$spaceId/items/$itemId/invite",
 			);
 
 			$request = HttpRequestHelper::createRequest(
 				$fullUrl,
 				"POST",
 				['Content-Type' => 'application/json'],
-				\json_encode($body)
+				\json_encode($body),
 			);
 			$requests[] = $request;
 		}
 
 		$client = HttpRequestHelper::createClient(
 			$this->featureContext->getActualUsername($user),
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 
 		return HttpRequestHelper::sendBatchRequest($requests, $client);
@@ -646,16 +646,16 @@ class SharingNgContext implements Context {
 	 */
 	public function userSendsTheFollowingSpaceShareInvitationUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRowsHash();
 		Assert::assertArrayNotHasKey(
 			"resource",
 			$rows,
-			"'resource' should not be provided in the data-table while sharing a space"
+			"'resource' should not be provided in the data-table while sharing a space",
 		);
 		$this->featureContext->setResponse(
-			$this->sendShareInvitation($user, $rows)
+			$this->sendShareInvitation($user, $rows),
 		);
 	}
 
@@ -671,16 +671,16 @@ class SharingNgContext implements Context {
 	 */
 	public function userSendsTheFollowingSpaceShareInvitationToFederatedUserUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRowsHash();
 		Assert::assertArrayNotHasKey(
 			"resource",
 			$rows,
-			"'resource' should not be provided in the data-table while sharing a space"
+			"'resource' should not be provided in the data-table while sharing a space",
 		);
 		$this->featureContext->setResponse(
-			$this->sendShareInvitation($user, $rows, null, true)
+			$this->sendShareInvitation($user, $rows, null, true),
 		);
 	}
 
@@ -697,7 +697,7 @@ class SharingNgContext implements Context {
 		$response = $this->updateResourceShare(
 			$user,
 			$table,
-			$permissionID
+			$permissionID,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "Expected response status code should be 200", $response);
 	}
@@ -716,8 +716,8 @@ class SharingNgContext implements Context {
 			$this->updateResourceShare(
 				$user,
 				$table,
-				$permissionID
-			)
+				$permissionID,
+			),
 		);
 	}
 
@@ -735,7 +735,7 @@ class SharingNgContext implements Context {
 		string $user,
 		string $shareType,
 		string $sharee,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$permissionID = "";
 		if ($shareType === "user") {
@@ -748,8 +748,8 @@ class SharingNgContext implements Context {
 			$this->updateResourceShare(
 				$user,
 				$table,
-				$permissionID
-			)
+				$permissionID,
+			),
 		);
 	}
 
@@ -788,7 +788,7 @@ class SharingNgContext implements Context {
 			$spaceId,
 			$itemId,
 			\json_encode($body),
-			$permissionID
+			$permissionID,
 		);
 
 		if ($response->getStatusCode() === 200) {
@@ -812,11 +812,11 @@ class SharingNgContext implements Context {
 	public function userSendsTheFollowingShareInvitationWithFileIdUsingTheGraphApi(
 		string $user,
 		string $fileId,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRowsHash();
 		$this->featureContext->setResponse(
-			$this->sendShareInvitation($user, $rows, $fileId)
+			$this->sendShareInvitation($user, $rows, $fileId),
 		);
 	}
 
@@ -845,7 +845,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userCreatesTheFollowingSpaceLinkShareUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$this->featureContext->setResponse($this->createLinkShare($user, $body));
 	}
@@ -861,7 +861,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userHasCreatedTheFollowingSpaceLinkShareUsingPermissionsEndpointOfTheGraphApi(
 		string $user,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$response = $this->createLinkShare($user, $body);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "Failed while creating public share link!", $response);
@@ -881,7 +881,7 @@ class SharingNgContext implements Context {
 		Assert::assertArrayHasKey(
 			"resource",
 			$rows,
-			"'resource' should be provided in the data-table while sharing a resource"
+			"'resource' should be provided in the data-table while sharing a resource",
 		);
 		$response = $this->createLinkShare($user, $body);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "Failed while creating public share link!", $response);
@@ -901,7 +901,7 @@ class SharingNgContext implements Context {
 		Assert::assertArrayNotHasKey(
 			"resource",
 			$rows,
-			"'resource' should not be provided in the data-table while sharing a space"
+			"'resource' should not be provided in the data-table while sharing a space",
 		);
 		$response = $this->createDriveLinkShare($user, $body);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "Failed while creating public share link!", $response);
@@ -921,7 +921,7 @@ class SharingNgContext implements Context {
 		$response = $this->updateLinkShare(
 			$user,
 			$body,
-			$this->featureContext->shareNgGetLastCreatedLinkShareID()
+			$this->featureContext->shareNgGetLastCreatedLinkShareID(),
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "Failed while updating public share link!", $response);
 	}
@@ -937,14 +937,14 @@ class SharingNgContext implements Context {
 	 */
 	public function userUpdatesTheLastPublicLinkShareUsingThePermissionsEndpointOfTheGraphApi(
 		string $user,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$this->featureContext->setResponse(
 			$this->updateLinkShare(
 				$user,
 				$body,
-				$this->featureContext->shareNgGetLastCreatedLinkShareID()
-			)
+				$this->featureContext->shareNgGetLastCreatedLinkShareID(),
+			),
 		);
 	}
 
@@ -987,7 +987,7 @@ class SharingNgContext implements Context {
 			$spaceId,
 			$itemId,
 			\json_encode($body),
-			$permissionID
+			$permissionID,
 		);
 
 		if ($response->getStatusCode() === 200) {
@@ -1027,7 +1027,7 @@ class SharingNgContext implements Context {
 			$spaceId,
 			$itemId,
 			\json_encode($body),
-			$permissionID
+			$permissionID,
 		);
 
 		if ($response->getStatusCode() === 200) {
@@ -1049,12 +1049,12 @@ class SharingNgContext implements Context {
 		$response = $this->setLinkSharePassword(
 			$user,
 			$body,
-			$this->featureContext->shareNgGetLastCreatedLinkShareID()
+			$this->featureContext->shareNgGetLastCreatedLinkShareID(),
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Failed while setting public share link password!",
-			$response
+			$response,
 		);
 	}
 
@@ -1069,14 +1069,14 @@ class SharingNgContext implements Context {
 	 */
 	public function userSetsOrUpdatesFollowingPasswordForLastLinkShareUsingTheGraphApi(
 		string $user,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$this->featureContext->setResponse(
 			$this->setLinkSharePassword(
 				$user,
 				$body,
-				$this->featureContext->shareNgGetLastCreatedLinkShareID()
-			)
+				$this->featureContext->shareNgGetLastCreatedLinkShareID(),
+			),
 		);
 	}
 
@@ -1098,7 +1098,7 @@ class SharingNgContext implements Context {
 		string $shareType,
 		string $space,
 		?string $resource = null,
-		?string $recipient = null
+		?string $recipient = null,
 	): ResponseInterface {
 		$spaceId = ($this->spacesContext->getSpaceByName($sharer, $space))["id"];
 		$itemId = (isset($resource)) ? $this->spacesContext->getResourceId($sharer, $space, $resource)
@@ -1128,7 +1128,7 @@ class SharingNgContext implements Context {
 				$this->featureContext->getPasswordForUser($sharer),
 				$spaceId,
 				$itemId,
-				$permissionID
+				$permissionID,
 			);
 	}
 
@@ -1148,7 +1148,7 @@ class SharingNgContext implements Context {
 		string $sharer,
 		string $shareType,
 		string $space,
-		?string $recipient = null
+		?string $recipient = null,
 	): ResponseInterface {
 		$spaceId = ($this->spacesContext->getSpaceByName($sharer, $space))["id"];
 
@@ -1165,7 +1165,7 @@ class SharingNgContext implements Context {
 				$sharer,
 				$this->featureContext->getPasswordForUser($sharer),
 				$spaceId,
-				$permissionID
+				$permissionID,
 			);
 	}
 
@@ -1187,7 +1187,7 @@ class SharingNgContext implements Context {
 		string $recipientType,
 		string $recipient,
 		string $resource,
-		string $space
+		string $space,
 	): void {
 		$response = $this->removeAccessToSpaceItem($sharer, $recipientType, $space, $resource);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
@@ -1211,10 +1211,10 @@ class SharingNgContext implements Context {
 		string $recipientType,
 		string $recipient,
 		string $resource,
-		string $space
+		string $space,
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeAccessToSpaceItem($sharer, $recipientType, $space, $resource, $recipient)
+			$this->removeAccessToSpaceItem($sharer, $recipientType, $space, $resource, $recipient),
 		);
 	}
 
@@ -1234,10 +1234,10 @@ class SharingNgContext implements Context {
 		string $sharer,
 		string $recipientType,
 		string $recipient,
-		string $space
+		string $space,
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeAccessToSpaceItem($sharer, $recipientType, $space, null, $recipient)
+			$this->removeAccessToSpaceItem($sharer, $recipientType, $space, null, $recipient),
 		);
 	}
 
@@ -1255,7 +1255,7 @@ class SharingNgContext implements Context {
 	public function userHasRemovedTheLastLinkShareOfFileOrFolderFromSpace(
 		string $sharer,
 		string $resource,
-		string $space
+		string $space,
 	): void {
 		$response = $this->removeAccessToSpaceItem($sharer, 'link', $space, $resource);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
@@ -1275,10 +1275,10 @@ class SharingNgContext implements Context {
 	public function userRemovesSharePermissionOfAResourceInLinkShareUsingGraphAPI(
 		string $sharer,
 		string $resource,
-		string $space
+		string $space,
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeAccessToSpaceItem($sharer, 'link', $space, $resource)
+			$this->removeAccessToSpaceItem($sharer, 'link', $space, $resource),
 		);
 	}
 
@@ -1299,10 +1299,10 @@ class SharingNgContext implements Context {
 		string $sharer,
 		string $recipientType,
 		string $recipient,
-		string $space
+		string $space,
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeAccessToSpace($sharer, $recipientType, $space, $recipient)
+			$this->removeAccessToSpace($sharer, $recipientType, $space, $recipient),
 		);
 	}
 
@@ -1318,10 +1318,10 @@ class SharingNgContext implements Context {
 	 */
 	public function userRemovesLinkFromSpaceUsingRootEndpointOfGraphAPI(
 		string $sharer,
-		string $space
+		string $space,
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeAccessToSpace($sharer, 'link', $space)
+			$this->removeAccessToSpace($sharer, 'link', $space),
 		);
 	}
 
@@ -1341,7 +1341,7 @@ class SharingNgContext implements Context {
 		string $sharer,
 		string $recipientType,
 		string $recipient,
-		string $space
+		string $space,
 	): void {
 		$response = $this->removeAccessToSpace($sharer, $recipientType, $space, $recipient);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
@@ -1361,7 +1361,7 @@ class SharingNgContext implements Context {
 		string $sharee,
 		string $shareID,
 		bool $hide = true,
-		bool $federatedShare = false
+		bool $federatedShare = false,
 	): ResponseInterface {
 		$shareSpaceId = GraphHelper::SHARES_SPACE_ID;
 		if ($federatedShare) {
@@ -1376,7 +1376,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getPasswordForUser($sharee),
 			$itemId,
 			$shareSpaceId,
-			$body
+			$body,
 		);
 	}
 
@@ -1402,7 +1402,7 @@ class SharingNgContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			204,
 			__METHOD__ . " could not disable sync of last share",
-			$response
+			$response,
 		);
 	}
 
@@ -1508,7 +1508,7 @@ class SharingNgContext implements Context {
 		string $user,
 		string $share,
 		string $offeredBy,
-		string $space
+		string $space,
 	): void {
 		$share = ltrim($share, '/');
 		$itemId = $this->spacesContext->getResourceId($offeredBy, $space, $share);
@@ -1518,7 +1518,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$itemId,
-			$shareSpaceId
+			$shareSpaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1542,7 +1542,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$remoteItemId,
-			GraphHelper::SHARES_SPACE_ID
+			GraphHelper::SHARES_SPACE_ID,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1568,7 +1568,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$itemId,
-			$shareSpaceId
+			$shareSpaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1591,7 +1591,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$itemId,
-			$shareSpaceId
+			$shareSpaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1608,7 +1608,7 @@ class SharingNgContext implements Context {
 		$response = GraphHelper::getSharesSharedWithMe(
 			$this->featureContext->getBaseUrl(),
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 
 		$shares = $this->featureContext->getJsonDecodedResponse($response)["value"];
@@ -1694,18 +1694,18 @@ class SharingNgContext implements Context {
 	 */
 	public function userShouldBeAbleToSendShareTheFollowingInvitationWithAllAllowedPermissionRoles(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$listPermissionResponse = $this->featureContext->getJsonDecodedResponseBodyContent();
 		if (!isset($listPermissionResponse->{'@libre.graph.permissions.roles.allowedValues'})) {
 			Assert::fail(
 				"The following response does not contain '@libre.graph.permissions.roles.allowedValues' property:\n"
-				. $listPermissionResponse
+				. $listPermissionResponse,
 			);
 		}
 		Assert::assertNotEmpty(
 			$listPermissionResponse->{'@libre.graph.permissions.roles.allowedValues'},
-			"'@libre.graph.permissions.roles.allowedValues' should not be empty"
+			"'@libre.graph.permissions.roles.allowedValues' should not be empty",
 		);
 		$allowedPermissionRoles = $listPermissionResponse->{'@libre.graph.permissions.roles.allowedValues'};
 		// this info is needed for log to see which roles allowed and which were not when tests fail
@@ -1723,10 +1723,10 @@ class SharingNgContext implements Context {
 			$roleAllowed = GraphHelper::getPermissionNameByPermissionRoleId($role->id);
 			$responseSendInvitation = $this->sendShareInvitation(
 				$user,
-				array_merge($rows, ['permissionsRole' => $roleAllowed])
+				array_merge($rows, ['permissionsRole' => $roleAllowed]),
 			);
 			$jsonResponseSendInvitation = $this->featureContext->getJsonDecodedResponseBodyContent(
-				$responseSendInvitation
+				$responseSendInvitation,
 			);
 			$httpsStatusCode = $responseSendInvitation->getStatusCode();
 			if ($httpsStatusCode === 200 && !empty($jsonResponseSendInvitation->value)) {
@@ -1760,7 +1760,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$spaceId
+			$spaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1785,7 +1785,7 @@ class SharingNgContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
-			$permissionID
+			$permissionID,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1803,7 +1803,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userListsPermissionOfSpaceSharedViaLinkUsingRootEndpointGraphApi(
 		string $user,
-		string $space
+		string $space,
 	): void {
 		$spaceId = ($this->spacesContext->getSpaceByName($user, $space))["id"];
 		$permissionId = $this->featureContext->shareNgGetLastCreatedLinkShareID();
@@ -1812,7 +1812,7 @@ class SharingNgContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
-			$permissionId
+			$permissionId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1828,7 +1828,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userSendsTheFollowingShareInvitationUsingRootEndPointTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->sendDriveShareInvitation($user, $table);
 		$this->featureContext->setResponse($response);
@@ -1845,7 +1845,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userSendsTheFollowingShareInvitationToFederatedUserUsingRootEndPointTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->sendDriveShareInvitation($user, $table, true);
 		$this->featureContext->setResponse($response);
@@ -1862,7 +1862,7 @@ class SharingNgContext implements Context {
 	 */
 	public function userUpdatesTheLastDriveShareWithTheFollowingUsingRootEndpointOfTheGraphApi(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$bodyRows = $table->getRowsHash();
 		$permissionID = match ($bodyRows['shareType']) {
@@ -1890,8 +1890,8 @@ class SharingNgContext implements Context {
 				$this->featureContext->getPasswordForUser($user),
 				$spaceId,
 				\json_encode($body),
-				$permissionID
-			)
+				$permissionID,
+			),
 		);
 	}
 
@@ -1906,13 +1906,13 @@ class SharingNgContext implements Context {
 	 */
 	public function userCreatesTheFollowingSpaceLinkShareUsingRootEndpointOfTheGraphApi(
 		string $user,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$rows = $body->getRowsHash();
 		Assert::assertArrayNotHasKey(
 			"resource",
 			$rows,
-			"'resource' should not be provided in the data-table while sharing a space"
+			"'resource' should not be provided in the data-table while sharing a space",
 		);
 		$response = $this->createDriveLinkShare($user, $body);
 
@@ -1930,13 +1930,13 @@ class SharingNgContext implements Context {
 	 */
 	public function userSetsTheFollowingPasswordForTheLastSpaceLinkShareUsingRootEndpointOfTheGraphAPI(
 		string $user,
-		TableNode $body
+		TableNode $body,
 	): void {
 		$rows = $body->getRowsHash();
 		Assert::assertArrayNotHasKey(
 			"resource",
 			$rows,
-			"'resource' should not be provided in the data-table while setting password in space shared link"
+			"'resource' should not be provided in the data-table while setting password in space shared link",
 		);
 
 		Assert::assertArrayHasKey("password", $rows, "'password' is missing in the data-table");
@@ -1953,7 +1953,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
 			\json_encode($body),
-			$this->featureContext->shareNgGetLastCreatedLinkShareID()
+			$this->featureContext->shareNgGetLastCreatedLinkShareID(),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1971,7 +1971,7 @@ class SharingNgContext implements Context {
 	public function userTriesToRemoveShareLinkOfSpaceOwnedByUsingRootEndpointOfTheGraphApi(
 		string $user,
 		string $space,
-		string $spaceOwner
+		string $spaceOwner,
 	): void {
 		$permissionID = $this->featureContext->shareNgGetLastCreatedLinkShareID();
 		$spaceId = ($this->spacesContext->getSpaceByName($spaceOwner, $space))["id"];
@@ -1981,7 +1981,7 @@ class SharingNgContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$spaceId,
-			$permissionID
+			$permissionID,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -2003,7 +2003,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$spaceId
+			$spaceId,
 		);
 		$responseBody = $this->featureContext->getJsonDecodedResponse($response);
 		foreach ($responseBody['value'] as $value) {
@@ -2012,14 +2012,14 @@ class SharingNgContext implements Context {
 					Assert::assertArrayNotHasKey(
 						'link',
 						$value,
-						$space . ' space should not have any link permissions but found ' . print_r($value, true)
+						$space . ' space should not have any link permissions but found ' . print_r($value, true),
 					);
 					break;
 				case $shareType === "share":
 					Assert::assertArrayNotHasKey(
 						'grantedToV2',
 						$value,
-						$space . ' space should not have any share permissions but found ' . print_r($value, true)
+						$space . ' space should not have any share permissions but found ' . print_r($value, true),
 					);
 					break;
 				default:
@@ -2041,18 +2041,18 @@ class SharingNgContext implements Context {
 	public function userShouldBeAbleToSendTheFollowingSpaceShareInvitationWithAllAllowedPermissionRolesUsingRootEndpointOFTheGraphApi(
 		// @codingStandardsIgnoreEnd
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$listPermissionResponse = $this->featureContext->getJsonDecodedResponseBodyContent();
 		if (!isset($listPermissionResponse->{'@libre.graph.permissions.roles.allowedValues'})) {
 			Assert::fail(
 				"The following response does not contain '@libre.graph.permissions.roles.allowedValues' property:\n"
-				. $listPermissionResponse
+				. $listPermissionResponse,
 			);
 		}
 		Assert::assertNotEmpty(
 			$listPermissionResponse->{'@libre.graph.permissions.roles.allowedValues'},
-			"'@libre.graph.permissions.roles.allowedValues' should not be empty"
+			"'@libre.graph.permissions.roles.allowedValues' should not be empty",
 		);
 		$allowedPermissionRoles = $listPermissionResponse->{'@libre.graph.permissions.roles.allowedValues'};
 		// this info is needed for log to see which roles allowed and which were not when tests fail
@@ -2069,10 +2069,10 @@ class SharingNgContext implements Context {
 			$roleAllowed = GraphHelper::getPermissionNameByPermissionRoleId($role->id);
 			$responseSendInvitation = $this->sendDriveShareInvitation(
 				$user,
-				new TableNode(array_merge($table->getTable(), [['permissionsRole', $roleAllowed]]))
+				new TableNode(array_merge($table->getTable(), [['permissionsRole', $roleAllowed]])),
 			);
 			$jsonResponseSendInvitation = $this->featureContext->getJsonDecodedResponseBodyContent(
-				$responseSendInvitation
+				$responseSendInvitation,
 			);
 			$httpsStatusCode = $responseSendInvitation->getStatusCode();
 			if ($httpsStatusCode === 200 && !empty($jsonResponseSendInvitation->value)) {
@@ -2101,7 +2101,7 @@ class SharingNgContext implements Context {
 	public function userTriesToListThePermissionsOfSpaceOwnedByUsingRootEndpointOfTheGraphApi(
 		string $user,
 		string $space,
-		string $spaceOwner
+		string $spaceOwner,
 	): void {
 		$spaceId = ($this->spacesContext->getSpaceByName($spaceOwner, $space))["id"];
 
@@ -2109,7 +2109,7 @@ class SharingNgContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$spaceId
+			$spaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -2124,10 +2124,10 @@ class SharingNgContext implements Context {
 	 */
 	public function userRemovesTheLastLinkShareOfSpaceUsingPermissionsEndpointOfGraphApi(
 		string $user,
-		string $space
+		string $space,
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeAccessToSpaceItem($user, 'link', $space, '')
+			$this->removeAccessToSpaceItem($user, 'link', $space, ''),
 		);
 	}
 
@@ -2152,7 +2152,7 @@ class SharingNgContext implements Context {
 		string $space = '',
 		bool $shouldExist = true,
 		bool $federatedShare = false,
-		string $role = ''
+		string $role = '',
 	): void {
 		$share = \ltrim($share, "/");
 		$wasOrNot = $shouldExist ? "was not" : "was";
@@ -2168,7 +2168,7 @@ class SharingNgContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$sharee,
 				$this->featureContext->getPasswordForUser($sharee),
-				""
+				"",
 			);
 			$driveList = HttpRequestHelper::getJsonDecodedResponseBodyContent($response)->value;
 			$foundShareMountpoint = false;
@@ -2183,7 +2183,7 @@ class SharingNgContext implements Context {
 			Assert::assertSame(
 				$shouldExist,
 				$foundShareMountpoint,
-				"Share mountpoint '$share' $wasOrNot found in the following drives list.\n" . json_encode($driveList)
+				"Share mountpoint '$share' $wasOrNot found in the following drives list.\n" . json_encode($driveList),
 			);
 		}
 
@@ -2191,7 +2191,7 @@ class SharingNgContext implements Context {
 		$response = GraphHelper::getSharesSharedWithMe(
 			$this->featureContext->getBaseUrl(),
 			$sharee,
-			$this->featureContext->getPasswordForUser($sharee)
+			$this->featureContext->getPasswordForUser($sharee),
 		);
 		$sharedWithMeList = HttpRequestHelper::getJsonDecodedResponseBodyContent($response)->value;
 		$foundShareInSharedWithMe = false;
@@ -2207,7 +2207,7 @@ class SharingNgContext implements Context {
 							Assert::assertSame(
 								$role,
 								$actualRole,
-								"Expected role '$role' for share '$share' but found '$actualRole'."
+								"Expected role '$role' for share '$share' but found '$actualRole'.",
 							);
 						}
 						break;
@@ -2219,7 +2219,7 @@ class SharingNgContext implements Context {
 		Assert::assertSame(
 			$shouldExist,
 			$foundShareInSharedWithMe,
-			"Share '$share' $wasOrNot found in the shared-with-me list.\n" . json_encode($sharedWithMeList)
+			"Share '$share' $wasOrNot found in the shared-with-me list.\n" . json_encode($sharedWithMeList),
 		);
 	}
 
@@ -2239,7 +2239,7 @@ class SharingNgContext implements Context {
 		string $shouldOrNot,
 		string $share,
 		string $sharer,
-		string $space
+		string $space,
 	): void {
 		$this->checkIfShareExists($share, $sharee, $sharer, $space, $shouldOrNot === "should");
 	}
@@ -2287,7 +2287,7 @@ class SharingNgContext implements Context {
 		string $shouldOrNot,
 		string $share,
 		string $sharer,
-		string $space
+		string $space,
 	): void {
 		$this->checkIfShareExists($share, $sharee, $sharer, $space, $shouldOrNot === "should", true);
 	}
@@ -2308,7 +2308,7 @@ class SharingNgContext implements Context {
 		string $space,
 		string $sharee,
 		string $role,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRows();
 		foreach ($rows as $row) {
@@ -2336,7 +2336,7 @@ class SharingNgContext implements Context {
 	 */
 	public function theJsonResponseShouldOrShouldNotContainTheFollowingShares(
 		string $shouldOrNot,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$responseBody = $this->featureContext->getJsonDecodedResponseBodyContent();
 
@@ -2355,12 +2355,12 @@ class SharingNgContext implements Context {
 			if ($shouldOrNot === "should not") {
 				Assert::assertFalse(
 					\in_array($expectedShare, $resourceNames),
-					"The share '$expectedShare' was found in the response."
+					"The share '$expectedShare' was found in the response.",
 				);
 			} else {
 				Assert::assertTrue(
 					\in_array($expectedShare, $resourceNames),
-					"The share '$expectedShare' was not found in the response."
+					"The share '$expectedShare' was not found in the response.",
 				);
 			}
 		}
@@ -2381,11 +2381,11 @@ class SharingNgContext implements Context {
 		string $user,
 		string $resource,
 		string $space,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$query = implode('&', $table->getColumn(0));
 		$this->featureContext->setResponse(
-			$this->getPermissionsList($user, $space, $resource, $query)
+			$this->getPermissionsList($user, $space, $resource, $query),
 		);
 	}
 
@@ -2403,7 +2403,7 @@ class SharingNgContext implements Context {
 	public function userGetsAllTheSharesOfTheResource(
 		string $user,
 		string $resource,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$permission = $this->getPermissionsList($user, "Shares", $resource);
 		$jsonBody = $this->featureContext->getJsonDecodedResponseBodyContent($permission);
@@ -2465,7 +2465,7 @@ class SharingNgContext implements Context {
 				Assert::assertSame(
 					$lastShareId,
 					$share['id'],
-					"Link share id is not the same. Expected '$lastShareId' but found '$share[id]'"
+					"Link share id is not the same. Expected '$lastShareId' but found '$share[id]'",
 				);
 			}
 		}

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -229,7 +229,7 @@ class SpacesContext implements Context {
 			$this->featureContext->theHttpStatusCodeShouldBe(
 				200,
 				"Failed to fetch me/drives for user '$user'",
-				$response
+				$response,
 			);
 			$spaces = $this->featureContext->getJsonDecodedResponseBodyContent($response)->value;
 
@@ -315,7 +315,7 @@ class SpacesContext implements Context {
 		$response = GraphHelper::getSharesSharedWithMe(
 			$this->featureContext->getBaseUrl(),
 			$credentials['username'],
-			$credentials['password']
+			$credentials['password'],
 		);
 
 		$jsonBody = $this->featureContext->getJsonDecodedResponseBodyContent($response);
@@ -378,7 +378,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $fileName,
-		bool $federatedShare = false
+		bool $federatedShare = false,
 	): ResponseInterface {
 		$baseUrl = $this->featureContext->getBaseUrl();
 
@@ -398,7 +398,7 @@ class SpacesContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			[],
-			"{}"
+			"{}",
 		);
 	}
 
@@ -472,16 +472,16 @@ class SpacesContext implements Context {
 			"0",
 			$spaceId,
 			"files",
-			WebDavHelper::DAV_VERSION_SPACES
+			WebDavHelper::DAV_VERSION_SPACES,
 		);
 		$responseArray = json_decode(
 			json_encode(
 				HttpRequestHelper::getResponseXml($response, __METHOD__)
-					->xpath("//d:response/d:propstat/d:prop/oc:privatelink")
+					->xpath("//d:response/d:propstat/d:prop/oc:privatelink"),
 			),
 			true,
 			512,
-			JSON_THROW_ON_ERROR
+			JSON_THROW_ON_ERROR,
 		);
 		Assert::assertNotEmpty($responseArray, "the PROPFIND response for $spaceName is empty");
 		return $responseArray[0][0];
@@ -610,7 +610,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $password,
 		$body,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		return HttpRequestHelper::post($fullUrl, $user, $password, $headers, $body);
 	}
@@ -633,7 +633,7 @@ class SpacesContext implements Context {
 		string $method,
 		string $user,
 		string $password,
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		return HttpRequestHelper::sendRequest($fullUrl, $method, $user, $password, $headers);
 	}
@@ -651,7 +651,7 @@ class SpacesContext implements Context {
 	public function listAllMySpaces(
 		string $user,
 		string $query = '',
-		array $headers = []
+		array $headers = [],
 	): ResponseInterface {
 		return GraphHelper::getMySpaces(
 			$this->featureContext->getBaseUrl(),
@@ -659,7 +659,7 @@ class SpacesContext implements Context {
 			$this->featureContext->getPasswordForUser($user),
 			$query,
 			[],
-			$headers
+			$headers,
 		);
 	}
 
@@ -692,11 +692,11 @@ class SpacesContext implements Context {
 	 */
 	public function theUserListsAllHisAvailableSpacesWithHeadersUsingTheGraphApi(
 		string $user,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$headersTable,
-			['header', 'value']
+			['header', 'value'],
 		);
 		$headers = [];
 		foreach ($headersTable as $row) {
@@ -742,7 +742,7 @@ class SpacesContext implements Context {
 	public function theUserLooksUpTheSingleSpaceUsingTheGraphApiByUsingItsId(
 		string $user,
 		string $spaceName,
-		string $ownerUser = ''
+		string $ownerUser = '',
 	): void {
 		$space = $this->getSpaceByName(($ownerUser !== "") ? $ownerUser : $user, $spaceName);
 		Assert::assertNotEmpty($space["id"]);
@@ -754,7 +754,7 @@ class SpacesContext implements Context {
 				$this->featureContext->getPasswordForUser($user),
 				$space["id"],
 				'',
-			)
+			),
 		);
 	}
 
@@ -776,7 +776,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $spaceType,
-		?int $quota = null
+		?int $quota = null,
 	): void {
 		$space = ["name" => $spaceName, "driveType" => $spaceType, "quota" => ["total" => $quota]];
 		$body = json_encode($space);
@@ -812,7 +812,7 @@ class SpacesContext implements Context {
 			null,
 			$spaceId,
 			'files',
-			WebDavHelper::DAV_VERSION_SPACES
+			WebDavHelper::DAV_VERSION_SPACES,
 		);
 	}
 
@@ -829,7 +829,7 @@ class SpacesContext implements Context {
 	public function theUserListsTheContentOfAPersonalSpaceRootUsingTheWebDAvApi(
 		string $user,
 		string $spaceName,
-		string $foldersPath = ''
+		string $foldersPath = '',
 	): void {
 		$this->featureContext->setResponse($this->propfindSpace($user, $spaceName, $foldersPath));
 	}
@@ -849,7 +849,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $owner,
-		string $data
+		string $data,
 	): void {
 		$space = $this->getSpaceByName($owner, $spaceName);
 		Assert::assertIsArray($space);
@@ -862,8 +862,8 @@ class SpacesContext implements Context {
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
 				null,
-				$data
-			)
+				$data,
+			),
 		);
 	}
 
@@ -879,7 +879,7 @@ class SpacesContext implements Context {
 	 */
 	public function thePropfindResultShouldContainEntries(
 		string $shouldOrNot,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$this->featureContext->propfindResultShouldContainEntries(
 			$shouldOrNot,
@@ -903,7 +903,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $shouldOrNot,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$this->featureContext->setResponse($this->propfindSpace($user, $spaceName));
@@ -913,7 +913,7 @@ class SpacesContext implements Context {
 			$user,
 			'PROPFIND',
 			'',
-			$space['id']
+			$space['id'],
 		);
 	}
 
@@ -935,7 +935,7 @@ class SpacesContext implements Context {
 		string $folderPath,
 		string $spaceName,
 		string $shouldOrNot,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$this->featureContext->setResponse($this->propfindSpace($user, $spaceName, $folderPath));
@@ -945,7 +945,7 @@ class SpacesContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			'PROPFIND',
 			$folderPath,
-			$space['id']
+			$space['id'],
 		);
 	}
 
@@ -965,7 +965,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $file,
 		string $spaceName,
-		string $fileContent
+		string $fileContent,
 	): void {
 		$actualFileContent = $this->getFileData($user, $spaceName, $file)->getBody()->getContents();
 		Assert::assertEquals($fileContent, $actualFileContent, "$file does not contain $fileContent");
@@ -987,13 +987,13 @@ class SpacesContext implements Context {
 		string $user,
 		string $file,
 		string $share,
-		string $fileContent
+		string $fileContent,
 	): void {
 		$actualFileContent = $this->getFileData(
 			$user,
 			$share,
 			$file,
-			true
+			true,
 		)->getBody()->getContents();
 		Assert::assertEquals($fileContent, $actualFileContent, "File content did not match");
 	}
@@ -1012,7 +1012,7 @@ class SpacesContext implements Context {
 		string $spaceName,
 		?string $userName = null,
 		?string $fileName = null,
-		?PyStringNode $schemaString = null
+		?PyStringNode $schemaString = null,
 	): void {
 		Assert::assertNotNull($schemaString, 'schema is not valid JSON');
 
@@ -1067,7 +1067,7 @@ class SpacesContext implements Context {
 		);
 		$this->featureContext->assertJsonDocumentMatchesSchema(
 			$responseBody,
-			$this->featureContext->getJSONSchema($schemaString)
+			$this->featureContext->getJSONSchema($schemaString),
 		);
 	}
 
@@ -1086,17 +1086,17 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $grantedUser,
-		string $role
+		string $role,
 	): void {
 		$response = $this->listAllMySpaces($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 		Assert::assertIsArray(
 			$spaceAsArray = $this->getSpaceByNameFromResponse($spaceName, $response),
-			"No space with name $spaceName found"
+			"No space with name $spaceName found",
 		);
 		$permissions = $spaceAsArray["root"]["permissions"];
 		$userId = $this->featureContext->getUserIdByUserName($grantedUser);
@@ -1121,11 +1121,11 @@ class SpacesContext implements Context {
 	 * @throws Exception
 	 */
 	public function jsonRespondedShouldNotContain(
-		string $spaceName
+		string $spaceName,
 	): void {
 		Assert::assertEmpty(
 			$this->getSpaceByNameFromResponse($spaceName),
-			"space $spaceName should not be available for a user"
+			"space $spaceName should not be available for a user",
 		);
 	}
 
@@ -1142,23 +1142,23 @@ class SpacesContext implements Context {
 	public function userShouldNotHaveSpace(
 		string $user,
 		string $shouldOrNot,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->listAllMySpaces($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 		if (\trim($shouldOrNot) === "not") {
 			Assert::assertEmpty(
 				$this->getSpaceByNameFromResponse($spaceName, $response),
-				"space $spaceName should not be available for a user"
+				"space $spaceName should not be available for a user",
 			);
 		} else {
 			Assert::assertNotEmpty(
 				$this->getSpaceByNameFromResponse($spaceName, $response),
-				"space '$spaceName' should be available for a user '$user' but not found"
+				"space '$spaceName' should be available for a user '$user' but not found",
 			);
 		}
 	}
@@ -1174,13 +1174,13 @@ class SpacesContext implements Context {
 	 */
 	public function theUserShouldHaveASpaceInTheDisableState(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->listAllMySpaces($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 		$decodedResponse = $this->featureContext->getJsonDecodedResponse($response);
 		if (isset($decodedResponse["value"])) {
@@ -1188,7 +1188,7 @@ class SpacesContext implements Context {
 				if ($spaceCandidate['name'] === $spaceName) {
 					if ($spaceCandidate['root']['deleted']['state'] !== 'trashed') {
 						throw new \Exception(
-							"space $spaceName should be in disable state but it's not "
+							"space $spaceName should be in disable state but it's not ",
 						);
 					}
 					return;
@@ -1209,7 +1209,7 @@ class SpacesContext implements Context {
 	 */
 	public function jsonRespondedShouldNotContainSpaceType(
 		string $onlyOrNot,
-		string $type
+		string $type,
 	): void {
 		Assert::assertNotEmpty(
 			$spaces = json_decode(
@@ -1217,8 +1217,8 @@ class SpacesContext implements Context {
 					->getResponse()->getBody(),
 				true,
 				512,
-				JSON_THROW_ON_ERROR
-			)
+				JSON_THROW_ON_ERROR,
+			),
 		);
 		$matches = [];
 		foreach ($spaces["value"] as $space) {
@@ -1249,7 +1249,7 @@ class SpacesContext implements Context {
 	 */
 	public function verifyTableNodeColumnsCount(
 		TableNode $table,
-		int $count
+		int $count,
 	): void {
 		if (\count($table->getRows()) < 1) {
 			throw new Exception("Table should have at least one row.");
@@ -1288,7 +1288,7 @@ class SpacesContext implements Context {
 	public function theUserCreatesAFolderUsingTheGraphApi(
 		string $user,
 		string $folder,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$folder = \trim($folder, '/');
 		$exploded = explode('/', $folder);
@@ -1314,7 +1314,7 @@ class SpacesContext implements Context {
 	public function userCreatesAFolderInsideFederatedShareUsingTheWebDavApi(
 		string $user,
 		string $folder,
-		string $federatedShare
+		string $federatedShare,
 	): void {
 		$folder = \trim($folder, '/');
 		$remoteItemId = $this->featureContext->spacesContext->getSharesRemoteItemId($user, $federatedShare);
@@ -1337,7 +1337,7 @@ class SpacesContext implements Context {
 	public function theUserTriesToCreateASubFolderUsingTheGraphApi(
 		string $user,
 		string $subfolder,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->createFolderInSpace($user, $subfolder, $spaceName);
 		$this->featureContext->setResponse($response);
@@ -1357,7 +1357,7 @@ class SpacesContext implements Context {
 	public function userHasCreatedAFolderInSpace(
 		string $user,
 		string $folder,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$folder = \trim($folder, '/');
 		$paths = explode('/', $folder);
@@ -1369,7 +1369,7 @@ class SpacesContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201",
-			$response
+			$response,
 		);
 	}
 
@@ -1387,7 +1387,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $folder,
 		string $spaceName,
-		string $ownerUser = ''
+		string $ownerUser = '',
 	): ResponseInterface {
 		if ($ownerUser === '') {
 			$ownerUser = $user;
@@ -1412,7 +1412,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $folder,
 		string $spaceName,
-		string $ownerUser = ''
+		string $ownerUser = '',
 	): void {
 		$response = $this->createFolderInSpace($user, $folder, $spaceName, $ownerUser);
 		$this->featureContext->setResponse($response);
@@ -1434,7 +1434,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $content,
-		string $destination
+		string $destination,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		if ($spaceName === "Shares" && !\str_starts_with($destination, "Shares/")) {
@@ -1466,8 +1466,8 @@ class SpacesContext implements Context {
 				$user,
 				$content,
 				'',
-				$spaceId
-			)
+				$spaceId,
+			),
 		);
 	}
 
@@ -1487,7 +1487,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$response = $this->featureContext->uploadFile($user, $source, $destination, $spaceId);
@@ -1510,14 +1510,14 @@ class SpacesContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$response = $this->featureContext->uploadFile($user, $source, $destination, $spaceId);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201",
-			$response
+			$response,
 		);
 	}
 
@@ -1539,14 +1539,14 @@ class SpacesContext implements Context {
 		string $spaceName,
 		string $ownerUser,
 		string $content,
-		string $destination
+		string $destination,
 	): void {
 		$spaceId = $this->getSpaceIdByName($ownerUser, $spaceName);
 		$response = $this->featureContext->uploadFileWithContent(
 			$user,
 			$content,
 			$destination,
-			$spaceId
+			$spaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -1565,7 +1565,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		array $bodyData,
-		string $owner = ''
+		string $owner = '',
 	): ResponseInterface {
 		if ($spaceName === "non-existing") {
 			// check sending invalid data
@@ -1603,11 +1603,11 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $newName,
-		string $owner = ''
+		string $owner = '',
 	): void {
 		$bodyData = ["Name" => $newName];
 		$this->featureContext->setResponse(
-			$this->updateSpace($user, $spaceName, $bodyData, $owner)
+			$this->updateSpace($user, $spaceName, $bodyData, $owner),
 		);
 	}
 
@@ -1628,11 +1628,11 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $newDescription,
-		string $owner = ''
+		string $owner = '',
 	): void {
 		$bodyData = ["description" => $newDescription];
 		$this->featureContext->setResponse(
-			$this->updateSpace($user, $spaceName, $bodyData, $owner)
+			$this->updateSpace($user, $spaceName, $bodyData, $owner),
 		);
 	}
 
@@ -1650,14 +1650,14 @@ class SpacesContext implements Context {
 	public function userHasChangedDescription(
 		string $user,
 		string $spaceName,
-		string $newDescription
+		string $newDescription,
 	): void {
 		$bodyData = ["description" => $newDescription];
 		$response = $this->updateSpace($user, $spaceName, $bodyData);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 	}
 
@@ -1678,11 +1678,11 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		int $newQuota,
-		string $owner = ''
+		string $owner = '',
 	): void {
 		$bodyData = ["quota" => ["total" => $newQuota]];
 		$this->featureContext->setResponse(
-			$this->updateSpace($user, $spaceName, $bodyData, $owner)
+			$this->updateSpace($user, $spaceName, $bodyData, $owner),
 		);
 	}
 
@@ -1700,14 +1700,14 @@ class SpacesContext implements Context {
 	public function userHasChangedTheQuotaOfTheSpaceTo(
 		string $user,
 		string $spaceName,
-		int $newQuota
+		int $newQuota,
 	): void {
 		$bodyData = ["quota" => ["total" => $newQuota]];
 		$response = $this->updateSpace($user, $spaceName, $bodyData);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 	}
 
@@ -1725,7 +1725,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $file,
 		string $type,
-		string $spaceName
+		string $spaceName,
 	): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$spaceId = $space["id"];
@@ -1764,15 +1764,15 @@ class SpacesContext implements Context {
 		string $user,
 		string $file,
 		string $type,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$this->featureContext->setResponse(
 			$this->updateSpaceSpecialSection(
 				$user,
 				$file,
 				$type,
-				$spaceName
-			)
+				$spaceName,
+			),
 		);
 	}
 
@@ -1792,13 +1792,13 @@ class SpacesContext implements Context {
 		string $user,
 		string $file,
 		string $type,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->updateSpaceSpecialSection($user, $file, $type, $spaceName);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 	}
 
@@ -1817,14 +1817,14 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $spaceType,
-		int $quota
+		int $quota,
 	): void {
 		$space = ["name" => $spaceName, "driveType" => $spaceType, "quota" => ["total" => $quota]];
 		$response = $this->createSpace($user, $space);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201 (Created)",
-			$response
+			$response,
 		);
 		$space = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 		$this->addToCreatedSpace($user, $space);
@@ -1843,14 +1843,14 @@ class SpacesContext implements Context {
 	 */
 	public function theUserHasCreatedASpaceByDefaultUsingTheGraphApi(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$space = ["name" => $spaceName];
 		$response = $this->createSpace($user, $space);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201 (Created)",
-			$response
+			$response,
 		);
 		$space = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 		$this->addToCreatedSpace($user, $space);
@@ -1866,7 +1866,7 @@ class SpacesContext implements Context {
 	 */
 	public function createSpace(
 		string $user,
-		array $space
+		array $space,
 	): ResponseInterface {
 		$body = json_encode($space, JSON_THROW_ON_ERROR);
 		return GraphHelper::createSpace(
@@ -1892,13 +1892,13 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileSource,
 		string $fileDestination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName(
 			$user,
 			$fileDestination,
-			$spaceName
+			$spaceName,
 		);
 
 		$encodedName = \rawurlencode(ltrim($fileSource, "/"));
@@ -1922,13 +1922,13 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileSource,
 		string $fileDestination,
-		string $spaceName
+		string $spaceName,
 	): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName(
 			$user,
 			$fileDestination,
-			$spaceName
+			$spaceName,
 		);
 		$headers['Overwrite'] = 'F';
 
@@ -1955,15 +1955,15 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileSource,
 		string $fileDestination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$this->featureContext->setResponse(
 			$this->moveFileWithinSpace(
 				$user,
 				$fileSource,
 				$fileDestination,
-				$spaceName
-			)
+				$spaceName,
+			),
 		);
 		$this->featureContext->pushToLastHttpStatusCodesArray();
 	}
@@ -1983,20 +1983,20 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileSource,
 		string $fileDestination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->moveFileWithinSpace(
 			$user,
 			$fileSource,
 			$fileDestination,
-			$spaceName
+			$spaceName,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			__METHOD__ . "Expected response status code should be 201 (Created)\n" .
 			"Actual response status code was: " . $response->getStatusCode() . "\n" .
 			"Actual response body was: " . $response->getBody(),
-			$response
+			$response,
 		);
 	}
 
@@ -2040,19 +2040,19 @@ class SpacesContext implements Context {
 		string $fromSpaceName,
 		string $fileDestination,
 		string $toSpaceName,
-		TableNode $table = null
+		TableNode $table = null,
 	): void {
 		$space = $this->getSpaceByName($user, $fromSpaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName(
 			$user,
 			$fileDestination,
-			$toSpaceName
+			$toSpaceName,
 		);
 
 		if ($table !== null) {
 			$this->featureContext->verifyTableNodeColumns(
 				$table,
-				['header', 'value']
+				['header', 'value'],
 			);
 			foreach ($table as $row) {
 				$headers[$row['header']] = $this->featureContext->substituteInLineCodes($row['value']);
@@ -2086,13 +2086,13 @@ class SpacesContext implements Context {
 		string $fromSpaceName,
 		string $fileDestination,
 		string $toSpaceName,
-		string $action
+		string $action,
 	): void {
 		$space = $this->getSpaceByName($user, $fromSpaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName(
 			$user,
 			$fileDestination,
-			$toSpaceName
+			$toSpaceName,
 		);
 		$headers['Overwrite'] = 'T';
 
@@ -2125,7 +2125,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $shouldOrNot,
 		string $fileName,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		if ($spaceName === "Shares"
@@ -2138,27 +2138,27 @@ class SpacesContext implements Context {
 			$fileName,
 			$this->featureContext->getPasswordForUser($user),
 			null,
-			$spaceId
+			$spaceId,
 		);
 		if ($shouldOrNot === 'should') {
 			$this->featureContext->theHTTPStatusCodeShouldBe(
 				200,
 				__METHOD__ . "Expected response status code is 200 but got " . $response->getStatusCode(),
-				$response
+				$response,
 			);
 		} else {
 			Assert::assertGreaterThanOrEqual(
 				400,
 				$response->getStatusCode(),
 				__METHOD__
-				. ' download must fail'
+				. ' download must fail',
 			);
 			Assert::assertLessThanOrEqual(
 				499,
 				$response->getStatusCode(),
 				__METHOD__
 				. ' 4xx error expected but got status code "'
-				. $response->getStatusCode() . '"'
+				. $response->getStatusCode() . '"',
 			);
 		}
 	}
@@ -2180,13 +2180,13 @@ class SpacesContext implements Context {
 		string $fileSource,
 		string $fromSpaceName,
 		string $fileDestination,
-		string $toSpaceName
+		string $toSpaceName,
 	): void {
 		$space = $this->getSpaceByName($user, $fromSpaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName(
 			$user,
 			$fileDestination,
-			$toSpaceName
+			$toSpaceName,
 		);
 
 		$encodedName = \rawurlencode(ltrim($fileSource, "/"));
@@ -2213,7 +2213,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileDestination,
 		string $spaceName,
-		string $endPath = null
+		string $endPath = null,
 	): string {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$fileDestination = $this->escapePath(\ltrim($fileDestination, "/"));
@@ -2261,7 +2261,7 @@ class SpacesContext implements Context {
 		string $fileId,
 		string $destinationFile,
 		string $destinationFolder,
-		string $toSpaceName
+		string $toSpaceName,
 	): void {
 		$destinationFile = \trim($destinationFile, "/");
 		$destinationFolder = \trim($destinationFolder, "/");
@@ -2277,17 +2277,17 @@ class SpacesContext implements Context {
 				$user,
 				$fileDestination,
 				$toSpaceName,
-				$fileId
+				$fileId,
 			);
 		}
 		$fullUrl = "$baseUrl/$sourceDavPath/$fileId";
 		if ($actionType === 'copies') {
 			$this->featureContext->setResponse(
-				$this->copyFilesAndFoldersRequest($user, $fullUrl, $headers)
+				$this->copyFilesAndFoldersRequest($user, $fullUrl, $headers),
 			);
 		} else {
 			$this->featureContext->setResponse(
-				$this->moveFilesAndFoldersRequest($user, $fullUrl, $headers)
+				$this->moveFilesAndFoldersRequest($user, $fullUrl, $headers),
 			);
 		}
 	}
@@ -2307,7 +2307,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileId,
 		string $destinationFile,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$destinationFile = \trim($destinationFile, "/");
 
@@ -2324,7 +2324,7 @@ class SpacesContext implements Context {
 				$user,
 				$fileDestination,
 				$spaceName,
-				$fileId
+				$fileId,
 			);
 		}
 		$fullUrl = "$baseUrl/$sourceDavPath/$fileId";
@@ -2368,7 +2368,7 @@ class SpacesContext implements Context {
 				$user,
 				$fileDestination,
 				$spaceName,
-				$fileId
+				$fileId,
 			);
 		}
 		$fullUrl = "$baseUrl/$sourceDavPath/$fileId";
@@ -2380,7 +2380,7 @@ class SpacesContext implements Context {
 		Assert::assertEquals(
 			201,
 			$response->getStatusCode(),
-			"Expected response status code should be 201"
+			"Expected response status code should be 201",
 		);
 	}
 
@@ -2399,7 +2399,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileId,
 		string $destinationFile,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$destinationFile = \trim($destinationFile, "/");
 
@@ -2416,7 +2416,7 @@ class SpacesContext implements Context {
 				$user,
 				$fileDestination,
 				$spaceName,
-				$fileId
+				$fileId,
 			);
 		}
 		$fullUrl = "$baseUrl/$sourceDavPath/$fileId";
@@ -2424,7 +2424,7 @@ class SpacesContext implements Context {
 		Assert::assertEquals(
 			201,
 			$response->getStatusCode(),
-			"Expected response status code should be 201"
+			"Expected response status code should be 201",
 		);
 	}
 
@@ -2446,7 +2446,7 @@ class SpacesContext implements Context {
 		string $source,
 		string $sourceSpace,
 		string $destinationType,
-		string $destinationName
+		string $destinationName,
 	): void {
 		$source = \trim($source, "/");
 		$baseUrl = $this->featureContext->getBaseUrl();
@@ -2485,7 +2485,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $fileContent,
-		string $destination
+		string $destination,
 	): array {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$response = $this->featureContext->uploadFileWithContent(
@@ -2493,7 +2493,7 @@ class SpacesContext implements Context {
 			$fileContent,
 			$destination,
 			$space["id"],
-			true
+			true,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(['201', '204'], "", $response);
 		return $response->getHeader('oc-fileid');
@@ -2513,7 +2513,7 @@ class SpacesContext implements Context {
 	public function sendShareSpaceRequest(
 		string $user,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRowsHash();
 		$this->featureContext->setResponse($this->shareSpace($user, $spaceName, $rows));
@@ -2571,7 +2571,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $shareType,
 		string $spaceName,
-		string $memberUser
+		string $memberUser,
 	): void {
 		$dateTime = new DateTime('yesterday');
 		$rows['expireDate'] = $dateTime->format('Y-m-d\\TH:i:sP');
@@ -2591,7 +2591,7 @@ class SpacesContext implements Context {
 	public function createShareResource(
 		string $user,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): ResponseInterface {
 		$rows = $table->getRowsHash();
 		$rows["path"] = \array_key_exists("path", $rows) ? $rows["path"] : null;
@@ -2638,10 +2638,10 @@ class SpacesContext implements Context {
 	public function userCreatesShareInsideOfSpaceWithSettings(
 		string $user,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->setResponse(
-			$this->createShareResource($user, $spaceName, $table)
+			$this->createShareResource($user, $spaceName, $table),
 		);
 	}
 
@@ -2658,7 +2658,7 @@ class SpacesContext implements Context {
 	public function userHasSharedTheFollowingEntityInsideOfSpace(
 		string $user,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->createShareResource($user, $spaceName, $table);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
@@ -2675,7 +2675,7 @@ class SpacesContext implements Context {
 	 */
 	public function changeShareResourceWithSettings(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$rows = $table->getRowsHash();
 		$this->featureContext->setResponse($this->updateSharedResource($user, $rows));
@@ -2701,7 +2701,7 @@ class SpacesContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			null,
-			$rows
+			$rows,
 		);
 	}
 
@@ -2718,7 +2718,7 @@ class SpacesContext implements Context {
 	public function userExpiresTheLastShareOfResourceInsideOfTheSpace(
 		string $user,
 		string $resource,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$rows['expireDate'] = $this->featureContext->formatExpiryDateTime('Y-m-d\\TH:i:sP');
 		if ($this->featureContext->isUsingSharingNG()) {
@@ -2733,7 +2733,7 @@ class SpacesContext implements Context {
 				$space["id"],
 				$itemId,
 				\json_encode($body),
-				$permissionID
+				$permissionID,
 			);
 
 			if ($response->getStatusCode() === 200) {
@@ -2757,7 +2757,7 @@ class SpacesContext implements Context {
 	public function createPublicLinkToEntityInsideOfSpaceRequest(
 		string $user,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$rows = $table->getRowsHash();
@@ -2806,10 +2806,10 @@ class SpacesContext implements Context {
 	public function userCreatesPublicLinkShareInsideOfSpaceWithSettings(
 		string $user,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->setResponse(
-			$this->createPublicLinkToEntityInsideOfSpaceRequest($user, $spaceName, $table)
+			$this->createPublicLinkToEntityInsideOfSpaceRequest($user, $spaceName, $table),
 		);
 	}
 
@@ -2826,14 +2826,14 @@ class SpacesContext implements Context {
 	public function userHasCreatedPublicLinkToEntityInsideOfSpaceRequest(
 		string $user,
 		string $spaceName,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->createPublicLinkToEntityInsideOfSpaceRequest($user, $spaceName, $table);
 
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 	}
 
@@ -2850,7 +2850,7 @@ class SpacesContext implements Context {
 	public function userHasSharedSpace(
 		string $user,
 		string $spaceName,
-		TableNode $tableNode
+		TableNode $tableNode,
 	): void {
 		$rows = $tableNode->getRowsHash();
 		$response = $this->shareSpace($user, $spaceName, $rows);
@@ -2858,15 +2858,15 @@ class SpacesContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus",
-			$response
+			$response,
 		);
 		$expectedOCSStatus = "200";
 		Assert::assertEquals(
 			$expectedOCSStatus,
 			$this->ocsContext->getOCSResponseStatusCode(
-				$response
+				$response,
 			),
-			"Expected OCS response status code $expectedOCSStatus"
+			"Expected OCS response status code $expectedOCSStatus",
 		);
 	}
 
@@ -2883,13 +2883,13 @@ class SpacesContext implements Context {
 	public function userHasUnsharedASpaceSharedWith(
 		string $user,
 		string $spaceName,
-		string $recipient
+		string $recipient,
 	): void {
 		$response = $this->sendUnshareSpaceRequest($user, $spaceName, $recipient);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 	}
 
@@ -2904,7 +2904,7 @@ class SpacesContext implements Context {
 	public function sendUnshareSpaceRequest(
 		string $user,
 		string $spaceName,
-		string $recipient
+		string $recipient,
 	): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$fullUrl = $this->featureContext->getBaseUrl()
@@ -2913,7 +2913,7 @@ class SpacesContext implements Context {
 		return HttpRequestHelper::delete(
 			$fullUrl,
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 	}
 
@@ -2930,10 +2930,10 @@ class SpacesContext implements Context {
 	public function userUnsharesSpace(
 		string $user,
 		string $spaceName,
-		string $recipient
+		string $recipient,
 	): void {
 		$this->featureContext->setResponse(
-			$this->sendUnshareSpaceRequest($user, $spaceName, $recipient)
+			$this->sendUnshareSpaceRequest($user, $spaceName, $recipient),
 		);
 	}
 
@@ -2948,7 +2948,7 @@ class SpacesContext implements Context {
 	public function removeObjectFromSpace(
 		string $user,
 		string $object,
-		string $spaceName
+		string $spaceName,
 	): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 
@@ -2960,7 +2960,7 @@ class SpacesContext implements Context {
 		return HttpRequestHelper::delete(
 			$fullUrl,
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 	}
 
@@ -2977,10 +2977,10 @@ class SpacesContext implements Context {
 	public function userRemovesFileOrFolderFromSpace(
 		string $user,
 		string $object,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$this->featureContext->setResponse(
-			$this->removeObjectFromSpace($user, $object, $spaceName)
+			$this->removeObjectFromSpace($user, $object, $spaceName),
 		);
 	}
 
@@ -2995,13 +2995,13 @@ class SpacesContext implements Context {
 	 */
 	public function userHasDeletedASpaceOwnedByUser(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->deleteSpace($user, $spaceName);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			204,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 	}
 
@@ -3016,7 +3016,7 @@ class SpacesContext implements Context {
 	public function disableSpace(
 		string $user,
 		string $spaceName,
-		string $owner = ''
+		string $owner = '',
 	): ResponseInterface {
 		$space = $this->getSpaceByName(($owner !== "") ? $owner : $user, $spaceName);
 		return GraphHelper::disableSpace(
@@ -3041,10 +3041,10 @@ class SpacesContext implements Context {
 	public function userDisablesSpace(
 		string $user,
 		string $spaceName,
-		string $owner = ''
+		string $owner = '',
 	): void {
 		$this->featureContext->setResponse(
-			$this->disableSpace($user, $spaceName, $owner)
+			$this->disableSpace($user, $spaceName, $owner),
 		);
 	}
 
@@ -3061,14 +3061,14 @@ class SpacesContext implements Context {
 	public function userHasRemovedFileOrFolderFromSpace(
 		string $user,
 		string $object,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->removeObjectFromSpace($user, $object, $spaceName);
 		$expectedHTTPStatus = "204";
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus",
-			$response
+			$response,
 		);
 	}
 
@@ -3083,14 +3083,14 @@ class SpacesContext implements Context {
 	 */
 	public function sendUserHasDisabledSpaceRequest(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->disableSpace($user, $spaceName);
 		$expectedHTTPStatus = "204";
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus",
-			$response
+			$response,
 		);
 	}
 
@@ -3105,7 +3105,7 @@ class SpacesContext implements Context {
 	public function deleteSpace(
 		string $user,
 		string $spaceName,
-		string $owner = ''
+		string $owner = '',
 	): ResponseInterface {
 		$space = $this->getSpaceByName(($owner !== "") ? $owner : $user, $spaceName);
 
@@ -3131,10 +3131,10 @@ class SpacesContext implements Context {
 	public function userDeletesSpace(
 		string $user,
 		string $spaceName,
-		string $owner = ''
+		string $owner = '',
 	): void {
 		$this->featureContext->setResponse(
-			$this->deleteSpace($user, $spaceName, $owner)
+			$this->deleteSpace($user, $spaceName, $owner),
 		);
 	}
 
@@ -3149,7 +3149,7 @@ class SpacesContext implements Context {
 	public function restoreSpace(
 		string $user,
 		string $spaceName,
-		string $owner = ''
+		string $owner = '',
 	): ResponseInterface {
 		$space = $this->getSpaceByName(($owner !== "") ? $owner : $user, $spaceName);
 		return GraphHelper::restoreSpace(
@@ -3174,10 +3174,10 @@ class SpacesContext implements Context {
 	public function userRestoresADisabledSpace(
 		string $user,
 		string $spaceName,
-		string $owner = ''
+		string $owner = '',
 	): void {
 		$this->featureContext->setResponse(
-			$this->restoreSpace($user, $spaceName, $owner)
+			$this->restoreSpace($user, $spaceName, $owner),
 		);
 	}
 
@@ -3192,14 +3192,14 @@ class SpacesContext implements Context {
 	 */
 	public function userHasRestoredSpaceRequest(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->restoreSpace($user, $spaceName);
 		$expectedHTTPStatus = "200";
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus",
-			$response
+			$response,
 		);
 	}
 
@@ -3212,21 +3212,21 @@ class SpacesContext implements Context {
 	 */
 	public function listAllDeletedFilesFromTrash(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_SPACES,
 			$space["id"],
-			"trash-bin"
+			"trash-bin",
 		);
 		$fullUrl = "$baseUrl/$davPath";
 		return HttpRequestHelper::sendRequest(
 			$fullUrl,
 			'PROPFIND',
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 	}
 
@@ -3241,10 +3241,10 @@ class SpacesContext implements Context {
 	 */
 	public function userListAllDeletedFilesInTrash(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$this->featureContext->setResponse(
-			$this->listAllDeletedFilesFromTrash($user, $spaceName)
+			$this->listAllDeletedFilesFromTrash($user, $spaceName),
 		);
 	}
 
@@ -3259,7 +3259,7 @@ class SpacesContext implements Context {
 	 */
 	public function adminListAllDeletedFilesInTrash(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): void {
 		// get space by admin user
 		$space = $this->getSpaceByName($this->featureContext->getAdminUserName(), $spaceName);
@@ -3267,7 +3267,7 @@ class SpacesContext implements Context {
 		$davPath = WebDavHelper::getDavPath(
 			WebDavHelper::DAV_VERSION_SPACES,
 			$space["id"],
-			"trash-bin"
+			"trash-bin",
 		);
 		$fullUrl = "$baseUrl/$davPath";
 		$this->featureContext->setResponse(
@@ -3275,8 +3275,8 @@ class SpacesContext implements Context {
 				$fullUrl,
 				'PROPFIND',
 				$user,
-				$this->featureContext->getPasswordForUser($user)
-			)
+				$this->featureContext->getPasswordForUser($user),
+			),
 		);
 	}
 
@@ -3301,16 +3301,16 @@ class SpacesContext implements Context {
 	 */
 	public function getObjectsInTrashbin(
 		string $user,
-		string $spaceName
+		string $spaceName,
 	): array {
 		$response = $this->listAllDeletedFilesFromTrash($user, $spaceName);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			207,
 			"Expected response status code should be 207",
-			$response
+			$response,
 		);
 		return $this->trashbinContext->getTrashbinContentFromResponseXml(
-			HttpRequestHelper::getResponseXml($response, __METHOD__)
+			HttpRequestHelper::getResponseXml($response, __METHOD__),
 		);
 	}
 
@@ -3329,7 +3329,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $object,
 		string $shouldOrNot,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$objectsInTrash = $this->getObjectsInTrashbin($user, $spaceName);
 
@@ -3362,7 +3362,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $object,
 		string $spaceName,
-		string $destination
+		string $destination,
 	): void {
 		$space = $this->getSpaceByName($user, $spaceName);
 
@@ -3377,7 +3377,7 @@ class SpacesContext implements Context {
 
 		if ($pathToDeletedObject === "") {
 			throw new Exception(
-				__METHOD__ . " Object '$object' was not found in the trashbin of space '$spaceName' by user '$user'"
+				__METHOD__ . " Object '$object' was not found in the trashbin of space '$spaceName' by user '$user'",
 			);
 		}
 
@@ -3394,8 +3394,8 @@ class SpacesContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				$header,
-				""
-			)
+				"",
+			),
 		);
 	}
 
@@ -3414,7 +3414,7 @@ class SpacesContext implements Context {
 	public function userDeletesObjectsFromTrashRequest(
 		string $user,
 		string $object,
-		string $spaceName
+		string $spaceName,
 	): void {
 		// find object in trash
 		$objectsInTrash = $this->getObjectsInTrashbin($user, $spaceName);
@@ -3427,7 +3427,7 @@ class SpacesContext implements Context {
 
 		if ($pathToDeletedObject === "") {
 			throw new Exception(
-				__METHOD__ . " Object '$object' was not found in the trashbin of space '$spaceName' by user '$user'"
+				__METHOD__ . " Object '$object' was not found in the trashbin of space '$spaceName' by user '$user'",
 			);
 		}
 
@@ -3439,8 +3439,8 @@ class SpacesContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 				[],
-				""
-			)
+				"",
+			),
 		);
 	}
 
@@ -3463,7 +3463,7 @@ class SpacesContext implements Context {
 		string $fileName,
 		string $spaceName,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		$eTag = str_replace("\"", "", $this->getETag($user, $spaceName, $fileName));
 		$urlParameters = [
@@ -3484,8 +3484,8 @@ class SpacesContext implements Context {
 			HttpRequestHelper::get(
 				$fullUrl,
 				$user,
-				$this->featureContext->getPasswordForUser($user)
-			)
+				$this->featureContext->getPasswordForUser($user),
+			),
 		);
 	}
 
@@ -3502,7 +3502,7 @@ class SpacesContext implements Context {
 	public function downloadFile(
 		string $user,
 		string $fileName,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$response = $this->featureContext->downloadFileAsUserUsingPassword(
@@ -3510,7 +3510,7 @@ class SpacesContext implements Context {
 			$fileName,
 			$this->featureContext->getPasswordForUser($user),
 			[],
-			$spaceId
+			$spaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3528,11 +3528,11 @@ class SpacesContext implements Context {
 	public function userRequestsTheChecksumViaPropfindInSpace(
 		string $user,
 		string $path,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$this->featureContext->setResponse(
-			$this->checksumContext->propfindResourceChecksum($user, $path, $spaceId)
+			$this->checksumContext->propfindResourceChecksum($user, $path, $spaceId),
 		);
 	}
 
@@ -3553,7 +3553,7 @@ class SpacesContext implements Context {
 		string $checksum,
 		string $content,
 		string $destination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$this->featureContext->setResponse(
@@ -3563,8 +3563,8 @@ class SpacesContext implements Context {
 				$content,
 				$destination,
 				false,
-				$spaceId
-			)
+				$spaceId,
+			),
 		);
 	}
 
@@ -3584,11 +3584,11 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileName,
 		string $index,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$this->featureContext->setResponse(
-			$this->filesVersionsContext->downloadVersion($user, $fileName, $index, $spaceId)
+			$this->filesVersionsContext->downloadVersion($user, $fileName, $index, $spaceId),
 		);
 	}
 
@@ -3605,7 +3605,7 @@ class SpacesContext implements Context {
 	public function userTriesToDownloadFileVersions(string $user, string $file, string $spaceName): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$this->featureContext->setResponse(
-			$this->filesVersionsContext->getFileVersions($user, $file, null, $spaceId)
+			$this->filesVersionsContext->getFileVersions($user, $file, null, $spaceId),
 		);
 	}
 
@@ -3640,7 +3640,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $space,
 		string $path,
-		?string $storePath = ""
+		?string $storePath = "",
 	): void {
 		if ($storePath === "") {
 			$storePath = $path;
@@ -3667,19 +3667,19 @@ class SpacesContext implements Context {
 			$user,
 			$this->storedEtags,
 			__METHOD__ . " No stored etags for user '$user' found"
-			. "\nFound: " . print_r($this->storedEtags, true)
+			. "\nFound: " . print_r($this->storedEtags, true),
 		);
 		Assert::assertArrayHasKey(
 			$space,
 			$this->storedEtags[$user],
 			__METHOD__ . " No stored etags for user '$user' with space '$space' found"
-			. "\nFound: " . implode(', ', array_keys($this->storedEtags[$user]))
+			. "\nFound: " . implode(', ', array_keys($this->storedEtags[$user])),
 		);
 		Assert::assertArrayHasKey(
 			$path,
 			$this->storedEtags[$user][$space],
 			__METHOD__ . " No stored etags for user '$user' with space '$space' with path '$path' found"
-			. '\nFound: ' . print_r($this->storedEtags[$user][$space], true)
+			. '\nFound: ' . print_r($this->storedEtags[$user][$space], true),
 		);
 		return $this->storedEtags[$user][$space][$path];
 	}
@@ -3756,14 +3756,14 @@ class SpacesContext implements Context {
 		string $user,
 		string $path,
 		string $storePath,
-		string $space
+		string $space,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->storeEtagOfElementInSpaceForUser(
 			$user,
 			$space,
 			$path,
-			$storePath
+			$storePath,
 		);
 		if ($this->storedEtags[$user][$space][$storePath] === ""
 			|| $this->storedEtags[$user][$space][$storePath] === null
@@ -3783,7 +3783,7 @@ class SpacesContext implements Context {
 	public function sendShareSpaceViaLinkRequest(
 		string $user,
 		string $spaceName,
-		?TableNode $table
+		?TableNode $table,
 	): ResponseInterface {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$rows = $table->getRowsHash();
@@ -3814,7 +3814,7 @@ class SpacesContext implements Context {
 		);
 
 		$this->featureContext->addToCreatedPublicShares(
-			HttpRequestHelper::getResponseXml($response, __METHOD__)->data
+			HttpRequestHelper::getResponseXml($response, __METHOD__)->data,
 		);
 		return $response;
 	}
@@ -3832,14 +3832,14 @@ class SpacesContext implements Context {
 	public function userCreatesAPublicLinkShareOfSpaceWithSettings(
 		string $user,
 		string $spaceName,
-		?TableNode $table
+		?TableNode $table,
 	): void {
 		$this->featureContext->setResponse(
 			$this->sendShareSpaceViaLinkRequest(
 				$user,
 				$spaceName,
-				$table
-			)
+				$table,
+			),
 		);
 	}
 
@@ -3856,7 +3856,7 @@ class SpacesContext implements Context {
 	public function userHasCreatedPublicLinkShareOfSpace(
 		string $user,
 		string $spaceName,
-		?TableNode $table
+		?TableNode $table,
 	): void {
 		$response = $this->sendShareSpaceViaLinkRequest($user, $spaceName, $table);
 
@@ -3864,7 +3864,7 @@ class SpacesContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			$expectedHTTPStatus,
 			"Expected response status code should be $expectedHTTPStatus",
-			$response
+			$response,
 		);
 	}
 
@@ -3887,7 +3887,7 @@ class SpacesContext implements Context {
 		string $spaceName,
 		string $shouldOrNot,
 		string $shareType = 'public link',
-		string $fileName = ''
+		string $fileName = '',
 	): void {
 		if (!empty($fileName)) {
 			$body = $this->getFileId($user, $spaceName, $fileName);
@@ -3909,7 +3909,7 @@ class SpacesContext implements Context {
 			json_encode(HttpRequestHelper::getResponseXml($response, __METHOD__)->data),
 			true,
 			512,
-			JSON_THROW_ON_ERROR
+			JSON_THROW_ON_ERROR,
 		);
 
 		if ($should) {
@@ -3948,14 +3948,14 @@ class SpacesContext implements Context {
 		string $user,
 		string $resourceName,
 		string $spaceName,
-		TableNode $propertiesTable
+		TableNode $propertiesTable,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$response = $this->webDavPropertiesContext->getPropertiesOfFolder(
 			$user,
 			$resourceName,
 			$spaceId,
-			$propertiesTable
+			$propertiesTable,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -3976,7 +3976,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $resourceName,
 		string $spaceName,
-		TableNode $propertiesTable
+		TableNode $propertiesTable,
 	): void {
 		// NOTE: extracting properties occurs asynchronously
 		// short wait is necessary before getting those properties
@@ -3986,7 +3986,7 @@ class SpacesContext implements Context {
 			$user,
 			$resourceName,
 			$spaceId,
-			$propertiesTable
+			$propertiesTable,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -4009,7 +4009,7 @@ class SpacesContext implements Context {
 		string $resourceName,
 		string $spaceName,
 		string $property,
-		string $value
+		string $value,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$this->webDavPropertiesContext->checkPropertyOfAFolder(
@@ -4018,7 +4018,7 @@ class SpacesContext implements Context {
 			$property,
 			$value,
 			null,
-			$spaceId
+			$spaceId,
 		);
 	}
 
@@ -4036,14 +4036,14 @@ class SpacesContext implements Context {
 		string $user,
 		string $path,
 		string $spaceName,
-		string $shouldOrNot
+		string $shouldOrNot,
 	): void {
 		$spaceId = $this->getSpaceIdByName($user, $spaceName);
 		$this->favoritesContext->asUserFileOrFolderShouldBeFavorited(
 			$user,
 			$path,
 			($shouldOrNot === 'should') ? 1 : 0,
-			$spaceId
+			$spaceId,
 		);
 	}
 
@@ -4095,7 +4095,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileOrFolder,
 		string $path,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$this->getSpaceIdByName($user, $spaceName);
 		$user = $this->featureContext->getActualUsername($user);
@@ -4106,7 +4106,7 @@ class SpacesContext implements Context {
 			$storedFileID,
 			__METHOD__
 			. " User '$user' $fileOrFolder '$path' does not have the previously stored id '"
-			. $storedFileID . "', but has '$currentFileID'."
+			. $storedFileID . "', but has '$currentFileID'.",
 		);
 	}
 
@@ -4123,11 +4123,11 @@ class SpacesContext implements Context {
 		// get a response after a Report request (called in the core)
 		$responseArray = json_decode(
 			json_encode(
-				HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath("//d:response/d:href")
+				HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath("//d:response/d:href"),
 			),
 			true,
 			512,
-			JSON_THROW_ON_ERROR
+			JSON_THROW_ON_ERROR,
 		);
 		Assert::assertNotEmpty($responseArray, "search result is empty");
 
@@ -4175,10 +4175,10 @@ class SpacesContext implements Context {
 	public function userSendsPropfindRequestToSpaceUsingTheWebdavApi(
 		string $user,
 		string $spaceName,
-		?string $folderDepth = "1"
+		?string $folderDepth = "1",
 	): void {
 		$this->featureContext->setResponse(
-			$this->sendPropfindRequestToSpace($user, $spaceName, "", null, $folderDepth)
+			$this->sendPropfindRequestToSpace($user, $spaceName, "", null, $folderDepth),
 		);
 	}
 
@@ -4201,7 +4201,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $resource,
-		?string $folderDepth = "1"
+		?string $folderDepth = "1",
 	): void {
 		$response = $this->sendPropfindRequestToSpace($user, $spaceName, $resource, null, $folderDepth);
 		$this->featureContext->setResponse($response);
@@ -4223,18 +4223,18 @@ class SpacesContext implements Context {
 	public function userSendsPropfindRequestToSpaceWithHeaders(
 		string $user,
 		string $spaceName,
-		TableNode $headersTable
+		TableNode $headersTable,
 	): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$headersTable,
-			['header', 'value']
+			['header', 'value'],
 		);
 		$headers = [];
 		foreach ($headersTable as $row) {
 			$headers[$row['header']] = $row ['value'];
 		}
 		$this->featureContext->setResponse(
-			$this->sendPropfindRequestToSpace($user, $spaceName, '', $headers, '0')
+			$this->sendPropfindRequestToSpace($user, $spaceName, '', $headers, '0'),
 		);
 	}
 
@@ -4257,7 +4257,7 @@ class SpacesContext implements Context {
 		?string $resource = "",
 		?array $headers = [],
 		?string $folderDepth = "1",
-		bool $federatedShare = false
+		bool $federatedShare = false,
 	): ResponseInterface {
 		// PROPFIND request to federated share via normal webdav path "remote.php/dav/spaces/{shares-space-id}/{resource}" returns 404 status code
 		// the federated share is only accessible using "remote-item-id", i.e. "remote.php/dav/spaces/{remote-item-id}"
@@ -4310,7 +4310,7 @@ class SpacesContext implements Context {
 			"files",
 			$davPathVersion,
 			null,
-			$headers
+			$headers,
 		);
 	}
 
@@ -4330,7 +4330,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $type,
 		string $resource,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['key', 'value']);
 		if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES && $type === 'space') {
@@ -4356,7 +4356,7 @@ class SpacesContext implements Context {
 	public function buildXpathErrorMessage(
 		SimpleXMLElement $responseXmlObject,
 		array $xpaths,
-		string $message
+		string $message,
 	): string {
 		return "Using xpaths:\n\t- " . \join("\n\t- ", $xpaths)
 			. "\n"
@@ -4376,7 +4376,7 @@ class SpacesContext implements Context {
 	public function getXpathSiblingValue(
 		SimpleXMLElement $responseXmlObject,
 		string $siblingXpath,
-		string $siblingToFind
+		string $siblingToFind,
 	): string {
 		$xpaths[] = $siblingXpath . "/preceding-sibling::$siblingToFind";
 		$xpaths[] = $siblingXpath . "/following-sibling::$siblingToFind";
@@ -4390,7 +4390,7 @@ class SpacesContext implements Context {
 		$errorMessage = $this->buildXpathErrorMessage(
 			$responseXmlObject,
 			$xpaths,
-			"Could not find sibling '<$siblingToFind>' element in the XML response"
+			"Could not find sibling '<$siblingToFind>' element in the XML response",
 		);
 		Assert::assertNotEmpty($foundSibling, $errorMessage);
 		return \preg_quote($foundSibling[0]->__toString(), "/");
@@ -4464,16 +4464,16 @@ class SpacesContext implements Context {
 				$this->buildXpathErrorMessage(
 					$responseXmlObject,
 					$xpaths,
-					"Found multiple elements for '<$itemToFind>' in the XML response"
-				)
+					"Found multiple elements for '<$itemToFind>' in the XML response",
+				),
 			);
 			Assert::assertNotEmpty(
 				$foundXmlItem,
 				$this->buildXpathErrorMessage(
 					$responseXmlObject,
 					$xpaths,
-					"Could not find '<$itemToFind>' element in the XML response"
-				)
+					"Could not find '<$itemToFind>' element in the XML response",
+				),
 			);
 
 			$actualValue = $foundXmlItem[0]->__toString();
@@ -4506,7 +4506,7 @@ class SpacesContext implements Context {
 					Assert::assertMatchesRegularExpression(
 						$expectedValue,
 						$actualValue,
-						'wrong "fileid" in the response'
+						'wrong "fileid" in the response',
 					);
 					break;
 				case "oc:file-parent":
@@ -4514,7 +4514,7 @@ class SpacesContext implements Context {
 					Assert::assertMatchesRegularExpression(
 						$expectedValue,
 						$actualValue,
-						'wrong "file-parent" in the response'
+						'wrong "file-parent" in the response',
 					);
 					break;
 				case "oc:privatelink":
@@ -4522,7 +4522,7 @@ class SpacesContext implements Context {
 					Assert::assertMatchesRegularExpression(
 						$expectedValue,
 						$actualValue,
-						'wrong "privatelink" in the response'
+						'wrong "privatelink" in the response',
 					);
 					break;
 				case "oc:tags":
@@ -4554,7 +4554,7 @@ class SpacesContext implements Context {
 					Assert::assertMatchesRegularExpression(
 						$expectedValue,
 						$actualValue,
-						'wrong "remote-item-id" in the response'
+						'wrong "remote-item-id" in the response',
 					);
 					break;
 				default:
@@ -4577,7 +4577,7 @@ class SpacesContext implements Context {
 	public function asUserTheKeyFromPropfindResponseShouldMatchWithSharedwithmeDriveitemidOfShare(
 		string $user,
 		string $key,
-		string $resource
+		string $resource,
 	): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml($this->featureContext->getResponse(), __METHOD__);
 		$fileId = $responseXmlObject->xpath("//oc:name[text()='$resource']/preceding-sibling::$key")[0]->__toString();
@@ -4585,7 +4585,7 @@ class SpacesContext implements Context {
 		$jsonResponse = GraphHelper::getSharesSharedWithMe(
 			$this->featureContext->getBaseUrl(),
 			$user,
-			$this->featureContext->getPasswordForUser($user)
+			$this->featureContext->getPasswordForUser($user),
 		);
 		$driveItemId = '';
 		$jsonResponseBody = $this->featureContext->getJsonDecodedResponseBodyContent($jsonResponse);
@@ -4620,8 +4620,8 @@ class SpacesContext implements Context {
 				'0',
 				['oc:fileid'],
 				null,
-				"public-files"
-			)
+				"public-files",
+			),
 		);
 		$resourceId = $responseXmlObject->xpath("//d:response/d:propstat/d:prop/oc:fileid");
 		$queryString = 'public-token=' . $token . '&id=' . $resourceId[0][0];
@@ -4629,8 +4629,8 @@ class SpacesContext implements Context {
 			HttpRequestHelper::get(
 				$this->archiverContext->getArchiverUrl($queryString),
 				'',
-				''
-			)
+				'',
+			),
 		);
 	}
 
@@ -4648,7 +4648,7 @@ class SpacesContext implements Context {
 			Assert::assertEquals(
 				$data->quota->relative,
 				$quotaAmount,
-				"Expected relative quota amount to be $quotaAmount but found to be $data->quota->relative"
+				"Expected relative quota amount to be $quotaAmount but found to be $data->quota->relative",
 			);
 			return;
 		}
@@ -4676,17 +4676,17 @@ class SpacesContext implements Context {
 		string $recipientType,
 		string $recipient,
 		string $role,
-		string $expirationDate = null
+		string $expirationDate = null,
 	): void {
 		$response = $this->listAllMySpaces($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			200,
 			"Expected response status code should be 200",
-			$response
+			$response,
 		);
 		Assert::assertIsArray(
 			$spaceAsArray = $this->getSpaceByNameFromResponse($spaceName, $response),
-			"No space with name $spaceName found"
+			"No space with name $spaceName found",
 		);
 		$recipientType === 'user' ?
 		$recipientId = $this->featureContext->getUserIdByUserName($recipient)
@@ -4702,7 +4702,7 @@ class SpacesContext implements Context {
 					Assert::assertEquals(
 						$expirationDate,
 						(preg_split("/[\sT]+/", $permission['expirationDateTime']))[0],
-						"$expirationDate is different in the response"
+						"$expirationDate is different in the response",
 					);
 				}
 				break;
@@ -4731,7 +4731,7 @@ class SpacesContext implements Context {
 				$url,
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-			)
+			),
 		);
 	}
 
@@ -4750,7 +4750,7 @@ class SpacesContext implements Context {
 		string $sharer,
 		string $path,
 		string $space,
-		string $sharee
+		string $sharee,
 	): void {
 		$sharer = $this->featureContext->getActualUsername($sharer);
 		$resource_id = $this->getResourceId($sharer, $space, $path);
@@ -4764,18 +4764,18 @@ class SpacesContext implements Context {
 			null,
 			null,
 			null,
-			$resource_id
+			$resource_id,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, "", $response);
 		$responseStatusCode = $this->ocsContext->getOCSResponseStatusCode(
-			$response
+			$response,
 		);
 		$statusCodes = ["100", "200"];
 		Assert::assertContainsEquals(
 			$responseStatusCode,
 			$statusCodes,
 			"OCS status code is not any of the expected values "
-			. \implode(",", $statusCodes) . " got " . $responseStatusCode
+			. \implode(",", $statusCodes) . " got " . $responseStatusCode,
 		);
 	}
 
@@ -4796,7 +4796,7 @@ class SpacesContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-				$file
+				$file,
 			);
 		} else {
 			$itemId = $this->getFileId($user, $space, $file);
@@ -4810,7 +4810,7 @@ class SpacesContext implements Context {
 				$url,
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-			)
+			),
 		);
 	}
 
@@ -4827,7 +4827,7 @@ class SpacesContext implements Context {
 	public function userHasExpiredTheMembershipOfUserFromSpace(
 		string $user,
 		string $memberUser,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$rows['expireDate'] = $this->featureContext->formatExpiryDateTime('Y-m-d\\TH:i:sP');
 		$rows['shareWith'] = $memberUser;

--- a/tests/acceptance/bootstrap/SpacesTUSContext.php
+++ b/tests/acceptance/bootstrap/SpacesTUSContext.php
@@ -65,7 +65,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$response = $this->tusContext->uploadFileUsingTus($user, $source, $destination, $spaceId);
@@ -73,7 +73,7 @@ class SpacesTUSContext implements Context {
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$destination' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -94,7 +94,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		try {
@@ -107,7 +107,7 @@ class SpacesTUSContext implements Context {
 			Assert::fail(
 				__METHOD__ .
 				" - Expected an exception, but the upload was successful. Status: " .
-				$response->getStatusCode()
+				$response->getStatusCode(),
 			);
 		} catch (ClientException $e) {
 			if (!\str_contains($e->getMessage(), "403 Forbidden")) {
@@ -132,7 +132,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$response = $this->tusContext->uploadFileUsingTus($user, $source, $destination, $spaceId);
@@ -153,7 +153,7 @@ class SpacesTUSContext implements Context {
 	public function thePublicUploadsFileViaTusInsideLastSharedFolderWithPasswordUsingTheWebdavApi(
 		string $source,
 		string $destination,
-		string $password
+		string $password,
 	): void {
 		$response = $this->tusContext->publicUploadFileUsingTus($source, $destination, $password);
 		$this->featureContext->setLastUploadDeleteTime(\time());
@@ -175,7 +175,7 @@ class SpacesTUSContext implements Context {
 	public function userHasCreatedANewTusResourceForTheSpaceUsingTheWebdavApiWithTheseHeaders(
 		string $user,
 		string $spaceName,
-		TableNode $headers
+		TableNode $headers,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$response = $this->tusContext->createNewTUSResourceWithHeaders($user, $headers, '', $spaceId);
@@ -199,7 +199,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $spaceName,
 		string $content,
-		TableNode $headers
+		TableNode $headers,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$response = $this->tusContext->createNewTUSResourceWithHeaders($user, $headers, $content, $spaceId);
@@ -221,7 +221,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $content,
 		string $resource,
-		string $spaceName
+		string $spaceName,
 	): ResponseInterface {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$tmpFile = $this->tusContext->writeDataToTempFile($content);
@@ -229,7 +229,7 @@ class SpacesTUSContext implements Context {
 			$user,
 			\basename($tmpFile),
 			$resource,
-			$spaceId
+			$spaceId,
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		\unlink($tmpFile);
@@ -251,7 +251,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $content,
 		string $file,
-		string $destination
+		string $destination,
 	): void {
 		$remoteItemId = $this->spacesContext->getSharesRemoteItemId($user, $destination);
 		$remoteItemId = \rawurlencode($remoteItemId);
@@ -260,7 +260,7 @@ class SpacesTUSContext implements Context {
 			$user,
 			\basename($tmpFile),
 			$file,
-			$remoteItemId
+			$remoteItemId,
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		\unlink($tmpFile);
@@ -282,7 +282,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $content,
 		string $resource,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$isSpacesDavPathVersion = $this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES;
 		$resource = \ltrim($resource, "/");
@@ -309,13 +309,13 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $content,
 		string $resource,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$response = $this->uploadFileViaTus($user, $content, $resource, $spaceName);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$resource' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -338,7 +338,7 @@ class SpacesTUSContext implements Context {
 		string $source,
 		string $destination,
 		string $mtime,
-		string $spaceName
+		string $spaceName,
 	): void {
 		switch ($mtime) {
 			case "today":
@@ -367,7 +367,7 @@ class SpacesTUSContext implements Context {
 			$source,
 			$destination,
 			$spaceId,
-			['mtime' => $mtime]
+			['mtime' => $mtime],
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		$this->featureContext->setResponse($response);
@@ -392,7 +392,7 @@ class SpacesTUSContext implements Context {
 		string $checksum,
 		string $offset,
 		string $content,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$resourceLocation = $this->tusContext->getLastTusResourceLocation();
 		$response = $this->tusContext->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $content, $checksum);
@@ -418,7 +418,7 @@ class SpacesTUSContext implements Context {
 		string $checksum,
 		string $offset,
 		string $content,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$resourceLocation = $this->tusContext->getLastTusResourceLocation();
 		$response = $this->tusContext->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $content, $checksum);
@@ -444,7 +444,7 @@ class SpacesTUSContext implements Context {
 		string $offset,
 		string $data,
 		string $checksum,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$resourceLocation = $this->tusContext->getLastTusResourceLocation();
 		$response = $this->tusContext->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data, $checksum);
@@ -464,7 +464,7 @@ class SpacesTUSContext implements Context {
 	public function userSendsAChunkToTheLastCreatedTusLocationWithDataInsideOfTheSpaceWithHeaders(
 		string $user,
 		string $data,
-		TableNode $headers
+		TableNode $headers,
 	): void {
 		$rows = $headers->getRowsHash();
 		$resourceLocation = $this->tusContext->getLastTusResourceLocation();
@@ -474,7 +474,7 @@ class SpacesTUSContext implements Context {
 			$rows['Upload-Offset'],
 			$data,
 			$rows['Upload-Checksum'],
-			['Origin' => $rows['Origin']]
+			['Origin' => $rows['Origin']],
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -500,7 +500,7 @@ class SpacesTUSContext implements Context {
 		string $data,
 		string $checksum,
 		string $spaceName,
-		TableNode $headers
+		TableNode $headers,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$createResponse = $this->tusContext->createNewTUSResource($user, $headers, $spaceId);
@@ -525,7 +525,7 @@ class SpacesTUSContext implements Context {
 		string $user,
 		string $resource,
 		string $spaceName,
-		string $mtime
+		string $mtime,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$mtime = new DateTime($mtime);
@@ -538,7 +538,7 @@ class SpacesTUSContext implements Context {
 				$resource,
 				$this->featureContext->getDavPathVersion(),
 				$spaceId,
-			)
+			),
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/TUSContext.php
+++ b/tests/acceptance/bootstrap/TUSContext.php
@@ -100,7 +100,7 @@ class TUSContext implements Context {
 		string $user,
 		TableNode $headersTable,
 		string $content = '',
-		?string $spaceId = null
+		?string $spaceId = null,
 	): ResponseInterface {
 		$this->featureContext->verifyTableNodeColumnsCount($headersTable, 2);
 		$user = $this->featureContext->getActualUsername($user);
@@ -117,7 +117,7 @@ class TUSContext implements Context {
 			"files",
 			null,
 			false,
-			$password
+			$password,
 		);
 		$locationHeader = $response->getHeader('Location');
 		if (\sizeof($locationHeader) > 0) {
@@ -192,7 +192,7 @@ class TUSContext implements Context {
 		string $offset,
 		string $data,
 		string $checksum = '',
-		?array $extraHeaders = null
+		?array $extraHeaders = null,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$password = $this->featureContext->getUserPassword($user);
@@ -210,7 +210,7 @@ class TUSContext implements Context {
 			$user,
 			$password,
 			$headers,
-			$data
+			$data,
 		);
 	}
 
@@ -260,7 +260,7 @@ class TUSContext implements Context {
 		array $uploadMetadata = [],
 		int $noOfChunks = 1,
 		int $bytes = null,
-		string $checksum = ''
+		string $checksum = '',
 	): void {
 		$response = $this->uploadFileUsingTus(
 			$user,
@@ -270,7 +270,7 @@ class TUSContext implements Context {
 			$uploadMetadata,
 			$noOfChunks,
 			$bytes,
-			$checksum
+			$checksum,
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		$this->featureContext->setResponse($response);
@@ -330,7 +330,7 @@ class TUSContext implements Context {
 			$sourceFile,
 			$destination,
 			WebDavHelper::getDavPath($davPathVersion, $suffixPath),
-			$uploadMetadata
+			$uploadMetadata,
 		);
 
 		$this->featureContext->pauseUploadDelete();
@@ -381,7 +381,7 @@ class TUSContext implements Context {
 			$headers,
 			$sourceFile,
 			$destination,
-			$url
+			$url,
 		);
 		$response = $client->createWithUploadRR("", 0);
 		return $response;
@@ -406,14 +406,14 @@ class TUSContext implements Context {
 		string $sourceFile,
 		string $destination,
 		string $path,
-		array $metadata = []
+		array $metadata = [],
 	): TusClient {
 		$client = new TusClient(
 			$baseUrl,
 			[
 				'verify' => false,
 				'headers' => $headers,
-			]
+			],
 		);
 		$client->setApiPath($path);
 		$client->setMetadata($metadata);
@@ -436,13 +436,13 @@ class TUSContext implements Context {
 	public function userUploadsAFileWithContentToUsingTus(
 		string $user,
 		string $content,
-		string $destination
+		string $destination,
 	): void {
 		$temporaryFileName = $this->writeDataToTempFile($content);
 		$response = $this->uploadFileUsingTus(
 			$user,
 			\basename($temporaryFileName),
-			$destination
+			$destination,
 		);
 		\unlink($temporaryFileName);
 		$this->featureContext->setResponse($response);
@@ -469,7 +469,7 @@ class TUSContext implements Context {
 		?string $user,
 		string $content,
 		?int $noOfChunks,
-		string $destination
+		string $destination,
 	): void {
 		$temporaryFileName = $this->writeDataToTempFile($content);
 		$response = $this->uploadFileUsingTus(
@@ -478,7 +478,7 @@ class TUSContext implements Context {
 			$destination,
 			null,
 			[],
-			$noOfChunks
+			$noOfChunks,
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		\unlink($temporaryFileName);
@@ -501,7 +501,7 @@ class TUSContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $mtime
+		string $mtime,
 	): void {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
@@ -511,13 +511,13 @@ class TUSContext implements Context {
 			$source,
 			$destination,
 			null,
-			['mtime' => $mtime]
+			['mtime' => $mtime],
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"Failed to upload file '$source' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -537,7 +537,7 @@ class TUSContext implements Context {
 		string $user,
 		string $source,
 		string $destination,
-		string $mtime
+		string $mtime,
 	): void {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
@@ -547,7 +547,7 @@ class TUSContext implements Context {
 			$source,
 			$destination,
 			null,
-			['mtime' => $mtime]
+			['mtime' => $mtime],
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		$this->featureContext->setResponse($response);
@@ -562,7 +562,7 @@ class TUSContext implements Context {
 	public function writeDataToTempFile(string $content): string {
 		$temporaryFileName = \tempnam(
 			$this->featureContext->acceptanceTestsDirLocation(),
-			"tus-upload-test-"
+			"tus-upload-test-",
 		);
 		if ($temporaryFileName === false) {
 			throw new \Exception("could not create a temporary filename");
@@ -606,7 +606,7 @@ class TUSContext implements Context {
 	public function userCreatesWithUpload(
 		string $user,
 		string $content,
-		TableNode $headers
+		TableNode $headers,
 	): void {
 		$response = $this->createNewTUSResourceWithHeaders($user, $headers, $content);
 		$this->featureContext->setResponse($response);
@@ -625,7 +625,7 @@ class TUSContext implements Context {
 	public function userUploadsWithCreatesWithUpload(
 		string $user,
 		string $source,
-		string $content
+		string $content,
 	): void {
 		$temporaryFileName = $this->writeDataToTempFile($content);
 		$response = $this->uploadFileUsingTus(
@@ -635,7 +635,7 @@ class TUSContext implements Context {
 			null,
 			[],
 			1,
-			-1
+			-1,
 		);
 		$this->featureContext->setLastUploadDeleteTime(\time());
 		\unlink($temporaryFileName);
@@ -657,7 +657,7 @@ class TUSContext implements Context {
 		string $user,
 		string $checksum,
 		string $offset,
-		string $content
+		string $content,
 	): void {
 		$resourceLocation = $this->getLastTusResourceLocation();
 		$response = $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $content, $checksum);
@@ -684,7 +684,7 @@ class TUSContext implements Context {
 		string $checksum,
 		string $offset,
 		string $locationIndex,
-		string $filename
+		string $filename,
 	): void {
 		$filenameHash = \base64_encode($filename);
 		$resourceLocation = $this->getTusResourceLocation($filenameHash, (int)$locationIndex);
@@ -707,7 +707,7 @@ class TUSContext implements Context {
 		string $user,
 		string $checksum,
 		string $offset,
-		string $content
+		string $content,
 	): void {
 		$resourceLocation = $this->getLastTusResourceLocation();
 		$response = $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $content, $checksum);
@@ -729,7 +729,7 @@ class TUSContext implements Context {
 		string $user,
 		string $offset,
 		string $data,
-		string $checksum
+		string $checksum,
 	): void {
 		$resourceLocation = $this->getLastTusResourceLocation();
 		$response = $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data, $checksum);
@@ -751,7 +751,7 @@ class TUSContext implements Context {
 		string $user,
 		string $offset,
 		string $data,
-		string $checksum
+		string $checksum,
 	): void {
 		$resourceLocation = $this->getLastTusResourceLocation();
 		$response = $this->uploadChunkToTUSLocation($user, $resourceLocation, $offset, $data, $checksum);
@@ -778,7 +778,7 @@ class TUSContext implements Context {
 		string $offset,
 		string $data,
 		string $checksum,
-		TableNode $headers
+		TableNode $headers,
 	): void {
 		$createResponse = $this->createNewTUSResource($user, $headers);
 		$this->featureContext->theHTTPStatusCodeShouldBe(201, "", $createResponse);

--- a/tests/acceptance/bootstrap/TagContext.php
+++ b/tests/acceptance/bootstrap/TagContext.php
@@ -69,7 +69,7 @@ class TagContext implements Context {
 		string $fileOrFolder,
 		string $resource,
 		string $space,
-		array $tagNameArray
+		array $tagNameArray,
 	): ResponseInterface {
 		if ($fileOrFolder === 'folder' || $fileOrFolder === 'folders') {
 			$resourceId = $this->spacesContext->getResourceId($user, $space, $resource);
@@ -82,7 +82,7 @@ class TagContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$resourceId,
-			$tagNameArray
+			$tagNameArray,
 		);
 	}
 
@@ -103,7 +103,7 @@ class TagContext implements Context {
 		string $fileOrFolder,
 		string $resource,
 		string $space,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$tagNameArray = [];
 		foreach ($table->getRows() as $value) {
@@ -130,7 +130,7 @@ class TagContext implements Context {
 		string $fileOrFolder,
 		string $resource,
 		string $space,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$tagNameArray = [];
 		foreach ($table->getRows() as $value) {
@@ -155,7 +155,7 @@ class TagContext implements Context {
 		string $user,
 		string $filesOrFolders,
 		string $space,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ["path", "tagName"]);
 		$rows = $table->getHash();
@@ -183,7 +183,7 @@ class TagContext implements Context {
 				$this->featureContext->getBaseUrl(),
 				$user,
 				$this->featureContext->getPasswordForUser($user),
-			)
+			),
 		);
 	}
 
@@ -200,19 +200,19 @@ class TagContext implements Context {
 		$rows = $table->getRows();
 		foreach ($rows as $row) {
 			$responseArray = $this->featureContext->getJsonDecodedResponse(
-				$this->featureContext->getResponse()
+				$this->featureContext->getResponse(),
 			)['value'];
 			if ($shouldOrNot === "not") {
 				Assert::assertFalse(
 					\in_array($row[0], $responseArray),
 					"the response should not contain the tag $row[0].\nResponse\n"
-					. print_r($responseArray, true)
+					. print_r($responseArray, true),
 				);
 			} else {
 				Assert::assertTrue(
 					\in_array($row[0], $responseArray),
 					"the response does not contain the tag $row[0].\nResponse\n"
-					. print_r($responseArray, true)
+					. print_r($responseArray, true),
 				);
 			}
 		}
@@ -233,7 +233,7 @@ class TagContext implements Context {
 		string $fileOrFolder,
 		string $resource,
 		string $space,
-		TableNode $table
+		TableNode $table,
 	): ResponseInterface {
 		$tagNameArray = [];
 		foreach ($table->getRows() as $value) {
@@ -251,7 +251,7 @@ class TagContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user),
 			$resourceId,
-			$tagNameArray
+			$tagNameArray,
 		);
 	}
 
@@ -272,14 +272,14 @@ class TagContext implements Context {
 		string $fileOrFolder,
 		string $resource,
 		string $space,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->removeTagsFromResourceOfTheSpace(
 			$user,
 			$fileOrFolder,
 			$resource,
 			$space,
-			$table
+			$table,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -301,7 +301,7 @@ class TagContext implements Context {
 		string $fileOrFolder,
 		string $resource,
 		string $space,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$response = $this->removeTagsFromResourceOfTheSpace($user, $fileOrFolder, $resource, $space, $table);
 		$this->featureContext->theHttpStatusCodeShouldBe(200, "", $response);
@@ -324,7 +324,7 @@ class TagContext implements Context {
 		int $numberOfTags,
 		string $fileOrFolder,
 		string $resource,
-		string $space
+		string $space,
 	): void {
 		$tagNames = [];
 		foreach (range(1, $numberOfTags) as $tagNumber) {

--- a/tests/acceptance/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/bootstrap/TrashbinContext.php
@@ -55,7 +55,7 @@ class TrashbinContext implements Context {
 			null,
 			null,
 			$davPathVersion,
-			'trash-bin'
+			'trash-bin',
 		);
 	}
 
@@ -100,7 +100,7 @@ class TrashbinContext implements Context {
 					static function (SimpleXMLElement $propStat) {
 						$status = $propStat->xpath('./d:status');
 						return (string) $status[0] === 'HTTP/1.1 200 OK';
-					}
+					},
 				);
 				if (isset($successPropStat[0])) {
 					$successPropStat = $successPropStat[0];
@@ -131,7 +131,7 @@ class TrashbinContext implements Context {
 					'original-location' => isset($originalLocation[0]) ? (string) $originalLocation[0] : null,
 				];
 			},
-			$xmlElements
+			$xmlElements,
 		);
 
 		return $files;
@@ -174,15 +174,15 @@ class TrashbinContext implements Context {
 				'd:getlastmodified',
 			],
 			'trash-bin',
-			$davPathVersion
+			$davPathVersion,
 		);
 		$this->featureContext->setResponse($response);
 
 		$files = $this->getTrashbinContentFromResponseXml(
 			HttpRequestHelper::getResponseXml(
 				$response,
-				__METHOD__
-			)
+				__METHOD__,
+			),
 		);
 		// filter root element
 		$files = \array_filter(
@@ -190,7 +190,7 @@ class TrashbinContext implements Context {
 			static function ($element) use ($davPathVersion, $suffixPath) {
 				$davPath = WebDavHelper::getDavPath($davPathVersion, $suffixPath, "trash-bin");
 				return ($element['href'] !== "/" . $davPath . "/");
-			}
+			},
 		);
 		return $files;
 	}
@@ -208,7 +208,7 @@ class TrashbinContext implements Context {
 		return $this->listTrashbinFolderCollection(
 			$user,
 			"",
-			$depth
+			$depth,
 		);
 	}
 
@@ -227,7 +227,7 @@ class TrashbinContext implements Context {
 		?string $user,
 		?string $collectionPath = "",
 		string $depth = "1",
-		int $level = 1
+		int $level = 1,
 	): array {
 		// $collectionPath should be some list of file-ids like 2147497661/2147497662
 		// or the empty string, which will list the whole trashbin from the top.
@@ -249,7 +249,7 @@ class TrashbinContext implements Context {
 				'd:getlastmodified',
 			],
 			'trash-bin',
-			$davPathVersion
+			$davPathVersion,
 		);
 		$response->getBody()->rewind();
 		$statusCode = $response->getStatusCode();
@@ -257,14 +257,14 @@ class TrashbinContext implements Context {
 		Assert::assertEquals(
 			"207",
 			$statusCode,
-			"Expected status code to be '207' but got $statusCode \nResponse\n$respBody"
+			"Expected status code to be '207' but got $statusCode \nResponse\n$respBody",
 		);
 
 		$files = $this->getTrashbinContentFromResponseXml(
 			HttpRequestHelper::getResponseXml(
 				$response,
-				__METHOD__ . " $collectionPath"
-			)
+				__METHOD__ . " $collectionPath",
+			),
 		);
 
 		$suffixPath = $user;
@@ -286,7 +286,7 @@ class TrashbinContext implements Context {
 					$path = $path . "/";
 				}
 				return ($element['href'] !== "/$endpoint/$path");
-			}
+			},
 		);
 
 		foreach ($files as $file) {
@@ -302,7 +302,7 @@ class TrashbinContext implements Context {
 				// in the response. That should never happen, or have been filtered out
 				// by the code above.
 				throw new Exception(
-					__METHOD__ . " Error: unexpected href in trashbin propfind at level $level: '$trashbinRef'"
+					__METHOD__ . " Error: unexpected href in trashbin propfind at level $level: '$trashbinRef'",
 				);
 			}
 			if ($file["collection"]) {
@@ -313,14 +313,14 @@ class TrashbinContext implements Context {
 					$user,
 					$trashbinId,
 					$depth,
-					$level + 1
+					$level + 1,
 				);
 				// Filter the collection element. We only want the members.
 				$nextFiles = \array_filter(
 					$nextFiles,
 					static function ($element) use ($user, $trashbinRef) {
 						return ($element['href'] !== $trashbinRef);
-					}
+					},
 				);
 				\array_push($files, ...$nextFiles);
 			}
@@ -352,7 +352,7 @@ class TrashbinContext implements Context {
 	public function theTrashbinDavResponseShouldNotContainTheseNodes(TableNode $table): void {
 		$this->featureContext->verifyTableNodeColumns($table, ['name']);
 		$files = $this->getTrashbinContentFromResponseXml(
-			HttpRequestHelper::getResponseXml($this->featureContext->getResponse(), __METHOD__)
+			HttpRequestHelper::getResponseXml($this->featureContext->getResponse(), __METHOD__),
 		);
 
 		foreach ($table->getHash() as $row) {
@@ -377,7 +377,7 @@ class TrashbinContext implements Context {
 		$this->featureContext->verifyTableNodeColumns($table, ['name']);
 
 		$files = $this->getTrashbinContentFromResponseXml(
-			HttpRequestHelper::getResponseXml($this->featureContext->getResponse(), __METHOD__)
+			HttpRequestHelper::getResponseXml($this->featureContext->getResponse(), __METHOD__),
 		);
 
 		foreach ($table->getHash() as $row) {
@@ -408,7 +408,7 @@ class TrashbinContext implements Context {
 	public function sendTrashbinListRequest(
 		string $user,
 		?string $asUser = null,
-		?string $password = null
+		?string $password = null,
 	): ResponseInterface {
 		$asUser = $asUser ?? $user;
 		$password = $password ?? $this->featureContext->getPasswordForUser($asUser);
@@ -428,7 +428,7 @@ class TrashbinContext implements Context {
 			null,
 			'trash-bin',
 			$this->featureContext->getDavPathVersion(),
-			$asUser
+			$asUser,
 		);
 	}
 
@@ -461,7 +461,7 @@ class TrashbinContext implements Context {
 	public function userTriesToListTheTrashbinContentForUserUsingPassword(
 		string $asUser,
 		string $user,
-		string $password
+		string $password,
 	): void {
 		$response = $this->sendTrashbinListRequest($user, $asUser, $password);
 		$this->featureContext->setResponse($response);
@@ -500,7 +500,7 @@ class TrashbinContext implements Context {
 	 */
 	public function theLastWebdavResponseShouldNotContainFollowingElements(TableNode $elements): void {
 		$files = $this->getTrashbinContentFromResponseXml(
-			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())
+			HttpRequestHelper::getResponseXml($this->featureContext->getResponse()),
 		);
 
 		// 'user' is also allowed in the table even though it is not used anywhere
@@ -553,7 +553,7 @@ class TrashbinContext implements Context {
 		string $user,
 		string $path,
 		string $ofUser,
-		string $password
+		string $password,
 	): void {
 		$response = $this->deleteItemFromTrashbin($user, $path, $ofUser, $password);
 		$this->featureContext->setResponse($response);
@@ -593,7 +593,7 @@ class TrashbinContext implements Context {
 		?string $asUser,
 		?string $path,
 		?string $user,
-		?string $password
+		?string $password,
 	): void {
 		$asUser = $this->featureContext->getActualUsername($asUser);
 		$user = $this->featureContext->getActualUsername($user);
@@ -627,7 +627,7 @@ class TrashbinContext implements Context {
 	 */
 	public function userTriesToDeleteFileWithOriginalPathFromTrashbinUsingTrashbinAPI(
 		string $user,
-		string $originalPath
+		string $originalPath,
 	): void {
 		$response = $this->deleteItemFromTrashbin($user, $originalPath);
 		$this->featureContext->setResponse($response);
@@ -645,7 +645,7 @@ class TrashbinContext implements Context {
 		string $user,
 		string $originalPath,
 		?string $ofUser = null,
-		?string $password = null
+		?string $password = null,
 	): ResponseInterface {
 		$ofUser = $ofUser ?? $user;
 		$user = $this->featureContext->getActualUsername($user);
@@ -668,7 +668,7 @@ class TrashbinContext implements Context {
 		if ($path === "") {
 			throw new Exception(
 				__METHOD__
-				. " could not find the trashbin entry for original path '$originalPath' of user '$user'"
+				. " could not find the trashbin entry for original path '$originalPath' of user '$user'",
 			);
 		}
 
@@ -679,7 +679,7 @@ class TrashbinContext implements Context {
 			$fullUrl,
 			"DELETE",
 			$user,
-			$password
+			$password,
 		);
 	}
 
@@ -751,7 +751,7 @@ class TrashbinContext implements Context {
 
 		Assert::assertNotNull(
 			$firstEntry,
-			"The first trash entry was not found while looking for trashbin entry '$path' of user '$user'"
+			"The first trash entry was not found while looking for trashbin entry '$path' of user '$user'",
 		);
 
 		if (\count($sections) !== 1) {
@@ -779,7 +779,7 @@ class TrashbinContext implements Context {
 		Assert::assertTrue(
 			$found,
 			__METHOD__
-			. " Could not find expected resource '$path' in the trash"
+			. " Could not find expected resource '$path' in the trash",
 		);
 	}
 
@@ -822,7 +822,7 @@ class TrashbinContext implements Context {
 		string $trashItemHRef,
 		string $destinationPath,
 		?string $asUser = null,
-		?string $password = null
+		?string $password = null,
 	): ResponseInterface {
 		$asUser = $asUser ?? $user;
 		$password = $password ?? $this->featureContext->getPasswordForUser($asUser);
@@ -860,7 +860,7 @@ class TrashbinContext implements Context {
 			false,
 			$password,
 			[],
-			$asUser
+			$asUser,
 		);
 	}
 
@@ -880,7 +880,7 @@ class TrashbinContext implements Context {
 		string $originalPath,
 		?string $destinationPath = null,
 		?string $asUser = null,
-		?string $password = null
+		?string $password = null,
 	): ResponseInterface {
 		$asUser = $asUser ?? $user;
 		$listing = $this->listTrashbinFolder($user);
@@ -895,7 +895,7 @@ class TrashbinContext implements Context {
 					$entry['href'],
 					$destinationPath,
 					$asUser,
-					$password
+					$password,
 				);
 			}
 		}
@@ -904,7 +904,8 @@ class TrashbinContext implements Context {
 		// is also no up-to-date response to examine in later test steps.
 		throw new \Exception(
 			__METHOD__
-			. " cannot restore from trashbin because no element was found for user $user at original path $originalPath"
+			. " cannot restore from trashbin."
+			. " No element was found for user $user at original path $originalPath",
 		);
 	}
 
@@ -919,7 +920,7 @@ class TrashbinContext implements Context {
 	 */
 	public function userRestoresResourceWithOriginalPathWithoutSpecifyingDestinationUsingTrashbinApi(
 		string $user,
-		string $originalPath
+		string $originalPath,
 	): void {
 		$listing = $this->listTrashbinFolder($user);
 		$originalPath = \trim($originalPath, '/');
@@ -935,8 +936,8 @@ class TrashbinContext implements Context {
 						[],
 						null,
 						null,
-						'trash-bin'
-					)
+						'trash-bin',
+					),
 				);
 			}
 		}
@@ -961,7 +962,7 @@ class TrashbinContext implements Context {
 		?string $fileName,
 		?string $user,
 		?string $content,
-		?string $alternativeContent
+		?string $alternativeContent,
 	): void {
 		$isInTrash = $this->isInTrash($user, $fileName);
 		$user = $this->featureContext->getActualUsername($user);
@@ -1039,7 +1040,7 @@ class TrashbinContext implements Context {
 	public function userRestoresTheFileWithOriginalPathToUsingTheTrashbinApi(
 		?string $user,
 		?string $originalPath,
-		?string $destinationPath
+		?string $destinationPath,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->featureContext->setResponse($this->restoreElement($user, $originalPath, $destinationPath));
@@ -1057,12 +1058,12 @@ class TrashbinContext implements Context {
 	 */
 	public function elementIsInTrashCheckingOriginalPath(
 		?string $user,
-		?string $originalPath
+		?string $originalPath,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		Assert::assertTrue(
 			$this->isInTrash($user, $originalPath),
-			"File previously located at $originalPath wasn't found in the trashbin of user $user"
+			"File previously located at $originalPath wasn't found in the trashbin of user $user",
 		);
 	}
 
@@ -1077,12 +1078,12 @@ class TrashbinContext implements Context {
 	 */
 	public function elementIsNotInTrashCheckingOriginalPath(
 		?string $user,
-		string $originalPath
+		string $originalPath,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		Assert::assertFalse(
 			$this->isInTrash($user, $originalPath),
-			"File previously located at $originalPath was found in the trashbin of user $user"
+			"File previously located at $originalPath was found in the trashbin of user $user",
 		);
 	}
 
@@ -1097,7 +1098,7 @@ class TrashbinContext implements Context {
 	 */
 	public function followingElementsAreNotInTrashCheckingOriginalPath(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -1106,7 +1107,7 @@ class TrashbinContext implements Context {
 			$user = $this->featureContext->getActualUsername($user);
 			Assert::assertFalse(
 				$this->isInTrash($user, $originalPath["path"]),
-				"File previously located at " . $originalPath["path"] . " was found in the trashbin of user $user"
+				"File previously located at " . $originalPath["path"] . " was found in the trashbin of user $user",
 			);
 		}
 	}
@@ -1122,7 +1123,7 @@ class TrashbinContext implements Context {
 	 */
 	public function followingElementsAreInTrashCheckingOriginalPath(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -1131,7 +1132,7 @@ class TrashbinContext implements Context {
 			$user = $this->featureContext->getActualUsername($user);
 			Assert::assertTrue(
 				$this->isInTrash($user, $originalPath["path"]),
-				"File previously located at " . $originalPath["path"] . " wasn't found in the trashbin of user $user"
+				"File previously located at " . $originalPath["path"] . " wasn't found in the trashbin of user $user",
 			);
 		}
 	}
@@ -1183,7 +1184,7 @@ class TrashbinContext implements Context {
 	 */
 	public function theDeletedFileFolderShouldHaveCorrectDeletionMtimeInTheResponse(string $resource): void {
 		$files = $this->getTrashbinContentFromResponseXml(
-			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())
+			HttpRequestHelper::getResponseXml($this->featureContext->getResponse()),
 		);
 
 		$found = false;
@@ -1203,7 +1204,7 @@ class TrashbinContext implements Context {
 		}
 		Assert::assertTrue(
 			$found,
-			"$resource expected to be listed in response with mtime '$expectedMtime' but found '$responseMtime'"
+			"$resource expected to be listed in response with mtime '$expectedMtime' but found '$responseMtime'",
 		);
 	}
 }

--- a/tests/acceptance/bootstrap/WebDav.php
+++ b/tests/acceptance/bootstrap/WebDav.php
@@ -296,7 +296,7 @@ trait WebDav {
 		?string $password = null,
 		?array $urlParameter = [],
 		?string $doDavRequestAsUser = null,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 
@@ -328,7 +328,7 @@ trait WebDav {
 			null,
 			$urlParameter,
 			$doDavRequestAsUser,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -349,7 +349,7 @@ trait WebDav {
 		string $folder,
 		?bool $isGivenStep = false,
 		?string $password = null,
-		?string $spaceId = null
+		?string $spaceId = null,
 	): ResponseInterface {
 		return $this->makeDavRequest(
 			$user,
@@ -364,7 +364,7 @@ trait WebDav {
 			$password,
 			[],
 			null,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -383,7 +383,7 @@ trait WebDav {
 		?string $path,
 		?string $doDavRequestAsUser,
 		?string $width,
-		?string $height
+		?string $height,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$doDavRequestAsUser = $this->getActualUsername($doDavRequestAsUser);
@@ -406,7 +406,7 @@ trait WebDav {
 			false,
 			$password,
 			$urlParameter,
-			$doDavRequestAsUser
+			$doDavRequestAsUser,
 		);
 	}
 
@@ -425,7 +425,7 @@ trait WebDav {
 		Assert::assertEquals(
 			$number,
 			$actualNumber,
-			"Expected number of versions was '$number', but got '$actualNumber'"
+			"Expected number of versions was '$number', but got '$actualNumber'",
 		);
 	}
 
@@ -444,7 +444,7 @@ trait WebDav {
 		Assert::assertEquals(
 			$number,
 			$actualNumber,
-			"Expected number of etag elements was '$number', but got '$actualNumber'"
+			"Expected number of etag elements was '$number', but got '$actualNumber'",
 		);
 	}
 
@@ -489,7 +489,7 @@ trait WebDav {
 	public function userHasMovedFile(
 		?string $user,
 		?string $fileSource,
-		?string $fileDestination
+		?string $fileDestination,
 	): void {
 		$response = $this->moveResource($user, $fileSource, $fileDestination);
 		$actualStatusCode = $response->getStatusCode();
@@ -497,7 +497,7 @@ trait WebDav {
 			201,
 			" Failed moving resource '$fileSource' to '$fileDestination'." .
 			" Expected status code was 201 but got '$actualStatusCode' ",
-			$response
+			$response,
 		);
 	}
 
@@ -512,13 +512,13 @@ trait WebDav {
 		$user = $this->getActualUsername($user);
 		$headers['Destination'] = $this->destinationHeaderValue(
 			$user,
-			$destination
+			$destination,
 		);
 		return $this->makeDavRequest(
 			$user,
 			"MOVE",
 			$source,
-			$headers
+			$headers,
 		);
 	}
 
@@ -537,7 +537,7 @@ trait WebDav {
 	public function userMovesFileOrFolderUsingTheWebDavAPI(
 		string $user,
 		string $source,
-		string $destination
+		string $destination,
 	): void {
 		$response = $this->moveResource($user, $source, $destination);
 		$this->setResponse($response);
@@ -560,7 +560,7 @@ trait WebDav {
 			$response = $this->moveResource($user, $row["source"], $row["destination"]);
 			$this->setResponse($response);
 			$this->pushToLastHttpStatusCodesArray(
-				(string) $response->getStatusCode()
+				(string) $response->getStatusCode(),
 			);
 		}
 	}
@@ -578,7 +578,7 @@ trait WebDav {
 	public function userMovesFollowingFileUsingTheAPI(
 		string $user,
 		string $type,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["from", "to"]);
 		$paths = $table->getHash();
@@ -586,7 +586,7 @@ trait WebDav {
 		foreach ($paths as $file) {
 			$response = $this->moveResource($user, $file['from'], $file['to']);
 			$this->pushToLastHttpStatusCodesArray(
-				(string) $response->getStatusCode()
+				(string) $response->getStatusCode(),
 			);
 		}
 	}
@@ -606,7 +606,7 @@ trait WebDav {
 		string $user,
 		string $entry,
 		string $source,
-		string $destination
+		string $destination,
 	): void {
 		$user = $this->getActualUsername($user);
 		$this->checkFileOrFolderExistsForUser($user, $entry, $source);
@@ -631,7 +631,7 @@ trait WebDav {
 		string $user,
 		string $entry,
 		string $source,
-		string $destination
+		string $destination,
 	): void {
 		$this->checkFileOrFolderExistsForUser($user, $entry, $source);
 		$response = $this->moveResource($user, $source, $destination);
@@ -650,18 +650,18 @@ trait WebDav {
 	public function copyFile(
 		string $user,
 		string $fileSource,
-		string $fileDestination
+		string $fileDestination,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$headers['Destination'] = $this->destinationHeaderValue(
 			$user,
-			$fileDestination
+			$fileDestination,
 		);
 		return $this->makeDavRequest(
 			$user,
 			"COPY",
 			$fileSource,
-			$headers
+			$headers,
 		);
 	}
 
@@ -677,7 +677,7 @@ trait WebDav {
 	public function userCopiesFileUsingTheAPI(
 		string $user,
 		string $fileSource,
-		string $fileDestination
+		string $fileDestination,
 	): void {
 		$response = $this->copyFile($user, $fileSource, $fileDestination);
 		$this->setResponse($response);
@@ -696,14 +696,14 @@ trait WebDav {
 	public function userHasCopiedFileUsingTheAPI(
 		string $user,
 		string $fileSource,
-		string $fileDestination
+		string $fileDestination,
 	): void {
 		$response = $this->copyFile($user, $fileSource, $fileDestination);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to copy resource "
 			. "'$fileSource' to '$fileDestination' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -721,7 +721,7 @@ trait WebDav {
 			$user,
 			"GET",
 			$fileSource,
-			$headers
+			$headers,
 		);
 	}
 
@@ -750,7 +750,7 @@ trait WebDav {
 	public function userUsingPasswordShouldNotBeAbleToDownloadFile(
 		string $user,
 		string $password,
-		string $fileName
+		string $fileName,
 	): void {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
@@ -759,14 +759,14 @@ trait WebDav {
 			400,
 			$response->getStatusCode(),
 			__METHOD__
-			. ' download must fail'
+			. ' download must fail',
 		);
 		Assert::assertLessThanOrEqual(
 			499,
 			$response->getStatusCode(),
 			__METHOD__
 			. ' 4xx error expected but got status code "'
-			. $response->getStatusCode() . '"'
+			. $response->getStatusCode() . '"',
 		);
 	}
 
@@ -781,7 +781,7 @@ trait WebDav {
 	 */
 	public function userShouldNotBeAbleToDownloadFile(
 		string $user,
-		string $fileName
+		string $fileName,
 	): void {
 		$user = $this->getActualUsername($user);
 		$password = $this->getPasswordForUser($user);
@@ -790,14 +790,14 @@ trait WebDav {
 			400,
 			$response->getStatusCode(),
 			__METHOD__
-			. ' download must fail'
+			. ' download must fail',
 		);
 		Assert::assertLessThanOrEqual(
 			499,
 			$response->getStatusCode(),
 			__METHOD__
 			. ' 4xx error expected but got status code "'
-			. $response->getStatusCode() . '"'
+			. $response->getStatusCode() . '"',
 		);
 	}
 
@@ -813,7 +813,7 @@ trait WebDav {
 		Assert::assertEquals(
 			$size,
 			$actualSize,
-			"Expected size of the downloaded file was '$size' but got '$actualSize'"
+			"Expected size of the downloaded file was '$size' but got '$actualSize'",
 		);
 	}
 
@@ -829,7 +829,7 @@ trait WebDav {
 		Assert::assertEquals(
 			$content,
 			$actualContent,
-			"The downloaded content was expected to end with '$content', but actually ended with '$actualContent'."
+			"The downloaded content was expected to end with '$content', but actually ended with '$actualContent'.",
 		);
 	}
 
@@ -854,7 +854,7 @@ trait WebDav {
 	public function checkDownloadedContentMatches(
 		string $expectedContent,
 		string $extraErrorText = "",
-		?ResponseInterface $response = null
+		?ResponseInterface $response = null,
 	): void {
 		$response = $response ?? $this->response;
 		$actualContent = (string) $response->getBody();
@@ -870,7 +870,7 @@ trait WebDav {
 			$expectedContent,
 			$actualContent,
 			$extraErrorText . "The content was expected to be '$expectedContent', but actually is "
-			. "'$actualContent'. HTTP status was $actualStatus"
+			. "'$actualContent'. HTTP status was $actualStatus",
 		);
 	}
 
@@ -895,7 +895,7 @@ trait WebDav {
 	public function theContentInTheResponseShouldIncludeTheFollowingContent(PyStringNode $content): void {
 		Assert::assertStringContainsString(
 			$content->getRaw(),
-			(string) $this->response->getBody()
+			(string) $this->response->getBody(),
 		);
 	}
 
@@ -919,7 +919,7 @@ trait WebDav {
 				$content,
 				$actualContent,
 				"The downloaded content was expected to be '$content', but actually is "
-				. "'$actualContent'. HTTP status was $actualStatusCode"
+				. "'$actualContent'. HTTP status was $actualStatusCode",
 			);
 		}
 	}
@@ -953,7 +953,7 @@ trait WebDav {
 		$actualStatus = $response->getStatusCode();
 		if ($actualStatus !== 200) {
 			throw new Exception(
-				"Expected status code to be '200', but got '$actualStatus'"
+				"Expected status code to be '200', but got '$actualStatus'",
 			);
 		}
 		$this->checkDownloadedContentMatches($content, '', $response);
@@ -980,7 +980,7 @@ trait WebDav {
 			Assert::assertEquals(
 				200,
 				$actualStatus,
-				"Expected status code to be '200', but got '$actualStatus'"
+				"Expected status code to be '200', but got '$actualStatus'",
 			);
 			$this->checkDownloadedContentMatches($content, '', $response);
 		}
@@ -1000,7 +1000,7 @@ trait WebDav {
 		string $fileName,
 		string $user,
 		?string $password,
-		string $content
+		string $content,
 	): void {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
@@ -1020,7 +1020,7 @@ trait WebDav {
 	public function contentOfFileForUserShouldBePyString(
 		string $fileName,
 		string $user,
-		PyStringNode $content
+		PyStringNode $content,
 	): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->downloadFileAsUserUsingPassword($user, $fileName);
@@ -1028,7 +1028,7 @@ trait WebDav {
 		Assert::assertEquals(
 			200,
 			$actualStatus,
-			"Expected status code to be '200', but got '$actualStatus'"
+			"Expected status code to be '200', but got '$actualStatus'",
 		);
 		$this->checkDownloadedContentMatches($content->getRaw(), '', $response);
 	}
@@ -1069,7 +1069,7 @@ trait WebDav {
 			__METHOD__
 			. " : File '$fileName' not in postprocessing."
 			. " Expected status code to be '425', but got '"
-			. $response->getStatusCode() . "'"
+			. $response->getStatusCode() . "'",
 		);
 	}
 
@@ -1084,7 +1084,7 @@ trait WebDav {
 	 */
 	public function userDownloadsFileUsingTheAPI(
 		string $user,
-		string $fileName
+		string $fileName,
 	): void {
 		$this->setResponse($this->downloadFileAsUserUsingPassword($user, $fileName));
 	}
@@ -1117,7 +1117,7 @@ trait WebDav {
 			"files",
 			null,
 			false,
-			$password
+			$password,
 		);
 	}
 
@@ -1134,7 +1134,7 @@ trait WebDav {
 		$url = "{$this->getBaseUrl()}/$davPath";
 		$this->response = HttpRequestHelper::sendRequest(
 			$url,
-			"PROPFIND"
+			"PROPFIND",
 		);
 	}
 
@@ -1159,7 +1159,7 @@ trait WebDav {
 			"0",
 			null,
 			"files",
-			$this->getDavPathVersion()
+			$this->getDavPathVersion(),
 		);
 	}
 
@@ -1174,7 +1174,7 @@ trait WebDav {
 	public function theSizeOfTheFileShouldBe(string $size): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->response,
-			__METHOD__
+			__METHOD__,
 		);
 		$xmlPart = $responseXmlObject->xpath("//d:prop/d:getcontentlength");
 		$actualSize = (string) $xmlPart[0];
@@ -1182,7 +1182,7 @@ trait WebDav {
 			$size,
 			$actualSize,
 			__METHOD__
-			. " Expected size of the file was '$size', but got '$actualSize' instead."
+			. " Expected size of the file was '$size', but got '$actualSize' instead.",
 		);
 	}
 
@@ -1202,7 +1202,7 @@ trait WebDav {
 		Assert::assertEquals(
 			200,
 			$actualStatus,
-			"Expected status code to be '200', but got '$actualStatus'"
+			"Expected status code to be '200', but got '$actualStatus'",
 		);
 		$this->checkDownloadedContentMatches("$content\n", '', $response);
 	}
@@ -1218,7 +1218,7 @@ trait WebDav {
 	public function theFollowingHeadersShouldBeSet(TableNode $table): void {
 		$this->verifyTableNodeColumns(
 			$table,
-			['header', 'value']
+			['header', 'value'],
 		);
 		foreach ($table->getColumnsHash() as $header) {
 			$headerName = $header['header'];
@@ -1230,8 +1230,8 @@ trait WebDav {
 				throw new Exception(
 					\sprintf(
 						"Missing expected header '%s'",
-						$headerName
-					)
+						$headerName,
+					),
 				);
 			}
 			$headerValue = $returnedHeader[0];
@@ -1240,7 +1240,8 @@ trait WebDav {
 				$expectedHeaderValue,
 				$headerValue,
 				__METHOD__
-				. " Expected value for header '$headerName' was '$expectedHeaderValue', but got '$headerValue' instead."
+				. " Expected value for header '$headerName' was '$expectedHeaderValue',"
+				. " but got '$headerValue' instead.",
 			);
 		}
 	}
@@ -1258,7 +1259,7 @@ trait WebDav {
 	public function asFileOrFolderShouldNotExist(
 		string $user,
 		string $entry,
-		string $path
+		string $path,
 	): void {
 		$this->checkFileOrFolderDoesNotExistsForUser($user, $entry, $path);
 	}
@@ -1275,7 +1276,7 @@ trait WebDav {
 		string $user,
 		string $entry = "file",
 		?string $path = null,
-		string $type = "files"
+		string $type = "files",
 	): void {
 		$user = $this->getActualUsername($user);
 		$path = $this->substituteInLineCodes($path);
@@ -1285,23 +1286,23 @@ trait WebDav {
 			'0',
 			null,
 			null,
-			$type
+			$type,
 		);
 		$statusCode = $response->getStatusCode();
 		if ($statusCode < 400 || $statusCode > 499) {
 			try {
 				$responseXmlObject = HttpRequestHelper::getResponseXml(
 					$response,
-					__METHOD__
+					__METHOD__,
 				);
 			} catch (Exception $e) {
 				Assert::fail(
-					"$entry '$path' should not exist. But API returned $statusCode without XML in the body"
+					"$entry '$path' should not exist. But API returned $statusCode without XML in the body",
 				);
 			}
 			Assert::assertTrue(
 				$this->isEtagValid($this->getEtagFromResponseXmlObject($responseXmlObject)),
-				"$entry '$path' should not exist. But API returned $statusCode without an etag in the body"
+				"$entry '$path' should not exist. But API returned $statusCode without an etag in the body",
 			);
 			$isCollection = $responseXmlObject->xpath("//d:prop/d:resourcetype/d:collection");
 			if (\count($isCollection) === 0) {
@@ -1312,7 +1313,7 @@ trait WebDav {
 
 			if ($entry === $actualResourceType) {
 				Assert::fail(
-					"$entry '$path' should not exist. But it does."
+					"$entry '$path' should not exist. But it does.",
 				);
 			}
 		}
@@ -1331,7 +1332,7 @@ trait WebDav {
 	public function followingFilesShouldNotExist(
 		string $user,
 		string $entry,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -1355,7 +1356,7 @@ trait WebDav {
 	public function asFileOrFolderShouldExist(
 		string $user,
 		string $entry,
-		string $path
+		string $path,
 	): void {
 		$this->checkFileOrFolderExistsForUser($user, $entry, $path);
 	}
@@ -1373,7 +1374,7 @@ trait WebDav {
 		string $user,
 		string $entry,
 		string $path,
-		?string $type = "files"
+		?string $type = "files",
 	): void {
 		$user = $this->getActualUsername($user);
 		$path = $this->substituteInLineCodes($path);
@@ -1384,13 +1385,13 @@ trait WebDav {
 				'0',
 				null,
 				null,
-				$type
-			)
+				$type,
+			),
 		);
 
 		Assert::assertTrue(
 			$this->isEtagValid($this->getEtagFromResponseXmlObject($responseXmlObject)),
-			"$entry '$path' expected to exist for user $user but not found"
+			"$entry '$path' expected to exist for user $user but not found",
 		);
 		$isCollection = $responseXmlObject->xpath("//d:prop/d:resourcetype/d:collection");
 		if ($entry === "folder") {
@@ -1413,7 +1414,7 @@ trait WebDav {
 	public function followingFilesOrFoldersShouldExist(
 		string $user,
 		string $entry,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -1437,7 +1438,7 @@ trait WebDav {
 		string $user,
 		string $entry,
 		string $path,
-		string $type = "files"
+		string $type = "files",
 	): bool {
 		try {
 			$this->checkFileOrFolderExistsForUser($user, $entry, $path, $type);
@@ -1465,7 +1466,7 @@ trait WebDav {
 		string $folderDepth,
 		?array $properties = null,
 		?string $spaceId = null,
-		string $type = "files"
+		string $type = "files",
 	): ResponseInterface {
 		return WebDavHelper::listFolder(
 			$this->getBaseUrl(),
@@ -1476,7 +1477,7 @@ trait WebDav {
 			$spaceId,
 			$properties,
 			$type,
-			$this->getDavPathVersion()
+			$this->getDavPathVersion(),
 		);
 	}
 
@@ -1511,7 +1512,7 @@ trait WebDav {
 	public function checkElementList(
 		string $user,
 		TableNode $elements,
-		bool $expectedToBeListed = true
+		bool $expectedToBeListed = true,
 	): void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeColumnsCount($elements, 1);
@@ -1524,8 +1525,8 @@ trait WebDav {
 				$this->listFolder(
 					$user,
 					"/",
-					"infinity"
-				)
+					"infinity",
+				),
 			);
 			foreach ($elementsSimplified as $expectedElement) {
 				// Allow the table of expected elements to have entries that do
@@ -1535,18 +1536,18 @@ trait WebDav {
 				$expectedElement = "/" . \ltrim($expectedElement, "/");
 				$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
 				$element = $responseXmlObject->xpath(
-					"//d:response/d:href[text() = \"$webdavPath\"]"
+					"//d:response/d:href[text() = \"$webdavPath\"]",
 				);
 				if ($expectedToBeListed
 					&& (!isset($element[0]) || urldecode($element[0]->__toString()) !== urldecode($webdavPath))
 				) {
 					Assert::fail(
-						"$webdavPath is not in propfind answer but should be"
+						"$webdavPath is not in propfind answer but should be",
 					);
 				} elseif (!$expectedToBeListed && isset($element[0])
 				) {
 					Assert::fail(
-						"$webdavPath is in propfind answer but should not be"
+						"$webdavPath is in propfind answer but should not be",
 					);
 				}
 			}
@@ -1567,27 +1568,27 @@ trait WebDav {
 					$this->listFolder(
 						$user,
 						$elementToRequest,
-						'1'
-					)
+						'1',
+					),
 				);
 
 				$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
 				// return xmlobject that matches the x-path pattern.
 				$element = $responseXmlObject->xpath(
-					"//d:response/d:href"
+					"//d:response/d:href",
 				);
 				// check the first element because the requested resource will always be the first one
 				if (!$expectedToBeListed && isset($element[0])
 				) {
 					Assert::fail(
-						"$webdavPath is in propfind answer but should not be"
+						"$webdavPath is in propfind answer but should not be",
 					);
 				};
 				if ($expectedToBeListed) {
 					$elementSanitized = rtrim($element[0]->__toString(), '/');
 					if (!isset($element[0]) || urldecode($elementSanitized) !== urldecode($webdavPath)) {
 						Assert::fail(
-							"$webdavPath is not in propfind answer but should be"
+							"$webdavPath is not in propfind answer but should be",
 						);
 					}
 				}
@@ -1609,7 +1610,7 @@ trait WebDav {
 		string $source,
 		string $destination,
 		string $spaceId = null,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$file = \fopen($this->acceptanceTestsDirLocation() . $source, 'r');
@@ -1627,7 +1628,7 @@ trait WebDav {
 			null,
 			[],
 			null,
-			$isGivenStep
+			$isGivenStep,
 		);
 		$this->lastUploadDeleteTime = \time();
 		return $response;
@@ -1645,12 +1646,12 @@ trait WebDav {
 	public function userUploadsAFileToUsingWebDavApi(
 		string $user,
 		string $source,
-		string $destination
+		string $destination,
 	): void {
 		$response = $this->uploadFile($user, $source, $destination);
 		$this->setResponse($response);
 		$this->pushToLastHttpStatusCodesArray(
-			(string) $response->getStatusCode()
+			(string) $response->getStatusCode(),
 		);
 	}
 
@@ -1669,7 +1670,7 @@ trait WebDav {
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file "
 			. "'$source' to '$destination' for user '$user'",
-			$response
+			$response,
 		);
 		return $response->getHeader('oc-fileid');
 	}
@@ -1691,7 +1692,7 @@ trait WebDav {
 		string $source,
 		string $destination,
 		?array $headers = [],
-		?int $noOfChunks = 0
+		?int $noOfChunks = 0,
 	): ResponseInterface {
 		$doChunkUpload = true;
 		if ($noOfChunks <= 0) {
@@ -1730,13 +1731,13 @@ trait WebDav {
 		string $destination,
 		int $noOfChunks = 2,
 		bool $async = false,
-		?array $headers = []
+		?array $headers = [],
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		Assert::assertGreaterThan(
 			0,
 			$noOfChunks,
-			"What does it mean to have $noOfChunks chunks?"
+			"What does it mean to have $noOfChunks chunks?",
 		);
 
 		if ($async === true) {
@@ -1747,7 +1748,7 @@ trait WebDav {
 			$this->acceptanceTestsDirLocation() . $source,
 			$destination,
 			$headers,
-			$noOfChunks
+			$noOfChunks,
 		);
 	}
 
@@ -1766,7 +1767,7 @@ trait WebDav {
 		string $user,
 		string $source,
 		string $destination,
-		int $noOfChunks = 2
+		int $noOfChunks = 2,
 	): void {
 		$response = $this->userUploadsAFileInChunk($user, $source, $destination, $noOfChunks);
 		$this->setResponse($response);
@@ -1787,13 +1788,13 @@ trait WebDav {
 			Assert::assertSame(
 				$statusCode,
 				\intval($duplicateRemovedStatusCodes[0]),
-				'Responses did not return expected http status code'
+				'Responses did not return expected http status code',
 			);
 			$this->emptyLastHTTPStatusCodesArray();
 		} else {
 			throw new Exception(
 				'Expected same but found different http status codes of last requested responses.' .
-				'Found status codes: ' . \implode(',', $this->lastHttpStatusCodesArray)
+				'Found status codes: ' . \implode(',', $this->lastHttpStatusCodesArray),
 			);
 		}
 	}
@@ -1824,7 +1825,7 @@ trait WebDav {
 		Assert::assertTrue(
 			$statusCodesAreAllOk,
 			'Expected HTTP status codes: "' . $statusCodes .
-			'". Found HTTP status codes: "' . \implode(',', $actualStatusCodes) . '"'
+			'". Found HTTP status codes: "' . \implode(',', $actualStatusCodes) . '"',
 		);
 	}
 
@@ -1851,7 +1852,7 @@ trait WebDav {
 	 */
 	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBeOcisReva(
 		string $ocisStatusCodes,
-		string $revaStatusCodes
+		string $revaStatusCodes,
 	): void {
 		if (OcisHelper::isTestingOnReva()) {
 			$expectedStatusCodes = $revaStatusCodes;
@@ -1877,13 +1878,13 @@ trait WebDav {
 				Assert::assertSame(
 					(int)\trim($statusCodes[$i]),
 					(int)$this->lastOCSStatusCodesArray[$i],
-					'Responses did not return expected OCS status code'
+					'Responses did not return expected OCS status code',
 				);
 			}
 		} else {
 			throw new Exception(
 				'Expected OCS status codes: "' . \implode(',', $statusCodes) .
-				'". Found OCS status codes: "' . \implode(',', $this->lastOCSStatusCodesArray) . '"'
+				'". Found OCS status codes: "' . \implode(',', $this->lastOCSStatusCodesArray) . '"',
 			);
 		}
 	}
@@ -1902,13 +1903,13 @@ trait WebDav {
 			Assert::assertSame(
 				\intval($statusCode),
 				\intval($duplicateRemovedStatusCodes[0]),
-				'Responses did not return expected ocs status code'
+				'Responses did not return expected ocs status code',
 			);
 			$this->emptyLastOCSStatusCodesArray();
 		} else {
 			throw new Exception(
 				'Expected same but found different ocs status codes of last requested responses.' .
-				'Found status codes: ' . \implode(',', $this->lastOCSStatusCodesArray)
+				'Found status codes: ' . \implode(',', $this->lastOCSStatusCodesArray),
 			);
 		}
 	}
@@ -1929,7 +1930,7 @@ trait WebDav {
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$destination'",
-			$response
+			$response,
 		);
 		$this->checkFileOrFolderExistsForUser($user, "file", $destination);
 	}
@@ -1959,7 +1960,7 @@ trait WebDav {
 				$initialContent,
 				$currentContent,
 				__METHOD__
-				. " user $user was unexpectedly able to upload $source to $destination - the content has changed:"
+				. " user $user was unexpectedly able to upload $source to $destination - the content has changed:",
 			);
 		} else {
 			$this->checkFileOrFolderDoesNotExistsForUser($user, "file", $destination);
@@ -1978,7 +1979,7 @@ trait WebDav {
 		string $user,
 		string $destination,
 		string $shouldOrNot,
-		?string $exceptChunkingType = ''
+		?string $exceptChunkingType = '',
 	): void {
 		switch ($exceptChunkingType) {
 			case 'old':
@@ -1999,7 +2000,7 @@ trait WebDav {
 						$this->checkFileOrFolderExistsForUser(
 							$user,
 							'file',
-							"$destination-$suffix"
+							"$destination-$suffix",
 						);
 					}
 				}
@@ -2011,7 +2012,7 @@ trait WebDav {
 						$this->checkFileOrFolderDoesNotExistsForUser(
 							$user,
 							'file',
-							"$destination-$suffix"
+							"$destination-$suffix",
 						);
 					}
 				}
@@ -2055,7 +2056,7 @@ trait WebDav {
 		string $user,
 		string $destination,
 		string $text,
-		string $bytes
+		string $bytes,
 	): void {
 		$filename = "filespecificSize.txt";
 		$this->createLocalFileOfSpecificSize($filename, $bytes, $text);
@@ -2121,7 +2122,7 @@ trait WebDav {
 	public function userUploadsAFileWithContentTo(
 		string $user,
 		?string $content,
-		string $destination
+		string $destination,
 	): void {
 		$response = $this->uploadFileWithContent($user, $content, $destination);
 		$this->setResponse($response);
@@ -2141,7 +2142,7 @@ trait WebDav {
 	public function userUploadsFollowingFilesWithContentTo(
 		string $user,
 		?string $content,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
@@ -2170,7 +2171,7 @@ trait WebDav {
 		string $source,
 		string $destination,
 		string $mtime,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): void {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
@@ -2185,7 +2186,7 @@ trait WebDav {
 			$this->getDavPathVersion(),
 			false,
 			1,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -2204,7 +2205,7 @@ trait WebDav {
 		string $user,
 		string $source,
 		string $destination,
-		string $mtime
+		string $mtime,
 	): void {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
@@ -2219,12 +2220,12 @@ trait WebDav {
 			$this->getDavPathVersion(),
 			false,
 			1,
-			true
+			true,
 		);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"",
-			$response
+			$response,
 		);
 	}
 
@@ -2241,7 +2242,7 @@ trait WebDav {
 	public function theMtimeOfTheFileShouldBe(
 		string $user,
 		string $resource,
-		string $mtime
+		string $mtime,
 	): void {
 		$user = $this->getActualUsername($user);
 		$password = $this->getPasswordForUser($user);
@@ -2255,8 +2256,8 @@ trait WebDav {
 				$password,
 				$baseUrl,
 				$resource,
-				$this->getDavPathVersion()
-			)
+				$this->getDavPathVersion(),
+			),
 		);
 	}
 
@@ -2274,14 +2275,14 @@ trait WebDav {
 	public function userHasUploadedAFileWithContentTo(
 		string $user,
 		?string $content,
-		string $destination
+		string $destination,
 	): array {
 		$user = $this->getActualUsername($user);
 		$response = $this->uploadFileWithContent($user, $content, $destination, null, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$destination' for user '$user'",
-			$response
+			$response,
 		);
 		return $response->getHeader('oc-fileid');
 	}
@@ -2304,7 +2305,7 @@ trait WebDav {
 		string $fileName,
 		string $content,
 		string $destination,
-		string $spaceName
+		string $spaceName,
 	): void {
 		$baseUrl = $this->getBaseUrl();
 		$user = $this->getActualUsername($user);
@@ -2323,12 +2324,12 @@ trait WebDav {
 			$user,
 			$password,
 			null,
-			$content
+			$content,
 		);
 		$this->theHTTPStatusCodeShouldBe(
 			["201"],
 			"HTTP status code was not 201 while trying to upload file '$destination' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -2345,7 +2346,7 @@ trait WebDav {
 	public function userHasUploadedFollowingFilesWithContent(
 		string $user,
 		?string $content,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$files = $table->getHash();
@@ -2357,7 +2358,7 @@ trait WebDav {
 			$this->theHTTPStatusCodeShouldBe(
 				["201", "204"],
 				"HTTP status code was not 201 or 204 while trying to upload file '$destination' for user '$user'",
-				$response
+				$response,
 			);
 		}
 	}
@@ -2373,7 +2374,7 @@ trait WebDav {
 	 */
 	public function userDownloadsFollowingFiles(
 		string $user,
-		TableNode $table
+		TableNode $table,
 	): void {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$files = $table->getHash();
@@ -2400,7 +2401,7 @@ trait WebDav {
 		string $user,
 		?string $content,
 		string $mtime,
-		string $destination
+		string $destination,
 	): void {
 		$user = $this->getActualUsername($user);
 		$mtime = new DateTime($mtime);
@@ -2410,7 +2411,7 @@ trait WebDav {
 			"PUT",
 			$destination,
 			["X-OC-Mtime" => $mtime],
-			$content
+			$content,
 		);
 		$this->setResponse($response);
 	}
@@ -2431,7 +2432,7 @@ trait WebDav {
 		?string $content,
 		string $destination,
 		?bool $isGivenStep = false,
-		?string $spaceId = null
+		?string $spaceId = null,
 	): ResponseInterface {
 		$this->pauseUploadDelete();
 		$response = $this->makeDavRequest(
@@ -2447,7 +2448,7 @@ trait WebDav {
 			null,
 			[],
 			null,
-			$isGivenStep
+			$isGivenStep,
 		);
 		$this->lastUploadDeleteTime = \time();
 		return $response;
@@ -2467,7 +2468,7 @@ trait WebDav {
 		string $user,
 		string $checksum,
 		string $content,
-		string $destination
+		string $destination,
 	): void {
 		$response = $this->uploadFileWithChecksumAndContent($user, $checksum, $content, $destination);
 		$this->setResponse($response);
@@ -2487,20 +2488,20 @@ trait WebDav {
 		string $user,
 		string $checksum,
 		?string $content,
-		string $destination
+		string $destination,
 	): void {
 		$response = $this->uploadFileWithChecksumAndContent(
 			$user,
 			$checksum,
 			$content,
 			$destination,
-			true
+			true,
 		);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file with checksum "
 			. "'$checksum' to '$destination' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -2579,7 +2580,7 @@ trait WebDav {
 		string $user,
 		string $filename,
 		string $space,
-		string $fileId
+		string $fileId,
 	): void {
 		$baseUrl = $this->getBaseUrl();
 		$davPath = WebDavHelper::getDavPath($this->getDavPathVersion());
@@ -2590,7 +2591,7 @@ trait WebDav {
 			$fullUrl,
 			'DELETE',
 			$user,
-			$password
+			$password,
 		);
 		$this->setResponse($response);
 		$this->pushToLastStatusCodesArrays();
@@ -2615,7 +2616,7 @@ trait WebDav {
 			$user,
 			$this->getPasswordForUser($user),
 			null,
-			$content
+			$content,
 		);
 		$this->theHTTPStatusCodeShouldBe('204', '', $response);
 	}
@@ -2642,7 +2643,7 @@ trait WebDav {
 		$this->theHTTPStatusCodeShouldBe(
 			["204"],
 			"HTTP status code was not 204 while trying to delete resource '$resource' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -2666,7 +2667,7 @@ trait WebDav {
 			$this->theHTTPStatusCodeShouldBe(
 				["204"],
 				"HTTP status code was not 204 while trying to delete resource '$file' for user '$user'",
-				$response
+				$response,
 			);
 		}
 	}
@@ -2744,7 +2745,7 @@ trait WebDav {
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -2762,13 +2763,13 @@ trait WebDav {
 		Assert::assertEquals(
 			"admin",
 			$admin,
-			__METHOD__ . "The provided user is not admin but '" . $admin . "'"
+			__METHOD__ . "The provided user is not admin but '" . $admin . "'",
 		);
 		$response = $this->createFolder($admin, $destination, true);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for admin '$admin'",
-			$response
+			$response,
 		);
 		$this->adminResources[] = $destination;
 	}
@@ -2793,7 +2794,7 @@ trait WebDav {
 			$this->theHTTPStatusCodeShouldBe(
 				["201", "204"],
 				"HTTP status code was not 201 or 204 while trying to create folder '$destination' for user '$user'",
-				$response
+				$response,
 			);
 		}
 	}
@@ -2813,12 +2814,12 @@ trait WebDav {
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for user '$user'",
-			$response
+			$response,
 		);
 		$this->checkFileOrFolderExistsForUser(
 			$user,
 			"folder",
-			$destination
+			$destination,
 		);
 	}
 
@@ -2835,19 +2836,19 @@ trait WebDav {
 	public function userShouldBeAbleToCreateFolderUsingPassword(
 		string $user,
 		string $destination,
-		string $password
+		string $password,
 	): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->createFolder($user, $destination, true, $password);
 		$this->theHTTPStatusCodeShouldBe(
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for user '$user'",
-			$response
+			$response,
 		);
 		$this->checkFileOrFolderExistsForUser(
 			$user,
 			"folder",
-			$destination
+			$destination,
 		);
 	}
 
@@ -2867,7 +2868,7 @@ trait WebDav {
 		$this->checkFileOrFolderDoesNotExistsForUser(
 			$user,
 			"folder",
-			$destination
+			$destination,
 		);
 	}
 
@@ -2884,7 +2885,7 @@ trait WebDav {
 	public function userShouldNotBeAbleToCreateFolderUsingPassword(
 		string $user,
 		string $destination,
-		string $password
+		string $password,
 	): void {
 		$user = $this->getActualUsername($user);
 		$response = $this->createFolder($user, $destination, false, $password);
@@ -2892,7 +2893,7 @@ trait WebDav {
 		$this->checkFileOrFolderDoesNotExistsForUser(
 			$user,
 			"folder",
-			$destination
+			$destination,
 		);
 	}
 	/**
@@ -2917,7 +2918,7 @@ trait WebDav {
 		string $user,
 		string $total,
 		string $file,
-		TableNode $chunkDetails
+		TableNode $chunkDetails,
 	): void {
 		$this->verifyTableNodeColumns($chunkDetails, ['number', 'content']);
 		foreach ($chunkDetails->getHash() as $chunkDetail) {
@@ -2947,7 +2948,7 @@ trait WebDav {
 	public function userUploadsTheFollowingChunksUsingOldChunking(
 		string $user,
 		string $file,
-		TableNode $chunkDetails
+		TableNode $chunkDetails,
 	): void {
 		$total = (string) \count($chunkDetails->getHash());
 		$this->verifyTableNodeColumns($chunkDetails, ['number', 'content']);
@@ -2976,7 +2977,7 @@ trait WebDav {
 		int $total,
 		?string $data,
 		string $destination,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$num -= 1;
@@ -2995,7 +2996,7 @@ trait WebDav {
 			null,
 			[],
 			null,
-			$isGivenStep
+			$isGivenStep,
 		);
 		$this->lastUploadDeleteTime = \time();
 		return $response;
@@ -3023,7 +3024,7 @@ trait WebDav {
 		string $type,
 		string $file,
 		TableNode $chunkDetails,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): void {
 		$user = $this->getActualUsername($user);
 		$async = false;
@@ -3037,7 +3038,7 @@ trait WebDav {
 			'chunking-42',
 			$chunkDetails->getHash(),
 			$async,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -3063,7 +3064,7 @@ trait WebDav {
 		string $chunkingId,
 		array $chunkDetails,
 		bool $async = false,
-		bool $isGivenStep = false
+		bool $isGivenStep = false,
 	): void {
 		$this->pauseUploadDelete();
 		if ($isGivenStep) {
@@ -3081,7 +3082,7 @@ trait WebDav {
 					$chunkNumber,
 					$chunkContent,
 					$chunkingId,
-					true
+					true,
 				);
 				$this->theHTTPStatusCodeShouldBeBetween(200, 299, $response);
 			} else {
@@ -3114,7 +3115,7 @@ trait WebDav {
 	public function userCreateANewChunkingUploadWithId(
 		string $user,
 		string $id,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$destination = "/uploads/$user/$id";
@@ -3131,7 +3132,7 @@ trait WebDav {
 			null,
 			[],
 			null,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -3149,7 +3150,7 @@ trait WebDav {
 		int $num,
 		?string $data,
 		string $id,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$destination = "/uploads/$user/$id/$num";
@@ -3166,7 +3167,7 @@ trait WebDav {
 			null,
 			[],
 			null,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -3182,7 +3183,7 @@ trait WebDav {
 		string $user,
 		string $id,
 		string $type,
-		string $dest
+		string $dest,
 	): ResponseInterface {
 		$headers = [];
 		if ($type === "asynchronously") {
@@ -3205,7 +3206,7 @@ trait WebDav {
 		string $user,
 		string $id,
 		string $type,
-		string $dest
+		string $dest,
 	): void {
 		$this->setResponse($this->userMoveNewChunkFileWithIdToMychunkedfile($user, $id, $type, $dest));
 	}
@@ -3224,7 +3225,7 @@ trait WebDav {
 		string $id,
 		string $type,
 		string $dest,
-		int $size
+		int $size,
 	): ResponseInterface {
 		$headers = ['OC-Total-Length' => $size];
 		if ($type === "asynchronously") {
@@ -3234,7 +3235,7 @@ trait WebDav {
 			$user,
 			$id,
 			$dest,
-			$headers
+			$headers,
 		);
 	}
 
@@ -3252,7 +3253,7 @@ trait WebDav {
 		string $id,
 		string $type,
 		string $dest,
-		string $checksum
+		string $checksum,
 	): ResponseInterface {
 		$headers = ['OC-Checksum' => $checksum];
 		if ($type === "asynchronously") {
@@ -3262,7 +3263,7 @@ trait WebDav {
 			$user,
 			$id,
 			$dest,
-			$headers
+			$headers,
 		);
 	}
 
@@ -3282,14 +3283,14 @@ trait WebDav {
 		string $id,
 		string $type,
 		string $dest,
-		string $checksum
+		string $checksum,
 	): void {
 		$response = $this->userMoveNewChunkFileWithIdToMychunkedfileWithChecksum(
 			$user,
 			$id,
 			$type,
 			$dest,
-			$checksum
+			$checksum,
 		);
 		$this->theHTTPStatusCodeShouldBe("201", "", $response);
 	}
@@ -3310,13 +3311,13 @@ trait WebDav {
 		string $id,
 		string $destination,
 		array $headers,
-		?bool $isGivenStep = false
+		?bool $isGivenStep = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
 		$source = "/uploads/$user/$id/.file";
 		$headers['Destination'] = $this->destinationHeaderValue(
 			$user,
-			$destination
+			$destination,
 		);
 
 		return $this->makeDavRequest(
@@ -3332,7 +3333,7 @@ trait WebDav {
 			null,
 			[],
 			null,
-			$isGivenStep
+			$isGivenStep,
 		);
 	}
 
@@ -3354,7 +3355,7 @@ trait WebDav {
 			$headers,
 			null,
 			null,
-			"uploads"
+			"uploads",
 		);
 	}
 
@@ -3381,7 +3382,7 @@ trait WebDav {
 			null,
 			'PROPFIND',
 			'',
-			[]
+			[],
 		);
 	}
 
@@ -3423,7 +3424,7 @@ trait WebDav {
 	public function theFollowingHeadersShouldNotBeSet(TableNode $table): void {
 		$this->verifyTableNodeColumns(
 			$table,
-			['header']
+			['header'],
 		);
 		foreach ($table->getColumnsHash() as $header) {
 			$headerName = $header['header'];
@@ -3433,7 +3434,7 @@ trait WebDav {
 			Assert::assertEmpty(
 				$headerValue,
 				"header $headerName should not exist " .
-				"but does and is set to $headerValue0"
+				"but does and is set to $headerValue0",
 			);
 		}
 	}
@@ -3463,14 +3464,14 @@ trait WebDav {
 			$expectedHeaderValue = $this->substituteInLineCodes(
 				$expectedHeaderValue,
 				null,
-				['preg_quote' => ['/']]
+				['preg_quote' => ['/']],
 			);
 
 			$returnedHeaders = $this->response->getHeader($headerName);
 			$returnedHeader = $returnedHeaders[0];
 			Assert::assertNotFalse(
 				(bool) \preg_match($expectedHeaderValue, $returnedHeader),
-				"'$expectedHeaderValue' does not match '$returnedHeader'"
+				"'$expectedHeaderValue' does not match '$returnedHeader'",
 			);
 		}
 	}
@@ -3509,14 +3510,14 @@ trait WebDav {
 			$expectedHeaderValue = $this->substituteInLineCodes(
 				$expectedHeaderValue,
 				$user,
-				['preg_quote' => ['/']]
+				['preg_quote' => ['/']],
 			);
 
 			$returnedHeaders = $this->response->getHeader($headerName);
 			$returnedHeader = $returnedHeaders[0];
 			Assert::assertNotFalse(
 				(bool) \preg_match($expectedHeaderValue, $returnedHeader),
-				"'$expectedHeaderValue' does not match '$returnedHeader'"
+				"'$expectedHeaderValue' does not match '$returnedHeader'",
 			);
 		}
 	}
@@ -3532,7 +3533,7 @@ trait WebDav {
 	 */
 	public function userDeletesEverythingInFolder(
 		string $user,
-		string $folder
+		string $folder,
 	): void {
 		$this->deleteEverythingInFolder($user, $folder, false);
 	}
@@ -3548,15 +3549,15 @@ trait WebDav {
 	public function deleteEverythingInFolder(
 		string $user,
 		string $folder,
-		bool $checkEachDelete = false
+		bool $checkEachDelete = false,
 	): void {
 		$user = $this->getActualUsername($user);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->listFolder(
 				$user,
 				$folder,
-				'1'
-			)
+				'1',
+			),
 		);
 		$elementList = $responseXmlObject->xpath("//d:response/d:href");
 		if (\is_array($elementList) && \count($elementList)) {
@@ -3570,7 +3571,7 @@ trait WebDav {
 					$this->theHTTPStatusCodeShouldBe(
 						["204"],
 						"HTTP status code was not 204 while trying to delete resource '$element' for user '$user'",
-						$response
+						$response,
 					);
 				} else {
 					$this->setResponse($this->deleteFile($user, $element));
@@ -3597,7 +3598,7 @@ trait WebDav {
 			$path,
 			null,
 			$width,
-			$height
+			$height,
 		);
 		$this->setResponse($response);
 	}
@@ -3616,7 +3617,7 @@ trait WebDav {
 		string $user,
 		string $path,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		$user = $this->getActualUsername($user);
 		$urlParameter = [
@@ -3654,7 +3655,7 @@ trait WebDav {
 		string $user,
 		string $path,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		if ($this->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
 			$this->setResponse($this->downloadSharedFilePreview($user, $path, $width, $height));
@@ -3679,7 +3680,7 @@ trait WebDav {
 		string $path,
 		string $width,
 		string $height,
-		string $processor
+		string $processor,
 	): void {
 		$user = $this->getActualUsername($user);
 		$urlParameter = [
@@ -3718,7 +3719,7 @@ trait WebDav {
 		string $user,
 		string $path,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		$user = $this->getActualUsername($user);
 		$urlParameter = [
@@ -3740,7 +3741,7 @@ trait WebDav {
 				false,
 				null,
 				$urlParameter,
-			)
+			),
 		);
 	}
 
@@ -3758,7 +3759,7 @@ trait WebDav {
 		string $user,
 		string $path,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		if ($this->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
 			$response = $this->downloadSharedFilePreview($user, $path, $width, $height);
@@ -3787,7 +3788,7 @@ trait WebDav {
 		string $user,
 		string $path,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		if ($this->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
 			$response = $this->downloadSharedFilePreview($user, $path, $width, $height);
@@ -3820,7 +3821,7 @@ trait WebDav {
 	public function userUploadsFileWithContentSharedResourceToUsingTheWebdavApi(
 		string $user,
 		string $content,
-		string $destination
+		string $destination,
 	): void {
 		$this->setResponse($this->uploadFileWithContent($user, $content, $destination));
 	}
@@ -3834,7 +3835,7 @@ trait WebDav {
 	 */
 	public function getSharesMountPath(
 		string $user,
-		string $path
+		string $path,
 	): string {
 		$user = $this->getActualUsername($user);
 		$path = trim($path, "/");
@@ -3845,7 +3846,7 @@ trait WebDav {
 			$this->getBaseUrl(),
 			$user,
 			$this->getPasswordForUser($user),
-			$sharedFolder
+			$sharedFolder,
 		);
 
 		$path = \array_slice($pathArray, array_search($sharedFolder, $pathArray) + 1);
@@ -3867,7 +3868,7 @@ trait WebDav {
 		string $user,
 		string $path,
 		?string $width = null,
-		?string $height = null
+		?string $height = null,
 	): ResponseInterface {
 		if ($width !== null && $height !== null) {
 			$urlParameter = [
@@ -3896,7 +3897,7 @@ trait WebDav {
 			$fullUrl,
 			'GET',
 			$user,
-			$this->getPasswordForUser($user)
+			$this->getPasswordForUser($user),
 		);
 	}
 
@@ -3916,14 +3917,14 @@ trait WebDav {
 		string $path,
 		string $ofUser,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		$response = $this->downloadPreviews(
 			$ofUser,
 			$path,
 			$user,
 			$width,
-			$height
+			$height,
 		);
 		$this->setResponse($response);
 	}
@@ -3986,14 +3987,14 @@ trait WebDav {
 		string $user,
 		string $path,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		$response = $this->downloadPreviews(
 			$user,
 			$path,
 			null,
 			$width,
-			$height
+			$height,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$this->checkImageDimensions($width, $height, $response);
@@ -4016,14 +4017,14 @@ trait WebDav {
 		string $user,
 		string $path,
 		string $width,
-		string $height
+		string $height,
 	): void {
 		$response = $this->downloadPreviews(
 			$user,
 			$path,
 			null,
 			$width,
-			$height
+			$height,
 		);
 		$this->theHTTPStatusCodeShouldBe(200, "", $response);
 		$newResponseBodyContents = $response->getBody()->getContents();
@@ -4054,7 +4055,7 @@ trait WebDav {
 				$this->getPasswordForUser($user),
 				$path,
 				$spaceId,
-				$this->getDavPathVersion()
+				$this->getDavPathVersion(),
 			);
 		} catch (Exception $e) {
 			return null;
@@ -4091,7 +4092,7 @@ trait WebDav {
 			$this->storedFileID,
 			__METHOD__
 			. " User '$user' $fileOrFolder '$path' does not have the previously stored id " .
-			"'$this->storedFileID', but has '$currentFileID'."
+			"'$this->storedFileID', but has '$currentFileID'.",
 		);
 	}
 
@@ -4110,7 +4111,7 @@ trait WebDav {
 			$element,
 			$message,
 			$responseXmlArray,
-			__METHOD__
+			__METHOD__,
 		);
 	}
 
@@ -4131,7 +4132,7 @@ trait WebDav {
 		?string $user = null,
 		?string $method = 'REPORT',
 		?string $folderpath = '',
-		?string $spaceId = null
+		?string $spaceId = null,
 	): void {
 		$folderpath = \trim($folderpath, "/");
 		$this->verifyTableNodeColumnsCount($expectedFiles, 1);
@@ -4158,18 +4159,18 @@ trait WebDav {
 					$user,
 					"files",
 					$folderpath,
-					$spaceId
+					$spaceId,
 				);
 			}
 			if ($should) {
 				Assert::assertNotEmpty(
 					$fileFound,
-					"response does not contain the entry '$resource'"
+					"response does not contain the entry '$resource'",
 				);
 			} else {
 				Assert::assertFalse(
 					$fileFound,
-					"response does contain the entry '$resource' but should not"
+					"response does contain the entry '$resource' but should not",
 				);
 			}
 		}
@@ -4188,13 +4189,13 @@ trait WebDav {
 	public function thePropfindResultShouldContainEntries(
 		string $user,
 		string $shouldOrNot,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$user = $this->getActualUsername($user);
 		$this->propfindResultShouldContainEntries(
 			$shouldOrNot,
 			$expectedFiles,
-			$user
+			$user,
 		);
 	}
 
@@ -4209,21 +4210,21 @@ trait WebDav {
 	 */
 	public function thePropfindResultShouldContainOnlyEntries(
 		string $user,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$user = $this->getActualUsername($user);
 
 		Assert::assertEquals(
 			\count($expectedFiles->getTable()),
 			$this->getNumberOfEntriesInPropfindResponse(
-				$user
+				$user,
 			),
-			"The number of elements in the response doesn't matches with expected number of elements"
+			"The number of elements in the response doesn't matches with expected number of elements",
 		);
 		$this->propfindResultShouldContainEntries(
 			'',
 			$expectedFiles,
-			$user
+			$user,
 		);
 	}
 
@@ -4248,12 +4249,12 @@ trait WebDav {
 
 		Assert::assertIsArray(
 			$responseXmlArray,
-			__METHOD__ . " is not an array"
+			__METHOD__ . " is not an array",
 		);
 		Assert::assertArrayHasKey(
 			"value",
 			$responseXmlArray,
-			__METHOD__ . " does not have key 'value'"
+			__METHOD__ . " does not have key 'value'",
 		);
 		$multistatusResults = $responseXmlArray["value"];
 		if ($multistatusResults === null) {
@@ -4267,7 +4268,7 @@ trait WebDav {
 			. $numFiles
 			. "' files/entries, but got '"
 			. \count($multistatusResults)
-			. "' files/entries."
+			. "' files/entries.",
 		);
 	}
 
@@ -4282,12 +4283,12 @@ trait WebDav {
 	 */
 	public function theSearchResultShouldContainAnyOfTheseEntries(
 		int $expectedNumber,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$this->checkIfSearchResultContainsFiles(
 			$this->getCurrentUser(),
 			$expectedNumber,
-			$expectedFiles
+			$expectedFiles,
 		);
 	}
 
@@ -4304,12 +4305,12 @@ trait WebDav {
 	public function theSearchResultOfUserShouldContainAnyOfTheseEntries(
 		string $user,
 		int $expectedNumber,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$this->checkIfSearchResultContainsFiles(
 			$user,
 			$expectedNumber,
-			$expectedFiles
+			$expectedFiles,
 		);
 	}
 
@@ -4323,7 +4324,7 @@ trait WebDav {
 	public function checkIfSearchResultContainsFiles(
 		string $user,
 		int $expectedNumber,
-		TableNode $expectedFiles
+		TableNode $expectedFiles,
 	): void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeColumnsCount($expectedFiles, 1);
@@ -4336,7 +4337,7 @@ trait WebDav {
 			function ($value) {
 				return \trim($value, "/");
 			},
-			$elementRows
+			$elementRows,
 		);
 		$resultEntries = $this->findEntryFromSearchResponse();
 		foreach ($resultEntries as $resultEntry) {
@@ -4357,12 +4358,12 @@ trait WebDav {
 	public function userListsTheResourcesInPathWithDepthUsingTheWebdavApi(
 		string $user,
 		string $path,
-		string $depth
+		string $depth,
 	): void {
 		$response = $this->listFolder(
 			$user,
 			$path,
-			$depth
+			$depth,
 		);
 		$this->setResponse($response);
 	}
@@ -4452,7 +4453,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function thePublicListsTheResourcesInTheLastCreatedPublicLinkWithDepthUsingTheWebdavApi(
-		string $depth
+		string $depth,
 	): void {
 		$token = ($this->isUsingSharingNG())
 		? $this->shareNgGetLastCreatedLinkShareToken() : $this->getLastCreatedPublicShareToken();
@@ -4463,8 +4464,8 @@ trait WebDav {
 				$depth,
 				null,
 				null,
-				"public-files"
-			)
+				"public-files",
+			),
 		);
 	}
 
@@ -4498,7 +4499,7 @@ trait WebDav {
 	 * @return int
 	 */
 	public function getNumberOfEntriesInPropfindResponse(
-		?string $user = null
+		?string $user = null,
 	): int {
 		$multistatusResults = $this->getMultiStatusResultFromPropfindResult($user);
 		return \count($multistatusResults);
@@ -4513,7 +4514,7 @@ trait WebDav {
 	 * @return array
 	 */
 	public function getMultiStatusResultFromPropfindResult(
-		?string $user = null
+		?string $user = null,
 	): array {
 		$responseXmlArray = HttpRequestHelper::parseResponseAsXml($this->response);
 
@@ -4523,12 +4524,12 @@ trait WebDav {
 		}
 		Assert::assertIsArray(
 			$responseXmlArray,
-			__METHOD__ . " response for user $user is not an array"
+			__METHOD__ . " response for user $user is not an array",
 		);
 		Assert::assertArrayHasKey(
 			"value",
 			$responseXmlArray,
-			__METHOD__ . " response for user $user does not have key 'value'"
+			__METHOD__ . " response for user $user does not have key 'value'",
 		);
 		$multistatus = $responseXmlArray["value"];
 		if ($multistatus == null) {
@@ -4574,7 +4575,7 @@ trait WebDav {
 		?string $user = null,
 		string $type = "files",
 		string $folderPath = '',
-		?string $spaceId = null
+		?string $spaceId = null,
 	): string|array|bool {
 		$trimmedEntryNameToSearch = '';
 		// trim any leading "/" passed by the caller, we can just match the "raw" name
@@ -4622,7 +4623,7 @@ trait WebDav {
 	 * @param bool|null $searchForHighlightString
 	 * @param string|null $spaceId
 	 *
-	 * @return string|array|boolean
+	 * @return SimpleXMLElement|array|boolean
 	 *
 	 * string if $entryNameToSearch is given and is found
 	 * array if $entryNameToSearch is not given
@@ -4633,8 +4634,8 @@ trait WebDav {
 	public function findEntryFromSearchResponse(
 		?string $entryNameToSearch = null,
 		?bool $searchForHighlightString = false,
-		?string $spaceId = null
-	): string|array|bool {
+		?string $spaceId = null,
+	): SimpleXMLElement|array|bool {
 		// trim any leading "/" passed by the caller, we can just match the "raw" name
 		if ($entryNameToSearch !== null) {
 			$entryNameToSearch = \trim($entryNameToSearch, "/");
@@ -4733,7 +4734,7 @@ trait WebDav {
 		$expectedUserDisplayName = $this->getUserDisplayName($expectedUsername);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->getResponse(),
-			__METHOD__
+			__METHOD__,
 		);
 
 		// the username should be in oc:meta-version-edited-by
@@ -4749,7 +4750,7 @@ trait WebDav {
 		if (!isset($authors[$index - 1])) {
 			Assert::fail(
 				'could not find version with index "' . $index
-				. '" for oc:meta-version-edited-by property in response to user "' . $this->responseUser . '"'
+				. '" for oc:meta-version-edited-by property in response to user "' . $this->responseUser . '"',
 			);
 		}
 		$actualUser = $authors[$index - 1];
@@ -4757,7 +4758,7 @@ trait WebDav {
 			$expectedUsername,
 			$actualUser,
 			"Expected user of version with index $index in response to user '$this->responseUser'"
-			. " was '$expectedUsername', but got '$actualUser'"
+			. " was '$expectedUsername', but got '$actualUser'",
 		);
 
 		// the user's display name should be in oc:meta-version-edited-by-name
@@ -4773,7 +4774,7 @@ trait WebDav {
 		if (!isset($displaynames[$index - 1])) {
 			Assert::fail(
 				'could not find version with index "' . $index
-				. '" for oc:meta-version-edited-by-name property in response to user "' . $this->responseUser . '"'
+				. '" for oc:meta-version-edited-by-name property in response to user "' . $this->responseUser . '"',
 			);
 		}
 		$actualUserDisplayName = $displaynames[$index - 1];
@@ -4781,7 +4782,7 @@ trait WebDav {
 			$expectedUserDisplayName,
 			$actualUserDisplayName,
 			"Expected display name of version with index $index in response to user '$this->responseUser'"
-			. " was '$expectedUserDisplayName', but got '$actualUserDisplayName'"
+			. " was '$expectedUserDisplayName', but got '$actualUserDisplayName'",
 		);
 	}
 
@@ -4817,7 +4818,7 @@ trait WebDav {
 		string $user,
 		string $filename,
 		string $space,
-		string $fileId
+		string $fileId,
 	): void {
 		$baseUrl = $this->getBaseUrl();
 		$davPath = WebDavHelper::getDavPath($this->getDavPathVersion());
@@ -4828,12 +4829,12 @@ trait WebDav {
 			$fullUrl,
 			'DELETE',
 			$user,
-			$password
+			$password,
 		);
 		$this->theHTTPStatusCodeShouldBe(
 			["204"],
 			"HTTP status code was not 204 while trying to delete resource '$filename' for user '$user'",
-			$response
+			$response,
 		);
 	}
 
@@ -4850,7 +4851,7 @@ trait WebDav {
 		$fullPath = UploadHelper::getUploadFilesDir($name);
 		if (\file_exists($fullPath)) {
 			throw new InvalidArgumentException(
-				__METHOD__ . " could not create '$fullPath'. File already exists."
+				__METHOD__ . " could not create '$fullPath'. File already exists.",
 			);
 		}
 		UploadHelper::createFileSpecificSize($fullPath, $size);

--- a/tests/acceptance/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/bootstrap/WebDavLockingContext.php
@@ -67,7 +67,7 @@ class WebDavLockingContext implements Context {
 		string $fullUrl = null,
 		bool $public = false,
 		bool $expectToSucceed = true,
-		?string $spaceId = null
+		?string $spaceId = null,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		if ($public === true) {
@@ -102,7 +102,7 @@ class WebDavLockingContext implements Context {
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
 				$headers,
-				$body
+				$body,
 			);
 		} else {
 			$baseUrl = $this->featureContext->getBaseUrl();
@@ -116,7 +116,7 @@ class WebDavLockingContext implements Context {
 				$spaceId,
 				$body,
 				$this->featureContext->getDavPathVersion(),
-				$type
+				$type,
 			);
 		}
 
@@ -144,7 +144,7 @@ class WebDavLockingContext implements Context {
 	public function userLocksFileSettingPropertiesUsingWebDavAPI(
 		string $user,
 		string $file,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$spaceId = null;
 		if (\str_starts_with($file, "Shares/")
@@ -169,7 +169,7 @@ class WebDavLockingContext implements Context {
 	public function userTriesToLockFileSettingPropertiesUsingWebDavAPI(
 		string $user,
 		string $file,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$response = $this->lockFile($user, $file, $properties, null, false, false);
 		$this->featureContext->setResponse($response);
@@ -190,7 +190,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $space,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$this->featureContext->setResponse($this->userLocksFileInProjectSpace($user, $file, $space, $properties));
 	}
@@ -209,7 +209,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $space,
-		TableNode $properties
+		TableNode $properties,
 	): ?ResponseInterface {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $space);
 		$baseUrl = $this->featureContext->getBaseUrl();
@@ -239,7 +239,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $space,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$response = $this->userLocksFileInProjectSpace($user, $file, $space, $properties);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
@@ -259,7 +259,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $space,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $space);
 		$davPathVersion = $this->featureContext->getDavPathVersion();
@@ -288,7 +288,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $fileId,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$davPath = WebdavHelper::getDavPath($this->featureContext->getDavPathVersion());
 		$davPath = \rtrim($davPath, '/');
@@ -311,7 +311,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $fileId,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$davPath = WebdavHelper::getDavPath($this->featureContext->getDavPathVersion());
 		$davPath = \rtrim($davPath, '/');
@@ -348,7 +348,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $spaceName,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($this->featureContext->getActualUsername($user), $spaceName);
 		$response = $this->lockFile($user, $file, $properties, null, false, true, $spaceId);
@@ -369,7 +369,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		string $fileId,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$davPath = WebdavHelper::getDavPath($this->featureContext->getDavPathVersion());
 		$davPath = \rtrim($davPath, '/');
@@ -391,7 +391,7 @@ class WebDavLockingContext implements Context {
 			"/",
 			$properties,
 			null,
-			true
+			true,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
@@ -414,7 +414,7 @@ class WebDavLockingContext implements Context {
 			$properties,
 			null,
 			true,
-			false
+			false,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -429,7 +429,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicHasLockedFileLastSharedFolder(
 		string $file,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -439,7 +439,7 @@ class WebDavLockingContext implements Context {
 			$file,
 			$properties,
 			null,
-			true
+			true,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
@@ -455,7 +455,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicLocksFileLastSharedFolder(
 		string $file,
-		TableNode $properties
+		TableNode $properties,
 	): void {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -466,7 +466,7 @@ class WebDavLockingContext implements Context {
 			$properties,
 			null,
 			true,
-			false
+			false,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -484,7 +484,7 @@ class WebDavLockingContext implements Context {
 			$user,
 			$file,
 			$user,
-			$file
+			$file,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -501,7 +501,7 @@ class WebDavLockingContext implements Context {
 	public function userUnlocksTheLastCreatedLockOfFileInsideSpaceUsingTheWebdavApi(
 		string $user,
 		string $spaceName,
-		string $file
+		string $file,
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($this->featureContext->getActualUsername($user), $spaceName);
 		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
@@ -511,7 +511,7 @@ class WebDavLockingContext implements Context {
 			$file,
 			false,
 			null,
-			$spaceId
+			$spaceId,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -528,7 +528,7 @@ class WebDavLockingContext implements Context {
 	public function userUnlocksTheLastCreatedLockOfFileWithFileIdPathUsingTheWebdavApi(
 		string $user,
 		string $itemToUnlock,
-		string $fileId
+		string $fileId,
 	): void {
 		$davPath = WebdavHelper::getDavPath($this->featureContext->getDavPathVersion());
 		$davPath = \rtrim($davPath, '/');
@@ -539,7 +539,7 @@ class WebDavLockingContext implements Context {
 			$user,
 			$itemToUnlock,
 			false,
-			$fullUrl
+			$fullUrl,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -556,13 +556,13 @@ class WebDavLockingContext implements Context {
 	public function unlockItemWithLastLockOfOtherItemUsingWebDavAPI(
 		string $user,
 		string $itemToUnlock,
-		string $itemToUseLockOf
+		string $itemToUseLockOf,
 	): void {
 		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
 			$user,
-			$itemToUseLockOf
+			$itemToUseLockOf,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -579,14 +579,14 @@ class WebDavLockingContext implements Context {
 	public function unlockItemWithLastPublicLockOfOtherItemUsingWebDavAPI(
 		string $user,
 		string $itemToUnlock,
-		string $itemToUseLockOf
+		string $itemToUseLockOf,
 	): void {
 		$lockOwner = $this->featureContext->getLastCreatedPublicShareToken();
 		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
 			$lockOwner,
-			$itemToUseLockOf
+			$itemToUseLockOf,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -602,7 +602,7 @@ class WebDavLockingContext implements Context {
 	 */
 	private function countLockOfResources(
 		string $user,
-		string $itemToUnlock
+		string $itemToUnlock,
 	): int {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
@@ -621,7 +621,7 @@ class WebDavLockingContext implements Context {
 			null,
 			null,
 			$body,
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
 		);
 		$responseXmlObject = HttpRequestHelper::getResponseXml($response, __METHOD__);
 		$xmlPart = $responseXmlObject->xpath("//d:response//d:lockdiscovery/d:activelock");
@@ -648,7 +648,7 @@ class WebDavLockingContext implements Context {
 		string $itemToUnlock,
 		string $lockOwner,
 		string $itemToUseLockOf,
-		bool $public = false
+		bool $public = false,
 	): void {
 		$lockCount = $this->countLockOfResources($user, $itemToUnlock);
 
@@ -657,7 +657,7 @@ class WebDavLockingContext implements Context {
 			$itemToUnlock,
 			$lockOwner,
 			$itemToUseLockOf,
-			$public
+			$public,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "", $response);
 
@@ -666,7 +666,7 @@ class WebDavLockingContext implements Context {
 		Assert::assertEquals(
 			$lockCount - 1,
 			$lockCountAfterUnlock,
-			"Expected $lockCount lock(s) for '$itemToUnlock' but found '$lockCount'"
+			"Expected $lockCount lock(s) for '$itemToUnlock' but found '$lockCount'",
 		);
 	}
 
@@ -705,7 +705,7 @@ class WebDavLockingContext implements Context {
 		if (!isset($this->tokenOfLastLock[$lockOwner][$itemToUseLockOf])) {
 			Assert::fail(
 				"could not find saved token of '$itemToUseLockOf' " .
-				"owned by user '$lockOwner'"
+				"owned by user '$lockOwner'",
 			);
 		}
 		$headers = [
@@ -717,7 +717,7 @@ class WebDavLockingContext implements Context {
 				"UNLOCK",
 				$this->featureContext->getActualUsername($user),
 				$this->featureContext->getPasswordForUser($user),
-				$headers
+				$headers,
 			);
 		} else {
 			$response = WebDavHelper::makeDavRequest(
@@ -730,7 +730,7 @@ class WebDavLockingContext implements Context {
 				$spaceId,
 				null,
 				$this->featureContext->getDavPathVersion(),
-				$type
+				$type,
 			);
 		}
 		return $response;
@@ -750,13 +750,13 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $itemToUnlock,
 		string $lockOwner,
-		string $itemToUseLockOf
+		string $itemToUseLockOf,
 	): void {
 		$response = $this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
 			$lockOwner,
-			$itemToUseLockOf
+			$itemToUseLockOf,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -773,7 +773,7 @@ class WebDavLockingContext implements Context {
 	public function unlockItemAsPublicWithLastLockOfUserAndItemUsingWebDavAPI(
 		string $itemToUnlock,
 		string $lockOwner,
-		string $itemToUseLockOf
+		string $itemToUseLockOf,
 	): void {
 		$token = ($this->featureContext->isUsingSharingNG())
 		? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
@@ -783,7 +783,7 @@ class WebDavLockingContext implements Context {
 			$itemToUnlock,
 			$lockOwner,
 			$itemToUseLockOf,
-			true
+			true,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -804,7 +804,7 @@ class WebDavLockingContext implements Context {
 			$itemToUnlock,
 			$token,
 			$itemToUnlock,
-			true
+			true,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -823,14 +823,14 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $fileSource,
 		string $fileDestination,
-		string $itemToUseLockOf
+		string $itemToUseLockOf,
 	): void {
 		$response = $this->moveItemSendingLockTokenOfUser(
 			$user,
 			$fileSource,
 			$fileDestination,
 			$itemToUseLockOf,
-			$user
+			$user,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -849,13 +849,13 @@ class WebDavLockingContext implements Context {
 		string $fileSource,
 		string $fileDestination,
 		string $itemToUseLockOf,
-		string $lockOwner
+		string $lockOwner,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$lockOwner = $this->featureContext->getActualUsername($lockOwner);
 		$destination = $this->featureContext->destinationHeaderValue(
 			$user,
-			$fileDestination
+			$fileDestination,
 		);
 		$token = $this->tokenOfLastLock[$lockOwner][$itemToUseLockOf];
 		$headers = [
@@ -866,7 +866,7 @@ class WebDavLockingContext implements Context {
 			$user,
 			"MOVE",
 			$fileSource,
-			$headers
+			$headers,
 		);
 	}
 
@@ -886,14 +886,14 @@ class WebDavLockingContext implements Context {
 		string $fileSource,
 		string $fileDestination,
 		string $itemToUseLockOf,
-		string $lockOwner
+		string $lockOwner,
 	): void {
 		$response = $this->moveItemSendingLockTokenOfUser(
 			$user,
 			$fileSource,
 			$fileDestination,
 			$itemToUseLockOf,
-			$lockOwner
+			$lockOwner,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -912,7 +912,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $content,
 		string $destination,
-		string $itemToUseLockOf
+		string $itemToUseLockOf,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$token = $this->tokenOfLastLock[$user][$itemToUseLockOf];
@@ -922,7 +922,7 @@ class WebDavLockingContext implements Context {
 			"PUT",
 			$destination,
 			["If" => "(<$token>)"],
-			$content
+			$content,
 		);
 		$this->featureContext->setResponse($response);
 		$this->featureContext->setLastUploadDeleteTime(\time());
@@ -943,7 +943,7 @@ class WebDavLockingContext implements Context {
 		Assert::assertEquals(
 			$count,
 			$lockCount,
-			"Expected $count lock(s) for '$file' but found '$lockCount'"
+			"Expected $count lock(s) for '$file' but found '$lockCount'",
 		);
 	}
 
@@ -973,7 +973,7 @@ class WebDavLockingContext implements Context {
 		int $count,
 		string $file,
 		string $spaceName,
-		string $user
+		string $user,
 	): void {
 		$response = $this->spacesContext->sendPropfindRequestToSpace($user, $spaceName, $file, null, '0');
 		$this->featureContext->theHTTPStatusCodeShouldBe(207, "", $response);
@@ -987,7 +987,7 @@ class WebDavLockingContext implements Context {
 		Assert::assertEquals(
 			$count,
 			$lockCount,
-			"Expected $count lock(s) for '$file' inside space '$spaceName' but found '$lockCount'"
+			"Expected $count lock(s) for '$file' inside space '$spaceName' but found '$lockCount'",
 		);
 	}
 

--- a/tests/acceptance/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/bootstrap/WebDavPropertiesContext.php
@@ -55,12 +55,12 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function userGetsThePropertiesOfFolder(
 		string $user,
-		string $path
+		string $path,
 	): void {
 		$response = $this->featureContext->listFolder(
 			$user,
 			$path,
-			'0'
+			'0',
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -78,12 +78,12 @@ class WebDavPropertiesContext implements Context {
 	public function userGetsThePropertiesOfFolderWithDepth(
 		string $user,
 		string $path,
-		string $depth
+		string $depth,
 	): void {
 		$response = $this->featureContext->listFolder(
 			$user,
 			$path,
-			$depth
+			$depth,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -101,7 +101,7 @@ class WebDavPropertiesContext implements Context {
 		string $user,
 		string $path,
 		?string $spaceId,
-		TableNode $propertiesTable
+		TableNode $propertiesTable,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		$properties = null;
@@ -132,7 +132,7 @@ class WebDavPropertiesContext implements Context {
 	public function userGetsFollowingPropertiesOfEntryUsingWebDavApi(
 		string $user,
 		string $path,
-		TableNode $propertiesTable
+		TableNode $propertiesTable,
 	): void {
 		$response = $this->getPropertiesOfFolder($user, $path, null, $propertiesTable);
 		$this->featureContext->setResponse($response);
@@ -153,7 +153,7 @@ class WebDavPropertiesContext implements Context {
 			$this->featureContext->getCurrentUser(),
 			$path,
 			null,
-			$propertiesTable
+			$propertiesTable,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -173,7 +173,7 @@ class WebDavPropertiesContext implements Context {
 	public function userHasSetFollowingPropertiesUsingProppatch(
 		string $username,
 		string $path,
-		TableNode $propertiesTable
+		TableNode $propertiesTable,
 	): void {
 		$username = $this->featureContext->getActualUsername($username);
 		$this->featureContext->verifyTableNodeColumns($propertiesTable, ['propertyName', 'propertyValue']);
@@ -184,7 +184,7 @@ class WebDavPropertiesContext implements Context {
 			$this->featureContext->getPasswordForUser($username),
 			$path,
 			$properties,
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(207, "", $response);
 	}
@@ -202,7 +202,7 @@ class WebDavPropertiesContext implements Context {
 	public function userGetsCustomPropertyOfFile(
 		string $user,
 		string $propertyName,
-		string $path
+		string $path,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$properties = [$propertyName];
@@ -215,7 +215,7 @@ class WebDavPropertiesContext implements Context {
 			"0",
 			null,
 			"files",
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -235,7 +235,7 @@ class WebDavPropertiesContext implements Context {
 		string $user,
 		string $propertyName,
 		string $namespace,
-		string $path
+		string $path,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$properties = [
@@ -250,7 +250,7 @@ class WebDavPropertiesContext implements Context {
 			"0",
 			null,
 			"files",
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -276,7 +276,7 @@ class WebDavPropertiesContext implements Context {
 			'0',
 			$properties,
 			null,
-			"public-files"
+			"public-files",
 		);
 	}
 
@@ -291,7 +291,7 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function thePublicGetsFollowingPropertiesOfEntryFromLastLinkShare(
 		string $path,
-		TableNode $propertiesTable
+		TableNode $propertiesTable,
 	): void {
 		$response = $this->getPropertiesOfEntryFromLastLinkShare($path, $propertiesTable);
 		$this->featureContext->setResponse($response);
@@ -323,7 +323,7 @@ class WebDavPropertiesContext implements Context {
 			$propertyName,
 			$propertyValue,
 			$namespace,
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
 		);
 	}
 
@@ -342,13 +342,13 @@ class WebDavPropertiesContext implements Context {
 		string $user,
 		string $propertyName,
 		string $path,
-		string $propertyValue
+		string $propertyValue,
 	): void {
 		$response = $this->setResourceProperty(
 			$user,
 			$propertyName,
 			$path,
-			$propertyValue
+			$propertyValue,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -370,14 +370,14 @@ class WebDavPropertiesContext implements Context {
 		string $propertyName,
 		string $namespace,
 		string $path,
-		string $propertyValue
+		string $propertyValue,
 	): void {
 		$response = $this->setResourceProperty(
 			$user,
 			$propertyName,
 			$path,
 			$propertyValue,
-			$namespace
+			$namespace,
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -397,13 +397,13 @@ class WebDavPropertiesContext implements Context {
 		string $user,
 		string $propertyName,
 		string $path,
-		string $propertyValue
+		string $propertyValue,
 	): void {
 		$response = $this->setResourceProperty(
 			$user,
 			$propertyName,
 			$path,
-			$propertyValue
+			$propertyValue,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(207, "", $response);
 	}
@@ -425,14 +425,14 @@ class WebDavPropertiesContext implements Context {
 		string $propertyName,
 		string $namespace,
 		string $path,
-		string $propertyValue
+		string $propertyValue,
 	): void {
 		$response = $this->setResourceProperty(
 			$user,
 			$propertyName,
 			$path,
 			$propertyValue,
-			$namespace
+			$namespace,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(207, "", $response);
 	}
@@ -450,21 +450,21 @@ class WebDavPropertiesContext implements Context {
 		$propertyValue = \str_replace('\"', '"', $propertyValue);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->featureContext->getResponse(),
-			__METHOD__
+			__METHOD__,
 		);
 		$xmlPart = $responseXmlObject->xpath(
-			"//d:prop/" . "$propertyName"
+			"//d:prop/" . "$propertyName",
 		);
 		Assert::assertArrayHasKey(
 			0,
 			$xmlPart,
-			"Cannot find property \"$propertyName\""
+			"Cannot find property \"$propertyName\"",
 		);
 		Assert::assertEquals(
 			$propertyValue,
 			$xmlPart[0]->__toString(),
 			"\"$propertyName\" has a value \"" .
-			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected"
+			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected",
 		);
 	}
 
@@ -481,32 +481,32 @@ class WebDavPropertiesContext implements Context {
 	public function theResponseShouldContainACustomPropertyWithNamespaceAndValue(
 		string $propertyName,
 		string $namespaceString,
-		string $propertyValue
+		string $propertyValue,
 	): void {
 		// let's unescape quotes first
 		$propertyValue = \str_replace('\"', '"', $propertyValue);
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->featureContext->getResponse(),
-			__METHOD__
+			__METHOD__,
 		);
 		$ns = WebDavHelper::parseNamespace($namespaceString);
 		$responseXmlObject->registerXPathNamespace(
 			$ns->prefix,
-			$ns->namespace
+			$ns->namespace,
 		);
 		$xmlPart = $responseXmlObject->xpath(
-			"//d:prop/$propertyName"
+			"//d:prop/$propertyName",
 		);
 		Assert::assertArrayHasKey(
 			0,
 			$xmlPart,
-			"Cannot find property \"$propertyName\""
+			"Cannot find property \"$propertyName\"",
 		);
 		Assert::assertEquals(
 			$propertyValue,
 			$xmlPart[0]->__toString(),
 			"\"$propertyName\" has a value \"" .
-			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected"
+			$xmlPart[0]->__toString() . "\" but \"$propertyValue\" expected",
 		);
 	}
 
@@ -524,20 +524,20 @@ class WebDavPropertiesContext implements Context {
 	public function theSingleResponseShouldContainAPropertyWithChildProperty(
 		string $property,
 		string $withOrWithout,
-		string $childProperty
+		string $childProperty,
 	): void {
 		$xmlPart = HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath(
-			"//d:prop/$property/$childProperty"
+			"//d:prop/$property/$childProperty",
 		);
 		if ($withOrWithout === "with") {
 			Assert::assertTrue(
 				isset($xmlPart[0]),
-				"Cannot find property \"$property/$childProperty\""
+				"Cannot find property \"$property/$childProperty\"",
 			);
 		} else {
 			Assert::assertFalse(
 				isset($xmlPart[0]),
-				"Found property \"$property/$childProperty\""
+				"Found property \"$property/$childProperty\"",
 			);
 		}
 	}
@@ -553,7 +553,7 @@ class WebDavPropertiesContext implements Context {
 	public function theResponseShouldContainProperty(string $key): void {
 		$this->checkResponseContainsProperty(
 			$this->featureContext->getResponse(),
-			$key
+			$key,
 		);
 	}
 
@@ -570,7 +570,7 @@ class WebDavPropertiesContext implements Context {
 		$this->checkResponseContainsProperty(
 			$this->featureContext->getResponse(),
 			$key,
-			$namespace
+			$namespace,
 		);
 	}
 
@@ -585,13 +585,13 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function theSingleResponseShouldContainAPropertyWithValue(
 		string $key,
-		string $expectedValue
+		string $expectedValue,
 	): void {
 		$this->checkResponseContainsAPropertyWithValue(
 			$this->featureContext->getResponse(),
 			$key,
 			$expectedValue,
-			$expectedValue
+			$expectedValue,
 		);
 	}
 
@@ -608,14 +608,14 @@ class WebDavPropertiesContext implements Context {
 	public function theSingleResponseAboutTheFileOwnedByShouldContainAPropertyWithValue(
 		string $user,
 		string $key,
-		string $expectedValue
+		string $expectedValue,
 	): void {
 		$this->checkResponseContainsAPropertyWithValue(
 			$this->featureContext->getResponse(),
 			$key,
 			$expectedValue,
 			$expectedValue,
-			$user
+			$user,
 		);
 	}
 
@@ -632,13 +632,13 @@ class WebDavPropertiesContext implements Context {
 	public function theSingleResponseShouldContainAPropertyWithValueAndAlternative(
 		string $key,
 		string $expectedValue,
-		string $altExpectedValue
+		string $altExpectedValue,
 	): void {
 		$this->checkResponseContainsAPropertyWithValue(
 			$this->featureContext->getResponse(),
 			$key,
 			$expectedValue,
-			$altExpectedValue
+			$altExpectedValue,
 		);
 	}
 
@@ -653,7 +653,7 @@ class WebDavPropertiesContext implements Context {
 	public function checkResponseContainsProperty(
 		ResponseInterface $response,
 		string $key,
-		string $namespaceString = null
+		string $namespaceString = null,
 	): SimpleXMLElement {
 		$xmlPart = HttpRequestHelper::getResponseXml($response, __METHOD__);
 		;
@@ -662,7 +662,7 @@ class WebDavPropertiesContext implements Context {
 			$ns = WebDavHelper::parseNamespace($namespaceString);
 			$xmlPart->registerXPathNamespace(
 				$ns->prefix,
-				$ns->namespace
+				$ns->namespace,
 			);
 		}
 
@@ -670,14 +670,14 @@ class WebDavPropertiesContext implements Context {
 
 		Assert::assertTrue(
 			isset($match[0]),
-			"Cannot find property \"$key\""
+			"Cannot find property \"$key\"",
 		);
 
 		$property = \explode(":", $key);
 		$propertyName = $property[\count($property) - 1];
 		Assert::assertEquals(
 			$match[0]->getName(),
-			$propertyName
+			$propertyName,
 		);
 		return $match[0];
 	}
@@ -697,13 +697,13 @@ class WebDavPropertiesContext implements Context {
 		string $key,
 		string $expectedValue,
 		string $altExpectedValue,
-		?string $user = null
+		?string $user = null,
 	): void {
 		$xmlPart = $this->checkResponseContainsProperty($response, $key);
 		$value = $xmlPart->__toString();
 		$expectedValue = $this->featureContext->substituteInLineCodes(
 			$expectedValue,
-			$user
+			$user,
 		);
 		$expectedValue = "#^$expectedValue$#";
 		$altExpectedValue = "#^$altExpectedValue$#";
@@ -712,7 +712,7 @@ class WebDavPropertiesContext implements Context {
 		) {
 			Assert::fail(
 				"Property \"$key\" found with value \"$value\", " .
-				"expected \"$expectedValue\" or \"$altExpectedValue\""
+				"expected \"$expectedValue\" or \"$altExpectedValue\"",
 			);
 		}
 	}
@@ -730,7 +730,7 @@ class WebDavPropertiesContext implements Context {
 		$this->assertValueOfItemInResponseAboutUserIs(
 			$xpath,
 			null,
-			$expectedValue
+			$expectedValue,
 		);
 	}
 
@@ -753,7 +753,7 @@ class WebDavPropertiesContext implements Context {
 		$this->assertValueOfItemInResponseAboutUserIs(
 			$fullXpath,
 			null,
-			$expectedValue
+			$expectedValue,
 		);
 	}
 
@@ -770,7 +770,7 @@ class WebDavPropertiesContext implements Context {
 	public function theValueOfTheItemInTheResponseAboutUserShouldBe(
 		string $xpath,
 		string $user,
-		string $expectedValue
+		string $expectedValue,
 	): void {
 		$this->assertValueOfItemInResponseAboutUserIs($xpath, $user, $expectedValue);
 	}
@@ -785,13 +785,13 @@ class WebDavPropertiesContext implements Context {
 	public function assertValueOfItemInResponseAboutUserIs(string $xpath, ?string $user, string $expectedValue): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->featureContext->getResponse(),
-			__METHOD__
+			__METHOD__,
 		);
 		$value = $this->getXmlItemByXpath($responseXmlObject, $xpath);
 		$user = $this->featureContext->getActualUsername($user);
 		$expectedValue = $this->featureContext->substituteInLineCodes(
 			$expectedValue,
-			$user
+			$user,
 		);
 
 		// The expected value can contain /%base_path%/ which can be empty some time
@@ -801,7 +801,7 @@ class WebDavPropertiesContext implements Context {
 			$expectedValue,
 			$value,
 			"item \"$xpath\" found with value \"$value\", " .
-			"expected \"$expectedValue\""
+			"expected \"$expectedValue\"",
 		);
 	}
 
@@ -820,25 +820,25 @@ class WebDavPropertiesContext implements Context {
 		string $xpath,
 		?string $user,
 		string $expectedValue1,
-		string $expectedValue2
+		string $expectedValue2,
 	): void {
 		if (!$expectedValue2) {
 			$expectedValue2 = $expectedValue1;
 		}
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->featureContext->getResponse(),
-			__METHOD__
+			__METHOD__,
 		);
 		$value = $this->getXmlItemByXpath($responseXmlObject, $xpath);
 		$user = $this->featureContext->getActualUsername($user);
 		$expectedValue1 = $this->featureContext->substituteInLineCodes(
 			$expectedValue1,
-			$user
+			$user,
 		);
 
 		$expectedValue2 = $this->featureContext->substituteInLineCodes(
 			$expectedValue2,
-			$user
+			$user,
 		);
 
 		// The expected value can contain /%base_path%/ which can be empty some time
@@ -849,7 +849,7 @@ class WebDavPropertiesContext implements Context {
 		$isExpectedValueInMessage = \in_array($value, $expectedValues);
 		Assert::assertTrue(
 			$isExpectedValueInMessage,
-			"The actual value \"$value\" is not one of the expected values: \"$expectedValue1\" or \"$expectedValue2\""
+			"The actual value \"$value\" is not one of the expected values: \"$expectedValue1\" or \"$expectedValue2\"",
 		);
 	}
 
@@ -861,12 +861,12 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function getXmlItemByXpath(
 		SimpleXMLElement $responseXmlObject,
-		string $xpath
+		string $xpath,
 	): string {
 		$xmlPart = $responseXmlObject->xpath($xpath);
 		Assert::assertTrue(
 			isset($xmlPart[0]),
-			"Cannot find item with xpath \"$xpath\""
+			"Cannot find item with xpath \"$xpath\"",
 		);
 		return $xmlPart[0]->__toString();
 	}
@@ -884,7 +884,7 @@ class WebDavPropertiesContext implements Context {
 		$this->assertXpathValueMatchesPattern(
 			HttpRequestHelper::getResponseXml($this->featureContext->getResponse()),
 			$xpath,
-			$pattern
+			$pattern,
 		);
 	}
 
@@ -901,7 +901,7 @@ class WebDavPropertiesContext implements Context {
 	public function publicGetsThePropertiesOfFolderAndAssertValueOfItemInResponseRegExp(
 		string $xpath,
 		string $path,
-		string $pattern
+		string $pattern,
 	): void {
 		$propertiesTable = new TableNode([['propertyName'],['d:lockdiscovery']]);
 		$response = $this->getPropertiesOfEntryFromLastLinkShare($path, $propertiesTable);
@@ -909,7 +909,7 @@ class WebDavPropertiesContext implements Context {
 		$this->assertXpathValueMatchesPattern(
 			HttpRequestHelper::getResponseXml($response, __METHOD__),
 			$xpath,
-			$pattern
+			$pattern,
 		);
 	}
 
@@ -925,14 +925,14 @@ class WebDavPropertiesContext implements Context {
 	public function assertEntryWithHrefMatchingRegExpInResponseToUser(string $expectedHref, string $user): void {
 		$responseXmlObject = HttpRequestHelper::getResponseXml(
 			$this->featureContext->getResponse(),
-			__METHOD__
+			__METHOD__,
 		);
 
 		$user = $this->featureContext->getActualUsername($user);
 		$expectedHref = $this->featureContext->substituteInLineCodes(
 			$expectedHref,
 			$user,
-			['preg_quote' => ['/']]
+			['preg_quote' => ['/']],
 		);
 		$expectedHref = WebdavHelper::prefixRemotePhp($expectedHref);
 
@@ -944,7 +944,7 @@ class WebDavPropertiesContext implements Context {
 			// If we have run out of entries in the response, then fail the test
 			Assert::assertTrue(
 				isset($xmlPart[0]),
-				"Cannot find any entry having href with value $expectedHref in response to $user"
+				"Cannot find any entry having href with value $expectedHref in response to $user",
 			);
 			$value = $xmlPart[0]->__toString();
 			$decodedValue = \rawurldecode($value);
@@ -985,12 +985,12 @@ class WebDavPropertiesContext implements Context {
 		SimpleXMLElement $responseXmlObject,
 		string $xpath,
 		string $pattern,
-		?string $user = null
+		?string $user = null,
 	): void {
 		$xmlPart = $responseXmlObject->xpath($xpath);
 		Assert::assertTrue(
 			isset($xmlPart[0]),
-			"Cannot find item with xpath \"$xpath\""
+			"Cannot find item with xpath \"$xpath\"",
 		);
 		$user = $this->featureContext->getActualUsername($user);
 		$value = $xmlPart[0]->__toString();
@@ -1015,13 +1015,13 @@ class WebDavPropertiesContext implements Context {
 					[$this->featureContext, $callback],
 					"parameter" => [],
 				],
-			]
+			],
 		);
 		Assert::assertMatchesRegularExpression(
 			$pattern,
 			$value,
 			"item \"$xpath\" found with value \"$value\", " .
-			"expected to match regex pattern: \"$pattern\""
+			"expected to match regex pattern: \"$pattern\"",
 		);
 	}
 
@@ -1040,21 +1040,21 @@ class WebDavPropertiesContext implements Context {
 		string $user,
 		string $xpath,
 		string $path,
-		string $pattern
+		string $pattern,
 	): void {
 		$propertiesTable = new TableNode([['propertyName'],['d:lockdiscovery']]);
 		$response = $this->getPropertiesOfFolder(
 			$user,
 			$path,
 			null,
-			$propertiesTable
+			$propertiesTable,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe('207', '', $response);
 		$this->assertXpathValueMatchesPattern(
 			HttpRequestHelper::getResponseXml($response, __METHOD__),
 			$xpath,
 			$pattern,
-			$user
+			$user,
 		);
 	}
 
@@ -1070,7 +1070,7 @@ class WebDavPropertiesContext implements Context {
 		$xmlPart = HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath($xpath);
 		Assert::assertFalse(
 			isset($xmlPart[0]),
-			"Found item with xpath \"$xpath\" but it should not exist"
+			"Found item with xpath \"$xpath\" but it should not exist",
 		);
 	}
 
@@ -1091,7 +1091,7 @@ class WebDavPropertiesContext implements Context {
 		string $path,
 		string $property,
 		string $expectedValue,
-		?string $altExpectedValue = null
+		?string $altExpectedValue = null,
 	): void {
 		$this->checkPropertyOfAFolder($user, $path, $property, $expectedValue, $altExpectedValue);
 	}
@@ -1128,7 +1128,7 @@ class WebDavPropertiesContext implements Context {
 			$response,
 			$property,
 			$expectedValue,
-			$altExpectedValue
+			$altExpectedValue,
 		);
 	}
 
@@ -1143,20 +1143,20 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function theSingleResponseShouldContainAPropertyWithValueLike(
 		string $key,
-		string $regex
+		string $regex,
 	): void {
 		$xmlPart = HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath(
-			"//d:prop/$key"
+			"//d:prop/$key",
 		);
 		Assert::assertTrue(
 			isset($xmlPart[0]),
-			"Cannot find property \"$key\""
+			"Cannot find property \"$key\"",
 		);
 		$value = $xmlPart[0]->__toString();
 		Assert::assertMatchesRegularExpression(
 			$regex,
 			$value,
-			"Property \"$key\" found with value \"$value\", expected \"$regex\""
+			"Property \"$key\" found with value \"$value\", expected \"$regex\"",
 		);
 	}
 
@@ -1172,7 +1172,7 @@ class WebDavPropertiesContext implements Context {
 		$this->featureContext->verifyTableNodeColumnsCount($table, 1);
 		WebdavTest::assertResponseContainsShareTypes(
 			HttpRequestHelper::getResponseXml($this->featureContext->getResponse()),
-			$table->getRows()
+			$table->getRows(),
 		);
 	}
 
@@ -1186,16 +1186,16 @@ class WebDavPropertiesContext implements Context {
 	 */
 	public function theResponseShouldContainAnEmptyProperty(string $property): void {
 		$xmlPart = HttpRequestHelper::getResponseXml($this->featureContext->getResponse())->xpath(
-			"//d:prop/$property"
+			"//d:prop/$property",
 		);
 		Assert::assertCount(
 			1,
 			$xmlPart,
-			"Cannot find property \"$property\""
+			"Cannot find property \"$property\"",
 		);
 		Assert::assertEmpty(
 			$xmlPart[0],
-			"Property \"$property\" is not empty"
+			"Property \"$property\" is not empty",
 		);
 	}
 
@@ -1212,7 +1212,7 @@ class WebDavPropertiesContext implements Context {
 		string $user,
 		string $path,
 		?string $storePath = "",
-		?string $spaceId = null
+		?string $spaceId = null,
 	): SimpleXMLElement {
 		if ($storePath === "") {
 			$storePath = $path;
@@ -1223,7 +1223,7 @@ class WebDavPropertiesContext implements Context {
 			$user,
 			$path,
 			$spaceId,
-			$propertiesTable
+			$propertiesTable,
 		);
 		$xmlObject = HttpRequestHelper::getResponseXml($response, __METHOD__);
 		$this->storedETAG[$user][$storePath]
@@ -1243,7 +1243,7 @@ class WebDavPropertiesContext implements Context {
 	public function userStoresEtagOfElement(string $user, string $path): void {
 		$this->storeEtagOfElement(
 			$user,
-			$path
+			$path,
 		);
 	}
 
@@ -1262,7 +1262,7 @@ class WebDavPropertiesContext implements Context {
 		$this->storeEtagOfElement(
 			$user,
 			$path,
-			$storePath
+			$storePath,
 		);
 		if ($storePath == "") {
 			$storePath = $path;
@@ -1285,7 +1285,7 @@ class WebDavPropertiesContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->storeEtagOfElement(
 			$user,
-			$path
+			$path,
 		);
 		if ($this->storedETAG[$user][$path] === "" || $this->storedETAG[$user][$path] === null) {
 			throw new Exception("Expected stored etag to be some string but found null!");
@@ -1302,7 +1302,7 @@ class WebDavPropertiesContext implements Context {
 		Assert::assertTrue(
 			$this->featureContext->isEtagValid($this->featureContext->getEtagFromResponseXmlObject()),
 			__METHOD__
-			. " getetag not found in response"
+			. " getetag not found in response",
 		);
 	}
 
@@ -1340,7 +1340,7 @@ class WebDavPropertiesContext implements Context {
 	public function theResponseShouldHavePropertyWithValue(string $username, TableNode $expectedPropTable): void {
 		$this->featureContext->verifyTableNodeColumns(
 			$expectedPropTable,
-			['resource', 'propertyName', 'propertyValue']
+			['resource', 'propertyName', 'propertyValue'],
 		);
 		$responseXmlObject = HttpRequestHelper::getResponseXml($this->featureContext->getResponse());
 
@@ -1356,7 +1356,7 @@ class WebDavPropertiesContext implements Context {
 				$col["propertyValue"],
 				$xmlPart[0],
 				__METHOD__
-				. " Expected '" . $col["propertyValue"] . "' but got '" . $xmlPart[0] . "'"
+				. " Expected '" . $col["propertyValue"] . "' but got '" . $xmlPart[0] . "'",
 			);
 		}
 	}
@@ -1375,10 +1375,10 @@ class WebDavPropertiesContext implements Context {
 			$user,
 			$path,
 			null,
-			$propertiesTable
+			$propertiesTable,
 		);
 		return $this->featureContext->getEtagFromResponseXmlObject(
-			HttpRequestHelper::getResponseXml($response, __METHOD__)
+			HttpRequestHelper::getResponseXml($response, __METHOD__),
 		);
 	}
 
@@ -1397,14 +1397,14 @@ class WebDavPropertiesContext implements Context {
 			$user,
 			$this->storedETAG,
 			$messageStart
-			. " Trying to check etag of element $path of user $user but the user does not have any stored etags"
+			. " Trying to check etag of element $path of user $user but the user does not have any stored etags",
 		);
 		Assert::assertArrayHasKey(
 			$path,
 			$this->storedETAG[$user],
 			$messageStart
 			. " Trying to check etag of element $path of user "
-			. "$user but the user does not have a stored etag for the element"
+			. "$user but the user does not have a stored etag for the element",
 		);
 		return $this->storedETAG[$user][$path];
 	}
@@ -1478,7 +1478,7 @@ class WebDavPropertiesContext implements Context {
 	public function etagOfElementOfUserShouldOrShouldNotHaveChanged(
 		string $path,
 		string $user,
-		string $shouldShouldNot
+		string $shouldShouldNot,
 	): void {
 		$user = $this->featureContext->getActualUsername($user);
 		$actualEtag = $this->getCurrentEtagOfElement($path, $user);
@@ -1489,7 +1489,7 @@ class WebDavPropertiesContext implements Context {
 				$actualEtag,
 				__METHOD__
 				. " The etag of element '$path' of user '$user' was not expected to change."
-				. " The stored etag was '$storedEtag' but got '$actualEtag' from the response"
+				. " The stored etag was '$storedEtag' but got '$actualEtag' from the response",
 			);
 		} else {
 			Assert::assertNotEquals(
@@ -1497,7 +1497,7 @@ class WebDavPropertiesContext implements Context {
 				$actualEtag,
 				__METHOD__
 				. " The etag of element '$path' of user '$user' was expected to change."
-				. " The stored etag was '$storedEtag' and also got '$actualEtag' from the response"
+				. " The stored etag was '$storedEtag' and also got '$actualEtag' from the response",
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Added the following php lint rules:
```php
'no_unused_imports' => true,
'array_indentation' => true,
'method_chaining_indentation' => true,
'trailing_comma_in_multiline' => [
    'elements' => ['arrays', 'arguments', 'parameters'],
],
'no_useless_else' => true,
'single_line_comment_spacing' => true,
'no_trailing_whitespace_in_comment' => true,
'no_empty_comment' => true,
'no_singleline_whitespace_before_semicolons' => true,
'type_declaration_spaces' => true,
'binary_operator_spaces' => true,
'phpdoc_to_return_type' => true,
'void_return' => true,
'no_useless_concat_operator' => true,
'concat_space' => [
    "spacing" => "one",
],
```

## Related Issue

## Motivation and Context
maintaint code standards

## How Has This Been Tested?
- test environment:


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
