### PR TITLE
fix: services uncontrolled data used in path expression

### DIFF
--- a/services/web/pkg/assets/server.go
+++ b/services/web/pkg/assets/server.go
@@ -81,6 +81,13 @@ func (f *fileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	uPath := path.Clean(path.Join("/", r.URL.Path))
 	r.URL.Path = uPath
 
+	// Additional path containment check to prevent traversal
+	rel := strings.TrimPrefix(uPath, "/")
+	if rel == "" || strings.HasPrefix(rel, "/") || strings.Contains(rel, "..") || strings.Contains(rel, "\\") {
+		http.NotFound(w, r)
+		return
+	}
+
 	tryIndex := func() {
 		r.URL.Path = "/index.html"
 


### PR DESCRIPTION

fix the problem, we should ensure that the resolved path is strictly contained within the intended root directory of the file server. This can be done by resolving the user-supplied path against the root, normalizing it, and then checking that the resulting absolute path is still within the root directory. In the context of Go's `http.FileSystem`, this means we should check that the cleaned path does not escape the root of the embedded filesystem. Since we may not have access to the actual filesystem path (e.g., with `embed.FS`), we can instead reject any path that, after cleaning, contains any parent directory references (`..`) or is absolute. We should also ensure that the path is not empty and does not contain any path separators at the start (other than the leading slash).

The best way to implement this is to add a check after cleaning the path, before opening the file, to ensure that the path is relative and does not contain any `..` components. This can be done by splitting the path and checking its components. The changes should be made in the `ServeHTTP` method in `services/web/pkg/assets/server.go`, specifically after line 81 and before line 99.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
