### PR TITLE
Backport [OCISDEV-141]

### DIFF
--- a/changelog/unreleased/fix-cli-upload.md
+++ b/changelog/unreleased/fix-cli-upload.md
@@ -1,0 +1,6 @@
+Bugfix: Fix storage-users cli
+
+Fix storage-users uploads --resume command.
+
+https://github.com/owncloud/ocis/pull/11464
+https://github.com/owncloud/ocis/issues/11290

--- a/services/storage-users/pkg/command/uploads.go
+++ b/services/storage-users/pkg/command/uploads.go
@@ -131,7 +131,7 @@ func ListUploadSessions(cfg *config.Config) *cli.Command {
 			}
 
 			var stream events.Stream
-			if c.Bool("restart") {
+			if c.Bool("restart") || c.Bool("resume") {
 				stream, err = event.NewStream(cfg)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to create event stream: %v\n", err)

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -393,9 +393,5 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 - [apiSharingNgDriveLinkShare/createInternalLinkShare.feature:339](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSharingNgDriveLinkShare/createInternalLinkShare.feature#L339)
 
-#### [[CLI] Error while resuming an upload](https://github.com/owncloud/ocis/issues/11290)
-
-- [cliCommands/uploadSessions.feature:162](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/cliCommands/uploadSessions.feature#L162)
-
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.


### PR DESCRIPTION
Backport to JIRA: [OCISDEV-141](https://kiteworks.atlassian.net/browse/OCISDEV-141)

Bugfix: Fix storage-users cli

Fix `storage-users uploads --resume` command.

https://github.com/owncloud/ocis/pull/11464
https://github.com/owncloud/ocis/issues/11290