### PR TITLE
fix(proxy): [OCISDEV-845] skip space reconciliation on signed URL requests

### DIFF
--- a/changelog/unreleased/fix-space-manager-signed-url.md
+++ b/changelog/unreleased/fix-space-manager-signed-url.md
@@ -1,0 +1,15 @@
+Bugfix: Fix space management middleware removing users from spaces on download
+
+The space management middleware ran on every authenticated request, including
+signed URL requests used for file downloads. Since signed URL auth does not
+carry OIDC claims, the middleware interpreted the absence of claims as "user
+should have no space access" and removed the user from all project spaces.
+On the next OIDC request the user was re-added, causing an oscillating
+add/remove cycle that led to intermittent download failures and transient
+"space not found" errors.
+
+The middleware now skips reconciliation entirely when no OIDC claims are
+present in the request context.
+
+https://github.com/owncloud/ocis/pull/12285
+https://github.com/owncloud/ocis/issues/12285

--- a/services/proxy/pkg/middleware/space_manager.go
+++ b/services/proxy/pkg/middleware/space_manager.go
@@ -68,6 +68,10 @@ func (csm claimSpaceManager) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		// no user in context, we omit this request
 		return
 	}
+	if spaceAssignments == nil {
+		// no OIDC claims available (e.g. signed URL auth), skip reconciliation
+		return
+	}
 
 	ctx, gwc, err := csm.getCtx()
 	if err != nil {
@@ -153,9 +157,15 @@ func (csm claimSpaceManager) evaluateContext(ctx context.Context) (string, map[s
 	return u.GetId().GetOpaqueId(), csm.getSpaceAssignments(ctx)
 }
 
-// returns a map[spaceID]role
+// returns a map[spaceID]role or nil if no OIDC claims are available in the context
 func (csm claimSpaceManager) getSpaceAssignments(ctx context.Context) map[string]string {
 	claims := oidc.FromContext(ctx)
+	if claims == nil {
+		// No OIDC claims in context (e.g. signed URL auth). Skip reconciliation
+		// to avoid removing the user from all spaces.
+		return nil
+	}
+
 	values, ok := claims[csm.claimName].([]any)
 	if !ok {
 		csm.logger.Error().Interface("claims", claims).Str("claimname", csm.claimName).Msg("configured claims are not an array")


### PR DESCRIPTION
## Summary

- Fix space management middleware removing users from all project spaces on signed URL (download) requests
- When no OIDC claims are in the request context (signed URL auth), the middleware now skips reconciliation entirely instead of interpreting absent claims as "user should have no access"
- Resolves intermittent download failures and transient "space not found" errors in EOSC environments

## Technical Details

`getSpaceAssignments()` now returns `nil` (not empty map) when `oidc.FromContext(ctx)` is nil, and `ServeHTTP` skips processing when assignments are nil. This distinguishes "no claims available" from "claims say no access".

## Test plan

- [ ] Deploy to EOSC test environment running claim-based space management
- [ ] Verify file downloads from project spaces succeed consistently
- [ ] Verify no more SpaceShared/SpaceUnshared oscillation in logs
- [ ] Verify OIDC-authenticated requests still correctly reconcile space memberships

Fixes: https://kiteworks.atlassian.net/browse/OCISDEV-845

🤖 Generated with [Claude Code](https://claude.com/claude-code)