### PR TITLE
[docs-only] Update ocis_full image versions

### DIFF
--- a/changelog/unreleased/update-ocis_full-images_II.md
+++ b/changelog/unreleased/update-ocis_full-images_II.md
@@ -1,0 +1,8 @@
+Enhancement: Update the ocis_full deployment example images
+
+
+* Traefic:   v3.6.6
+* Collabora: 25.04.8.1.1
+* Onlyoffice: 9.2.1.1
+
+https://github.com/owncloud/ocis/pull/11890

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -12,7 +12,7 @@ INSECURE=true
 # Note: Traefik is always enabled and can't be disabled.
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://github.com/traefik/traefik/releases
-TRAEFIK_DOCKER_TAG=v3.6.4
+TRAEFIK_DOCKER_TAG=v3.6.6
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=
@@ -179,7 +179,7 @@ TIKA_IMAGE=
 COLLABORA=:collabora.yml
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://www.collaboraonline.com/release-notes/
-COLLABORA_DOCKER_TAG=25.04.7.3.1
+COLLABORA_DOCKER_TAG=25.04.8.1.1
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.owncloud.test"
 COLLABORA_DOMAIN=
@@ -230,7 +230,7 @@ CLAMAV_DOCKER_TAG=
 ONLYOFFICE_IMAGE=onlyoffice/documentserver
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://github.com/ONLYOFFICE/DocumentServer/releases
-ONLYOFFICE_DOCKER_TAG=9.2.0.1
+ONLYOFFICE_DOCKER_TAG=9.2.1.1
 
 # EE only: the path to your license file on the host.
 # To activate a license file, comment ONLYOFFICE_DEACTIVATE_LICENSE. Otherwise, it <must> stay uncommented.


### PR DESCRIPTION
This PR updates some `ocsi_full`  deployment example image versions:

* Traefic:  v3.6.6
* Collabora: 25.04.8.1.1
* Onlyoffice: 9.2.1.1