### PR TITLE
feat(web): [OCISDEV-840] apply Kiteworks branding to theme

### DIFF
--- a/changelog/unreleased/change-kiteworks-branding.md
+++ b/changelog/unreleased/change-kiteworks-branding.md
@@ -1,0 +1,6 @@
+Change: Apply Kiteworks branding to the web theme
+
+The default oCIS theme now uses the Kiteworks OSPO name, slogan and logos
+across all regular and vault mode themes.
+
+https://github.com/owncloud/ocis/pull/12464

--- a/changelog/unreleased/enhancement-kiteworks-branding.md
+++ b/changelog/unreleased/enhancement-kiteworks-branding.md
@@ -1,4 +1,4 @@
-Change: Apply Kiteworks branding to the web theme
+Enhancement: Apply Kiteworks branding to the web theme
 
 The default oCIS theme now uses the Kiteworks OSPO name, slogan and logos
 across all regular and vault mode themes.

--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -1,8 +1,8 @@
 {
   "common": {
-    "name": "ownCloud",
-    "slogan": "ownCloud – A safe home for all your data",
-    "logo": "themes/owncloud/assets/logo.svg",
+    "name": "ownCloud – a Kiteworks company",
+    "slogan": "Kiteworks Open Source Program Office",
+    "logo": "themes/owncloud/assets/oc_coloured.svg",
     "urls": {
       "accessDeniedHelp": "",
       "imprint": "",
@@ -73,6 +73,11 @@
         {
           "isDark": false,
           "name": "Light Theme",
+          "logo": {
+            "topbar": "themes/owncloud/assets/logo_white.svg",
+            "favicon": "themes/owncloud/assets/favicon.jpg",
+            "login": "themes/owncloud/assets/logo_white.svg"
+          },
           "designTokens": {
             "colorPalette": {
               "background-accentuate": "rgba(255, 255, 5, 0.1)",
@@ -141,7 +146,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo.svg"
+            "login": "themes/owncloud/assets/logo_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -208,6 +213,11 @@
         {
           "isDark": true,
           "name": "Dark Theme",
+          "logo": {
+            "topbar": "themes/owncloud/assets/logo.svg",
+            "favicon": "themes/owncloud/assets/favicon.jpg",
+            "login": "themes/owncloud/assets/logo_white.svg"
+          },
           "designTokens": {
             "colorPalette": {
               "background-accentuate": "#696969",
@@ -275,6 +285,11 @@
         {
           "isDark": true,
           "name": "Dark Theme – High Contrast",
+          "logo": {
+            "topbar": "themes/owncloud/assets/logo.svg",
+            "favicon": "themes/owncloud/assets/favicon.jpg",
+            "login": "themes/owncloud/assets/logo_white.svg"
+          },
           "designTokens": {
             "colorPalette": {
               "background-accentuate": "#696969",
@@ -346,7 +361,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo.svg"
+            "login": "themes/owncloud/assets/logo_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -417,7 +432,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo.svg"
+            "login": "themes/owncloud/assets/logo_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -485,6 +500,11 @@
           "isDark": true,
           "mode": "vault",
           "name": "Dark Theme",
+          "logo": {
+            "topbar": "themes/owncloud/assets/logo.svg",
+            "favicon": "themes/owncloud/assets/favicon.jpg",
+            "login": "themes/owncloud/assets/logo_white.svg"
+          },
           "designTokens": {
             "colorPalette": {
               "background-accentuate": "#696969",
@@ -557,7 +577,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo.svg"
+            "login": "themes/owncloud/assets/logo_white.svg"
           },
           "designTokens": {
             "colorPalette": {

--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -74,9 +74,9 @@
           "isDark": false,
           "name": "Light Theme",
           "logo": {
-            "topbar": "themes/owncloud/assets/logo_white.svg",
+            "topbar": "themes/owncloud/assets/oc_white.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -146,7 +146,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -216,7 +216,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -288,7 +288,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -361,7 +361,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -432,7 +432,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -503,7 +503,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {
@@ -577,7 +577,7 @@
           "logo": {
             "topbar": "themes/owncloud/assets/logo_dark.svg",
             "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/logo_white.svg"
+            "login": "themes/owncloud/assets/oc_white.svg"
           },
           "designTokens": {
             "colorPalette": {

--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -20,9 +20,9 @@
       "defaults": {
         "appBanner": {},
         "logo": {
-          "topbar": "themes/owncloud/assets/logo.svg",
+          "topbar": "themes/owncloud/assets/oc_white.svg",
           "favicon": "themes/owncloud/assets/favicon.jpg",
-          "login": "themes/owncloud/assets/logo.svg"
+          "login": "themes/owncloud/assets/oc_white.svg"
         },
         "loginPage": {
           "backgroundImg": "themes/owncloud/assets/loginBackground.jpg"
@@ -73,11 +73,6 @@
         {
           "isDark": false,
           "name": "Light Theme",
-          "logo": {
-            "topbar": "themes/owncloud/assets/oc_white.svg",
-            "favicon": "themes/owncloud/assets/favicon.jpg",
-            "login": "themes/owncloud/assets/oc_white.svg"
-          },
           "designTokens": {
             "colorPalette": {
               "background-accentuate": "rgba(255, 255, 5, 0.1)",


### PR DESCRIPTION
## Description

The [Web PR](https://github.com/owncloud/web/pull/13587) bringing the assets has been already merged. This is a follow up PR that uses the new assets and updates the name and slogan.

## Related Issue

- https://kiteworks.atlassian.net/browse/OCISDEV-840

## Motivation and Context

Kiteworks OSPO branding is everywhere.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: browse through all regular themes
- test case 2: browse through all vault themes

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
