### PR TITLE
ci: [k6-test] [OCISDEV-842] Add concurrency group for each job with [k6-test] flag

### DIFF
--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: k6-load-test-server
+  cancel-in-progress: false
+
 jobs:
   k6-load-test:
     name: k6-load-test


### PR DESCRIPTION
## Summary

- Adds a `concurrency` group (`k6-load-test-server`) to the k6 Load Test workflow to ensure only one workflow run SSHs into the shared real servers at a time
- Uses `cancel-in-progress: false` so queued runs wait instead of cancelling in-progress ones

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [#OCISDEV-842](https://kiteworks.atlassian.net/browse/OCISDEV-842)

## Test plan

- [ ] Trigger two workflow runs simultaneously (e.g., two PRs with "k6-test" in the title)
- [ ] Confirm in the Actions tab that the second run shows "Queued" while the first is running
- [ ] Confirm the second run starts automatically after the first completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)