### PR TITLE
Update Discover OCIS with Docker Documentation

### DIFF
--- a/docs/ocis/guides/ocis-local-docker.md
+++ b/docs/ocis/guides/ocis-local-docker.md
@@ -47,6 +47,7 @@ services:
 ```
 
 ### Prepare Paths
+
 Create directories if not exists:
 
 ```bash

--- a/docs/ocis/guides/ocis-local-docker.md
+++ b/docs/ocis/guides/ocis-local-docker.md
@@ -55,6 +55,7 @@ mkdir -p $(pwd)/ocis-config \
 mkdir -p $(pwd)/ocis-data
 ```
 
+
 Set the user for the directories to be the same as the user inside the container:
 
 ```bash

--- a/docs/ocis/guides/ocis-local-docker.md
+++ b/docs/ocis/guides/ocis-local-docker.md
@@ -46,9 +46,22 @@ services:
       OCIS_LOG_LEVEL: info
 ```
 
-### Initialize
+### Prepare Paths
+Create directories if not exists:
 
-Run ocis init to create a config
+```bash
+mkdir -p $(pwd)/ocis-config \
+mkdir -p $(pwd)/ocis-data
+```
+
+Set the user for the directories to be the same as the user inside the container:
+
+```bash
+sudo chown -Rfv 1000:1000 $(pwd)/ocis-config/ \
+sudo chown -Rfv 1000:1000 $(pwd)/ocis-data
+```
+
+### Initialize
 
 ```bash
 docker run --rm -it -v $(pwd):/etc/ocis/ owncloud/ocis:latest init


### PR DESCRIPTION
The "Discover OCIS with Docker" lacks the critical piece of ownership of the folders. Otherwise it will not start.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The documentation for the Discovery of OCIS lacks the information of the required user for the files that need to be read by OCIS

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-

## Motivation and Context
I wanted to give it a spin, this part of the documentation seemed more appropriate and therefore failed upon that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Used the commands from the "Minimalistic Evaluation Guide for oCIS with Docker"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
