### PR TITLE
[tests-only][full-ci] Test: run `Core-API-3` test suite over k8s

### DIFF
--- a/tests/acceptance/features/coreApiSharePublicLink2/enforcePasswordPublicLink.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink2/enforcePasswordPublicLink.feature
@@ -36,8 +36,10 @@ Feature: enforce password on public link
   Scenario Outline: create a public link with viewer permission without a password when enforce-password is enabled
     Given the following configs have been set:
       | service  | config                                                 | value |
-      | sharing  | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD           | false |
-      | sharing  | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
+      | sharing  | SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD                | false |
+      | sharing  | SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD      | true  |
+      | frontend | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD           | false |
+      | frontend | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
     And user "Alice" has been created with default attributes
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
@@ -57,6 +59,8 @@ Feature: enforce password on public link
       | service  | config                                                 | value |
       | sharing  | SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD                | false |
       | sharing  | SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD      | true  |
+      | frontend | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD           | false |
+      | frontend | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
     And user "Alice" has been created with default attributes
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
@@ -179,14 +183,19 @@ Feature: enforce password on public link
 
   Scenario Outline: try to update a public link with a password that does not comply with the password policy
     Given the following configs have been set:
-      | service | config                                                 | value |
-      | sharing | OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD           | false |
-      | sharing | OCIS_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
-      | sharing | OCIS_PASSWORD_POLICY_MIN_CHARACTERS                    | 13    |
-      | sharing | OCIS_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS          | 3     |
-      | sharing | OCIS_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS          | 2     |
-      | sharing | OCIS_PASSWORD_POLICY_MIN_DIGITS                        | 1     |
-      | sharing | OCIS_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS            | 2     |
+      | service  | config                                            | value |
+      | sharing  | SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD           | false |
+      | sharing  | SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD | true  |
+      | sharing  | SHARING_PASSWORD_POLICY_MIN_CHARACTERS            | 13    |
+      | sharing  | SHARING_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS  | 3     |
+      | sharing  | SHARING_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS  | 2     |
+      | sharing  | SHARING_PASSWORD_POLICY_MIN_DIGITS                | 1     |
+      | sharing  | SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS    | 2     |
+      | frontend | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS           | 13    |
+      | frontend | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS | 3     |
+      | frontend | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS | 2     |
+      | frontend | FRONTEND_PASSWORD_POLICY_MIN_DIGITS               | 1     |
+      | frontend | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 2     |
     And user "Alice" has been created with default attributes
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
     And using OCS API version "<ocs-api-version>"
@@ -215,7 +224,10 @@ Feature: enforce password on public link
 
 
   Scenario Outline: create a public link with a password in accordance with the password policy (valid cases)
-    Given the config "<config>" has been set to "<config-value>" for "<service>" service
+    Given the following configs have been set:
+      | service  | config            | value          |
+      | sharing  | <sharing-config>  | <config-value> |
+      | frontend | <frontend-config> | <config-value> |
     And using OCS API version "2"
     And user "Alice" has been created with default attributes
     And user "Alice" has uploaded file with content "test file" to "/testfile.txt"
@@ -230,15 +242,15 @@ Feature: enforce password on public link
     And the public should not be able to download file "/testfile.txt" from inside the last public link shared folder using the public WebDAV API with password "wrong pass"
     But the public should be able to download file "/testfile.txt" from inside the last public link shared folder using the public WebDAV API with password "<password>"
     Examples:
-      | service | config                                           | config-value | password                             |
-      | sharing | OCIS_PASSWORD_POLICY_MIN_CHARACTERS              | 4            | Ps-1                                 |
-      | sharing | SHARING_PASSWORD_POLICY_MIN_CHARACTERS           | 14           | Ps1:with space                       |
-      | sharing | SHARING_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS | 4            | PS1:test                             |
-      | sharing | SHARING_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS | 3            | PS1:TeƒsT                            |
-      | sharing | SHARING_PASSWORD_POLICY_MIN_DIGITS               | 2            | PS1:test2                            |
-      | sharing | SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 2            | PS1:test pass                        |
-      | sharing | SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 33           | pS1! #$%&'()*+,-./:;<=>?@[\]^_`{  }~ |
-      | sharing | SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 5            | 1sameCharacterShouldWork!!!!!        |
+      | sharing-config                                   | frontend-config                                   | config-value | password                             |
+      | SHARING_PASSWORD_POLICY_MIN_CHARACTERS           | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS           | 4            | Ps-1                                 |
+      | SHARING_PASSWORD_POLICY_MIN_CHARACTERS           | FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS           | 14           | Ps1:with space                       |
+      | SHARING_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS | FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS | 4            | PS1:test                             |
+      | SHARING_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS | FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS | 3            | PS1:TeƒsT                            |
+      | SHARING_PASSWORD_POLICY_MIN_DIGITS               | FRONTEND_PASSWORD_POLICY_MIN_DIGITS               | 2            | PS1:test2                            |
+      | SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 2            | PS1:test pass                        |
+      | SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 33           | pS1! #$%&'()*+,-./:;<=>?@[\]^_`{  }~ |
+      | SHARING_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS   | 5            | 1sameCharacterShouldWork!!!!!        |
 
 
   Scenario Outline: try to create a public link with a password that does not comply with the password policy (invalid cases)


### PR DESCRIPTION
## Description
Enable test suite `coreAPITest3` to run over `k8s` setup

## Passing CI
https://drone.owncloud.com/owncloud/ocis/49869
https://drone.owncloud.com/owncloud/ocis/49768/16/10

## Related Issue
- Part of: https://github.com/owncloud/ocis/issues/11658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
  Locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
