### PR TITLE
fix(ci): match docs files in subdirectories for docs-only detection

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -37,8 +37,9 @@ jobs:
           DOCS_ONLY=true
           while IFS= read -r file; do
             case "$file" in
+              .github/workflows/*) DOCS_ONLY=false; break ;;
               .github/*|.vscode/*|changelog/*|docs/*|deployments/*) ;;
-              CHANGELOG.md|CONTRIBUTING.md|LICENSE|README.md) ;;
+              */CHANGELOG.md|*/CONTRIBUTING.md|*/README.md|CHANGELOG.md|CONTRIBUTING.md|LICENSE|README.md) ;;
               *) DOCS_ONLY=false; break ;;
             esac
           done <<< "$CHANGED_FILES"


### PR DESCRIPTION
## Description

  The docs-only detection in the acceptance tests workflow only matched CHANGELOG.md, CONTRIBUTING.md, and README.md at the repository root. Files like services/storage-users/README.md were not recognized as documentation, causing full CI to run unnecessarily.

  This adds */CHANGELOG.md, */CONTRIBUTING.md, and */README.md glob patterns to also match these files in subdirectories.

  # Related Issue

  - Fixes the false-positive full CI trigger observed when only a nested README was changed (e.g. services/storage-users/README.md)

  ## Motivation and Context

  After #12381 introduced the docs-only skip logic, PRs that only touched a service-level README still triggered full acceptance tests, defeating the purpose of the optimization.

  ## How Has This Been Tested?

  - Verified the bash case pattern matches paths like services/storage-users/README.md, services/web/assets/core/fonts/ubuntu/CONTRIBUTING.md
  - Confirmed root-level files (README.md, CHANGELOG.md, CONTRIBUTING.md, LICENSE) still match

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Checklist:

  - [x] Code changes
  - [ ] Unit tests added
  - [ ] Acceptance tests added
  - [ ] Documentation ticket raised: N/A
