### PR TITLE
fix: [OCISDEV-673] stable order for user search attributes

### DIFF
--- a/changelog/unreleased/bugfix-user-attributes-order.md
+++ b/changelog/unreleased/bugfix-user-attributes-order.md
@@ -1,0 +1,8 @@
+Bugfix: Stable order for user search attributes
+
+The `attributes` field returned from the user search endpoint came back in a
+random order because `getUsersAttributes` ranged over a Go map. The function
+now iterates over the configured `UserSearchDisplayedAttributes` slice, so
+the returned attribute values follow the configured order.
+
+https://github.com/owncloud/ocis/pull/12337

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -287,8 +287,9 @@ func getUsersAttributes(displayedAttributes []string, user *libregraph.User) ([]
 
 	attributes := []string{}
 
-	for attrStr, val := range userMap {
-		if !slices.Contains(displayedAttributes, attrStr) {
+	for _, attrStr := range displayedAttributes {
+		val, ok := userMap[attrStr]
+		if !ok {
 			continue
 		}
 
@@ -300,8 +301,7 @@ func getUsersAttributes(displayedAttributes []string, user *libregraph.User) ([]
 				attributes = append(attributes, *v)
 			}
 		case []libregraph.Group:
-			groups := userMap[attrStr].([]libregraph.Group)
-			for _, group := range groups {
+			for _, group := range v {
 				attributes = append(attributes, *group.DisplayName)
 			}
 		default:


### PR DESCRIPTION
## Summary
- `getUsersAttributes` ranged over a Go map, so the `attributes` field on user search responses came back in a different order on each call.
- Iterate over the configured `UserSearchDisplayedAttributes` slice instead, giving stable, configured order.

## Test plan
- [x] `go test ./services/graph/pkg/service/v0/...` passes
- [ ] Verify user search response has deterministic `attributes` ordering across repeated calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)