### PR TITLE
fix(revisions): pass space ID when purging revision blobs to avoid orphans

### DIFF
--- a/changelog/unreleased/bugfix-revisions-purge-orphaned-blob.md
+++ b/changelog/unreleased/bugfix-revisions-purge-orphaned-blob.md
@@ -1,0 +1,11 @@
+Bugfix: Pass the space ID when purging revision blobs
+
+The `revisions purge` command removed a revision's metadata but did not delete
+its blob, because it called the blobstore without the space ID. The blobstore
+builds the blob path from the space ID and blob ID, so an empty space ID
+targeted the wrong path: the deletion was a no-op (S3) or missed the file
+(POSIX), leaving the blob orphaned while the revision was already removed. The
+space ID parsed from the revision path is now passed to the blobstore.
+
+https://github.com/owncloud/ocis/issues/11644
+https://github.com/owncloud/ocis/pull/12422

--- a/ocis/pkg/revisions/purge_test.go
+++ b/ocis/pkg/revisions/purge_test.go
@@ -1,0 +1,55 @@
+package revisions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/shamaton/msgpack/v2"
+	"github.com/test-go/testify/require"
+)
+
+// recordingBlobstore records the nodes passed to Delete so the test can assert
+// the blob path inputs (SpaceID + BlobID).
+type recordingBlobstore struct {
+	deleted []*node.Node
+}
+
+func (r *recordingBlobstore) Delete(n *node.Node) error {
+	r.deleted = append(r.deleted, n)
+	return nil
+}
+
+// TestPurgeRevisionsDeletesBlobWithSpaceID guards against orphaning blobs: the
+// blobstore derives the blob path from the node's SpaceID and BlobID, so
+// PurgeRevisions must pass the SpaceID parsed from the revision path. Without
+// it the blobstore targets the wrong path (no-op delete) while the revision
+// metadata is still removed, leaving the blob orphaned.
+func TestPurgeRevisionsDeletesBlobWithSpaceID(t *testing.T) {
+	const (
+		spaceID = "spaceid1"
+		nodeID  = "nodeid1"
+		blobID  = "blob-abc"
+	)
+
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "storage", "users", "spaces", spaceID, "nodes")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	revPath := filepath.Join(dir, nodeID+".REV.2024-05-22T07:32:53.123456789Z.mpk")
+	value, err := msgpack.Marshal(map[string][]byte{"user.ocis.blobid": []byte(blobID)})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(revPath, value, 0o644))
+
+	nodes := make(chan string, 1)
+	nodes <- revPath
+	close(nodes)
+
+	bs := &recordingBlobstore{}
+	PurgeRevisions(nodes, bs, false, false)
+
+	require.Len(t, bs.deleted, 1, "expected exactly one blob delete")
+	require.Equal(t, blobID, bs.deleted[0].BlobID)
+	require.Equal(t, spaceID, bs.deleted[0].SpaceID, "SpaceID must be passed to the blobstore, otherwise the blob is orphaned")
+}

--- a/ocis/pkg/revisions/revisions.go
+++ b/ocis/pkg/revisions/revisions.go
@@ -164,8 +164,13 @@ func PurgeRevisions(nodes <-chan string, bs DelBlobstore, dryRun, verbose bool) 
 
 		if !dryRun {
 			if blobID != "" {
-				//  TODO: needs spaceID for s3ng
-				if err := bs.Delete(&node.Node{BlobID: blobID}); err != nil {
+				// The blobstore derives the blob path from the node's SpaceID and
+				// BlobID, so the SpaceID must be set. Without it the wrong (empty
+				// space) path is targeted: the s3ng delete is a no-op and the
+				// posix delete misses, leaving the blob orphaned while the
+				// revision metadata below is still removed.
+				spaceID, _ := getIDsFromPath(d)
+				if err := bs.Delete(&node.Node{SpaceID: spaceID, BlobID: blobID}); err != nil {
 					fmt.Printf("error deleting blob %s: %v\n", blobID, err)
 					continue
 				}


### PR DESCRIPTION
## Problem

Fixes #11644. Running `ocis revisions purge` removes a file version's revision entry but leaves its blob behind in the blobstore — an orphaned blob that accumulates and is never reclaimed.

## Root cause

In `PurgeRevisions` (`ocis/pkg/revisions/revisions.go`) the blobstore delete was called without a space ID:

```go
//  TODO: needs spaceID for s3ng
if err := bs.Delete(&node.Node{BlobID: blobID}); err != nil { ... }
```

The blobstore builds the blob path from **both** the space ID and the blob ID — e.g. s3ng `Blobstore.Path`:

```go
return filepath.Clean(filepath.Join(node.SpaceID, lookup.Pathify(node.BlobID, 4, 2)))
```

With an empty `SpaceID` the path is wrong, so the delete is a no-op on S3 (`RemoveObject` is idempotent) and misses the file on POSIX (`os.Remove` → `ENOENT`). Either way the error is swallowed, and the code then unconditionally `os.Remove`s the revision metadata file — so the revision reference disappears while the blob remains. Orphaned blob.

The space ID is readily available: `getIDsFromPath(d)` already parses it from the revision path (it's used a few lines later for verbose output).

## Fix

Parse the space ID from the revision path and pass it to the blobstore:

```go
spaceID, _ := getIDsFromPath(d)
if err := bs.Delete(&node.Node{SpaceID: spaceID, BlobID: blobID}); err != nil { ... }
```

## Testing

- New `purge_test.go` (`TestPurgeRevisionsDeletesBlobWithSpaceID`): builds a revision `.mpk` under `…/spaces/<id>/nodes/…REV…`, runs `PurgeRevisions` with a recording blobstore, and asserts the deleted node carries both the blob ID and the space ID. Fails on master (empty space ID), passes with the fix.
- `go test ./ocis/pkg/revisions/`, `go build ./ocis/...`, `go vet` all pass.

## Risk

Low. Purely oCIS-native (the `revisions` CLI tool); no vendored reva or CS3 API change. The only behavioural change is that the blob is now actually deleted instead of leaked.
