### PR TITLE
chore(docs): document how to check vault mode in the frontend

### DIFF
--- a/services/storage-users/README.md
+++ b/services/storage-users/README.md
@@ -482,6 +482,20 @@ users-vault
 └── uploads
 ```
 
+### Checking Vault Mode in the Frontend
+
+To check whether vault mode is enabled in the frontend, use the `@ownclouders/web-pkg` package:
+
+```typescript
+import { useAbility } from '@ownclouders/web-pkg'
+import { useCapabilityStore } from '@ownclouders/web-pkg'
+
+const capabilityStore = useCapabilityStore()
+const { can } = useAbility()
+
+const isVaultModeEnabled = capabilityStore.vaultEnabled && can('read-all', 'Vault')
+```
+
 ### Running with Docker
 
 To enable vault mode in the `ocis_full` docker-compose stack, edit `deployments/examples/ocis_full/.env` and uncomment the following lines:


### PR DESCRIPTION
## Description
  Document how to check vault mode status in the frontend using the `@ownclouders/web-pkg` package.

  ## Related Issue
  - N/A

  ## Motivation and Context
  Developers working on the frontend need a reference for how to determine if
  vault mode is enabled. This adds a code snippet showing the correct approach
   using `useCapabilityStore` and `useAbility`.

  ## How Has This Been Tested?
  - Documentation-only change, no functional code modified.

  ## Screenshots (if appropriate):
  N/A

  ## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Technical debt
  - [ ] Tests only (no source changes)

  ## Checklist:
  - [ ] Code changes
  - [ ] Unit tests added
  - [ ] Acceptance tests added
  - [ ] Documentation ticket raised: N/A