### PR TITLE
feat(invitations): provision guests directly into the directory (ldap backend)

### DIFF
--- a/changelog/unreleased/enhancement-invitations-idm-backend.md
+++ b/changelog/unreleased/enhancement-invitations-idm-backend.md
@@ -1,0 +1,19 @@
+Enhancement: Provision invited guests directly into the identity backend
+
+The invitations service can now provision invited guests directly into the oCIS
+identity backend (LDAP) instead of an external Keycloak IdP. The backend is selected
+with the new `INVITATIONS_BACKEND` environment variable: `keycloak` (default, the
+previous behaviour) or `ldap`.
+
+A guest created via the `ldap` backend is written into the same directory oCIS reads
+for share-recipient resolution, so it is immediately resolvable through the Graph API
+and usable as a share recipient right after the invitation. This closes the
+provisioning-delay gap that previously existed between creating a guest in an external
+IdP and being able to share with them. The `ldap` backend requires
+`OCIS_LDAP_SERVER_WRITE_ENABLED=true`.
+
+The `ocis_full` example deployment enables this by default so invited guests can be
+shared with out of the box. Note: the `ldap` backend only provisions the guest; it
+does not send a credential-setup email (that remains a Keycloak feature).
+
+https://github.com/owncloud/ocis/pull/12469

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -127,7 +127,7 @@ SMTP_INSECURE=
 # manually defined for startup:
 # IMPORTANT: The notification service is MANDATORY, do not delete!
 # IMPORTANT: Add any services to the startup list comma separated like "notifications,antivirus" etc.
-START_ADDITIONAL_SERVICES="notifications"
+START_ADDITIONAL_SERVICES="notifications,invitations"
 
 
 ## oCIS Web Extensions ##

--- a/deployments/examples/ocis_full/ocis.yml
+++ b/deployments/examples/ocis_full/ocis.yml
@@ -36,6 +36,16 @@ services:
       IDM_ADMIN_PASSWORD: "${ADMIN_PASSWORD:-admin}" # this overrides the admin password from the configuration file
       # demo users
       IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
+      # Provision invited guests directly into the (writable) identity backend so
+      # they are immediately resolvable and usable as share recipients (closes the
+      # invitation provisioning-delay gap). NOTE: the 'ldap' invitation backend
+      # provisions the guest but does NOT send a credential-setup mail (that is a
+      # Keycloak feature); combine with the keycloak.yml overlay for a guest
+      # login/email flow. See services/invitations.
+      OCIS_LDAP_SERVER_WRITE_ENABLED: "${LDAP_WRITE_ENABLED:-true}"
+      INVITATIONS_BACKEND: "${INVITATIONS_BACKEND:-ldap}"
+      # the bundled idm ships a self-signed cert; skip LDAP TLS verification when running insecure
+      INVITATIONS_LDAP_INSECURE: "${INSECURE:-false}"
       # email server (if configured)
       NOTIFICATIONS_SMTP_HOST: "${SMTP_HOST}"
       NOTIFICATIONS_SMTP_PORT: "${SMTP_PORT}"

--- a/ocis/pkg/init/init.go
+++ b/ocis/pkg/init/init.go
@@ -215,6 +215,14 @@ func CreateConfig(insecure, forceOverwrite, diff bool, configPath, adminPassword
 			},
 			ServiceAccount: serviceAccount,
 		},
+		// The invitations service can provision guests directly into the identity
+		// backend (INVITATIONS_BACKEND=ldap). It binds with the same service user
+		// as the graph identity backend, so it shares the idm service password.
+		Invitations: LdapBasedService{
+			Ldap: LdapSettings{
+				BindPassword: idmServicePassword,
+			},
+		},
 		Thumbnails: ThumbnailService{
 			Thumbnail: ThumbnailSettings{
 				TransferSecret: thumbnailsTransferSecret,

--- a/ocis/pkg/init/structs.go
+++ b/ocis/pkg/init/structs.go
@@ -46,6 +46,7 @@ type OcisConfig struct {
 	AuthService       AuthService           `yaml:"auth_service"`
 	Clientlog         Clientlog             `yaml:"clientlog"`
 	Activitylog       Activitylog           `yaml:"activitylog"`
+	Invitations       LdapBasedService      `yaml:"invitations,omitempty"`
 }
 
 // Activitylog is the configuration for the activitylog service

--- a/services/invitations/pkg/backends/idm/backend.go
+++ b/services/invitations/pkg/backends/idm/backend.go
@@ -1,0 +1,100 @@
+// Package idm provides an invitation backend that provisions invited guests
+// directly into the oCIS identity backend (the "IDM" provisioning mode described
+// in the invitations service README). Unlike the Keycloak backend, which creates
+// the guest in an external IdP, this backend writes the guest into the directory
+// that oCIS itself reads (via the Graph identity backend), so the invited guest
+// is immediately resolvable through the Graph API and therefore an immediately
+// shareable principal — closing the provisioning-delay gap that prevents
+// "invite by email, then share now".
+//
+// PROTOTYPE SCOPE / LIMITATION: this backend only *provisions* the guest. It does
+// not send a credential-setup email, because the local identity backend has no
+// execute-actions-email equivalent (that is a Keycloak feature). It therefore
+// fits IDM-managed deployments. In a Keycloak-backed deployment, the guest also
+// needs a Keycloak account to authenticate; there the better lever is creating
+// the guest in Keycloak with a WRITABLE LDAP federation, so a single write
+// satisfies both authentication and directory resolution.
+package idm
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/invitations/pkg/invitations"
+)
+
+const userType = "Guest"
+
+// DirectoryProvisioner is the subset of the Graph identity backend that this
+// invitation backend needs. *identity.LDAP (services/graph/pkg/identity)
+// satisfies it, so in production the guest is created in the same directory oCIS
+// reads for share-recipient resolution.
+type DirectoryProvisioner interface {
+	CreateUser(ctx context.Context, user libregraph.User) (*libregraph.User, error)
+}
+
+// Backend provisions invited guests into the oCIS identity backend.
+type Backend struct {
+	logger      log.Logger
+	provisioner DirectoryProvisioner
+}
+
+// New instantiates an IDM invitation backend backed by the given provisioner.
+func New(logger log.Logger, provisioner DirectoryProvisioner) *Backend {
+	return &Backend{
+		logger:      log.Logger{Logger: logger.With().Str("invitationBackend", "idm").Logger()},
+		provisioner: provisioner,
+	}
+}
+
+// CreateUser provisions the invited guest as a local user (userType "Guest") and
+// records the created user on the invitation as invitedUser. The returned id is
+// the directory id of the created user, which is immediately usable as a share
+// recipient.
+func (b Backend) CreateUser(ctx context.Context, invitation *invitations.Invitation) (string, error) {
+	id := uuid.New().String()
+
+	displayName := invitation.InvitedUserDisplayName
+	if displayName == "" {
+		displayName = invitation.InvitedUserEmailAddress
+	}
+
+	b.logger.Info().
+		Str("email", invitation.InvitedUserEmailAddress).
+		Msg("Provisioning new guest in the identity backend")
+
+	user := libregraph.User{
+		Id:                       &id,
+		Mail:                     &invitation.InvitedUserEmailAddress,
+		DisplayName:              displayName,
+		OnPremisesSamAccountName: invitation.InvitedUserEmailAddress,
+		AccountEnabled:           boolP(true),
+		UserType:                 stringP(userType),
+	}
+
+	created, err := b.provisioner.CreateUser(ctx, user)
+	if err != nil {
+		b.logger.Error().
+			Str("email", invitation.InvitedUserEmailAddress).
+			Err(err).
+			Msg("Failed to provision guest")
+		return "", err
+	}
+
+	// Record the created user so the service returns it as invitedUser, and hand
+	// back its directory id (immediately resolvable / shareable).
+	invitation.InvitedUser = created
+	return created.GetId(), nil
+}
+
+// CanSendMail reports false: the IDM backend only provisions the guest and has no
+// credential-setup mail flow (see the package doc).
+func (b Backend) CanSendMail() bool { return false }
+
+// SendMail is a no-op for the IDM backend.
+func (b Backend) SendMail(_ context.Context, _ string) error { return nil }
+
+func boolP(b bool) *bool       { return &b }
+func stringP(s string) *string { return &s }

--- a/services/invitations/pkg/backends/idm/backend_test.go
+++ b/services/invitations/pkg/backends/idm/backend_test.go
@@ -1,0 +1,85 @@
+package idm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/invitations/pkg/backends/idm"
+	"github.com/owncloud/ocis/v2/services/invitations/pkg/invitations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProvisioner records the user it was asked to create and returns a
+// configurable result, standing in for *identity.LDAP in unit tests.
+type fakeProvisioner struct {
+	gotUser libregraph.User
+	err     error
+}
+
+func (f *fakeProvisioner) CreateUser(_ context.Context, user libregraph.User) (*libregraph.User, error) {
+	f.gotUser = user
+	if f.err != nil {
+		return nil, f.err
+	}
+	created := user // the directory backend echoes the created user (id preserved)
+	return &created, nil
+}
+
+func TestBackend_CreateUser_ProvisionsGuest(t *testing.T) {
+	f := &fakeProvisioner{}
+	b := idm.New(log.NopLogger(), f)
+	inv := &invitations.Invitation{InvitedUserEmailAddress: "guest@example.org"}
+
+	id, err := b.CreateUser(context.Background(), inv)
+	require.NoError(t, err)
+	assert.NotEmpty(t, id)
+
+	// the provisioner received a Guest user built from the invitation
+	assert.Equal(t, "guest@example.org", f.gotUser.GetMail())
+	assert.Equal(t, "Guest", f.gotUser.GetUserType())
+	assert.Equal(t, "guest@example.org", f.gotUser.GetOnPremisesSamAccountName())
+	assert.True(t, f.gotUser.GetAccountEnabled())
+
+	// the invitation now carries the created user as invitedUser
+	require.NotNil(t, inv.InvitedUser)
+	assert.Equal(t, id, inv.InvitedUser.GetId())
+	assert.Equal(t, "guest@example.org", inv.InvitedUser.GetMail())
+}
+
+func TestBackend_CreateUser_DisplayNameFallsBackToEmail(t *testing.T) {
+	f := &fakeProvisioner{}
+	b := idm.New(log.NopLogger(), f)
+
+	// no display name -> falls back to the email
+	_, err := b.CreateUser(context.Background(), &invitations.Invitation{InvitedUserEmailAddress: "g@example.org"})
+	require.NoError(t, err)
+	assert.Equal(t, "g@example.org", f.gotUser.GetDisplayName())
+
+	// explicit display name is kept
+	_, err = b.CreateUser(context.Background(), &invitations.Invitation{
+		InvitedUserEmailAddress: "g@example.org",
+		InvitedUserDisplayName:  "Guest Person",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Guest Person", f.gotUser.GetDisplayName())
+}
+
+func TestBackend_CreateUser_ProvisionError(t *testing.T) {
+	f := &fakeProvisioner{err: errors.New("ldap write failed")}
+	b := idm.New(log.NopLogger(), f)
+	inv := &invitations.Invitation{InvitedUserEmailAddress: "g@example.org"}
+
+	_, err := b.CreateUser(context.Background(), inv)
+	require.Error(t, err)
+	assert.Nil(t, inv.InvitedUser)
+}
+
+func TestBackend_CanSendMail_IsFalse(t *testing.T) {
+	b := idm.New(log.NopLogger(), &fakeProvisioner{})
+	assert.False(t, b.CanSendMail())
+	assert.NoError(t, b.SendMail(context.Background(), "some-id"))
+}

--- a/services/invitations/pkg/config/config.go
+++ b/services/invitations/pkg/config/config.go
@@ -18,7 +18,9 @@ type Config struct {
 
 	HTTP HTTP `yaml:"http"`
 
+	Backend      string        `yaml:"backend" env:"INVITATIONS_BACKEND" desc:"The backend used to provision invited guests. Supported values are 'keycloak' (default; creates the guest in the configured Keycloak realm and sends a credential-setup email) and 'ldap' (creates the guest directly in the oCIS identity backend, so it is immediately usable as a share recipient; requires OCIS_LDAP_SERVER_WRITE_ENABLED)." introductionVersion:"NEXT"`
 	Keycloak     Keycloak      `yaml:"keycloak"`
+	LDAP         LDAP          `yaml:"ldap"`
 	TokenManager *TokenManager `yaml:"token_manager"`
 
 	Context context.Context `yaml:"-"`
@@ -32,4 +34,18 @@ type Keycloak struct {
 	ClientRealm        string `yaml:"client_realm" env:"OCIS_KEYCLOAK_CLIENT_REALM;INVITATIONS_KEYCLOAK_CLIENT_REALM" desc:"The realm the client is defined in." introductionVersion:"pre5.0"`
 	UserRealm          string `yaml:"user_realm" env:"OCIS_KEYCLOAK_USER_REALM;INVITATIONS_KEYCLOAK_USER_REALM" desc:"The realm users are defined." introductionVersion:"pre5.0"`
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" env:"OCIS_KEYCLOAK_INSECURE_SKIP_VERIFY;INVITATIONS_KEYCLOAK_INSECURE_SKIP_VERIFY" desc:"Disable TLS certificate validation for Keycloak connections. Do not set this in production environments." introductionVersion:"pre5.0"`
+}
+
+// LDAP configures the 'ldap' invitation backend, which provisions invited guests
+// directly into the oCIS identity backend (the directory oCIS reads for
+// share-recipient resolution). The connection settings reuse the shared
+// OCIS_LDAP_* configuration of the graph service so both resolve the same entries.
+type LDAP struct {
+	URI          string `yaml:"uri" env:"OCIS_LDAP_URI;INVITATIONS_LDAP_URI" desc:"URI of the LDAP server to provision guests into. Only used when INVITATIONS_BACKEND is 'ldap'." introductionVersion:"NEXT"`
+	CACert       string `yaml:"cacert" env:"OCIS_LDAP_CACERT;INVITATIONS_LDAP_CACERT" desc:"Path to the root CA certificate (PEM) used to validate the LDAP server's TLS certificate." introductionVersion:"NEXT"`
+	Insecure     bool   `yaml:"insecure" env:"OCIS_LDAP_INSECURE;INVITATIONS_LDAP_INSECURE" desc:"Disable TLS certificate validation for the LDAP connection. Do not set this in production environments." introductionVersion:"NEXT"`
+	BindDN       string `yaml:"bind_dn" env:"OCIS_LDAP_BIND_DN;INVITATIONS_LDAP_BIND_DN" desc:"LDAP DN used for simple bind authentication when provisioning guests." introductionVersion:"NEXT"`
+	BindPassword string `yaml:"bind_password" env:"OCIS_LDAP_BIND_PASSWORD;INVITATIONS_LDAP_BIND_PASSWORD" desc:"Password for the 'bind_dn'." introductionVersion:"NEXT"`
+	UserBaseDN   string `yaml:"user_base_dn" env:"OCIS_LDAP_USER_BASE_DN;INVITATIONS_LDAP_USER_BASE_DN" desc:"Search base DN under which invited guests are created." introductionVersion:"NEXT"`
+	WriteEnabled bool   `yaml:"write_enabled" env:"OCIS_LDAP_SERVER_WRITE_ENABLED;INVITATIONS_LDAP_WRITE_ENABLED" desc:"Allow creating users in LDAP. Must be 'true' for the 'ldap' backend to provision guests." introductionVersion:"NEXT"`
 }

--- a/services/invitations/pkg/config/defaults/defaultconfig.go
+++ b/services/invitations/pkg/config/defaults/defaultconfig.go
@@ -32,12 +32,18 @@ func DefaultConfig() *config.Config {
 		Service: config.Service{
 			Name: "invitations",
 		},
+		Backend: "keycloak",
 		Keycloak: config.Keycloak{
 			BasePath:     "",
 			ClientID:     "",
 			ClientSecret: "",
 			ClientRealm:  "",
 			UserRealm:    "",
+		},
+		LDAP: config.LDAP{
+			URI:        "ldaps://localhost:9235",
+			BindDN:     "uid=libregraph,ou=sysusers,o=libregraph-idm",
+			UserBaseDN: "ou=users,o=libregraph-idm",
 		},
 	}
 }

--- a/services/invitations/pkg/service/v0/service.go
+++ b/services/invitations/pkg/service/v0/service.go
@@ -2,9 +2,16 @@ package service
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"os"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	graphdefaults "github.com/owncloud/ocis/v2/services/graph/pkg/config/defaults"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/identity"
+	graphldap "github.com/owncloud/ocis/v2/services/graph/pkg/identity/ldap"
+	"github.com/owncloud/ocis/v2/services/invitations/pkg/backends/idm"
 	"github.com/owncloud/ocis/v2/services/invitations/pkg/backends/keycloak"
 	"github.com/owncloud/ocis/v2/services/invitations/pkg/config"
 	"github.com/owncloud/ocis/v2/services/invitations/pkg/invitations"
@@ -48,22 +55,87 @@ type Backend interface {
 func New(opts ...Option) (Service, error) {
 	options := newOptions(opts...)
 
-	// Harcode keycloak backend for now, but this should be configurable in the future.
-	backend := keycloak.New(
-		options.Logger,
-		options.Config.Keycloak.BasePath,
-		options.Config.Keycloak.ClientID,
-		options.Config.Keycloak.ClientSecret,
-		options.Config.Keycloak.ClientRealm,
-		options.Config.Keycloak.UserRealm,
-		options.Config.Keycloak.InsecureSkipVerify,
-	)
+	backend, err := newBackend(options)
+	if err != nil {
+		return nil, err
+	}
 
 	return svc{
 		log:     options.Logger,
 		config:  options.Config,
 		backend: backend,
 	}, nil
+}
+
+// newBackend selects the invitation backend based on configuration.
+func newBackend(options Options) (Backend, error) {
+	switch options.Config.Backend {
+	case "ldap", "cs3", "idm":
+		return newLDAPBackend(options)
+	default:
+		return keycloak.New(
+			options.Logger,
+			options.Config.Keycloak.BasePath,
+			options.Config.Keycloak.ClientID,
+			options.Config.Keycloak.ClientSecret,
+			options.Config.Keycloak.ClientRealm,
+			options.Config.Keycloak.UserRealm,
+			options.Config.Keycloak.InsecureSkipVerify,
+		), nil
+	}
+}
+
+// newLDAPBackend builds the backend that provisions guests directly into the
+// oCIS identity backend. The LDAP schema defaults are reused from the graph
+// service so invitations and graph resolve the same directory entries; only the
+// connection and write settings come from the invitations configuration.
+func newLDAPBackend(options Options) (Backend, error) {
+	logger := options.Logger
+	cfg := options.Config.LDAP
+
+	lc := graphdefaults.DefaultConfig().Identity.LDAP
+	if cfg.URI != "" {
+		lc.URI = cfg.URI
+	}
+	if cfg.BindDN != "" {
+		lc.BindDN = cfg.BindDN
+	}
+	if cfg.BindPassword != "" {
+		lc.BindPassword = cfg.BindPassword
+	}
+	if cfg.CACert != "" {
+		lc.CACert = cfg.CACert
+	}
+	if cfg.UserBaseDN != "" {
+		lc.UserBaseDN = cfg.UserBaseDN
+	}
+	lc.Insecure = cfg.Insecure
+	lc.WriteEnabled = cfg.WriteEnabled
+
+	tlsConf := &tls.Config{InsecureSkipVerify: lc.Insecure} //nolint:gosec
+	if !lc.Insecure && lc.CACert != "" {
+		certs := x509.NewCertPool()
+		pemData, err := os.ReadFile(lc.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("invitations: reading LDAP CA cert %q: %w", lc.CACert, err)
+		}
+		if !certs.AppendCertsFromPEM(pemData) {
+			return nil, fmt.Errorf("invitations: adding LDAP CA cert %q failed", lc.CACert)
+		}
+		tlsConf.RootCAs = certs
+	}
+
+	conn := graphldap.NewLDAPWithReconnect(&logger, graphldap.Config{
+		URI:          lc.URI,
+		BindDN:       lc.BindDN,
+		BindPassword: lc.BindPassword,
+		TLSConfig:    tlsConf,
+	})
+	lb, err := identity.NewLDAPBackend(conn, lc, &logger, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("invitations: initializing LDAP backend: %w", err)
+	}
+	return idm.New(logger, lb), nil
 }
 
 type svc struct {


### PR DESCRIPTION
## Problem

The invitations service (`POST /graph/v1.0/invitations`) provisions invited guests in
an external Keycloak IdP. Such a guest is **not** immediately present in the directory
oCIS reads for share-recipient resolution (the documented "provisioning delay" in
`services/invitations/README.md`), so it cannot be used as a share recipient until it
has been synced/logged in. The graph invite handler validates the recipient via
`identityCache.GetUser` (`services/graph/.../api_driveitem_permissions.go`) and rejects
unknown ids, so "invite an external by email, then share with them" cannot work right
after the invitation.

## Solution

Add a second invitation backend that provisions the guest **directly into the oCIS
identity backend** (LDAP), selected with a new `INVITATIONS_BACKEND` env var:

- `keycloak` (default) — unchanged behaviour.
- `ldap` — creates the guest (`userType=Guest`) in the same directory oCIS reads, via
  the existing `identity.LDAP` backend. The guest is therefore **immediately resolvable
  through the Graph API and usable as a share recipient**. Requires
  `OCIS_LDAP_SERVER_WRITE_ENABLED=true`.

The invitation response also returns the created user as `invitedUser` (id, email,
userType), which a client needs to then share with the guest.

### Changes

- `services/invitations/pkg/backends/idm/` — new backend provisioning guests via a
  `DirectoryProvisioner` (satisfied by `*identity.LDAP`); unit-tested.
- `services/invitations/pkg/service/v0/service.go` — `INVITATIONS_BACKEND` selector;
  the `ldap` backend reuses the graph LDAP schema defaults and only overrides the
  connection/write settings from the invitations config.
- `services/invitations/pkg/config` — `INVITATIONS_BACKEND` + `INVITATIONS_LDAP_*`.
- `ocis/pkg/init` — `ocis init` now provisions the invitations LDAP bind password with
  the same idm service password the graph identity backend uses, so the `ldap` backend
  works out of the box.
- `deployments/examples/ocis_full` — enables LDAP write + the `ldap` invitation backend
  and runs the invitations service, so an invited guest is shareable out of the box.

## Testing

- `go test ./services/invitations/... -race` — passes (new `idm` backend unit tests +
  existing keycloak tests).
- **End-to-end against a running oCIS** (single binary, `INVITATIONS_BACKEND=ldap`,
  `OCIS_LDAP_SERVER_WRITE_ENABLED=true`):
  1. `POST /graph/v1.0/invitations` → `201`, `invitedUser` returned with `userType=Guest`.
  2. `GET /graph/v1.0/users/{id}` → `200` immediately (resolvable).
  3. graph invite of that guest onto a folder → `200` (share succeeds).
  Verified relying solely on the `ocis init`-provisioned bind password (no manual secret).

## Notes / limitations

- The `ldap` backend **provisions** the guest but does not send a credential-setup email
  (that remains a Keycloak feature). It fits IDM-managed deployments; for a guest
  login/email flow, combine with Keycloak.
- Prototype: the `ldap` backend reuses `services/graph/pkg/identity` + its config
  defaults. A cleaner long-term home would be a shared identity package.

## Risk

Low. `INVITATIONS_BACKEND` defaults to `keycloak` (unchanged behaviour); the new path is
opt-in. The `ocis_full` change is confined to the example deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
