### PR TITLE
[tests-only][full-ci] test: adjust PHP code to support v8.4

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -40,7 +40,7 @@ SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:11.0"
 KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.2.5"
 POSTGRES_ALPINE_IMAGE = "postgres:alpine3.18"
 
-DEFAULT_PHP_VERSION = "8.2"
+DEFAULT_PHP_VERSION = "8.4"
 DEFAULT_NODEJS_VERSION = "22"
 
 dirs = {
@@ -1010,6 +1010,9 @@ def codestyle(ctx):
                              {
                                  "name": "php-style",
                                  "image": OC_CI_PHP % phpVersion,
+                                 "environment": {
+                                     "PHP_CS_FIXER_IGNORE_ENV": "true",
+                                 },
                                  "commands": [
                                      "make test-php-style",
                                  ],

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "owncloud/ocis",
-  "config" : {
+  "config": {
     "platform": {
-      "php": "8.2"
+      "php": "8.4"
     },
     "vendor-dir": "./vendor-php",
     "allow-plugins": {

--- a/tests/acceptance/TestHelpers/SharingHelper.php
+++ b/tests/acceptance/TestHelpers/SharingHelper.php
@@ -99,7 +99,7 @@ class SharingHelper {
 		$shareType,
 		?string $shareWith = null,
 		?bool $publicUpload = false,
-		string $sharePassword = null,
+		?string $sharePassword = null,
 		$permissions = null,
 		?string $linkName = null,
 		?string $expireDate = null,

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -719,7 +719,7 @@ class CliContext implements Context {
 	 * @return array
 	 */
 	protected function getTrashedResourceFromCliCommandResponse(
-		ResponseInterface $response = null,
+		?ResponseInterface $response = null,
 	): array {
 		$responseArray = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 		$lines = explode("\n", $responseArray->message);

--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -91,7 +91,7 @@ class CollaborationContext implements Context {
 		string $file,
 		string $space,
 		string $app,
-		string $viewMode = null,
+		?string $viewMode = null,
 	): void {
 		$fileId = $this->spacesContext->getFileId($user, $space, $file);
 		$response = \json_decode(

--- a/tests/acceptance/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/bootstrap/FavoritesContext.php
@@ -43,7 +43,7 @@ class FavoritesContext implements Context {
 	 *
 	 * @return ResponseInterface
 	 */
-	public function userFavoritesElement(string $user, string $path, string $spaceId = null): ResponseInterface {
+	public function userFavoritesElement(string $user, string $path, ?string $spaceId = null): ResponseInterface {
 		return $this->changeFavStateOfAnElement(
 			$user,
 			$path,
@@ -179,7 +179,7 @@ class FavoritesContext implements Context {
 		string $user,
 		string $path,
 		int $expectedValue = 1,
-		string $spaceId = null,
+		?string $spaceId = null,
 	): void {
 		$property = "oc:favorite";
 		$this->webDavPropertiesContext->checkPropertyOfAFolder(

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -1583,7 +1583,7 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @return mixed
 	 */
-	public function getJsonDecodedResponseBodyContent(ResponseInterface $response = null): mixed {
+	public function getJsonDecodedResponseBodyContent(?ResponseInterface $response = null): mixed {
 		$response = $response ?? $this->response;
 		$response->getBody()->rewind();
 		return HttpRequestHelper::getJsonDecodedResponseBodyContent($response);

--- a/tests/acceptance/bootstrap/GraphContext.php
+++ b/tests/acceptance/bootstrap/GraphContext.php
@@ -205,10 +205,10 @@ class GraphContext implements Context {
 	public function editUserUsingTheGraphApi(
 		string $byUser,
 		string $user,
-		string $userName = null,
-		string $password = null,
-		string $email = null,
-		string $displayName = null,
+		?string $userName = null,
+		?string $password = null,
+		?string $email = null,
+		?string $displayName = null,
 		bool $accountEnabled = true,
 		string $method = "PATCH",
 	): ResponseInterface {
@@ -2342,7 +2342,7 @@ class GraphContext implements Context {
 	public function downloadedJsonContentShouldContainEventTypeInItemAndShouldMatch(
 		string $eventType,
 		?string $spaceType = null,
-		PyStringNode $schemaString = null,
+		?PyStringNode $schemaString = null,
 	): void {
 		$actualResponseToAssert = null;
 		$events = $this->featureContext->getJsonDecodedResponseBodyContent()->events;

--- a/tests/acceptance/bootstrap/OcmContext.php
+++ b/tests/acceptance/bootstrap/OcmContext.php
@@ -73,13 +73,17 @@ class OcmContext implements Context {
 
 	/**
 	 * @param string $user
-	 * @param string $email
-	 * @param string $description
+	 * @param string|null $email
+	 * @param string|null $description
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public function createInvitation(string $user, $email = null, $description = null): ResponseInterface {
+	public function createInvitation(
+		string $user,
+		?string $email = null,
+		?string $description = null,
+	): ResponseInterface {
 		$response = OcmHelper::createInvitation(
 			$this->featureContext->getBaseUrl(),
 			$user,
@@ -99,13 +103,17 @@ class OcmContext implements Context {
 	 * @When :user creates the federation share invitation with email :email and description :description
 	 *
 	 * @param string $user
-	 * @param string $email
-	 * @param string $description
+	 * @param string|null $email
+	 * @param string|null $description
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function userCreatesTheFederationShareInvitation(string $user, $email = null, $description = null): void {
+	public function userCreatesTheFederationShareInvitation(
+		string $user,
+		?string $email = null,
+		?string $description = null,
+	): void {
 		$this->featureContext->setResponse($this->createInvitation($user, $email, $description));
 	}
 
@@ -114,25 +122,29 @@ class OcmContext implements Context {
 	 * @Given :user has created the federation share invitation with email :email and description :description
 	 *
 	 * @param string $user
-	 * @param string $email
-	 * @param string $description
+	 * @param string|null $email
+	 * @param string|null $description
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function userHasCreatedTheFederationShareInvitation(string $user, $email = null, $description = null): void {
+	public function userHasCreatedTheFederationShareInvitation(
+		string $user,
+		?string $email = null,
+		?string $description = null,
+	): void {
 		$response = $this->createInvitation($user, $email, $description);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**
 	 * @param string $user
-	 * @param string $token
+	 * @param string|null $token
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public function acceptInvitation(string $user, string $token = null): ResponseInterface {
+	public function acceptInvitation(string $user, ?string $token = null): ResponseInterface {
 		$providerDomain = $this->featureContext->getLocalBaseUrlWithoutScheme();
 		if ($this->featureContext->getCurrentServer() === "LOCAL") {
 			$providerDomain = $this->featureContext->getRemoteBaseUrlWithoutScheme();
@@ -350,7 +362,7 @@ class OcmContext implements Context {
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	public function deleteConnection(string $user, string $ocmUser, string $idp = null): ResponseInterface {
+	public function deleteConnection(string $user, string $ocmUser, ?string $idp = null): ResponseInterface {
 		$ocmUser = $this->getAcceptedUserByName($user, $ocmUser);
 		$ocmUser['idp'] = $idp ?? $ocmUser['idp'];
 		return OcmHelper::deleteConnection(

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -1055,7 +1055,7 @@ trait Provisioning {
 	 */
 	public function userHasBeenCreated(
 		array $userData,
-		string $byUser = null,
+		?string $byUser = null,
 	): void {
 		$userId = null;
 

--- a/tests/acceptance/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/bootstrap/PublicWebDavContext.php
@@ -787,7 +787,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publiclyUploadingWithPasswordShouldNotWork(
 		string $password,
-		string $expectedHttpCode = null,
+		?string $expectedHttpCode = null,
 	): void {
 		$response = $this->publicUploadContent(
 			'whateverfilefortesting.txt',

--- a/tests/acceptance/bootstrap/SettingsContext.php
+++ b/tests/acceptance/bootstrap/SettingsContext.php
@@ -350,14 +350,14 @@ class SettingsContext implements Context {
 
 	/**
 	 * @param string $user
-	 * @param array $headers
+	 * @param array|null $headers
 	 *
 	 * @return ResponseInterface
 	 *
 	 * @throws GuzzleException
 	 * @throws Exception
 	 */
-	public function sendRequestGetSettingsValuesList(string $user, array $headers = null): ResponseInterface {
+	public function sendRequestGetSettingsValuesList(string $user, ?array $headers = null): ResponseInterface {
 		return SettingsHelper::getValuesList(
 			$this->featureContext->getBaseUrl(),
 			$user,

--- a/tests/acceptance/bootstrap/Sharing.php
+++ b/tests/acceptance/bootstrap/Sharing.php
@@ -552,7 +552,7 @@ trait Sharing {
 		string $user,
 		string $path,
 		bool $publicUpload = false,
-		string $sharePassword = null,
+		?string $sharePassword = null,
 		$permissions = null,
 		?string $linkName = null,
 		?string $expireDate = null,
@@ -1711,7 +1711,7 @@ trait Sharing {
 	 */
 	public function deleteLastShareUsingSharingApi(
 		string $user,
-		string $sharer = null,
+		?string $sharer = null,
 		bool $deleteLastPublicLink = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);

--- a/tests/acceptance/bootstrap/SharingNgContext.php
+++ b/tests/acceptance/bootstrap/SharingNgContext.php
@@ -310,7 +310,7 @@ class SharingNgContext implements Context {
 	public function sendShareInvitation(
 		string $user,
 		array $shareInfo,
-		string $fileId = null,
+		?string $fileId = null,
 		bool $federatedShare = false,
 	): ResponseInterface {
 		$space = $this->spacesContext->getSpaceByName($user, $shareInfo['space']);

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2040,7 +2040,7 @@ class SpacesContext implements Context {
 		string $fromSpaceName,
 		string $fileDestination,
 		string $toSpaceName,
-		TableNode $table = null,
+		?TableNode $table = null,
 	): void {
 		$space = $this->getSpaceByName($user, $fromSpaceName);
 		$headers['Destination'] = $this->destinationHeaderValueWithSpaceName(
@@ -2213,7 +2213,7 @@ class SpacesContext implements Context {
 		string $user,
 		string $fileDestination,
 		string $spaceName,
-		string $endPath = null,
+		?string $endPath = null,
 	): string {
 		$space = $this->getSpaceByName($user, $spaceName);
 		$fileDestination = $this->escapePath(\ltrim($fileDestination, "/"));
@@ -4676,7 +4676,7 @@ class SpacesContext implements Context {
 		string $recipientType,
 		string $recipient,
 		string $role,
-		string $expirationDate = null,
+		?string $expirationDate = null,
 	): void {
 		$response = $this->listAllMySpaces($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe(

--- a/tests/acceptance/bootstrap/TUSContext.php
+++ b/tests/acceptance/bootstrap/TUSContext.php
@@ -259,7 +259,7 @@ class TUSContext implements Context {
 		string $destination,
 		array $uploadMetadata = [],
 		int $noOfChunks = 1,
-		int $bytes = null,
+		?int $bytes = null,
 		string $checksum = '',
 	): void {
 		$response = $this->uploadFileUsingTus(
@@ -283,7 +283,7 @@ class TUSContext implements Context {
 	 * @param string|null $spaceId
 	 * @param array $uploadMetadata
 	 * @param integer $noOfChunks
-	 * @param integer $bytes
+	 * @param integer|null $bytes
 	 * @param string $checksum
 	 *
 	 * @return ResponseInterface
@@ -295,7 +295,7 @@ class TUSContext implements Context {
 		?string $spaceId = null,
 		array $uploadMetadata = [],
 		int $noOfChunks = 1,
-		int $bytes = null,
+		?int $bytes = null,
 		string $checksum = '',
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);

--- a/tests/acceptance/bootstrap/WebDav.php
+++ b/tests/acceptance/bootstrap/WebDav.php
@@ -1600,7 +1600,7 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
-	 * @param string $spaceId
+	 * @param string|null $spaceId
 	 * @param bool|null $isGivenStep
 	 *
 	 * @return ResponseInterface
@@ -1609,7 +1609,7 @@ trait WebDav {
 		string $user,
 		string $source,
 		string $destination,
-		string $spaceId = null,
+		?string $spaceId = null,
 		?bool $isGivenStep = false,
 	): ResponseInterface {
 		$user = $this->getActualUsername($user);
@@ -4042,11 +4042,11 @@ trait WebDav {
 	/**
 	 * @param string $user
 	 * @param string $path
-	 * @param string $spaceId
+	 * @param string|null $spaceId
 	 *
 	 * @return string|null
 	 */
-	public function getFileIdForPath(string $user, string $path, string $spaceId = null): ?string {
+	public function getFileIdForPath(string $user, string $path, ?string $spaceId = null): ?string {
 		$user = $this->getActualUsername($user);
 		try {
 			return WebDavHelper::getFileIdForPath(

--- a/tests/acceptance/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/bootstrap/WebDavLockingContext.php
@@ -64,7 +64,7 @@ class WebDavLockingContext implements Context {
 		string $user,
 		string $file,
 		TableNode $properties,
-		string $fullUrl = null,
+		?string $fullUrl = null,
 		bool $public = false,
 		bool $expectToSucceed = true,
 		?string $spaceId = null,
@@ -689,7 +689,7 @@ class WebDavLockingContext implements Context {
 		string $lockOwner,
 		string $itemToUseLockOf,
 		bool $public = false,
-		string $fullUrl = null,
+		?string $fullUrl = null,
 		?string $spaceId = null,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);

--- a/tests/acceptance/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/bootstrap/WebDavPropertiesContext.php
@@ -312,7 +312,7 @@ class WebDavPropertiesContext implements Context {
 		string $propertyName,
 		string $path,
 		string $propertyValue,
-		string $namespace = null,
+		?string $namespace = null,
 	): ResponseInterface {
 		$user = $this->featureContext->getActualUsername($user);
 		return WebDavHelper::proppatch(
@@ -653,7 +653,7 @@ class WebDavPropertiesContext implements Context {
 	public function checkResponseContainsProperty(
 		ResponseInterface $response,
 		string $key,
-		string $namespaceString = null,
+		?string $namespaceString = null,
 	): SimpleXMLElement {
 		$xmlPart = HttpRequestHelper::getResponseXml($response, __METHOD__);
 		;

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "platform": {
-      "php": "8.2"
+      "php": "8.4"
     },
     "allow-plugins": {
       "composer/package-versions-deprecated": true


### PR DESCRIPTION
**JIRA:** [OCISDEV-80](https://kiteworks.atlassian.net/browse/OCISDEV-80)
---

## Description

The implicite nullable type has been deprecated. This fixes it by explicitely typing every nullable type. PHP is also bumped in composer and drone to run tests with v8.4.

## Motivation and Context

Tests can be run with PHP v8.4.

## How Has This Been Tested?

- test environment: macOS 15.5
- test case 1: run acceptance tests with PHP v8.4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)
