### PR TITLE
fix: remove default ocis image type from ocis_full (set in .env already)

### DIFF
--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -38,10 +38,9 @@ TRAEFIK_ACME_CASERVER=
 # Disable only for testing purposes.
 # Note: the leading colon is required to enable the service.
 OCIS=:ocis.yml
-# The oCIS container image.
+# The oCIS container image type, must not be undefined.
 # For production releases: "owncloud/ocis"
 # For rolling releases:    "owncloud/ocis-rolling"
-# Defaults to production if not set otherwise
 OCIS_DOCKER_IMAGE=owncloud/ocis
 # The oCIS container version.
 # Defaults to "latest" and points to the latest stable tag.

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -12,7 +12,7 @@ services:
       GRAPH_AVAILABLE_ROLES: "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6"
 
   collaboration:
-    image: ${OCIS_DOCKER_IMAGE:-owncloud/ocis}:${OCIS_DOCKER_TAG}
+    image: ${OCIS_DOCKER_IMAGE}:${OCIS_DOCKER_TAG}
     networks:
       ocis-net:
     depends_on:

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -6,7 +6,7 @@ services:
         aliases:
           - ${OCIS_DOMAIN:-ocis.owncloud.test}
   ocis:
-    image: ${OCIS_DOCKER_IMAGE:-owncloud/ocis}:${OCIS_DOCKER_TAG}
+    image: ${OCIS_DOCKER_IMAGE}:${OCIS_DOCKER_TAG}
     # changelog: https://github.com/owncloud/ocis/tree/master/changelog
     # release notes: https://doc.owncloud.com/ocis_release_notes.html
     networks:

--- a/deployments/examples/ocis_full/onlyoffice.yml
+++ b/deployments/examples/ocis_full/onlyoffice.yml
@@ -7,7 +7,7 @@ services:
           - ${ONLYOFFICE_DOMAIN:-onlyoffice.owncloud.test}
 
   collaboration-oo:
-    image: ${OCIS_DOCKER_IMAGE:-owncloud/ocis}:${OCIS_DOCKER_TAG}
+    image: ${OCIS_DOCKER_IMAGE}:${OCIS_DOCKER_TAG}
     networks:
       ocis-net:
     depends_on:


### PR DESCRIPTION
To be consistent with other image definitions, we remove the default image for ocis from all the yml files.
This has been done for the tag already, the type was a left-over that needed to be cleaned up.