### PR TITLE
feat(webdav): [OCISDEV-602] add spaceid to report

### DIFF
--- a/changelog/unreleased/enhancement-add-spaceid-to-report.md
+++ b/changelog/unreleased/enhancement-add-spaceid-to-report.md
@@ -1,0 +1,5 @@
+Enhancement: Add spaceid to REPORT
+
+Added the `spaceid` to the REPORT responses. This is aligning the `REPORT` method with the `PROPFIND` method.
+
+https://github.com/owncloud/ocis/pull/12028

--- a/services/webdav/pkg/service/v0/search.go
+++ b/services/webdav/pkg/service/v0/search.go
@@ -256,6 +256,9 @@ func matchToPropResponse(match *searchmsg.Match, hrefPrefix string) (*propfind.R
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:permissions", match.Entity.Permissions))
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:highlights", match.Entity.Highlights))
 
+	spaceId := storagespace.FormatStorageID(match.Entity.Id.StorageId, match.Entity.Id.SpaceId)
+	propstatOK.Prop = appendStringProp(propstatOK.Prop, "oc:spaceid", &spaceId)
+
 	t := tags.New(match.Entity.Tags...)
 	propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:tags", t.AsList()))
 


### PR DESCRIPTION
## Description

Added the `spaceid` to the REPORT responses. This is aligning the `REPORT` method with the `PROPFIND` method.

## Motivation and Context

Align `REPORT` and `PROPFIND` and support envs where the file ID does not include space ID.

## How Has This Been Tested?

- test environment: macos v26.3, chrome v144.0.7559.133
- test case 1: search for files and check response

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
