### PR TITLE
[docs-only] Update the ocis_full images for Balch

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -11,7 +11,7 @@ INSECURE=true
 ## Traefik Settings ##
 # Note: Traefik is always enabled and can't be disabled.
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
-TRAEFIK_DOCKER_TAG=v3.5.2
+TRAEFIK_DOCKER_TAG=v3.5.3
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=
@@ -177,7 +177,7 @@ TIKA_IMAGE=
 # Note: the leading colon is required to enable the service.
 COLLABORA=:collabora.yml
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
-COLLABORA_DOCKER_TAG=25.04.5.2.1
+COLLABORA_DOCKER_TAG=25.04.5.3.1
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.owncloud.test"
 COLLABORA_DOMAIN=


### PR DESCRIPTION
This PR updates the `ocis_full` deployment images where a version number is required.

* traefik and collabora
* web-extensions
NOT UPDATED YET - on the works, commit will be added when versions are available @mzner @LukasHirt 