### PR TITLE
Relocate the Transifex resources for services with translations to another project

### DIFF
--- a/changelog/unreleased/relocate transifex resources.md
+++ b/changelog/unreleased/relocate transifex resources.md
@@ -1,0 +1,6 @@
+Enhancement: Relocate Transifex resources
+
+The resources for services with translations are relocated in Transifex from
+owncloud to owncloud-web. Now all ocis related resources are in one project.
+
+https://github.com/owncloud/ocis/pull/11889

--- a/docs/services/general-info/add-translations.md
+++ b/docs/services/general-info/add-translations.md
@@ -8,10 +8,9 @@ geekdocFilePath: add-translations.md
 geekdocCollapseSection: true
 ---
 
-Services can have texts that need to be translated. These translations will be shown in the ownCloud Web UI. Compared to web, these translations are:
+Services can have texts that need to be translated. These translations will be shown in the ownCloud Web UI. Compared to web, these translations:
 
-* Independent of [ownCloud Web](https://app.transifex.com/owncloud-org/owncloud-web/translate/) on Transifex.
-* Are located in the [ownCloud](https://app.transifex.com/owncloud-org/owncloud/translate) Transifex Project.
+* Are located in the same Transifex project as the web, which is named [ownCloud Web](https://app.transifex.com/owncloud-org/owncloud-web/translate/).
 * Have a name starting with `ocis-` for ease of identification.
 
 The process for _synchronisation_ with Transifex is already setup and nothing needs to be done here. For any translation, it is necessary to set it up in the respective service and tell to sync it.
@@ -48,7 +47,7 @@ Translations have a `context` and a `translatable string`. The context is shown 
   [main]
   host = https://www.transifex.com
 
-  [o:owncloud-org:p:owncloud:r:ocis-<service-name>]
+  [o:owncloud-org:p:owncloud-web:r:ocis-<service-name>]
   file_filter = locale/<lang>/LC_MESSAGES/<service-name>.po
   minimum_perc = 75
   resource_name = ocis-<service-name>

--- a/services/activitylog/pkg/service/l10n/.tx/config
+++ b/services/activitylog/pkg/service/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud:r:ocis-activitylog]
+[o:owncloud-org:p:owncloud-web:r:ocis-activitylog]
 file_filter = locale/<lang>/LC_MESSAGES/activitylog.po
 minimum_perc = 75
 resource_name = ocis-activitylog

--- a/services/graph/pkg/l10n/.tx/config
+++ b/services/graph/pkg/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud:r:ocis-graph]
+[o:owncloud-org:p:owncloud-web:r:ocis-graph]
 file_filter = locale/<lang>/LC_MESSAGES/graph.po
 minimum_perc = 75
 resource_name = ocis-graph

--- a/services/notifications/pkg/email/l10n/.tx/config
+++ b/services/notifications/pkg/email/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud:r:ocis-notifications]
+[o:owncloud-org:p:owncloud-web:r:ocis-notifications]
 file_filter = locale/<lang>/LC_MESSAGES/notifications.po
 minimum_perc = 75
 resource_name = ocis-notifications

--- a/services/settings/pkg/service/v0/l10n/.tx/config
+++ b/services/settings/pkg/service/v0/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud:r:ocis-settings]
+[o:owncloud-org:p:owncloud-web:r:ocis-settings]
 file_filter = locale/<lang>/LC_MESSAGES/settings.po
 minimum_perc = 75
 resource_name = ocis-settings

--- a/services/userlog/pkg/service/l10n/.tx/config
+++ b/services/userlog/pkg/service/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud:r:ocis-userlog]
+[o:owncloud-org:p:owncloud-web:r:ocis-userlog]
 file_filter = locale/<lang>/LC_MESSAGES/userlog.po
 minimum_perc = 75
 resource_name = ocis-userlog


### PR DESCRIPTION
I just **copied** the `ocis-xxx` resources including their translations in Transifex from the original location [owncloud](https://app.transifex.com/owncloud-org/owncloud/translate/#de) to the [owncloud-web](https://app.transifex.com/owncloud-org/owncloud-web/translate/#de) slug. Now ALL ocis related resources are in the same Transifex project named `ownCloud Infinite Scale`.

When this PR is merged and `translation-sync` has run (manually or nightly) AND we have no issues, I can finally delete the resources located in the owncloud project in TX.

Note that I have prepared a full and tested documentation about this migration process, see PR https://github.com/owncloud/translation-sync/pull/85.
