### PR TITLE
fix: disabled TLS certificate check

### DIFF
--- a/ocis-pkg/service/grpc/client.go
+++ b/ocis-pkg/service/grpc/client.go
@@ -74,10 +74,7 @@ func NewClient(opts ...ClientOption) (client.Client, error) {
 	}
 	switch options.tlsMode {
 	case "insecure":
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-		cOpts = append(cOpts, mgrpcc.AuthTLS(tlsConfig))
+		return nil, errors.New("insecure TLS mode is not allowed: certificate verification must not be disabled")
 	case "on":
 		tlsConfig = &tls.Config{
 			MinVersion: tls.VersionTLS12,


### PR DESCRIPTION
https://github.com/owncloud/ocis/blob/dff22670e8f61cd5bb9d8cc0bb3cf67e5f97e979/ocis-pkg/service/grpc/client.go#L77-L80

The field `InsecureSkipVerify` controls whether a TLS client verifies the server's certificate chain and host name. If set to `true`, the client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.



fix the problem, we should prevent the use of `InsecureSkipVerify: true` in production code. The best approach is to remove or disable the `"insecure"` mode entirely, or at minimum, ensure that it cannot be used except in explicit test or development builds. If `"insecure"` mode must be retained for development, add a clear error or panic if it is selected outside of a test/dev environment, or log a strong warning and refuse to create the client. 

For this fix, we will remove the `"insecure"` mode handling from the `NewClient` function. If `"insecure"` is selected, the function will return an error indicating that insecure TLS is not allowed. This ensures that the client cannot be created with certificate verification disabled, eliminating the security risk.

**Changes to make:**
- In `NewClient`, remove the case for `"insecure"` that sets `InsecureSkipVerify: true`.
- Instead, if `"insecure"` is selected, return an error stating that insecure TLS is not allowed.
- No new imports are needed, as `errors` is already imported.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
