### PR TITLE
fix(audit): always set a non-empty action for share updates

### DIFF
--- a/changelog/unreleased/bugfix-audit-share-update-action.md
+++ b/changelog/unreleased/bugfix-audit-share-update-action.md
@@ -1,0 +1,18 @@
+Bugfix: Always set an audit action for share updates
+
+Share-update audit events were written with an empty `action` and a message of
+`updated field ''`, because the conversion read the deprecated
+`ShareUpdated.Updated` field, which reva no longer populates (it now sets
+`UpdateMask`). Received-share declines were also not audited correctly because
+the conversion matched `SHARE_STATE_DECLINED`, which is not a CS3 share state
+(the enum value is `SHARE_STATE_REJECTED`), again producing an empty action and
+message.
+
+The conversion now derives the updated field and action from `UpdateMask`
+(falling back to the deprecated field), maps `SHARE_STATE_REJECTED` to the
+declined action, and uses a generic, non-empty action for any unrecognized
+update field or share state, so every audit entry carries a meaningful,
+countable action.
+
+https://github.com/owncloud/ocis/issues/7661
+https://github.com/owncloud/ocis/pull/12423

--- a/services/audit/pkg/service/service_test.go
+++ b/services/audit/pkg/service/service_test.go
@@ -252,7 +252,7 @@ var testCases = []struct {
 				GranteeGroupID: nil,
 				Sharer:         userID("sharing-userid"),
 				MTime:          timestamp(10e8),
-				State:          "SHARE_STATE_DECLINED",
+				State:          "SHARE_STATE_REJECTED",
 			},
 		},
 		CheckAuditEvent: func(t *testing.T, b []byte) {

--- a/services/audit/pkg/types/conversion.go
+++ b/services/audit/pkg/types/conversion.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -95,7 +94,7 @@ func LinkCreated(ev events.LinkCreated) AuditEventShareCreated {
 func ShareUpdated(ev events.ShareUpdated) AuditEventShareUpdated {
 	uid := ev.Sharer.OpaqueId
 	with, typ := extractGrantee(ev.GranteeUserID, ev.GranteeGroupID)
-	base := BasicAuditEvent(uid, formatTime(ev.MTime), MessageShareUpdated(uid, ev.ShareID.OpaqueId, ev.Updated), updateType(ev.Updated))
+	base := BasicAuditEvent(uid, formatTime(ev.MTime), MessageShareUpdated(uid, ev.ShareID.OpaqueId, shareUpdateField(ev.Updated, ev.UpdateMask)), shareUpdateAction(ev.Updated, ev.UpdateMask))
 	return AuditEventShareUpdated{
 		AuditEventSharing: SharingAuditEvent(ev.ShareID.GetOpaqueId(), ev.ItemID.OpaqueId, uid, base),
 		ShareOwner:        uid,
@@ -115,7 +114,7 @@ func ShareUpdated(ev events.ShareUpdated) AuditEventShareUpdated {
 func LinkUpdated(ev events.LinkUpdated) AuditEventShareUpdated {
 	uid := ev.Sharer.OpaqueId
 	with, typ := "", _linktype
-	base := BasicAuditEvent(uid, formatTime(ev.MTime), MessageLinkUpdated(uid, ev.ShareID.GetOpaqueId(), ev.FieldUpdated), updateType(ev.FieldUpdated))
+	base := BasicAuditEvent(uid, formatTime(ev.MTime), MessageLinkUpdated(uid, ev.ShareID.GetOpaqueId(), ev.FieldUpdated), shareUpdateAction(ev.FieldUpdated, nil))
 	return AuditEventShareUpdated{
 		AuditEventSharing: SharingAuditEvent(ev.ShareID.GetOpaqueId(), ev.ItemID.OpaqueId, uid, base),
 		ShareOwner:        uid,
@@ -181,14 +180,21 @@ func ReceivedShareUpdated(ev events.ReceivedShareUpdated) AuditEventReceivedShar
 	with, typ := extractGrantee(ev.GranteeUserID, ev.GranteeGroupID)
 	itemID := ev.ItemID.GetOpaqueId()
 
-	msg, utype := "", ""
+	var msg, utype string
 	switch ev.State {
 	case "SHARE_STATE_ACCEPTED":
 		msg = MessageShareAccepted(with, sid, uid)
 		utype = ActionShareAccepted
-	case "SHARE_STATE_DECLINED":
+	// the CS3 share state enum is SHARE_STATE_REJECTED; "SHARE_STATE_DECLINED"
+	// is not a valid value and never matched, so declines were not audited.
+	case "SHARE_STATE_REJECTED":
 		msg = MessageShareDeclined(with, sid, uid)
 		utype = ActionShareDeclined
+	default:
+		// keep the action non-empty for any other state (e.g. pending) so the
+		// event remains attributable instead of producing an empty record.
+		msg = MessageShareStateChanged(with, sid, uid, ev.State)
+		utype = ActionShareStateChanged
 	}
 	base := BasicAuditEvent(with, formatTime(ev.MTime), msg, utype)
 	return AuditEventReceivedShareUpdated{
@@ -552,24 +558,39 @@ func formatTime(t *types.Timestamp) string {
 	return time.Unix(int64(t.Seconds), int64(t.Nanos)).UTC().Format(time.RFC3339)
 }
 
-func updateType(u string) string {
-	switch u {
-	case "permissions":
-		return ActionSharePermissionUpdated
-	case "displayname":
-		return ActionShareDisplayNameUpdated
-	case "TYPE_PERMISSIONS":
-		return ActionSharePermissionUpdated
-	case "TYPE_DISPLAYNAME":
-		return ActionShareDisplayNameUpdated
-	case "TYPE_PASSWORD":
-		return ActionSharePasswordUpdated
-	case "TYPE_EXPIRATION":
-		return ActionShareExpirationUpdated
-	default:
-		fmt.Println("Unknown update type", u)
-		return ""
+// shareUpdateField resolves the name of the updated field for the audit message.
+// reva deprecated the single Updated field in favour of UpdateMask, so prefer
+// the mask when Updated is empty.
+func shareUpdateField(updated string, updateMask []string) string {
+	if updated != "" {
+		return updated
 	}
+	return strings.Join(updateMask, ", ")
+}
+
+// shareUpdateAction resolves the audit action for a share or link update. It
+// prefers the deprecated Updated field and falls back to the UpdateMask, mapping
+// the first recognized field to its specific action. Unknown or empty updates
+// map to the generic ActionShareUpdated so every update stays attributable
+// (an empty action cannot be counted for telemetry).
+func shareUpdateAction(updated string, updateMask []string) string {
+	candidates := updateMask
+	if updated != "" {
+		candidates = []string{updated}
+	}
+	for _, c := range candidates {
+		switch c {
+		case "permissions", "TYPE_PERMISSIONS":
+			return ActionSharePermissionUpdated
+		case "displayname", "TYPE_DISPLAYNAME":
+			return ActionShareDisplayNameUpdated
+		case "TYPE_PASSWORD":
+			return ActionSharePasswordUpdated
+		case "expiration", "TYPE_EXPIRATION":
+			return ActionShareExpirationUpdated
+		}
+	}
+	return ActionShareUpdated
 }
 
 // normalizeString tries to create a somewhat stable string

--- a/services/audit/pkg/types/conversion_test.go
+++ b/services/audit/pkg/types/conversion_test.go
@@ -1,0 +1,90 @@
+package types
+
+import (
+	"testing"
+
+	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/owncloud/reva/v2/pkg/events"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShareUpdateAction ensures every share/link update maps to a non-empty,
+// countable audit action, including the case where reva only sets the
+// UpdateMask (the single Updated field is deprecated and no longer populated).
+func TestShareUpdateAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		updated string
+		mask    []string
+		want    string
+	}{
+		{"share permissions", "permissions", nil, ActionSharePermissionUpdated},
+		{"link permissions", "TYPE_PERMISSIONS", nil, ActionSharePermissionUpdated},
+		{"link password", "TYPE_PASSWORD", nil, ActionSharePasswordUpdated},
+		{"share expiration", "expiration", nil, ActionShareExpirationUpdated},
+		{"share displayname", "displayname", nil, ActionShareDisplayNameUpdated},
+		{"deprecated empty, mask permissions", "", []string{"permissions"}, ActionSharePermissionUpdated},
+		{"deprecated empty, mask expiration", "", []string{"expiration"}, ActionShareExpirationUpdated},
+		{"empty updated and empty mask", "", nil, ActionShareUpdated},
+		{"unknown field", "somethingelse", nil, ActionShareUpdated},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shareUpdateAction(tt.updated, tt.mask)
+			require.Equal(t, tt.want, got)
+			require.NotEmpty(t, got, "audit action must never be empty")
+		})
+	}
+}
+
+// TestShareUpdatedDerivesActionFromUpdateMask reproduces the reported bug:
+// reva populates UpdateMask (not the deprecated Updated field), so the audit
+// event must still carry a specific action and a meaningful field in the
+// message rather than an empty action and "updated field ''".
+func TestShareUpdatedDerivesActionFromUpdateMask(t *testing.T) {
+	ev := events.ShareUpdated{
+		Sharer:        &user.UserId{OpaqueId: "sharer"},
+		ShareID:       &collaboration.ShareId{OpaqueId: "shareid"},
+		ItemID:        &provider.ResourceId{OpaqueId: "itemid"},
+		GranteeUserID: &user.UserId{OpaqueId: "grantee"},
+		Permissions:   &collaboration.SharePermissions{},
+		MTime:         &types.Timestamp{Seconds: 1},
+		// reva sets the mask; the deprecated Updated field stays empty
+		UpdateMask: []string{"permissions"},
+	}
+
+	out := ShareUpdated(ev)
+	require.Equal(t, ActionSharePermissionUpdated, out.Action)
+	require.NotEmpty(t, out.Action)
+	require.Contains(t, out.Message, "permissions")
+}
+
+// TestReceivedShareUpdatedStates ensures the received-share state changes map to
+// non-empty actions, including the rejected case (CS3 uses SHARE_STATE_REJECTED,
+// which previously did not match "SHARE_STATE_DECLINED") and a generic fallback.
+func TestReceivedShareUpdatedStates(t *testing.T) {
+	build := func(state string) events.ReceivedShareUpdated {
+		return events.ReceivedShareUpdated{
+			Sharer:        &user.UserId{OpaqueId: "sharer"},
+			ShareID:       &collaboration.ShareId{OpaqueId: "shareid"},
+			ItemID:        &provider.ResourceId{OpaqueId: "itemid"},
+			GranteeUserID: &user.UserId{OpaqueId: "grantee"},
+			MTime:         &types.Timestamp{Seconds: 1},
+			State:         state,
+		}
+	}
+
+	accepted := ReceivedShareUpdated(build("SHARE_STATE_ACCEPTED"))
+	require.Equal(t, ActionShareAccepted, accepted.Action)
+
+	rejected := ReceivedShareUpdated(build("SHARE_STATE_REJECTED"))
+	require.Equal(t, ActionShareDeclined, rejected.Action)
+	require.NotEmpty(t, rejected.Message)
+
+	pending := ReceivedShareUpdated(build("SHARE_STATE_PENDING"))
+	require.Equal(t, ActionShareStateChanged, pending.Action)
+	require.NotEmpty(t, pending.Message)
+}

--- a/services/audit/pkg/types/messages.go
+++ b/services/audit/pkg/types/messages.go
@@ -12,6 +12,7 @@ import (
 const (
 	// Sharing
 	ActionShareCreated            = "file_shared"
+	ActionShareUpdated            = "share_updated"
 	ActionSharePermissionUpdated  = "share_permission_updated"
 	ActionShareDisplayNameUpdated = "share_name_updated"
 	ActionSharePasswordUpdated    = "share_password_updated"
@@ -19,6 +20,7 @@ const (
 	ActionShareRemoved            = "file_unshared"
 	ActionShareAccepted           = "share_accepted"
 	ActionShareDeclined           = "share_declined"
+	ActionShareStateChanged       = "share_state_changed"
 	ActionLinkAccessed            = "public_link_accessed"
 
 	// Files
@@ -94,6 +96,12 @@ func MessageShareAccepted(userid, shareID, sharerID string) string {
 // MessageShareDeclined returns the human-readable string that describes the action
 func MessageShareDeclined(userid, shareID, sharerID string) string {
 	return fmt.Sprintf("user '%s' declined share '%s' from user '%s'", userid, shareID, sharerID)
+}
+
+// MessageShareStateChanged returns the human-readable string that describes a
+// received-share state change that is neither an accept nor a decline.
+func MessageShareStateChanged(userid, shareID, sharerID, state string) string {
+	return fmt.Sprintf("user '%s' changed the state of share '%s' from user '%s' to '%s'", userid, shareID, sharerID, state)
 }
 
 // MessageLinkAccessed returns the human-readable string that describes the action


### PR DESCRIPTION
## Problem

Addresses part of #7661 (inconsistent audit log). Two classes of share-related audit events are written with an **empty `action`** (and a partly-empty message), which makes them inconsistent and impossible to count/aggregate (e.g. for usage telemetry):

- **Every share update** is logged as `"action": ""` with `"message": "...updated field '' of share '...'"`.
- **Received-share declines** are not audited at all (empty `action` and `message`).

## Root cause

`services/audit/pkg/types/conversion.go`:

1. **Share/link updates** — `ShareUpdated`/`LinkUpdated` read `ev.Updated` and pass it to `updateType`, whose `default` returns `""`. But reva **deprecated** `ShareUpdated.Updated` and now populates `UpdateMask` instead:

   ```go
   // reva pkg/events/sharing.go
   Updated string // Deprecated
   UpdateMask []string // indicates what was updated
   ```

   So `ev.Updated` is always empty → `updateType("")` → empty action, and the message shows `updated field ''`. (`updateType` also printed `fmt.Println("Unknown update type", …)` to stdout.)

2. **Received-share state changes** — `ReceivedShareUpdated` matched `"SHARE_STATE_DECLINED"`, which is **not** a CS3 share state. reva sets the state from `collaboration.ShareState_name`, whose value for a decline is `"SHARE_STATE_REJECTED"`. The decline branch therefore never matched, leaving `msg`/`action` empty.

## Fix

- Derive the updated field and action from `UpdateMask` (falling back to the deprecated `Updated`), via `shareUpdateField` / `shareUpdateAction`. Unknown/empty updates map to a new generic `share_updated` action so the entry is never empty.
- Map `SHARE_STATE_REJECTED` to the declined action, and add a generic `share_state_changed` action + message for any other state, so received-share updates always carry a non-empty action.
- Remove the stray `fmt.Println` debug.

The persistently-empty `remoteaddr`/`url`/`method`/`useragent` fields noted in the issue are a separate, documented limitation (the async events carry no HTTP request context) and are out of scope here.

## Testing

- New `services/audit/pkg/types/conversion_test.go`:
  - `TestShareUpdateAction` — every field (incl. `UpdateMask`-only and unknown) maps to a non-empty action.
  - `TestShareUpdatedDerivesActionFromUpdateMask` — a `ShareUpdated` with only `UpdateMask` set yields the specific action and a meaningful message (empty on master).
  - `TestReceivedShareUpdatedStates` — `SHARE_STATE_REJECTED` → declined; other states → non-empty fallback.
- Updated the existing `TestAuditLogging/Share_declined` to use the real `SHARE_STATE_REJECTED` (it previously used the non-existent `SHARE_STATE_DECLINED`, which is why declines silently went unaudited). On master that corrected input fails; with the fix it passes.
- `go test ./services/audit/... -race` passes.

## Risk

Low. Confined to the audit event conversion; action strings for already-handled cases are unchanged, and the only new behaviour is that previously-empty actions now carry a value. No CS3 API or vendored-code change.
