### PR TITLE
[tests-only] test: add test to download multiple files from public link

### DIFF
--- a/tests/acceptance/bootstrap/ArchiverContext.php
+++ b/tests/acceptance/bootstrap/ArchiverContext.php
@@ -31,6 +31,7 @@ use Psr\Http\Message\ResponseInterface;
 use splitbrain\PHPArchive\Tar;
 use splitbrain\PHPArchive\Zip;
 use splitbrain\PHPArchive\Archive;
+use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';
 
@@ -253,6 +254,109 @@ class ArchiverContext implements Context {
 				$user,
 				$this->featureContext->getPasswordForUser($user),
 			),
+		);
+	}
+
+	/**
+	 * Sends a PROPFIND request to the public WebDAV endpoint for the last created public link
+	 * and extracts archive-related metadata from the XML response.
+	 *
+	 * The returned data includes:
+	 * - fileIds: IDs of all files included in the public link
+	 * - signature: signature required for archive download
+	 * - expiration: expiration timestamp required for archive download
+	 *
+	 * @param string $password
+	 *
+	 * @return array {
+	 *     fileIds: string[],
+	 *     signature: string|null,
+	 *     expiration: string|null
+	 * }
+	 *
+	 * @throws GuzzleException
+	 */
+	private function fetchPublicLinkArchiveData(string $password = ''): array {
+		$token = $this->featureContext->isUsingSharingNG()
+			? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
+			: $this->featureContext->getLastCreatedPublicShareToken();
+		$password = $this->featureContext->getActualPassword($password);
+		$response = WebDavHelper::propfind(
+			$this->featureContext->getBaseUrl(),
+			null,
+			(string) $password,
+			(string) $token,
+			['oc:public-link-item-type', 'oc:fileid', 'oc:downloadURL', 'oc:signature-auth'],
+			null,
+			null,
+			"public-files",
+		);
+		$xmlDocument = HttpRequestHelper::getResponseXml($response);
+
+		$fileIds = [];
+		$signature = null;
+		$expiration = null;
+
+		foreach ($xmlDocument->xpath('//d:response') as $responseNode) {
+			$type = $responseNode->xpath('.//oc:public-link-item-type');
+			$fileId = $responseNode->xpath('.//oc:fileid');
+
+			$sig = $responseNode->xpath('.//oc:signature-auth/oc:signature');
+			$exp = $responseNode->xpath('.//oc:signature-auth/oc:expiration');
+
+			if (!empty($type) && (string)$type[0] === 'file' && !empty($fileId)) {
+				$fileIds[] = (string)$fileId[0];
+			}
+
+			if ($signature === null && !empty($sig)) {
+				$signature = (string)$sig[0];
+			}
+
+			if ($expiration === null && !empty($exp)) {
+				$expiration = (string)$exp[0];
+			}
+		}
+
+		return [
+			'fileIds' => $fileIds,
+			'signature' => $signature,
+			'expiration' => $expiration,
+		];
+	}
+
+	/**
+	 * @When /^the public downloads the archive of the last created public link with password "([^"]*)"$/
+	 *
+	 * @param string $password
+	 *
+	 * @return void
+	 *
+	 * @throws GuzzleException|Exception
+	 */
+	public function publicDownloadsTheArchiveOfTheLastCreatedPublicLink(string $password = ""): void {
+		$data = $this->fetchPublicLinkArchiveData($password);
+		$fileIds = $data['fileIds'];
+		$signature = $data['signature'];
+		$expiration = $data['expiration'];
+
+		$token = $this->featureContext->isUsingSharingNG()
+				? $this->featureContext->shareNgGetLastCreatedLinkShareToken()
+				: $this->featureContext->getLastCreatedPublicShareToken();
+		$password = $this->featureContext->getActualPassword($password);
+		$queryParts = [];
+		$queryParts[] = "public-token=" . urlencode($token);
+
+		foreach ($fileIds as $fileId) {
+			$queryParts[] = "id=" . urlencode($fileId);
+		}
+
+		$queryParts[] = "signature=" . urlencode($signature);
+		$queryParts[] = "expiration=" . urlencode($expiration);
+		$queryString = implode('&', $queryParts);
+		$url = $this->featureContext->getBaseUrl() . "/archiver?" . $queryString;
+
+		$this->featureContext->setResponse(
+			HttpRequestHelper::get($url, 'public', $password),
 		);
 	}
 

--- a/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
+++ b/tests/acceptance/features/apiSpacesShares/publicLinkDownload.feature
@@ -45,3 +45,29 @@ Feature: Public can download folders from project space public link
     And the downloaded zip archive should contain these files:
       | name            | content      |
       | folder/test.txt | some content |
+
+  @env-config
+  Scenario Outline: download an archive of a password protected public link share (project space)
+    And using SharingNG
+    And user "Alice" has created a folder "project-folder" in space "new-space"
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content1" to "project-folder/test1.txt"
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content2" to "project-folder/test2.txt"
+    And user "Alice" has uploaded a file inside space "new-space" with content "some content3" to "project-folder/test3.txt"
+    And user "Alice" has created the following resource link share:
+      | resource         | project-folder    |
+      | space            | new-space         |
+      | permissionsRole  | <permissionsRole> |
+      | password         | %public%          |
+    When the public downloads the archive of the last created public link with password "%public%"
+    Then the HTTP status code should be "200"
+    And the downloaded "zip" archive should contain these files:
+      | name      | content       |
+      | test1.txt | some content1 |
+      | test2.txt | some content2 |
+      | test3.txt | some content3 |
+
+    Examples:
+      | permissionsRole |
+      | Edit            |
+      | View            |
+      | Upload          |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This test verifies that a public user can successfully download a ZIP archive of files from a shared folder inside a space using a public link.

- Sets up a space and folder structure with multiple uploaded files
- Creates a public resource link share for the folder with a password
- Fetches archive metadata via a PROPFIND request to the public WebDAV API
- Uses the retrieved metadata to download the archive from the public link
- Validates that the archive download request is successful with HTTP status 200

## Related Issue
https://github.com/owncloud/ocis/issues/12037

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
