### PR TITLE
[bump] Update pnpm to 1.28.0 in services/idp

### DIFF
--- a/services/idp/package.json
+++ b/services/idp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "homepage": ".",
-  "packageManager": "pnpm@10.27.0",
+  "packageManager": "pnpm@10.28.0",
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "build": "node --openssl-legacy-provider scripts/build.js && rm -f build/service-worker.js",


### PR DESCRIPTION
Identified when running `make generate` --> pnpm needed an update (again).