### PR TITLE
feat(settings): [OCISDEV-869] add VaultMode permission

### DIFF
--- a/changelog/unreleased/add-vault-mode-permission.md
+++ b/changelog/unreleased/add-vault-mode-permission.md
@@ -1,0 +1,7 @@
+Enhancement: Add VaultMode permission
+
+Add a new `VaultMode.ReadWriteEnabled` permission that gates the visibility of the
+vault mode switcher in the web UI. The permission is assigned to the admin,
+space admin and user roles. The user light role does not receive it.
+
+https://github.com/owncloud/ocis/pull/12328

--- a/services/settings/pkg/store/defaults/defaults.go
+++ b/services/settings/pkg/store/defaults/defaults.go
@@ -142,6 +142,7 @@ func generateBundleAdminRole() *settingsmsg.Bundle {
 			SetProjectSpaceQuotaPermission(All),
 			SettingsManagementPermission(All),
 			SpaceAbilityPermission(All),
+			VaultModePermission(Own),
 			WriteFavoritesPermission(Own),
 		},
 	}
@@ -183,6 +184,7 @@ func generateBundleSpaceAdminRole() *settingsmsg.Bundle {
 			SelfManagementPermission(Own),
 			SetProjectSpaceQuotaPermission(All),
 			SpaceAbilityPermission(All),
+			VaultModePermission(Own),
 			WriteFavoritesPermission(Own),
 		},
 	}
@@ -217,6 +219,7 @@ func generateBundleUserRole() *settingsmsg.Bundle {
 			LanguageManagementPermission(Own),
 			ListFavoritesPermission(Own),
 			SelfManagementPermission(Own),
+			VaultModePermission(Own),
 			WriteFavoritesPermission(Own),
 		},
 	}

--- a/services/settings/pkg/store/defaults/permissions.go
+++ b/services/settings/pkg/store/defaults/permissions.go
@@ -622,6 +622,25 @@ func SpaceAbilityPermission(c settingsmsg.Permission_Constraint) *settingsmsg.Se
 	}
 }
 
+// VaultModePermission is the permission to see and toggle the vault mode switcher
+func VaultModePermission(c settingsmsg.Permission_Constraint) *settingsmsg.Setting {
+	return &settingsmsg.Setting{
+		Id:          "cc29df49-f86a-4d23-be72-f873f6f1e55d",
+		Name:        "VaultMode.ReadWriteEnabled",
+		DisplayName: "Vault mode",
+		Description: "This permission allows seeing the vault mode switcher.",
+		Resource: &settingsmsg.Resource{
+			Type: settingsmsg.Resource_TYPE_SYSTEM,
+		},
+		Value: &settingsmsg.Setting_PermissionValue{
+			PermissionValue: &settingsmsg.Permission{
+				Operation:  settingsmsg.Permission_OPERATION_READWRITE,
+				Constraint: c,
+			},
+		},
+	}
+}
+
 // WriteFavoritesPermission is the permission to mark/unmark files as favorites
 func WriteFavoritesPermission(c settingsmsg.Permission_Constraint) *settingsmsg.Setting {
 	return &settingsmsg.Setting{


### PR DESCRIPTION
## Description
Adds a new `VaultMode.ReadWriteEnabled` permission to the settings service that gates the visibility of the vault mode switcher in the web UI. The permission is assigned to the `admin`, `spaceadmin` and `user` role bundles. The `user-light` role intentionally does not receive it.

## Related Issue
- OCISDEV-869 (sub-task of OCISDEV-527 — *Only show view switcher for specific users*)

## Motivation and Context
Sub-task of OCISDEV-527: the web frontend needs a permission flag it can read to decide whether to render the vault mode switcher for the current user. This change introduces that permission and seeds it into the appropriate built-in roles.

## How Has This Been Tested?
- test environment: local build (`make -C ocis build`)
- test case 1: `make -C services/settings test` — all unit tests pass
- test case 2: `go build ./services/settings/...` and full `ocis` binary build succeed

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>

🤖 Generated with [Claude Code](https://claude.com/claude-code)