### PR TITLE
[docs-only] Update the traefik image for some deployment examples

### DIFF
--- a/changelog/unreleased/update-some-depl-traefik-image.md
+++ b/changelog/unreleased/update-some-depl-traefik-image.md
@@ -1,0 +1,5 @@
+Enhancement: Update the traefik image for some deployment examples
+
+* Traefik: 3.6.6 --> 3.6.7
+
+https://github.com/owncloud/ocis/pull/11915

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -12,7 +12,7 @@ INSECURE=true
 # Note: Traefik is always enabled and can't be disabled.
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://github.com/traefik/traefik/releases
-TRAEFIK_DOCKER_TAG=v3.6.6
+TRAEFIK_DOCKER_TAG=v3.6.7
 # Serve Traefik dashboard.
 # Defaults to "false".
 TRAEFIK_DASHBOARD=

--- a/deployments/examples/ocis_multi/docker-compose.yml
+++ b/deployments/examples/ocis_multi/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:v3.6.4
+    image: traefik:v3.6.7
     networks:
       ocis-net:
         aliases:


### PR DESCRIPTION
Update the Traefik image for `ocis_full` and `ocis_multi` to 3.6.7
Tested on Hetzner, works.