### PR TITLE
[docs-only] Updating ocis_full web-extensions image versions

### DIFF
--- a/deployments/examples/ocis_full/web_extensions/drawio.yml
+++ b/deployments/examples/ocis_full/web_extensions/drawio.yml
@@ -6,7 +6,7 @@ services:
         condition: service_completed_successfully
 
   drawio-init:
-    image: owncloud/web-extensions:draw-io-0.3.0
+    image: owncloud/web-extensions:draw-io-0.3.1
     user: root
     volumes:
       - ocis-apps:/apps

--- a/deployments/examples/ocis_full/web_extensions/externalsites.yml
+++ b/deployments/examples/ocis_full/web_extensions/externalsites.yml
@@ -6,7 +6,7 @@ services:
         condition: service_completed_successfully
 
   externalsites-init:
-    image: owncloud/web-extensions:external-sites-0.3.0
+    image: owncloud/web-extensions:external-sites-0.3.1
     user: root
     volumes:
       - ocis-apps:/apps

--- a/deployments/examples/ocis_full/web_extensions/jsonviewer.yml
+++ b/deployments/examples/ocis_full/web_extensions/jsonviewer.yml
@@ -6,7 +6,7 @@ services:
         condition: service_completed_successfully
 
   jsonviewer-init:
-    image: owncloud/web-extensions:json-viewer-0.3.0
+    image: owncloud/web-extensions:json-viewer-0.3.1
     user: root
     volumes:
       - ocis-apps:/apps

--- a/deployments/examples/ocis_full/web_extensions/progressbars.yml
+++ b/deployments/examples/ocis_full/web_extensions/progressbars.yml
@@ -6,7 +6,7 @@ services:
         condition: service_completed_successfully
 
   progressbars-init:
-    image: owncloud/web-extensions:progress-bars-0.3.0
+    image: owncloud/web-extensions:progress-bars-0.3.1
     user: root
     volumes:
       - ocis-apps:/apps

--- a/deployments/examples/ocis_full/web_extensions/unzip.yml
+++ b/deployments/examples/ocis_full/web_extensions/unzip.yml
@@ -6,7 +6,7 @@ services:
         condition: service_completed_successfully
 
   unzip-init:
-    image: owncloud/web-extensions:unzip-0.4.0
+    image: owncloud/web-extensions:unzip-0.4.1
     user: root
     volumes:
       - ocis-apps:/apps


### PR DESCRIPTION
This PR updates the image versions for `ocis_full/web-extensions`.
Related to tags/images created in https://github.com/owncloud/web-extensions/releases on 2025.06.20

Note that importer is handled in another PR #10880 (chore: update importer)