### PR TITLE
[docs-only] Update of the ocis_full compose example

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -11,7 +11,8 @@ INSECURE=true
 ## Traefik Settings ##
 # Note: Traefik is always enabled and can't be disabled.
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
-TRAEFIK_DOCKER_TAG=v3.5.3
+# release notes: https://github.com/traefik/traefik/releases
+TRAEFIK_DOCKER_TAG=v3.5.4
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=
@@ -177,7 +178,8 @@ TIKA_IMAGE=
 # Note: the leading colon is required to enable the service.
 COLLABORA=:collabora.yml
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
-COLLABORA_DOCKER_TAG=25.04.5.3.1
+# release notes: https://www.collaboraonline.com/release-notes/
+COLLABORA_DOCKER_TAG=25.04.6.2.1
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.owncloud.test"
 COLLABORA_DOMAIN=
@@ -227,7 +229,8 @@ CLAMAV_DOCKER_TAG=
 # Defaults to community if not set otherwise
 ONLYOFFICE_IMAGE=onlyoffice/documentserver
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
-ONLYOFFICE_DOCKER_TAG=9.0.4.1
+# release notes: https://github.com/ONLYOFFICE/DocumentServer/releases
+ONLYOFFICE_DOCKER_TAG=9.1.0.1
 
 # EE only: the path to your license file on the host.
 # To activate a license file, comment ONLYOFFICE_DEACTIVATE_LICENSE. Otherwise, it <must> stay uncommented.
@@ -249,9 +252,12 @@ ONLYOFFICE_DOMAIN=
 # Mailpit serves as both an email server and a catcher tool for testing purposes.
 # DO NOT use in Production.
 # Note: the leading colon is required to enable the service.
-# MAIL_SERVER=:mailserver.yml
+#MAIL_SERVER=:mailserver.yml
 # Domain for mail server. Defaults to "mail.owncloud.test".
 MAIL_SERVER_DOMAIN=
+# The recommended (and tested) version to pull. If no version is used, it pulls "latest"
+# release notes: https://github.com/axllent/mailpit/releases
+MAIL_SERVER_DOCKER_TAG=v1.27.10
 
 
 ## IMPORTANT ##

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -50,7 +50,6 @@ services:
 
   collabora:
     image: collabora/code:${COLLABORA_DOCKER_TAG:-latest}
-    # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       ocis-net:
     environment:

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -2,7 +2,6 @@
 services:
   traefik:
     image: traefik:${TRAEFIK_DOCKER_TAG:-latest}
-    # release notes: https://github.com/traefik/traefik/releases
     networks:
       ocis-net:
     command:

--- a/deployments/examples/ocis_full/mailserver.yml
+++ b/deployments/examples/ocis_full/mailserver.yml
@@ -8,7 +8,7 @@ services:
       NOTIFICATIONS_SMTP_INSECURE: "true"
 
   mailserver:
-    image: axllent/mailpit:v1.26
+    image: axllent/mailpit:${MAIL_SERVER_DOCKER_TAG:-latest}
     networks:
       - ocis-net
     ports:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -46,7 +46,6 @@ services:
   onlyoffice:
     # note, you also need to add a volume when using the enterprise version, see below
     image: ${ONLYOFFICE_IMAGE:-onlyoffice/documentserver}:${ONLYOFFICE_DOCKER_TAG:-latest}
-    # changelog https://github.com/ONLYOFFICE/DocumentServer/releases
     networks:
       ocis-net:
     entrypoint:


### PR DESCRIPTION
This PR updates the `ocis_full`  deployment example:

* Update of defined image versions
* Moving comment lines to look for versions from individual yml to the .env file
* Adding a variable for the mailserver image version in .env. This was defined formerly in the .yml file

Tested on Hetzner, works fine.