### PR TITLE
ci: skip acceptance tests on docs-only changes

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -5,8 +5,51 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect-changes:
+    name: detect-changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.check.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check if changes are docs-only
+        id: check
+        run: |
+          # Always run full CI on workflow_dispatch, tags, or when PR title contains [full-ci]
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if echo "$PR_TITLE" | grep -qi "\[full-ci\]"; then
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get changed files between the PR base and head
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" 2>/dev/null || git diff --name-only HEAD~1)
+
+          # Patterns that are considered documentation/non-code changes
+          DOCS_ONLY=true
+          while IFS= read -r file; do
+            case "$file" in
+              .github/*|.vscode/*|changelog/*|docs/*|deployments/*) ;;
+              CHANGELOG.md|CONTRIBUTING.md|LICENSE|README.md) ;;
+              *) DOCS_ONLY=false; break ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+          echo "docs-only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
+          echo "Changed files docs-only: $DOCS_ONLY"
+
   build-and-test:
     name: build-and-test
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.docs-only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -514,12 +557,17 @@ jobs:
         run: python3 tests/acceptance/run-wopi.py --type cs3
 
   all-acceptance-tests:
-    needs: [local-api-tests, cli-tests, core-api-tests, litmus, cs3api, wopi-builtin, wopi-cs3, e2e-tests]
+    needs: [detect-changes, local-api-tests, cli-tests, core-api-tests, litmus, cs3api, wopi-builtin, wopi-cs3, e2e-tests]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
+          # If docs-only, all test jobs are expected to be skipped — that's a pass
+          if [[ "${{ needs.detect-changes.outputs.docs-only }}" == "true" ]]; then
+            echo "Docs-only change — skipping tests is expected."
+            exit 0
+          fi
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             exit 1
           fi


### PR DESCRIPTION
## Description

  Port the `skipIfUnchanged` logic from the old Drone `.drone.star` to GitHub Actions. A new `detect-changes` job gates all test jobs when a PR only touches documentation/non-code files.

  ## Related Issue

  - Fixes the gap left after Drone was removed in #12243

  ## Motivation and Context

  After Drone was dropped, docs-only PRs trigger the full acceptance test suite unnecessarily, wasting CI minutes and slowing down merges for trivial changes.

  ## How Has This Been Tested?

  - test environment: GitHub Actions
  - test case 1: PR with only `docs/` changes — all test jobs should be skipped, `all-acceptance-tests` passes
  - test case 2: PR with `.go` file changes — full CI runs as before
  - test case 3: PR with only doc changes but `[full-ci]` in title — full CI runs

  ## Screenshots (if appropriate):

  N/A

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Technical debt
  - [ ] Tests only (no source changes)

  ## Checklist:

  - [x] Code changes
  - [ ] Unit tests added
  - [ ] Acceptance tests added
  - [ ] Documentation ticket raised: N/A