### PR TITLE
ci: [k6-test] [OCISDEV-847] Add checks for if not cancelled()

### DIFF
--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -41,13 +41,14 @@ jobs:
         run: apk add --no-cache openssh-client sshpass
 
       - name: Run k6 load tests
+        if: ${{ !cancelled() }}
         run: sh tests/config/drone/run_k6_tests.sh
 
       - name: Retrieve OCIS logs
-        if: always()
+        if: ${{ !cancelled() }}
         run: sh tests/config/drone/run_k6_tests.sh --ocis-log
 
       - name: Show Grafana dashboard link
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           echo "Grafana Dashboard: https://grafana.k6.infra.owncloud.works"


### PR DESCRIPTION
## Summary

- Replace `if: always()` with `if: ${{ !cancelled() }}` on the "Retrieve OCIS logs" and "Show Grafana dashboard link" steps
- Add `if: ${{ !cancelled() }}` to the "Run k6 load tests" step

This ensures the steps run on success and failure but are skipped when the workflow is manually cancelled, avoiding unnecessary SSH connections to the remote server after a cancel.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [#OCISDEV-847](https://kiteworks.atlassian.net/browse/OCISDEV-847)


## Test plan

- [x] Trigger a PR with `[k6-test]` in the title and let it complete — all steps should run
- [x] Trigger and then manually cancel a run — the three steps should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)