### PR TITLE
build(deps): bump golang.org/x/image v0.38.0 to v0.39.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
-	golang.org/x/image v0.38.0
+	golang.org/x/image v0.39.0
 	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1039,8 +1039,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aI
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
-golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
-golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
+golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/vendor/golang.org/x/image/font/sfnt/sfnt.go
+++ b/vendor/golang.org/x/image/font/sfnt/sfnt.go
@@ -214,8 +214,9 @@ func u32(b []byte) uint32 {
 // copying from the source to a caller-supplied buffer, and instead provide
 // direct access to the underlying []byte data.
 type source struct {
-	b []byte
-	r io.ReaderAt
+	b       []byte
+	r       io.ReaderAt
+	minSize int // r is known to contain at least minSize bytes
 
 	// TODO: add a caching layer, if we're using the io.ReaderAt? Note that
 	// this might make a source no longer safe to use concurrently.
@@ -253,6 +254,17 @@ func (s *source) view(buf []byte, offset, length int) ([]byte, error) {
 			return nil, errInvalidBounds
 		}
 		return s.b[offset : offset+length], nil
+	}
+
+	if end := offset + length; end > s.minSize && length > 1<<20 {
+		// We're reading more than 1MiB, and we don't know whether
+		// the file contains this data. Check that the data exists
+		// before we try to allocate.
+		var oneByte [1]byte
+		if n, err := s.r.ReadAt(oneByte[:], int64(end)-1); err != nil || n != 1 {
+			return nil, errInvalidBounds
+		}
+		s.minSize = end
 	}
 
 	// Read from the io.ReaderAt.

--- a/vendor/golang.org/x/image/webp/decode.go
+++ b/vendor/golang.org/x/image/webp/decode.go
@@ -134,6 +134,12 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 			wantAlpha = (buf[0] & alphaBit) != 0
 			widthMinusOne = uint32(buf[4]) | uint32(buf[5])<<8 | uint32(buf[6])<<16
 			heightMinusOne = uint32(buf[7]) | uint32(buf[8])<<8 | uint32(buf[9])<<16
+			if uint64(widthMinusOne+1)*uint64(heightMinusOne+1) > 1<<32-1 {
+				// The product of _Canvas Width_ and _Canvas Height_ MUST be
+				// at most 2^32 - 1.
+				// https://www.rfc-editor.org/rfc/rfc9649.html#section-2.7-12
+				return nil, image.Config{}, errInvalidFormat
+			}
 			if configOnly {
 				if wantAlpha {
 					return nil, image.Config{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2281,7 +2281,7 @@ golang.org/x/exp/slices
 golang.org/x/exp/slog
 golang.org/x/exp/slog/internal
 golang.org/x/exp/slog/internal/buffer
-# golang.org/x/image v0.38.0
+# golang.org/x/image v0.39.0
 ## explicit; go 1.25.0
 golang.org/x/image/bmp
 golang.org/x/image/ccitt


### PR DESCRIPTION
build(deps): bump golang.org/x/image v0.38.0 to v0.39.0