### PR TITLE
fix(proxy): guard against empty signing key store in presigned URL auth

### DIFF
--- a/changelog/unreleased/bugfix-proxy-signed-url-empty-signing-key.md
+++ b/changelog/unreleased/bugfix-proxy-signed-url-empty-signing-key.md
@@ -1,0 +1,14 @@
+Bugfix: Prevent panic in presigned URL authentication when the signing key is missing
+
+The presigned-URL authenticator read the per-user signing key from a store and
+indexed the first record without checking that the result was non-empty. When
+the store returns an empty result without an error — which the `noop` store
+does, and `OCIS_CACHE_STORE=noop` also switches the presigned-URL signing-key
+store to `noop` — every signed-URL request panicked with `index out of range
+[0] with length 0` (recovered per request as an HTTP 502), so all signed-URL
+downloads failed. The authenticator now guards the lookup and returns a normal
+authentication error instead of panicking; it also no longer returns a nil
+error when the stored key is empty.
+
+https://github.com/owncloud/ocis/issues/12384
+https://github.com/owncloud/ocis/pull/12418

--- a/services/proxy/pkg/middleware/signed_url_auth.go
+++ b/services/proxy/pkg/middleware/signed_url_auth.go
@@ -150,9 +150,13 @@ func (m SignedURLAuthenticator) signatureIsValid(req *http.Request) (err error) 
 		m.Logger.Error().Err(err).Msg("could not retrieve signing key")
 		return err
 	}
-	if len(signingKey[0].Value) == 0 {
-		m.Logger.Error().Err(err).Msg("signing key empty")
-		return err
+	// A store may return an empty result set without an error (e.g. the "noop"
+	// store, or a store that has no signing key for this user). Guard the index
+	// access to avoid an out-of-range panic, and return a real error so the
+	// request fails authentication instead of proceeding with an empty key.
+	if len(signingKey) == 0 || len(signingKey[0].Value) == 0 {
+		m.Logger.Error().Str("userid", c.Id.OpaqueId).Msg("signing key empty or not found")
+		return errors.New("signing key not found")
 	}
 	u := m.buildUrlToSign(req)
 	computedSignature := m.createSignature(u, signingKey[0].Value)

--- a/services/proxy/pkg/middleware/signed_url_auth_test.go
+++ b/services/proxy/pkg/middleware/signed_url_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/proxy/pkg/config"
 	revactx "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/stretchr/testify/assert"
@@ -156,6 +157,34 @@ func TestSignedURLAuth_createSignature(t *testing.T) {
 	if s != expected {
 		t.Fail()
 	}
+}
+
+// TestSignedURLAuth_validateEmptySigningKeyStore guards against an out-of-range
+// panic when the signing-key store returns no record without an error. This
+// happens with the "noop" store (e.g. when OCIS_CACHE_STORE=noop, which also
+// governs the presigned-URL signing-key store). The request must fail
+// authentication, not panic.
+func TestSignedURLAuth_validateEmptySigningKeyStore(t *testing.T) {
+	pua := SignedURLAuthenticator{
+		PreSignedURLConfig: config.PreSignedURL{
+			AllowedHTTPMethods: []string{"get"},
+			Enabled:            true,
+		},
+		Store:  store.NewNoopStore(),
+		Logger: log.NewLogger(),
+		Now: func() time.Time {
+			tm, _ := time.Parse(time.RFC3339, "2019-05-14T11:02:00.000Z")
+			return tm
+		},
+	}
+
+	u := userpb.User{Id: &userpb.UserId{OpaqueId: "useri"}, DisplayName: "Test User"}
+	ctx := revactx.ContextSetUser(context.Background(), &u)
+	r := httptest.NewRequest("", "http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6", nil).WithContext(ctx)
+
+	var err error
+	assert.NotPanics(t, func() { err = pua.validate(r) }, "validate must not panic when the signing key store is empty")
+	assert.Error(t, err, "validate must reject the request when no signing key is found")
 }
 
 func TestSignedURLAuth_validate(t *testing.T) {


### PR DESCRIPTION
## Problem

Fixes #12384. With `OCIS_CACHE_STORE=noop`, every signed-URL download fails with HTTP 502, and the proxy logs a panic:

```
panic: runtime error: index out of range [0] with length 0
  ... signatureIsValid -> validate -> Authenticate
```

## Root cause

`SignedURLAuthenticator.signatureIsValid` (`services/proxy/pkg/middleware/signed_url_auth.go`) reads the per-user signing key and then indexes the first record:

```go
signingKey, err := m.Store.Read(c.Id.OpaqueId)
if err != nil { ... return err }
if len(signingKey[0].Value) == 0 {   // <- indexes [0] with no length check
```

The `noop` store's `Read` returns an **empty slice with a nil error** (`vendor/go-micro.dev/v4/store/noop.go`), so the `err != nil` branch is skipped and `signingKey[0]` panics. The presigned-URL signing-key store is bound to `OCIS_CACHE_STORE` (`services/proxy/pkg/config/config.go` — `env:"OCIS_CACHE_STORE;PROXY_PRESIGNEDURL_SIGNING_KEYS_STORE"`), so a global `OCIS_CACHE_STORE=noop` (a common deployment setting) turns it into a no-op store and triggers the panic for every signed-URL request.

There's also a latent second defect: the original empty-value branch did `return err` where `err` is `nil`, so an empty signing key would have *passed* authentication rather than failing it.

## Fix

Guard the index access and return a real error:

```go
if len(signingKey) == 0 || len(signingKey[0].Value) == 0 {
    m.Logger.Error().Str("userid", c.Id.OpaqueId).Msg("signing key empty or not found")
    return errors.New("signing key not found")
}
```

This converts the panic into a normal authentication failure (the `Authenticate` path already logs and returns `false`), and an empty key is now correctly rejected.

This is the minimal, safe fix. The underlying config coupling (the signing-key store sharing the `OCIS_CACHE_STORE` env, so it can be silently turned off) is worth decoupling separately, but the guard alone removes the outage.

## Testing

- New `TestSignedURLAuth_validateEmptySigningKeyStore` (`signed_url_auth_test.go`) drives `validate` with a `noop` store and a valid, non-expired request. On master it panics with `index out of range [0] with length 0`; with the fix it does not panic and returns an authentication error.
- `go test ./services/proxy/pkg/middleware/ -run TestSignedURLAuth -race` — passes, race-clean.
- `go build ./services/proxy/...` and `go vet` clean.

(Note: running the *whole* `services/proxy/pkg/middleware` suite with `-race` surfaces a pre-existing data race in the OIDC ginkgo suite's shared mock — unrelated to this change and addressed separately in #12414.)

## Risk

Low. Confined to one guard in the signed-URL authenticator; turns a panic/502 into a clean auth rejection. No public/CS3 API change, no vendored code modified.
