### PR TITLE
[full-ci] chore(web): bump ownCloud Web to v12.4.1

### DIFF
--- a/changelog/unreleased/enhancement-bump-web-to-v12.4.1.md
+++ b/changelog/unreleased/enhancement-bump-web-to-v12.4.1.md
@@ -1,0 +1,13 @@
+Enhancement: Bump Web to 12.4.1
+
+- Security [owncloud/web#13844](https://github.com/owncloud/web/issues/13844): Validate postMessage origin in embed mode modals
+- Bugfix [owncloud/web#13822](https://github.com/owncloud/web/issues/13822): Add explicit size to space header image
+- Bugfix [owncloud/web#13826](https://github.com/owncloud/web/pull/13826): Apply vault theme after OIDC callback
+- Bugfix [owncloud/web#13827](https://github.com/owncloud/web/pull/13827): Gate MFA expiry dialog on vault capability
+- Bugfix [owncloud/web#13834](https://github.com/owncloud/web/pull/13834): Logo not rendering in Firefox
+- Bugfix [owncloud/web#13843](https://github.com/owncloud/web/pull/13843): Fix theme switching issues
+- Bugfix [owncloud/web#13867](https://github.com/owncloud/web/pull/13867): Pass vault parameter to capabilities endpoint
+- Bugfix [owncloud/web#13877](https://github.com/owncloud/web/pull/13877): Filter notifications by vault mode
+
+https://github.com/owncloud/ocis/pull/12450
+https://github.com/owncloud/web/releases/tag/v12.4.1

--- a/ci.env
+++ b/ci.env
@@ -1,4 +1,4 @@
 # Pins the ownCloud Web frontend version used in CI tests.
 # Read by: tests/acceptance/run-e2e.py and .github/workflows/acceptance-tests.yml (Playwright cache key).
-WEB_COMMITID=7dbf6ee5d4df704d19cc33da5564042e226e6871
+WEB_COMMITID=107cd8581fc066b215a74c7c1d608a60f4b1c3e8
 WEB_BRANCH=stable-12.4

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 NAME := web
-WEB_ASSETS_VERSION = v12.4.0
+WEB_ASSETS_VERSION = v12.4.1
 
 include ../../.make/recursion.mk
 


### PR DESCRIPTION
## Changelog

- Security [owncloud/web#13844](https://github.com/owncloud/web/issues/13844): Validate postMessage origin in embed mode modals
- Bugfix [owncloud/web#13822](https://github.com/owncloud/web/issues/13822): Add explicit size to space header image
- Bugfix [owncloud/web#13826](https://github.com/owncloud/web/pull/13826): Apply vault theme after OIDC callback
- Bugfix [owncloud/web#13827](https://github.com/owncloud/web/pull/13827): Gate MFA expiry dialog on vault capability
- Bugfix [owncloud/web#13834](https://github.com/owncloud/web/pull/13834): Logo not rendering in Firefox
- Bugfix [owncloud/web#13843](https://github.com/owncloud/web/pull/13843): Fix theme switching issues
- Bugfix [owncloud/web#13867](https://github.com/owncloud/web/pull/13867): Pass vault parameter to capabilities endpoint
- Bugfix [owncloud/web#13877](https://github.com/owncloud/web/pull/13877): Filter notifications by vault mode