### PR TITLE
[full-ci] chore: [OCISDEV-483] bump reva

### DIFF
--- a/changelog/unreleased/enhancement-bump-reva-11-10-2025.md
+++ b/changelog/unreleased/enhancement-bump-reva-11-10-2025.md
@@ -1,0 +1,6 @@
+Enhancement: Bump Reva
+
+This updates the ownCloud Reva dependency to commit `a122a9538794530267743edfd5dc67b48aa90325`.
+Changelog: https://github.com/owncloud/reva/compare/751223b32d4852c73a43388f6f55308c2065afeb...a122a9538794530267743edfd5dc67b48aa90325
+
+https://github.com/owncloud/ocis/pull/11808

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/open-policy-agent/opa v1.6.0
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20251107084958-31937a4ea3f1
-	github.com/owncloud/reva/v2 v2.0.0-20251106102926-751223b32d48
+	github.com/owncloud/reva/v2 v2.0.0-20251107154850-a122a9538794
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.23.2
@@ -154,7 +154,7 @@ require (
 	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/bombsimon/logrusr/v3 v3.1.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/ceph/go-ceph v0.35.0 // indirect
+	github.com/ceph/go-ceph v0.36.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cevaris/ordered_map v0.0.0-20190319150403-3adeae072e73 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/ceph/go-ceph v0.35.0 h1:wcDUbsjeNJ7OfbWCE7I5prqUL794uXchopw3IvrGQkk=
-github.com/ceph/go-ceph v0.35.0/go.mod h1:ILF8WKhQQ2p2YuX1oWigkmsfT39U8T/HS2NrqxExq2s=
+github.com/ceph/go-ceph v0.36.0 h1:IDE4vEF+4fmjve+CPjD1WStgfQ+Lh6vD+9PMUI712KI=
+github.com/ceph/go-ceph v0.36.0/go.mod h1:fGCbndVDLuHW7q2954d6y+tgPFOBnRLqJRe2YXyngw4=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -717,8 +717,8 @@ github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HD
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20251107084958-31937a4ea3f1 h1:uW3BUPdaAhti2aP8x3Vb79vzmqAgDaWZ0yrW+4ujjU8=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20251107084958-31937a4ea3f1/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
-github.com/owncloud/reva/v2 v2.0.0-20251106102926-751223b32d48 h1:RGnvbZNOE1ss3b0BOM8J+bPrk6prfXB0paKnWaDA/Xg=
-github.com/owncloud/reva/v2 v2.0.0-20251106102926-751223b32d48/go.mod h1:XenQR69s8JQ5Q4/+/vQbSg6B4+0iM6inYjNxB7SJAhI=
+github.com/owncloud/reva/v2 v2.0.0-20251107154850-a122a9538794 h1:j5IbfxSCcnMaIi8yei//NsXyHTEsJRz5tJSPnNcCERA=
+github.com/owncloud/reva/v2 v2.0.0-20251107154850-a122a9538794/go.mod h1:3PTzYZopTiFJ6DWdZ19HP3iHh2I3Gav0cDNFQ1gMT6g=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.9 h1:njquRbBU7fuwIe5rEvtaniVBjwWzcpdUVptSgzFqZsw=

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -97,26 +97,43 @@ Feature: collaboration (wopi)
       }
       """
 
-  @issue-9928
+
   Scenario: user tries to open text file without app name in url query (MIME type not registered in app-registry)
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
     And we save it into "FILEID"
     When user "Alice" tries to send HTTP method "POST" to URL "/app/open?file_id=<<FILEID>>"
-    Then the HTTP status code should be "500"
+    Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
       {
         "type": "object",
         "required": [
-          "code",
-          "message"
+          "app_url",
+          "method",
+          "form_parameters"
         ],
         "properties": {
-          "code": {
-            "const": "SERVER_ERROR"
+          "app_url": {
+            "type": "string",
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
           },
-          "message": {
-            "const": "Error contacting the requested application, please use a different one or try again later"
+          "method": {
+            "const": "POST"
+          },
+          "form_parameters": {
+            "type": "object",
+            "required": [
+              "access_token",
+              "access_token_ttl"
+            ],
+            "properties": {
+              "access_token": {
+                "type": "string"
+              },
+              "access_token_ttl": {
+                "type": "string"
+              }
+            }
           }
         }
       }
@@ -229,7 +246,7 @@ Feature: collaboration (wopi)
   Scenario Outline: user tries to open unsupported file format
     Given user "Alice" has uploaded file "filesForUpload/simple.pdf" to "simple.pdf"
     And we save it into "FILEID"
-    When user "Alice" tries to send HTTP method "POST" to URL "<app-endpoint>"
+    When user "Alice" tries to send HTTP method "POST" to URL "/app/open?file_id=<<FILEID>>&app_name=FakeOffice"
     Then the HTTP status code should be "500"
     And the JSON data of the response should match
       """
@@ -249,10 +266,6 @@ Feature: collaboration (wopi)
         }
       }
       """
-    Examples:
-      | app-endpoint                                     |
-      | /app/open?file_id=<<FILEID>>&app_name=FakeOffice |
-      | /app/open?file_id=<<FILEID>>                     |
 
 
   Scenario Outline: user tries to open deleted file
@@ -355,7 +368,7 @@ Feature: collaboration (wopi)
     Examples:
       | app-endpoint                                              | url-query       |
       | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice& |
-      | /app/open-with-web?file_id=<<FILEID>>                     |                 |
+      | /app/open-with-web?file_id=<<FILEID>>                     | app=FakeOffice& |
 
 
   Scenario: open text file using open-with-web with app name in url query (MIME type not registered in app-registry)
@@ -379,26 +392,23 @@ Feature: collaboration (wopi)
       }
       """
 
-  @issue-9928
+
   Scenario: user tries to open text file using open-with-web without app name in url query (MIME type not registered in app-registry)
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
     And we save it into "FILEID"
     When user "Alice" tries to send HTTP method "POST" to URL "/app/open-with-web?file_id=<<FILEID>>"
-    Then the HTTP status code should be "500"
+    Then the HTTP status code should be "200"
     And the JSON data of the response should match
       """
       {
         "type": "object",
         "required": [
-          "code",
-          "message"
+          "uri"
         ],
         "properties": {
-          "code": {
-            "const": "SERVER_ERROR"
-          },
-          "message": {
-            "const": "Error contacting the requested application, please use a different one or try again later"
+          "uri": {
+            "type": "string",
+             "pattern": "%base_url%/external\\?app=FakeOffice&contextRouteName=files-spaces-personal&fileId=%uuidv4_pattern%%24%uuidv4_pattern%%21%uuidv4_pattern%$"
           }
         }
       }
@@ -433,7 +443,7 @@ Feature: collaboration (wopi)
     Examples:
       | app-endpoint                                              | url-query       |
       | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice& |
-      | /app/open-with-web?file_id=<<FILEID>>                     |                 |
+      | /app/open-with-web?file_id=<<FILEID>>                     | app=FakeOffice& |
 
 
   Scenario Outline: sharee open file with .odt extension (open-with-web)
@@ -465,7 +475,7 @@ Feature: collaboration (wopi)
     Examples:
       | app-endpoint                                              | url-query       |
       | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice& |
-      | /app/open-with-web?file_id=<<FILEID>>                     |                 |
+      | /app/open-with-web?file_id=<<FILEID>>                     | app=FakeOffice& |
 
 
   Scenario Outline: open file with .odt extension with different view mode (open-with-web)
@@ -498,7 +508,7 @@ Feature: collaboration (wopi)
   Scenario Outline: user tries to open unsupported file format (open-with-web)
     Given user "Alice" has uploaded file "filesForUpload/simple.pdf" to "simple.pdf"
     And we save it into "FILEID"
-    When user "Alice" tries to send HTTP method "POST" to URL "<app-endpoint>"
+    When user "Alice" tries to send HTTP method "POST" to URL "/app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice"
     Then the HTTP status code should be "500"
     And the JSON data of the response should match
       """
@@ -518,10 +528,6 @@ Feature: collaboration (wopi)
         }
       }
       """
-    Examples:
-      | app-endpoint                                              |
-      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice |
-      | /app/open-with-web?file_id=<<FILEID>>                     |
 
 
   Scenario Outline: user tries to open deleted file (open-with-web)

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/subvolume_snapshot_path.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/subvolume_snapshot_path.go
@@ -1,4 +1,4 @@
-//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+//go:build !(octopus || pacific || quincy || reef || squid)
 
 package admin
 

--- a/vendor/github.com/owncloud/reva/v2/internal/http/services/appprovider/errors.go
+++ b/vendor/github.com/owncloud/reva/v2/internal/http/services/appprovider/errors.go
@@ -37,6 +37,7 @@ const (
 	appErrorInvalidParameter appErrorCode = "INVALID_PARAMETER"
 	appErrorServerError      appErrorCode = "SERVER_ERROR"
 	appErrorTooEarly         appErrorCode = "TOO_EARLY"
+	appErrorProviderNotFound appErrorCode = "PROVIDER_NOT_FOUND"
 )
 
 // appErrorCodeMapping stores the HTTP error code mapping for various APIErrorCodes
@@ -49,6 +50,7 @@ var appErrorCodeMapping = map[appErrorCode]int{
 	appErrorServerError:      http.StatusInternalServerError,
 	appErrorPermissionDenied: http.StatusForbidden,
 	appErrorTooEarly:         http.StatusTooEarly,
+	appErrorProviderNotFound: http.StatusNotFound,
 }
 
 // APIError encompasses the error type and message

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -283,8 +283,8 @@ github.com/cenkalti/backoff
 # github.com/cenkalti/backoff/v5 v5.0.3
 ## explicit; go 1.23
 github.com/cenkalti/backoff/v5
-# github.com/ceph/go-ceph v0.35.0
-## explicit; go 1.23.0
+# github.com/ceph/go-ceph v0.36.0
+## explicit; go 1.24.0
 github.com/ceph/go-ceph/cephfs
 github.com/ceph/go-ceph/cephfs/admin
 github.com/ceph/go-ceph/common/admin/manager
@@ -1247,7 +1247,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20251107084958-31937a4ea3f1
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20251106102926-751223b32d48
+# github.com/owncloud/reva/v2 v2.0.0-20251107154850-a122a9538794
 ## explicit; go 1.24.0
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
This updates the ownCloud Reva dependency to commit `82c22e954c1cdabb62a14fbe5c1a4ec3e1dabd45`. Changelog: https://github.com/owncloud/reva/compare/82c22e954c1cdabb62a14fbe5c1a4ec3e1dabd45...a122a9538794530267743edfd5dc67b48aa90325