### PR TITLE
docs: add delta envvar tables for 8.1

### DIFF
--- a/docs/helpers/changed_envvars.py
+++ b/docs/helpers/changed_envvars.py
@@ -17,27 +17,35 @@ from urllib.request import urlopen
 ## like: python3 docs/helpers/changed_envvars.py
 ## create a branch to prepare the changes
 
+## WHAT TO CHANGE FOR A NEW RELEASE
+##
+## versionOld: To do a proper change comparision from the old to new version, update this var to the FORMER release
+## versionNew: Change only if master already contains new ennvars that are NOT part of the new release. Set to heads/stable-<new-release>
+##             For the latter case, the relevant env_vars.yaml file mustr be part of the branch referenced !!
+## from_version and to_version are print strings only used in the generated adoc files
+## excludePattern: add the FORMER release to the list. The code then searches for anything that does not match the exclude pattern.
+
 # CHANGE according your needs
 # old is the base version to compare from which is always a tagged release
 # new is the target version to compare to and can be a branch or tagged
 # tagged versions must be of format:            'tags/v7.1.0'
 # branches are different, master or stable-x.y: 'heads/master'
 # stick with master because the follow up process is much easier and you avoid confusion
-versionOld: str = 'tags/v7.3.0'
+versionOld: str = 'tags/v8.0.0'
 versionNew: str = 'heads/master'
 
 # CHANGE according your needs
-from_version: str = '7.3.0'
-to_version: str = '8.0.0'
+from_version: str = '8.0.0'
+to_version: str = '8.1.0'
 
 # CHANGE according your needs
 # this will create files like 5.0.0-7.0.0-added and 5.0.0-7.0.0-removed
 # this should match which versions you compare. master is ok if that is the base for a named release
-nameComponent: str = '7.3.0-8.0.0'
+nameComponent: str = '8.0.0-8.1.0'
 
 # ADD new elements when a new version has been published so that it gets excluded
 # array of version patterns to be excluded for added items. we dont need patch versions
-excludePattern: list[str] = ['pre5.0', '5.0', '6.0', '6.0.0', '6.0.1', '6.1.0', '6.7', '7.0', '7.0.0', '7.1.0', '7.2.0', '7.3.0']
+excludePattern: list[str] = ['pre5.0', '5.0', '6.0', '6.0.0', '6.0.1', '6.1.0', '6.7', '7.0', '7.0.0', '7.1.0', '7.2.0', '7.3.0', '8.0.0']
 
 # DO NOT CHANGE
 # this is the path the added/removed result is written to

--- a/docs/services/general-info/envvars/env-var-deltas/8.0.0-8.1.0-added.adoc
+++ b/docs/services/general-info/envvars/env-var-deltas/8.0.0-8.1.0-added.adoc
@@ -1,0 +1,72 @@
+// # Added Variables between oCIS 8.0.0 and oCIS 8.1.0
+// commenting the headline to make it better includable
+
+// table created per 2026.06.15
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+| xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
+| OCIS_ENABLE_VAULT_MODE
+| Enable vault mode in addition to the regular graph service. This only applies when the additional storage-users-vault service is running, which is a special configured storage-users service.
+| false
+
+| xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
+| OCIS_LDAP_GROUP_ADDITIONAL_OBJECTCLASSES
+| Additional object classes to set when creating new groups (e.g. 'posixGroup'). The value of 'GRAPH_LDAP_GROUP_OBJECTCLASS' is always included.
+| []
+
+| xref:deployment/services/env-vars-special-scope.adoc[Special Scope Envvars]
+| OCIS_MFA_SESSION_DURATION
+| The duration in seconds that a multi-factor authentication session is valid. After this time the user will be prompted to re-authenticate. Defaults to 3600 (1 hour).
+| 3600
+
+| xref:{s-path}/frontend.adoc[Frontend]
+| FRONTEND_ENABLE_VAULT_MODE
+| Enable vault mode. When enabled, the capabilities endpoint will report vault as enabled and the capabilities?vault=true endpoint will return capabilities with public sharing and federation disabled.
+| false
+
+| xref:{s-path}/gateway.adoc[Gateway]
+| GATEWAY_ENABLE_VAULT_MODE
+| Set this to true to enable the default rule for vault storage provider configuration. Only applicable if the storage-users-vault service, a specially configured storage-users service, is configured.
+| false
+
+| 
+| GATEWAY_STORAGE_USERS_VAULT_ENDPOINT
+| The endpoint of the storage-users-vault service. The storage-users-vault is an additional storage-users service that runs in vault mode. It can take a service name or a gRPC URI with the dns, kubernetes or unix protocol.
+| com.owncloud.api.storage-users-vault
+
+| xref:{s-path}/graph.adoc[Graph]
+| GRAPH_ENABLE_VAULT_MODE
+| Enable vault mode in addition to the regular graph service. This only applies when the additional storage-users-vault service is running, which is a special configured storage-users service.
+| false
+
+| 
+| GRAPH_LDAP_GROUP_ADDITIONAL_OBJECTCLASSES
+| Additional object classes to set when creating new groups (e.g. 'posixGroup'). The value of 'GRAPH_LDAP_GROUP_OBJECTCLASS' is always included.
+| []
+
+| 
+| GRAPH_SPACES_STORAGE_USERS_VAULT_ADDRESS
+| The address of the storage-users-vault service, a special configured storage-users service. Applicable only when 'GRAPH_ENABLE_VAULT_MODE' is enabled.
+| com.owncloud.api.storage-users-vault
+
+| xref:{s-path}/proxy.adoc[Proxy]
+| PROXY_ENABLE_VAULT_MODE
+| Set this to true to automatically create a new vault home for the user if it does not exist. Only applicapable if the storage-users-vault service, a special configured storage-users service is configured.
+| false
+
+| xref:{s-path}/storage-users.adoc[Storage-Users]
+| STORAGE_USERS_ENABLE_VAULT_MODE
+| Enabling the flag forces the storage-users service to run with a MountID set to VaultStorageProviderID. Not applicable for use with the primary storage-users service. Use only if an additional storage-users-vault service, a special configured storage-users service is configured.
+| false
+
+| 
+| STORAGE_USERS_EVENTS_CONSUMER_GROUP
+| The name of the consumer group to be used at the event to help consumers identify the unique group.
+| 
+
+|===
+

--- a/docs/services/general-info/envvars/env-var-deltas/8.0.0-8.1.0-deprecated.adoc
+++ b/docs/services/general-info/envvars/env-var-deltas/8.0.0-8.1.0-deprecated.adoc
@@ -1,0 +1,12 @@
+// # Deprecated Variables between oCIS 8.0.0 and oCIS 8.1.0
+// commenting the headline to make it better includable
+
+// table created per 2026.06.15
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Removal Version | Deprecation Info
+
+|===
+

--- a/docs/services/general-info/envvars/env-var-deltas/8.0.0-8.1.0-removed.adoc
+++ b/docs/services/general-info/envvars/env-var-deltas/8.0.0-8.1.0-removed.adoc
@@ -1,0 +1,12 @@
+// # Removed Variables between oCIS 8.0.0 and oCIS 8.1.0
+// commenting the headline to make it better includable
+
+// table created per 2026.06.15
+// the table should be recreated/updated on source () changes
+
+[width="100%",cols="~,~,~,~",options="header"]
+|===
+| Service | Variable | Description | Default
+
+|===
+


### PR DESCRIPTION
This PR creates delta envvar tables for 8.1
I also updates the Script with more explanatory text how to use it.

Must be backported into `stable-8.1`