### PR TITLE
[docs-only][OCISDEV-536]Update AND fix ocis_full when using Traefik 3.6.4

### DIFF
--- a/changelog/unreleased/update-ocis_full-traefik-image.md
+++ b/changelog/unreleased/update-ocis_full-traefik-image.md
@@ -1,0 +1,6 @@
+Enhancement: Update the ocis_full deployment example traefik image
+
+* Traefik: 3.6.4
+* Traefik fix for Collabora
+
+https://github.com/owncloud/ocis/pull/11867

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -12,7 +12,7 @@ INSECURE=true
 # Note: Traefik is always enabled and can't be disabled.
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://github.com/traefik/traefik/releases
-TRAEFIK_DOCKER_TAG=v3.6.2
+TRAEFIK_DOCKER_TAG=v3.6.4
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_full/docker-compose.yml
+++ b/deployments/examples/ocis_full/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - "--entryPoints.https.transport.respondingTimeouts.readTimeout=12h"
       - "--entryPoints.https.transport.respondingTimeouts.writeTimeout=12h"
       - "--entryPoints.https.transport.respondingTimeouts.idleTimeout=3m"
+      # allow encoded characters which is required for collaboration/Collabora
+      - "--entryPoints.https.http.encodedCharacters.allowEncodedSlash=true"
+      - "--entryPoints.https.http.encodedCharacters.allowEncodedQuestionMark=true"
+      - "--entryPoints.https.http.encodedCharacters.allowEncodedPercent=true"
       # docker provider (get configuration from container labels)
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"
       - "--providers.docker.exposedByDefault=false"


### PR DESCRIPTION
References: #11860 ([docs-only] Update ocis_full image versions)

This PR:

* Update traefik from 3.6.2 to 3.6.4
* Fixes the use of Collabora combined with this traefik version

Tested, works