### PR TITLE
[OCISDEV-704] Dont write ExternalID when empty

### DIFF
--- a/changelog/unreleased/fix-dont-write-empty-externalid-to-ldap.md
+++ b/changelog/unreleased/fix-dont-write-empty-externalid-to-ldap.md
@@ -1,0 +1,6 @@
+Bugfix: Don't write empty externalID to LDAP
+
+When creating new users in the graph service, the externalID attribute was being written to LDAP even when it was empty.
+Now, the externalID attribute is only written when it has a non-empty value.
+
+https://github.com/owncloud/ocis/pull/12085

--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -1059,7 +1059,6 @@ func (i *LDAP) userToLDAPAttrValues(user libregraph.User) (map[string][]string, 
 		"objectClass":                  {"inetOrgPerson", "organizationalPerson", "person", "top", "ownCloudUser"},
 		"cn":                           {user.GetOnPremisesSamAccountName()},
 		i.userAttributeMap.userType:    {user.GetUserType()},
-		i.userAttributeMap.externalID:  {user.GetExternalID()},
 	}
 
 	if identities, ok := user.GetIdentitiesOk(); ok {
@@ -1098,6 +1097,11 @@ func (i *LDAP) userToLDAPAttrValues(user libregraph.User) (map[string][]string, 
 	// When we get a givenName, we set the attribute.
 	if givenName := user.GetGivenName(); givenName != "" {
 		attrs[i.userAttributeMap.givenName] = []string{givenName}
+	}
+
+	// Only set externalID when it's not empty.
+	if externalID := user.GetExternalID(); externalID != "" {
+		attrs[i.userAttributeMap.externalID] = []string{externalID}
 	}
 
 	if !i.usePwModifyExOp && user.PasswordProfile != nil && user.PasswordProfile.Password != nil {

--- a/services/graph/pkg/identity/ldap_test.go
+++ b/services/graph/pkg/identity/ldap_test.go
@@ -129,49 +129,72 @@ func TestCreateUser(t *testing.T) {
 	givenName := "givenName"
 	userType := "Member"
 
-	ar := ldap.NewAddRequest(fmt.Sprintf("uid=user,%s", lconfig.UserBaseDN), nil)
-	ar.Attribute(lconfig.UserDisplayNameAttribute, []string{displayName})
-	ar.Attribute(lconfig.UserEmailAttribute, []string{mail})
-	ar.Attribute(lconfig.UserNameAttribute, []string{userName})
-	ar.Attribute("sn", []string{surname})
-	ar.Attribute("givenname", []string{givenName})
-	ar.Attribute(lconfig.UserEnabledAttribute, []string{"TRUE"})
-	ar.Attribute(lconfig.UserTypeAttribute, []string{"Member"})
-	ar.Attribute(lconfig.ExternalIDAttribute, []string{"abcd-efgh-ijkl-mnop"})
-	ar.Attribute("cn", []string{userName})
-	ar.Attribute("objectClass", []string{"inetOrgPerson", "organizationalPerson", "person", "top", "ownCloudUser"})
+	tests := []struct {
+		name       string
+		externalID string
+	}{
+		{
+			name:       "with externalID",
+			externalID: "abcd-efgh-ijkl-mnop",
+		},
+		{
+			name:       "without externalID",
+			externalID: "",
+		},
+	}
 
-	l := &mocks.Client{}
-	l.On("Search", mock.Anything).
-		Return(
-			&ldap.SearchResult{
-				Entries: []*ldap.Entry{userEntry},
-			},
-			nil)
-	l.On("Add", ar).Return(nil)
-	logger := log.NewLogger(log.Level("debug"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ar := ldap.NewAddRequest(fmt.Sprintf("uid=user,%s", lconfig.UserBaseDN), nil)
+			ar.Attribute(lconfig.UserDisplayNameAttribute, []string{displayName})
+			ar.Attribute(lconfig.UserEmailAttribute, []string{mail})
+			ar.Attribute(lconfig.UserNameAttribute, []string{userName})
+			ar.Attribute("sn", []string{surname})
+			ar.Attribute("givenname", []string{givenName})
+			ar.Attribute(lconfig.UserEnabledAttribute, []string{"TRUE"})
+			ar.Attribute(lconfig.UserTypeAttribute, []string{"Member"})
+			if tt.externalID != "" {
+				ar.Attribute(lconfig.ExternalIDAttribute, []string{tt.externalID})
+			}
+			ar.Attribute("cn", []string{userName})
+			ar.Attribute("objectClass", []string{"inetOrgPerson", "organizationalPerson", "person", "top", "ownCloudUser"})
 
-	user := libregraph.NewUser(displayName, userName)
-	user.SetMail(mail)
-	user.SetSurname(surname)
-	user.SetGivenName(givenName)
-	user.SetAccountEnabled(true)
-	user.SetUserType(userType)
-	user.SetExternalID("abcd-efgh-ijkl-mnop")
+			l := &mocks.Client{}
+			l.On("Search", mock.Anything).
+				Return(
+					&ldap.SearchResult{
+						Entries: []*ldap.Entry{userEntry},
+					},
+					nil)
+			l.On("Add", ar).Return(nil)
+			logger := log.NewLogger(log.Level("debug"))
 
-	c := lconfig
-	c.UseServerUUID = true
-	b, _ := NewLDAPBackend(l, c, &logger, "")
+			user := libregraph.NewUser(displayName, userName)
+			user.SetMail(mail)
+			user.SetSurname(surname)
+			user.SetGivenName(givenName)
+			user.SetAccountEnabled(true)
+			user.SetUserType(userType)
+			if tt.externalID != "" {
+				user.SetExternalID(tt.externalID)
+			}
 
-	newUser, err := b.CreateUser(context.Background(), *user)
-	assert.Nil(t, err)
-	assert.Equal(t, displayName, newUser.GetDisplayName())
-	assert.Equal(t, mail, newUser.GetMail())
-	assert.Equal(t, userName, newUser.GetOnPremisesSamAccountName())
-	assert.Equal(t, givenName, newUser.GetGivenName())
-	assert.Equal(t, surname, newUser.GetSurname())
-	assert.True(t, newUser.GetAccountEnabled())
-	assert.Equal(t, userType, newUser.GetUserType())
+			c := lconfig
+			c.UseServerUUID = true
+			b, err := NewLDAPBackend(l, c, &logger, "")
+			assert.Nil(t, err)
+
+			newUser, err := b.CreateUser(context.Background(), *user)
+			assert.Nil(t, err)
+			assert.Equal(t, displayName, newUser.GetDisplayName())
+			assert.Equal(t, mail, newUser.GetMail())
+			assert.Equal(t, userName, newUser.GetOnPremisesSamAccountName())
+			assert.Equal(t, givenName, newUser.GetGivenName())
+			assert.Equal(t, surname, newUser.GetSurname())
+			assert.True(t, newUser.GetAccountEnabled())
+			assert.Equal(t, userType, newUser.GetUserType())
+		})
+	}
 }
 
 func TestCreateUserModelFromLDAP(t *testing.T) {


### PR DESCRIPTION
Fixes issue with ocis not being able to create new users in 8.0.0
