### PR TITLE
[tests-only][full-ci] Test: Include apiCollaboration test suite to run in k8s

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -273,6 +273,7 @@ config = {
                 "apiCollaboration",
             ],
             "skip": False,
+            "k8s": True,
             "withRemotePhp": [False],
             "collaborationServiceNeeded": True,
             "extraServerEnvironment": {
@@ -1121,21 +1122,36 @@ def localApiTestPipeline(ctx):
                             ocis_url = "https://%s" % OCIS_SERVER_NAME
                             ocis_fed_url = "https://%s" % FED_OCIS_SERVER_NAME
 
-                            deployment_steps = waitK3sCluster()
+                            deployment_steps = waitK3sCluster() + prepareOcisDeployment() + setupOcisConfigMaps()
                             if params["federationServer"]:
                                 deployment_steps += waitK3sCluster(name = FED_OCIS_SERVER_NAME)
                             if params["antivirusNeeded"]:
                                 deployment_steps += enableAntivirusServiceK8s()
                             if params["emailNeeded"]:
                                 deployment_steps += emailServiceK8s()
+                            if params["collaborationServiceNeeded"]:
+                                deployment_steps += enableAppsIntegrationK8s()
+                                deployment_steps += exposeExternalServersK8s([["collabora", 9980], ["fakeoffice", 8080], ["onlyoffice", 443]])
 
-                            deployment_steps += prepareOcisDeployment() + setupOcisConfigMaps() + deployOcis() + streamK8sOcisLogs() + waitForOcis(ocis_url = ocis_url)
+                            deployment_steps += deployOcis() + streamK8sOcisLogs() + waitForOcis(ocis_url = ocis_url)
                             if params["federationServer"]:
                                 deployment_steps += setupOcisConfigMaps(name = FED_OCIS_SERVER_NAME) + deployOcis(name = FED_OCIS_SERVER_NAME) + waitForOcis(name = "federation-ocis", ocis_url = ocis_fed_url)
 
                             deployment_steps += ociswrapper() + waitForOciswrapper()
+
+                            # post deploy steps
+                            if params["collaborationServiceNeeded"]:
+                                deployment_steps += exposeNodePortsK8s([
+                                    ["collaboration-collabora", 9300],
+                                    ["collaboration-fakeoffice", 9300],
+                                    ["collaboration-onlyoffice", 9300],
+                                    ["collaboration-fakeoffice", 9304],
+                                ])
                         else:
                             deployment_steps = ocisServer(storage, extra_server_environment = params["extraServerEnvironment"], with_wrapper = True, tika_enabled = params["tikaNeeded"], volumes = [stepVolumeOcisStorage])
+                            if params["collaborationServiceNeeded"]:
+                                deployment_steps += wopiCollaborationService("fakeoffice", ocis_url) + wopiCollaborationService("collabora", ocis_url) + wopiCollaborationService("onlyoffice", ocis_url)
+                                deployment_steps += ocisHealthCheck("wopi", ["wopi-collabora:9304", "wopi-onlyoffice:9304", "wopi-fakeoffice:9304"])
 
                         pipeline = {
                             "kind": "pipeline",
@@ -1149,12 +1165,10 @@ def localApiTestPipeline(ctx):
                                      ([] if run_on_k8s else restoreBuildArtifactCache(ctx, "ocis-binary-amd64", "ocis/bin")) +
                                      (tikaService() if params["tikaNeeded"] and not run_on_k8s else tikaServiceK8s() if params["tikaNeeded"] and run_on_k8s else []) +
                                      (waitForServices("online-offices", ["collabora:9980", "onlyoffice:443", "fakeoffice:8080"]) if params["collaborationServiceNeeded"] else []) +
-                                     deployment_steps +
                                      (waitForClamavService() if params["antivirusNeeded"] and not run_on_k8s else exposeAntivirusServiceK8s() if params["antivirusNeeded"] and run_on_k8s else []) +
                                      (waitForEmailService() if params["emailNeeded"] and not run_on_k8s else exposeEmailServiceK8s() if params["emailNeeded"] and run_on_k8s else []) +
                                      (ocisServer(storage, deploy_type = "federation", extra_server_environment = params["extraServerEnvironment"]) if params["federationServer"] and not run_on_k8s else []) +
-                                     ((wopiCollaborationService("fakeoffice") + wopiCollaborationService("collabora") + wopiCollaborationService("onlyoffice")) if params["collaborationServiceNeeded"] else []) +
-                                     (ocisHealthCheck("wopi", ["wopi-collabora:9304", "wopi-onlyoffice:9304", "wopi-fakeoffice:9304"]) if params["collaborationServiceNeeded"] else []) +
+                                     deployment_steps +
                                      localApiTests(name, params["suites"], storage, params["extraEnvironment"], run_with_remote_php, ocis_url = ocis_url, ocis_fed_url = ocis_fed_url, k8s = run_on_k8s) +
                                      apiTestFailureLog() +
                                      (generateCoverageFromAPITest(ctx, name) if not run_on_k8s else []),
@@ -1230,7 +1244,7 @@ def localApiTests(name, suites, storage = "ocis", extra_environment = {}, with_r
         "UPLOAD_DELETE_WAIT_TIME": "1" if storage == "owncloud" else 0,
         "OCIS_WRAPPER_URL": "http://ociswrapper:5200" if k8s else "http://%s:5200" % OCIS_SERVER_NAME,
         "WITH_REMOTE_PHP": with_remote_php,
-        "COLLABORATION_SERVICE_URL": "http://wopi-fakeoffice:9300",
+        "COLLABORATION_SERVICE_URL": "http://ocis-server:9304" if k8s else "http://wopi-fakeoffice:9300",
         "K8S": k8s,
     }
 
@@ -1322,7 +1336,7 @@ def wopiValidatorTests(ctx, storage, wopiServerType):
             "OCIS_EXCLUDE_RUN_SERVICES": "app-provider",
         }
 
-        wopiServer = wopiCollaborationService("fakeoffice")
+        wopiServer = wopiCollaborationService("fakeoffice", OCIS_URL)
 
     for testgroup in testgroups:
         validatorTests.append({
@@ -3489,10 +3503,11 @@ def fakeOffice():
         },
     ]
 
-def wopiCollaborationService(name):
+def wopiCollaborationService(name, ocis_url):
     service_name = "wopi-%s" % name
 
     environment = {
+        "OCIS_URL": ocis_url,
         "MICRO_REGISTRY": "nats-js-kv",
         "MICRO_REGISTRY_ADDRESS": "%s:9233" % OCIS_SERVER_NAME,
         "COLLABORATION_LOG_LEVEL": "debug",
@@ -3697,7 +3712,7 @@ def collaboraService():
             "detach": True,
             "environment": {
                 "DONT_GEN_SSL_CERT": "set",
-                "extra_params": "--o:ssl.enable=true --o:ssl.termination=true --o:welcome.enable=false --o:net.frame_ancestors=%s" % OCIS_URL,
+                "extra_params": "--o:ssl.enable=true --o:ssl.termination=true --o:welcome.enable=false --o:net.frame_ancestors=https://%s" % OCIS_SERVER_NAME,
             },
             "commands": [
                 "coolconfig generate-proof-key",
@@ -3916,6 +3931,8 @@ def prepareOcisDeployment():
         "sed -i '/- name: THUMBNAILS_TRANSFER_TOKEN/i\\\\            - name: THUMBNAILS_TXT_FONTMAP_FILE\\\n              value: /etc/ocis/fontsMap.json\\\n' ./charts/ocis/templates/thumbnails/deployment.yaml",
         "sed -i '/volumeMounts:/a\\\\            - name: ocis-fonts-ttf\\\n              mountPath: /etc/ocis/fonts\\\n            - name: ocis-fonts-map\\\n              mountPath: /etc/ocis/fontsMap.json\\\n              subPath: fontsMap.json' ./charts/ocis/templates/thumbnails/deployment.yaml",
         "sed -i '/volumes:/a\\\\        - name: ocis-fonts-ttf\\\n          configMap:\\\n            name: ocis-fonts-ttf\\\n        - name: ocis-fonts-map\\\n          configMap:\\\n            name: ocis-fonts-map' ./charts/ocis/templates/thumbnails/deployment.yaml",
+        "sed -i -E 's|value: http:\\\\/\\\\/.*:9300|value: {{ $officeSuite.wopiSrc }}|' ./charts/ocis/templates/collaboration/deployment.yaml",
+        "cat ./charts/ocis/templates/collaboration/deployment.yaml",
     ]
 
     return [{
@@ -3965,6 +3982,10 @@ def deployOcis(name = OCIS_SERVER_NAME):
         ])
 
     commands.extend([
+        # [NOTE]
+        # Remove schema validation to add extra configs in values.yaml.
+        # Also this allows us to use fakeoffice as web-office server
+        "rm ./charts/ocis/values.schema.json",
         "make helm-install-atomic",
     ])
     return [{
@@ -3996,9 +4017,18 @@ def enableAntivirusServiceK8s():
         "image": OC_CI_ALPINE,
         "commands": [
             "cp -r %s/tests/config/drone/k8s/clamav %s/ocis-charts/charts/ocis/templates/" % (dirs["base"], dirs["base"]),
-            "sed -i '/^  virusscan:/,/^ *[^ ]/ s/enabled: .*/enabled: true/' %s/tests/config/drone/k8s/values.yaml" % dirs["base"],
+            "sed -i '/^  virusscan:/,/^ *[^ ]/ s/enabled: .*/enabled: true/' %s/ocis-charts/charts/ocis/ci/deployment-values.yaml" % dirs["base"],
             "sed -i '/name: ANTIVIRUS_SCANNER_TYPE/{n;s/value: *\"icap\"/value: \"clamav\"/}' %s/ocis-charts/charts/ocis/templates/antivirus/deployment.yaml" % dirs["base"],
             "sed -i '/- name: ANTIVIRUS_SCANNER_TYPE/i\\\\            - name: ANTIVIRUS_CLAMAV_SOCKET\\\n              value: \"tcp://clamav:3310\"' %s/ocis-charts/charts/ocis/templates/antivirus/deployment.yaml" % dirs["base"],
+        ],
+    }]
+
+def enableAppsIntegrationK8s():
+    return [{
+        "name": "enable-apps-integration",
+        "image": OC_CI_ALPINE,
+        "commands": [
+            "sed -i '/^  appsIntegration:/,/^ *[^ ]/ s/enabled: .*/enabled: true/' %s/ocis-charts/charts/ocis/ci/deployment-values.yaml" % dirs["base"],
         ],
     }]
 
@@ -4073,4 +4103,47 @@ def tikaServiceK8s():
             "cp -r %s/tests/config/drone/k8s/tika %s/ocis-charts/charts/ocis/templates/" % (dirs["base"], dirs["base"]),
             "sed -i '/^[[:space:]]*storagesystem:/i\\\\  search:\\\n    extractor:\\\n      type: \"tika\"\\\n      tika:\\\n        url: \"http://tika:9998\"\\\n    persistence:\\\n      enabled: true\\\n      accessModes:\\\n        - ReadWriteOnce' %s/tests/config/drone/k8s/values.yaml" % dirs["base"],
         ],
+    }]
+
+def exposeNodePortsK8s(services = [], name = OCIS_SERVER_NAME):
+    commands = []
+    for idx, service in enumerate(services):
+        deploy_name = service[0]
+        service_port = str(service[1])
+        node_port = service_port.replace("9", "30", 1)
+
+        # there can be multiple collaboration services
+        if service_port == "9300" and "collaboration" in deploy_name:
+            node_port = "3030%d" % idx
+        service_name = "%s-%s-np" % (deploy_name, node_port)
+        commands.append("kubectl -n ocis expose deployment %s --type=NodePort --port=%s --name=%s" % (deploy_name, service_port, service_name))
+        commands.append("kubectl -n ocis patch svc %s -p '{\"spec\":{\"ports\":[{\"port\":%s,\"nodePort\":%s}]}}'" % (service_name, service_port, node_port))
+
+    return [{
+        "name": "expose-nodeports",
+        "image": K3D_IMAGE,
+        "commands": [
+            "export KUBECONFIG=kubeconfig-$${DRONE_BUILD_NUMBER}-%s.yaml" % name,
+            "until test -f $${KUBECONFIG}; do sleep 1s; done",
+        ] + commands,
+    }]
+
+def exposeExternalServersK8s(servers = [], name = OCIS_SERVER_NAME):
+    commands = []
+    for server in servers:
+        server_name = server[0]
+        server_port = str(server[1])
+        commands.append("SERVER_IP=$(getent hosts %s | awk '{print $1}')" % server_name)
+        commands.append('echo -e "apiVersion: v1\nkind: Endpoints\nmetadata:\n  name: %s\n  namespace: ocis\n' % server_name +
+                        'subsets:\n- addresses:\n  - ip: $SERVER_IP\n  ports:\n  - port: %s" | kubectl apply -f -' % server_port)
+        commands.append('echo -e "apiVersion: v1\nkind: Service\nmetadata:\n  name: %s\n  namespace: ocis\n' % server_name +
+                        'spec:\n  ports:\n  - port: %s\n    targetPort: %s" | kubectl apply -f -' % (server_port, server_port))
+
+    return [{
+        "name": "expose-external-servers",
+        "image": K3D_IMAGE,
+        "commands": [
+            "export KUBECONFIG=kubeconfig-$${DRONE_BUILD_NUMBER}-%s.yaml" % name,
+            "until test -f $${KUBECONFIG}; do sleep 1s; done",
+        ] + commands,
     }]

--- a/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
+++ b/tests/acceptance/features/apiCollaboration/checkFileInfo.feature
@@ -168,7 +168,7 @@ Feature: check file info with different wopi apps
             "const": "textfile0.txt"
           },
           "PostMessageOrigin": {
-            "const": "https://localhost:9200"
+            "const": "%base_url%"
           },
           "DisablePrint": {
             "const": false
@@ -566,7 +566,7 @@ Feature: check file info with different wopi apps
             "const": "textfile0.txt"
           },
           "PostMessageOrigin": {
-            "const": "https://localhost:9200"
+            "const": "%base_url%"
           },
           "DisablePrint": {
             "const": <disable-print>
@@ -676,7 +676,7 @@ Feature: check file info with different wopi apps
             "const": "textfile0.txt"
           },
           "PostMessageOrigin": {
-            "const": "https://localhost:9200"
+            "const": "%base_url%"
           },
           "DisablePrint": {
             "const": false
@@ -1062,7 +1062,7 @@ Feature: check file info with different wopi apps
             "const": "renamedfile.txt"
           },
           "PostMessageOrigin": {
-            "const": "https://localhost:9200"
+            "const": "%base_url%"
           },
           "DisablePrint": {
             "const": false
@@ -1409,7 +1409,7 @@ Feature: check file info with different wopi apps
             "const": "text.txt"
           },
           "PostMessageOrigin": {
-            "const": "https://localhost:9200"
+            "const": "%base_url%"
           },
           "DisablePrint": {
             "const": false
@@ -1795,7 +1795,7 @@ Feature: check file info with different wopi apps
             "const": "text.txt"
           },
           "PostMessageOrigin": {
-            "const": "https://localhost:9200"
+            "const": "%base_url%"
           },
           "DisablePrint": {
             "const": <disable-print>

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -27,7 +27,7 @@ Feature: collaboration (wopi)
         "properties": {
           "app_url": {
             "type": "string",
-            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}"
           },
           "method": {
             "const": "POST"
@@ -73,7 +73,7 @@ Feature: collaboration (wopi)
         "properties": {
           "app_url": {
             "type": "string",
-            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}"
           },
           "method": {
             "const": "POST"
@@ -115,7 +115,7 @@ Feature: collaboration (wopi)
         "properties": {
           "app_url": {
             "type": "string",
-            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}"
           },
           "method": {
             "const": "POST"
@@ -163,7 +163,7 @@ Feature: collaboration (wopi)
         "properties": {
           "app_url": {
             "type": "string",
-            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}"
           },
           "method": {
             "const": "POST"
@@ -214,7 +214,7 @@ Feature: collaboration (wopi)
         "properties": {
           "app_url": {
             "type": "string",
-            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}"
           },
           "method": {
             "const": "POST"
@@ -315,7 +315,7 @@ Feature: collaboration (wopi)
         "properties": {
           "app_url": {
             "type": "string",
-            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}"
           },
           "method": {
             "const": "POST"
@@ -366,9 +366,9 @@ Feature: collaboration (wopi)
       }
       """
     Examples:
-      | app-endpoint                                              | url-query       |
-      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice& |
-      | /app/open-with-web?file_id=<<FILEID>>                     | app=FakeOffice& |
+      | app-endpoint                                              | url-query                                |
+      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice&                          |
+      | /app/open-with-web?file_id=<<FILEID>>                     | app=(FakeOffice\|Collabora\|OnlyOffice)& |
 
 
   Scenario: open text file using open-with-web with app name in url query (MIME type not registered in app-registry)
@@ -408,7 +408,7 @@ Feature: collaboration (wopi)
         "properties": {
           "uri": {
             "type": "string",
-             "pattern": "%base_url%/external\\?app=FakeOffice&contextRouteName=files-spaces-personal&fileId=%uuidv4_pattern%%24%uuidv4_pattern%%21%uuidv4_pattern%$"
+             "pattern": "%base_url%/external\\?app=(FakeOffice|Collabora|OnlyOffice)&contextRouteName=files-spaces-personal&fileId=%uuidv4_pattern%%24%uuidv4_pattern%%21%uuidv4_pattern%$"
           }
         }
       }
@@ -441,9 +441,9 @@ Feature: collaboration (wopi)
       }
       """
     Examples:
-      | app-endpoint                                              | url-query       |
-      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice& |
-      | /app/open-with-web?file_id=<<FILEID>>                     | app=FakeOffice& |
+      | app-endpoint                                              | url-query                                |
+      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice&                          |
+      | /app/open-with-web?file_id=<<FILEID>>                     | app=(FakeOffice\|Collabora\|OnlyOffice)& |
 
 
   Scenario Outline: sharee open file with .odt extension (open-with-web)
@@ -473,9 +473,9 @@ Feature: collaboration (wopi)
       }
       """
     Examples:
-      | app-endpoint                                              | url-query       |
-      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice& |
-      | /app/open-with-web?file_id=<<FILEID>>                     | app=FakeOffice& |
+      | app-endpoint                                              | url-query                                |
+      | /app/open-with-web?file_id=<<FILEID>>&app_name=FakeOffice | app=FakeOffice&                          |
+      | /app/open-with-web?file_id=<<FILEID>>                     | app=(FakeOffice\|Collabora\|OnlyOffice)& |
 
 
   Scenario Outline: open file with .odt extension with different view mode (open-with-web)
@@ -1108,7 +1108,7 @@ Feature: collaboration (wopi)
         "properties": {
           "app_url": {
             "type": "string",
-            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}$"
+            "pattern": "^.*\\?WOPISrc=.*wopi%2Ffiles%2F[a-fA-F0-9]{64}"
           },
           "method": {
             "const": "POST"

--- a/tests/config/drone/k8s/values.yaml
+++ b/tests/config/drone/k8s/values.yaml
@@ -103,6 +103,43 @@ features:
   quotas:
     default: "1000000000"
     max: "0"
+  appsIntegration:
+    enabled: false
+    wopiIntegration:
+      officeSuites:
+        - name: "Collabora"
+          uri: "https://collabora:9980"
+          wopiSrc: "http://ocis-server:9300"
+          product: "Collabora"
+          enabled: true
+          insecure: true
+          disableProof: true
+          secureViewEnabled: false
+          disableChat: true
+          ingress:
+            enabled: false
+        - name: "FakeOffice"
+          uri: "http://fakeoffice:8080"
+          wopiSrc: "http://ocis-server:9301"
+          product: "FakeOffice"
+          enabled: true
+          insecure: true
+          disableProof: true
+          secureViewEnabled: false
+          disableChat: true
+          ingress:
+            enabled: false
+        - name: "OnlyOffice"
+          uri: "https://onlyoffice"
+          wopiSrc: "http://ocis-server:9302"
+          product: "OnlyOffice"
+          enabled: true
+          insecure: true
+          disableProof: true
+          secureViewEnabled: false
+          disableChat: true
+          ingress:
+            enabled: false
 
 http:
   cors:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds WOPI collaboration test suite to run in k8s CI pipeline.

**1. `wopiCollaborationService` needs `ocis_url` parameter**
Because in k8s, OCIS runs at a different URL than the hardcoded `OCIS_URL` constant. The collaboration service needs to know where OCIS is to communicate with it.

**2. Patch `collaboration/deployment.yaml` to use `{{ $officeSuite.wopiSrc }}`**
In k8s, the WOPI source URL is not a fixed `http://*:9300` — it varies per office suite (collabora, fakeoffice, onlyoffice). Using the Helm template variable makes it dynamic.

**3. Remove `values.schema.json` before helm install**
The schema validation was blocking extra configs needed for WOPI/fakeoffice setup in k8s. Removing it allows the custom `deployment-values.yaml` overrides to pass through.

**4. `enableAppsIntegrationK8s`**
WOPI requires `appsIntegration` to be enabled in the Helm values — it's off by default.

**5. `exposeExternalServersK8s`**
Collabora, fakeoffice, and onlyoffice run as Drone services (outside k8s). This bridges them into the k8s cluster so OCIS pods can reach them.

**6. `exposeNodePortsK8s`**
The collaboration services running inside k8s need to be reachable from outside (i.e., from the test runner). NodePort exposes them on the k3s node.

Changes made in `tests/acceptance/features/apiCollaboration/wopi.feature`:
1. Removed `$` from `WOPISrc` URL regex patterns — the old pattern required the URL to end after the file ID `([a-fA-F0-9]{64}$)`, but in k8s the URL has additional query parameters after it, so the `$` end anchor was too strict.
2. Expanded app name matching — changed `app=FakeOffice` to `app=(FakeOffice|Collabora|OnlyOffice)` because in k8s all three office suites are registered and any one of them could be returned.

Passing build:
- https://drone.owncloud.com/owncloud/ocis/52004/15/18

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/11658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
