### PR TITLE
[k6-test] ci: [OCISDEV-827] Add GitHub Actions workflow for k6 load tests

### DIFF
--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Show Grafana dashboard link
         if: always()
-        run: echo 'Grafana Dashboard: https://grafana.k6.infra.owncloud.works'
+        run: echo "Grafana Dashboard: https://grafana.k6.infra.owncloud.works"

--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -22,13 +22,13 @@ jobs:
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.title || '', 'k6-test'))
     env:
-      SSH_OCIS_REMOTE: ${{ secrets.K6_SSH_OCIS_REMOTE }}
-      SSH_OCIS_USERNAME: ${{ secrets.K6_SSH_OCIS_USER }}
-      SSH_OCIS_PASSWORD: ${{ secrets.K6_SSH_OCIS_PASS }}
-      TEST_SERVER_URL: ${{ secrets.K6_SSH_OCIS_SERVER_URL }}
-      SSH_K6_REMOTE: ${{ secrets.K6_SSH_K6_REMOTE }}
-      SSH_K6_USERNAME: ${{ secrets.K6_SSH_K6_USER }}
-      SSH_K6_PASSWORD: ${{ secrets.K6_SSH_K6_PASS }}
+      SSH_OCIS_REMOTE: ${{ secrets.SSH_OCIS_REMOTE }}
+      SSH_OCIS_USERNAME: ${{ secrets.SSH_OCIS_USERNAME }}
+      SSH_OCIS_PASSWORD: ${{ secrets.SSH_OCIS_PASSWORD }}
+      TEST_SERVER_URL: ${{ secrets.TEST_SERVER_URL }}
+      SSH_K6_REMOTE: ${{ secrets.SSH_K6_REMOTE }}
+      SSH_K6_USERNAME: ${{ secrets.SSH_K6_USERNAME }}
+      SSH_K6_PASSWORD: ${{ secrets.SSH_K6_PASSWORD }}
       DRONE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -45,4 +45,5 @@ jobs:
 
       - name: Show Grafana dashboard link
         if: always()
-        run: echo "Grafana Dashboard: https://grafana.k6.infra.owncloud.works"
+        run: |
+          echo "Grafana Dashboard: https://grafana.k6.infra.owncloud.works"

--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -20,7 +20,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.title, 'k6-test'))
+       contains(github.event.pull_request.title || '', 'k6-test'))
     env:
       SSH_OCIS_REMOTE: ${{ secrets.K6_SSH_OCIS_REMOTE }}
       SSH_OCIS_USERNAME: ${{ secrets.K6_SSH_OCIS_USER }}

--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -1,0 +1,48 @@
+name: k6 Load Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  k6-load-test:
+    name: k6-load-test
+    runs-on: ubuntu-latest
+    container:
+      image: owncloudci/alpine:latest
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.title, 'k6-test'))
+    env:
+      SSH_OCIS_REMOTE: ${{ secrets.K6_SSH_OCIS_REMOTE }}
+      SSH_OCIS_USERNAME: ${{ secrets.K6_SSH_OCIS_USER }}
+      SSH_OCIS_PASSWORD: ${{ secrets.K6_SSH_OCIS_PASS }}
+      TEST_SERVER_URL: ${{ secrets.K6_SSH_OCIS_SERVER_URL }}
+      SSH_K6_REMOTE: ${{ secrets.K6_SSH_K6_REMOTE }}
+      SSH_K6_USERNAME: ${{ secrets.K6_SSH_K6_USER }}
+      SSH_K6_PASSWORD: ${{ secrets.K6_SSH_K6_PASS }}
+      DRONE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install SSH dependencies
+        run: apk add --no-cache openssh-client sshpass
+
+      - name: Run k6 load tests
+        run: sh tests/config/drone/run_k6_tests.sh
+
+      - name: Retrieve OCIS logs
+        if: always()
+        run: sh tests/config/drone/run_k6_tests.sh --ocis-log
+
+      - name: Show Grafana dashboard link
+        if: always()
+        run: echo 'Grafana Dashboard: https://grafana.k6.infra.owncloud.works'

--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -29,7 +29,7 @@ jobs:
       SSH_K6_REMOTE: ${{ secrets.SSH_K6_REMOTE }}
       SSH_K6_USERNAME: ${{ secrets.SSH_K6_USERNAME }}
       SSH_K6_PASSWORD: ${{ secrets.SSH_K6_PASSWORD }}
-      DRONE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      OCIS_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/tests/config/drone/run_k6_tests.sh
+++ b/tests/config/drone/run_k6_tests.sh
@@ -12,7 +12,7 @@ fi
 # start ocis server
 sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" \
     "OCIS_URL=${TEST_SERVER_URL} \
-    OCIS_COMMIT_ID=${DRONE_COMMIT} \
+    OCIS_COMMIT_ID=${OCIS_COMMIT_SHA} \
     bash ~/scripts/ocis.sh start"
 
 # wait for ocis to be ready (via SSH since TEST_SERVER_URL is on a private network)

--- a/tests/config/drone/run_k6_tests.sh
+++ b/tests/config/drone/run_k6_tests.sh
@@ -2,21 +2,43 @@
 
 set -e
 
+SSH_OPTS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+
 if [ "$1" = "--ocis-log" ]; then
-    sshpass -p "$SSH_OCIS_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" "bash ~/scripts/ocis.sh log"
+    sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" "bash ~/scripts/ocis.sh log"
     exit 0
 fi
 
 # start ocis server
-sshpass -p "$SSH_OCIS_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" \
+sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" \
     "OCIS_URL=${TEST_SERVER_URL} \
     OCIS_COMMIT_ID=${DRONE_COMMIT} \
     bash ~/scripts/ocis.sh start"
 
+# wait for ocis to be ready (via SSH since TEST_SERVER_URL is on a private network)
+echo "Waiting for OCIS to be ready at ${TEST_SERVER_URL}..."
+RETRIES=0
+MAX_RETRIES=24
+until [ "$RETRIES" -ge "$MAX_RETRIES" ]; do
+    STATUS=$(sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" \
+        "curl -s -o /dev/null -w '%{http_code}' -k '${TEST_SERVER_URL}/.well-known/openid-configuration'" 2>/dev/null || echo "000")
+    if [ "$STATUS" = "200" ]; then
+        echo "OCIS is ready (HTTP ${STATUS})"
+        break
+    fi
+    RETRIES=$((RETRIES + 1))
+    echo "OCIS not ready (HTTP ${STATUS}), retrying in 5s... (${RETRIES}/${MAX_RETRIES})"
+    sleep 5
+done
+if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "ERROR: OCIS did not become ready within $((MAX_RETRIES * 5))s"
+    exit 1
+fi
+
 # start k6 tests
-sshpass -p "$SSH_K6_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_K6_USERNAME@$SSH_K6_REMOTE" \
+sshpass -p "$SSH_K6_PASSWORD" ssh $SSH_OPTS "$SSH_K6_USERNAME@$SSH_K6_REMOTE" \
     "TEST_SERVER_URL=${TEST_SERVER_URL} \
     bash ~/scripts/k6-tests.sh"
 
 # stop ocis server
-sshpass -p "$SSH_OCIS_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" "bash ~/scripts/ocis.sh stop"
+sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" "bash ~/scripts/ocis.sh stop"


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow (`.github/workflows/k6-load-test.yml`) that replicates the existing Drone CI k6 load test pipeline
- Triggers on PRs with "k6-test" in the title (case-insensitive), daily schedule, or manual dispatch
- Reuses the existing `tests/config/drone/run_k6_tests.sh` script with the same SSH-based remote execution model

## Details
Migrates the k6 load test pipeline from Drone (`.drone.star` `k6LoadTests` function) to GitHub Actions:
- Runs in `owncloudci/alpine:latest` container (same image as Drone)
- Maps 7 Drone secrets to GitHub Actions secrets (`SSH_OCIS_REMOTE`, `SSH_OCIS_USERNAME`, `SSH_OCIS_PASSWORD`, `TEST_SERVER_URL`, `SSH_K6_REMOTE`, `SSH_K6_USERNAME`, `SSH_K6_PASSWORD`)
- Replaces Drone-specific `DRONE_COMMIT` env var with `OCIS_COMMIT_SHA` set from `github.event.pull_request.head.sha || github.sha`
- OCIS log retrieval and Grafana dashboard link steps run on success or failure (`if: always()`)
- Adds OCIS health check (polls `/.well-known/openid-configuration` via SSH on the OCIS remote, up to 120s) before starting k6 tests
- Adds SSH keepalive (`ServerAliveInterval=60`, `ServerAliveCountMax=10`) to prevent broken pipe disconnects during long test runs

## Test plan
- [x] Verify the 7 GitHub secrets are created in repo Settings > Secrets and variables > Actions
- [x] Open a PR with "k6-test" in the title — workflow should trigger and job should run
- [x] Open a PR without "k6-test" — workflow triggers but job is skipped
- [x] Edit a PR title to add "k6-test" — workflow re-triggers via `edited` event
- [ ] Test `workflow_dispatch` from the Actions tab
- [x] Verify "Waiting for OCIS to be ready" / "OCIS is ready" messages appear in logs
- [x] Verify SSH session survives the full k6 test run without broken pipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)