### PR TITLE
[docs-only] fix: add ResourceID field to UploadReady event with file's node ID

### DIFF
--- a/changelog/unreleased/fix-uploadready-resource-id.md
+++ b/changelog/unreleased/fix-uploadready-resource-id.md
@@ -10,3 +10,4 @@ file's unique identifier for Graph API or WebDAV operations can now use
 https://github.com/owncloud/ocis/pull/12060
 https://github.com/owncloud/ocis/issues/12056
 https://github.com/owncloud/reva/pull/547
+https://github.com/owncloud/reva/pull/560


### PR DESCRIPTION
## Summary

The `UploadReady` event's `FileRef.ResourceId.OpaqueId` is set to the space root ID (required for CS3 gateway path resolution). NATS consumers that need the file's actual node ID for Graph API URLs or metadata writes get the space root instead.

## Problem

`FileRef` uses `OpaqueId = session.SpaceID()` because `NodeFromResource()` uses `OpaqueId` as the anchor for `WalkPath(Path)`. This is correct for CS3 gateway resolution, but means `FileRef.ResourceId` cannot be used as a file identifier.

A previous fix attempt (PR #12057, closed) changed `OpaqueId` to `session.NodeID()`, which broke:
- CS3 gateway resolution (`WalkPath` from a file node fails with `CODE_NOT_FOUND`)
- Removing `Path` to work around that broke external consumers that need the file path

## Fix

Add a separate `ResourceID` field to the `UploadReady` event, following the same pattern already used by `BytesReceived`:

```go
ResourceID: &provider.ResourceId{
    StorageId: session.ProviderID(),
    SpaceId:   session.SpaceID(),
    OpaqueId:  session.NodeID(),  // actual file node ID
},
```

`FileRef` is unchanged — CS3 gateway resolution and `Path` continue to work. JSON deserialization silently ignores unknown fields, so existing consumers are unaffected.

## Changes

| File | Change |
|------|--------|
| `vendor/.../events/postprocessing.go` | Add `ResourceID *provider.ResourceId` to `UploadReady` struct |
| `vendor/.../decomposedfs/decomposedfs.go` | Populate `ResourceID` with `session.NodeID()` |
| `vendor/.../posix/tree/assimilation.go` | Populate `ResourceID` from existing `ref.ResourceId` |
| `changelog/unreleased/fix-uploadready-resource-id.md` | Changelog entry |

## Test plan

- [ ] Upload a file and verify `UploadReady` NATS event contains both `FileRef` (with Path) and `ResourceID` (with correct OpaqueId)
- [ ] Verify activitylog, clientlog, search continue to work (they use `FileRef`)
- [ ] Verify external consumer can read `ResourceID.OpaqueId` as the file's node ID

Upstream reva PR: https://github.com/owncloud/reva/pull/547
Related: https://github.com/owncloud/ocis/issues/12056

🤖 Generated with [Claude Code](https://claude.com/claude-code)