### PR TITLE
fix: auth-app will create the user home if needed

### DIFF
--- a/changelog/unreleased/bugfix-auth-app-creates-user-home.md
+++ b/changelog/unreleased/bugfix-auth-app-creates-user-home.md
@@ -1,0 +1,9 @@
+Bugfix: The auth-app will create the user's home if needed
+
+When the user logs in, his home must be created. This happens automatically
+during login via OIDC (web access). Some recent changes in the code broke
+this behavior when the user logs in via auth-app.
+Now, this behavior is restored, and the user's home will be created when the
+user logs in via auth-app.
+
+https://github.com/owncloud/ocis/pull/12457

--- a/services/proxy/pkg/middleware/app_auth.go
+++ b/services/proxy/pkg/middleware/app_auth.go
@@ -6,6 +6,7 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	cs3rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 	revactx "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 )
@@ -48,6 +49,16 @@ func (m AppAuthAuthenticator) Authenticate(r *http.Request) (*http.Request, bool
 	}
 
 	r.Header.Set(revactx.TokenHeader, authenticateResponse.GetToken())
+
+	user := authenticateResponse.GetUser()
+	// fake oidc claims for the account resolver
+	claims := map[string]interface{}{
+		oidc.Iss:               user.Id.Idp,
+		oidc.PreferredUsername: user.Username,
+		oidc.Email:             user.Mail,
+		oidc.OwncloudUUID:      user.Id.OpaqueId,
+	}
+	r = r.WithContext(oidc.NewContext(r.Context(), claims))
 
 	return r, true
 }

--- a/services/proxy/pkg/middleware/app_auth.go
+++ b/services/proxy/pkg/middleware/app_auth.go
@@ -53,10 +53,10 @@ func (m AppAuthAuthenticator) Authenticate(r *http.Request) (*http.Request, bool
 	user := authenticateResponse.GetUser()
 	// fake oidc claims for the account resolver
 	claims := map[string]interface{}{
-		oidc.Iss:               user.Id.Idp,
-		oidc.PreferredUsername: user.Username,
-		oidc.Email:             user.Mail,
-		oidc.OwncloudUUID:      user.Id.OpaqueId,
+		oidc.Iss:               user.GetId().GetIdp(),
+		oidc.PreferredUsername: user.GetUsername(),
+		oidc.Email:             user.GetMail(),
+		oidc.OwncloudUUID:      user.GetId().GetOpaqueId(),
 	}
 	r = r.WithContext(oidc.NewContext(r.Context(), claims))
 

--- a/services/proxy/pkg/middleware/app_auth_test.go
+++ b/services/proxy/pkg/middleware/app_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 	"google.golang.org/grpc"
@@ -25,16 +26,29 @@ var _ = Describe("Authenticating requests", Label("AppAuthAuthenticator"), func(
 				"com.owncloud.api.gateway",
 				func(cc grpc.ClientConnInterface) gateway.GatewayAPIClient {
 					return mockGatewayClient{
-						AuthenticateFunc: func(authType, clientID, clientSecret string) (string, rpcv1beta1.Code) {
+						AuthenticateFunc: func(authType, clientID, clientSecret string) *gateway.AuthenticateResponse {
 							if authType != "appauth" {
-								return "", rpcv1beta1.Code_CODE_NOT_FOUND
+								return &gateway.AuthenticateResponse{
+									Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_NOT_FOUND},
+								}
 							}
 
 							if clientID == "test-user" && clientSecret == "AppPassword" {
-								return "reva-token", rpcv1beta1.Code_CODE_OK
+								return &gateway.AuthenticateResponse{
+									Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK},
+									Token:  "reva-token",
+									User: &userv1beta1.User{
+										Id:          &userv1beta1.UserId{Idp: "testIDP", OpaqueId: "abcd-1234", Type: userv1beta1.UserType_USER_TYPE_PRIMARY},
+										Username:    "alice",
+										Mail:        "alice@example.prv",
+										DisplayName: "Alice Wong",
+									},
+								}
 							}
 
-							return "", rpcv1beta1.Code_CODE_NOT_FOUND
+							return &gateway.AuthenticateResponse{
+								Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_NOT_FOUND},
+							}
 						},
 					}
 				},

--- a/services/proxy/pkg/middleware/app_auth_test.go
+++ b/services/proxy/pkg/middleware/app_auth_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/ocis-pkg/oidc"
 )
 
 var _ = Describe("Authenticating requests", Label("AppAuthAuthenticator"), func() {
@@ -66,6 +67,13 @@ var _ = Describe("Authenticating requests", Label("AppAuthAuthenticator"), func(
 			Expect(valid).To(Equal(true))
 			Expect(req2).ToNot(BeNil())
 			Expect(req2.Header.Get("x-access-token")).To(Equal("reva-token"))
+
+			claims := oidc.FromContext(req2.Context())
+			Expect(claims).ToNot(BeNil())
+			Expect(claims[oidc.Iss]).To(Equal("testIDP"))
+			Expect(claims[oidc.PreferredUsername]).To(Equal("alice"))
+			Expect(claims[oidc.Email]).To(Equal("alice@example.prv"))
+			Expect(claims[oidc.OwncloudUUID]).To(Equal("abcd-1234"))
 		})
 	})
 

--- a/services/proxy/pkg/middleware/authentication_test.go
+++ b/services/proxy/pkg/middleware/authentication_test.go
@@ -98,20 +98,30 @@ var _ = Describe("Authenticating requests", Label("Authentication"), func() {
 					"com.owncloud.api.gateway",
 					func(cc grpc.ClientConnInterface) gateway.GatewayAPIClient {
 						return mockGatewayClient{
-							AuthenticateFunc: func(authType, clientID, clientSecret string) (string, rpcv1beta1.Code) {
+							AuthenticateFunc: func(authType, clientID, clientSecret string) *gateway.AuthenticateResponse {
 								if authType != "publicshares" {
-									return "", rpcv1beta1.Code_CODE_NOT_FOUND
+									return &gateway.AuthenticateResponse{
+										Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_NOT_FOUND},
+									}
 								}
 
 								if clientID == "sharetoken" && (clientSecret == "password|examples3cr3t" || clientSecret == "signature|examplesignature|exampleexpiration") {
-									return "exampletoken", rpcv1beta1.Code_CODE_OK
+									return &gateway.AuthenticateResponse{
+										Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK},
+										Token:  "exampletoken",
+									}
 								}
 
 								if clientID == "sharetoken" && clientSecret == "password|" {
-									return "otherexampletoken", rpcv1beta1.Code_CODE_OK
+									return &gateway.AuthenticateResponse{
+										Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK},
+										Token:  "otherexampletoken",
+									}
 								}
 
-								return "", rpcv1beta1.Code_CODE_NOT_FOUND
+								return &gateway.AuthenticateResponse{
+									Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_NOT_FOUND},
+								}
 							},
 						}
 					},

--- a/services/proxy/pkg/middleware/public_share_auth_test.go
+++ b/services/proxy/pkg/middleware/public_share_auth_test.go
@@ -26,20 +26,30 @@ var _ = Describe("Authenticating requests", Label("PublicShareAuthenticator"), f
 				"com.owncloud.api.gateway",
 				func(cc grpc.ClientConnInterface) gateway.GatewayAPIClient {
 					return mockGatewayClient{
-						AuthenticateFunc: func(authType, clientID, clientSecret string) (string, rpcv1beta1.Code) {
+						AuthenticateFunc: func(authType, clientID, clientSecret string) *gateway.AuthenticateResponse {
 							if authType != "publicshares" {
-								return "", rpcv1beta1.Code_CODE_NOT_FOUND
+								return &gateway.AuthenticateResponse{
+									Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_NOT_FOUND},
+								}
 							}
 
 							if clientID == "sharetoken" && (clientSecret == "password|examples3cr3t" || clientSecret == "signature|examplesignature|exampleexpiration") {
-								return "exampletoken", rpcv1beta1.Code_CODE_OK
+								return &gateway.AuthenticateResponse{
+									Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK},
+									Token:  "exampletoken",
+								}
 							}
 
 							if clientID == "sharetoken" && clientSecret == "password|" {
-								return "otherexampletoken", rpcv1beta1.Code_CODE_OK
+								return &gateway.AuthenticateResponse{
+									Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK},
+									Token:  "otherexampletoken",
+								}
 							}
 
-							return "", rpcv1beta1.Code_CODE_NOT_FOUND
+							return &gateway.AuthenticateResponse{
+								Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_NOT_FOUND},
+							}
 						},
 					}
 				},
@@ -102,13 +112,10 @@ var _ = Describe("Authenticating requests", Label("PublicShareAuthenticator"), f
 
 type mockGatewayClient struct {
 	gatewayv1beta1.GatewayAPIClient
-	AuthenticateFunc func(authType, clientID, clientSecret string) (string, rpcv1beta1.Code)
+	AuthenticateFunc func(authType, clientID, clientSecret string) *gatewayv1beta1.AuthenticateResponse
 }
 
 func (c mockGatewayClient) Authenticate(ctx context.Context, in *gatewayv1beta1.AuthenticateRequest, opts ...grpc.CallOption) (*gatewayv1beta1.AuthenticateResponse, error) {
-	token, code := c.AuthenticateFunc(in.GetType(), in.GetClientId(), in.GetClientSecret())
-	return &gatewayv1beta1.AuthenticateResponse{
-		Status: &rpcv1beta1.Status{Code: code},
-		Token:  token,
-	}, nil
+	response := c.AuthenticateFunc(in.GetType(), in.GetClientId(), in.GetClientSecret())
+	return response, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The create_home middleware was failing when logging through auth-app, causing further storage requests to fail. In particular, the tool to migrate from OC10 to oCIS was failing.
A possible workaround was to login with the user (through oidc) so the home was created. However, this wasn't possible with the migration tool.

Based on code already in place for other authentication mechanisms, we'll fake oidc claims so the account resolver can get the user information properly (including the role), and the create home middleware can make a successful request.

Note that this happened due to recent changes.

## Related Issue
https://github.com/owncloud/ocis/issues/12447

## Motivation and Context
It needs to be fixed for the migration tool

## How Has This Been Tested?
Manually tested:
* After creating a new user, use the auth-app to create a token for the new user and try to create a folder using the token through webdav.
* Run the migration tool and migrate several files from several users.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
