### PR TITLE
backport: [OCISDEV-151] the watermark is visible to user with a `viewer role` in Collabora

### DIFF
--- a/changelog/unreleased/fix-watermark-viewer-role.md
+++ b/changelog/unreleased/fix-watermark-viewer-role.md
@@ -1,0 +1,6 @@
+Bugfix: Fix the OCM role editor
+
+Fix the issue when the watermark is visible to user with a viewer role in Collabora
+
+https://github.com/owncloud/ocis/pull/11484
+https://github.com/owncloud/ocis/issues/11474

--- a/services/collaboration/pkg/connector/fileconnector.go
+++ b/services/collaboration/pkg/connector/fileconnector.go
@@ -1308,7 +1308,7 @@ func (f *FileConnector) CheckFileInfo(ctx context.Context) (*ConnectorResponse, 
 		infoMap[fileinfo.KeyDisableExport] = true // only for collabora
 		infoMap[fileinfo.KeyDisableCopy] = true   // only for collabora
 		infoMap[fileinfo.KeyDisablePrint] = true
-		if !isPublicShare {
+		if !isPublicShare && wopiContext.ViewOnlyToken != "" {
 			infoMap[fileinfo.KeyWatermarkText] = f.watermarkText(user) // only for collabora
 		}
 	}


### PR DESCRIPTION
JIRA: [OCISDEV-164](https://kiteworks.atlassian.net/browse/OCISDEV-164)
---
Fix the OCM role editor

Fix the issue when the watermark is visible to user with a viewer role in Collabora

https://github.com/owncloud/ocis/pull/11484
https://github.com/owncloud/ocis/issues/11474