### PR TITLE
[full-ci] chore: bump web version to 12.3.3

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for UI tests
-WEB_COMMITID=d6ad32c81d05f9f1d572a59629a6203b63352e7d
+WEB_COMMITID=39d6215da6daa184cd2365966915a659bdbd2c8b
 WEB_BRANCH=stable-12.3

--- a/changelog/unreleased/enhancement-bump-web-to-12.3.3.md
+++ b/changelog/unreleased/enhancement-bump-web-to-12.3.3.md
@@ -1,0 +1,8 @@
+Enhancement: Bump Web to 12.3.3
+
+- Bugfix [owncloud/web#13638](https://github.com/owncloud/web/pull/13638): Share button not usable when role dropdown text is too long
+- Bugfix [owncloud/web#13667](https://github.com/owncloud/web/pull/13667): Shared with does not show members
+- Bugfix [owncloud/web#13680](https://github.com/owncloud/web/pull/13680): Escape strings when returned from server
+
+https://github.com/owncloud/web/pull/13705
+https://github.com/owncloud/web/releases/tag/v12.3.3

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v12.3.2
+WEB_ASSETS_VERSION = v12.3.3
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
Bump Web to 12.3.3

- Bugfix [owncloud/web#13638](https://github.com/owncloud/web/pull/13638): Share button not usable when role dropdown text is too long
- Bugfix [owncloud/web#13667](https://github.com/owncloud/web/pull/13667): Shared with does not show members
- Bugfix [owncloud/web#13680](https://github.com/owncloud/web/pull/13680): Escape strings when returned from server

https://github.com/owncloud/web/pull/13705
https://github.com/owncloud/web/releases/tag/v12.3.3