### PR TITLE
fix: flaky cli test

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -563,6 +563,51 @@ class CliContext implements Context {
 	}
 
 	/**
+	 * @Given the administrator has waited until the file :filename has finished processing
+	 *
+	 * @param string $filename
+	 *
+	 * @return void
+	 * @throws JsonException
+	 */
+	public function theAdministratorHasWaitedUntilFileHasFinishedProcessing(string $filename): void {
+		$timeout = 30; // seconds
+		$interval = 1; // seconds
+		$startTime = \time();
+
+		// Poll until file is no longer in --processing list (allows time for state transitions).
+		// Replaces fixed wait that assumed deterministic timing.
+		while (true) {
+			$this->theAdministratorListsAllTheUploadSessions("processing");
+			$this->featureContext->theHTTPStatusCodeShouldBe(200);
+			$responseArray = $this->getJSONDecodedCliMessage($this->featureContext->getResponse());
+
+			$found = false;
+			foreach ($responseArray as $item) {
+				if (isset($item->filename) && $item->filename === $filename) {
+					$found = true;
+					break;
+				}
+			}
+
+			if (!$found) {
+				// File is no longer in processing list - abort completed and state updated
+				return;
+			}
+
+			$elapsed = \time() - $startTime;
+			if ($elapsed >= $timeout) {
+				Assert::fail(
+					"Timeout after {$timeout}s: file '{$filename}' is still in processing upload sessions list. " .
+					"Virus scan + abort may not have completed within timeout period.",
+				);
+			}
+
+			\sleep($interval);
+		}
+	}
+
+	/**
 	 * @param ResponseInterface $response
 	 *
 	 * @return array
@@ -575,7 +620,7 @@ class CliContext implements Context {
 		// Example Output: "INFO memory is not limited, skipping package=github.com/KimMachineGun/automemlimit/memlimit [{<output-json>}]"
 		// So, only extracting the array of output json from the message
 		\preg_match('/(\[.*\])/', $responseBody["message"], $matches);
-		return \json_decode($matches[1], null, 512, JSON_THROW_ON_ERROR);
+		return isset($matches[1]) ? \json_decode($matches[1], null, 512, JSON_THROW_ON_ERROR) : [];
 	}
 
 	/**

--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -29,7 +29,8 @@ Feature: List upload sessions via CLI command
       | antivirus      | ANTIVIRUS_INFECTED_FILE_HANDLING | abort     |
     And user "Alice" has uploaded file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt"
     And the config "POSTPROCESSING_DELAY" has been set to "10s" for "postprocessing" service
-    And the administrator has waited for "2" seconds
+    # Polls --processing list until virusFile.txt is absent (30s timeout). Replaces fixed 2s wait.
+    And the administrator has waited until the file "virusFile.txt" has finished processing
     And user "Alice" has uploaded file with content "uploaded content" to "/file1.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/file2.txt"
     When the administrator lists all the upload sessions with flag "processing"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

Test uses fixed 2-second wait after uploading virus file before querying `--processing` list. Virus scan + abort may take longer than 2 seconds, so `virusFile.txt` still appears in results when state transition hasn't completed.

**Test behavior:** Scenario "list all upload sessions that are currently in postprocessing" (uploadSessions.feature **25-41**) uploads virus file, waits 2 seconds, then queries `--processing` and asserts `virusFile.txt` is absent.

**State transition timing:** Virus scan completion and abort state update are asynchronous operations with variable timing. CLI command queries current state snapshot without waiting for pending transitions.

**Evidence:** drone logs: failure message `"The resource 'virusFile.txt' was found in the response."` Same pattern in builds 50975, 50972, 50936, 50832 (40 failures total).

### Fix

Replace fixed 2-second wait with polling that checks `--processing` list until `virusFile.txt` is absent (30s timeout, 1s interval). This waits for actual state transition completion rather than assuming deterministic timing.

### Alternative approaches considered

1. Increase fixed wait time (rejected: still assumes deterministic timing)
2. Query `--has-virus` first, then wait before querying `--processing` (viable but more complex)
3. Make abort synchronous or guarantee atomic state update (requires server-side changes)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
