### PR TITLE
fix(graph): honor $select=actions on the permissions list endpoint

### DIFF
--- a/changelog/unreleased/bugfix-graph-permissions-select-actions.md
+++ b/changelog/unreleased/bugfix-graph-permissions-select-actions.md
@@ -1,0 +1,13 @@
+Bugfix: Honor $select=actions on the drive item permissions endpoint
+
+Listing the permissions of a drive item with
+`$select=@libre.graph.permissions.actions.allowedValues` still returned the
+roles allowedValues as well. The handler only had a projection for the roles
+selection (`@libre.graph.permissions.roles.allowedValues`), which drops the
+actions, but no symmetric handling for an actions-only selection, so the roles
+were always included. The actions selection now drops the roles allowedValues
+(and, like the roles selection, skips the share lookup since only the allowed
+values are requested).
+
+https://github.com/owncloud/ocis/issues/10816
+https://github.com/owncloud/ocis/pull/12419

--- a/services/graph/mocks/drive_item_permissions_provider.go
+++ b/services/graph/mocks/drive_item_permissions_provider.go
@@ -411,8 +411,8 @@ func (_c *DriveItemPermissionsProvider_Invite_Call) RunAndReturn(run func(contex
 }
 
 // ListPermissions provides a mock function with given fields: ctx, itemID, listFederatedRoles, selectRoles
-func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
-	ret := _m.Called(ctx, itemID, listFederatedRoles, selectRoles)
+func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, itemID *providerv1beta1.ResourceId, listFederatedRoles bool, selectRoles bool, selectActions bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+	ret := _m.Called(ctx, itemID, listFederatedRoles, selectRoles, selectActions)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPermissions")
@@ -420,17 +420,17 @@ func (_m *DriveItemPermissionsProvider) ListPermissions(ctx context.Context, ite
 
 	var r0 libregraph.CollectionOfPermissionsWithAllowedValues
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
-		return rf(ctx, itemID, listFederatedRoles, selectRoles)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool, bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)); ok {
+		return rf(ctx, itemID, listFederatedRoles, selectRoles, selectActions)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
-		r0 = rf(ctx, itemID, listFederatedRoles, selectRoles)
+	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.ResourceId, bool, bool, bool) libregraph.CollectionOfPermissionsWithAllowedValues); ok {
+		r0 = rf(ctx, itemID, listFederatedRoles, selectRoles, selectActions)
 	} else {
 		r0 = ret.Get(0).(libregraph.CollectionOfPermissionsWithAllowedValues)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, bool, bool) error); ok {
-		r1 = rf(ctx, itemID, listFederatedRoles, selectRoles)
+	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.ResourceId, bool, bool, bool) error); ok {
+		r1 = rf(ctx, itemID, listFederatedRoles, selectRoles, selectActions)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/services/graph/pkg/service/v0/api_driveitem_permissions.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions.go
@@ -52,7 +52,7 @@ const (
 type DriveItemPermissionsProvider interface {
 	Invite(ctx context.Context, resourceId *storageprovider.ResourceId, invite libregraph.DriveItemInvite) (libregraph.Permission, error)
 	SpaceRootInvite(ctx context.Context, driveID *storageprovider.ResourceId, invite libregraph.DriveItemInvite) (libregraph.Permission, error)
-	ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)
+	ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles, selectRoles, selectActions bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error)
 	ListSpaceRootPermissions(ctx context.Context, driveID *storageprovider.ResourceId) (libregraph.CollectionOfPermissionsWithAllowedValues, error)
 	DeletePermission(ctx context.Context, itemID *storageprovider.ResourceId, permissionID string) error
 	DeleteSpaceRootPermission(ctx context.Context, driveID *storageprovider.ResourceId, permissionID string) error
@@ -390,7 +390,7 @@ func (s DriveItemPermissionsService) SpaceRootInvite(ctx context.Context, driveI
 }
 
 // ListPermissions lists the permissions of a driveItem
-func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID *storageprovider.ResourceId, listFederatedRoles, selectRoles, selectActions bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
 
 	ctx, span := s.tp.Tracer("graph").Start(ctx, "ListPermissions")
 	defer span.End()
@@ -440,6 +440,13 @@ func (s DriveItemPermissionsService) ListPermissions(ctx context.Context, itemID
 		// drop the actions
 		collectionOfPermissions.LibreGraphPermissionsActionsAllowedValues = nil
 		// no need to fetch shares, we are only interested in the roles
+		return collectionOfPermissions, nil
+	}
+
+	if selectActions {
+		// drop the roles
+		collectionOfPermissions.LibreGraphPermissionsRolesAllowedValues = nil
+		// no need to fetch shares, we are only interested in the actions
 		return collectionOfPermissions, nil
 	}
 
@@ -527,7 +534,7 @@ func (s DriveItemPermissionsService) ListSpaceRootPermissions(ctx context.Contex
 	}
 
 	rootResourceID := space.GetRoot()
-	return s.ListPermissions(ctx, rootResourceID, false, false) // federated roles are not supported for spaces
+	return s.ListPermissions(ctx, rootResourceID, false, false, false) // federated roles are not supported for spaces
 }
 
 // GetPermission returns a single permission of a drive item identified by permissionID
@@ -536,7 +543,7 @@ func (s DriveItemPermissionsService) GetPermission(ctx context.Context, itemID *
 	defer span.End()
 
 	// Reuse ListPermissions to obtain all permissions and select the requested one
-	collection, err := s.ListPermissions(ctx, itemID, false, false)
+	collection, err := s.ListPermissions(ctx, itemID, false, false, false)
 	if err != nil {
 		return libregraph.Permission{}, err
 	}
@@ -887,9 +894,14 @@ func (api DriveItemPermissionsApi) ListPermissions(w http.ResponseWriter, r *htt
 		selectRoles = true
 	}
 
+	var selectActions bool
+	if GetSelectParam(r) == "@libre.graph.permissions.actions.allowedValues" {
+		selectActions = true
+	}
+
 	ctx := r.Context()
 
-	permissions, err := api.driveItemPermissionsService.ListPermissions(ctx, itemID, listFederatedRoles, selectRoles)
+	permissions, err := api.driveItemPermissionsService.ListPermissions(ctx, itemID, listFederatedRoles, selectRoles, selectActions)
 	if err != nil {
 		errorcode.RenderError(w, r, err)
 		return

--- a/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions_test.go
@@ -391,10 +391,24 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(statResponse, nil)
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
+		})
+		It("returns only the roles allowedValues when roles are selected", func() {
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(statResponse, nil)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, true, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
+			Expect(permissions.LibreGraphPermissionsActionsAllowedValues).To(BeEmpty())
+		})
+		It("returns only the actions allowedValues when actions are selected", func() {
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(statResponse, nil)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false, true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
+			Expect(permissions.LibreGraphPermissionsRolesAllowedValues).To(BeEmpty())
 		})
 		It("returns one permission per share", func() {
 			statResponse.Info.PermissionSet = roleconversions.NewEditorRole().CS3ResourcePermissions()
@@ -439,7 +453,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
@@ -475,7 +489,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
@@ -511,7 +525,7 @@ var _ = Describe("DriveItemPermissionsService", func() {
 			gatewayClient.On("ListShares", mock.Anything, mock.Anything).Return(listSharesResponse, nil)
 			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponse, nil)
 			gatewayClient.On("ListPublicShares", mock.Anything, mock.Anything).Return(listPublicSharesResponse, nil)
-			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false)
+			permissions, err := driveItemPermissionsService.ListPermissions(context.Background(), itemID, false, false, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(permissions.LibreGraphPermissionsActionsAllowedValues)).ToNot(BeZero())
 			Expect(len(permissions.LibreGraphPermissionsRolesAllowedValues)).ToNot(BeZero())
@@ -1476,8 +1490,8 @@ var _ = Describe("DriveItemPermissionsApi", func() {
 			inviteJson, err := json.Marshal(invite)
 			Expect(err).ToNot(HaveOccurred())
 
-			mockProvider.On("ListPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, itemid *provider.ResourceId, listFederatedRoles, selectRoles bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
+			mockProvider.On("ListPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return(func(ctx context.Context, itemid *provider.ResourceId, listFederatedRoles, selectRoles, selectActions bool) (libregraph.CollectionOfPermissionsWithAllowedValues, error) {
 					Expect(listFederatedRoles).To(Equal(false))
 					Expect(storagespace.FormatResourceID(itemid)).To(Equal("1$2!3"))
 					return libregraph.CollectionOfPermissionsWithAllowedValues{}, nil


### PR DESCRIPTION
## Problem

Fixes #10816. Requesting the permissions of a drive item with `$select=@libre.graph.permissions.actions.allowedValues` returns the **roles** allowedValues as well, even though only the actions were selected.

## Root cause

In `DriveItemPermissionsApi.ListPermissions` / `DriveItemPermissionsService.ListPermissions` (`services/graph/pkg/service/v0/api_driveitem_permissions.go`), the `$select` projection is asymmetric. The handler only sets a `selectRoles` flag for `@libre.graph.permissions.roles.allowedValues`, and the service prunes the **actions** field when `selectRoles` is set:

```go
if selectRoles {
    collectionOfPermissions.LibreGraphPermissionsActionsAllowedValues = nil
    return collectionOfPermissions, nil
}
```

There is no equivalent flag/branch for an actions-only selection, so the response is always built with both `…ActionsAllowedValues` and `…RolesAllowedValues` and nothing prunes the roles — they're returned regardless of `$select`.

## Fix

Add the symmetric projection. The handler computes a `selectActions` flag for `@libre.graph.permissions.actions.allowedValues` and passes it through; the service drops the roles allowedValues (and skips the share lookup, mirroring the roles path, since only the allowed values are requested):

```go
if selectActions {
    collectionOfPermissions.LibreGraphPermissionsRolesAllowedValues = nil
    return collectionOfPermissions, nil
}
```

This required threading `selectActions` through the `DriveItemPermissionsProvider.ListPermissions` signature (plus its generated mock and the two internal callers, which pass `false`).

## Testing

- New specs in `api_driveitem_permissions_test.go`:
  - *returns only the roles allowedValues when roles are selected* — actions empty (existing behaviour, now covered).
  - *returns only the actions allowedValues when actions are selected* — roles empty (the regression for #10816). Removing the new branch makes this spec fail.
- `go test ./services/graph/pkg/service/v0/` — full package passes.
- `go build ./services/graph/...` and `go vet` (no new issues in the touched file).

## Risk

Low. Adds a projection branch symmetric to the existing roles handling; the default request (no `$select`) is unchanged. No CS3 API change, no vendored code modified. The interface signature gains one bool, updated in the generated mock and the two internal callers.
