### PR TITLE
[OCISDEV-454] Add Permission to allow external shares

### DIFF
--- a/changelog/unreleased/external-shares-permission.md
+++ b/changelog/unreleased/external-shares-permission.md
@@ -1,0 +1,5 @@
+Enhancement: Introduce external shares permission
+
+Introduces a permission allowing to share between instances in multi-instance ocis. This permission is by default added to the admin and space-admin role.
+
+https://github.com/owncloud/ocis/pull/11931

--- a/services/graph/pkg/service/v0/api_driveitem_permissions_links_test.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions_links_test.go
@@ -55,7 +55,7 @@ var _ = Describe("createLinkTests", func() {
 		cache := identity.NewIdentityCache(identity.IdentityCacheWithGatewaySelector(gatewaySelector))
 
 		cfg := defaults.FullDefaultConfig()
-		svc, err = service.NewDriveItemPermissionsService(logger, gatewaySelector, cache, cfg, otel.GetTracerProvider(), nil)
+		svc, err = service.NewDriveItemPermissionsService(logger, gatewaySelector, cache, cfg, otel.GetTracerProvider(), nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		driveItemId = &provider.ResourceId{
 			StorageId: "1",

--- a/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
@@ -80,7 +80,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 		cfg.UnifiedRoles.AvailableRoles = slices.DeleteFunc(cfg.UnifiedRoles.AvailableRoles, func(s string) bool {
 			return s == unifiedrole.UnifiedRoleSecureViewerID
 		})
-		service, err := svc.NewDriveItemPermissionsService(logger, gatewaySelector, cache, cfg, otel.GetTracerProvider(), nil)
+		service, err := svc.NewDriveItemPermissionsService(logger, gatewaySelector, cache, cfg, otel.GetTracerProvider(), nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		driveItemPermissionsService = service
 		ctx = revactx.ContextSetUser(context.Background(), currentUser)
@@ -270,7 +270,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 				// remove SecureViewer from allowed roles for this unit test
 				return s == unifiedrole.UnifiedRoleSecureViewerID
 			})
-			service, err := svc.NewDriveItemPermissionsService(log.NewLogger(), gatewaySelector, cache, cfg, otel.GetTracerProvider(), nil)
+			service, err := svc.NewDriveItemPermissionsService(log.NewLogger(), gatewaySelector, cache, cfg, otel.GetTracerProvider(), nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			driveItemInvite.Roles = []string{unifiedrole.UnifiedRoleViewerID, unifiedrole.UnifiedRoleSecureViewerID}

--- a/services/graph/pkg/service/v0/service.go
+++ b/services/graph/pkg/service/v0/service.go
@@ -213,7 +213,7 @@ func NewService(opts ...Option) (Graph, error) { //nolint:maintidx
 		return svc, err
 	}
 
-	driveItemPermissionsService, err := NewDriveItemPermissionsService(options.Logger, options.GatewaySelector, identityCache, options.Config, options.TraceProvider, svc.identityBackend)
+	driveItemPermissionsService, err := NewDriveItemPermissionsService(options.Logger, options.GatewaySelector, identityCache, options.Config, options.TraceProvider, svc.identityBackend, svc.contextUserHasExternalSharePermission)
 	if err != nil {
 		return svc, err
 	}

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -114,6 +114,7 @@ func generateBundleAdminRole() *settingsmsg.Bundle {
 			AccountManagementPermission(All),
 			AutoAcceptSharesPermission(Own),
 			ChangeLogoPermission(All),
+			CreateExternalSharePermission(All),
 			CreatePublicLinkPermission(All),
 			CreateSharePermission(All),
 			CreateSpacesPermission(All),
@@ -158,6 +159,7 @@ func generateBundleSpaceAdminRole() *settingsmsg.Bundle {
 		},
 		Settings: []*settingsmsg.Setting{
 			AutoAcceptSharesPermission(Own),
+			CreateExternalSharePermission(All),
 			CreatePublicLinkPermission(All),
 			CreateSharePermission(All),
 			CreateSpacesPermission(All),

--- a/services/settings/pkg/store/defaults/permissions.go
+++ b/services/settings/pkg/store/defaults/permissions.go
@@ -67,6 +67,25 @@ func ChangeLogoPermission(c settingsmsg.Permission_Constraint) *settingsmsg.Sett
 	}
 }
 
+// CreateExternalSharePermission is the permission to create shares to other instances (Multi-Instance only)
+func CreateExternalSharePermission(c settingsmsg.Permission_Constraint) *settingsmsg.Setting {
+	return &settingsmsg.Setting{
+		Id:          "5c03dc05-0bef-4b30-8ee6-e5a51713fd3a",
+		Name:        "ExternalShare.Write",
+		DisplayName: "Write external share",
+		Description: "This permission allows creating shares to users on other instances.",
+		Resource: &settingsmsg.Resource{
+			Type: settingsmsg.Resource_TYPE_SHARE,
+		},
+		Value: &settingsmsg.Setting_PermissionValue{
+			PermissionValue: &settingsmsg.Permission{
+				Operation:  settingsmsg.Permission_OPERATION_WRITE,
+				Constraint: c,
+			},
+		},
+	}
+}
+
 // CreatePublicLinkPermission is the permission to create public links
 func CreatePublicLinkPermission(c settingsmsg.Permission_Constraint) *settingsmsg.Setting {
 	return &settingsmsg.Setting{


### PR DESCRIPTION
Introduces a new permission (id=5c03dc05-0bef-4b30-8ee6-e5a51713fd3a) which allows sharing to other instances in multi-instance ocis. By default admins and space admins get this permission.
