### PR TITLE
[tests-only][full-ci] CI: Replace hardcoded repo in wget URL with dynamic ctx.repo.slug

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2496,7 +2496,7 @@ def notify(ctx):
                     },
                 },
                 "commands": [
-                    "wget https://raw.githubusercontent.com/owncloud/ocis/%s/tests/config/drone/notification.sh" % ctx.build.commit,
+                    "wget https://raw.githubusercontent.com/%s/%s/tests/config/drone/notification.sh" % (ctx.repo.slug, ctx.build.commit),
                     "bash notification.sh",
                 ],
             },


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Replaces the hardcoded GitHub repo (`owncloud/ocis`) in the `wget` command with `ctx.repo.slug`, making the URL generation dynamic.
