### PR TITLE
fix(proxy): use events endpoint (not cluster id) for the readyz NATS check

### DIFF
--- a/changelog/unreleased/bugfix-proxy-readyz-nats-check.md
+++ b/changelog/unreleased/bugfix-proxy-readyz-nats-check.md
@@ -1,0 +1,11 @@
+Bugfix: Fix the proxy readiness check for NATS
+
+The proxy readiness check passed the events cluster ID instead of the events
+endpoint to the NATS reachability check. NATS then tried to resolve the cluster
+ID (e.g. `ocis-cluster`) as a host name, which always failed, so the proxy
+`/readyz` endpoint reported the service as not ready even when NATS was
+reachable. The check now uses the events endpoint, consistent with every other
+service.
+
+https://github.com/owncloud/ocis/issues/10661
+https://github.com/owncloud/ocis/pull/12421

--- a/services/proxy/pkg/server/debug/server.go
+++ b/services/proxy/pkg/server/debug/server.go
@@ -22,7 +22,7 @@ func Server(opts ...Option) (*http.Server, error) {
 		WithCheck("web reachability", checks.NewHTTPCheck(options.Config.HTTP.Addr))
 
 	readyHandlerConfiguration := healthHandlerConfiguration.
-		WithCheck("nats reachability", checks.NewNatsCheck(options.Config.Events.Cluster))
+		WithCheck("nats reachability", checks.NewNatsCheck(options.Config.Events.Endpoint))
 
 	var configDumpFunc http.HandlerFunc = configDump(options.Config)
 	return debug.NewService(

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -292,7 +292,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 #### [Readiness check for some services returns 500 status code](https://github.com/owncloud/ocis/issues/10661)
 
-- [apiServiceAvailability/serviceAvailabilityCheck.feature:115](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L115)
 - [apiServiceAvailability/serviceAvailabilityCheck.feature:124](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L124)
 - [apiServiceAvailability/serviceAvailabilityCheck.feature:135](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature#L135)
 


### PR DESCRIPTION
## Problem

Part of #10661. The proxy `/readyz` endpoint reports the service as **not ready** even when NATS is reachable, so the proxy can be flagged unhealthy / fail readiness gating in orchestrators.

## Root cause

The proxy readiness check (`services/proxy/pkg/server/debug/server.go`) passes `options.Config.Events.Cluster` — the **cluster ID** (e.g. `ocis-cluster`) — to `checks.NewNatsCheck`, which forwards its argument straight to `nats.Connect` as the connection address. NATS then tries to resolve `ocis-cluster` as a host name, which always fails, so the readiness check always reports failure (HTTP 500).

Every other service passes `Events.Endpoint` (the address, e.g. `127.0.0.1:9233`) — the proxy was the lone outlier:

```
services/proxy/...      NewNatsCheck(options.Config.Events.Cluster)   <- wrong
services/graph/...      NewNatsCheck(options.Config.Events.Endpoint)
services/sse/...        NewNatsCheck(options.Config.Events.Endpoint)
... (all others use Endpoint)
```

## Fix

Use `Events.Endpoint`, matching every other service.

## Testing

- `go build ./services/proxy/...` clean.
- The fix is a one-line field correction that aligns the proxy with the ~18 other services' NATS readiness checks; the debug-server wiring has no unit-test seam, so correctness is established by that consistency and the field semantics (`Endpoint` is the address consumed by `nats.Connect`; `Cluster` is the cluster ID).

## Risk

Minimal. One-line change to the readiness check wiring; no behavioural change beyond `/readyz` correctly reflecting NATS reachability. (The issue's separate LDAP "too many colons" symptom is already fixed in the graph/idp debug servers; the `auth-bearer` debug-addr point is a separate matter.)
