### PR TITLE
[tests-only][full-ci] Test: run `Core-API-1` test suite over k8s

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -300,6 +300,7 @@ config = {
             ],
             "skip": False,
             "withRemotePhp": [False],
+            "k8s": True,
         },
         "2": {
             "suites": [


### PR DESCRIPTION
## Description
Enable test suite `coreAPITest1` to run over `k8s` setup

Passing CI: https://drone.owncloud.com/owncloud/ocis/49181

## Related Issue
- Part of: https://github.com/owncloud/ocis/issues/11658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
  Locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
