### PR TITLE
fix(userlog): serialize concurrent event-list updates to avoid lost notifications

### DIFF
--- a/changelog/unreleased/bugfix-userlog-concurrent-event-list-race.md
+++ b/changelog/unreleased/bugfix-userlog-concurrent-event-list-race.md
@@ -1,0 +1,11 @@
+Bugfix: Prevent lost notifications from a concurrent userlog event list race
+
+The userlog service processes events with `MaxConcurrency` workers. Updating a
+user's stored event list (`alterUserEventList`) and the shared global events
+(`alterGlobalEvents`) was a read-modify-write against the key-value store with
+no locking, so two workers operating on the same user (or on the single
+global-events key) could interleave their read and write and silently drop each
+other's update — losing in-app notifications. The read-modify-write cycles are
+now serialized with a mutex, mirroring the activitylog service.
+
+https://github.com/owncloud/ocis/pull/12415

--- a/services/userlog/pkg/service/race_test.go
+++ b/services/userlog/pkg/service/race_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	microstore "go-micro.dev/v4/store"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestAlterUserEventListConcurrentDoesNotLoseEvents asserts that concurrent
+// modifications of a single user's event list do not drop updates. Events are
+// processed by MaxConcurrency workers, so two of them appending to the same
+// user list must not lose each other's writes. The small sleep widens the
+// read-modify-write window so the missing-lock case fails deterministically.
+func TestAlterUserEventListConcurrentDoesNotLoseEvents(t *testing.T) {
+	ul := &UserlogService{store: microstore.NewMemoryStore()}
+
+	const userID = "user-1"
+	const n = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := strconv.Itoa(i)
+			if err := ul.alterUserEventList(userID, func(ids []string) []string {
+				time.Sleep(time.Millisecond)
+				return append(ids, id)
+			}); err != nil {
+				t.Errorf("alterUserEventList: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	recs, err := ul.store.Read(userID)
+	if err != nil {
+		t.Fatalf("read back user event list: %v", err)
+	}
+	var ids []string
+	if len(recs) > 0 {
+		if err := json.Unmarshal(recs[0].Value, &ids); err != nil {
+			t.Fatalf("unmarshal user event list: %v", err)
+		}
+	}
+	if len(ids) != n {
+		t.Fatalf("lost user events under concurrency: got %d, want %d", len(ids), n)
+	}
+}
+
+// TestAlterGlobalEventsConcurrentDoesNotLoseEvents asserts the same atomicity
+// for the single shared global-events key, which every global event mutates.
+func TestAlterGlobalEventsConcurrentDoesNotLoseEvents(t *testing.T) {
+	ul := &UserlogService{
+		store:  microstore.NewMemoryStore(),
+		tracer: trace.NewNoopTracerProvider().Tracer(""),
+	}
+
+	const n = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := strconv.Itoa(i)
+			if err := ul.alterGlobalEvents(context.Background(), func(evs map[string]json.RawMessage) error {
+				time.Sleep(time.Millisecond)
+				evs[key] = json.RawMessage(`"x"`)
+				return nil
+			}); err != nil {
+				t.Errorf("alterGlobalEvents: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	evs, err := ul.GetGlobalEvents(context.Background())
+	if err != nil {
+		t.Fatalf("GetGlobalEvents: %v", err)
+	}
+	if len(evs) != n {
+		t.Fatalf("lost global events under concurrency: got %d, want %d", len(evs), n)
+	}
+}

--- a/services/userlog/pkg/service/service.go
+++ b/services/userlog/pkg/service/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -40,6 +41,13 @@ type UserlogService struct {
 	tracer           trace.Tracer
 	publisher        events.Publisher
 	filter           *userlogFilter
+
+	// storeMu serializes the read-modify-write cycles in alterUserEventList and
+	// alterGlobalEvents. The events are processed by MaxConcurrency workers, so
+	// without this lock two workers operating on the same user event list (or on
+	// the single global-events key) can interleave their read and write and drop
+	// each other's updates, silently losing notifications.
+	storeMu sync.Mutex
 }
 
 // NewUserlogService returns an EventHistory service
@@ -416,6 +424,9 @@ func (ul *UserlogService) removeExpiredEvents(userid string, all []string, recei
 }
 
 func (ul *UserlogService) alterUserEventList(userid string, alter func([]string) []string) error {
+	ul.storeMu.Lock()
+	defer ul.storeMu.Unlock()
+
 	recs, err := ul.store.Read(userid)
 	if err != nil && err != store.ErrNotFound {
 		return err
@@ -449,6 +460,10 @@ func (ul *UserlogService) alterUserEventList(userid string, alter func([]string)
 func (ul *UserlogService) alterGlobalEvents(ctx context.Context, alter func(map[string]json.RawMessage) error) error {
 	_, span := ul.tracer.Start(ctx, "alterGlobalEvents")
 	defer span.End()
+
+	ul.storeMu.Lock()
+	defer ul.storeMu.Unlock()
+
 	evs, err := ul.GetGlobalEvents(ctx)
 	if err != nil && err != store.ErrNotFound {
 		return err


### PR DESCRIPTION
## Problem

In-app notifications could be silently lost. Under concurrent event processing, some notification entries written to a user's event list (or to the shared global-events list) would disappear, so the affected user never saw those notifications.

## Root cause

The userlog service processes incoming events with `MaxConcurrency` worker goroutines (`MemorizeEvents`, `services/userlog/pkg/service/service.go`). Both `alterUserEventList` and `alterGlobalEvents` implement a read-modify-write against the go-micro key-value store:

```
read list -> unmarshal -> alter (append/remove) -> marshal -> write
```

with no locking. When two workers operate on the same key concurrently — the same user's event list, or the single `global-events` key that *every* global event mutates — their read/modify/write cycles interleave and the later write overwrites the earlier one, dropping event IDs. This is a classic lost-update race.

The sibling activitylog service guards the identical store read-modify-write pattern with a `sync.RWMutex`; userlog had no such guard.

## Fix

Add a `sync.Mutex` to `UserlogService` and take it around the read-modify-write cycles in `alterUserEventList` and `alterGlobalEvents`. The alter callbacks are pure in-memory transforms and these are the only functions doing the store read-modify-write, so a single non-reentrant mutex is sufficient and cannot deadlock. This mirrors the established activitylog approach.

A per-key/sharded lock would allow more concurrency across distinct users, but a single mutex keeps the fix minimal and matches the existing precedent; userlog is not a high-throughput path.

## Testing

- `go test ./services/userlog/... -race` — passes and is race-clean.
- New `services/userlog/pkg/service/race_test.go`:
  - `TestAlterUserEventListConcurrentDoesNotLoseEvents` — 50 goroutines append distinct IDs to one user list, asserts all 50 survive.
  - `TestAlterGlobalEventsConcurrentDoesNotLoseEvents` — same for the shared global-events key.
  - On master both fail dramatically (got **1**, want 50 — 49 lost updates); with the fix both pass.

## Risk

Low. The mutex only serializes the store read-modify-write cycles, which are short. No public/CS3 API change, no behavioural change other than no longer dropping concurrent updates. No vendored code touched.
