### PR TITLE
fix(notifications): don't HTML-escape email template vars in place

### DIFF
--- a/changelog/unreleased/bugfix-notification-email-double-escape.md
+++ b/changelog/unreleased/bugfix-notification-email-double-escape.md
@@ -1,0 +1,12 @@
+Bugfix: Fix double HTML-escaping of notification emails for multiple recipients
+
+The notifications service reuses the same template variables map for every
+recipient of an event (for example when a group is invited to a space). The
+helper that HTML-escapes those variables for the HTML email body escaped the
+map in place, so every recipient after the first received a plain-text body
+containing HTML entities and an HTML body with one additional layer of escaping
+per recipient (a space named `R&D` became `R&amp;amp;D`). The helper now returns
+a new map and leaves the shared variables untouched, so every recipient renders
+from the original values.
+
+https://github.com/owncloud/ocis/pull/12413

--- a/services/notifications/pkg/email/email.go
+++ b/services/notifications/pkg/email/email.go
@@ -203,9 +203,15 @@ func validateMime(incipit []byte) bool {
 	return false
 }
 
+// escapeStringMap returns a new map holding the HTML-escaped values of vars.
+// It must not mutate its input: callers (e.g. the per-recipient render loop)
+// reuse the same vars map across multiple renders, and the unescaped values are
+// also consumed by the plain-text template. Escaping in place would corrupt the
+// text body and add one extra layer of HTML escaping to every subsequent render.
 func escapeStringMap(vars map[string]string) map[string]string {
-	for k := range vars {
-		vars[k] = html.EscapeString(vars[k])
+	escaped := make(map[string]string, len(vars))
+	for k, v := range vars {
+		escaped[k] = html.EscapeString(v)
 	}
-	return vars
+	return escaped
 }

--- a/services/notifications/pkg/email/email_test.go
+++ b/services/notifications/pkg/email/email_test.go
@@ -1,0 +1,94 @@
+package email
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEscapeStringMapDoesNotMutateInput guards the root cause: escapeStringMap
+// must return a new map and leave its argument untouched. The render loop reuses
+// the same vars map for every recipient and also feeds the unescaped values to
+// the plain-text template, so in-place mutation corrupts later renders.
+func TestEscapeStringMapDoesNotMutateInput(t *testing.T) {
+	in := map[string]string{
+		"SpaceName":   "R&D",
+		"SpaceSharer": "<Alice>",
+		"ShareLink":   "https://example.test/s/x?a=1&b=2",
+	}
+	want := map[string]string{
+		"SpaceName":   "R&D",
+		"SpaceSharer": "<Alice>",
+		"ShareLink":   "https://example.test/s/x?a=1&b=2",
+	}
+
+	out := escapeStringMap(in)
+
+	// Input must be unchanged.
+	for k, v := range want {
+		if in[k] != v {
+			t.Errorf("escapeStringMap mutated input[%q]: got %q, want %q", k, in[k], v)
+		}
+	}
+
+	// Output must be escaped exactly once.
+	if got, want := out["SpaceName"], "R&amp;D"; got != want {
+		t.Errorf("out[SpaceName] = %q, want %q", got, want)
+	}
+	if got, want := out["SpaceSharer"], "&lt;Alice&gt;"; got != want {
+		t.Errorf("out[SpaceSharer] = %q, want %q", got, want)
+	}
+
+	// Calling again with the same (still-unescaped) input must be stable.
+	out2 := escapeStringMap(in)
+	for k := range out {
+		if out[k] != out2[k] {
+			t.Errorf("escapeStringMap not stable for %q: %q vs %q", k, out[k], out2[k])
+		}
+	}
+}
+
+// TestRenderEmailTemplateRepeatableWithSharedVars reproduces the user-facing
+// symptom: the notifications render loop calls RenderEmailTemplate once per
+// recipient with the SAME vars map. Rendering twice with the same map must yield
+// identical output. Before the fix the map was escaped in place on the first
+// render, so the second render's text body and subject carried already-escaped
+// values and its HTML body was double-escaped.
+func TestRenderEmailTemplateRepeatableWithSharedVars(t *testing.T) {
+	vars := map[string]string{
+		"SpaceSharer":  "A&B",
+		"SpaceGrantee": "Bob",
+		"SpaceName":    "R&D",
+		"ShareLink":    "https://example.test/s/abc?a=1&b=2",
+	}
+
+	first, err := RenderEmailTemplate(SharedSpace, "en", "en", "", "", vars)
+	if err != nil {
+		t.Fatalf("first render failed: %v", err)
+	}
+	second, err := RenderEmailTemplate(SharedSpace, "en", "en", "", "", vars)
+	if err != nil {
+		t.Fatalf("second render failed: %v", err)
+	}
+
+	if first.Subject != second.Subject {
+		t.Errorf("subject differs across renders with a shared vars map:\n first  = %q\n second = %q", first.Subject, second.Subject)
+	}
+	if first.TextBody != second.TextBody {
+		t.Errorf("text body differs across renders with a shared vars map:\n first  = %q\n second = %q", first.TextBody, second.TextBody)
+	}
+	if first.HTMLBody != second.HTMLBody {
+		t.Errorf("html body differs across renders with a shared vars map:\n first  = %q\n second = %q", first.HTMLBody, second.HTMLBody)
+	}
+
+	// The plain-text body must contain the raw ampersand, not an HTML entity.
+	if !strings.Contains(first.TextBody, "R&D") {
+		t.Errorf("text body should contain the unescaped space name %q, got: %q", "R&D", first.TextBody)
+	}
+	// The HTML body must contain the value escaped exactly once (not double-escaped).
+	if !strings.Contains(first.HTMLBody, "R&amp;D") {
+		t.Errorf("html body should contain the single-escaped space name %q, got: %q", "R&amp;D", first.HTMLBody)
+	}
+	if strings.Contains(first.HTMLBody, "R&amp;amp;D") {
+		t.Errorf("html body is double-escaped, contains %q: %q", "R&amp;amp;D", first.HTMLBody)
+	}
+}


### PR DESCRIPTION
## Problem

Notification emails sent to multiple recipients were corrupted for every recipient after the first. When a notification fans out to several grantees — most visibly when a group is invited to a space — the plain-text body of the 2nd+ recipient contained HTML entities (e.g. `R&amp;D` instead of `R&D`) and the HTML body was escaped one extra time per recipient (`R&amp;amp;D`, `R&amp;amp;amp;D`, …).

Reproduced with a unit test that renders `SharedSpace` twice with the same vars map: on master the second render differs from the first; with the fix they are identical.

## Root cause

`escapeStringMap` (`services/notifications/pkg/email/email.go`) HTML-escaped the values of the map it was passed **in place** and returned that same map. The render loop `eventsNotifier.render` (`services/notifications/pkg/service/service.go`) reuses a single `fields` map for every recipient, and `RenderEmailTemplate` feeds that map to the plain-text template (unescaped) and then calls `escapeStringMap(vars)` for the HTML template. Because the escape mutated the shared map:

- the plain-text template of later recipients read already-escaped values, and
- each subsequent HTML render added another escaping layer.

## Fix

`escapeStringMap` now allocates and returns a new map, leaving its input untouched. No caller changes are required: the plain-text template keeps reading the original values and each HTML render escapes exactly once. (Conceptually the same direction taken upstream in opencloud-eu/opencloud, implemented independently for oCIS.)

## Testing

- `go test ./services/notifications/... -race` — passes.
- New `services/notifications/pkg/email/email_test.go`:
  - `TestEscapeStringMapDoesNotMutateInput` — guards the root cause (helper must not mutate its argument).
  - `TestRenderEmailTemplateRepeatableWithSharedVars` — renders `SharedSpace` twice with a shared vars map and asserts identical, single-escaped output; also asserts the text body keeps the raw value and the HTML body is not double-escaped.
  - Both tests fail on master and pass with the fix.

## Risk

Low. The change is confined to one helper and makes output match the already-correct behaviour of the first recipient. Plain-text bodies now always contain the raw value (correct for a text email) and HTML bodies are escaped exactly once.
