### PR TITLE
[docs-only] Fix missing type for envvar in extended_vars.yaml

### DIFF
--- a/docs/helpers/extended_vars.yaml
+++ b/docs/helpers/extended_vars.yaml
@@ -148,7 +148,7 @@ variables:
   path: ocis-pkg/service/grpc/client.go:77
   foundincode: true
   name: OCIS_INSECURE
-  type: ""
+  type: bool
   default_value: "false"
   description: Insecure TLS mode is only allowed in development environments with
     OCIS_INSECURE=true


### PR DESCRIPTION
Found while working on another PR.

The extended envvar `OCIS_INSECURE` did not had a type set. Must somehow got deleted... This is now fixed --> `bool`.
The change will finally show up correctly in the admin docs.

Needs backport to `stable-7.3`.