### PR TITLE
feat: Homogenize tracing of requests to other services

### DIFF
--- a/ocis-pkg/middleware/tracing.go
+++ b/ocis-pkg/middleware/tracing.go
@@ -15,7 +15,6 @@ var propagator = propagation.NewCompositeTextMapPropagator(
 func TraceContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
-		propagator.Inject(ctx, propagation.HeaderCarrier(r.Header))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/services/collaboration/pkg/connector/contentconnector.go
+++ b/services/collaboration/pkg/connector/contentconnector.go
@@ -21,7 +21,6 @@ import (
 	revactx "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/rs/zerolog"
-	"go.opentelemetry.io/otel/propagation"
 )
 
 // ContentConnectorService is the interface to implement the "File contents"
@@ -57,7 +56,7 @@ func NewContentConnector(gws pool.Selectable[gatewayv1beta1.GatewayAPIClient], c
 }
 
 func newHttpRequest(ctx context.Context, wopiContext middleware.WopiContext, method, url, transferToken string, body io.Reader) (*http.Request, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, method, url, body)
+	httpReq, err := tracing.GetNewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +71,6 @@ func newHttpRequest(ctx context.Context, wopiContext middleware.WopiContext, met
 	} else {
 		httpReq.Header.Add("X-Access-Token", wopiContext.AccessToken)
 	}
-	tracingProp := tracing.GetPropagator()
-	tracingProp.Inject(ctx, propagation.HeaderCarrier(httpReq.Header))
 	return httpReq, nil
 }
 

--- a/services/search/pkg/content/cs3.go
+++ b/services/search/pkg/content/cs3.go
@@ -11,6 +11,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	revactx "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 )
@@ -66,7 +67,7 @@ func (s cs3) Retrieve(ctx context.Context, rID *provider.ResourceId) (io.ReadClo
 		ep, tt = res.Protocols[0].DownloadEndpoint, res.Protocols[0].Token
 	}
 
-	req, err := http.NewRequest(http.MethodGet, ep, nil)
+	req, err := tracing.GetNewRequest(ctx, http.MethodGet, ep, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/services/thumbnails/pkg/thumbnail/imgsource/cs3.go
+++ b/services/thumbnails/pkg/thumbnail/imgsource/cs3.go
@@ -10,6 +10,7 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/config"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/errors"
 	"github.com/owncloud/reva/v2/pkg/bytesize"
@@ -58,7 +59,7 @@ func (s CS3) Get(ctx context.Context, path string) (io.ReadCloser, error) {
 		}
 	}
 
-	ctx = metadata.AppendToOutgoingContext(context.Background(), revactx.TokenHeader, auth)
+	ctx = metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, auth)
 	err = s.checkImageFileSize(ctx, ref)
 	if err != nil {
 		return nil, err
@@ -89,6 +90,7 @@ func (s CS3) Get(ctx context.Context, path string) (io.ReadCloser, error) {
 	}
 
 	httpReq, err := rhttp.NewRequest(ctx, "GET", ep, nil)
+	tracing.InjectTracingHeaders(ctx, httpReq)
 	if err != nil {
 		return nil, err
 	}

--- a/services/thumbnails/pkg/thumbnail/imgsource/webdav.go
+++ b/services/thumbnails/pkg/thumbnail/imgsource/webdav.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/owncloud/ocis/v2/ocis-pkg/tracing"
 	"github.com/owncloud/ocis/v2/services/thumbnails/pkg/config"
 	thumbnailerErrors "github.com/owncloud/ocis/v2/services/thumbnails/pkg/errors"
 	"github.com/owncloud/reva/v2/pkg/bytesize"
@@ -34,7 +35,7 @@ type WebDav struct {
 // Get downloads the file from a webdav service
 // The caller MUST make sure to close the returned ReadCloser
 func (s WebDav) Get(ctx context.Context, url string) (io.ReadCloser, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := tracing.GetNewRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, `could not get the image "%s"`, url)
 	}

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -471,7 +471,7 @@ func (g Webdav) sendThumbnailResponse(rsp *thumbnailssvc.GetThumbnailResponse, w
 		// Timeout: time.Second * 5,
 	}
 
-	dlReq, err := http.NewRequest(http.MethodGet, rsp.DataEndpoint, http.NoBody)
+	dlReq, err := tracing.GetNewRequest(r.Context(), http.MethodGet, rsp.DataEndpoint, http.NoBody)
 	if err != nil {
 		renderError(w, r, errInternalError(err.Error()))
 		logger.Error().Err(err).Msg("could not create download thumbnail request")


### PR DESCRIPTION
The "tracing.GetNewRequest" and "tracing.GetNewRequestWithContext" aim to replace the "http.NewRequest" and "http.NewRequestWithContext" respectively by including tracing data.

For requests that have been already created, such as the case of some reva requests, "tracing.InjectTracingHeaders" is provided.

Note that some outgoing requests might be required NOT to use tracing headers.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Described above

## Related Issue
No open issue

## Motivation and Context
Improve visibility of the traces

## How Has This Been Tested?
Manually checked with jaeger and the affected services.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Note
There are some services that still have the `http.NewRequest` method:
* antivirus -> A new background context is created for each event that we're processing. This context doesn't have "previous data", so we won't get the whole picture, just from that point onward.
  In addition, we'd need some additional changes to forward that context to the target request in order to inject the data.
* graph ; personaldata.go -> the context comes from a reva function that doesn't seem to come from a request, so the context won't likely have any data.

We'll leave them for now because they'll likely need more work.

### Known issue
There seems to be a problem linking traces from services using our protobuffers (checked with the search and thumbnails services), so they show up disconnected in jaeger as if there was a direct request made to that services instead of somewhere on top of it.
To be checked in a different ticket.