### PR TITLE
chore: telemetry updates for the deployments

### DIFF
--- a/deployments/examples/oc10_ocis_parallel/monitoring_tracing/docker-compose-additions.yml
+++ b/deployments/examples/oc10_ocis_parallel/monitoring_tracing/docker-compose-additions.yml
@@ -6,8 +6,8 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       # if oCIS runs as a single process, all  <debug>/metrics endpoints
       # will expose the same metrics, so it's sufficient to query one endpoint
@@ -15,4 +15,3 @@ services:
 
 networks:
   ocis-net:
-    external: true

--- a/deployments/examples/ocis_full/monitoring_tracing/monitoring-oo.yml
+++ b/deployments/examples/ocis_full/monitoring_tracing/monitoring-oo.yml
@@ -5,8 +5,8 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       # if oCIS runs as a single process, all  <debug>/metrics endpoints
       # will expose the same metrics, so it's sufficient to query one endpoint
@@ -16,11 +16,10 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       COLLABORATION_DEBUG_ADDR: 0.0.0.0:9304
 
 networks:
   ocis-net:
-    external: true

--- a/deployments/examples/ocis_full/monitoring_tracing/monitoring.yml
+++ b/deployments/examples/ocis_full/monitoring_tracing/monitoring.yml
@@ -5,8 +5,8 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       # if oCIS runs as a single process, all  <debug>/metrics endpoints
       # will expose the same metrics, so it's sufficient to query one endpoint
@@ -16,11 +16,10 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       COLLABORATION_DEBUG_ADDR: 0.0.0.0:9304
 
 networks:
   ocis-net:
-    external: true

--- a/deployments/examples/ocis_hello/monitoring_tracing/docker-compose-additions.yml
+++ b/deployments/examples/ocis_hello/monitoring_tracing/docker-compose-additions.yml
@@ -6,8 +6,8 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       # if oCIS runs as a single process, all  <debug>/metrics endpoints
       # will expose the same metrics, so it's sufficient to query one endpoint
@@ -15,4 +15,3 @@ services:
 
 networks:
   ocis-net:
-    external: true

--- a/deployments/examples/ocis_keycloak/.env
+++ b/deployments/examples/ocis_keycloak/.env
@@ -33,6 +33,8 @@ KEYCLOAK_REALM=
 KEYCLOAK_ADMIN_USER=
 # Admin user login password. Defaults to "admin"
 KEYCLOAK_ADMIN_PASSWORD=
+# Enable tracing in Keycloak. Traces will be sent to "http://jaeger:4317" Defaults to "false"
+KEYCLOAK_TRACING=
 
 
 # If you want to use debugging and tracing with this stack,

--- a/deployments/examples/ocis_keycloak/config/keycloak/docker-entrypoint-override.sh
+++ b/deployments/examples/ocis_keycloak/config/keycloak/docker-entrypoint-override.sh
@@ -2,7 +2,7 @@
 printenv
 # replace oCIS domain in keycloak realm import
 mkdir /opt/keycloak/data/import
-sed -e "s/ocis.owncloud.test/${OCIS_DOMAIN}/g" /opt/keycloak/data/import-dist/ocis-realm.json > /opt/keycloak/data/import/ocis-realm.json
+sed -e "s/ocis.owncloud.test/${OCIS_DOMAIN}/g" /opt/keycloak/data/import-dist/ocis-realm.json > /opt/keycloak/data/import/oCIS-realm.json
 
 # run original docker-entrypoint
 /opt/keycloak/bin/kc.sh "$@"

--- a/deployments/examples/ocis_keycloak/docker-compose.yml
+++ b/deployments/examples/ocis_keycloak/docker-compose.yml
@@ -112,10 +112,10 @@ services:
     restart: always
 
   keycloak:
-    image: quay.io/keycloak/keycloak:25.0.0
+    image: quay.io/keycloak/keycloak:26.2.5
     networks:
       ocis-net:
-    command: ["start", "--proxy=edge", "--spi-connections-http-client-default-disable-trust-manager=${INSECURE:-false}", "--import-realm"]
+    command: ["start", "--spi-connections-http-client-default-disable-trust-manager=${INSECURE:-false}", "--import-realm"]
     entrypoint: ["/bin/sh", "/opt/keycloak/bin/docker-entrypoint-override.sh"]
     volumes:
       - "./config/keycloak/docker-entrypoint-override.sh:/opt/keycloak/bin/docker-entrypoint-override.sh"
@@ -127,9 +127,15 @@ services:
       KC_DB_URL: "jdbc:postgresql://postgres:5432/keycloak"
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: keycloak
-      KC_FEATURES: impersonation
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN_USER:-admin}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_FEATURES: impersonation,opentelemetry
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN_USER:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      # as replacement of --proxy=edge
+      KC_PROXY_HEADERS: xforwarded
+      KC_HTTP_ENABLED: true
+      # tracing
+      KC_TRACING_ENABLED: ${KEYCLOAK_TRACING:-false}
+      KC_TRACING_ENDPOINT: http://jaeger:4317
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.keycloak.entrypoints=https"

--- a/deployments/examples/ocis_keycloak/monitoring_tracing/docker-compose-additions.yml
+++ b/deployments/examples/ocis_keycloak/monitoring_tracing/docker-compose-additions.yml
@@ -6,8 +6,8 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       # if oCIS runs as a single process, all  <debug>/metrics endpoints
       # will expose the same metrics, so it's sufficient to query one endpoint
@@ -15,4 +15,3 @@ services:
 
 networks:
   ocis-net:
-    external: true

--- a/deployments/examples/ocis_ldap/monitoring_tracing/docker-compose-additions.yml
+++ b/deployments/examples/ocis_ldap/monitoring_tracing/docker-compose-additions.yml
@@ -6,8 +6,8 @@ services:
     environment:
       # tracing
       OCIS_TRACING_ENABLED: "true"
-      OCIS_TRACING_TYPE: "jaeger"
-      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+      OCIS_TRACING_TYPE: "otlp"
+      OCIS_TRACING_ENDPOINT: jaeger:4317
       # metrics
       # if oCIS runs as a single process, all  <debug>/metrics endpoints
       # will expose the same metrics, so it's sufficient to query one endpoint
@@ -15,4 +15,3 @@ services:
 
 networks:
   ocis-net:
-    external: true


### PR DESCRIPTION
Keycloak example will be updated to 26.2.5, which contains support for telemetry. The committed setup changes are required for the Keycloak update.

Due to the Keycloak update to 26.2.5, jaeger will also need to be updated. It isn't part of the deployment, but the expected docker image is jaegertracing/jaeger:2.7.0 (which is supported by Keycloak 26.2.5).

The jaeger update also brings changes in oCIS. Previous 6831 port in jaeger isn't available in recent versions (particularly 2.7.0), and has changed to port 4317, which supports the "otlp" tracing type in oCIS. No code change is needed.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Update setup for telemetry. Note that there are references to `jaeger:4317`, but such container isn't provided (as it wasn't before this PR). You can use the container below if needed (adjust what you need)
```
  jaeger:
    image: jaegertracing/jaeger:2.7.0
    networks:
      ocis-net:
    ports:
      - "16686:16686"
    environment:
      COLLECTOR_ZIPKIN_HTTP_PORT: 9411
    restart: always

```

## Related Issue
https://github.com/owncloud/ocis/issues/11298

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested with the jaeger container shown above. There are traces for keycloak and ocis services in the jaeger instance.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
