### PR TITLE
[tests-only][full-ci] Add test for updating space name to an empty string

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -401,5 +401,9 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiGraphUser/getUser.feature:696](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUser/getUser.feature#L696)
 - [apiGraphUser/getUser.feature:700](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiGraphUser/getUser.feature#L700)
 
+#### [PATCH /v1.0/drives/{drive-id} accepts empty name](https://github.com/owncloud/ocis/issues/11887)
+
+- [apiSpaces/changeSpaces.feature:603](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpaces/changeSpaces.feature#L603)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file requires that the last line has a newline on the end.

--- a/tests/acceptance/features/apiSpaces/changeSpaces.feature
+++ b/tests/acceptance/features/apiSpaces/changeSpaces.feature
@@ -598,3 +598,8 @@ Feature: Change data of space
       | role                          |
       | Space Editor Without Versions |
       | Space Editor                  |
+
+  @issue-11887
+  Scenario: space manager tries to change the name of a space to an empty string
+    When user "Alice" changes the name of the "Project Jupiter" space to ""
+    Then the HTTP status code should be "400"


### PR DESCRIPTION
## Description

Add test for updating space name to an empty string

## Related Issue

https://github.com/owncloud/ocis/issues/11887
