### PR TITLE
ci: [k6-test] [backport-8.0] [OCISDEV-835] Added rm -rf k6-ocis via SSH before ocis.sh start

### DIFF
--- a/tests/config/drone/run_k6_tests.sh
+++ b/tests/config/drone/run_k6_tests.sh
@@ -9,6 +9,9 @@ if [ "$1" = "--ocis-log" ]; then
     exit 0
 fi
 
+# clean up from previous runs
+sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" "rm -rf k6-ocis"
+
 # start ocis server
 sshpass -p "$SSH_OCIS_PASSWORD" ssh $SSH_OPTS "$SSH_OCIS_USERNAME@$SSH_OCIS_REMOTE" \
     "OCIS_URL=${TEST_SERVER_URL} \


### PR DESCRIPTION
## Description
Fix for failing pipeline job when restarting the `k6 load test` job more than once

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [#OCISDEV-835](https://kiteworks.atlassian.net/browse/OCISDEV-835)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- test environment: running the CI pipeline job
- 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
