### PR TITLE
[docs-only] Fix mermaid diagrams

### DIFF
--- a/docs/architecture/upload-processing.md
+++ b/docs/architecture/upload-processing.md
@@ -27,8 +27,9 @@ sequenceDiagram
     Client->>+ocdav: PUT /dav/spaces/{spaceid}/newfile.bin
     ocdav->>+storageprovider: InitiateFileUpload
     storageprovider-->>-ocdav: OK, Protocol simple, UploadEndpoint: /data, Token: {jwt}
-    Note right of ocdav: The {jwt} contains the internal actual target, eg.:<br>http://localhost:9158/data/simple/91cc9882-db71-4b37-b694-a522850fcee1
-    ocdav->>+dataprovider: PUT /data<br>X-Reva-Transfer: {jwt}
+    Note right of ocdav: The {jwt} contains the internal actual target, eg.: http://localhost:9158/data/simple/91cc9882-db71-4b37-b694-a522850fcee1
+    ocdav->>+dataprovider: PUT /data
+    Note right of dataprovider: X-Reva-Transfer: {jwt}
     dataprovider-->>-ocdav: 201 Created
     ocdav-->>-Client: 201 Created
 
@@ -48,19 +49,18 @@ sequenceDiagram
     participant datagateway
     participant dataprovider
 
-
-    Client->>+ocdav: POST /dav/spaces/{spaceid}<br>Upload-Metadata: {base64 encoded filename etc}<br>TUS-Resumable: 1.0.0
+    Client->>+ocdav: POST /dav/spaces/{spaceid}\nUpload-Metadata: {base64 encoded filename etc}\nTUS-Resumable: 1.0.0
     ocdav->>+storageprovider: InitiateFileUpload
     storageprovider-->>-ocdav: OK, Protocol tus, UploadEndpoint: /data, Token: {jwt}
-    Note right of ocdav: The {jwt} contains the internal actual target, eg.:<br>http://localhost:9158/data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160
-    ocdav-->>-Client: 201 Created<br>Location: /data/{jwt}<br>TUS-Resumable: 1.0.0
+    Note right of ocdav: The {jwt} contains the internal actual target, eg.:\nhttp://localhost:9158/data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160
+    ocdav-->>-Client: 201 Created\nLocation: /data/{jwt}\nTUS-Resumable: 1.0.0
 
-    Client->>+datagateway: PATCH /data/{jwt}<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 0
+    Client->>+datagateway: PATCH /data/{jwt}\nTUS-Resumable: 1.0.0\nUpload-Offset: 0
     Note over datagateway: unwrap the {jwt} target
-    datagateway->>+dataprovider: PATCH /data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160<br>X-Reva-Transfer: {jwt}
-    Note over dataprovider: storage driver<br>handles request
-    dataprovider-->>-datagateway: 204 No Content<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 363976
-    datagateway-->>-Client: 204 No Content<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 363976
+    datagateway->>+dataprovider: PATCH /data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160\nX-Reva-Transfer: {jwt}
+    Note over dataprovider: storage driver\nhandles request
+    dataprovider-->>-datagateway: 204 No Content\nTUS-Resumable: 1.0.0\nUpload-Offset: 363976
+    datagateway-->>-Client: 204 No Content\nTUS-Resumable: 1.0.0\nUpload-Offset: 363976
 
 {{</mermaid>}}
 
@@ -81,35 +81,47 @@ sequenceDiagram
     participant datagateway
     participant dataprovider
     participant nats
+    participant processing
 
-
-    Client->>+ocdav: POST /dav/spaces/{spaceid}<br>Upload-Metadata: {base64 encoded filename etc}<br>TUS-Resumable: 1.0.0
+    Client->>+ocdav: POST /dav/spaces/{spaceid}
+    Note left of Client: Upload-Metadata: {base64 encoded filename etc}\nTUS-Resumable: 1.0.0
     ocdav->>+storageprovider: InitiateFileUpload
     storageprovider-->>-ocdav: OK, Protocol tus, UploadEndpoint: /data, Token: {jwt}
-    Note right of ocdav: The {jwt} contains the internal actual target, eg.:<br>http://localhost:9158/data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160
-    ocdav-->>-Client: 201 Created<br>Location: /data/{jwt}<br>TUS-Resumable: 1.0.0
+    Note right of ocdav: The {jwt} contains the internal actual target, eg.: http://localhost:9158/data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160
+    ocdav-->>-Client: 201 Created
+    Note right of Client: Location: /data/{jwt}
+    Note right of Client: TUS-Resumable: 1.0.0
 
-    Client->>+datagateway: PATCH /data/{jwt}<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 0
+    Client->>+datagateway: PATCH /data/{jwt}
+    Note right of datagateway: TUS-Resumable: 1.0.0\nUpload-Offset: 0
 
     Note over datagateway: unwrap the {jwt} target
-    datagateway->>+dataprovider: PATCH /data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160<br>X-Reva-Transfer: {jwt}
-    Note over dataprovider: storage driver<br>handles request
+    datagateway->>+dataprovider: PATCH /data/tus/24d893f5-b942-4bc7-9fb0-28f49f980160
+    Note over dataprovider: X-Reva-Transfer: {jwt}
+    Note over dataprovider: storage driver
+    Note over dataprovider: handles request
     dataprovider-)nats: emit all-bytes-received event
     nats-)processing: all-bytes-received({uploadid}) event
-    Note over dataprovider: TODO: A lot of time may pass here, we could use<br> the `Prefer: respond-async` header to return early<br>with a 202 Accepted status and a Location header<br>to a websocket endpoint
+    Note over dataprovider: TODO: A lot of time may pass here, we could use the `Prefer: respond-async` header to return early with a 202 Accepted status and a Location header to a websocket endpoint
     alt success
-    processing-)nats: emit processing-finished({uploadid}) event
+        processing-)nats: emit processing-finished({uploadid}) event
         nats-)dataprovider: processing-finished({uploadid}) event
-        dataprovider-->>-datagateway: 204 No Content<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 363976
-        datagateway-->>-Client: 204 No Content<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 363976
+        dataprovider-->>-datagateway: 204 No Content
+        Note over datagateway: TUS-Resumable: 1.0.0\nUpload-Offset: 363976
+        datagateway-->>-Client: 204 No Content
+        Note over Client: TUS-Resumable: 1.0.0\nUpload-Offset: 363976
     else failure
         activate dataprovider
         activate datagateway
         processing-)nats: emit processing-aborted({uploadid}) event
         nats-)dataprovider: processing-aborted({uploadid}) event
-        Note over dataprovider: FIXME: What HTTP status code should we report?<br>422 Unprocessable Content is just a proposal, see<br>https://httpwg.org/specs/rfc9110.html#status.422
-        dataprovider-->>-datagateway: 422 Unprocessable Content<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 363976
-        datagateway-->>-Client: 422 Unprocessable Content<br>TUS-Resumable: 1.0.0<br>Upload-Offset: 363976
+        Note over dataprovider: FIXME: What HTTP status code should we report?
+        Note over dataprovider: 422 Unprocessable Content is just a proposal
+        Note over dataprovider: see https://httpwg.org/specs/rfc9110.html#status.422
+        dataprovider-->>-datagateway: 422 Unprocessable Content
+        Note over datagateway: TUS-Resumable: 1.0.0\nUpload-Offset: 363976
+        datagateway-->>-Client: 422 Unprocessable Content
+        Note over Client: TUS-Resumable: 1.0.0\nUpload-Offset: 363976
     end
 
 {{</mermaid>}}


### PR DESCRIPTION
The mermaid diagrams in `docs/architecture/upload-processing/upload-processing.md` were broken.
Fixed and locally tested - works again.