### PR TITLE
feat(graph): [OCISDEV-807] add SpaceEditorWithoutVersionsWithoutTrashbin role

### DIFF
--- a/changelog/unreleased/add-space-editor-without-versions-without-trashbin-role.md
+++ b/changelog/unreleased/add-space-editor-without-versions-without-trashbin-role.md
@@ -1,0 +1,7 @@
+Enhancement: Add SpaceEditorWithoutVersionsWithoutTrashbin space membership role
+
+Added a new space membership role "Can edit" (SpaceEditorWithoutVersionsWithoutTrashbin)
+that grants full editor permissions (create, upload, download, edit, move, delete) on a
+space without access to file versions or the trashbin.
+
+https://github.com/owncloud/ocis/pull/12245

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/open-policy-agent/opa v1.12.3
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64
-	github.com/owncloud/reva/v2 v2.0.0-20260305165853-c9204c730c66
+	github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -744,6 +744,10 @@ github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64 h1:z
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
 github.com/owncloud/reva/v2 v2.0.0-20260305165853-c9204c730c66 h1:Krzzphe3EkE09Enxy6s5eIFPNF6Kodw/H8EcHo+jT+E=
 github.com/owncloud/reva/v2 v2.0.0-20260305165853-c9204c730c66/go.mod h1:eHbT6pmVlcjdiBeVEYw7exlfJmemMzKBh4R+HFgx9Cc=
+github.com/owncloud/reva/v2 v2.0.0-20260422074541-76ccb5a8a681 h1:OQggVr2fg23feOlcm/qgAUAgZjNDkYnJT7CKNwKyet8=
+github.com/owncloud/reva/v2 v2.0.0-20260422074541-76ccb5a8a681/go.mod h1:eHbT6pmVlcjdiBeVEYw7exlfJmemMzKBh4R+HFgx9Cc=
+github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5 h1:G0klmj4V7z7U1nYm0GzgEN+G4C/g5yajnG5FQdsF6ec=
+github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5/go.mod h1:eHbT6pmVlcjdiBeVEYw7exlfJmemMzKBh4R+HFgx9Cc=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.9 h1:njquRbBU7fuwIe5rEvtaniVBjwWzcpdUVptSgzFqZsw=

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -19,6 +19,7 @@ var (
 		unifiedrole.UnifiedRoleSecureViewerID,
 		unifiedrole.UnifiedRoleSpaceEditorWithoutVersionsID,
 		unifiedrole.UnifiedRoleSpaceEditorWithoutTrashbinID,
+		unifiedrole.UnifiedRoleSpaceEditorWithoutVersionsWithoutTrashbinID,
 		unifiedrole.UnifiedRoleViewerListGrantsID,
 		unifiedrole.UnifiedRoleEditorListGrantsID,
 		unifiedrole.UnifiedRoleEditorListGrantsWithVersionsID,

--- a/services/graph/pkg/unifiedrole/export_test.go
+++ b/services/graph/pkg/unifiedrole/export_test.go
@@ -8,8 +8,9 @@ var (
 	RoleEditorListGrants                 = roleEditorListGrants
 	RoleEditorListGrantsWithVersions     = roleEditorListGrantsWithVersions
 	RoleSpaceEditor                      = roleSpaceEditor
-	RoleSpaceEditorWithoutVersions       = roleSpaceEditorWithoutVersions
-	RoleSpaceEditorWithoutTrashbin       = roleSpaceEditorWithoutTrashbin
+	RoleSpaceEditorWithoutVersions                      = roleSpaceEditorWithoutVersions
+	RoleSpaceEditorWithoutVersionsWithoutTrashbin       = roleSpaceEditorWithoutVersionsWithoutTrashbin
+	RoleSpaceEditorWithoutTrashbin                      = roleSpaceEditorWithoutTrashbin
 	RoleFileEditor                       = roleFileEditor
 	RoleFileEditorListGrants             = roleFileEditorListGrants
 	RoleFileEditorListGrantsWithVersions = roleFileEditorListGrantsWithVersions

--- a/services/graph/pkg/unifiedrole/filter.go
+++ b/services/graph/pkg/unifiedrole/filter.go
@@ -53,6 +53,7 @@ func buildInRoles() []*libregraph.UnifiedRoleDefinition {
 		roleEditorListGrantsWithVersions(),
 		roleSpaceEditor(),
 		roleSpaceEditorWithoutVersions(),
+		roleSpaceEditorWithoutVersionsWithoutTrashbin(),
 		roleSpaceEditorWithoutTrashbin(),
 		roleFileEditor(),
 		roleFileEditorListGrants(),

--- a/services/graph/pkg/unifiedrole/roles.go
+++ b/services/graph/pkg/unifiedrole/roles.go
@@ -32,6 +32,8 @@ const (
 	UnifiedRoleSpaceEditorWithoutVersionsID = "3284f2d5-0070-4ad8-ac40-c247f7c1fb27"
 	// UnifiedRoleSpaceEditorWithoutTrashbinID Unified role space editor without list/restore resources in trashbin id.
 	UnifiedRoleSpaceEditorWithoutTrashbinID = "8f4701d9-c68f-4109-a482-88e22ee32805"
+	// UnifiedRoleSpaceEditorWithoutVersionsWithoutTrashbinID Unified role space editor without list/restore versions and without list/restore resources in trashbin id.
+	UnifiedRoleSpaceEditorWithoutVersionsWithoutTrashbinID = "a5f73816-4d4b-452d-8973-3b61c3d0bed4"
 	// UnifiedRoleFileEditorID Unified role file editor id.
 	UnifiedRoleFileEditorID = "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
 	// UnifiedRoleFileEditorListGrantsID Unified role file editor id.
@@ -203,9 +205,9 @@ var (
 
 	// Editor without Versions
 	// UnifiedRole SpaceEditorWithoutVersions, Role DisplayName (resolves directly)
-	_spaceEditorWithoutVersionsUnifiedRoleDisplayName = l10n.Template("Can edit")
+	_spaceEditorWithoutVersionsUnifiedRoleDisplayName = l10n.Template("Can edit with trashbin")
 	// UnifiedRole SpaceEditorWithoutVersions, Role Description (resolves directly)
-	_spaceEditorWithoutVersionsUnifiedRoleDescription = l10n.Template("View, download, upload, edit and add.")
+	_spaceEditorWithoutVersionsUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add, delete and restore from trash bin.")
 	// UnifiedRole SpaceEditorWithoutVersions, Permissions
 	_spaceEditorWithoutVersionsRole = conversions.NewSpaceEditorWithoutVersionsRole()
 
@@ -217,11 +219,19 @@ var (
 	// UnifiedRole SpaceEditorWithoutTrashbin, Permissions
 	_spaceEditorWithoutTrashbinRole = conversions.NewSpaceEditorWithoutTrashbinRole()
 
+	// Editor without Versions without Trashbin
+	// UnifiedRole SpaceEditorWithoutVersionsWithoutTrashbin, Role DisplayName (resolves directly)
+	_spaceEditorWithoutVersionsWithoutTrashbinUnifiedRoleDisplayName = l10n.Template("Can edit")
+	// UnifiedRole SpaceEditorWithoutVersionsWithoutTrashbin, Role Description (resolves directly)
+	_spaceEditorWithoutVersionsWithoutTrashbinUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add and delete.")
+	// UnifiedRole SpaceEditorWithoutVersionsWithoutTrashbin, Permissions
+	_spaceEditorWithoutVersionsWithoutTrashbinRole = conversions.NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
+
 	// Editor
 	// UnifiedRole SpaceEditor, Role DisplayName (resolves directly)
-	_spaceEditorUnifiedRoleDisplayName = l10n.Template("Can edit with versions and trashbin")
+	_spaceEditorUnifiedRoleDisplayName = l10n.Template("Can edit with versions and trash bin")
 	// UnifiedRole SpaceEditor, Role Description (resolves directly)
-	_spaceEditorUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add, show all versions and delete.")
+	_spaceEditorUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add, delete, show all versions and restore from trash bin.")
 	// UnifiedRole SpaceEditor, Permissions
 	_spaceEditorRole = conversions.NewSpaceEditorRole()
 
@@ -229,7 +239,7 @@ var (
 	// UnifiedRole Manager, Role DisplayName (resolves directly)
 	_managerUnifiedRoleDisplayName = l10n.Template("Can manage")
 	// UnifiedRole Manager, Role Description (resolves directly)
-	_managerUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add, show all versions, delete and manage members.")
+	_managerUnifiedRoleDescription = l10n.Template("View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members.")
 	// UnifiedRole Manager, Permissions
 	_managerRole = conversions.NewManagerRole()
 
@@ -243,7 +253,8 @@ var (
 		UnifiedRoleEditorListGrantsWithVersionsID:     "EditorListGrantsWithVersions",
 		UnifiedRoleSpaceEditorID:                      "SpaceEditor",
 		UnifiedRoleSpaceEditorWithoutVersionsID:       "SpaceEditorWithoutVersions",
-		UnifiedRoleSpaceEditorWithoutTrashbinID:       "SpaceEditorWithoutTrashbin",
+		UnifiedRoleSpaceEditorWithoutTrashbinID:                      "SpaceEditorWithoutTrashbin",
+		UnifiedRoleSpaceEditorWithoutVersionsWithoutTrashbinID:       "SpaceEditorWithoutVersionsWithoutTrashbin",
 		UnifiedRoleFileEditorID:                       "FileEditor",
 		UnifiedRoleFileEditorListGrantsID:             "FileEditorListGrants",
 		UnifiedRoleFileEditorListGrantsWithVersionsID: "FileEditorListGrantsWithVersions",
@@ -504,6 +515,22 @@ var (
 			RolePermissions: []libregraph.UnifiedRolePermission{
 				{
 					AllowedResourceActions: CS3ResourcePermissionsToLibregraphActions(_spaceViewerRole.CS3ResourcePermissions()),
+					Condition:              proto.String(UnifiedRoleConditionDrive),
+				},
+			},
+			LibreGraphWeight: proto.Int32(0),
+		}
+	}
+
+	// roleSpaceEditorWithoutVersionsWithoutTrashbin creates an editor without versions and without trashbin role
+	roleSpaceEditorWithoutVersionsWithoutTrashbin = func() *libregraph.UnifiedRoleDefinition {
+		return &libregraph.UnifiedRoleDefinition{
+			Id:          proto.String(UnifiedRoleSpaceEditorWithoutVersionsWithoutTrashbinID),
+			DisplayName: proto.String(_spaceEditorWithoutVersionsWithoutTrashbinUnifiedRoleDisplayName),
+			Description: proto.String(_spaceEditorWithoutVersionsWithoutTrashbinUnifiedRoleDescription),
+			RolePermissions: []libregraph.UnifiedRolePermission{
+				{
+					AllowedResourceActions: CS3ResourcePermissionsToLibregraphActions(_spaceEditorWithoutVersionsWithoutTrashbinRole.CS3ResourcePermissions()),
 					Condition:              proto.String(UnifiedRoleConditionDrive),
 				},
 			},

--- a/services/graph/pkg/unifiedrole/roles_test.go
+++ b/services/graph/pkg/unifiedrole/roles_test.go
@@ -188,6 +188,7 @@ func TestGetRolesByPermissions(t *testing.T) {
 			constraints:  unifiedrole.UnifiedRoleConditionDrive,
 			unifiedRoleDefinition: []*libregraph.UnifiedRoleDefinition{
 				unifiedrole.RoleSpaceViewer(),
+				unifiedrole.RoleSpaceEditorWithoutVersionsWithoutTrashbin(),
 				unifiedrole.RoleSpaceEditorWithoutVersions(),
 				unifiedrole.RoleSpaceEditorWithoutTrashbin(),
 				unifiedrole.RoleSpaceEditor(),

--- a/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
+++ b/tests/acceptance/features/apiGraph/roleManagementEndpoint.feature
@@ -296,10 +296,10 @@ Feature: permissions role definitions
                   "const": 0
                 },
                 "description": {
-                  "const": "View, download, upload, edit, add, show all versions and delete."
+                  "const": "View, download, upload, edit, add, delete, show all versions and restore from trash bin."
                 },
                 "displayName": {
-                  "const": "Can edit with versions and trashbin"
+                  "const": "Can edit with versions and trash bin"
                 },
                 "id": {
                   "const": "58c63c02-1d89-4572-916a-870abc5a1b7d"
@@ -491,7 +491,7 @@ Feature: permissions role definitions
                   "const": 0
                 },
                 "description": {
-                  "const": "View, download, upload, edit, add, show all versions, delete and manage members."
+                  "const": "View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members."
                 },
                 "displayName": {
                   "const": "Can manage"

--- a/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature
+++ b/tests/acceptance/features/apiSharingNgPermissions/listPermissions.feature
@@ -209,10 +209,10 @@ Feature: List a sharing permissions
                       "const": 2
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions and delete."
+                      "const": "View, download, upload, edit, add, delete, show all versions and restore from trash bin."
                     },
                     "displayName": {
-                      "const": "Can edit with versions and trashbin"
+                      "const": "Can edit with versions and trash bin"
                     },
                     "id": {
                       "const": "58c63c02-1d89-4572-916a-870abc5a1b7d"
@@ -232,7 +232,7 @@ Feature: List a sharing permissions
                       "const": 3
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions, delete and manage members."
+                      "const": "View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members."
                     },
                     "displayName": {
                       "const": "Can manage"
@@ -342,10 +342,10 @@ Feature: List a sharing permissions
                       "const": 2
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions and delete."
+                      "const": "View, download, upload, edit, add, delete, show all versions and restore from trash bin."
                     },
                     "displayName": {
-                      "const": "Can edit with versions and trashbin"
+                      "const": "Can edit with versions and trash bin"
                     },
                     "id": {
                       "const": "58c63c02-1d89-4572-916a-870abc5a1b7d"
@@ -365,7 +365,7 @@ Feature: List a sharing permissions
                       "const": 3
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions, delete and manage members."
+                      "const": "View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members."
                     },
                     "displayName": {
                       "const": "Can manage"
@@ -954,10 +954,10 @@ Feature: List a sharing permissions
                       "const": 2
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions and delete."
+                      "const": "View, download, upload, edit, add, delete, show all versions and restore from trash bin."
                     },
                     "displayName": {
-                      "const": "Can edit with versions and trashbin"
+                      "const": "Can edit with versions and trash bin"
                     },
                     "id": {
                       "const": "58c63c02-1d89-4572-916a-870abc5a1b7d"
@@ -978,7 +978,7 @@ Feature: List a sharing permissions
                       "const": 3
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions, delete and manage members."
+                      "const": "View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members."
                     },
                     "displayName": {
                       "const": "Can manage"
@@ -1077,10 +1077,10 @@ Feature: List a sharing permissions
                       "const": 2
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions and delete."
+                      "const": "View, download, upload, edit, add, delete, show all versions and restore from trash bin."
                     },
                     "displayName": {
-                      "const": "Can edit with versions and trashbin"
+                      "const": "Can edit with versions and trash bin"
                     },
                     "id": {
                       "const": "58c63c02-1d89-4572-916a-870abc5a1b7d"
@@ -1100,7 +1100,7 @@ Feature: List a sharing permissions
                       "const": 3
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions, delete and manage members."
+                      "const": "View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members."
                     },
                     "displayName": {
                       "const": "Can manage"
@@ -1361,10 +1361,10 @@ Feature: List a sharing permissions
                       "const": 2
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions and delete."
+                      "const": "View, download, upload, edit, add, delete, show all versions and restore from trash bin."
                     },
                     "displayName": {
-                      "const": "Can edit with versions and trashbin"
+                      "const": "Can edit with versions and trash bin"
                     },
                     "id": {
                       "const": "58c63c02-1d89-4572-916a-870abc5a1b7d"
@@ -1385,7 +1385,7 @@ Feature: List a sharing permissions
                       "const": 3
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions, delete and manage members."
+                      "const": "View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members."
                     },
                     "displayName": {
                       "const": "Can manage"
@@ -1703,10 +1703,10 @@ Feature: List a sharing permissions
                       "const": 2
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions and delete."
+                      "const": "View, download, upload, edit, add, delete, show all versions and restore from trash bin."
                     },
                     "displayName": {
-                      "const": "Can edit with versions and trashbin"
+                      "const": "Can edit with versions and trash bin"
                     },
                     "id": {
                       "const": "58c63c02-1d89-4572-916a-870abc5a1b7d"
@@ -1726,7 +1726,7 @@ Feature: List a sharing permissions
                       "const": 3
                     },
                     "description": {
-                      "const": "View, download, upload, edit, add, show all versions, delete and manage members."
+                      "const": "View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members."
                     },
                     "displayName": {
                       "const": "Can manage"
@@ -2332,7 +2332,7 @@ Feature: List a sharing permissions
                   ],
                   "properties": {
                     "displayName": {
-                      "const": "Can edit with versions and trashbin"
+                      "const": "Can edit with versions and trash bin"
                     }
                   }
                 },

--- a/tests/acceptance/features/cliCommands/listUnifiedRoles.feature
+++ b/tests/acceptance/features/cliCommands/listUnifiedRoles.feature
@@ -16,13 +16,14 @@ Feature: List unified roles
       | Editor                           | enabled  | View, download, upload, edit, add and delete.                                        |
       | EditorListGrants                 | disabled | View, download, upload, edit, add, delete and show all invited people.               |
       | EditorListGrantsWithVersions     | disabled | View, download, upload, edit, delete, show all versions and all invited people.      |
-      | SpaceEditor                      | enabled  | View, download, upload, edit, add, show all versions and delete.                     |
-      | SpaceEditorWithoutVersions       | disabled | View, download, upload, edit and add.                                                |
-      | SpaceEditorWithoutTrashbin       | disabled | View, download, upload, edit, add and show all versions.                             |
+      | SpaceEditor                              | enabled  | View, download, upload, edit, add, delete, show all versions and restore from trash bin.                         |
+      | SpaceEditorWithoutVersions               | disabled | View, download, upload, edit, add, delete and restore from trash bin.                                            |
+      | SpaceEditorWithoutTrashbin               | disabled | View, download, upload, edit, add and show all versions.                                                         |
+      | SpaceEditorWithoutVersionsWithoutTrashbin | disabled | View, download, upload, edit, add and delete.                                                                    |
       | FileEditor                       | enabled  | View, download, upload and edit.                                                     |
       | FileEditorListGrants             | disabled | View, download, upload, edit and show all invited people.                            |
       | FileEditorListGrantsWithVersions | disabled | View, download, upload, edit, show all versions and all invited people.              |
       | EditorLite                       | enabled  | View, download, upload, edit and add.                                                |
-      | Manager                          | enabled  | View, download, upload, edit, add, show all versions, delete and manage members.     |
+      | Manager                                   | enabled  | View, download, upload, edit, add, delete, show all versions, restore from trash bin, empty the trash bin and manage members. |
       | SecureViewer                     | disabled | View only documents, images and PDFs. Watermarks will be applied.                    |
       | Denied                           | disabled | Deny all access.                                                                     |

--- a/vendor/github.com/owncloud/reva/v2/pkg/conversions/role.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/conversions/role.go
@@ -53,6 +53,8 @@ const (
 	RoleSpaceEditorWithoutVersions = "spaceeditor-without-versions"
 	// RoleSpaceEditorWithoutTrashbin grants editor permission without list/restore resources in trashbin on a space.
 	RoleSpaceEditorWithoutTrashbin = "spaceeditor-without-trashbin"
+	// RoleSpaceEditorWithoutVersionsWithoutTrashbin grants editor permission without list/restore versions and without list/restore resources in trashbin on a space.
+	RoleSpaceEditorWithoutVersionsWithoutTrashbin = "spaceeditor-without-versions-without-trashbin"
 	// RoleFileEditor grants editor permission on a single file.
 	RoleFileEditor = "file-editor"
 	// RoleFileEditorListGrants grants editor permission on a single file.
@@ -183,6 +185,8 @@ func RoleFromName(name string) *Role {
 		return NewSpaceEditorRole()
 	case RoleSpaceEditorWithoutTrashbin:
 		return NewSpaceEditorWithoutTrashbinRole()
+	case RoleSpaceEditorWithoutVersionsWithoutTrashbin:
+		return NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
 	case RoleFileEditor:
 		return NewFileEditorRole()
 	case RoleFileEditorListGrants:
@@ -295,10 +299,10 @@ func NewEditorListGrantsWithVersionsRole() *Role {
 	return role
 }
 
-// NewSpaceEditorRole creates an editor role
-func NewSpaceEditorRole() *Role {
+// NewSpaceEditorWithoutVersionsWithoutTrashbinRole creates an editor role without list/restore versions and without list/restore resources in trashbin on a space.
+func NewSpaceEditorWithoutVersionsWithoutTrashbinRole() *Role {
 	return &Role{
-		Name: RoleSpaceEditor,
+		Name: RoleSpaceEditorWithoutVersionsWithoutTrashbin,
 		cS3ResourcePermissions: &provider.ResourcePermissions{
 			CreateContainer:      true,
 			Delete:               true,
@@ -307,12 +311,8 @@ func NewSpaceEditorRole() *Role {
 			InitiateFileDownload: true,
 			InitiateFileUpload:   true,
 			ListContainer:        true,
-			ListFileVersions:     true,
 			ListGrants:           true,
-			ListRecycle:          true,
 			Move:                 true,
-			RestoreFileVersion:   true,
-			RestoreRecycleItem:   true,
 			Stat:                 true,
 		},
 		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
@@ -321,46 +321,29 @@ func NewSpaceEditorRole() *Role {
 
 // NewSpaceEditorWithoutVersionsRole creates an editor without list/restore versions role
 func NewSpaceEditorWithoutVersionsRole() *Role {
-	return &Role{
-		Name: RoleSpaceEditorWithoutVersions,
-		cS3ResourcePermissions: &provider.ResourcePermissions{
-			CreateContainer:      true,
-			Delete:               true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
-			InitiateFileUpload:   true,
-			ListContainer:        true,
-			ListGrants:           true,
-			ListRecycle:          true,
-			Move:                 true,
-			RestoreRecycleItem:   true,
-			Stat:                 true,
-		},
-		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
-	}
+	role := NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
+	role.Name = RoleSpaceEditorWithoutVersions
+	role.cS3ResourcePermissions.ListRecycle = true
+	role.cS3ResourcePermissions.RestoreRecycleItem = true
+	return role
 }
 
 // NewSpaceEditorWithoutTrashbinRole creates an editor role without list/restore resources in trashbin on a space.
 func NewSpaceEditorWithoutTrashbinRole() *Role {
-	return &Role{
-		Name: RoleSpaceEditorWithoutTrashbin,
-		cS3ResourcePermissions: &provider.ResourcePermissions{
-			CreateContainer:      true,
-			Delete:               true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
-			InitiateFileUpload:   true,
-			ListContainer:        true,
-			ListFileVersions:     true,
-			ListGrants:           true,
-			Move:                 true,
-			RestoreFileVersion:   true,
-			Stat:                 true,
-		},
-		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
-	}
+	role := NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
+	role.Name = RoleSpaceEditorWithoutTrashbin
+	role.cS3ResourcePermissions.ListFileVersions = true
+	role.cS3ResourcePermissions.RestoreFileVersion = true
+	return role
+}
+
+// NewSpaceEditorRole creates an editor role
+func NewSpaceEditorRole() *Role {
+	role := NewSpaceEditorWithoutVersionsRole()
+	role.Name = RoleSpaceEditor
+	role.cS3ResourcePermissions.ListFileVersions = true
+	role.cS3ResourcePermissions.RestoreFileVersion = true
+	return role
 }
 
 // NewFileEditorRole creates a file-editor role

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1313,7 +1313,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20260305165853-c9204c730c66
+# github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5
 ## explicit; go 1.24.0
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
## Summary

- Adds new `SpaceEditorWithoutVersionsWithoutTrashbin` space membership role ("Can edit") that grants full editor permissions (create, upload, download, edit, move, delete) without access to file versions or the trashbin
- Excluded from default roles (opt-in via config, consistent with the other `SpaceEditor*` variants)
- Bumps reva to stable-8.0 after owncloud/reva#575

## Test plan

- [x] `go test ./services/graph/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)