### PR TITLE
[tests-only][full-ci] fix: correct regex on test script

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -264,7 +264,7 @@ function run_behat_tests() {
 	# Thanks to https://en.wikipedia.org/wiki/Tee_(command) and
 	# https://stackoverflow.com/questions/23416278/how-to-strip-ansi-escape-sequences-from-a-variable
 	# for ideas.
-	FAILED_SCENARIO_PATHS=$(echo "${FAILED_SCENARIO_PATHS_COLORED}" | sed "s/\x1b[^m]*m//g")
+	FAILED_SCENARIO_PATHS=$(echo "${FAILED_SCENARIO_PATHS_COLORED}" | sed "s/\x1b\[[0-9;]*m//g" | sed 's/\(\.feature:[0-9]\+\).*/\1/')
 
 	# If something else went wrong, and there were no failed scenarios,
 	# then the awk, grep, sed command sequence above ends up with an empty string.


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

Due to [changes In Behat](https://github.com/Behat/Behat/pull/1615) `v3.24.0`, the output format changed and now includes the extra `(on line X)` text in failed scenario reporting.

New format in v3.24.0:

```console
coreApiAuth/webDavMKCOLAuth.feature:42 (on line 50)
```

Previous versions v3.13:

```console
coreApiAuth/webDavMKCOLAuth.feature:42
```

This is why in script file `FAILED_SCENARIO_PATHS` variable was getting the extra text `(on line 50)`.

So, this PR added regex that removes everything after `.feature:X`, including the new `(on line X)` text.



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When tests fail, the output was showing broken text like:

```console
coreApiAuth/webDavMKCOLAuth.feature:42
./(on
./line
./50)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
