### PR TITLE
[docs-only] Fix of storage-publiclink readme

### DIFF
--- a/services/storage-publiclink/README.md
+++ b/services/storage-publiclink/README.md
@@ -6,6 +6,10 @@ The brute force protection will prevent access to public links if wrong
 passwords are entered. The implementation is very similar to a rate limiter,
 but taking into account only wrong password attempts.
 
+This feature is enabled by default with predefined settings.
+
+If you want to disable this feature, set the related configuration values to 0.
+
 By default, you're allowed a maximum of 5 failed attempts in 1 hour:
 
 * `STORAGE_PUBLICLINK_BRUTEFORCE_MAXATTEMPTS=5`
@@ -17,10 +21,10 @@ threshold (5 failures per hour, by default).
 If the failure rate threshold is exceeded, the public link will be blocked
 until such rate goes below the threshold. This means that it will remain
 blocked for an undefined time: a couple of seconds in the best case, or up
-to `STORAGE_PUBLICLINK_BRUTEFORCE_TIME` in the worst case.
+to `STORAGE_PUBLICLINK_BRUTEFORCE_TIMEGAP` in the worst case.
 
 If the public link is blocked by the brute force protection, it will be blocked
-for all the users.
+for all the users. Any attempt with a false password will restart the trigger.
 
-As said, this feature is enabled by default, with a 5 failures per hour rate.
-If you want to disable this feature, set the related configuration values to 0.
+Note that this feature uses the configurable store. No setting changes need to
+be made when using defaults.


### PR DESCRIPTION
The `storage-publiclink` readme needs a fix because of wrong respectively missing content.
The changes are already incorporated in the admin docs.