### PR TITLE
Update pnpm version in the IDP service

### DIFF
--- a/services/idp/package.json
+++ b/services/idp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "homepage": ".",
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.27.0",
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "build": "node --openssl-legacy-provider scripts/build.js && rm -f build/service-worker.js",


### PR DESCRIPTION
While running `make generate`, the output informed that `pnpm` used in the IDP service can be updated from `10.24.0` to `10.27.0`. With this change, the message goes away.