### PR TITLE
fix: propagate telemetry to the IDP

### DIFF
--- a/ocis-pkg/oidc/client.go
+++ b/ocis-pkg/oidc/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
+	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/oauth2"
 )
 
@@ -104,11 +105,17 @@ func (c *oidcClient) lookupWellKnownOpenidConfiguration(ctx context.Context) err
 	c.providerLock.Lock()
 	defer c.providerLock.Unlock()
 	if c.provider == nil {
+		propagator := propagation.NewCompositeTextMapPropagator(
+			propagation.Baggage{},
+			propagation.TraceContext{},
+		)
+
 		wellKnown := strings.TrimSuffix(c.issuer, "/") + wellknownPath
 		req, err := http.NewRequest("GET", wellKnown, nil)
 		if err != nil {
 			return err
 		}
+		propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
 		resp, err := c.httpClient.Do(req.WithContext(ctx))
 		if err != nil {
 			return err
@@ -214,6 +221,11 @@ func (u *UserInfo) Claims(v interface{}) error {
 
 // UserInfo retrieves the userinfo from a Token
 func (c *oidcClient) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource) (*UserInfo, error) {
+	propagator := propagation.NewCompositeTextMapPropagator(
+		propagation.Baggage{},
+		propagation.TraceContext{},
+	)
+
 	if err := c.lookupWellKnownOpenidConfiguration(ctx); err != nil {
 		return nil, err
 	}
@@ -226,6 +238,7 @@ func (c *oidcClient) UserInfo(ctx context.Context, tokenSource oauth2.TokenSourc
 	if err != nil {
 		return nil, fmt.Errorf("oidc: create GET request: %v", err)
 	}
+	propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
 
 	token, err := tokenSource.Token()
 	if err != nil {


### PR DESCRIPTION
Assuming a compatible telemetry is available in the external IDP, requests made by oCIS against the IDP will contain telemetry data to propagate the information to the IDP.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Send the telemetry headers to the IDP

## Related Issue
https://github.com/owncloud/ocis/issues/11298

## Motivation and Context
The IDP can follow the opentelemetry standard, so sending the headers would allow us to link the requests

## How Has This Been Tested?
Manually tested during login and logout. Checked with Keycloak 26.2.5 and jaeger 2.7.0

## Screenshots (if appropriate):
<img width="1851" height="817" alt="image" src="https://github.com/user-attachments/assets/bcc7671a-e813-4e72-ba75-e21c098d9022" />

Note that Keycloak makes a "backchannel logout" request, which is catched by ocis, which also sends another requests to the ".well-known" Keycloak endpoint. This means that the token is caught and then resent to Keycloak

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
