### PR TITLE
feat(web): [OCISDEV-389] increase primary hover color contrast

### DIFF
--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -104,7 +104,7 @@
               "swatch-passive-muted": "#283e5d",
               "swatch-passive-contrast": "#ffffff",
               "swatch-primary-default": "#456FB3",
-              "swatch-primary-hover": "#80a7d7",
+              "swatch-primary-hover": "oklch(0.5698 0.1232 258.67)",
               "swatch-primary-muted": "#2c588e",
               "swatch-primary-muted-hover": "rgb(36, 75, 119)",
               "swatch-primary-gradient": "#4e85c8",


### PR DESCRIPTION
## Description

Change the primary swatch hover color to slightly darker one to improve contrast on white background. This change affects only the default light theme.

## Motivation and Context

Better contrast.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: check the contrast using devtools

## Screenshots (if appropriate):

<img width="507" height="95" alt="image" src="https://github.com/user-attachments/assets/52b0bdae-8447-4fa0-9567-d7576f235d09" />

<img width="359" height="280" alt="image" src="https://github.com/user-attachments/assets/add22baa-c9cf-42c5-b8d3-8da990ad82aa" />
