### PR TITLE
chore: [OCISDEV-251] add universal access theme values

### DIFF
--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -6,7 +6,10 @@
     "urls": {
       "accessDeniedHelp": "",
       "imprint": "",
-      "privacy": ""
+      "privacy": "",
+      "accessibilityStatement": "",
+      "universalAccessEasyLanguage": "",
+      "universalAccessSignLanguage": ""
     }
   },
   "clients": {
@@ -23,6 +26,11 @@
         },
         "loginPage": {
           "backgroundImg": "themes/owncloud/assets/loginBackground.jpg"
+        },
+        "icons": {
+          "universalAccess": "",
+          "universalAccessEasyLanguage": "",
+          "universalAccessSignLanguage": ""
         },
         "designTokens": {
           "breakpoints": {


### PR DESCRIPTION
## Description

Added necessary keys into the ownCloud theme to support universal access. Their values are empty strings so that the universal access is hidden in the UI by default.

## Motivation and Context

Follow up on https://github.com/owncloud/web/pull/12933
