### PR TITLE
fix(graph): [OCISDEV-964] education user delete uses wrong id

### DIFF
--- a/changelog/unreleased/fix-education-user-delete.md
+++ b/changelog/unreleased/fix-education-user-delete.md
@@ -1,0 +1,9 @@
+Bugfix: DELETE /graph/v1.0/education/users/{id} no longer 404s while leaving the LDAP entry behind
+
+The education user delete handler used `user.GetExternalID()` for the backend
+DELETE, while the regular `/users` handler and the pre-v8.0 code path used
+`user.GetId()`. With the default `RequireExternalID=false`, the LDAP backend
+looked up the user by name-or-UUID, so the externalID never matched, the LDAP
+entry was never removed, and the response was a 404. This is now fixed.
+
+https://github.com/owncloud/ocis/pull/12405

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -285,8 +285,8 @@ func (g Graph) DeleteEducationUser(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logger.Debug().Str("id", user.GetExternalID()).Msg("calling delete education user on backend")
-	err = g.identityEducationBackend.DeleteEducationUser(r.Context(), user.GetExternalID())
+	logger.Debug().Str("id", user.GetId()).Msg("calling delete education user on backend")
+	err = g.identityEducationBackend.DeleteEducationUser(r.Context(), user.GetId())
 
 	if err != nil {
 		logger.Debug().Err(err).Msg("could not delete education user: backend error")

--- a/services/graph/pkg/service/v0/educationuser_test.go
+++ b/services/graph/pkg/service/v0/educationuser_test.go
@@ -446,6 +446,8 @@ var _ = Describe("EducationUsers", func() {
 			svc.DeleteEducationUser(rr, r)
 
 			Expect(rr.Code).To(Equal(http.StatusNoContent))
+			identityEducationBackend.AssertCalled(GinkgoT(), "DeleteEducationUser", mock.Anything, lu.GetId())
+			identityEducationBackend.AssertNotCalled(GinkgoT(), "DeleteEducationUser", mock.Anything, lu.GetExternalID())
 			gatewayClient.AssertNumberOfCalls(GinkgoT(), "DeleteStorageSpace", 2) // 2 calls for the home space. first trash, then purge
 		})
 	})


### PR DESCRIPTION
## Summary

Forward-port of #12395 (stable-8.0) to `master`. Companion PR for stable-8.1: #12400.

`DeleteEducationUser` called the LDAP backend with `user.GetExternalID()`, while the regular `/users` handler and the pre-v8.0 code path used `user.GetId()`. With the default `RequireExternalID=false`, the LDAP backend looked up the user by name-or-UUID, so the externalID never matched, the LDAP entry was never removed, and the response was a 404.

Cherry-picked from 27c9de6c7278df4d20a31c3c585da9983920172b. No conflicts.

## Test plan

- [ ] CI green
- [ ] Manual: `DELETE /graph/v1.0/education/users/{id}` returns 204 and removes the LDAP entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)