### PR TITLE
[docs-only] Add envvar deltas to the docs for 7.3 -> 8.0

### DIFF
--- a/docs/helpers/changed_envvars.py
+++ b/docs/helpers/changed_envvars.py
@@ -148,6 +148,8 @@ def create_table(type_text: str, source_dict: set[str], from_version: str, to_ve
 		for key, value in source_dict.items():
 			if key.startswith('OCIS_'):
 				a += add_adoc_line_1(
+						# note that any envvar starting with ocis cant be assigned to a service automatically
+						# the xref must be corrected in the output file manually
 						'xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]',
 						key,
 						value['description'],

--- a/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-added.adoc
+++ b/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-added.adoc
@@ -1,0 +1,62 @@
+// # Added Variables between oCIS 7.3.0 and oCIS 8.0.0
+// commenting the headline to make it better includable
+
+// table created per 2026.01.13
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+| xref:{s-path}/collaboration.adoc[Collaboration]
+| COLLABORATION_WOPI_DISABLED_EXTENSIONS
+| List of extensions to disable: Disabling an extension will make it unavailable to the Office web front end. The list is comma-separated with no spaces between the items, such as 'docx,xlsx,pptx'.
+| []
+
+| xref:{s-path}/graph.adoc[Graph]
+| GRAPH_LDAP_EXTERNAL_ID_ATTRIBUTE
+| LDAP attribute that references the external ID of users during the provisioning process. The final ID is provided by an external identity provider. If it is not set, a default attribute will be used instead.
+| owncloudExternalID
+
+|
+| GRAPH_LDAP_REQUIRE_EXTERNAL_ID
+| If enabled, the 'OCIS_LDAP_USER_SCHEMA_EXTERNAL_ID' is used as primary identifier for the provisioning API.
+| false
+
+|
+| OCIS_LDAP_USER_SCHEMA_EXTERNAL_ID
+| LDAP attribute that references the external ID of users during the provisioning process. The final ID is provided by an external identity provider. If it is not set, a default attribute will be used instead.
+| owncloudExternalID
+
+| xref:{s-path}/proxy.adoc[Proxy]
+| PROXY_FORCE_STRICT_TRANSPORT_SECURITY
+| Force emission of the Strict-Transport-Security header on all responses, including plain HTTP requests. See also: PROXY_TLS
+| false
+
+|
+| OCIS_MULTI_INSTANCE_ENABLED
+| Enable multiple instances of Infinite Scale.
+| false
+
+|
+| OCIS_MULTI_INSTANCE_GUEST_CLAIM
+| The claim name for the 'guestOf' property
+| guestOf
+
+|
+| OCIS_MULTI_INSTANCE_GUEST_ROLE
+| The role that should be assigned to a guest user
+| user-light
+
+|
+| OCIS_MULTI_INSTANCE_INSTANCEID
+| The unique id of this instance
+| c1f28cf2-d363-4671-a8fe-8d7a80b36b87
+
+|
+| OCIS_MULTI_INSTANCE_MEMBER_CLAIM
+| The claim name for the 'memberOf' property
+| memberOf
+
+|===
+

--- a/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-added.md
+++ b/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-added.md
@@ -1,0 +1,12 @@
+| Service | Variable | Description | Default |
+| --- | --- | --- | --- |
+| [Collaboration]({s-path}/collaboration.adoc) | COLLABORATION_WOPI_DISABLED_EXTENSIONS | List of extensions to disable: Disabling an extension will make it unavailable to the Office web front end. The list is comma-separated with no spaces between the items, such as 'docx,xlsx,pptx'. | [] |
+| [Graph]({s-path}/graph.adoc) | GRAPH_LDAP_EXTERNAL_ID_ATTRIBUTE | LDAP attribute that references the external ID of users during the provisioning process. The final ID is provided by an external identity provider. If it is not set, a default attribute will be used instead. | owncloudExternalID |
+|  | GRAPH_LDAP_REQUIRE_EXTERNAL_ID | If enabled, the 'OCIS_LDAP_USER_SCHEMA_EXTERNAL_ID' is used as primary identifier for the provisioning API. | false |
+|  | OCIS_LDAP_USER_SCHEMA_EXTERNAL_ID | LDAP attribute that references the external ID of users during the provisioning process. The final ID is provided by an external identity provider. If it is not set, a default attribute will be used instead. | owncloudExternalID |
+| [Proxy]({s-path}/proxy.adoc) | PROXY_FORCE_STRICT_TRANSPORT_SECURITY | Force emission of the Strict-Transport-Security header on all responses, including plain HTTP requests. See also: PROXY_TLS | false |
+|  | OCIS_MULTI_INSTANCE_ENABLED | Enable multiple instances of Infinite Scale. | false |
+|  | OCIS_MULTI_INSTANCE_GUEST_CLAIM | The claim name for the 'guestOf' property | guestOf |
+|  | OCIS_MULTI_INSTANCE_GUEST_ROLE | The role that should be assigned to a guest user | user-light |
+|  | OCIS_MULTI_INSTANCE_INSTANCEID | The unique id of this instance | c1f28cf2-d363-4671-a8fe-8d7a80b36b87 |
+|  | OCIS_MULTI_INSTANCE_MEMBER_CLAIM | The claim name for the 'memberOf' property | memberOf |

--- a/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-deprecated.adoc
+++ b/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-deprecated.adoc
@@ -1,0 +1,12 @@
+// # Deprecated Variables between oCIS 7.3.0 and oCIS 8.0.0
+// commenting the headline to make it better includable
+
+// table created per 2026.01.13
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Removal Version | Deprecation Info
+
+|===
+

--- a/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-deprecated.md
+++ b/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-deprecated.md
@@ -1,0 +1,2 @@
+| Service | Variable | Description | Removal Version | Deprecation Info |
+| --- | --- | --- | --- | --- |

--- a/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-removed.adoc
+++ b/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-removed.adoc
@@ -1,0 +1,12 @@
+// # Removed Variables between oCIS 7.3.0 and oCIS 8.0.0
+// commenting the headline to make it better includable
+
+// table created per 2026.01.13
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+|===
+

--- a/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-removed.md
+++ b/docs/services/general-info/envvars/env-var-deltas/7.3.0-8.0.0-removed.md
@@ -1,0 +1,2 @@
+| Service | Variable | Description | Default |
+| --- | --- | --- | --- |

--- a/docs/services/general-info/envvars/env-var-deltas/_index.md
+++ b/docs/services/general-info/envvars/env-var-deltas/_index.md
@@ -22,19 +22,18 @@ To create the changed envvar tables, you must proceed the following steps in ord
 1. Install, if not already done, the converter for adoc to markdown tables: `npm install -g downdoc`\
 This is only required when converting adoc to markdown tables but it is highly recommended to show them in the dev docs too!
 
-1. Run `make docs-generate` from the ocis root.\
+1. Run `make docs-local` from the ocis root.\
 Usually, a file named `env_vars.yaml` gets changed. Check for validity. If issues are found, fix them in the service sources first which need to be merged before you rerun make. For details how to do so, see [Maintain the 'env_vars.yaml' File]({{< ref "../new-release-process.md#maintain-the-env_varsyaml-file" >}}). Any delta information is based on an actual `env_vars.yaml` file which is pulled **from master** by the python script described below!
 
 1. Configure the Python script `docs/helpers/changed_envvars.py` variables for the new version.\
 Note that you **must** use semver and not code names!
 
 1. Run the python script from the ocis root such as `python3 docs/helpers/changed_envvars.py`.\
-Note that the script pulls data from the master branch as base reference, therefore the `env_vars.yaml` file MUST be up to date.\
-adoc tables will be generated which are used for the admin docs and are the basis for markdown.
+Note that the script pulls data from the master branch as a base reference, therefore the `env_vars.yaml` file must be kept up to date. The adoc tables generated are used for the admin documentation and form the basis for Markdown.
 
-1. Because the script can not determine the link target in the `Service` column, you must manually adapt them in the generated adoc files with respect to the name and target. Only one entry per identical service block is required, delete the cell content for the rest for ease of readability. See existing files for an example.
+1. As the script cannot determine the link target (xref:) in the `Service` column, you must adapt these manually in the generated adoc files according to the file name and printed name. Envvars starting with `OCIS_` are displayed differently in the `Service` column because the file name and printed name cannot be easily identified and must be resolved differently. You have to check where they are defined, unlike the others where the name provides a clue. The final xref path must be corrected manually in all cases. Only one entry per identical service is required to generate an easy block view. Delete the cell content except for the pipe symbol (`|`) to make it easier to read. See existing files for an example.
 
-1. Run `npx downdoc <filename.adoc>` for each of the newly generated `added`, `removed` and `deprecated` files. This will generate markdown files for the dev docs.
+1. Change into the directory that contains the generated adoc files and run `npx downdoc <filename.adoc>` for each of the newly generated `added`, `removed` and `deprecated` files. This will generate markdown files for the dev docs.
 
 1. Add in each markdown file on top the following sentence:\
 `Note that the links provided in the service column are non functional when clicked.`, including a newline.


### PR DESCRIPTION
This PR adds files for added/removed/deprecated envvars (.md and .adoc) and precises the dev docs a bit more.

If new envvars will be introduced after this PR, we just need to add them with another PR but with that PR we can start adapting the admin docs.