### PR TITLE
fix(proxy): re-verify access token when cached userinfo has expired

### DIFF
--- a/changelog/unreleased/bugfix-oidc-userinfo-cache-expiry-reverify.md
+++ b/changelog/unreleased/bugfix-oidc-userinfo-cache-expiry-reverify.md
@@ -1,0 +1,13 @@
+Bugfix: Re-verify access tokens with an expired userinfo cache entry
+
+The proxy authenticated requests against a cached userinfo entry. When the
+cached entry's expiry had passed, the request was rejected outright instead of
+re-verifying the access token. The cached expiry is not always the real token
+expiry — for opaque access tokens it falls back to the configured cache TTL —
+so a still-valid token could be rejected just because its cache entry aged out,
+causing spurious logouts (most noticeable under frequent PROPFIND requests). The
+proxy now treats an expired cache entry as a cache miss and re-verifies the
+access token, while a genuinely expired or invalid token is still rejected by
+the re-verification.
+
+https://github.com/owncloud/ocis/pull/12414

--- a/services/proxy/pkg/middleware/oidc_auth.go
+++ b/services/proxy/pkg/middleware/oidc_auth.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 	"github.com/pkg/errors"
@@ -66,14 +65,22 @@ func (m *OIDCAuthenticator) getClaims(token string, req *http.Request) (map[stri
 		m.Logger.Error().Err(err).Msg("could not read from userinfo cache")
 	}
 	if len(record) > 0 {
-		if err = msgpack.UnmarshalAsMap(record[0].Value, &claims); err == nil {
+		if err = msgpack.UnmarshalAsMap(record[0].Value, &claims); err != nil {
+			m.Logger.Error().Err(err).Msg("could not unmarshal userinfo")
+		} else if verifyExpiresAt(claims, m.TimeFunc()) {
 			m.Logger.Debug().Interface("claims", claims).Msg("cache hit for userinfo")
-			if ok := verifyExpiresAt(claims, m.TimeFunc()); !ok {
-				return nil, false, jwt.ErrTokenExpired
-			}
 			return claims, false, nil
+		} else {
+			// The cached claims have expired. Treat this as a cache miss and
+			// re-verify the access token below instead of failing the request.
+			// The cached "exp" can be a fallback cache TTL rather than the real
+			// token expiry (e.g. for opaque access tokens, where extractExpiration
+			// falls back to DefaultTokenCacheTTL), so a token that is still valid
+			// must not be rejected just because its cache entry aged out. A
+			// genuinely expired or invalid token is still rejected by the
+			// VerifyAccessToken/UserInfo re-verification that follows.
+			m.Logger.Debug().Msg("cached userinfo claims expired, re-verifying access token")
 		}
-		m.Logger.Error().Err(err).Msg("could not unmarshal userinfo")
 	}
 
 	aClaims, claims, err := m.oidcClient.VerifyAccessToken(req.Context(), token)

--- a/services/proxy/pkg/middleware/oidc_auth_test.go
+++ b/services/proxy/pkg/middleware/oidc_auth_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -11,23 +13,33 @@ import (
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 	oidcmocks "github.com/owncloud/ocis/v2/ocis-pkg/oidc/mocks"
+	"github.com/shamaton/msgpack/v2"
 	"github.com/stretchr/testify/mock"
 	"go-micro.dev/v4/store"
+	"golang.org/x/crypto/sha3"
 )
 
 var _ = Describe("Authenticating requests", Label("OIDCAuthenticator"), func() {
 	var authenticator Authenticator
 
 	oc := oidcmocks.OIDCClient{}
+	// Return a fresh claims map on every call. getClaims mutates the returned
+	// map (claims["exp"] = ...) and then reads it from a fire-and-forget cache
+	// goroutine, so handing every call the same map instance would let one
+	// spec's goroutine race another spec's mutation. The real OIDC client
+	// returns a new map per call, which this mirrors.
 	oc.On("VerifyAccessToken", mock.Anything, mock.Anything).Return(
 		oidc.RegClaimsWithSID{
 			SessionID: "a-session-id",
 			RegisteredClaims: jwt.RegisteredClaims{
 				ExpiresAt: jwt.NewNumericDate(time.Unix(1147483647, 0)),
 			},
-		}, jwt.MapClaims{
-			"sid": "a-session-id",
-			"exp": 1147483647,
+		},
+		func(_ context.Context, _ string) jwt.MapClaims {
+			return jwt.MapClaims{
+				"sid": "a-session-id",
+				"exp": 1147483647,
+			}
 		},
 		nil,
 	)
@@ -96,6 +108,88 @@ var _ = Describe("Authenticating requests", Label("OIDCAuthenticator"), func() {
 			//Expect(req2).To(BeNil())
 			Expect(valid).To(Equal(true))
 			Expect(req2).ToNot(BeNil())
+		})
+	})
+
+	When("the userinfo cache holds an entry whose cached expiry has passed", func() {
+		It("re-verifies the access token instead of rejecting the request", func() {
+			const token = "jwt.token.sig"
+
+			// Reproduce the cache key the authenticator computes for the token.
+			hash := make([]byte, 64)
+			sha3.ShakeSum256(hash, []byte(token))
+			encodedHash := base64.URLEncoding.EncodeToString(hash)
+
+			// Seed the cache with claims whose "exp" already lies in the past,
+			// but keep the store record itself readable (no Expiry) to simulate
+			// the window where the entry has not been evicted yet while its
+			// cached expiry has passed.
+			cachedClaims := map[string]interface{}{
+				"sub": "cached-subject",
+				"exp": time.Now().Add(-time.Hour).Unix(),
+			}
+			value, err := msgpack.MarshalAsMap(cachedClaims)
+			Expect(err).ToNot(HaveOccurred())
+
+			cache := store.NewMemoryStore()
+			Expect(cache.Write(&store.Record{Key: encodedHash, Value: value})).To(Succeed())
+
+			oidcAuth := &OIDCAuthenticator{
+				OIDCIss:       "http://idp.example.com",
+				Logger:        log.NewLogger(),
+				oidcClient:    &oc,
+				userInfoCache: cache,
+				skipUserInfo:  true,
+				TimeFunc:      time.Now,
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/example/path", http.NoBody)
+			claims, _, err := oidcAuth.getClaims(token, req)
+
+			// Before the fix getClaims returned jwt.ErrTokenExpired here. The
+			// token is still valid (the mock re-verifies it), so authentication
+			// must succeed via the re-verification fall-through.
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims).ToNot(BeNil())
+			Expect(claims["sid"]).To(Equal("a-session-id"))
+		})
+
+		It("still rejects a token that the IDP no longer accepts", func() {
+			const token = "rejected.token.sig"
+
+			hash := make([]byte, 64)
+			sha3.ShakeSum256(hash, []byte(token))
+			encodedHash := base64.URLEncoding.EncodeToString(hash)
+
+			value, err := msgpack.MarshalAsMap(map[string]interface{}{
+				"sub": "cached-subject",
+				"exp": time.Now().Add(-time.Hour).Unix(),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			cache := store.NewMemoryStore()
+			Expect(cache.Write(&store.Record{Key: encodedHash, Value: value})).To(Succeed())
+
+			rejectingClient := oidcmocks.OIDCClient{}
+			rejectingClient.On("VerifyAccessToken", mock.Anything, mock.Anything).Return(
+				oidc.RegClaimsWithSID{}, jwt.MapClaims{}, jwt.ErrTokenExpired,
+			)
+
+			oidcAuth := &OIDCAuthenticator{
+				OIDCIss:       "http://idp.example.com",
+				Logger:        log.NewLogger(),
+				oidcClient:    &rejectingClient,
+				userInfoCache: cache,
+				skipUserInfo:  true,
+				TimeFunc:      time.Now,
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/example/path", http.NoBody)
+			_, _, err = oidcAuth.getClaims(token, req)
+
+			// A genuinely invalid/expired token must still be rejected by the
+			// re-verification path, so the expiry fall-through does not weaken auth.
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
## Problem

When an OIDC-authenticated request hit the proxy's userinfo cache and the cached entry's expiry had already passed, the request was rejected (`jwt.ErrTokenExpired` → 401) instead of re-verifying the access token. This produces spurious logouts: the user is signed out even though their token is still valid. It is most visible under web navigation, where frequent PROPFIND requests make the narrow expiry window get hit often.

## Root cause

In `getClaims` (`services/proxy/pkg/middleware/oidc_auth.go`), the cache-hit branch returned `jwt.ErrTokenExpired` as soon as `verifyExpiresAt(claims, …)` reported the cached claims as expired.

The cached `exp` is not always the real token expiry. `extractExpiration` reads the access token's `exp` only when one is present; for opaque access tokens (`PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD=none`) it falls back to `now + DefaultTokenCacheTTL`, i.e. the cache TTL. So when a cache entry's stored `exp` lapses but the underlying token is still valid, the request was wrongly rejected instead of re-validated.

## Fix

`getClaims` now treats an expired cache entry as a **cache miss** and falls through to the existing `VerifyAccessToken` / `UserInfo` re-verification, re-caching the result. A genuinely expired or invalid token is still rejected by that re-verification, so authentication is not weakened — the only behavioural change is that a still-valid token whose cache entry merely aged out is now accepted. (Conceptually the same direction as upstream opencloud-eu/opencloud, implemented independently.)

The restructure also drops a dead `could not unmarshal userinfo` log that previously executed with a `nil` error on the success path.

## Testing

- `go test ./services/proxy/pkg/middleware/ -race` — passes and is race-clean.
- New specs in `oidc_auth_test.go`:
  - *re-verifies the access token instead of rejecting the request* — seeds the cache with an entry whose `exp` is in the past, asserts the request succeeds via re-verification. Fails on master, passes with the fix.
  - *still rejects a token that the IDP no longer accepts* — confirms an expired/invalid token is still rejected through the re-verification path (no auth weakening).
- The shared test mock now returns a fresh claims map per call (mirroring the real OIDC client), fixing a pre-existing data race in the suite — `getClaims` mutates the returned map and reads it from a fire-and-forget cache-write goroutine, so a shared map instance let one spec race another. This made `-race` fail on master independently of this change.

## Risk

Low. The change only affects the cache-hit-but-expired path and defers the decision to the same re-verification used for cache misses. No public/CS3 API change, no vendored code touched.
