### PR TITLE
chore: bump web to v12.1.2

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=d54d39f6b2799df9e60b0898e95d2f5762654aab
+WEB_COMMITID=47cefe55ec749a4e6ea4bdc6e815579d52929a96
 WEB_BRANCH=stable-12.1

--- a/changelog/unreleased/enhancement-bump-web-to-v12.1.2.md
+++ b/changelog/unreleased/enhancement-bump-web-to-v12.1.2.md
@@ -1,0 +1,6 @@
+Enhancement: Bump Web to v12.1.2
+
+- Bugfix [owncloud/web#13213](https://github.com/owncloud/web/pull/13213): Do not disable sharing of resources when managing spaces via claims
+
+https://github.com/owncloud/ocis/pull/11836
+https://github.com/owncloud/web/releases/tag/v12.1.2

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v12.1.1
+WEB_ASSETS_VERSION = v12.1.2
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Changelog for ownCloud Web 12.1.2 (2025-11-24)
=======

Summary
-------

* Bugfix - Do not disable sharing of resources when managing spaces via claims: [#13213](https://github.com/owncloud/web/pull/13213)

Details
-------

* Bugfix - Do not disable sharing of resources when managing spaces via claims: [#13213](https://github.com/owncloud/web/pull/13213)

   When managing spaces via claims, we were disabling sharing of resources when the
   server managed spaces capability was enabled. This was not correct, as we should
   only disable sharing of spaces.

   https://github.com/owncloud/web/pull/13213

