### PR TITLE
fix(proxy,graph): do not disable personal space when permission check is inconclusive

### DIFF
--- a/changelog/unreleased/bugfix-personal-space-fail-closed.md
+++ b/changelog/unreleased/bugfix-personal-space-fail-closed.md
@@ -1,0 +1,17 @@
+Bugfix: Do not disable the personal space when the Drives.Create permission check is inconclusive
+
+When a user's role is (re-)assigned, both the proxy (on OIDC login) and the graph
+appRoleAssignment handler check the `Drives.Create` permission to decide whether to
+restore or disable the user's personal space. The permission check collapsed two very
+different outcomes into a single `false`: the user genuinely lacks the permission, and
+the permission could not be determined (a transport error, or a non-OK status such as
+`CODE_INTERNAL` returned by the settings/gateway service). In the second case the code
+proceeded to disable the personal space, moving it to the trash, even though the user's
+entitlement was never actually denied.
+
+The permission check now distinguishes the three cases. A transport error or a non-OK
+status other than `PERMISSION_DENIED` is surfaced as an error and the caller fails closed:
+the personal space is left untouched and the role transition is retried on the next login,
+rather than the space being trashed on an indeterminate result.
+
+https://github.com/owncloud/ocis/pull/12429

--- a/services/graph/pkg/service/v0/approleassignments.go
+++ b/services/graph/pkg/service/v0/approleassignments.go
@@ -7,6 +7,8 @@ import (
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	libregraph "github.com/owncloud/libre-graph-api-go"
@@ -100,7 +102,15 @@ func (g Graph) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	canCreateDrives := g.checkPermission(r.Context(), "Drives.Create", userID, client)
+	canCreateDrives, err := g.checkPermission(r.Context(), "Drives.Create", userID, client)
+	if err != nil {
+		// The permission could not be determined. Fail closed and leave the
+		// personal space untouched rather than disabling (trashing) it on an
+		// indeterminate result.
+		logger.Error().Any("userID", userID).Err(err).Msg("could not determine Drives.Create permission, leaving personal space unchanged")
+		errorcode.RenderError(w, r, err)
+		return
+	}
 	if canCreateDrives {
 		err = shared.RestorePersonalSpace(r.Context(), client, userID)
 		if err != nil {
@@ -192,17 +202,40 @@ func (g Graph) assignmentToAppRoleAssignment(assignment *settingsmsg.UserRoleAss
 	return *appRoleAssignment
 }
 
-func (g Graph) checkPermission(ctx context.Context, perm string, userID string, gwc gateway.GatewayAPIClient) bool {
+// checkPermission reports whether the given user holds the given permission.
+//
+// It distinguishes three outcomes that must not be collapsed into a single
+// boolean: the permission is granted (true, nil), the permission is
+// authoritatively denied (false, nil), or the permission could not be
+// determined (false, err). The last case happens when the user lookup or the
+// gateway/settings permission call fails at the transport level or returns a
+// non-OK status other than PERMISSION_DENIED. Callers must treat a non-nil
+// error as "unknown" and fail closed: an indeterminate result must never be
+// mistaken for a deliberate denial, because the caller acts destructively
+// (disabling the personal space) on denial.
+func (g Graph) checkPermission(ctx context.Context, perm string, userID string, gwc gateway.GatewayAPIClient) (bool, error) {
 	u, err := utils.GetUserWithContext(ctx, &userv1beta1.UserId{OpaqueId: userID}, gwc)
 	if err != nil {
-		g.logger.Error().Err(err).Msg("could not get user")
-		return false
+		return false, err
 	}
 
-	if ok, err := utils.CheckPermission(revactx.ContextSetUser(context.Background(), u), perm, gwc); ok {
-		return true
-	} else if err != nil {
-		g.logger.Error().Err(err).Msg("error checking permission")
+	resp, err := gwc.CheckPermission(revactx.ContextSetUser(context.Background(), u), &permissions.CheckPermissionRequest{
+		SubjectRef: &permissions.SubjectReference{
+			Spec: &permissions.SubjectReference_UserId{
+				UserId: u.GetId(),
+			},
+		},
+		Permission: perm,
+	})
+	if err != nil {
+		return false, err
 	}
-	return false
+	switch code := resp.GetStatus().GetCode(); code {
+	case rpc.Code_CODE_OK:
+		return true, nil
+	case rpc.Code_CODE_PERMISSION_DENIED:
+		return false, nil
+	default:
+		return false, fmt.Errorf("permission check for %q returned non-authoritative status %q: %s", perm, code, resp.GetStatus().GetMessage())
+	}
 }

--- a/services/graph/pkg/service/v0/approleassignments_test.go
+++ b/services/graph/pkg/service/v0/approleassignments_test.go
@@ -511,7 +511,60 @@ var _ = Describe("AppRoleAssignments", func() {
 			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
 			svc.CreateAppRoleAssignment(rr, r)
 
-			Expect(rr.Code).To(Equal(http.StatusCreated))
+			// The user lookup failed, so the Drives.Create permission could not be
+			// determined. The code must fail closed: surface the error and leave
+			// the personal space untouched rather than trashing it.
+			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+			gatewayClient.AssertNotCalled(GinkgoT(), "DeleteStorageSpace", mock.Anything, mock.Anything)
+		})
+
+		It("does not disable the personal space when the permission check is inconclusive", func() {
+			userRoleAssignment := &settingsmsg.UserRoleAssignment{
+				Id:          "some-appRoleAssignment-ID",
+				AccountUuid: "user1",
+				RoleId:      settingsService.BundleUUIDRoleUserLight,
+			}
+			roleService.On("ListRoleAssignments", mock.Anything, mock.Anything, mock.Anything).Return(&settings.ListRoleAssignmentsResponse{Assignments: []*settingsmsg.UserRoleAssignment{}}, nil)
+			roleService.On("AssignRoleToUser", mock.Anything, mock.Anything, mock.Anything).Return(&settings.AssignRoleToUserResponse{Assignment: userRoleAssignment}, nil)
+
+			// CheckPermission returns a non-OK status that is NOT PERMISSION_DENIED
+			// (here: an internal error in the settings service). The permission
+			// therefore could not be authoritatively determined, so the code must
+			// fail closed and must NOT delete (trash) the personal space.
+			gatewayClient.ExpectedCalls = nil
+			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(&userv1beta1.GetUserResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				User:   currentUser,
+			}, nil)
+			gatewayClient.On("CheckPermission", mock.Anything, mock.Anything).Return(&permissions.CheckPermissionResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_INTERNAL, Message: "settings unavailable"},
+			}, nil)
+			gatewayClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(&storageprovider.ListStorageSpacesResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				StorageSpaces: []*storageprovider.StorageSpace{
+					{Id: &storageprovider.StorageSpaceId{OpaqueId: "ps1"}},
+				},
+			}, nil)
+			gatewayClient.On("DeleteStorageSpace", mock.Anything, mock.Anything).Return(&storageprovider.DeleteStorageSpaceResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+			}, nil)
+
+			ara := libregraph.NewAppRoleAssignmentWithDefaults()
+			ara.SetAppRoleId(settingsService.BundleUUIDRoleUserLight)
+			ara.SetPrincipalId("user1")
+			ara.SetResourceId(cfg.Application.ID)
+
+			araJson, err := json.Marshal(ara)
+			Expect(err).ToNot(HaveOccurred())
+
+			r := httptest.NewRequest(http.MethodPost, "/graph/v1.0/users/user1/appRoleAssignments", bytes.NewBuffer(araJson))
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("userID", "user1")
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, currentUser), chi.RouteCtxKey, rctx))
+			svc.CreateAppRoleAssignment(rr, r)
+
+			Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+			gatewayClient.AssertNotCalled(GinkgoT(), "DeleteStorageSpace", mock.Anything, mock.Anything)
 		})
 	})
 

--- a/services/proxy/pkg/userroles/oidcroles.go
+++ b/services/proxy/pkg/userroles/oidcroles.go
@@ -3,12 +3,15 @@ package userroles
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"sync"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	cs3user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/owncloud/ocis/v2/ocis-pkg/middleware"
 	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 	"github.com/owncloud/ocis/v2/ocis-pkg/shared"
@@ -170,7 +173,14 @@ func (ra oidcRoleAssigner) UpdateUserRoleAssignment(ctx context.Context, user *c
 			return nil, err
 		}
 
-		canCreateDrives := ra.checkPermission("Drives.Create", user, client)
+		canCreateDrives, err := ra.checkPermission("Drives.Create", user, client)
+		if err != nil {
+			// The permission could not be determined. Fail closed and leave the
+			// personal space untouched rather than disabling (trashing) it on an
+			// indeterminate result. The role transition is retried on the next login.
+			logger.Error().Any("userID", userID).Err(err).Msg("could not determine Drives.Create permission, leaving personal space unchanged")
+			return nil, err
+		}
 		if canCreateDrives {
 			libreUser := identity.CreateUserModelFromCS3(user)
 			err = shared.RestorePersonalSpace(newctx, client, libreUser.GetId())
@@ -275,11 +285,35 @@ func (ra oidcRoleAssigner) roleNamesToRoleIDs() (map[string]string, error) {
 	return roleNameToID.roleNameToID, nil
 }
 
-func (ra oidcRoleAssigner) checkPermission(perm string, user *cs3user.User, gwc gateway.GatewayAPIClient) bool {
-	if ok, err := utils.CheckPermission(revactx.ContextSetUser(context.Background(), user), perm, gwc); ok {
-		return true
-	} else if err != nil {
-		ra.logger.Error().Err(err).Msg("error checking permission")
+// checkPermission reports whether the user holds the given permission.
+//
+// It distinguishes three outcomes that must not be collapsed into a single
+// boolean: the permission is granted (true, nil), the permission is
+// authoritatively denied (false, nil), or the permission could not be
+// determined (false, err). The last case happens when the gateway/settings
+// call fails at the transport level or returns a non-OK status other than
+// PERMISSION_DENIED. Callers must treat a non-nil error as "unknown" and fail
+// closed: an indeterminate result must never be mistaken for a deliberate
+// denial, because the caller acts destructively (disabling the personal space)
+// on denial.
+func (ra oidcRoleAssigner) checkPermission(perm string, user *cs3user.User, gwc gateway.GatewayAPIClient) (bool, error) {
+	resp, err := gwc.CheckPermission(revactx.ContextSetUser(context.Background(), user), &permissions.CheckPermissionRequest{
+		SubjectRef: &permissions.SubjectReference{
+			Spec: &permissions.SubjectReference_UserId{
+				UserId: user.GetId(),
+			},
+		},
+		Permission: perm,
+	})
+	if err != nil {
+		return false, err
 	}
-	return false
+	switch code := resp.GetStatus().GetCode(); code {
+	case rpc.Code_CODE_OK:
+		return true, nil
+	case rpc.Code_CODE_PERMISSION_DENIED:
+		return false, nil
+	default:
+		return false, fmt.Errorf("permission check for %q returned non-authoritative status %q: %s", perm, code, resp.GetStatus().GetMessage())
+	}
 }


### PR DESCRIPTION
## Problem

When a user's role is (re-)assigned, oCIS reconciles the user's personal space: if the
user is allowed to create drives it restores the personal space, otherwise it disables it
(moves it to the trash). This happens in two places:

- `proxy` `oidcRoleAssigner.UpdateUserRoleAssignment` (runs on OIDC login when the claimed
  role differs from the currently assigned one), and
- `graph` `Graph.CreateAppRoleAssignment` (the `POST .../appRoleAssignments` handler).

Both decide via a `Drives.Create` permission check that returns a plain `bool`. That boolean
collapses two fundamentally different outcomes into a single `false`:

1. the user genuinely lacks the permission (a deliberate denial), and
2. the permission could not be determined: a transport error talking to the
   gateway/settings service, or a non-OK status such as `CODE_INTERNAL`.

In case (2) the code proceeded as if the permission were denied and **disabled the personal
space, moving it to the trash**, even though the user's entitlement was never actually
denied. A transient hiccup in the settings/gateway path during a routine login could
therefore trash a user's personal space. There is no automatic re-enable.

## Root cause

`reva`'s `utils.CheckPermission` returns `resp.GetStatus().GetCode() == rpc.Code_CODE_OK`
as its boolean. Any non-OK status (`CODE_INTERNAL`, `CODE_PERMISSION_DENIED`, ...) maps to
`false`, and a non-OK status accompanied by a `nil` transport error is indistinguishable
from a real denial. The two `checkPermission` helpers built on top of it
(`services/proxy/pkg/userroles/oidcroles.go` and
`services/graph/pkg/service/v0/approleassignments.go`) inherited that ambiguity and only
logged the transport-error case, so an indeterminate result silently became "denied" and
fell into the destructive `DisablePersonalSpace` branch.

## Fix

Make the permission check distinguish all three outcomes and make the callers fail closed:

- Each `checkPermission` helper now returns `(bool, error)` and calls the gateway
  `CheckPermission` directly so it can inspect the rpc status code:
  `CODE_OK` → granted, `CODE_PERMISSION_DENIED` → denied, any other status (or a transport
  error, or a failed user lookup) → a non-nil error meaning "could not determine".
- Both call sites now return/render the error and **leave the personal space untouched**
  on an indeterminate result instead of disabling it. The proxy path reconciles again on
  the next login; the graph handler surfaces a 500 so the caller can retry.

Disabling a space is destructive, so the safe default for "unknown" is to do nothing rather
than to delete. A defensive guard (refuse to disable a non-empty space) was considered but
left out to keep the change focused on the root cause.

## Testing

- `go test ./services/graph/pkg/service/v0/... ./services/proxy/pkg/userroles/... -race` — passes, race-clean.
- Added two regression tests in `approleassignments_test.go`:
  - `CheckPermission` returns `CODE_INTERNAL` (a non-denial, non-OK status): the handler
    now fails closed (500) and `DeleteStorageSpace` is **not** called.
  - The existing "GetUser fails" case used to assert `201 Created` while silently trashing
    the space; it now asserts the space is left intact and the error is surfaced.
  Both new assertions **fail on the unfixed code** (the handler returns `201` and the space
  is deleted) and pass with the fix, confirming the fault and the remediation.
- The trigger is an internal fault in the gateway/settings permission path, which is not
  reproducible through the public API without fault injection; the unit tests inject the
  exact `CODE_INTERNAL` status / transport failure and assert the before/after behavior.

## Risk

Low. Behavior only changes on the previously-mishandled path (permission indeterminate). On
an authoritative `PERMISSION_DENIED` the personal space is still disabled exactly as before,
and on `CODE_OK` it is still restored. The new behavior is that an indeterminate result no
longer trashes the space: the proxy retries on next login, and the graph handler returns an
error (the role assignment itself has already been persisted, so a client retry re-runs the
idempotent reconciliation). No new concurrency or shared state is introduced.
