### PR TITLE
[docs-only] Changelog: Update enhc-sse-support.md referernced PR

### DIFF
--- a/changelog/unreleased/enhc-sse-support.md
+++ b/changelog/unreleased/enhc-sse-support.md
@@ -2,4 +2,4 @@ Enhancement: The sse support added for the public links
 
 The sse support added for the public links
 
-https://github.com/owncloud/ocis/pull/11623
+https://github.com/owncloud/ocis/pull/11627


### PR DESCRIPTION
Found while writing the release notes:

The referenced PR in the changelog pointed to a closed PR and not the merged one (11623 --> [11627](https://github.com/owncloud/ocis/pull/11627))