### PR TITLE
feat: expose MFA session duration as configurable capability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/open-policy-agent/opa v1.12.3
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
-	github.com/owncloud/reva/v2 v2.0.0-20260521074552-d5606d565e45
+	github.com/owncloud/reva/v2 v2.0.0-20260521084623-a3fad40c3868
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -737,8 +737,8 @@ github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HD
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245 h1:JRidLTAKhnvyLMRtVtSF4lhBa0NSAOs6fof+d6JnKII=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
-github.com/owncloud/reva/v2 v2.0.0-20260521074552-d5606d565e45 h1:9sKXesgq5vMgsZI2Rwn3sKv9LLzf37T+QR4CC/9HMOQ=
-github.com/owncloud/reva/v2 v2.0.0-20260521074552-d5606d565e45/go.mod h1:oHjvB9PhfF8QqiNGz7Hd4AVvR7CSPx3CLVRxUzmjK0w=
+github.com/owncloud/reva/v2 v2.0.0-20260521084623-a3fad40c3868 h1:O27SKPxuJrzsrG6ulB55WSb0dGdTukGtBLWLNgGN7vQ=
+github.com/owncloud/reva/v2 v2.0.0-20260521084623-a3fad40c3868/go.mod h1:oHjvB9PhfF8QqiNGz7Hd4AVvR7CSPx3CLVRxUzmjK0w=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.9 h1:njquRbBU7fuwIe5rEvtaniVBjwWzcpdUVptSgzFqZsw=

--- a/services/frontend/pkg/config/config.go
+++ b/services/frontend/pkg/config/config.go
@@ -207,6 +207,7 @@ type Validation struct {
 
 // MFAConfig configures multi factor multifactor authentication
 type MFAConfig struct {
-	Enabled        bool     `yaml:"enabled" env:"OCIS_MFA_ENABLED" desc:"Set to true to enable multi factor authentication. See the documentation for more details." introductionVersion:"7.3.0"`
-	AuthLevelNames []string `yaml:"auth_level_names" env:"OCIS_MFA_AUTH_LEVEL_NAMES" desc:"This authentication level name indicates that multi-factor authentication was performed. The name must match the ACR claim in the access token received. Note: If multiple names are required, use a comma-separated list. The front-end service will use the first name in the list when requesting multi-factor authentication (MFA)." introductionVersion:"7.3.0"`
+	Enabled         bool     `yaml:"enabled" env:"OCIS_MFA_ENABLED" desc:"Set to true to enable multi factor authentication. See the documentation for more details." introductionVersion:"7.3.0"`
+	AuthLevelNames  []string `yaml:"auth_level_names" env:"OCIS_MFA_AUTH_LEVEL_NAMES" desc:"This authentication level name indicates that multi-factor authentication was performed. The name must match the ACR claim in the access token received. Note: If multiple names are required, use a comma-separated list. The front-end service will use the first name in the list when requesting multi-factor authentication (MFA)." introductionVersion:"7.3.0"`
+	SessionDuration int      `yaml:"session_duration" env:"OCIS_MFA_SESSION_DURATION" desc:"The duration in seconds that a multi-factor authentication session is valid. After this time the user will be prompted to re-authenticate. Defaults to 3600 (1 hour)." introductionVersion:"8.1.0"`
 }

--- a/services/frontend/pkg/config/defaults/defaultconfig.go
+++ b/services/frontend/pkg/config/defaults/defaultconfig.go
@@ -142,7 +142,8 @@ func DefaultConfig() *config.Config {
 			MaxTagLength: 100,
 		},
 		MultiFactorAuthentication: config.MFAConfig{
-			AuthLevelNames: []string{"advanced"},
+			AuthLevelNames:  []string{"advanced"},
+			SessionDuration: 3600,
 		},
 	}
 }

--- a/services/frontend/pkg/revaconfig/config.go
+++ b/services/frontend/pkg/revaconfig/config.go
@@ -347,8 +347,9 @@ func FrontendConfigFromStruct(cfg *config.Config, logger log.Logger) (map[string
 							},
 							"auth": map[string]interface{}{
 								"mfa": map[string]interface{}{
-									"enabled":    cfg.MultiFactorAuthentication.Enabled,
-									"levelnames": cfg.MultiFactorAuthentication.AuthLevelNames,
+									"enabled":          cfg.MultiFactorAuthentication.Enabled,
+									"levelnames":       cfg.MultiFactorAuthentication.AuthLevelNames,
+									"session_duration": cfg.MultiFactorAuthentication.SessionDuration,
 								},
 							},
 							"vault": map[string]interface{}{

--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -130,8 +130,9 @@ type JWKS struct {
 }
 
 type MFAConfig struct {
-	Enabled        bool     `yaml:"enabled" env:"OCIS_MFA_ENABLED" desc:"Enable MFA enforcement. If enabled users need to complete MFA before they can access specific paths" introductionVersion:"7.3.0"`
-	AuthLevelNames []string `yaml:"auth_level_name" env:"OCIS_MFA_AUTH_LEVEL_NAMES" desc:"This authentication level name indicates that multi-factor authentication was performed. The name must match the ACR claim in the access token received. Note: If multiple names are required, use a comma-separated list. The front-end service will use the first name in the list when requesting multi-factor authentication (MFA)." introductionVersion:"7.3.0"`
+	Enabled         bool     `yaml:"enabled" env:"OCIS_MFA_ENABLED" desc:"Enable MFA enforcement. If enabled users need to complete MFA before they can access specific paths" introductionVersion:"7.3.0"`
+	AuthLevelNames  []string `yaml:"auth_level_name" env:"OCIS_MFA_AUTH_LEVEL_NAMES" desc:"This authentication level name indicates that multi-factor authentication was performed. The name must match the ACR claim in the access token received. Note: If multiple names are required, use a comma-separated list. The front-end service will use the first name in the list when requesting multi-factor authentication (MFA)." introductionVersion:"7.3.0"`
+	SessionDuration int      `yaml:"session_duration" env:"OCIS_MFA_SESSION_DURATION" desc:"The duration in seconds that a multi-factor authentication session is valid for non-OIDC requests. Defaults to 3600 (1 hour)." introductionVersion:"7.3.0"`
 }
 
 // Cache is a TTL cache configuration.

--- a/services/proxy/pkg/config/defaults/defaultconfig.go
+++ b/services/proxy/pkg/config/defaults/defaultconfig.go
@@ -101,7 +101,8 @@ func DefaultConfig() *config.Config {
 			EnableTLS: false,
 		},
 		MultiFactorAuthentication: config.MFAConfig{
-			AuthLevelNames: []string{"advanced"},
+			AuthLevelNames:  []string{"advanced"},
+			SessionDuration: 3600,
 		},
 	}
 }

--- a/services/proxy/pkg/middleware/mfa.go
+++ b/services/proxy/pkg/middleware/mfa.go
@@ -13,33 +13,37 @@ import (
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
 )
 
-// mfaStoreTTL is how long a verified MFA status is remembered for non-OIDC
-// requests (e.g. signed-URL archiver downloads). It should be at least as
-// long as the signed-URL expiry (OC-Expires). Default: 1 hour.
-const mfaStoreTTL = time.Hour
+const defaultMFASessionDuration = 3600
 
 // MultiFactor returns a middleware that checks requests for mfa
 func MultiFactor(cfg config.MFAConfig, opts ...Option) func(next http.Handler) http.Handler {
 	options := newOptions(opts...)
 	logger := options.Logger
 
+	sessionDuration := cfg.SessionDuration
+	if sessionDuration <= 0 {
+		sessionDuration = defaultMFASessionDuration
+	}
+
 	return func(next http.Handler) http.Handler {
 		return &MultiFactorAuthentication{
-			next:           next,
-			logger:         logger,
-			enabled:        cfg.Enabled,
-			authLevelNames: cfg.AuthLevelNames,
-			store:          options.MFAStore,
+			next:            next,
+			logger:          logger,
+			enabled:         cfg.Enabled,
+			authLevelNames:  cfg.AuthLevelNames,
+			store:           options.MFAStore,
+			sessionDuration: time.Duration(sessionDuration) * time.Second,
 		}
 	}
 }
 
 // MultiFactorAuthentication is a authenticator that checks for mfa on specific paths
 type MultiFactorAuthentication struct {
-	next           http.Handler
-	logger         log.Logger
-	enabled        bool
-	authLevelNames []string
+	next            http.Handler
+	logger          log.Logger
+	enabled         bool
+	authLevelNames  []string
+	sessionDuration time.Duration
 	// store persists verified MFA status so that non-OIDC requests (e.g.
 	// signed-URL archiver downloads) can inherit it from the user's most
 	// recent OIDC session. Nil when no store is configured.
@@ -103,7 +107,7 @@ func (m MultiFactorAuthentication) ServeHTTP(w http.ResponseWriter, req *http.Re
 	// Persist the verified MFA status so that subsequent non-OIDC requests
 	// (e.g. signed-URL archiver downloads) can inherit it. The entry is
 	// refreshed on every successful OIDC MFA verification and expires after
-	// mfaStoreTTL if no further OIDC requests are made.
+	// the configured session duration if no further OIDC requests are made.
 	if m.store != nil {
 		if u, ok := revactx.ContextGetUser(req.Context()); ok && u.GetId().GetOpaqueId() != "" {
 			m.writeMFAToStore(u.GetId().GetOpaqueId())
@@ -123,7 +127,7 @@ func (m MultiFactorAuthentication) writeMFAToStore(userID string) {
 	if err := m.store.Write(&microstore.Record{
 		Key:    key(userID),
 		Value:  []byte("true"),
-		Expiry: mfaStoreTTL,
+		Expiry: m.sessionDuration,
 	}); err != nil {
 		m.logger.Error().Err(err).Str("userID", userID).Msg("failed to write MFA status to store")
 	}

--- a/vendor/github.com/owncloud/reva/v2/pkg/owncloud/ocs/capabilities.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/owncloud/ocs/capabilities.go
@@ -101,8 +101,9 @@ type CapabilitiesAuth struct {
 
 // CapabilitiesMFA holds mfa capabilities
 type CapabilitiesMFA struct {
-	Enabled    bool     `json:"enabled,omitempty" xml:"enabled,omitempty" mapstructure:"enabled"`
-	LevelNames []string `json:"levelnames,omitempty" xml:"levelnames,omitempty" mapstructure:"levelnames"`
+	Enabled         bool     `json:"enabled,omitempty" xml:"enabled,omitempty" mapstructure:"enabled"`
+	LevelNames      []string `json:"levelnames,omitempty" xml:"levelnames,omitempty" mapstructure:"levelnames"`
+	SessionDuration int      `json:"session_duration,omitempty" xml:"session_duration,omitempty" mapstructure:"session_duration"`
 }
 
 // Spaces lets a service configure its advertised options related to Storage Spaces.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1319,7 +1319,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20260521074552-d5606d565e45
+# github.com/owncloud/reva/v2 v2.0.0-20260521084623-a3fad40c3868
 ## explicit; go 1.25.7
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
## Description
Expose MFA session duration as a configurable capability so the frontend can warn users before their MFA session expires.

- Added `SessionDuration` field to `MFAConfig` in both the frontend and proxy services
- Configurable via `OCIS_MFA_SESSION_DURATION` env var (defaults to 3600 seconds / 1 hour)
- Exposed as `capabilities.auth.mfa.session_duration` in the capabilities API response
- Replaced the hardcoded `mfaStoreTTL = time.Hour` constant in the proxy MFA middleware with the configurable value

## Related Issue

- Fixes [[OCISDEV-862](https://kiteworks.atlassian.net/browse/OCISDEV-534)](https://kiteworks.atlassian.net/browse/OCISDEV-534)

## Motivation and Context

The frontend needs to know when the MFA session is about to expire so it can prompt the user to extend it (silent reauthentication). Previously the 1-hour TTL was hardcoded in the proxy middleware and not communicated to the frontend at all. With this change, the frontend reads `session_duration` from capabilities and shows a warning popup 5 minutes before expiry.

## How Has This Been Tested?

- test environment: local oCIS with Keycloak IDP, MFA enabled
- test case 1: `OCIS_MFA_SESSION_DURATION` not set → defaults to 3600, capabilities response includes `"session_duration": 3600`
- test case 2: `OCIS_MFA_SESSION_DURATION=1800` → capabilities response includes `"session_duration": 1800`, proxy store TTL set to 30 minutes
- test case 3: `OCIS_MFA_SESSION_DURATION=0` or negative → falls back to default 3600

## Screenshots (if appropriate):
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>