### PR TITLE
ci: [k6-test] [OCISDEV-833] Clean up remote OCIS directory before start

### DIFF
--- a/tests/config/drone/run_k6_tests.sh
+++ b/tests/config/drone/run_k6_tests.sh
@@ -9,6 +9,9 @@ if [ "$1" = "--ocis-log" ]; then
     exit 0
 fi
 
+# clean up from previous runs
+sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" "rm -rf k6-ocis"
+
 # start ocis server
 sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" \
     "OCIS_URL=${TEST_SERVER_URL} \


### PR DESCRIPTION
## Related Issue
- Fixes [#OCISDEV-833](https://kiteworks.atlassian.net/browse/OCISDEV-833)

## Summary
- Remove `k6-ocis` directory on the remote OCIS host before calling `ocis.sh start`, preventing `mkdir: cannot create directory 'k6-ocis': File exists` errors when a previous run left state behind.