### PR TITLE
feat(ocm): add WAYF configuration for reva OCM service

### DIFF
--- a/changelog/unreleased/add-ocm-wayf-configuration.md
+++ b/changelog/unreleased/add-ocm-wayf-configuration.md
@@ -1,0 +1,7 @@
+Enhancement: Add WAYF configuration for reva OCM service
+
+Add WAYF (Where Are You From) configuration support for the Reva OCM service,
+enabling federation discovery functionality for Open Cloud Mesh.
+This includes configuration for federations file storage and invite accept dialog URL.
+
+https://github.com/owncloud/ocis/pull/11758

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -83,8 +83,10 @@ type GRPCConfig struct {
 }
 
 type ScienceMesh struct {
-	Prefix           string `yaml:"prefix" env:"OCM_SCIENCEMESH_PREFIX" desc:"URL path prefix for the ScienceMesh service. Note that the string must not start with '/'." introductionVersion:"5.0"`
-	MeshDirectoryURL string `yaml:"science_mesh_directory_url" env:"OCM_MESH_DIRECTORY_URL" desc:"URL of the mesh directory service." introductionVersion:"5.0"`
+	Prefix             string `yaml:"prefix" env:"OCM_SCIENCEMESH_PREFIX" desc:"URL path prefix for the ScienceMesh service. Note that the string must not start with '/'." introductionVersion:"5.0"`
+	MeshDirectoryURL   string `yaml:"science_mesh_directory_url" env:"OCM_MESH_DIRECTORY_URL" desc:"URL of the mesh directory service." introductionVersion:"5.0"`
+	Federations        string `yaml:"federations_file" env:"OCM_FEDERATIONS_FILE" desc:"Path to the JSON file where OCM federations data will be stored." introductionVersion:"7.1"`
+	InviteAcceptDialog string `yaml:"invite_accept_dialog" env:"OCM_INVITE_ACCEPT_DIALOG" desc:"/open-cloud-mesh/accept-invite;The frontend URL where to land when receiving an invitation" introductionVersion:"7.1"`
 }
 
 type OCMD struct {

--- a/services/ocm/pkg/config/config.go
+++ b/services/ocm/pkg/config/config.go
@@ -83,10 +83,10 @@ type GRPCConfig struct {
 }
 
 type ScienceMesh struct {
-	Prefix             string `yaml:"prefix" env:"OCM_SCIENCEMESH_PREFIX" desc:"URL path prefix for the ScienceMesh service. Note that the string must not start with '/'." introductionVersion:"5.0"`
-	MeshDirectoryURL   string `yaml:"science_mesh_directory_url" env:"OCM_MESH_DIRECTORY_URL" desc:"URL of the mesh directory service." introductionVersion:"5.0"`
-	Federations        string `yaml:"federations_file" env:"OCM_FEDERATIONS_FILE" desc:"Path to the JSON file where OCM federations data will be stored." introductionVersion:"7.1"`
-	InviteAcceptDialog string `yaml:"invite_accept_dialog" env:"OCM_INVITE_ACCEPT_DIALOG" desc:"/open-cloud-mesh/accept-invite;The frontend URL where to land when receiving an invitation" introductionVersion:"7.1"`
+	Prefix               string `yaml:"prefix" env:"OCM_SCIENCEMESH_PREFIX" desc:"URL path prefix for the ScienceMesh service. Note that the string must not start with '/'." introductionVersion:"5.0"`
+	MeshDirectoryURL     string `yaml:"science_mesh_directory_url" env:"OCM_MESH_DIRECTORY_URL" desc:"URL of the mesh directory service." introductionVersion:"5.0"`
+	DirectoryServiceURLs string `yaml:"directory_service_urls" env:"OCM_DIRECTORY_SERVICE_URLS" desc:"Space delimited URLs of the directory services." introductionVersion:"7.1"`
+	InviteAcceptDialog   string `yaml:"invite_accept_dialog" env:"OCM_INVITE_ACCEPT_DIALOG" desc:"/open-cloud-mesh/accept-invite;The frontend URL where to land when receiving an invitation" introductionVersion:"7.1"`
 }
 
 type OCMD struct {

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -91,7 +91,6 @@ func DefaultConfig() *config.Config {
 		},
 		ScienceMesh: config.ScienceMesh{
 			Prefix:             "sciencemesh",
-			Federations:        filepath.Join(defaults.BaseConfigPath(), "federations.json"),
 			InviteAcceptDialog: "/open-cloud-mesh/accept-invite",
 		},
 		OCMD: config.OCMD{

--- a/services/ocm/pkg/config/defaults/defaultconfig.go
+++ b/services/ocm/pkg/config/defaults/defaultconfig.go
@@ -90,7 +90,9 @@ func DefaultConfig() *config.Config {
 			Cluster:  "ocis-cluster",
 		},
 		ScienceMesh: config.ScienceMesh{
-			Prefix: "sciencemesh",
+			Prefix:             "sciencemesh",
+			Federations:        filepath.Join(defaults.BaseConfigPath(), "federations.json"),
+			InviteAcceptDialog: "/open-cloud-mesh/accept-invite",
 		},
 		OCMD: config.OCMD{
 			Prefix: "ocm",

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -70,12 +70,12 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 					},
 				},
 				"sciencemesh": map[string]interface{}{
-					"prefix":             cfg.ScienceMesh.Prefix,
-					"smtp_credentials":   map[string]string{},
-					"gatewaysvc":         cfg.Reva.Address,
-					"mesh_directory_url": cfg.ScienceMesh.MeshDirectoryURL,
-					"federations_file":   cfg.ScienceMesh.Federations,
-					"provider_domain":    providerDomain,
+					"prefix":                 cfg.ScienceMesh.Prefix,
+					"smtp_credentials":       map[string]string{},
+					"gatewaysvc":             cfg.Reva.Address,
+					"mesh_directory_url":     cfg.ScienceMesh.MeshDirectoryURL,
+					"directory_service_urls": cfg.ScienceMesh.DirectoryServiceURLs,
+					"provider_domain":        providerDomain,
 					"events": map[string]interface{}{
 						"natsaddress":          cfg.Events.Endpoint,
 						"natsclusterid":        cfg.Events.Cluster,

--- a/services/ocm/pkg/revaconfig/config.go
+++ b/services/ocm/pkg/revaconfig/config.go
@@ -59,13 +59,14 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 				"wellknown": map[string]interface{}{
 					"prefix": ".well-known",
 					"ocmprovider": map[string]interface{}{
-						"ocm_prefix":    cfg.OCMD.Prefix,
-						"endpoint":      cfg.Commons.OcisURL,
-						"provider":      "oCIS",
-						"webdav_root":   "/dav/ocm",
-						"webapp_root":   cfg.ScienceMesh.Prefix,
-						"enable_webapp": false,
-						"enable_datatx": false,
+						"ocm_prefix":           cfg.OCMD.Prefix,
+						"endpoint":             cfg.Commons.OcisURL,
+						"provider":             "oCIS",
+						"webdav_root":          "/dav/ocm",
+						"webapp_root":          cfg.ScienceMesh.Prefix,
+						"invite_accept_dialog": cfg.ScienceMesh.InviteAcceptDialog,
+						"enable_webapp":        false,
+						"enable_datatx":        false,
 					},
 				},
 				"sciencemesh": map[string]interface{}{
@@ -73,6 +74,7 @@ func OCMConfigFromStruct(cfg *config.Config, logger log.Logger) map[string]inter
 					"smtp_credentials":   map[string]string{},
 					"gatewaysvc":         cfg.Reva.Address,
 					"mesh_directory_url": cfg.ScienceMesh.MeshDirectoryURL,
+					"federations_file":   cfg.ScienceMesh.Federations,
 					"provider_domain":    providerDomain,
 					"events": map[string]interface{}{
 						"natsaddress":          cfg.Events.Endpoint,

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -168,6 +168,18 @@ func DefaultPolicies() []config.Policy {
 					Service:     "com.owncloud.web.frontend",
 					Unprotected: true,
 				},
+				// OCM WAYF public endpoints
+				{
+					Endpoint:    "/sciencemesh/federations",
+					Service:     "com.owncloud.web.ocm",
+					Unprotected: true,
+				},
+				{
+					Endpoint:    "/sciencemesh/discover",
+					Service:     "com.owncloud.web.ocm",
+					Unprotected: true,
+				},
+				// General sciencemesh endpoints
 				{
 					Endpoint: "/sciencemesh/",
 					Service:  "com.owncloud.web.ocm",


### PR DESCRIPTION
Although this PR is referenced under https://github.com/cs3org/OCM-STA/issues/1, it is not directly part of the STA funded work. However, since the changes are closely related and beneficial to OCM, I decided to port them here as well for consistency.

This PR depends on this PR https://github.com/owncloud/reva/pull/432 to be merged in Reva.

## Description
This PR adds "Where Are You From" configuration support for the Reva OCM service, enabling federation discovery functionality for Web application.

## Technical
- **OCM Configuration**: Added two new configuration fields to `ScienceMesh` struct:
  - `Federations`: Path to JSON file for storing OCM federations data (default: `{basepath}/federations.json`)
  - `InviteAcceptDialog`: Frontend URL for landing when receiving an invitation (default: `/open-cloud-mesh/accept-invite`)

- **Reva Integration**: Updated OCM service configuration to pass WAYF related settings:
  - Added `invite_accept_dialog` to well-known OCM provider configuration
  - Added `federations_file` to ScienceMesh configuration

- **Proxy Routes**: Added two new unprotected endpoints for WAYF public access:
  - `/sciencemesh/federations` Federation listing endpoint
  - `/sciencemesh/discover` Federation discovery endpoint
