### PR TITLE
fix(graph): [OCISDEV-751] return correct issuerAssignedId on /me

### DIFF
--- a/changelog/unreleased/fix-issuerassignedid-on-me.md
+++ b/changelog/unreleased/fix-issuerassignedid-on-me.md
@@ -1,0 +1,13 @@
+Bugfix: Return correct issuerAssignedId on /me
+
+The `/graph/v1.0/me` endpoint reported the internal user UUID as
+`identities[].issuerAssignedId` instead of the issuer-assigned identity (the
+OIDC `sub`). The endpoint took a fast path that built the user model from the
+CS3 user in the request context, which does not carry the external identity, so
+it fell back to the internal UUID. `/me` now always resolves the user through
+the identity backend, which reads the stored external identity and returns the
+correct value. Group memberships are still only expanded when
+`$expand=memberOf` is requested.
+
+https://github.com/owncloud/ocis/pull/12431
+https://github.com/owncloud/ocis/pull/12411

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -62,22 +62,22 @@ func (g Graph) GetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var me *libregraph.User
-	// We can just return the user from context unless we need to expand the group memberships
-	if !slices.Contains(exp, "memberOf") {
-		me = identity.CreateUserModelFromCS3(u)
-	} else {
-		var err error
-		logger.Debug().Msg("calling get user on backend")
-		me, err = g.identityBackend.GetUser(r.Context(), u.GetId().GetOpaqueId(), odataReq)
-		if err != nil {
-			logger.Debug().Err(err).Interface("user", u).Msg("could not get user from backend")
-			errorcode.RenderError(w, r, err)
-			return
-		}
-		if me.MemberOf == nil {
-			me.MemberOf = []libregraph.Group{}
-		}
+	// Always resolve the user through the identity backend. The CS3 user from
+	// the request context does not carry the issuer-assigned identity (OIDC
+	// sub), so building the model from it (CreateUserModelFromCS3) would report
+	// the internal user UUID as identities[].issuerAssignedId. The backend reads
+	// the stored external identity and returns the correct value. Group
+	// memberships are only expanded (and thus only queried) when $expand=memberOf
+	// is requested, so the extra cost here is a single user lookup.
+	logger.Debug().Msg("calling get user on backend")
+	me, err := g.identityBackend.GetUser(r.Context(), u.GetId().GetOpaqueId(), odataReq)
+	if err != nil {
+		logger.Debug().Err(err).Interface("user", u).Msg("could not get user from backend")
+		errorcode.RenderError(w, r, err)
+		return
+	}
+	if slices.Contains(exp, "memberOf") && me.MemberOf == nil {
+		me.MemberOf = []libregraph.Group{}
 	}
 
 	// expand appRoleAssignments if requested

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -116,6 +116,16 @@ var _ = Describe("Users", func() {
 			})
 
 			It("gets the information", func() {
+				user := &libregraph.User{
+					Id: libregraph.PtrString("user"),
+					Identities: []libregraph.ObjectIdentity{
+						{
+							Issuer:           libregraph.PtrString("https://idp.example.com"),
+							IssuerAssignedId: libregraph.PtrString("the-oidc-sub"),
+						},
+					},
+				}
+				identityBackend.On("GetUser", mock.Anything, mock.Anything, mock.Anything).Return(user, nil)
 				valueService.On("GetValueByUniqueIdentifiers", mock.Anything, mock.Anything, mock.Anything).
 					Return(&settings.GetValueResponse{
 						Value: &settingsmsg.ValueWithIdentifier{
@@ -140,6 +150,19 @@ var _ = Describe("Users", func() {
 				svc.GetMe(rr, r)
 
 				Expect(rr.Code).To(Equal(http.StatusOK))
+
+				data, err := io.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				responseUser := &libregraph.User{}
+				err = json.Unmarshal(data, &responseUser)
+				Expect(err).ToNot(HaveOccurred())
+
+				// The identity (issuerAssignedId, the OIDC sub) must come from the
+				// backend, not be fabricated from the internal user UUID. See
+				// OCISDEV-751.
+				Expect(responseUser.GetIdentities()).To(HaveLen(1))
+				Expect(responseUser.GetIdentities()[0].GetIssuerAssignedId()).To(Equal("the-oidc-sub"))
 			})
 
 			It("expands the memberOf", func() {
@@ -194,6 +217,10 @@ var _ = Describe("Users", func() {
 						RoleId:      "some-appRole-ID",
 					},
 				}
+				user := &libregraph.User{
+					Id: libregraph.PtrString("user"),
+				}
+				identityBackend.On("GetUser", mock.Anything, mock.Anything, mock.Anything).Return(user, nil)
 				roleService.On("ListRoleAssignments", mock.Anything, mock.Anything, mock.Anything).Return(&settings.ListRoleAssignmentsResponse{Assignments: assignments}, nil)
 				valueService.On("GetValueByUniqueIdentifiers", mock.Anything, mock.Anything, mock.Anything).
 					Return(&settings.GetValueResponse{


### PR DESCRIPTION
## Description

Forward-port of #12411 (merged to `stable-8.1`) to `master`.

The `/graph/v1.0/me` endpoint reported the internal user UUID as `identities[].issuerAssignedId` instead of the issuer-assigned identity (the OIDC `sub`).

`GetMe` took a fast path that built the user model from the CS3 user in the request context (`CreateUserModelFromCS3`). The CS3 user does not carry the external identity, so it fell back to setting `IssuerAssignedId` to the internal user UUID. The correct value (the OIDC `sub`) is stored in the identity backend's `oCExternalIdentity` attribute at provisioning time and was only read back when `$expand=memberOf` was requested (forcing the LDAP code path).

`/me` now always resolves the user through the identity backend, which returns the correct identity. Group memberships are still only expanded — and thus only queried — when `$expand=memberOf` is requested, so the added cost on a plain `/me` is a single user lookup.

## Related Issue

OCISDEV-751

## Motivation and Context

OIDC-federated clients (e.g. the EOSC / open-science-cloud deployment) use `identities[0].issuerAssignedId` as the user's `OC-Credential` for pre-signed download URLs. Because the field returned the internal UUID, the credential lookup failed and downloads prompted for credentials.

## How Has This Been Tested?

- `go build ./services/graph/...`
- `go test ./services/graph/pkg/service/v0/` (GetMe specs, including a regression assertion that `issuerAssignedId` equals the backend-provided sub on a plain `/me`)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code changes
- [x] Unit tests added
- [x] Changelog item

🤖 Generated with [Claude Code](https://claude.com/claude-code)