### PR TITLE
[full-ci] chore: bump nodejs to v24

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -46,7 +46,7 @@ K3D_IMAGE = "ghcr.io/k3d-io/k3d:5-dind"
 OC_CI_HUGO_STATIC_IMAGE = "hugomods/hugo:base-0.129.0"
 
 DEFAULT_PHP_VERSION = "8.4"
-DEFAULT_NODEJS_VERSION = "22"
+DEFAULT_NODEJS_VERSION = "24"
 
 dirs = {
     "base": "/drone/src",

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # is a lot faster than the build steps below.
 
 
-FROM owncloudci/nodejs:18 AS generate
+FROM owncloudci/nodejs:24 AS generate
 
 COPY ./ /ocis/
 


### PR DESCRIPTION
## Description

Bumped nodejs version in drone and in dockerfile to v24.

## Motivation and Context

Up-to-date nodejs version.

## How Has This Been Tested?

- test environment: macos
- test case 1: build docker image
- test case 2: let CI pass
