### PR TITLE
fix: [OCISDEV-330] add OCS v2 capabilities endpoint to public paths

### DIFF
--- a/changelog/unreleased/fix-capabilities-public-path.md
+++ b/changelog/unreleased/fix-capabilities-public-path.md
@@ -1,0 +1,5 @@
+Bugfix: Add OCS v2 capabilities endpoint to public paths
+
+Following the same behavior as OCS v1, we added the OCS v2 capabilities endpoint to the public paths.
+
+https://github.com/owncloud/ocis/pull/11665

--- a/services/proxy/pkg/middleware/authentication.go
+++ b/services/proxy/pkg/middleware/authentication.go
@@ -23,14 +23,15 @@ var (
 	ProxyWwwAuthenticate = []regexp.Regexp{*regexp.MustCompile("/ocs/v[12].php/cloud/")}
 
 	_publicPaths = [...]string{
-		"/dav/public-files/",
 		"/remote.php/dav/ocm/",
 		"/dav/ocm/",
 		"/ocm/",
 		"/remote.php/dav/public-files/",
+		"/dav/public-files/",
 		"/ocs/v1.php/apps/files_sharing/api/v1/tokeninfo/unprotected",
 		"/ocs/v2.php/apps/files_sharing/api/v1/tokeninfo/unprotected",
 		"/ocs/v1.php/cloud/capabilities",
+		"/ocs/v2.php/cloud/capabilities",
 		"/ocs/v1.php/cloud/user/signing-key",
 		"/ocs/v2.php/cloud/user/signing-key",
 		"/ocs/v2.php/apps/notifications/api/v1/notifications/sse",


### PR DESCRIPTION
## Description

Following the same behavior as OCS v1, we added the OCS v2 capabilities endpoint to the public paths.

## Motivation and Context

Capabilities can be retrieved in public links context same as with OCS v1.

## Related issues

- resolves https://github.com/owncloud/web/issues/13130

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open public link and see successful capabilities request in network tab

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
