### PR TITLE
[backport stable-8.1] fix(graph): [OCISDEV-964] education user delete uses wrong id

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -370,7 +370,9 @@ jobs:
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24"
+          # 24.16.0 breaks playwright install (yauzl zip extraction hangs); pin to last known good.
+          # https://github.com/microsoft/playwright/issues/40724
+          node-version: "24.15.0"
       - name: Enable pnpm
         run: corepack enable && corepack prepare pnpm@10.28.1 --activate
       - name: Generate code

--- a/changelog/unreleased/fix-education-user-delete.md
+++ b/changelog/unreleased/fix-education-user-delete.md
@@ -1,0 +1,9 @@
+Bugfix: DELETE /graph/v1.0/education/users/{id} no longer 404s while leaving the LDAP entry behind
+
+The education user delete handler used `user.GetExternalID()` for the backend
+DELETE, while the regular `/users` handler and the pre-v8.0 code path used
+`user.GetId()`. With the default `RequireExternalID=false`, the LDAP backend
+looked up the user by name-or-UUID, so the externalID never matched, the LDAP
+entry was never removed, and the response was a 404. This is now fixed.
+
+https://github.com/owncloud/ocis/pull/12400

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
-	golang.org/x/image v0.39.0
+	golang.org/x/image v0.41.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1034,8 +1034,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aI
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
-golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
-golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -285,8 +285,8 @@ func (g Graph) DeleteEducationUser(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logger.Debug().Str("id", user.GetExternalID()).Msg("calling delete education user on backend")
-	err = g.identityEducationBackend.DeleteEducationUser(r.Context(), user.GetExternalID())
+	logger.Debug().Str("id", user.GetId()).Msg("calling delete education user on backend")
+	err = g.identityEducationBackend.DeleteEducationUser(r.Context(), user.GetId())
 
 	if err != nil {
 		logger.Debug().Err(err).Msg("could not delete education user: backend error")

--- a/services/graph/pkg/service/v0/educationuser_test.go
+++ b/services/graph/pkg/service/v0/educationuser_test.go
@@ -446,6 +446,8 @@ var _ = Describe("EducationUsers", func() {
 			svc.DeleteEducationUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
+			identityEducationBackend.AssertCalled(GinkgoT(), "DeleteEducationUser", mock.Anything, lu.GetId())
+			identityEducationBackend.AssertNotCalled(GinkgoT(), "DeleteEducationUser", mock.Anything, lu.GetExternalID())
 			gatewayClient.AssertNumberOfCalls(GinkgoT(), "DeleteStorageSpace", 2) // 2 calls for the home space. first trash, then purge
 		})
 	})

--- a/vendor/golang.org/x/image/bmp/reader.go
+++ b/vendor/golang.org/x/image/bmp/reader.go
@@ -18,6 +18,8 @@ import (
 // feature.
 var ErrUnsupported = errors.New("bmp: unsupported BMP image")
 
+var errInvalidPaletteIndex = errors.New("bmp: invalid palette index")
+
 func readUint16(b []byte) uint16 {
 	return uint16(b[0]) | uint16(b[1])<<8
 }
@@ -29,7 +31,8 @@ func readUint32(b []byte) uint32 {
 // decodePaletted reads a 1, 2, 4 or 8 bit-per-pixel BMP image from r.
 // If topDown is false, the image rows will be read bottom-up.
 func decodePaletted(r io.Reader, c image.Config, topDown bool, bpp int) (image.Image, error) {
-	paletted := image.NewPaletted(image.Rect(0, 0, c.Width, c.Height), c.ColorModel.(color.Palette))
+	palette := c.ColorModel.(color.Palette)
+	paletted := image.NewPaletted(image.Rect(0, 0, c.Width, c.Height), palette)
 	if c.Width == 0 || c.Height == 0 {
 		return paletted, nil
 	}
@@ -51,7 +54,11 @@ func decodePaletted(r io.Reader, c image.Config, topDown bool, bpp int) (image.I
 		byteIndex, bitIndex, mask := 0, 8, byte((1<<bpp)-1)
 		for pixIndex := 0; pixIndex < c.Width; pixIndex++ {
 			bitIndex -= bpp
-			p[pixIndex] = (b[byteIndex]) >> bitIndex & mask
+			paletteIndex := (b[byteIndex]) >> bitIndex & mask
+			if int(paletteIndex) >= len(palette) {
+				return nil, errInvalidPaletteIndex
+			}
+			p[pixIndex] = paletteIndex
 			if bitIndex == 0 {
 				byteIndex++
 				bitIndex = 8

--- a/vendor/golang.org/x/image/tiff/compress.go
+++ b/vendor/golang.org/x/image/tiff/compress.go
@@ -15,11 +15,12 @@ type byteReader interface {
 }
 
 // unpackBits decodes the PackBits-compressed data in src and returns the
-// uncompressed data.
+// uncompressed data. The output size is limited to lim bytes to prevent
+// decompression bombs.
 //
 // The PackBits compression format is described in section 9 (p. 42)
 // of the TIFF spec.
-func unpackBits(r io.Reader) ([]byte, error) {
+func unpackBits(r io.Reader, lim int64) ([]byte, error) {
 	buf := make([]byte, 128)
 	dst := make([]byte, 0, 1024)
 	br, ok := r.(byteReader)
@@ -53,6 +54,9 @@ func unpackBits(r io.Reader) ([]byte, error) {
 				buf[j] = b
 			}
 			dst = append(dst, buf[:1-code]...)
+		}
+		if int64(len(dst)) > lim {
+			return nil, FormatError("PackBits: decompressed data too large")
 		}
 	}
 }

--- a/vendor/golang.org/x/image/tiff/reader.go
+++ b/vendor/golang.org/x/image/tiff/reader.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -500,6 +501,9 @@ func newDecoder(r io.Reader) (*decoder, error) {
 
 	d.config.Width = int(d.firstVal(tImageWidth))
 	d.config.Height = int(d.firstVal(tImageLength))
+	if d.config.Width == 0 || d.config.Height == 0 {
+		return nil, errors.New("tiff: zero-size image")
+	}
 
 	if _, ok := d.features[tBitsPerSample]; !ok {
 		// Default is 1 per specification.
@@ -752,7 +756,7 @@ func Decode(r io.Reader) (img image.Image, err error) {
 				d.buf, err = readBuf(r, d.buf, blockMaxDataSize)
 				r.Close()
 			case cPackBits:
-				d.buf, err = unpackBits(io.NewSectionReader(d.r, offset, n))
+				d.buf, err = unpackBits(io.NewSectionReader(d.r, offset, n), blockMaxDataSize)
 			default:
 				err = UnsupportedError(fmt.Sprintf("compression value %d", d.firstVal(tCompression)))
 			}

--- a/vendor/golang.org/x/image/tiff/writer.go
+++ b/vendor/golang.org/x/image/tiff/writer.go
@@ -292,6 +292,10 @@ type Options struct {
 func Encode(w io.Writer, m image.Image, opt *Options) error {
 	d := m.Bounds().Size()
 
+	if d.X == 0 || d.Y == 0 {
+		return errors.New("tiff: zero-size image")
+	}
+
 	compression := uint32(cNone)
 	predictor := false
 	if opt != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2278,7 +2278,7 @@ golang.org/x/exp/slices
 golang.org/x/exp/slog
 golang.org/x/exp/slog/internal
 golang.org/x/exp/slog/internal/buffer
-# golang.org/x/image v0.39.0
+# golang.org/x/image v0.41.0
 ## explicit; go 1.25.0
 golang.org/x/image/bmp
 golang.org/x/image/ccitt


### PR DESCRIPTION
## Summary

Backport of #12395 to `stable-8.1`.

`DeleteEducationUser` called the LDAP backend with `user.GetExternalID()`, while the regular `/users` handler and the pre-v8.0 code path used `user.GetId()`. With the default `RequireExternalID=false`, the LDAP backend looked up the user by name-or-UUID, so the externalID never matched, the LDAP entry was never removed, and the response was a 404.

Cherry-picked from 27c9de6c7278df4d20a31c3c585da9983920172b. No conflicts.

## Test plan

- [ ] CI green
- [ ] Manual: `DELETE /graph/v1.0/education/users/{id}` returns 204 and removes the LDAP entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)