### PR TITLE
[docs-only][7.3][PR 11818] Fix missing type for envvar in extended_vars.yaml

### DIFF
--- a/docs/helpers/extended_vars.yaml
+++ b/docs/helpers/extended_vars.yaml
@@ -148,7 +148,7 @@ variables:
   path: ocis-pkg/service/grpc/client.go:77
   foundincode: true
   name: OCIS_INSECURE
-  type: ""
+  type: bool
   default_value: "false"
   description: Insecure TLS mode is only allowed in development environments with
     OCIS_INSECURE=true


### PR DESCRIPTION
Backport of #11818