### PR TITLE
fix(deps): [OCISDEV-822] bump reva to stable-8.0 HEAD (488fb352f5)

### DIFF
--- a/changelog/unreleased/fix-preserve-upload-bin-on-finalize-failure.md
+++ b/changelog/unreleased/fix-preserve-upload-bin-on-finalize-failure.md
@@ -1,0 +1,12 @@
+Bugfix: Preserve upload bin when synchronous blobstore finalization fails
+
+When a synchronous upload finalization failed (e.g. due to a transient NFS error during
+WriteBlob), decomposedfs deleted the bin file from uploads/ unconditionally. This made
+the blob permanently unrecoverable — including via move-stuck-upload-blobs — and caused
+affected nodes (e.g. received.json in the share manager metadata space) to fail on every
+access with "no such file or directory".
+
+Fixed by bumping reva to stable-8.0 HEAD (488fb352f5), which only cleans the bin file
+when Finalize succeeds.
+
+https://github.com/owncloud/ocis/pull/12264

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/open-policy-agent/opa v1.12.3
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64
-	github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5
+	github.com/owncloud/reva/v2 v2.0.0-20260424080655-488fb352f575
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -742,12 +742,8 @@ github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HD
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64 h1:z9djjzd+leAy6QZpi8dLy3OVjc/um+1XAGk1SJEvwE8=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
-github.com/owncloud/reva/v2 v2.0.0-20260305165853-c9204c730c66 h1:Krzzphe3EkE09Enxy6s5eIFPNF6Kodw/H8EcHo+jT+E=
-github.com/owncloud/reva/v2 v2.0.0-20260305165853-c9204c730c66/go.mod h1:eHbT6pmVlcjdiBeVEYw7exlfJmemMzKBh4R+HFgx9Cc=
-github.com/owncloud/reva/v2 v2.0.0-20260422074541-76ccb5a8a681 h1:OQggVr2fg23feOlcm/qgAUAgZjNDkYnJT7CKNwKyet8=
-github.com/owncloud/reva/v2 v2.0.0-20260422074541-76ccb5a8a681/go.mod h1:eHbT6pmVlcjdiBeVEYw7exlfJmemMzKBh4R+HFgx9Cc=
-github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5 h1:G0klmj4V7z7U1nYm0GzgEN+G4C/g5yajnG5FQdsF6ec=
-github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5/go.mod h1:eHbT6pmVlcjdiBeVEYw7exlfJmemMzKBh4R+HFgx9Cc=
+github.com/owncloud/reva/v2 v2.0.0-20260424080655-488fb352f575 h1:pY3TC7iXOwNRBMWO6NMID2UOk8sdZbrefY0U1UJAWoE=
+github.com/owncloud/reva/v2 v2.0.0-20260424080655-488fb352f575/go.mod h1:eHbT6pmVlcjdiBeVEYw7exlfJmemMzKBh4R+HFgx9Cc=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.9 h1:njquRbBU7fuwIe5rEvtaniVBjwWzcpdUVptSgzFqZsw=

--- a/vendor/github.com/owncloud/reva/v2/internal/http/services/ocmd/notifications.go
+++ b/vendor/github.com/owncloud/reva/v2/internal/http/services/ocmd/notifications.go
@@ -28,6 +28,7 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	ocmcore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/go-chi/render"
 	"github.com/owncloud/reva/v2/pkg/appctx"
@@ -43,7 +44,9 @@ const (
 // var validate = validator.New()
 
 type notifHandler struct {
-	gatewaySelector *pool.Selector[gateway.GatewayAPIClient]
+	gatewaySelector      *pool.Selector[gateway.GatewayAPIClient]
+	serviceAccountID     string
+	serviceAccountSecret string
 }
 
 func (h *notifHandler) init(c *config) error {
@@ -52,6 +55,8 @@ func (h *notifHandler) init(c *config) error {
 		return err
 	}
 	h.gatewaySelector = gatewaySelector
+	h.serviceAccountID = c.ServiceAccountID
+	h.serviceAccountSecret = c.ServiceAccountSecret
 
 	return nil
 }
@@ -161,6 +166,7 @@ func (h *notifHandler) handleShareUnshared(ctx context.Context, req *notificatio
 	return res.GetStatus(), nil
 }
 
+// Current implementation supports only WebDAV protocol permissions update
 func (h *notifHandler) handleShareChangePermission(ctx context.Context, req *notificationRequest) (*rpc.Status, error) {
 	gatewayClient, err := h.gatewaySelector.Next()
 	if err != nil {
@@ -171,17 +177,67 @@ func (h *notifHandler) handleShareChangePermission(ctx context.Context, req *not
 		return nil, fmt.Errorf("error getting protocols from notification")
 	}
 
+	// get the grantee user ID object
+	granteeUser, err := getUserIDFromOCMUser(req.Notification.Grantee)
+	if err != nil {
+		return nil, fmt.Errorf("error getting grantee user id: %w", err)
+	}
+
+	// authenticate as a service account
+	authCtx, err := utils.GetServiceUserContextWithContext(ctx, gatewayClient, h.serviceAccountID, h.serviceAccountSecret)
+	if err != nil {
+		return nil, fmt.Errorf("error authenticating as service account: %w", err)
+	}
+	ctx = authCtx
+
 	o := &typesv1beta1.Opaque{}
 	utils.AppendPlainToOpaque(o, "grantee", req.Notification.Grantee)
 	utils.AppendPlainToOpaque(o, "resourceType", req.ResourceType)
 
+	getRes, err := gatewayClient.GetReceivedOCMShare(ctx, &ocm.GetReceivedOCMShareRequest{
+		Opaque: utils.AppendJSONToOpaque(nil, "userid", granteeUser),
+		Ref: &ocm.ShareReference{
+			Spec: &ocm.ShareReference_Id{
+				Id: &ocm.ShareId{
+					OpaqueId: req.ProviderId,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting received ocm share: %w", err)
+	}
+	if getRes.Status.Code != rpc.Code_CODE_OK {
+		return getRes.Status, nil
+	}
+
+	share := getRes.Share
+	newProtocols := getProtocols(req.Notification.Protocols, o)
+
+	var newWebdav *ocm.WebDAVProtocol
+	for _, p := range newProtocols {
+		if wd := p.GetWebdavOptions(); wd != nil {
+			newWebdav = wd
+			break
+		}
+	}
+
+	if newWebdav != nil && newWebdav.Permissions != nil {
+		for _, p := range share.Protocols {
+			if wd := p.GetWebdavOptions(); wd != nil {
+				wd.Permissions = newWebdav.Permissions
+				break
+			}
+		}
+	}
+
 	res, err := gatewayClient.UpdateOCMCoreShare(ctx, &ocmcore.UpdateOCMCoreShareRequest{
 		OcmShareId: req.ProviderId,
-		Protocols:  getProtocols(req.Notification.Protocols, o),
+		Protocols:  share.Protocols,
 		Opaque:     o,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error calling DeleteOCMCoreShare: %w", err)
+		return nil, fmt.Errorf("error calling UpdateOCMCoreShare: %w", err)
 	}
 	return res.GetStatus(), nil
 }

--- a/vendor/github.com/owncloud/reva/v2/internal/http/services/ocmd/ocm.go
+++ b/vendor/github.com/owncloud/reva/v2/internal/http/services/ocmd/ocm.go
@@ -37,6 +37,8 @@ type config struct {
 	Prefix                     string `mapstructure:"prefix"`
 	GatewaySvc                 string `mapstructure:"gatewaysvc"                    validate:"required"`
 	ExposeRecipientDisplayName bool   `mapstructure:"expose_recipient_display_name"`
+	ServiceAccountID           string `mapstructure:"service_account_id"`
+	ServiceAccountSecret       string `mapstructure:"service_account_secret"`
 }
 
 func (c *config) ApplyDefaults() {

--- a/vendor/github.com/owncloud/reva/v2/pkg/auth/manager/publicshares/publicshares.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/auth/manager/publicshares/publicshares.go
@@ -27,6 +27,7 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/auth"
@@ -34,6 +35,7 @@ import (
 	"github.com/owncloud/reva/v2/pkg/auth/scope"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/owncloud/reva/v2/pkg/storage/utils/grants"
 	"github.com/owncloud/reva/v2/pkg/store"
 	"github.com/owncloud/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
@@ -160,6 +162,12 @@ func (m *manager) Authenticate(ctx context.Context, token, secret string) (*user
 		return nil, nil, errtypes.InvalidCredentials(publicShareResponse.Status.Message)
 	case publicShareResponse.Status.Code != rpcv1beta1.Code_CODE_OK:
 		return nil, nil, errtypes.InternalError(publicShareResponse.Status.Message)
+	}
+
+	// Reject internal links — they require authentication and cannot be accessed anonymously.
+	// An internal link has no effective permissions.
+	if grants.PermissionsEqual(publicShareResponse.GetShare().GetPermissions().GetPermissions(), &provider.ResourcePermissions{}) {
+		return nil, nil, errtypes.PermissionDenied("internal links require authentication and cannot be accessed anonymously")
 	}
 
 	var owner *user.User

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -238,7 +238,7 @@ func (session *OcisSession) FinishUploadDecomposed(ctx context.Context) error {
 	if !session.store.async || session.info.Size == 0 {
 		// handle postprocessing synchronously
 		err = session.Finalize(ctx)
-		session.Cleanup(err != nil, true, true, true)
+		session.Cleanup(err != nil, err == nil, true, true)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to upload")
 			return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1313,7 +1313,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20260116104114-10074a92be64
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20260422094911-a697030257f5
+# github.com/owncloud/reva/v2 v2.0.0-20260424080655-488fb352f575
 ## explicit; go 1.24.0
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
## Summary

- Bumps reva to `stable-8.0` HEAD (`488fb352f5`)
- Includes fix for decomposedfs permanently losing blobs when `WriteBlob` fails during synchronous finalization (`cleanBin` was unconditionally `true`, now only `true` on success)
- Blob loss caused affected nodes (e.g. `received.json` in the share manager metadata space) to fail on every access with "no such file or directory", breaking all share operations for the affected user

Related reva PR: https://github.com/owncloud/reva/pull/578

## Test plan

- [ ] Trigger a `WriteBlob` failure during synchronous finalization; confirm bin file is preserved in `uploads/`
- [ ] Confirm successful uploads still clean up the bin file normally
- [ ] Run `move-stuck-upload-blobs` after a failed finalization; confirm the bin is recoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)