### PR TITLE
chore(idp): [OCISDEV-352] remove file-loader from webpack.config.js

### DIFF
--- a/services/idp/ui_config/webpack.config.js
+++ b/services/idp/ui_config/webpack.config.js
@@ -424,25 +424,7 @@ module.exports = function (webpackEnv) {
                 },
                 'sass-loader'
               )
-            },
-            // "file" loader makes sure those assets get served by WebpackDevServer.
-            // When you `import` an asset, you get its (virtual) filename.
-            // In production, they would get copied to the `build` folder.
-            // This loader doesn't use a "test" so it will catch all modules
-            // that fall through the other loaders.
-            {
-              loader: require.resolve('file-loader'),
-              // Exclude `js` files to keep "css" loader working as it injects
-              // its runtime that would otherwise be processed through "file" loader.
-              // Also exclude `html` and `json` extensions so they get processed
-              // by webpacks internal loaders.
-              exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
-              options: {
-                name: 'static/media/[name].[hash:8].[ext]'
-              }
             }
-            // ** STOP ** Are you adding a new loader?
-            // Make sure to add the new loader(s) before the "file" loader.
           ]
         }
       ]


### PR DESCRIPTION
## Description

Remove file-loader from webpack.config.js to avoid error with new Go version. The file-loader is also legacy loader from older webpack versions. Since we are using webpack 5, we don't need it anymore. We are already using the asset modules instead.

## Motivation and Context

Drop legacy code, exclude unwanted files in prod builds, and prevent build errors with Go v1.25.x.

## How Has This Been Tested?

- test environment: macos, go v1.25.1, node v22.19.0, pnpm v10.4.1
- test case 1: run `make -C ocis clean generate build`
