### PR TITLE
chore(deps): bump alpine from 3.20 to 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=generate /ocis /ocis
 WORKDIR /ocis/ocis
 RUN make ci-go-generate build ENABLE_VIPS=true
 
-FROM alpine:3.20
+FROM alpine:3.23
 
 RUN apk add --no-cache attr ca-certificates curl mailcap tree vips && \
 	echo 'hosts: files dns' >| /etc/nsswitch.conf


### PR DESCRIPTION
Bumps alpine from 3.20 to 3.23.

---
updated-dependencies:
- dependency-name: alpine dependency-version: '3.23' dependency-type: direct:production update-type: version-update:semver-minor ...

backport to 7.3 of #11935 