### PR TITLE
[docs-only] Update the ocis_full deployment example

### DIFF
--- a/changelog/unreleased/update_ocis_full.md
+++ b/changelog/unreleased/update_ocis_full.md
@@ -1,0 +1,5 @@
+Enhancement: Update the ocis_full deployment example
+
+Fix description texts, move image versions from yaml to .env where applicapable
+
+https://github.com/owncloud/ocis/pull/11666

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -228,9 +228,15 @@ CLAMAV_DOCKER_TAG=
 ONLYOFFICE_IMAGE=onlyoffice/documentserver
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 ONLYOFFICE_DOCKER_TAG=9.0.4.1
-# EE only: path to your license on the host.
-# Note that you need to additionally uncomment one line in onlyoffice.yml/volumes
+
+# EE only: the path to your license file on the host.
+# To activate a license file, comment ONLYOFFICE_DEACTIVATE_LICENSE. Otherwise, it <must> stay uncommented.
+# This mechanism can be used to access an OO dev/ee image without a license during the trial period.
+# Please note that if a license file is provided AND activated, it must be valid; otherwise, OO will stop operating immediately!
+# DO NOT change the value of ONLYOFFICE_DEACTIVATE_LICENSE, this must be /dev/null only (un)commenting is allowed.
+ONLYOFFICE_DEACTIVATE_LICENSE=/dev/null
 #ONLYOFFICE_LICENSE_LOCAL=./config/onlyoffice/license.lic
+
 # Domain for OnlyOffice. Defaults to "onlyoffice.owncloud.test".
 ONLYOFFICE_DOMAIN=
 # Runtime env (works for both; EE typically wants these).
@@ -246,6 +252,7 @@ ONLYOFFICE_DOMAIN=
 # MAIL_SERVER=:mailserver.yml
 # Domain for mail server. Defaults to "mail.owncloud.test".
 MAIL_SERVER_DOMAIN=
+
 
 ## IMPORTANT ##
 # This MUST be the last line as it assembles the supplemental compose files to be used.

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -10,6 +10,8 @@ INSECURE=true
 
 ## Traefik Settings ##
 # Note: Traefik is always enabled and can't be disabled.
+# The recommended (and tested) version to pull. If no version is used, it pulls "latest"
+TRAEFIK_DOCKER_TAG=v3.5.2
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=
@@ -39,7 +41,7 @@ OCIS=:ocis.yml
 # For production releases: "owncloud/ocis"
 # For rolling releases:    "owncloud/ocis-rolling"
 # Defaults to production if not set otherwise
-OCIS_DOCKER_IMAGE=owncloud/ocis-rolling
+OCIS_DOCKER_IMAGE=owncloud/ocis
 # The oCIS container version.
 # Defaults to "latest" and points to the latest stable tag.
 OCIS_DOCKER_TAG=
@@ -174,6 +176,8 @@ TIKA_IMAGE=
 # Collabora web office is default enabled, comment if not required.
 # Note: the leading colon is required to enable the service.
 COLLABORA=:collabora.yml
+# The recommended (and tested) version to pull. If no version is used, it pulls "latest"
+COLLABORA_DOCKER_TAG=25.04.5.2.1
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.owncloud.test"
 COLLABORA_DOMAIN=
@@ -217,18 +221,22 @@ CLAMAV_DOCKER_TAG=
 ### OnlyOffice Settings ###
 # Note: the leading colon is required to enable the service.
 #ONLYOFFICE=:onlyoffice.yml
+# The OnlyOffice container image.
+# For community releases:  "onlyoffice/documentserver"
+# For enterprise releases: "onlyoffice/documentserver-ee"
+# Defaults to community if not set otherwise
+ONLYOFFICE_IMAGE=onlyoffice/documentserver
+# The recommended (and tested) version to pull. If no version is used, it pulls "latest"
+ONLYOFFICE_DOCKER_TAG=9.0.4.1
+# EE only: path to your license on the host.
+# Note that you need to additionally uncomment one line in onlyoffice.yml/volumes
+#ONLYOFFICE_LICENSE_LOCAL=./config/onlyoffice/license.lic
 # Domain for OnlyOffice. Defaults to "onlyoffice.owncloud.test".
 ONLYOFFICE_DOMAIN=
-# Set onlyoffice/documentserver-ee to use the Enterprise Edition.
-#ONLYOFFICE_IMAGE=onlyoffice/documentserver-ee
-# Defaults to "latest". Optional: pin a version (recommended)
-ONLYOFFICE_DOCKER_TAG=
 # Runtime env (works for both; EE typically wants these).
 #ONLYOFFICE_JWT_ENABLED=false
 #ONLYOFFICE_REDIS_HOST=localhost
 #ONLYOFFICE_REDIS_PORT=6379
-# EE only: path to your license on the host.
-#ONLYOFFICE_LICENSE_LOCAL=./config/onlyoffice/license.lic
 
 
 ### Mail Server Settings ###

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -49,7 +49,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.4.2.1
+    image: collabora/code:${COLLABORA_DOCKER_TAG:-latest}
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       ocis-net:

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   traefik:
-    image: traefik:v3.5.0
+    image: traefik:${TRAEFIK_DOCKER_TAG:-latest}
     # release notes: https://github.com/traefik/traefik/releases
     networks:
       ocis-net:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -44,8 +44,7 @@ services:
     restart: always
 
   onlyoffice:
-    # if you want to use oo enterprise edition, use: onlyoffice/documentserver-ee:<version>
-    # note, you also need to add a volume, see below
+    # note, you also need to add a volume when using the enterprise version, see below
     image: ${ONLYOFFICE_IMAGE:-onlyoffice/documentserver}:${ONLYOFFICE_DOCKER_TAG:-latest}
     # changelog https://github.com/ONLYOFFICE/DocumentServer/releases
     networks:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -63,11 +63,14 @@ services:
       # paths are relative to the main compose file
       - ./config/onlyoffice/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/onlyoffice/local.json:/etc/onlyoffice/documentserver/local.dist.json
-      # Mount the license file only if using enterprise edition.
+      #
+      # Mount the license file only if using the enterprise edition.
       # For details see: Registering your Enterprise Edition version:
       # https://helpcenter.onlyoffice.com/installation/docs-enterprise-install-docker.aspx
-      # Uncomment and set ONLYOFFICE_LICENSE_LOCAL to the license file path.
-      #- ${ONLYOFFICE_LICENSE_LOCAL:-/dev/null}:/var/www/onlyoffice/Data/license.lic:ro
+      #
+      # if deactivate is commented in .env, any source will point to the license file in the oo container
+      # if deactivate is uncommented (default) in .env, any source will point to /dev/null in the oo container
+      - ${ONLYOFFICE_LICENSE_LOCAL:-/dev/null}:${ONLYOFFICE_DEACTIVATE_LICENSE:-/var/www/onlyoffice/Data/license.lic:ro}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.onlyoffice.entrypoints=https"


### PR DESCRIPTION
This PR updates the `ocis_full` deployment example:

* Fix description texts
* Move image version from collabora, onlyoffice and traefik  `.yaml` files to `.env` file
* Ease OnlyOffice EE license handling
* Set the default ocis image base to production 

Note that it is not advised to use the latest version for images where a specific version is preferred. We know from experience that issues may arise, especially with web office images. They need individual testing!

Everything has been tested on Hetzner including OnlyOffice-ee, the latter without license key = trial period.