### PR TITLE
[full-ci][tests-only] add step to try to restore trashed file

### DIFF
--- a/tests/acceptance/features/apiSharingNgAdditionalShareRole/SpaceEditorWithoutTrashbin.feature
+++ b/tests/acceptance/features/apiSharingNgAdditionalShareRole/SpaceEditorWithoutTrashbin.feature
@@ -21,6 +21,8 @@ Feature: an user shares resources
       | shareType       | user                          |
       | permissionsRole | Space Editor Without Trashbin |
     And user "Brian" has removed the file "textfile.txt" from space "new-space"
-    When user "Brian" lists all deleted files in the trash bin of the space "new-space"
+    When user "Brian" tries to list all deleted files in the trash bin of the space "new-space"
+    Then the HTTP status code should be "403"
+    When user "Brian" tries to restore the file "textfile.txt" from the trash of the space "new-space" to "/textfile.txt"
     Then the HTTP status code should be "403"
     And as "Alice" file "textfile.txt" should exist in the trashbin of the space "new-space"


### PR DESCRIPTION
## Description
Check that the user with `SpaceEditorWithoutTrashbinRole` role cannot restore the trashed file

## Related Issue
From https://github.com/owncloud/ocis/pull/11448/files#r2168717736
- https://github.com/owncloud/reva/pull/293

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
