### PR TITLE
[docs-only] Update ocis_full image versions

### DIFF
--- a/changelog/unreleased/update-ocis_full-images.md
+++ b/changelog/unreleased/update-ocis_full-images.md
@@ -1,0 +1,8 @@
+Enhancement: Update the ocis_full deployment example images
+
+* Traefik    3.6.2
+* Collabora  27.4.7.3
+* OnlyOffice 9.2.0
+* Mailpit    1.28.0
+
+https://github.com/owncloud/ocis/pull/11860

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -12,7 +12,7 @@ INSECURE=true
 # Note: Traefik is always enabled and can't be disabled.
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://github.com/traefik/traefik/releases
-TRAEFIK_DOCKER_TAG=v3.5.4
+TRAEFIK_DOCKER_TAG=v3.6.2
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=
@@ -179,7 +179,7 @@ TIKA_IMAGE=
 COLLABORA=:collabora.yml
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://www.collaboraonline.com/release-notes/
-COLLABORA_DOCKER_TAG=25.04.6.2.1
+COLLABORA_DOCKER_TAG=25.04.7.3.1
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.owncloud.test"
 COLLABORA_DOMAIN=
@@ -230,7 +230,7 @@ CLAMAV_DOCKER_TAG=
 ONLYOFFICE_IMAGE=onlyoffice/documentserver
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://github.com/ONLYOFFICE/DocumentServer/releases
-ONLYOFFICE_DOCKER_TAG=9.1.0.1
+ONLYOFFICE_DOCKER_TAG=9.2.0.1
 
 # EE only: the path to your license file on the host.
 # To activate a license file, comment ONLYOFFICE_DEACTIVATE_LICENSE. Otherwise, it <must> stay uncommented.
@@ -257,7 +257,7 @@ ONLYOFFICE_DOMAIN=
 MAIL_SERVER_DOMAIN=
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://github.com/axllent/mailpit/releases
-MAIL_SERVER_DOCKER_TAG=v1.27.10
+MAIL_SERVER_DOCKER_TAG=v1.28.0
 
 
 ## IMPORTANT ##


### PR DESCRIPTION
This PR updates the `ocis_full` docker image versions

* Traefik    3.6.2
* Collabora  27.4.7.3
* OnlyOffice 9.2.0
* Mailpit    1.28.0