### PR TITLE
chore(web): adjust primary color contrast

### DIFF
--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -103,7 +103,7 @@
               "swatch-passive-hover-outline": "#f7fafd",
               "swatch-passive-muted": "#283e5d",
               "swatch-passive-contrast": "#ffffff",
-              "swatch-primary-default": "#4a76ac",
+              "swatch-primary-default": "#456FB3",
               "swatch-primary-hover": "#80a7d7",
               "swatch-primary-muted": "#2c588e",
               "swatch-primary-muted-hover": "rgb(36, 75, 119)",


### PR DESCRIPTION
## Description

In the default theme, the primary color is adjusted to have a better contrast ratio.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: check contrast in the browser
