### PR TITLE
fix(reva): populate ID field in ItemRestored events

### DIFF
--- a/changelog/unreleased/bugfix-item-restored-missing-id.md
+++ b/changelog/unreleased/bugfix-item-restored-missing-id.md
@@ -1,0 +1,5 @@
+Bugfix: Populate ID field in ItemRestored events
+
+The ItemRestored event was missing the restored file's resource ID, making it impossible for event consumers to identify the restored file without additional API calls. This fix populates the ID field by extracting the file's opaque_id from the restore request key, mirroring how the ItemTrashed event correctly includes the trashed file's ID.
+
+https://github.com/owncloud/ocis/pull/11991

--- a/vendor/github.com/owncloud/reva/v2/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/vendor/github.com/owncloud/reva/v2/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -309,10 +309,16 @@ func ItemRestored(r *provider.RestoreRecycleItemResponse, req *provider.RestoreR
 	if req.RestoreRef != nil {
 		ref = req.RestoreRef
 	}
+	opaqueID := utils.ReadPlainFromOpaque(r.Opaque, "opaque_id")
 	return events.ItemRestored{
-		SpaceOwner:        spaceOwner,
-		Executant:         executant.GetId(),
-		Ref:               ref,
+		SpaceOwner: spaceOwner,
+		Executant:  executant.GetId(),
+		Ref:        ref,
+		ID: &provider.ResourceId{
+			StorageId: ref.GetResourceId().GetStorageId(),
+			SpaceId:   ref.GetResourceId().GetSpaceId(),
+			OpaqueId:  opaqueID,
+		},
 		OldReference:      req.Ref,
 		Key:               req.Key,
 		Timestamp:         utils.TSNow(),

--- a/vendor/github.com/owncloud/reva/v2/internal/grpc/services/storageprovider/storageprovider.go
+++ b/vendor/github.com/owncloud/reva/v2/internal/grpc/services/storageprovider/storageprovider.go
@@ -977,6 +977,18 @@ func (s *Service) RestoreRecycleItem(ctx context.Context, req *provider.RestoreR
 	res := &provider.RestoreRecycleItemResponse{
 		Status: status.NewStatusFromErrType(ctx, "restore recycle item", err),
 	}
+
+	// The key from the restore request IS the file's opaque_id.
+	// Include it in the response so the events middleware can populate
+	// the ItemRestored event's ID field (mirroring how Delete works).
+	if err == nil && key != "" {
+		res.Opaque = &typesv1beta1.Opaque{
+			Map: map[string]*typesv1beta1.OpaqueEntry{
+				"opaque_id": {Decoder: "plain", Value: []byte(key)},
+			},
+		}
+	}
+
 	return res, nil
 }
 


### PR DESCRIPTION
## Summary

The `ItemRestored` event was missing the restored file's resource ID (`ID` field was always `nil`), making it impossible for event consumers to identify the restored file without additional API calls.

**Root cause:** Unlike `ItemTrashed` which extracts the file's `opaque_id` from the Delete response and populates the event's `ID` field, `ItemRestored` never set this field.

**Fix:** 
1. In `storageprovider.go`: After a successful restore, include the file's `opaque_id` (which is the `key` from the restore request) in the response `Opaque`
2. In `conversion.go`: Extract `opaque_id` from the response and populate the `ID` field, mirroring the `ItemTrashed` pattern

## Test plan

- [x] Upload a file, trash it, restore it
- [x] Verify `ItemRestored` event now contains `ID.opaque_id` matching the file's UUID
- [x] Verify the `ID.opaque_id` matches what `ItemTrashed` reported for the same file

## Files changed

- `vendor/github.com/owncloud/reva/v2/internal/grpc/services/storageprovider/storageprovider.go`
- `vendor/github.com/owncloud/reva/v2/internal/grpc/interceptors/eventsmiddleware/conversion.go`
- `changelog/unreleased/bugfix-item-restored-missing-id.md`

🤖 Generated with [Claude Code](https://claude.ai/code)