### PR TITLE
[tests-only][full-ci] add tests for post processing command for different steps

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -457,6 +457,42 @@ class CliContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator resumes all uploads session using post processing command$/
+	 *
+	 * @param string $step
+	 *
+	 * @return void
+	 * @throws JsonException
+	 */
+	public function theAdministratorResumesAllUploadsSessionUsingPostprocessingCommand(string $step): void {
+		$command = "postprocessing resume -s $step";
+		var_dump($command);
+		$body = [
+			"command" => $command,
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When /^the administrator resumes all uploads session in (finished|virusscan) step using post processing command$/
+	 *
+	 * @param string $step
+	 *
+	 * @return void
+	 * @throws JsonException
+	 */
+	public function theAdministratorResumesAllUploadsSessionInFinishedOrVirusScanStepUsingPostprocessingCommand(
+		string $step,
+	): void {
+		$command = "postprocessing resume -s $step";
+		var_dump($command);
+		$body = [
+			"command" => $command,
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
 	 * @Then /^the CLI response (should|should not) contain these entries:$/
 	 *
 	 * @param string $shouldOrNot

--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -245,3 +245,58 @@ Feature: List upload sessions via CLI command
     When the administrator waits for "3" seconds
     Then for user "Alice" file "file2.txt" of space "Personal" should be in postprocessing
     And the content of file "file1.txt" for user "Alice" should be "uploaded content"
+
+
+  Scenario: resume all failed upload using postprocessing command
+    Given the config "POSTPROCESSING_DELAY" has been set to "3s"
+    And user "Alice" has uploaded file with content "uploaded content" to "file1.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "file2.txt"
+    And the administrator has waited for "1" seconds
+    And the administrator has stopped the server
+    And the administrator has started the server
+    When the administrator waits for "3" seconds
+    Then for user "Alice" file "file1.txt" of space "Personal" should be in postprocessing
+    And for user "Alice" file "file2.txt" of space "Personal" should be in postprocessing
+    When the administrator resumes all uploads session using post processing command
+    Then the command should be successful
+    When the administrator waits for "3" seconds
+    And the content of file "file1.txt" for user "Alice" should be "uploaded content"
+    And the content of file "file2.txt" for user "Alice" should be "uploaded content"
+
+
+  Scenario: resume all failed upload on finished step using postprocessing command
+    Given the config "POSTPROCESSING_DELAY" has been set to "3s"
+    And user "Alice" has uploaded file with content "uploaded content" to "file1.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "file2.txt"
+    And the administrator has waited for "1" seconds
+    And the administrator has stopped the server
+    And the administrator has started the server
+    When the administrator waits for "3" seconds
+    Then for user "Alice" file "file1.txt" of space "Personal" should be in postprocessing
+    And for user "Alice" file "file2.txt" of space "Personal" should be in postprocessing
+    When the administrator resumes all uploads session in finished step using post processing command
+    Then the command should be successful
+    When the administrator waits for "3" seconds
+    And the content of file "file1.txt" for user "Alice" should be "uploaded content"
+    And the content of file "file2.txt" for user "Alice" should be "uploaded content"
+
+
+#  Scenario: resume all failed upload on virus scan step using postprocessing command
+#    Given the following configs have been set:
+#      | config                           | value     |
+#      | POSTPROCESSING_STEPS             | virusscan |
+#      | ANTIVIRUS_INFECTED_FILE_HANDLING | abort     |
+#      | POSTPROCESSING_DELAY             | 10s       |
+#    And user "Alice" has uploaded file with content "uploaded content" to "file1.txt"
+#    And user "Alice" has uploaded file with content "uploaded content" to "file2.txt"
+#    And the administrator has waited for "1" seconds
+#    And the administrator has stopped the server
+#    And the administrator has started the server
+#    When the administrator waits for "3" seconds
+#    Then for user "Alice" file "file1.txt" of space "Personal" should be in postprocessing
+#    And for user "Alice" file "file2.txt" of space "Personal" should be in postprocessing
+#    When the administrator resumes all uploads session in virusscan step using post processing command
+#    Then the command should be successful
+#    When the administrator waits for "3" seconds
+#    And the content of file "file1.txt" for user "Alice" should be "uploaded content"
+#    And the content of file "file2.txt" for user "Alice" should be "uploaded content"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds a test for postprocessing command to resume  on `finished` and `virusscan` steps defined failed uploads.

```console
ocis postprocessing resume                # Resumes all uploads where postprocessing is finished, but upload is not finished.
ocis postprocessing resume -s "finished"  # Equivalent to the above.
ocis postprocessing resume -s "virusscan" # Resume all uploads currently in virusscan step.
```




## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
