### PR TITLE
fix(proxy): keep group memberships when the OIDC groups claim is absent

### DIFF
--- a/changelog/unreleased/bugfix-proxy-oidc-group-sync-absent-claim.md
+++ b/changelog/unreleased/bugfix-proxy-oidc-group-sync-absent-claim.md
@@ -1,0 +1,16 @@
+Bugfix: Keep group memberships when the OIDC groups claim is absent
+
+When auto-provisioning group memberships from an OIDC claim, the proxy
+reconciled the user's groups against the groups claim and removed them from any
+group not present in the claim. If a token carried no groups claim at all — for
+example a token issued for an OIDC client that has no groups mapper configured,
+such as a dedicated desktop-client registration — the parsed group set was empty
+and the user was removed from all of their groups.
+
+The sync is now skipped when the groups claim is absent or null in the token. A
+present-but-empty claim is still treated as a legitimate "no groups" and
+reconciled as before. This mirrors the guard the role-assignment path already
+has for a missing roles claim.
+
+https://github.com/owncloud/ocis/issues/11435
+https://github.com/owncloud/ocis/pull/12420

--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -259,10 +259,28 @@ func (c *cs3backend) UpdateUserIfNeeded(ctx context.Context, user *cs3.User, cla
 	return nil
 }
 
+// groupsClaimPresent reports whether the configured groups claim is present and
+// non-null in the token claims. An absent or null claim must not be treated as
+// an empty group list, otherwise the user would be removed from all groups.
+func groupsClaimPresent(claims map[string]interface{}, claimName string) bool {
+	v, ok := claims[claimName]
+	return ok && v != nil
+}
+
 // SyncGroupMemberships maintains a users group memberships based on an OIDC claim
 func (c *cs3backend) SyncGroupMemberships(ctx context.Context, user *cs3.User, claims map[string]interface{}) error {
 	if c.autoProvisionClaims.Groups == "" {
 		// do not sync groups when claim is not set
+		return nil
+	}
+
+	if !groupsClaimPresent(claims, c.autoProvisionClaims.Groups) {
+		// The token does not carry the groups claim (e.g. it was issued for an
+		// OIDC client that has no groups mapper configured). Treating an absent
+		// claim as an empty group list would remove the user from all of their
+		// groups, so skip the sync entirely. A present-but-empty claim is a
+		// legitimate "no groups" signal and still triggers reconciliation.
+		c.logger.Debug().Msg("groups claim not present in token, skipping group membership sync")
 		return nil
 	}
 

--- a/services/proxy/pkg/user/backend/cs3_test.go
+++ b/services/proxy/pkg/user/backend/cs3_test.go
@@ -1,0 +1,31 @@
+package backend
+
+import "testing"
+
+// TestGroupsClaimPresent guards the decision that protects users from losing all
+// group memberships: only a present (and non-null) groups claim may trigger
+// membership reconciliation. An absent or null claim must be treated as "do not
+// sync", not as "no groups".
+func TestGroupsClaimPresent(t *testing.T) {
+	const claim = "groups"
+
+	tests := []struct {
+		name   string
+		claims map[string]interface{}
+		want   bool
+	}{
+		{"claim absent", map[string]interface{}{"other": "x"}, false},
+		{"claim null", map[string]interface{}{claim: nil}, false},
+		{"empty claims", map[string]interface{}{}, false},
+		{"present but empty", map[string]interface{}{claim: []interface{}{}}, true},
+		{"present with groups", map[string]interface{}{claim: []interface{}{"admins"}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := groupsClaimPresent(tt.claims, claim); got != tt.want {
+				t.Errorf("groupsClaimPresent(%v) = %v, want %v", tt.claims, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Addresses the behavior reported in #11435: a user is removed from all of their groups after authenticating, when the OIDC token does not carry the configured groups claim. This happens, for example, when a dedicated OIDC client (such as the one used by the desktop app) has no groups-claim mapper configured, while the web client does.

> Note: #11435 was closed as *completed* after the reporter worked around it by adding the groups mapper to the desktop client in Keycloak. The maintainer's analysis in that thread confirms the underlying oCIS behavior — *"the code will compare the list of claims with the list of existing membership and remove the user if he is in a group that is not in the claims"* — and that code behavior was never changed. This PR fixes the code so the workaround is no longer required.

## Root cause

`cs3backend.SyncGroupMemberships` (`services/proxy/pkg/user/backend/cs3.go`) builds the desired group set only from a successful type assertion on the claim:

```go
newGroupSet := make(map[string]struct{})
if groups, ok := claims[c.autoProvisionClaims.Groups].([]interface{}); ok { ... }
```

When the groups claim is **absent** from the token, the assertion fails, `newGroupSet` stays empty, and the reconciliation loop then deletes the user from every group not in the (empty) set — i.e. all of them. The code cannot distinguish "claim absent for this token" from "claim present and lists no groups".

## Fix

Skip the sync when the groups claim is absent or null, via a small, directly testable helper:

```go
func groupsClaimPresent(claims map[string]interface{}, claimName string) bool {
    v, ok := claims[claimName]
    return ok && v != nil
}
```

A **present-but-empty** claim still reconciles as before (a legitimate "no groups"). This mirrors the guard the auto-provision role-assignment path already applies for a missing roles claim, so the two stay consistent.

## Testing

- New `cs3_test.go` (`TestGroupsClaimPresent`): absent / null / empty-map → `false` (skip, no removal); present-empty / present-with-groups → `true` (reconcile). `go test ./services/proxy/pkg/user/backend/ -race` passes.
- `go build ./services/proxy/...` and `go vet` (no new issues in the touched code).
- A full end-to-end test of `SyncGroupMemberships` would require mocking the libregraph HTTP client and the gateway; the package currently has no such harness, so the fix is covered by the pure decision helper plus the early-return guard.

## Risk

Low. The only behavioural change is that a token without the groups claim no longer wipes the user's group memberships. Group sync only runs when `PROXY_AUTOPROVISION_CLAIM_GROUPS` is configured, and a present (even empty) claim behaves exactly as before. No CS3 API change, no vendored code modified.
