### PR TITLE
[Backport] fix: some notifications were translated wrong due to an empty l10n key

### DIFF
--- a/services/notifications/pkg/email/composer.go
+++ b/services/notifications/pkg/email/composer.go
@@ -3,9 +3,10 @@ package email
 import (
 	"bytes"
 	"embed"
-	"github.com/pkg/errors"
 	"strings"
 	"text/template"
+
+	"github.com/pkg/errors"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/l10n"
 )
@@ -32,9 +33,14 @@ func NewTextTemplate(mt MessageTemplate, locale, defaultLocale string, translati
 	if err != nil {
 		return mt, err
 	}
-	mt.CallToAction, err = composeMessage(t.Get(mt.CallToAction), vars)
-	if err != nil {
-		return mt, err
+
+	if mt.CallToAction != "" {
+		// Some templates have an empty call-to-action. We don't want to translate
+		// an empty key and get an unexpected message.
+		mt.CallToAction, err = composeMessage(t.Get(mt.CallToAction), vars)
+		if err != nil {
+			return mt, err
+		}
 	}
 	return mt, nil
 }
@@ -55,9 +61,13 @@ func NewHTMLTemplate(mt MessageTemplate, locale, defaultLocale string, translati
 	if err != nil {
 		return mt, err
 	}
-	mt.CallToAction, err = composeMessage(callToActionToHTML(t.Get(mt.CallToAction)), vars)
-	if err != nil {
-		return mt, err
+	if mt.CallToAction != "" {
+		// Some templates have an empty call-to-action. We don't want to translate
+		// an empty key and get an unexpected message.
+		mt.CallToAction, err = composeMessage(callToActionToHTML(t.Get(mt.CallToAction)), vars)
+		if err != nil {
+			return mt, err
+		}
 	}
 	return mt, nil
 }


### PR DESCRIPTION
The expected translatable message was empty, which caused the translation system to use the empty key, which contains "weird" unrelated data.
With the fix, if there is no translatable message, the related output will remain empty.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Backport of https://github.com/owncloud/ocis/pull/11979 to stable 8.0

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
