### PR TITLE
[full-ci][k6-test] Backport UserLight Creation Fix

### DIFF
--- a/changelog/unreleased/fix-user-light-creation.md
+++ b/changelog/unreleased/fix-user-light-creation.md
@@ -1,0 +1,6 @@
+Bugfix: Fix user light creation
+
+When trying to switch a user to user light before they logged in for the first time, an error would occur.
+The server now correctly handles this case and allows switching to user light even before the first login.
+
+https://github.com/owncloud/ocis/pull/11765

--- a/ocis-pkg/shared/storage_utils.go
+++ b/ocis-pkg/shared/storage_utils.go
@@ -30,6 +30,10 @@ var (
 func DisablePersonalSpace(ctx context.Context, client gateway.GatewayAPIClient, userID string) error {
 	logger := appctx.GetLogger(ctx)
 	sp, err := getPersonalSpace(ctx, client, userID)
+	if err == ErrNotFound {
+		logger.Debug().Str("userID", userID).Msg("no personal space found to delete")
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to retrieve personal space: %w", err)
 	}


### PR DESCRIPTION
Backports the user-light creation fix 

https://github.com/owncloud/ocis/pull/11765
