### PR TITLE
[docs-only] Fix chat link in dev docs

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -13,7 +13,7 @@ Before you start reading, if you are interested in:
 - deployment examples,
 - detailed settings and more
 
-we would recommend to continue with the [ownCloud Admin Documentation for Infinite Scale](https://doc.owncloud.com/ocis/next/).
+we would recommend to continue with the [ownCloud Admin Documentation for Infinite Scale](https://doc.owncloud.com/ocis/latest/).
 
 ## Developer Documentation
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -39,7 +39,7 @@ You can also find all client sources on [GitHub](https://github.com/owncloud/).
 
 The [server repository](https://github.com/owncloud/ocis) on [GitHub](https://www.github.com) is a good entry point to the oCIS project. In addition to that there are also ownCloud projects for clients for [iOS](https://github.com/owncloud/ios-app), [Android](https://github.com/owncloud/android), the major [Desktop](https://github.com/owncloud/desktop) platforms and [ownCloud Web](https://github.com/owncloud/web).
 
-To chat about development, [join our public chat](https://talk.owncloud.com/channel/ocis)
+To chat about development, join our public chat on [matrix: ownCloud Infinite Scale](https://matrix.to/#/#ocis:matrix.org).
 
 If you want to help and improve ownCloud or oCIS, start coding or open issues on GitHub in the related repository.
 


### PR DESCRIPTION
This PR replaces the old talk link with matrix.
I also changes the admin doc link from `next` to `latest`