### PR TITLE
feat(graph): [OCISDEV-602] add space ID to incoming shares

### DIFF
--- a/changelog/unreleased/enhancement-add-spaceid-to-incoming-shares.md
+++ b/changelog/unreleased/enhancement-add-spaceid-to-incoming-shares.md
@@ -1,0 +1,6 @@
+Enhancement: Add space ID to incoming shares
+
+Added the `spaceId` to the incoming shares. This is aligning the graph API with the WebDAV API where the clients can use `spaceid` property.
+This change allows clients to get the space ID directly instead of having to parse the resource ID.
+
+https://github.com/owncloud/ocis/pull/12024

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/onsi/gomega v1.39.0
 	github.com/open-policy-agent/opa v1.12.3
 	github.com/orcaman/concurrent-map v1.0.0
-	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64
+	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
 	github.com/owncloud/reva/v2 v2.0.0-20260213104810-a8d45f58b2d5
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HDbW65HOY=
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64 h1:z9djjzd+leAy6QZpi8dLy3OVjc/um+1XAGk1SJEvwE8=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
+github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245 h1:JRidLTAKhnvyLMRtVtSF4lhBa0NSAOs6fof+d6JnKII=
+github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
 github.com/owncloud/reva/v2 v2.0.0-20260213104810-a8d45f58b2d5 h1:JyDXgzdkdfAPt9uRMQu49AreYpaUl+RinrNVITyfHu4=
 github.com/owncloud/reva/v2 v2.0.0-20260213104810-a8d45f58b2d5/go.mod h1:ahCZbT/ltp5J8aURUpTOfpA/dLBeTvHaMm772cvj7+U=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=

--- a/services/graph/pkg/service/v0/export_test.go
+++ b/services/graph/pkg/service/v0/export_test.go
@@ -2,4 +2,5 @@ package svc
 
 var (
 	CS3ReceivedShareToLibreGraphPermissions = cs3ReceivedShareToLibreGraphPermissions
+	Cs3ReceivedSharesToDriveItems           = cs3ReceivedSharesToDriveItems
 )

--- a/services/graph/pkg/service/v0/utils.go
+++ b/services/graph/pkg/service/v0/utils.go
@@ -235,6 +235,7 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 			{
 				if id := shareStat.GetInfo().GetId(); id != nil {
 					remoteItem.SetId(storagespace.FormatResourceID(id))
+					remoteItem.SpaceId = libregraph.PtrString(storagespace.FormatStorageID(id.StorageId, id.SpaceId))
 				}
 
 				if name := shareStat.GetInfo().GetName(); name != "" {
@@ -264,7 +265,6 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 				if !reflect.ValueOf(*parentReference).IsZero() {
 					remoteItem.ParentReference = parentReference
 				}
-
 			}
 
 			// the parentReference of the outer driveItem should be the drive

--- a/vendor/github.com/owncloud/libre-graph-api-go/model_remote_item.go
+++ b/vendor/github.com/owncloud/libre-graph-api-go/model_remote_item.go
@@ -54,6 +54,8 @@ type RemoteItem struct {
 	WebDavUrl *string `json:"webDavUrl,omitempty"`
 	// URL that displays the resource in the browser. Read-only.
 	WebUrl *string `json:"webUrl,omitempty"`
+	// The UUID of the space that contains the item.
+	SpaceId *string `json:"spaceId,omitempty"`
 }
 
 // NewRemoteItem instantiates a new RemoteItem object
@@ -745,6 +747,38 @@ func (o *RemoteItem) SetWebUrl(v string) {
 	o.WebUrl = &v
 }
 
+// GetSpaceId returns the SpaceId field value if set, zero value otherwise.
+func (o *RemoteItem) GetSpaceId() string {
+	if o == nil || IsNil(o.SpaceId) {
+		var ret string
+		return ret
+	}
+	return *o.SpaceId
+}
+
+// GetSpaceIdOk returns a tuple with the SpaceId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RemoteItem) GetSpaceIdOk() (*string, bool) {
+	if o == nil || IsNil(o.SpaceId) {
+		return nil, false
+	}
+	return o.SpaceId, true
+}
+
+// HasSpaceId returns a boolean if a field has been set.
+func (o *RemoteItem) HasSpaceId() bool {
+	if o != nil && !IsNil(o.SpaceId) {
+		return true
+	}
+
+	return false
+}
+
+// SetSpaceId gets a reference to the given string and assigns it to the SpaceId field.
+func (o *RemoteItem) SetSpaceId(v string) {
+	o.SpaceId = &v
+}
+
 func (o RemoteItem) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -817,6 +851,9 @@ func (o RemoteItem) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.WebUrl) {
 		toSerialize["webUrl"] = o.WebUrl
+	}
+	if !IsNil(o.SpaceId) {
+		toSerialize["spaceId"] = o.SpaceId
 	}
 	return toSerialize, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1310,7 +1310,7 @@ github.com/opentracing/opentracing-go/log
 # github.com/orcaman/concurrent-map v1.0.0
 ## explicit
 github.com/orcaman/concurrent-map
-# github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64
+# github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
 # github.com/owncloud/reva/v2 v2.0.0-20260213104810-a8d45f58b2d5


### PR DESCRIPTION
## Description

Added the `spaceId` to the incoming shares. This is aligning the graph API with the WebDAV API where the clients can use `spaceid` property. This change allows clients to get the space ID directly instead of having to parse the resource ID.

## Motivation and Context

Align behaviour with WebDAV API and allow clients to get the space ID directly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: macos v26.3
- test case 1: opening the "Shared with me" page in oC Web and check response
- test case 2: new test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
