### PR TITLE
fix: Useless conditional simplify ensureSlash function by removing needsSlash

### DIFF
--- a/services/idp/ui_config/paths.js
+++ b/services/idp/ui_config/paths.js
@@ -11,15 +11,13 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
 
-function ensureSlash(inputPath, needsSlash) {
+function ensureSlash(inputPath) {
   const hasSlash = inputPath.endsWith('/');
-  if (hasSlash && !needsSlash) {
-    return inputPath.slice(0, -1);
-  } else if (!hasSlash && needsSlash) {
-    return `${inputPath}/`;
-  } else {
+  if (hasSlash) {
     return inputPath;
   }
+
+  return `${inputPath}/`;
 }
 
 const getPublicUrl = appPackageJson =>
@@ -35,7 +33,7 @@ function getServedPath(appPackageJson) {
   const publicUrl = getPublicUrl(appPackageJson);
   const servedUrl =
     envPublicUrl || (publicUrl ? url.parse(publicUrl).pathname : '/');
-  return ensureSlash(servedUrl, true);
+  return ensureSlash(servedUrl);
 }
 
 const moduleFileExtensions = [


### PR DESCRIPTION
fix a condition that always evaluates to a constant, we either (a) remove the unused variability and simplify the code to reflect its actual usage, or (b) introduce or preserve true variability if the parameter is meant to have two behaviors. Here, the project only ever calls `ensureSlash` with `needsSlash` set to `true`, so we can safely simplify the function to a single-behavior helper that always ensures a trailing slash when one is missing.

The best minimal-impact fix is to remove the `needsSlash` parameter and the unused branch, converting `ensureSlash` into a function that always enforces the presence of a trailing slash. This preserves current behavior (since the only current call passes `true`), eliminates the logically constant condition, and avoids changing any other functionality. Concretely:
- Change the function definition from `function ensureSlash(inputPath, needsSlash)` to `function ensureSlash(inputPath)`.
- Replace the internal `if/else if/else` that checks `needsSlash` with a simpler check: if `inputPath` already ends with `/`, return it; otherwise append `/`.
- Update the single call site in `getServedPath` to call `ensureSlash(servedUrl)` without the second argument.
All changes are within `services/idp/ui_config/paths.js`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: <link> 
